### PR TITLE
Fix odd behavior in Stripe.retrievePossibleBrands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+### Payments
+*[FIXED][6977](https://github.com/stripe/stripe-android/pull/6977) Fixed an issue where `Stripe.retrievePossibleBrands()` returned incorrect results.
+
 ## 20.27.2 - 2023-07-18
 
 ### PaymentSheet

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -238,7 +238,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         return Result.failure(NotImplementedError())
     }
 
-    override suspend fun getCardMetadata(bin: Bin, options: ApiRequest.Options): CardMetadata {
+    override suspend fun getCardMetadata(bin: Bin, options: ApiRequest.Options): Result<CardMetadata> {
         TODO("Not yet implemented")
     }
 

--- a/payments-core/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepository.kt
@@ -14,11 +14,13 @@ internal class DefaultCardAccountRangeRepository(
         cardNumber: CardNumber.Unvalidated
     ): AccountRange? {
         return cardNumber.bin?.let { bin ->
-            if (store.contains(bin)) {
+            val range = if (store.contains(bin)) {
                 inMemorySource.getAccountRange(cardNumber)
             } else {
                 remoteSource.getAccountRange(cardNumber)
-            } ?: staticSource.getAccountRange(cardNumber)
+            }
+
+            range ?: staticSource.getAccountRange(cardNumber)
         }
     }
 
@@ -26,11 +28,13 @@ internal class DefaultCardAccountRangeRepository(
         cardNumber: CardNumber.Unvalidated
     ): List<AccountRange>? {
         return cardNumber.bin?.let { bin ->
-            if (store.contains(bin)) {
+            val ranges = if (store.contains(bin)) {
                 inMemorySource.getAccountRanges(cardNumber)
             } else {
                 remoteSource.getAccountRanges(cardNumber)
-            } ?: staticSource.getAccountRanges(cardNumber)
+            }
+
+            ranges?.takeIf { it.isNotEmpty() } ?: staticSource.getAccountRanges(cardNumber)
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeStore.kt
+++ b/payments-core/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeStore.kt
@@ -44,7 +44,8 @@ internal class DefaultCardAccountRangeStore(
     internal fun createPrefKey(bin: Bin): String = "$PREF_KEY_ACCOUNT_RANGES:$bin"
 
     private companion object {
-        private const val PREF_FILE = "InMemoryCardAccountRangeSource.Store"
+        private const val VERSION = 2
+        private const val PREF_FILE = "InMemoryCardAccountRangeSource.Store.$VERSION"
         private const val PREF_KEY_ACCOUNT_RANGES = "key_account_ranges"
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -860,21 +860,17 @@ class StripeApiRepository @JvmOverloads internal constructor(
     override suspend fun getCardMetadata(
         bin: Bin,
         options: ApiRequest.Options
-    ): CardMetadata? {
-        return runCatching {
-            fetchStripeModel(
-                apiRequestFactory.createGet(
-                    getEdgeUrl("card-metadata"),
-                    options.copy(stripeAccount = null),
-                    mapOf("key" to options.apiKey, "bin_prefix" to bin.value)
-                ),
-                CardMetadataJsonParser(bin)
-            ) {
-                // no-op
-            }
-        }.onFailure {
+    ): Result<CardMetadata> {
+        return fetchStripeModelResult(
+            apiRequestFactory.createGet(
+                getEdgeUrl("card-metadata"),
+                options.copy(stripeAccount = null),
+                mapOf("key" to options.apiKey, "bin_prefix" to bin.value)
+            ),
+            CardMetadataJsonParser(bin)
+        ).onFailure {
             fireAnalyticsRequest(PaymentAnalyticsEvent.CardMetadataLoadFailure)
-        }.getOrNull()
+        }
     }
 
     /**

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1434,14 +1434,6 @@ class StripeApiRepository @JvmOverloads internal constructor(
         }
     }
 
-    private suspend fun <ModelType : StripeModel> fetchStripeModel(
-        apiRequest: ApiRequest,
-        jsonParser: ModelJsonParser<ModelType>,
-        onResponse: () -> Unit
-    ): ModelType? {
-        return jsonParser.parse(makeApiRequest(apiRequest, onResponse).responseJson())
-    }
-
     private suspend fun <ModelType : StripeModel> fetchStripeModelResult(
         apiRequest: ApiRequest,
         jsonParser: ModelJsonParser<ModelType>,

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -862,12 +862,12 @@ class StripeApiRepository @JvmOverloads internal constructor(
         options: ApiRequest.Options
     ): Result<CardMetadata> {
         return fetchStripeModelResult(
-            apiRequestFactory.createGet(
-                getEdgeUrl("card-metadata"),
-                options.copy(stripeAccount = null),
-                mapOf("key" to options.apiKey, "bin_prefix" to bin.value)
+            apiRequest = apiRequestFactory.createGet(
+                url = getEdgeUrl("card-metadata"),
+                options = options.copy(stripeAccount = null),
+                params = mapOf("key" to options.apiKey, "bin_prefix" to bin.value),
             ),
-            CardMetadataJsonParser(bin)
+            jsonParser = CardMetadataJsonParser(bin),
         ).onFailure {
             fireAnalyticsRequest(PaymentAnalyticsEvent.CardMetadataLoadFailure)
         }

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -217,7 +217,7 @@ interface StripeRepository {
     suspend fun getCardMetadata(
         bin: Bin,
         options: ApiRequest.Options
-    ): CardMetadata?
+    ): Result<CardMetadata>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun start3ds2Auth(

--- a/payments-core/src/test/java/com/stripe/android/cards/RemoteCardAccountRangeSourceTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/cards/RemoteCardAccountRangeSourceTest.kt
@@ -109,6 +109,7 @@ internal class RemoteCardAccountRangeSourceTest {
             )
         )
 
+        remoteCardAccountRangeSource.getAccountRange(CardNumberFixtures.VISA)
         verify(cardAccountRangeStore, never()).save(any(), any())
     }
 
@@ -187,7 +188,7 @@ internal class RemoteCardAccountRangeSourceTest {
         override suspend fun getCardMetadata(
             bin: Bin,
             options: ApiRequest.Options
-        ) = cardMetadata
+        ): Result<CardMetadata> = Result.success(cardMetadata)
     }
 
     private companion object {

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -1127,8 +1127,7 @@ internal class StripeApiRepositoryTest {
             stripeApiRepository.getCardMetadata(
                 BinFixtures.VISA,
                 ApiRequest.Options(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
-            )
-        requireNotNull(cardMetadata)
+            ).getOrThrow()
         assertThat(cardMetadata.bin)
             .isEqualTo(BinFixtures.VISA)
         assertThat(cardMetadata.accountRanges)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes some odd behavior that affects `stripe.retrievePossibleBrands()`.

In `RemoteCardAccountRangeSource`, we stored _any_ response from the backend in our persistent storage. This is problematic for two reasons: Firstly, the backend returns empty ranges for (seemingly?) valid BINs. Secondly, we don’t filter out invalid responses due to network or parsing errors. In both cases, we’d store an empty response on the device, which we’d continue to serve to callers into eternity, as we never clear the local storage. Now, we will fall back to the static ranges if the response from the local or remote data sources are empty.

Also, the conditions under which we called `onCardMetadataMissingRange()` was wrong, leading us to send way too many events.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Correctly working card brand functionality in preparation for CBC.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

[FIXED] Fixed an issue where `Stripe.retrievePossibleBrands()` returned incorrect results.
