### PR TITLE
Add retrievePaymentOptionSelection to CustomerSheet

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/CustomerSheetExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/CustomerSheetExampleActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -15,20 +16,22 @@ import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.stripe.android.customersheet.CustomerSheet
-import com.stripe.android.customersheet.CustomerSheetResult
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.customersheet.rememberCustomerSheet
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.R
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentSheetExampleTheme
+import com.stripe.android.paymentsheet.example.utils.rememberDrawablePainter
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 internal class CustomerSheetExampleActivity : AppCompatActivity() {
@@ -49,6 +52,11 @@ internal class CustomerSheetExampleActivity : AppCompatActivity() {
 
                 val viewState by viewModel.state.collectAsState()
 
+                LaunchedEffect(Unit) {
+                    val result = customerSheet.retrievePaymentOptionSelection()
+                    viewModel.onCustomerSheetResult(result)
+                }
+
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
@@ -61,12 +69,8 @@ internal class CustomerSheetExampleActivity : AppCompatActivity() {
 
                     when (val state = viewState) {
                         is CustomerSheetExampleViewState.Data -> {
-                            val label = (state.result as? CustomerSheetResult.Selected)
-                                ?.selection
-                                ?.paymentOption
-                                ?.label
-                            PaymentDefaults(
-                                paymentMethodLabel = label ?: "Select",
+                            CustomerPaymentMethods(
+                                state = state,
                                 onUpdateDefaultPaymentMethod = {
                                     customerSheet.present()
                                 }
@@ -106,25 +110,45 @@ internal class CustomerSheetExampleActivity : AppCompatActivity() {
     }
 }
 
+@OptIn(ExperimentalCustomerSheetApi::class)
 @Composable
-private fun PaymentDefaults(
-    paymentMethodLabel: String,
+private fun CustomerPaymentMethods(
+    state: CustomerSheetExampleViewState.Data,
     onUpdateDefaultPaymentMethod: () -> Unit
 ) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween,
-    ) {
-        Text(
-            "Payment default",
-            fontWeight = FontWeight.Bold,
-        )
-        TextButton(
-            onClick = onUpdateDefaultPaymentMethod
+    Column {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             Text(
-                text = paymentMethodLabel,
+                "Payment default",
+                fontWeight = FontWeight.Bold,
+            )
+            TextButton(
+                onClick = onUpdateDefaultPaymentMethod,
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    state.selection?.paymentOption?.icon()?.let {
+                        Image(
+                            painter = rememberDrawablePainter(
+                                drawable = it
+                            ),
+                            contentDescription = "Payment Method Icon",
+                            modifier = Modifier.height(32.dp)
+                        )
+                    }
+                    Text(
+                        text = state.selection?.paymentOption?.label ?: "Select",
+                    )
+                }
+            }
+        }
+        state.errorMessage?.let {
+            Text(
+                text = it,
+                color = Color.Red,
             )
         }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/CustomerSheetExampleViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/CustomerSheetExampleViewModel.kt
@@ -12,6 +12,7 @@ import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.CustomerEphemeralKey
 import com.stripe.android.customersheet.CustomerSheetResult
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.customersheet.PaymentOptionSelection
 import com.stripe.android.paymentsheet.example.samples.networking.ExampleCreateSetupIntentRequest
 import com.stripe.android.paymentsheet.example.samples.networking.ExampleCreateSetupIntentResponse
 import com.stripe.android.paymentsheet.example.samples.networking.ExampleCustomerSheetRequest
@@ -142,12 +143,53 @@ class CustomerSheetExampleViewModel(
         }
     }
 
-    fun onCustomerSheetResult(result: CustomerSheetResult) {
+    fun setInitialSelection(selection: PaymentOptionSelection?) {
         (state.value as? CustomerSheetExampleViewState.Data)?.let { state ->
             _state.update {
                 state.copy(
-                    result = result
+                    selection = selection
                 )
+            }
+        }
+    }
+
+    fun onCustomerSheetResult(result: CustomerSheetResult) {
+        when (result) {
+            is CustomerSheetResult.Canceled -> {
+                updateDataViewState {
+                    it.copy(
+                        selection = result.selection,
+                        errorMessage = null,
+                    )
+                }
+            }
+            is CustomerSheetResult.Selected -> {
+                updateDataViewState {
+                    it.copy(
+                        selection = result.selection,
+                        errorMessage = null,
+                    )
+                }
+            }
+            is CustomerSheetResult.Error -> {
+                updateDataViewState {
+                    it.copy(
+                        selection = null,
+                        errorMessage = result.exception.message,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun updateDataViewState(
+        transform: (CustomerSheetExampleViewState.Data) -> CustomerSheetExampleViewState.Data,
+    ) {
+        _state.update {
+            if (it is CustomerSheetExampleViewState.Data) {
+                transform(it)
+            } else {
+                it
             }
         }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/CustomerSheetExampleViewState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/CustomerSheetExampleViewState.kt
@@ -1,8 +1,8 @@
 package com.stripe.android.paymentsheet.example.samples.ui.customersheet
 
 import com.stripe.android.customersheet.CustomerEphemeralKey
-import com.stripe.android.customersheet.CustomerSheetResult
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.customersheet.PaymentOptionSelection
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 sealed class CustomerSheetExampleViewState {
@@ -13,6 +13,7 @@ sealed class CustomerSheetExampleViewState {
     @Suppress("unused")
     data class Data(
         val customerEphemeralKey: CustomerEphemeralKey,
-        val result: CustomerSheetResult? = null,
+        val selection: PaymentOptionSelection? = null,
+        val errorMessage: String? = null
     ) : CustomerSheetExampleViewState()
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
@@ -158,13 +158,20 @@ interface CustomerAdapter {
                 }
             }
 
-            internal fun SavedSelection.toPaymentOption():
-                PaymentOption? {
+            internal fun SavedSelection.toPaymentOption(): PaymentOption? {
                 return when (this) {
                     is SavedSelection.GooglePay -> GooglePay
                     is SavedSelection.Link -> Link
                     is SavedSelection.None -> null
                     is SavedSelection.PaymentMethod -> StripeId(id)
+                }
+            }
+
+            internal fun PaymentSelection.toPaymentOption(): PaymentOption? {
+                return when (this) {
+                    is PaymentSelection.GooglePay -> GooglePay
+                    is PaymentSelection.Saved -> StripeId(paymentMethod.id!!)
+                    else -> null
                 }
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapterResultKt.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapterResultKt.kt
@@ -72,7 +72,7 @@ internal inline fun <R, T> CustomerAdapter.Result<T>.onSuccess(
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 internal inline fun <R, T> CustomerAdapter.Result<T>.onFailure(
-    action: (cause: Throwable?, displayMessage: String?) -> R
+    action: (cause: Throwable, displayMessage: String?) -> R
 ): CustomerAdapter.Result<T> {
     failureOrNull()?.let {
         val displayMessage = it.displayMessage

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetActivity.kt
@@ -16,8 +16,6 @@ import androidx.core.view.WindowCompat
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.common.ui.BottomSheet
 import com.stripe.android.common.ui.rememberBottomSheetState
-import com.stripe.android.customersheet.CustomerSheetViewAction.OnDismissed
-import com.stripe.android.customersheet.InternalCustomerSheetResult.Canceled
 import com.stripe.android.customersheet.ui.CustomerSheetScreen
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.utils.AnimationConstants
@@ -63,17 +61,15 @@ internal class CustomerSheetActivity : AppCompatActivity() {
                 }
 
                 BackHandler {
-                    // TODO This should call viewModel.handleViewAction(OnBackPressed). However,
-                    //  we need to change CustomerSheetActivityTest first to make that work.
                     coroutineScope.launch {
                         bottomSheetState.hide()
-                        finishWithResult(Canceled)
+                        viewModel.handleViewAction(CustomerSheetViewAction.OnBackPressed)
                     }
                 }
 
                 BottomSheet(
                     state = bottomSheetState,
-                    onDismissed = { viewModel.handleViewAction(OnDismissed) },
+                    onDismissed = { viewModel.handleViewAction(CustomerSheetViewAction.OnDismissed) },
                 ) {
                     CustomerSheetScreen(
                         viewState = viewState,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetResult.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetResult.kt
@@ -5,6 +5,7 @@ import androidx.annotation.RestrictTo
 import androidx.core.os.bundleOf
 import com.stripe.android.paymentsheet.model.PaymentOption
 import com.stripe.android.view.ActivityStarter
+import com.stripe.android.model.PaymentMethod as StripePaymentMethod
 
 @ExperimentalCustomerSheetApi
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -16,7 +17,7 @@ sealed class CustomerSheetResult {
     @ExperimentalCustomerSheetApi
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class Selected internal constructor(
-        val selection: PaymentOptionSelection
+        val selection: PaymentOptionSelection?
     ) : CustomerSheetResult()
 
     /**
@@ -24,10 +25,9 @@ sealed class CustomerSheetResult {
      */
     @ExperimentalCustomerSheetApi
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    class Canceled internal constructor() : CustomerSheetResult() {
-        override fun equals(other: Any?): Boolean = this === other
-        override fun hashCode(): Int = System.identityHashCode(this)
-    }
+    class Canceled internal constructor(
+        val selection: PaymentOptionSelection?
+    ) : CustomerSheetResult()
 
     /**
      * An error occurred when presenting the sheet
@@ -35,7 +35,7 @@ sealed class CustomerSheetResult {
     @ExperimentalCustomerSheetApi
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class Error internal constructor(
-        val exception: Exception
+        val exception: Throwable
     ) : CustomerSheetResult()
 
     internal companion object {
@@ -49,12 +49,30 @@ sealed class CustomerSheetResult {
 
 /**
  * The customer's payment option selection
- * @param paymentMethodId, the Stripe payment method ID
  * @param paymentOption, contains the drawable and label to display
  */
 @ExperimentalCustomerSheetApi
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-data class PaymentOptionSelection internal constructor(
-    val paymentMethodId: String,
-    val paymentOption: PaymentOption,
-)
+sealed class PaymentOptionSelection private constructor(
+    open val paymentOption: PaymentOption
+) {
+
+    /**
+     * A Stripe payment method was selected.
+     */
+    @ExperimentalCustomerSheetApi
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class PaymentMethod internal constructor(
+        val paymentMethod: StripePaymentMethod,
+        override val paymentOption: PaymentOption,
+    ) : PaymentOptionSelection(paymentOption)
+
+    /**
+     * Google Pay is the selected payment option.
+     */
+    @ExperimentalCustomerSheetApi
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class GooglePay internal constructor(
+        override val paymentOption: PaymentOption,
+    ) : PaymentOptionSelection(paymentOption)
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetComponent.kt
@@ -8,7 +8,11 @@ import dagger.BindsInstance
 import dagger.Subcomponent
 
 @OptIn(ExperimentalCustomerSheetApi::class)
-@Subcomponent
+@Subcomponent(
+    modules = [
+        CustomerSheetModule::class
+    ]
+)
 internal interface CustomerSheetComponent {
     val customerSheet: CustomerSheet
     val sessionComponent: CustomerSessionComponent

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetModule.kt
@@ -1,0 +1,14 @@
+package com.stripe.android.customersheet.injection
+
+import android.content.Context
+import com.stripe.android.uicore.image.StripeImageLoader
+import dagger.Module
+import dagger.Provides
+
+@Module
+internal class CustomerSheetModule {
+    @Provides
+    fun provideStripeImageLoader(context: Context): StripeImageLoader {
+        return StripeImageLoader(context)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -8,10 +8,12 @@ import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.customersheet.StripeCustomerAdapter.Companion.CACHED_CUSTOMER_MAX_AGE_MILLIS
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.FakePrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.utils.FakeCustomerRepository
@@ -468,6 +470,38 @@ class CustomerAdapterTest {
         )
 
         assertThat(adapter.canCreateSetupIntents).isTrue()
+    }
+
+    @Test
+    fun `toPaymentSelection returns the right results`() = runTest {
+        val paymentMethodProvider: (paymentMethodId: String) -> PaymentMethod? = {
+            if (it == PaymentMethodFixtures.CARD_PAYMENT_METHOD.id) {
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD
+            } else {
+                null
+            }
+        }
+        val savedPaymentOption = CustomerAdapter.PaymentOption.StripeId(
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!
+        )
+        val savedSelection = savedPaymentOption.toPaymentSelection(paymentMethodProvider)
+        assertThat(savedSelection)
+            .isInstanceOf(PaymentSelection.Saved::class.java)
+
+        val googlePaymentOption = CustomerAdapter.PaymentOption.GooglePay
+        val googleSelection = googlePaymentOption.toPaymentSelection(paymentMethodProvider)
+        assertThat(googleSelection)
+            .isInstanceOf(PaymentSelection.GooglePay::class.java)
+
+        val linkPaymentOption = CustomerAdapter.PaymentOption.Link
+        val linkSelection = linkPaymentOption.toPaymentSelection(paymentMethodProvider)
+        assertThat(linkSelection)
+            .isInstanceOf(PaymentSelection.Link::class.java)
+
+        val nullSavedPaymentOption = CustomerAdapter.PaymentOption.StripeId("id_123")
+        val nullSavedSelection = nullSavedPaymentOption.toPaymentSelection(paymentMethodProvider)
+        assertThat(nullSavedSelection)
+            .isNull()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
@@ -8,6 +8,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.customersheet.CustomerSheetTestHelper.createViewModel
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodFixtures
@@ -16,18 +17,15 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils.viewModelFactoryFor
 import com.stripe.android.utils.injectableActivityScenario
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.kotlin.any
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import org.robolectric.annotation.Config
+import java.util.Stack
 
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [Build.VERSION_CODES.Q])
+@OptIn(ExperimentalCustomerSheetApi::class)
 internal class CustomerSheetActivityTest {
     @get:Rule
     val rule = InstantTaskExecutorRule()
@@ -52,61 +50,31 @@ internal class CustomerSheetActivityTest {
             assertThat(
                 InternalCustomerSheetResult.fromIntent(scenario.getResult().resultData)
             ).isEqualTo(
-                InternalCustomerSheetResult.Canceled
+                InternalCustomerSheetResult.Canceled(null)
             )
         }
     }
 
     @Test
-    fun `Finish with cancel on canceled result`() = runTest {
+    fun `Finish with cancel and payment selection on back press`() {
         runActivityScenario(
-            viewState = createSelectPaymentMethodViewState(),
-            result = InternalCustomerSheetResult.Canceled,
+            viewState = createSelectPaymentMethodViewState(
+                paymentSelection = PaymentSelection.Saved(
+                    PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                )
+            )
         ) {
             composeTestRule.waitForIdle()
-            activity.finish()
+            pressBack()
+            composeTestRule.waitForIdle()
             assertThat(
                 InternalCustomerSheetResult.fromIntent(scenario.getResult().resultData)
             ).isEqualTo(
-                InternalCustomerSheetResult.Canceled
-            )
-        }
-    }
-
-    @Test
-    fun `Finish with selected on selected result`() = runTest {
-        runActivityScenario(
-            viewState = createSelectPaymentMethodViewState(),
-            result = InternalCustomerSheetResult.Selected(
-                paymentMethodId = "pm_123",
-                drawableResourceId = 123,
-                label = "test",
-            ),
-        ) {
-            composeTestRule.waitForIdle()
-            activity.finish()
-            assertThat(
-                InternalCustomerSheetResult.fromIntent(scenario.getResult().resultData)
-            ).isInstanceOf(
-                InternalCustomerSheetResult.Selected::class.java
-            )
-        }
-    }
-
-    @Test
-    fun `Finish with error on error result`() = runTest {
-        runActivityScenario(
-            viewState = createSelectPaymentMethodViewState(),
-            result = InternalCustomerSheetResult.Error(
-                exception = Exception("test")
-            ),
-        ) {
-            composeTestRule.waitForIdle()
-            activity.finish()
-            assertThat(
-                InternalCustomerSheetResult.fromIntent(scenario.getResult().resultData)
-            ).isInstanceOf(
-                InternalCustomerSheetResult.Error::class.java
+                InternalCustomerSheetResult.Canceled(
+                    paymentSelection = PaymentSelection.Saved(
+                        PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                    )
+                )
             )
         }
     }
@@ -200,21 +168,12 @@ internal class CustomerSheetActivityTest {
 
     private fun activityScenario(
         viewState: CustomerSheetViewState,
-        result: InternalCustomerSheetResult?,
-        providePaymentMethodName: (PaymentMethodCode) -> String,
     ): InjectableActivityScenario<CustomerSheetActivity> {
-        val viewModel = mock<CustomerSheetViewModel>()
-
-        whenever(viewModel.viewState).thenReturn(
-            MutableStateFlow(viewState)
+        val viewModel = createViewModel(
+            backstack = Stack<CustomerSheetViewState>().apply {
+                push(viewState)
+            }
         )
-        whenever(viewModel.result).thenReturn(
-            MutableStateFlow(result)
-        )
-        whenever(viewModel.providePaymentMethodName(any())).then {
-            val code = it.arguments.first() as PaymentMethodCode
-            providePaymentMethodName(code)
-        }
 
         return injectableActivityScenario {
             injectActivity {
@@ -227,14 +186,10 @@ internal class CustomerSheetActivityTest {
         viewState: CustomerSheetViewState = CustomerSheetViewState.Loading(
             isLiveMode = false,
         ),
-        result: InternalCustomerSheetResult? = null,
-        providePaymentMethodName: (PaymentMethodCode) -> String = { it },
         testBlock: CustomerSheetTestData.() -> Unit,
     ) {
         activityScenario(
             viewState = viewState,
-            result = result,
-            providePaymentMethodName = providePaymentMethodName,
         )
             .launchForResult(intent)
             .use { injectableActivityScenario ->
@@ -287,7 +242,7 @@ internal class CustomerSheetActivityTest {
             formViewData = formViewData,
             enabled = enabled,
             isLiveMode = isLiveMode,
-            isProcessing = isProcessing
+            isProcessing = isProcessing,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -158,7 +158,7 @@ class CustomerSheetScreenshotTest {
                     enabled = true,
                     isLiveMode = false,
                     isProcessing = false,
-                    errorMessage = "This is an error message."
+                    errorMessage = "This is an error message.",
                 ),
                 paymentMethodNameProvider = { it!! }
             )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTestHelper.kt
@@ -1,0 +1,94 @@
+package com.stripe.android.customersheet
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.Logger
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.networking.StripeRepository
+import com.stripe.android.paymentsheet.forms.FormViewModel
+import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
+import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
+import com.stripe.android.testing.PaymentIntentFactory
+import com.stripe.android.ui.core.forms.resources.LpmRepository
+import com.stripe.android.uicore.address.AddressRepository
+import kotlinx.coroutines.Dispatchers
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.util.Stack
+import javax.inject.Provider
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+object CustomerSheetTestHelper {
+    internal val application = ApplicationProvider.getApplicationContext<Application>()
+    internal val lpmRepository = LpmRepository(
+        LpmRepository.LpmRepositoryArguments(
+            resources = application.resources,
+            isFinancialConnectionsAvailable = { true },
+        )
+    ).apply {
+        update(
+            PaymentIntentFactory.create(paymentMethodTypes = this.supportedPaymentMethodTypes),
+            null
+        )
+    }
+
+    internal fun createViewModel(
+        lpmRepository: LpmRepository = this.lpmRepository,
+        isLiveMode: Boolean = false,
+        backstack: Stack<CustomerSheetViewState> = Stack<CustomerSheetViewState>().apply {
+            push(CustomerSheetViewState.Loading(isLiveMode))
+        },
+        customerAdapter: CustomerAdapter = FakeCustomerAdapter(),
+        stripeRepository: StripeRepository = FakeStripeRepository(),
+        paymentConfiguration: PaymentConfiguration = PaymentConfiguration(
+            publishableKey = "pk_test_123",
+            stripeAccountId = null,
+        ),
+        configuration: CustomerSheet.Configuration = CustomerSheet.Configuration(),
+    ): CustomerSheetViewModel {
+        val formViewModel = FormViewModel(
+            context = application,
+            formArguments = FormArguments(
+                PaymentMethod.Type.Card.code,
+                showCheckbox = false,
+                showCheckboxControlledFields = false,
+                initialPaymentMethodCreateParams = null,
+                merchantName = configuration.merchantDisplayName
+                    ?: application.applicationInfo.loadLabel(application.packageManager).toString(),
+                billingDetails = configuration.defaultBillingDetails,
+                billingDetailsCollectionConfiguration = configuration.billingDetailsCollectionConfiguration
+            ),
+            lpmRepository = lpmRepository,
+            addressRepository = AddressRepository(
+                resources = ApplicationProvider.getApplicationContext<Application>().resources,
+                workContext = Dispatchers.Unconfined,
+            ),
+            showCheckboxFlow = mock()
+        )
+        val mockFormBuilder = mock<FormViewModelSubcomponent.Builder>()
+        val mockFormSubcomponent = mock<FormViewModelSubcomponent>()
+        val mockFormSubComponentBuilderProvider =
+            mock<Provider<FormViewModelSubcomponent.Builder>>()
+        whenever(mockFormBuilder.build()).thenReturn(mockFormSubcomponent)
+        whenever(mockFormBuilder.formArguments(any())).thenReturn(mockFormBuilder)
+        whenever(mockFormBuilder.showCheckboxFlow(any())).thenReturn(mockFormBuilder)
+        whenever(mockFormSubcomponent.viewModel).thenReturn(formViewModel)
+        whenever(mockFormSubComponentBuilderProvider.get()).thenReturn(mockFormBuilder)
+
+        return CustomerSheetViewModel(
+            application = application,
+            backstack = backstack,
+            paymentConfiguration = paymentConfiguration,
+            formViewModelSubcomponentBuilderProvider = mockFormSubComponentBuilderProvider,
+            resources = application.resources,
+            stripeRepository = stripeRepository,
+            customerAdapter = customerAdapter,
+            lpmRepository = lpmRepository,
+            configuration = configuration,
+            isLiveMode = isLiveMode,
+            logger = Logger.noop(),
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -1,58 +1,28 @@
 package com.stripe.android.customersheet
 
-import android.app.Application
-import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.test
 import app.cash.turbine.testIn
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.core.Logger
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
-import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.customersheet.CustomerSheetTestHelper.createViewModel
 import com.stripe.android.customersheet.injection.CustomerSheetViewModelModule
-import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
-import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.SetupIntentFixtures
-import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.forms.FormViewModel
-import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
-import com.stripe.android.testing.AbsFakeStripeRepository
-import com.stripe.android.testing.PaymentIntentFactory
-import com.stripe.android.ui.core.forms.resources.LpmRepository
-import com.stripe.android.uicore.address.AddressRepository
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.kotlin.any
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import java.util.Stack
-import javax.inject.Provider
 
 @RunWith(RobolectricTestRunner::class)
 @OptIn(ExperimentalCustomerSheetApi::class)
 class CustomerSheetViewModelTest {
-    private val application = ApplicationProvider.getApplicationContext<Application>()
-    private val lpmRepository = LpmRepository(
-        LpmRepository.LpmRepositoryArguments(
-            resources = application.resources,
-            isFinancialConnectionsAvailable = { true },
-        )
-    ).apply {
-        update(
-            PaymentIntentFactory.create(paymentMethodTypes = this.supportedPaymentMethodTypes),
-            null
-        )
-    }
 
     @Test
     fun `isLiveMode is true when publishable key is live`() {
@@ -98,7 +68,7 @@ class CustomerSheetViewModelTest {
         viewModel.result.test {
             assertThat(awaitItem()).isEqualTo(null)
             viewModel.handleViewAction(CustomerSheetViewAction.OnBackPressed)
-            assertThat(awaitItem()).isEqualTo(InternalCustomerSheetResult.Canceled)
+            assertThat(awaitItem()).isEqualTo(InternalCustomerSheetResult.Canceled(null))
         }
     }
 
@@ -602,7 +572,7 @@ class CustomerSheetViewModelTest {
             viewModel.handleViewAction(CustomerSheetViewAction.OnPrimaryButtonPressed)
 
             val result = awaitItem() as InternalCustomerSheetResult.Selected
-            assertThat(result.label).isEqualTo("Google Pay")
+            assertThat(result.paymentSelection).isEqualTo(PaymentSelection.GooglePay)
         }
     }
 
@@ -942,91 +912,11 @@ class CustomerSheetViewModelTest {
         }
     }
 
-    private fun createViewModel(
-        isLiveMode: Boolean = false,
-        backstack: Stack<CustomerSheetViewState> = Stack<CustomerSheetViewState>().apply {
-            push(CustomerSheetViewState.Loading(isLiveMode))
-        },
-        customerAdapter: CustomerAdapter = FakeCustomerAdapter(),
-        stripeRepository: StripeRepository = FakeStripeRepository(),
-        lpmRepository: LpmRepository = this.lpmRepository,
-        paymentConfiguration: PaymentConfiguration = PaymentConfiguration(
-            publishableKey = "pk_test_123",
-            stripeAccountId = null,
-        ),
-        configuration: CustomerSheet.Configuration = CustomerSheet.Configuration(),
-    ): CustomerSheetViewModel {
-        val formViewModel = FormViewModel(
-            context = application,
-            formArguments = FormArguments(
-                PaymentMethod.Type.Card.code,
-                showCheckbox = false,
-                showCheckboxControlledFields = false,
-                initialPaymentMethodCreateParams = null,
-                merchantName = configuration.merchantDisplayName
-                    ?: application.applicationInfo.loadLabel(application.packageManager).toString(),
-                billingDetails = configuration.defaultBillingDetails,
-                billingDetailsCollectionConfiguration = configuration.billingDetailsCollectionConfiguration
-            ),
-            lpmRepository = lpmRepository,
-            addressRepository = AddressRepository(
-                resources = ApplicationProvider.getApplicationContext<Application>().resources,
-                workContext = Dispatchers.Unconfined,
-            ),
-            showCheckboxFlow = mock()
-        )
-        val mockFormBuilder = mock<FormViewModelSubcomponent.Builder>()
-        val mockFormSubcomponent = mock<FormViewModelSubcomponent>()
-        val mockFormSubComponentBuilderProvider =
-            mock<Provider<FormViewModelSubcomponent.Builder>>()
-        whenever(mockFormBuilder.build()).thenReturn(mockFormSubcomponent)
-        whenever(mockFormBuilder.formArguments(any())).thenReturn(mockFormBuilder)
-        whenever(mockFormBuilder.showCheckboxFlow(any())).thenReturn(mockFormBuilder)
-        whenever(mockFormSubcomponent.viewModel).thenReturn(formViewModel)
-        whenever(mockFormSubComponentBuilderProvider.get()).thenReturn(mockFormBuilder)
-
-        return CustomerSheetViewModel(
-            application = application,
-            backstack = backstack,
-            paymentConfiguration = paymentConfiguration,
-            formViewModelSubcomponentBuilderProvider = mockFormSubComponentBuilderProvider,
-            logger = Logger.noop(),
-            resources = application.resources,
-            stripeRepository = stripeRepository,
-            customerAdapter = customerAdapter,
-            lpmRepository = lpmRepository,
-            configuration = configuration,
-            isLiveMode = isLiveMode,
-        )
-    }
-
     private fun buildBackstack(vararg states: CustomerSheetViewState): Stack<CustomerSheetViewState> {
         return Stack<CustomerSheetViewState>().apply {
             states.forEach {
                 push(it)
             }
-        }
-    }
-
-    class FakeStripeRepository(
-        private val onCreatePaymentMethod:
-            ((paymentMethodCreateParams: PaymentMethodCreateParams) -> PaymentMethod)? = null,
-        private val onConfirmSetupIntent:
-            (() -> SetupIntent?)? = null
-    ) : AbsFakeStripeRepository() {
-        override suspend fun createPaymentMethod(
-            paymentMethodCreateParams: PaymentMethodCreateParams,
-            options: ApiRequest.Options
-        ): PaymentMethod? {
-            return onCreatePaymentMethod?.invoke(paymentMethodCreateParams)
-        }
-
-        override suspend fun confirmSetupIntent(
-            confirmSetupIntentParams: ConfirmSetupIntentParams,
-            options: ApiRequest.Options,
-            expandFields: List<String>
-        ): SetupIntent? {
-            return onConfirmSetupIntent?.invoke()
         }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeStripeRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeStripeRepository.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.customersheet
+
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.model.ConfirmSetupIntentParams
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.testing.AbsFakeStripeRepository
+
+class FakeStripeRepository(
+    private val onCreatePaymentMethod:
+        ((paymentMethodCreateParams: PaymentMethodCreateParams) -> PaymentMethod)? = null,
+    private val onConfirmSetupIntent:
+        (() -> SetupIntent?)? = null
+) : AbsFakeStripeRepository() {
+    override suspend fun createPaymentMethod(
+        paymentMethodCreateParams: PaymentMethodCreateParams,
+        options: ApiRequest.Options
+    ): PaymentMethod? {
+        return onCreatePaymentMethod?.invoke(paymentMethodCreateParams)
+    }
+
+    override suspend fun confirmSetupIntent(
+        confirmSetupIntentParams: ConfirmSetupIntentParams,
+        options: ApiRequest.Options,
+        expandFields: List<String>
+    ): SetupIntent? {
+        return onConfirmSetupIntent?.invoke()
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Add convenience function `retrievePaymentOptionSelection` to `CustomerSheet`. `PaymentOptionSelection` is a concern of `CustomerSheet` and not `CustomerAdapter`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

This was missed during API review, but merchants need a way to retrieve the persisted payment option in order to display the payment method's label and icon. This is different from `CustomerAdapter#retrieveSelectedPaymentOption`, which returns the id of the selected payment method.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots

[selectedpms.webm](https://github.com/stripe/stripe-android/assets/99316447/cca1db14-82f3-4d64-9c02-e7949dc9d53d)

