### PR TITLE
Animate items in payment options carousel

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsItem.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsItem.kt
@@ -61,6 +61,12 @@ internal sealed class PaymentOptionsItem {
         SavedPaymentMethod,
         AddCard,
         GooglePay,
-        Link
+        Link,
     }
 }
+
+internal val PaymentOptionsItem.key: String
+    get() {
+        val paymentMethodId = (this as? PaymentOptionsItem.SavedPaymentMethod)?.paymentMethod?.id
+        return listOfNotNull(viewType, paymentMethodId).joinToString("-")
+    }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsUI.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.ui
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -27,6 +28,7 @@ import com.stripe.android.paymentsheet.PaymentOptionUi
 import com.stripe.android.paymentsheet.PaymentOptionsItem
 import com.stripe.android.paymentsheet.PaymentOptionsState
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.key
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.toPaymentSelection
 import com.stripe.android.uicore.DefaultStripeTheme
@@ -34,7 +36,7 @@ import com.stripe.android.uicore.shouldUseDarkDynamicColor
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.R as StripeR
 
-@OptIn(ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalFoundationApi::class)
 @Composable
 internal fun PaymentOptions(
     state: PaymentOptionsState,
@@ -54,7 +56,10 @@ internal fun PaymentOptions(
             userScrollEnabled = !isProcessing,
             contentPadding = PaddingValues(horizontal = 17.dp),
         ) {
-            items(state.items) { item ->
+            items(
+                items = state.items,
+                key = { it.key },
+            ) { item ->
                 val isEnabled = !isProcessing && (!isEditing || item.isEnabledDuringEditing)
                 val isSelected = item == state.selectedItem && !isEditing
 
@@ -70,6 +75,7 @@ internal fun PaymentOptions(
                     modifier = Modifier
                         .semantics { testTagsAsResourceId = true }
                         .testTag(item.viewType.name)
+                        .animateItemPlacement(),
                 )
             }
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds item animations in the payment options carousel. They will primarily run when the user removes a payment method.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

UX polish.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screen recordings

### Before

https://github.com/stripe/stripe-android/assets/110940675/6e635677-8db5-4c70-b1fe-8ad57fb68a1d

### After

https://github.com/stripe/stripe-android/assets/110940675/508401dc-546d-4bfa-9366-25984bac0a70

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
