### PR TITLE
Remove beta tag for decoupling in example app

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/MainActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/MainActivity.kt
@@ -1,8 +1,6 @@
 package com.stripe.android.paymentsheet.example
 
-import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.appcompat.app.AppCompatActivity
@@ -70,20 +68,12 @@ class MainActivity : AppCompatActivity() {
                 titleResId = R.string.paymentsheet_serverside_confirmation_title,
                 subtitleResId = R.string.paymentsheet_serverside_confirmation_subtitle,
                 klass = ServerSideConfirmationCompleteFlowActivity::class.java,
-                badge = MenuItem.Badge(
-                    labelResId = R.string.beta_badge_label,
-                    onClick = this::openDecouplingBetaLink,
-                ),
                 section = MenuItem.Section.CompleteFlow,
             ),
             MenuItem(
                 titleResId = R.string.paymentsheet_custom_serverside_confirmation_title,
                 subtitleResId = R.string.paymentsheet_serverside_confirmation_subtitle,
                 klass = ServerSideConfirmationCustomFlowActivity::class.java,
-                badge = MenuItem.Badge(
-                    labelResId = R.string.beta_badge_label,
-                    onClick = this::openDecouplingBetaLink,
-                ),
                 section = MenuItem.Section.CustomFlow,
             ),
             MenuItem(
@@ -258,12 +248,4 @@ private fun MenuItemRow(item: MenuItem) {
             }
         }
     }
-}
-
-private fun Context.openDecouplingBetaLink() {
-    val url = "https://stripe.com/docs/payments/finalize-payments-on-the-server?platform=mobile"
-    val intent = Intent(Intent.ACTION_VIEW).apply {
-        data = Uri.parse(url)
-    }
-    startActivity(intent)
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request removes the `This is currently in beta` tag from the decoupling examples.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Decoupling GA.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
