### PR TITLE
[Identity] Support the 'closed' field in submit endpoint

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/IdentityOnBackPressedHandler.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityOnBackPressedHandler.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
 import com.stripe.android.identity.navigation.ConfirmationDestination
+import com.stripe.android.identity.navigation.ConsentDestination
 import com.stripe.android.identity.navigation.DebugDestination
 import com.stripe.android.identity.navigation.ErrorDestination
 import com.stripe.android.identity.navigation.InitialLoadingDestination
@@ -36,7 +37,8 @@ internal class IdentityOnBackPressedHandler(
             return
         }
         if (navController.previousBackStackEntry?.destination?.route == InitialLoadingDestination.ROUTE.route ||
-            navController.previousBackStackEntry?.destination?.route == DebugDestination.ROUTE.route
+            navController.previousBackStackEntry?.destination?.route == DebugDestination.ROUTE.route ||
+            destination?.route == ConsentDestination.ROUTE.route
         ) {
             finishWithCancelResult(
                 identityViewModel,

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/ClearDataParam.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/ClearDataParam.kt
@@ -24,7 +24,11 @@ internal data class ClearDataParam(
     @SerialName("name")
     val name: Boolean = false,
     @SerialName("address")
-    val address: Boolean = false
+    val address: Boolean = false,
+    @SerialName("phone")
+    val phone: Boolean = false,
+    @SerialName("phone_otp")
+    val phoneOtp: Boolean = false
 ) {
     internal companion object {
         private const val CLEAR_DATA_PARAM = "clear_data"
@@ -47,7 +51,9 @@ internal data class ClearDataParam(
             idNumber = requirements.contains(Requirement.IDNUMBER),
             dob = requirements.contains(Requirement.DOB),
             name = requirements.contains(Requirement.NAME),
-            address = requirements.contains(Requirement.ADDRESS)
+            address = requirements.contains(Requirement.ADDRESS),
+            phone = requirements.contains(Requirement.PHONE_NUMBER),
+            phoneOtp = requirements.contains(Requirement.PHONE_OTP)
         )
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/Requirement.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/Requirement.kt
@@ -11,6 +11,7 @@ import com.stripe.android.identity.navigation.IDUploadDestination
 import com.stripe.android.identity.navigation.IdentityTopLevelDestination
 import com.stripe.android.identity.navigation.IndividualDestination
 import com.stripe.android.identity.navigation.IndividualWelcomeDestination
+import com.stripe.android.identity.navigation.OTPDestination
 import com.stripe.android.identity.navigation.PassportScanDestination
 import com.stripe.android.identity.navigation.PassportUploadDestination
 import com.stripe.android.identity.navigation.SelfieDestination
@@ -94,8 +95,11 @@ internal enum class Requirement {
                 FACE -> {
                     fromRoute == SelfieDestination.ROUTE.route
                 }
-                DOB, NAME, IDNUMBER, ADDRESS, PHONE_NUMBER, PHONE_OTP -> {
+                DOB, NAME, IDNUMBER, ADDRESS, PHONE_NUMBER -> {
                     fromRoute == IndividualDestination.ROUTE.route
+                }
+                PHONE_OTP -> {
+                    fromRoute == OTPDestination.ROUTE.route
                 }
             }
 

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageData.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageData.kt
@@ -22,7 +22,10 @@ internal data class VerificationPageData(
     val status: Status,
     /* If true, the associated VerificationSession has been submitted for processing. */
     @SerialName("submitted")
-    val submitted: Boolean
+    val submitted: Boolean,
+    /* If true, the associated VerificationSession has been is finished and can no longer be changed. */
+    @SerialName("closed")
+    val closed: Boolean,
 ) {
     /**
      * Status of the associated VerificationSession.
@@ -73,5 +76,14 @@ internal data class VerificationPageData(
                     Requirement.PHONE_NUMBER
                 )
             )?.isNotEmpty() == true
+
+        /**
+         * When submitted but is not closed and there is still missing requirements, need to
+         * fallback.
+         */
+        fun VerificationPageData.needsFallback() =
+            submitted && !closed && requirements.missings?.isEmpty() == false
+
+        fun VerificationPageData.submittedAndClosed() = submitted && closed
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/ui/OTPScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/OTPScreen.kt
@@ -318,7 +318,7 @@ private fun postErrorAndNavigateToFinalErrorScreen(
 }
 
 private const val EMPTY_PHONE_NUMBER = ""
-internal const val PHONE_NUMBER_PATTERN = "&phone_number&"
+internal const val PHONE_NUMBER_PATTERN = "{phone_number}"
 internal const val OTP_TITLE_TAG = "OtpTitleTag"
 internal const val OTP_BODY_TAG = "OtpBodyTag"
 internal const val OTP_ELEMENT_TAG = "OtpElementTag"

--- a/identity/src/main/java/com/stripe/android/identity/ui/OTPScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/OTPScreen.kt
@@ -70,10 +70,6 @@ internal fun OTPScreen(
             factory = otpViewModelFactory
         )
 
-        LaunchedEffect(Unit) {
-            otpViewModel.initialize()
-        }
-
         val viewState by otpViewModel.viewState.collectAsState()
         val otpStaticPage = requireNotNull(verificationPage.phoneOtp)
         val focusRequester = remember { FocusRequester() }
@@ -301,6 +297,7 @@ private fun OTPViewStateEffect(
     }
 
     DisposableEffect(Unit) {
+        viewModel.initialize()
         onDispose {
             viewModel.resetViewState()
         }

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/OTPViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/OTPViewModel.kt
@@ -44,7 +44,7 @@ internal class OTPViewModel(
             controller = OTPController()
         )
 
-    init {
+    internal fun initialize() {
         // transition to submittingOTP when otp is fully input
         viewModelScope.launch {
             otpElement.otpCompleteFlow.collectLatest {
@@ -121,6 +121,10 @@ internal class OTPViewModel(
                 }
             )
         }
+    }
+
+    internal fun resetViewState() {
+        _viewState.update { null }
     }
 
     private fun onRequestingCannotVerifySuccess(verificationPageData: VerificationPageData) {

--- a/identity/src/test/java/com/stripe/android/identity/IdentityOnBackPressedHandlerTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/IdentityOnBackPressedHandlerTest.kt
@@ -7,12 +7,12 @@ import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
 import com.stripe.android.identity.navigation.ConfirmationDestination
+import com.stripe.android.identity.navigation.ConsentDestination
 import com.stripe.android.identity.navigation.ConsentDestination.CONSENT
 import com.stripe.android.identity.navigation.DocSelectionDestination
 import com.stripe.android.identity.navigation.ErrorDestination
 import com.stripe.android.identity.navigation.ErrorDestination.Companion.ARG_SHOULD_FAIL
 import com.stripe.android.identity.navigation.InitialLoadingDestination
-import com.stripe.android.identity.navigation.clearDataAndNavigateUp
 import com.stripe.android.identity.navigation.routeToScreenName
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import org.junit.Test
@@ -106,6 +106,30 @@ class IdentityOnBackPressedHandlerTest {
     }
 
     @Test
+    fun testBackPressOnConsentPage() {
+        val mockDestination = mock<NavDestination> {
+            on { route } doReturn ConsentDestination.ROUTE.route
+        }
+
+        handler.updateState(
+            destination = mockDestination,
+            args = null
+        )
+
+        handler.handleOnBackPressed()
+
+        verify(mockAnalyticsRequestFactory).verificationCanceled(
+            eq(false),
+            eq(CONSENT.routeToScreenName()),
+            anyOrNull(),
+            anyOrNull()
+        )
+        verify(mockFlowFinishable).finishWithResult(
+            eq(IdentityVerificationSheet.VerificationFlowResult.Canceled)
+        )
+    }
+
+    @Test
     fun testBackPressOnErrorPageWithArgShouldFail() {
         val mockDestination = mock<NavDestination> {
             on { route } doReturn ErrorDestination.ROUTE.route
@@ -151,9 +175,7 @@ class IdentityOnBackPressedHandlerTest {
             )
         )
         handler.handleOnBackPressed()
-        verify(mockNavController).clearDataAndNavigateUp(
-            mockIdentityViewModel
-        )
+        verify(mockNavController).navigateUp()
     }
 
     @Test
@@ -167,8 +189,6 @@ class IdentityOnBackPressedHandlerTest {
             args = null
         )
         handler.handleOnBackPressed()
-        verify(mockNavController).clearDataAndNavigateUp(
-            mockIdentityViewModel
-        )
+        verify(mockNavController).navigateUp()
     }
 }

--- a/identity/src/test/java/com/stripe/android/identity/TestFixtures.kt
+++ b/identity/src/test/java/com/stripe/android/identity/TestFixtures.kt
@@ -14,14 +14,43 @@ internal const val ERROR_BODY = "errorBody"
 internal const val ERROR_BUTTON_TEXT = "error button text"
 internal const val ERROR_TITLE = "errorTitle"
 
-internal val CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA = VerificationPageData(
+internal val SUBMITTED_AND_CLOSED_VERIFICATION_PAGE_DATA = VerificationPageData(
     id = "id",
     objectType = "type",
     requirements = VerificationPageDataRequirements(
         errors = emptyList()
     ),
     status = VerificationPageData.Status.VERIFIED,
-    submitted = false
+    submitted = true,
+    closed = true
+)
+
+internal val SUBMITTED_AND_NOT_CLOSED_VERIFICATION_PAGE_DATA = VerificationPageData(
+    id = "id",
+    objectType = "type",
+    requirements = VerificationPageDataRequirements(
+        errors = emptyList(),
+        missings = listOf(
+            Requirement.BIOMETRICCONSENT,
+            Requirement.IDDOCUMENTFRONT,
+            Requirement.IDDOCUMENTBACK
+        )
+    ),
+    status = VerificationPageData.Status.VERIFIED,
+    submitted = true,
+    closed = false
+)
+
+internal val SUBMITTED_AND_NOT_CLOSED_NO_MISSING_VERIFICATION_PAGE_DATA = VerificationPageData(
+    id = "id",
+    objectType = "type",
+    requirements = VerificationPageDataRequirements(
+        errors = emptyList(),
+        missings = emptyList()
+    ),
+    status = VerificationPageData.Status.VERIFIED,
+    submitted = true,
+    closed = false
 )
 
 internal val CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA = VerificationPageData(
@@ -32,7 +61,8 @@ internal val CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA = Verificatio
         missings = emptyList()
     ),
     status = VerificationPageData.Status.VERIFIED,
-    submitted = true
+    submitted = true,
+    closed = true
 )
 
 internal val VERIFICATION_PAGE_DATA_MISSING_FRONT = VerificationPageData(
@@ -43,7 +73,8 @@ internal val VERIFICATION_PAGE_DATA_MISSING_FRONT = VerificationPageData(
         missings = listOf(Requirement.IDDOCUMENTFRONT)
     ),
     status = VerificationPageData.Status.REQUIRESINPUT,
-    submitted = false
+    submitted = false,
+    closed = false
 )
 
 internal val VERIFICATION_PAGE_DATA_MISSING_BACK = VerificationPageData(
@@ -54,7 +85,8 @@ internal val VERIFICATION_PAGE_DATA_MISSING_BACK = VerificationPageData(
         missings = listOf(Requirement.IDDOCUMENTBACK)
     ),
     status = VerificationPageData.Status.REQUIRESINPUT,
-    submitted = false
+    submitted = false,
+    closed = false
 )
 
 internal val VERIFICATION_PAGE_DATA_MISSING_PHONE_OTP = VerificationPageData(
@@ -65,7 +97,8 @@ internal val VERIFICATION_PAGE_DATA_MISSING_PHONE_OTP = VerificationPageData(
         missings = listOf(Requirement.PHONE_OTP)
     ),
     status = VerificationPageData.Status.REQUIRESINPUT,
-    submitted = false
+    submitted = false,
+    closed = false
 )
 
 internal val VERIFICATION_PAGE_DATA_MISSING_CONSENT = VerificationPageData(
@@ -76,7 +109,8 @@ internal val VERIFICATION_PAGE_DATA_MISSING_CONSENT = VerificationPageData(
         missings = listOf(Requirement.BIOMETRICCONSENT)
     ),
     status = VerificationPageData.Status.REQUIRESINPUT,
-    submitted = false
+    submitted = false,
+    closed = false
 )
 
 internal val VERIFICATION_PAGE_DATA_MISSING_DOCTYPE = VerificationPageData(
@@ -87,7 +121,8 @@ internal val VERIFICATION_PAGE_DATA_MISSING_DOCTYPE = VerificationPageData(
         missings = listOf(Requirement.IDDOCUMENTTYPE)
     ),
     status = VerificationPageData.Status.REQUIRESINPUT,
-    submitted = false
+    submitted = false,
+    closed = false
 )
 
 internal val VERIFICATION_PAGE_DATA_NOT_MISSING_BACK = VerificationPageData(
@@ -98,7 +133,8 @@ internal val VERIFICATION_PAGE_DATA_NOT_MISSING_BACK = VerificationPageData(
         missings = emptyList()
     ),
     status = VerificationPageData.Status.REQUIRESINPUT,
-    submitted = false
+    submitted = false,
+    closed = false
 )
 
 internal val VERIFICATION_PAGE_DATA_MISSING_SELFIE = VerificationPageData(
@@ -109,7 +145,8 @@ internal val VERIFICATION_PAGE_DATA_MISSING_SELFIE = VerificationPageData(
         missings = listOf(Requirement.FACE)
     ),
     status = VerificationPageData.Status.REQUIRESINPUT,
-    submitted = false
+    submitted = false,
+    closed = false
 )
 
 internal val VERIFICATION_PAGE_DATA_HAS_ERROR = VerificationPageData(
@@ -127,7 +164,8 @@ internal val VERIFICATION_PAGE_DATA_HAS_ERROR = VerificationPageData(
         missings = listOf(Requirement.BIOMETRICCONSENT)
     ),
     status = VerificationPageData.Status.REQUIRESINPUT,
-    submitted = false
+    submitted = false,
+    closed = false
 )
 
 internal val json: Json = Json {

--- a/identity/src/test/java/com/stripe/android/identity/networking/IdentityNetworkResponseFixtures.kt
+++ b/identity/src/test/java/com/stripe/android/identity/networking/IdentityNetworkResponseFixtures.kt
@@ -15,7 +15,8 @@ internal val VERIFICATION_PAGE_DATA_JSON_STRING = """
         ]
       },
       "status": "requires_input",
-      "submitted": false
+      "submitted": false,
+      "closed": false
     }
 """.trimIndent()
 
@@ -132,6 +133,7 @@ internal val VERIFICATION_PAGE_NOT_REQUIRE_LIVE_CAPTURE_JSON_STRING = """
       },
       "status": "requires_input",
       "submitted": false,
+      "closed": false,
       "success": {
         "body": "\u003Cp\u003E\u003Cb\u003EThank you for providing your information\u003C/b\u003E\u003C/p\u003E\u003Cp\u003Emlgb.band will reach out if additional details are required.\u003C/p\u003E\u003Cp\u003E\u003Cb\u003ENext steps\u003C/b\u003E\u003C/p\u003E\u003Cp\u003Emlgb.band will contact you regarding the outcome of your identification process.\u003C/p\u003E\u003Cp\u003E\u003Cb\u003EMore about Stripe Identity\u003C/b\u003E\u003C/p\u003E\u003Cp\u003E\u003Ca href='https://support.stripe.com/questions/common-questions-about-stripe-identity'\u003ECommon questions about Stripe Identity\u003C/a\u003E\u003C/p\u003E\u003Cp\u003E\u003Ca href='https://stripe.com/privacy-center/legal#stripe-identity'\u003ELearn how Stripe uses data\u003C/a\u003E\u003C/p\u003E\u003Cp\u003E\u003Ca href='https://stripe.com/privacy'\u003EStripe Privacy Policy\u003C/a\u003E\u003C/p\u003E\u003Cp\u003E\u003Ca href='mailto:privacy@stripe.com'\u003EContact Stripe\u003C/a\u003E\u003C/p\u003E",
         "button_text": "Complete",
@@ -254,6 +256,7 @@ internal val VERIFICATION_PAGE_REQUIRE_LIVE_CAPTURE_JSON_STRING = """
       },
       "status": "requires_input",
       "submitted": false,
+      "closed": false,
       "success": {
         "body": "\u003Cp\u003E\u003Cb\u003EThank you for providing your information\u003C/b\u003E\u003C/p\u003E\u003Cp\u003Emlgb.band will reach out if additional details are required.\u003C/p\u003E\u003Cp\u003E\u003Cb\u003ENext steps\u003C/b\u003E\u003C/p\u003E\u003Cp\u003Emlgb.band will contact you regarding the outcome of your identification process.\u003C/p\u003E\u003Cp\u003E\u003Cb\u003EMore about Stripe Identity\u003C/b\u003E\u003C/p\u003E\u003Cp\u003E\u003Ca href='https://support.stripe.com/questions/common-questions-about-stripe-identity'\u003ECommon questions about Stripe Identity\u003C/a\u003E\u003C/p\u003E\u003Cp\u003E\u003Ca href='https://stripe.com/privacy-center/legal#stripe-identity'\u003ELearn how Stripe uses data\u003C/a\u003E\u003C/p\u003E\u003Cp\u003E\u003Ca href='https://stripe.com/privacy'\u003EStripe Privacy Policy\u003C/a\u003E\u003C/p\u003E\u003Cp\u003E\u003Ca href='mailto:privacy@stripe.com'\u003EContact Stripe\u003C/a\u003E\u003C/p\u003E",
         "button_text": "Complete",
@@ -404,6 +407,7 @@ internal val VERIFICATION_PAGE_REQUIRE_SELFIE_LIVE_CAPTURE_JSON_STRING = """
       },
       "status": "requires_input",
       "submitted": false,
+      "closed": false,
       "success": {
         "body": "<p>Thank you for providing your information. Andrew's Audio will reach out if additional details are required.</p><p><b>Next steps</b></p><p>Andrew's Audio will contact you regarding the outcome of your identification process.</p><p><b>More about Stripe Identity</b></p><p><a href='https://support.stripe.com/questions/common-questions-about-stripe-identity'>Common questions about Stripe Identity</a></p><p><a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn how Stripe uses data</a></p><p><a href='https://stripe.com/privacy'>Stripe Privacy Policy</a></p><p><a href='mailto:privacy@stripe.com'>Contact Stripe</a></p>",
         "button_text": "Complete",
@@ -561,6 +565,7 @@ internal val VERIFICATION_PAGE_TYPE_DOCUMENT_REQUIRE_ID_NUMBER_JSON_STRING = """
       "selfie": null,
       "status": "requires_input",
       "submitted": false,
+      "closed": false,
       "success": {
         "body": "<p>Thank you for providing your information. Tora's catfood will reach out if additional details are required.</p><p><b>Next steps</b></p><p>Tora's catfood will contact you regarding the outcome of your identification process.</p><p><b>More about Stripe Identity</b></p><p><a href='https://support.stripe.com/questions/common-questions-about-stripe-identity'>Common questions about Stripe Identity</a></p><p><a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn how Stripe uses data</a></p><p><a href='https://stripe.com/privacy'>Stripe Privacy Policy</a></p><p><a href='mailto:privacy@stripe.com'>Contact Stripe</a></p>",
         "button_text": "Complete",
@@ -691,6 +696,7 @@ internal val VERIFICATION_PAGE_TYPE_DOCUMENT_REQUIRE_ADDRESS_JSON_STRING = """
       "selfie": null,
       "status": "requires_input",
       "submitted": false,
+      "closed": false,
       "success": {
         "body": "<p>Thank you for providing your information. Tora's catfood will reach out if additional details are required.</p><p><b>Next steps</b></p><p>Tora's catfood will contact you regarding the outcome of your identification process.</p><p><b>More about Stripe Identity</b></p><p><a href='https://support.stripe.com/questions/common-questions-about-stripe-identity'>Common questions about Stripe Identity</a></p><p><a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn how Stripe uses data</a></p><p><a href='https://stripe.com/privacy'>Stripe Privacy Policy</a></p><p><a href='mailto:privacy@stripe.com'>Contact Stripe</a></p>",
         "button_text": "Complete",
@@ -821,6 +827,7 @@ internal val VERIFICATION_PAGE_TYPE_DOCUMENT_REQUIRE_ADDRESS_AND_ID_NUMBER_JSON_
       "selfie": null,
       "status": "requires_input",
       "submitted": false,
+      "closed": false,
       "success": {
         "body": "<p>Thank you for providing your information. Tora's catfood will reach out if additional details are required.</p><p><b>Next steps</b></p><p>Tora's catfood will contact you regarding the outcome of your identification process.</p><p><b>More about Stripe Identity</b></p><p><a href='https://support.stripe.com/questions/common-questions-about-stripe-identity'>Common questions about Stripe Identity</a></p><p><a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn how Stripe uses data</a></p><p><a href='https://stripe.com/privacy'>Stripe Privacy Policy</a></p><p><a href='mailto:privacy@stripe.com'>Contact Stripe</a></p>",
         "button_text": "Complete",
@@ -948,6 +955,7 @@ internal val VERIFICATION_PAGE_TYPE_ID_NUMBER_JSON_STRING = """
       "selfie": null,
       "status": "requires_input",
       "submitted": false,
+      "closed": false,
       "success": {
         "body": "<p>Thank you for providing your information. Tora's catfood will reach out if additional details are required.</p><p><b>Next steps</b></p><p>Tora's catfood will contact you regarding the outcome of your identification process.</p><p><b>More about Stripe Identity</b></p><p><a href='https://support.stripe.com/questions/common-questions-about-stripe-identity'>Common questions about Stripe Identity</a></p><p><a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn how Stripe uses data</a></p><p><a href='https://stripe.com/privacy'>Stripe Privacy Policy</a></p><p><a href='mailto:privacy@stripe.com'>Contact Stripe</a></p>",
         "button_text": "Complete",
@@ -1075,6 +1083,7 @@ internal val VERIFICATION_PAGE_TYPE_ADDRESS_JSON_STRING = """
       "selfie": null,
       "status": "requires_input",
       "submitted": false,
+      "closed": false,
       "success": {
         "body": "<p>Thank you for providing your information. Tora's catfood will reach out if additional details are required.</p><p><b>Next steps</b></p><p>Tora's catfood will contact you regarding the outcome of your identification process.</p><p><b>More about Stripe Identity</b></p><p><a href='https://support.stripe.com/questions/common-questions-about-stripe-identity'>Common questions about Stripe Identity</a></p><p><a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn how Stripe uses data</a></p><p><a href='https://stripe.com/privacy'>Stripe Privacy Policy</a></p><p><a href='mailto:privacy@stripe.com'>Contact Stripe</a></p>",
         "button_text": "Complete",


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Introduced a new `closed` boolean in submit API endpoint, after submitting
* When `submitted` and `closed` are `true` -> navigate to success page
* When `submitted`=`true` and `closed`=`false`, need to fallback, check `missings` and fallback accordingly - currently this only happens when `phone` type verification fallback to `document`

iOS change: https://github.com/stripe/stripe-ios/pull/2700

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Support phoneV


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
