### PR TITLE
Replace static `rememberLauncher` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 ### Financial Connections
 * [CHANGED][6919](https://github.com/stripe/stripe-android/pull/6919) Updated polling options for account retrieval and OAuth results to match other platforms.
 
+## Payments
+[ADDED][6925](https://github.com/stripe/stripe-android/pull/6925) Added top-level remember methods for `PaymentLauncher`, `GooglePayLauncher`, and `GooglePayPaymentMethodLauncher`.
+[DEPRECATED][6925](https://github.com/stripe/stripe-android/pull/6925) Deprecated static `rememberLauncher()` methods for `PaymentLauncher`, `GooglePayLauncher`, and `GooglePayPaymentMethodLauncher`.
+
 ## 20.25.7 - 2023-06-20
 
 ### Financial Connections

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -3,9 +3,15 @@
 ## Migrating from versions < 20.26.0
 - Changes to `PaymentSheetContract`:
   * The class has been deprecated and will be removed in a future release. Use the `PaymentSheet` constructor or the new `rememberPaymentSheet()` method.
-- Changes to `GooglePayLauncherContract`
+- Changes to `PaymentLauncher`:
+  * `PaymentLauncher.rememberLauncher()` has been deprecated and will be removed in a future release. Use the top-level `rememberPaymentLauncher()` method instead.
+- Changes to `GooglePayLauncher`:
+  * `GooglePayLauncher.rememberLauncher()` has been deprecated and will be removed in a future release. Use the top-level `rememberGooglePayLauncher()` method instead.
+- Changes to `GooglePayPaymentMethodLauncher`:
+  * `GooglePayPaymentMethodLauncher.rememberLauncher()` has been deprecated and will be removed in a future release. Use the top-level `rememberGooglePayPaymentMethodLauncher()` method instead.
+- Changes to `GooglePayLauncherContract`:
   * The class has been deprecated and will be removed in a future release. Use `GooglePayLauncher` directly.
-- Changes to `GooglePayPaymentMethodLauncherContract`
+- Changes to `GooglePayPaymentMethodLauncherContract`:
   * The class has been deprecated and will be removed in a future release. Use `GooglePayPaymentMethodLauncher` directly.
 
 ## Migrating from versions < 20.5.0
@@ -15,7 +21,6 @@
     * `PrimaryButton.colorsLight/colorsDark.backgroundColor`
 
 ## Migrating from versions < 20.2.0
-
 - Changes to `CollectBankAccountLauncher`
   * Required, dependent artifact `com.stripe.connections` has been renamed to `com.stripe.financial-connections`.
   

--- a/example/src/main/java/com/stripe/example/activity/ComposeExampleActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/ComposeExampleActivity.kt
@@ -25,6 +25,7 @@ import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.payments.paymentlauncher.PaymentLauncher
 import com.stripe.android.payments.paymentlauncher.PaymentResult
+import com.stripe.android.payments.paymentlauncher.rememberPaymentLauncher
 import com.stripe.example.R
 import com.stripe.example.Settings
 import com.stripe.example.module.StripeIntentViewModel
@@ -46,7 +47,15 @@ class ComposeExampleActivity : AppCompatActivity() {
     fun ComposeScreen() {
         val inProgress by viewModel.inProgress.observeAsState(false)
         val status by viewModel.status.observeAsState("")
-        val paymentLauncher = rememberPaymentLauncher()
+
+        val context = LocalContext.current
+        val settings = remember { Settings(context) }
+
+        val paymentLauncher = rememberPaymentLauncher(
+            publishableKey = settings.publishableKey,
+            stripeAccountId = settings.stripeAccountId,
+            callback = ::onPaymentResult
+        )
 
         ComposeScreen(
             inProgress = inProgress,
@@ -86,20 +95,6 @@ class ComposeExampleActivity : AppCompatActivity() {
             Divider(modifier = Modifier.padding(vertical = 5.dp))
             Text(text = status)
         }
-    }
-
-    /**
-     * Create [PaymentLauncher] in a [Composable]
-     */
-    @Composable
-    private fun rememberPaymentLauncher(): PaymentLauncher {
-        val context = LocalContext.current
-        val settings = remember { Settings(context) }
-        return PaymentLauncher.rememberLauncher(
-            publishableKey = settings.publishableKey,
-            stripeAccountId = settings.stripeAccountId,
-            callback = ::onPaymentResult
-        )
     }
 
     private fun onPaymentResult(paymentResult: PaymentResult) {

--- a/example/src/main/java/com/stripe/example/activity/GooglePayLauncherComposeActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/GooglePayLauncherComposeActivity.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayLauncher
+import com.stripe.android.googlepaylauncher.rememberGooglePayLauncher
 import kotlinx.coroutines.launch
 
 class GooglePayLauncherComposeActivity : StripeIntentActivity() {
@@ -79,7 +80,7 @@ class GooglePayLauncherComposeActivity : StripeIntentActivity() {
             }
         }
 
-        val googlePayLauncher = GooglePayLauncher.rememberLauncher(
+        val googlePayLauncher = rememberGooglePayLauncher(
             config = googlePayConfig,
             readyCallback = { ready ->
                 if (googlePayReady == null) {

--- a/example/src/main/java/com/stripe/example/activity/GooglePayPaymentMethodLauncherComposeActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/GooglePayPaymentMethodLauncherComposeActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
+import com.stripe.android.googlepaylauncher.rememberGooglePayPaymentMethodLauncher
 import kotlinx.coroutines.launch
 
 class GooglePayPaymentMethodLauncherComposeActivity : AppCompatActivity() {
@@ -48,7 +49,7 @@ class GooglePayPaymentMethodLauncherComposeActivity : AppCompatActivity() {
         val scope = rememberCoroutineScope()
         var enabled by remember { mutableStateOf(false) }
 
-        val googlePayLauncher = GooglePayPaymentMethodLauncher.rememberLauncher(
+        val googlePayLauncher = rememberGooglePayPaymentMethodLauncher(
             config = googlePayConfig,
             readyCallback = { ready ->
                 if (ready) {

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -1309,6 +1309,10 @@ public final class com/stripe/android/googlepaylauncher/GooglePayLauncherContrac
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/googlepaylauncher/GooglePayLauncherKt {
+	public static final fun rememberGooglePayLauncher (Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$ReadyCallback;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$ResultCallback;Landroidx/compose/runtime/Composer;I)Lcom/stripe/android/googlepaylauncher/GooglePayLauncher;
+}
+
 public final class com/stripe/android/googlepaylauncher/GooglePayLauncherResult$Canceled$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/googlepaylauncher/GooglePayLauncherResult$Canceled;
@@ -1347,7 +1351,6 @@ public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLa
 	public static final field DEVELOPER_ERROR I
 	public static final field INTERNAL_ERROR I
 	public static final field NETWORK_ERROR I
-	public synthetic fun <init> (Landroid/content/Context;Lkotlinx/coroutines/CoroutineScope;Landroidx/activity/result/ActivityResultLauncher;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$ReadyCallback;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Landroidx/activity/ComponentActivity;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$ReadyCallback;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$ResultCallback;)V
 	public fun <init> (Landroidx/fragment/app/Fragment;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$ReadyCallback;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$ResultCallback;)V
 	public final fun present (Ljava/lang/String;)V
@@ -1578,6 +1581,10 @@ public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLa
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2$Args$InjectionParams;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherKt {
+	public static final fun rememberGooglePayPaymentMethodLauncher (Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$ReadyCallback;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$ResultCallback;Landroidx/compose/runtime/Composer;I)Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher;
 }
 
 public abstract interface class com/stripe/android/googlepaylauncher/GooglePayRepository {
@@ -6919,6 +6926,10 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherCo
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherKt {
+	public static final fun rememberPaymentLauncher (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;Landroidx/compose/runtime/Composer;II)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
 }
 
 public abstract class com/stripe/android/payments/paymentlauncher/PaymentResult : android/os/Parcelable {

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -172,7 +172,7 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
         readyCallback
     )
 
-    private constructor (
+    internal constructor(
         context: Context,
         lifecycleScope: CoroutineScope,
         activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
@@ -421,32 +421,57 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
          * The GooglePayPaymentMethodLauncher created is remembered across recompositions.
          * Recomposition will always return the value produced by composition.
          */
+        @Deprecated(
+            message = "Use rememberGooglePayPaymentMethodLauncher() instead",
+            replaceWith = ReplaceWith(
+                expression = "rememberGooglePayPaymentMethodLauncher(config, readyCallback, resultCallback)",
+            ),
+        )
         @Composable
         fun rememberLauncher(
             config: Config,
             readyCallback: ReadyCallback,
             resultCallback: ResultCallback
         ): GooglePayPaymentMethodLauncher {
-            val currentReadyCallback by rememberUpdatedState(readyCallback)
-
-            val context = LocalContext.current
-            val lifecycleScope = LocalLifecycleOwner.current.lifecycleScope
-            val activityResultLauncher = rememberLauncherForActivityResult(
-                GooglePayPaymentMethodLauncherContractV2(),
-                resultCallback::onResult
-            )
-
-            return remember(config) {
-                GooglePayPaymentMethodLauncher(
-                    context = context,
-                    lifecycleScope = lifecycleScope,
-                    activityResultLauncher = activityResultLauncher,
-                    config = config,
-                    readyCallback = {
-                        currentReadyCallback.onReady(it)
-                    }
-                )
-            }
+            return rememberGooglePayPaymentMethodLauncher(config, readyCallback, resultCallback)
         }
+    }
+}
+
+/**
+ * Creates a [GooglePayPaymentMethodLauncher] that is remembered across compositions.
+ *
+ * This *must* be called unconditionally, as part of the initialization path.
+ *
+ * @param config The [GooglePayPaymentMethodLauncher.Config] used to configure the integration.
+ * @param readyCallback Called after determining whether Google Pay is available and ready to use.
+ * [GooglePayPaymentMethodLauncher.present] may only be called if Google Pay is ready.
+ * @param resultCallback Called with the result of the [GooglePayPaymentMethodLauncher] operation
+ */
+@Composable
+fun rememberGooglePayPaymentMethodLauncher(
+    config: GooglePayPaymentMethodLauncher.Config,
+    readyCallback: GooglePayPaymentMethodLauncher.ReadyCallback,
+    resultCallback: GooglePayPaymentMethodLauncher.ResultCallback
+): GooglePayPaymentMethodLauncher {
+    val currentReadyCallback by rememberUpdatedState(readyCallback)
+
+    val context = LocalContext.current
+    val lifecycleScope = LocalLifecycleOwner.current.lifecycleScope
+    val activityResultLauncher = rememberLauncherForActivityResult(
+        GooglePayPaymentMethodLauncherContractV2(),
+        resultCallback::onResult
+    )
+
+    return remember(config) {
+        GooglePayPaymentMethodLauncher(
+            context = context,
+            lifecycleScope = lifecycleScope,
+            activityResultLauncher = activityResultLauncher,
+            config = config,
+            readyCallback = {
+                currentReadyCallback.onReady(it)
+            }
+        )
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
@@ -85,9 +85,10 @@ interface PaymentLauncher {
          * recompositions.
          */
         @Deprecated(
-            "This method creates a new PaymentLauncher object every time it is called, even" +
-                "during recompositions.",
-            replaceWith = ReplaceWith("PaymentLauncher.rememberLauncher(publishableKey, stripeAccountId, callback)")
+            message = "Use rememberPaymentLauncher() instead",
+            replaceWith = ReplaceWith(
+                expression = "rememberPaymentLauncher(publishableKey, stripeAccountId, callback)",
+            ),
         )
         @Composable
         fun createForCompose(
@@ -95,16 +96,7 @@ interface PaymentLauncher {
             stripeAccountId: String? = null,
             callback: PaymentResultCallback
         ): PaymentLauncher {
-            val context = LocalContext.current
-            val activity = rememberActivityOrNull()
-            return PaymentLauncherFactory(
-                context = context,
-                hostActivityLauncher = rememberLauncherForActivityResult(
-                    PaymentLauncherContract(),
-                    callback::onPaymentResult
-                ),
-                statusBarColor = activity?.window?.statusBarColor,
-            ).create(publishableKey, stripeAccountId)
+            return rememberPaymentLauncher(publishableKey, stripeAccountId, callback)
         }
 
         /**
@@ -116,27 +108,51 @@ interface PaymentLauncher {
          * The PaymentLauncher created is remembered across recompositions. Recomposition will
          * always return the value produced by composition.
          */
+        @Deprecated(
+            message = "Use rememberPaymentLauncher() instead",
+            replaceWith = ReplaceWith(
+                expression = "rememberPaymentLauncher(publishableKey, stripeAccountId, callback)",
+            ),
+        )
         @Composable
         fun rememberLauncher(
             publishableKey: String,
             stripeAccountId: String? = null,
             callback: PaymentResultCallback
         ): PaymentLauncher {
-            val context = LocalContext.current
-            val activity = rememberActivityOrNull()
-
-            val activityResultLauncher = rememberLauncherForActivityResult(
-                PaymentLauncherContract(),
-                callback::onPaymentResult
-            )
-
-            return remember(publishableKey, stripeAccountId) {
-                PaymentLauncherFactory(
-                    context = context,
-                    hostActivityLauncher = activityResultLauncher,
-                    statusBarColor = activity?.window?.statusBarColor,
-                ).create(publishableKey, stripeAccountId)
-            }
+            return rememberPaymentLauncher(publishableKey, stripeAccountId, callback)
         }
+    }
+}
+
+/**
+ * Creates a [PaymentLauncher] that is remembered across compositions.
+ *
+ * This *must* be called unconditionally, as part of the initialization path.
+ *
+ * @param publishableKey The publishable key to use
+ * @param stripeAccountId Optional, the Connect account to associate with this request
+ * @param callback Called with the result of the payment operation
+ */
+@Composable
+fun rememberPaymentLauncher(
+    publishableKey: String,
+    stripeAccountId: String? = null,
+    callback: PaymentLauncher.PaymentResultCallback
+): PaymentLauncher {
+    val context = LocalContext.current
+    val activity = rememberActivityOrNull()
+
+    val activityResultLauncher = rememberLauncherForActivityResult(
+        PaymentLauncherContract(),
+        callback::onPaymentResult
+    )
+
+    return remember(publishableKey, stripeAccountId) {
+        PaymentLauncherFactory(
+            context = context,
+            hostActivityLauncher = activityResultLauncher,
+            statusBarColor = activity?.window?.statusBarColor,
+        ).create(publishableKey, stripeAccountId)
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/utils/GooglePayLauncherTestRunner.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/utils/GooglePayLauncherTestRunner.kt
@@ -19,6 +19,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayLauncher
 import com.stripe.android.googlepaylauncher.GooglePayLauncherContract
+import com.stripe.android.googlepaylauncher.rememberGooglePayLauncher
 import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -97,7 +98,7 @@ private fun runGooglePayLauncherTest(
                 }
                 LauncherIntegrationType.Compose -> {
                     activity.setContent {
-                        launcher = GooglePayLauncher.rememberLauncher(
+                        launcher = rememberGooglePayLauncher(
                             config = defaultConfig,
                             readyCallback = readyCallback,
                             resultCallback = resultCallback,

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/utils/GooglePayPaymentMethodLauncherTestRunner.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/utils/GooglePayPaymentMethodLauncherTestRunner.kt
@@ -20,6 +20,7 @@ import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayLauncherContract
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher.Result.Completed
+import com.stripe.android.googlepaylauncher.rememberGooglePayPaymentMethodLauncher
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
 import org.mockito.Mockito
 import org.mockito.kotlin.any
@@ -99,7 +100,7 @@ private fun runGooglePayPaymentMethodLauncherTest(
                 }
                 LauncherIntegrationType.Compose -> {
                     activity.setContent {
-                        launcher = GooglePayPaymentMethodLauncher.rememberLauncher(
+                        launcher = rememberGooglePayPaymentMethodLauncher(
                             config = defaultConfig,
                             readyCallback = readyCallback,
                             resultCallback = resultCallback,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request follows the example of https://github.com/stripe/stripe-android/pull/6583 and replaces the existing static remember methods with top-level remember functions.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[MOBILE_APIREVIEW-35](https://jira.corp.stripe.com/browse/MOBILE_APIREVIEW-35)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
