### PR TITLE
Add test runners for GooglePayLauncher and GooglePayPaymentMethodLauncher

### DIFF
--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherTest.kt
@@ -1,34 +1,16 @@
 package com.stripe.android.googlepaylauncher
 
-import android.app.Activity
-import android.app.Instrumentation
-import android.content.Context
-import android.content.Intent
 import androidx.activity.ComponentActivity
-import androidx.core.os.bundleOf
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.test.core.app.ActivityScenario
-import androidx.test.espresso.Espresso
-import androidx.test.espresso.intent.Intents.intending
-import androidx.test.espresso.intent.matcher.IntentMatchers.anyIntent
 import androidx.test.espresso.intent.rule.IntentsTestRule
-import com.google.android.gms.tasks.Tasks
-import com.google.android.gms.wallet.PaymentsClient
-import com.google.android.gms.wallet.Wallet
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.googlepaylauncher.utils.LauncherIntegrationType
+import com.stripe.android.googlepaylauncher.utils.runGooglePayLauncherTest
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import org.junit.Rule
 import org.junit.runner.RunWith
-import org.mockito.Mockito.mockStatic
-import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.isA
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
@@ -41,29 +23,19 @@ internal class GooglePayLauncherTest {
 
     @Test
     fun `presentForPaymentIntent() should successfully return a result when Google Pay is available`() {
-        val readyCallback = mock<GooglePayLauncher.ReadyCallback>()
-        val resultCallback = mock<GooglePayLauncher.ResultCallback>()
-
-        runGooglePayLauncherTest { scenario, activity ->
-            val launcher = GooglePayLauncher(
-                activity = activity,
-                config = CONFIG,
-                readyCallback = readyCallback,
-                resultCallback = resultCallback,
-            )
-            scenario.moveToState(Lifecycle.State.RESUMED)
+        runGooglePayLauncherTest { _, launcher ->
             launcher.presentForPaymentIntent("pi_123_secret_456")
         }
-
-        verify(readyCallback).onReady(eq(true))
-        verify(resultCallback).onResult(eq(GooglePayLauncher.Result.Completed))
     }
 
     @Test
     fun `init should fire expected event`() {
-        val firedEvents = mutableListOf<String>()
+        runGooglePayLauncherTest(
+            integrationTypes = arrayOf(LauncherIntegrationType.Activity),
+            expectResult = false,
+        ) { activity, _ ->
+            val firedEvents = mutableListOf<String>()
 
-        runGooglePayLauncherTest { _, activity ->
             // Have to use the internal constructor here to provide a mock request executor
             // ¯\_(ツ)_/¯
             GooglePayLauncher(
@@ -78,32 +50,21 @@ internal class GooglePayLauncherTest {
                 ),
                 analyticsRequestExecutor = { firedEvents += it.params["event"].toString() },
             )
-        }
 
-        assertThat(firedEvents).containsExactly("stripe_android.googlepaylauncher_init")
+            assertThat(firedEvents).containsExactly("stripe_android.googlepaylauncher_init")
+        }
     }
 
     @Test
     fun `presentForPaymentIntent() should throw IllegalStateException when Google Pay is not available`() {
-        val readyCallback = mock<GooglePayLauncher.ReadyCallback>()
-        val resultCallback = mock<GooglePayLauncher.ResultCallback>()
-
-        runGooglePayLauncherTest(isReady = false) { scenario, activity ->
-            val launcher = GooglePayLauncher(
-                activity = activity,
-                config = CONFIG,
-                readyCallback = readyCallback,
-                resultCallback = resultCallback,
-            )
-
-            scenario.moveToState(Lifecycle.State.RESUMED)
-
+        runGooglePayLauncherTest(
+            isReady = false,
+            expectResult = false,
+        ) { _, launcher ->
             assertFailsWith<IllegalStateException> {
                 launcher.presentForPaymentIntent("pi_123")
             }
         }
-
-        verify(readyCallback).onReady(eq(false))
     }
 
     @Test
@@ -119,40 +80,6 @@ internal class GooglePayLauncherTest {
         assertThat(
             CONFIG.copy(merchantCountryCode = "jp").isJcbEnabled
         ).isTrue()
-    }
-
-    private fun runGooglePayLauncherTest(
-        isReady: Boolean = true,
-        result: GooglePayLauncher.Result = GooglePayLauncher.Result.Completed,
-        block: (ActivityScenario<ComponentActivity>, ComponentActivity) -> Unit,
-    ) {
-        mockStatic(Wallet::class.java).use { wallet ->
-            val paymentsClient = mock<PaymentsClient>()
-            whenever(paymentsClient.isReadyToPay(any())).thenReturn(Tasks.forResult(isReady))
-
-            // Provide a static mock here because DefaultGooglePayRepository calls this static
-            // create method.
-            wallet.`when`<PaymentsClient> {
-                Wallet.getPaymentsClient(isA<Context>(), any())
-            }.thenReturn(paymentsClient)
-
-            // Mock the return value from GooglePayLauncherActivity so that we immediately return
-            val resultData = Intent().putExtras(
-                bundleOf(GooglePayLauncherContract.EXTRA_RESULT to result)
-            )
-            val activityResult = Instrumentation.ActivityResult(Activity.RESULT_OK, resultData)
-            intending(anyIntent()).respondWith(activityResult)
-
-            val scenario = ActivityScenario.launch(ComponentActivity::class.java)
-            scenario.moveToState(Lifecycle.State.CREATED)
-
-            scenario.onActivity { activity ->
-                PaymentConfiguration.init(activity, "pk_test")
-                block(scenario, activity)
-            }
-
-            Espresso.onIdle()
-        }
     }
 
     private companion object {

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherTest.kt
@@ -1,41 +1,17 @@
 package com.stripe.android.googlepaylauncher
 
-import android.app.Activity
-import android.app.Instrumentation
-import android.content.Context
-import android.content.Intent
-import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
-import android.widget.FrameLayout
 import androidx.activity.ComponentActivity
-import androidx.core.os.bundleOf
-import androidx.fragment.app.Fragment
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.test.core.app.ActivityScenario
-import androidx.test.espresso.Espresso
-import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.intent.rule.IntentsTestRule
-import com.google.android.gms.tasks.Tasks
-import com.google.android.gms.wallet.PaymentsClient
-import com.google.android.gms.wallet.Wallet
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.googlepaylauncher.utils.LauncherIntegrationType
+import com.stripe.android.googlepaylauncher.utils.runGooglePayPaymentMethodLauncherTest
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import org.junit.Rule
 import org.junit.runner.RunWith
-import org.mockito.Mockito
-import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.isA
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
@@ -50,30 +26,21 @@ class GooglePayPaymentMethodLauncherTest {
     fun `present() should successfully return a result when Google Pay is available`() {
         val result = GooglePayPaymentMethodLauncher.Result.Completed(CARD_PAYMENT_METHOD)
 
-        val readyCallback = mock<GooglePayPaymentMethodLauncher.ReadyCallback>()
-        val resultCallback = mock<GooglePayPaymentMethodLauncher.ResultCallback>()
-
-        runGooglePayPaymentMethodLauncherTest(result) { scenario, activity ->
-            val launcher = GooglePayPaymentMethodLauncher(
-                activity = activity,
-                config = CONFIG,
-                readyCallback = readyCallback,
-                resultCallback = resultCallback,
-            )
-            scenario.moveToState(Lifecycle.State.RESUMED)
+        runGooglePayPaymentMethodLauncherTest(
+            result = result,
+        ) { _, launcher ->
             launcher.present(currencyCode = "usd")
         }
-
-        verify(readyCallback).onReady(eq(true))
-        verify(resultCallback).onResult(eq(result))
     }
 
     @Test
     fun `init should fire expected event`() {
-        val firedEvents = mutableListOf<String>()
-        val result = GooglePayPaymentMethodLauncher.Result.Completed(CARD_PAYMENT_METHOD)
+        runGooglePayPaymentMethodLauncherTest(
+            integrationTypes = arrayOf(LauncherIntegrationType.Activity),
+            expectResult = false,
+        ) { activity, _ ->
+            val firedEvents = mutableListOf<String>()
 
-        runGooglePayPaymentMethodLauncherTest(result) { scenario, activity ->
             val launcher = GooglePayPaymentMethodLauncher(
                 lifecycleScope = activity.lifecycleScope,
                 config = CONFIG,
@@ -91,74 +58,22 @@ class GooglePayPaymentMethodLauncherTest {
                 ),
                 analyticsRequestExecutor = { firedEvents += it.params["event"].toString() },
             )
-            scenario.moveToState(Lifecycle.State.RESUMED)
             launcher.present(currencyCode = "usd")
-        }
 
-        assertThat(firedEvents).containsExactly("stripe_android.googlepaypaymentmethodlauncher_init")
+            assertThat(firedEvents).containsExactly("stripe_android.googlepaypaymentmethodlauncher_init")
+        }
     }
 
     @Test
     fun `present() should throw IllegalStateException when Google Pay is not available`() {
-        val result = GooglePayPaymentMethodLauncher.Result.Completed(CARD_PAYMENT_METHOD)
-        val readyCallback = mock<GooglePayPaymentMethodLauncher.ReadyCallback>()
-
-        runGooglePayPaymentMethodLauncherTest(isReady = false, result = result) { _, activity ->
-            val launcher = GooglePayPaymentMethodLauncher(
-                activity = activity,
-                config = CONFIG,
-                readyCallback = readyCallback,
-                resultCallback = mock(),
-            )
-
+        runGooglePayPaymentMethodLauncherTest(
+            isReady = false,
+            expectResult = false,
+        ) { _, launcher ->
             assertFailsWith<IllegalStateException> {
                 launcher.present(currencyCode = "usd")
             }
         }
-
-        verify(readyCallback).onReady(eq(false))
-    }
-
-    private fun runGooglePayPaymentMethodLauncherTest(
-        result: GooglePayPaymentMethodLauncher.Result,
-        isReady: Boolean = true,
-        block: (ActivityScenario<ComponentActivity>, ComponentActivity) -> Unit,
-    ) {
-        Mockito.mockStatic(Wallet::class.java).use { wallet ->
-            val paymentsClient = mock<PaymentsClient>()
-            whenever(paymentsClient.isReadyToPay(any())).thenReturn(Tasks.forResult(isReady))
-
-            // Provide a static mock here because DefaultGooglePayRepository calls this static
-            // create method.
-            wallet.`when`<PaymentsClient> {
-                Wallet.getPaymentsClient(isA<Context>(), any())
-            }.thenReturn(paymentsClient)
-
-            // Mock the return value from GooglePayLauncherActivity so that we immediately return
-            val resultData = Intent().putExtras(
-                bundleOf(GooglePayPaymentMethodLauncherContractV2.EXTRA_RESULT to result)
-            )
-            val activityResult = Instrumentation.ActivityResult(Activity.RESULT_OK, resultData)
-            Intents.intending(IntentMatchers.anyIntent()).respondWith(activityResult)
-
-            val scenario = ActivityScenario.launch(ComponentActivity::class.java)
-            scenario.moveToState(Lifecycle.State.CREATED)
-
-            scenario.onActivity { activity ->
-                PaymentConfiguration.init(activity, "pk_test")
-                block(scenario, activity)
-            }
-
-            Espresso.onIdle()
-        }
-    }
-
-    internal class TestFragment : Fragment() {
-        override fun onCreateView(
-            inflater: LayoutInflater,
-            container: ViewGroup?,
-            savedInstanceState: Bundle?
-        ): View = FrameLayout(inflater.context)
     }
 
     private companion object {

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/utils/GooglePayLauncherTestRunner.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/utils/GooglePayLauncherTestRunner.kt
@@ -1,0 +1,124 @@
+package com.stripe.android.googlepaylauncher.utils
+
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Context
+import android.content.Intent
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.core.os.bundleOf
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.intent.Intents.intending
+import androidx.test.espresso.intent.matcher.IntentMatchers.anyIntent
+import com.google.android.gms.tasks.Tasks
+import com.google.android.gms.wallet.PaymentsClient
+import com.google.android.gms.wallet.Wallet
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.googlepaylauncher.GooglePayEnvironment
+import com.stripe.android.googlepaylauncher.GooglePayLauncher
+import com.stripe.android.googlepaylauncher.GooglePayLauncherContract
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isA
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+private val defaultConfig = GooglePayLauncher.Config(
+    environment = GooglePayEnvironment.Test,
+    merchantCountryCode = "US",
+    merchantName = "Widget Store",
+)
+
+internal fun runGooglePayLauncherTest(
+    isReady: Boolean = true,
+    result: GooglePayLauncher.Result = GooglePayLauncher.Result.Completed,
+    integrationTypes: Array<LauncherIntegrationType> = LauncherIntegrationType.values(),
+    expectResult: Boolean = true,
+    block: (ComponentActivity, GooglePayLauncher) -> Unit,
+) {
+    for (integrationType in integrationTypes) {
+        runGooglePayLauncherTest(
+            integrationType = integrationType,
+            isReady = isReady,
+            result = result,
+            verifyResult = expectResult,
+            block = block,
+        )
+    }
+}
+
+private fun runGooglePayLauncherTest(
+    integrationType: LauncherIntegrationType,
+    isReady: Boolean,
+    result: GooglePayLauncher.Result,
+    verifyResult: Boolean,
+    block: (ComponentActivity, GooglePayLauncher) -> Unit,
+) {
+    val readyCallback = mock<GooglePayLauncher.ReadyCallback>()
+    val resultCallback = mock<GooglePayLauncher.ResultCallback>()
+
+    Mockito.mockStatic(Wallet::class.java).use { wallet ->
+        val paymentsClient = mock<PaymentsClient>()
+        whenever(paymentsClient.isReadyToPay(any())).thenReturn(Tasks.forResult(isReady))
+
+        // Provide a static mock here because DefaultGooglePayRepository calls this static
+        // create method.
+        wallet.`when`<PaymentsClient> {
+            Wallet.getPaymentsClient(isA<Context>(), any())
+        }.thenReturn(paymentsClient)
+
+        // Mock the return value from GooglePayLauncherActivity so that we immediately return
+        val resultData = Intent().putExtras(
+            bundleOf(GooglePayLauncherContract.EXTRA_RESULT to result)
+        )
+        val activityResult = Instrumentation.ActivityResult(Activity.RESULT_OK, resultData)
+        intending(anyIntent()).respondWith(activityResult)
+
+        val scenario = ActivityScenario.launch(ComponentActivity::class.java)
+        scenario.moveToState(Lifecycle.State.CREATED)
+
+        scenario.onActivity { activity ->
+            PaymentConfiguration.init(activity, "pk_test")
+
+            lateinit var launcher: GooglePayLauncher
+
+            when (integrationType) {
+                LauncherIntegrationType.Activity -> {
+                    launcher = GooglePayLauncher(
+                        activity = activity,
+                        config = defaultConfig,
+                        readyCallback = readyCallback,
+                        resultCallback = resultCallback,
+                    )
+                }
+                LauncherIntegrationType.Compose -> {
+                    activity.setContent {
+                        launcher = GooglePayLauncher.rememberLauncher(
+                            config = defaultConfig,
+                            readyCallback = readyCallback,
+                            resultCallback = resultCallback,
+                        )
+                    }
+                }
+            }
+
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            block(activity, launcher)
+        }
+
+        Espresso.onIdle()
+    }
+
+    verify(readyCallback).onReady(eq(isReady))
+
+    if (verifyResult) {
+        verify(resultCallback).onResult(eq(result))
+    }
+
+    reset(readyCallback, resultCallback)
+}

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/utils/GooglePayLauncherTestRunner.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/utils/GooglePayLauncherTestRunner.kt
@@ -24,7 +24,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isA
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -119,6 +118,4 @@ private fun runGooglePayLauncherTest(
     if (verifyResult) {
         verify(resultCallback).onResult(eq(result))
     }
-
-    reset(readyCallback, resultCallback)
 }

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/utils/GooglePayPaymentMethodLauncherTestRunner.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/utils/GooglePayPaymentMethodLauncherTestRunner.kt
@@ -26,7 +26,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isA
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -121,6 +120,4 @@ private fun runGooglePayPaymentMethodLauncherTest(
     if (expectResult) {
         verify(resultCallback).onResult(eq(result))
     }
-
-    reset(readyCallback, resultCallback)
 }

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/utils/GooglePayPaymentMethodLauncherTestRunner.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/utils/GooglePayPaymentMethodLauncherTestRunner.kt
@@ -1,0 +1,126 @@
+package com.stripe.android.googlepaylauncher.utils
+
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Context
+import android.content.Intent
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.core.os.bundleOf
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.intent.Intents.intending
+import androidx.test.espresso.intent.matcher.IntentMatchers.anyIntent
+import com.google.android.gms.tasks.Tasks
+import com.google.android.gms.wallet.PaymentsClient
+import com.google.android.gms.wallet.Wallet
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.googlepaylauncher.GooglePayEnvironment
+import com.stripe.android.googlepaylauncher.GooglePayLauncherContract
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher.Result.Completed
+import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isA
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+private val defaultConfig = GooglePayPaymentMethodLauncher.Config(
+    environment = GooglePayEnvironment.Test,
+    merchantCountryCode = "US",
+    merchantName = "Widget Store",
+)
+
+internal fun runGooglePayPaymentMethodLauncherTest(
+    integrationTypes: Array<LauncherIntegrationType> = LauncherIntegrationType.values(),
+    result: GooglePayPaymentMethodLauncher.Result = Completed(CARD_PAYMENT_METHOD),
+    isReady: Boolean = true,
+    expectResult: Boolean = true,
+    block: (ComponentActivity, GooglePayPaymentMethodLauncher) -> Unit,
+) {
+    for (integrationType in integrationTypes) {
+        runGooglePayPaymentMethodLauncherTest(
+            integrationType = integrationType,
+            isReady = isReady,
+            result = result,
+            expectResult = expectResult,
+            block = block,
+        )
+    }
+}
+
+private fun runGooglePayPaymentMethodLauncherTest(
+    integrationType: LauncherIntegrationType,
+    isReady: Boolean,
+    result: GooglePayPaymentMethodLauncher.Result,
+    expectResult: Boolean,
+    block: (ComponentActivity, GooglePayPaymentMethodLauncher) -> Unit,
+) {
+    val readyCallback = mock<GooglePayPaymentMethodLauncher.ReadyCallback>()
+    val resultCallback = mock<GooglePayPaymentMethodLauncher.ResultCallback>()
+
+    Mockito.mockStatic(Wallet::class.java).use { wallet ->
+        val paymentsClient = mock<PaymentsClient>()
+        whenever(paymentsClient.isReadyToPay(any())).thenReturn(Tasks.forResult(isReady))
+
+        // Provide a static mock here because DefaultGooglePayRepository calls this static
+        // create method.
+        wallet.`when`<PaymentsClient> {
+            Wallet.getPaymentsClient(isA<Context>(), any())
+        }.thenReturn(paymentsClient)
+
+        // Mock the return value from GooglePayLauncherActivity so that we immediately return
+        val resultData = Intent().putExtras(
+            bundleOf(GooglePayLauncherContract.EXTRA_RESULT to result)
+        )
+        val activityResult = Instrumentation.ActivityResult(Activity.RESULT_OK, resultData)
+        intending(anyIntent()).respondWith(activityResult)
+
+        val scenario = ActivityScenario.launch(ComponentActivity::class.java)
+        scenario.moveToState(Lifecycle.State.CREATED)
+
+        scenario.onActivity { activity ->
+            PaymentConfiguration.init(activity, "pk_test")
+
+            lateinit var launcher: GooglePayPaymentMethodLauncher
+
+            when (integrationType) {
+                LauncherIntegrationType.Activity -> {
+                    launcher = GooglePayPaymentMethodLauncher(
+                        activity = activity,
+                        config = defaultConfig,
+                        readyCallback = readyCallback,
+                        resultCallback = resultCallback,
+                    )
+                }
+                LauncherIntegrationType.Compose -> {
+                    activity.setContent {
+                        launcher = GooglePayPaymentMethodLauncher.rememberLauncher(
+                            config = defaultConfig,
+                            readyCallback = readyCallback,
+                            resultCallback = resultCallback,
+                        )
+                    }
+                }
+            }
+
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            block(activity, launcher)
+        }
+
+        Espresso.onIdle()
+    }
+
+    verify(readyCallback).onReady(eq(isReady))
+
+    if (expectResult) {
+        verify(resultCallback).onResult(eq(result))
+    }
+
+    reset(readyCallback, resultCallback)
+}

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/utils/LauncherIntegrationType.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/utils/LauncherIntegrationType.kt
@@ -1,0 +1,6 @@
+package com.stripe.android.googlepaylauncher.utils
+
+internal enum class LauncherIntegrationType {
+    Activity,
+    Compose,
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request extends the `GooglePayLauncherTest` and `GooglePayPaymentMethodLauncherTest` to test the Compose integration in addition to the framework integration.

This is also a preparation for https://github.com/stripe/stripe-android/pull/6925.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
