### PR TITLE
Fix cancelling link in paymentsheet.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -237,7 +237,8 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     private fun handleLinkProcessingState(processingState: LinkHandler.ProcessingState) {
         when (processingState) {
             LinkHandler.ProcessingState.Cancelled -> {
-                _paymentSheetResult.tryEmit(PaymentSheetResult.Canceled)
+                setContentVisible(true)
+                resetViewState()
             }
             is LinkHandler.ProcessingState.PaymentMethodCollected -> {
                 setContentVisible(true)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When cancelling link in payment sheet, it would close Link as well as payment sheet. This was unintended behavior. The new behavior is to just close link, and reset the payment sheet, allowing you to continue paying with another payment method.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Bug