### PR TITLE
Fix lookup when link inline is used with defaults.

### DIFF
--- a/link/src/main/java/com/stripe/android/link/ui/inline/Debouncer.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/Debouncer.kt
@@ -8,9 +8,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
-internal class Debouncer(
-    private val initialEmail: String?
-) {
+internal class Debouncer {
     /**
      * Holds a Job that looks up the email after a delay, so that we can cancel it if the user
      * continues typing.
@@ -25,16 +23,6 @@ internal class Debouncer(
     ) {
         coroutineScope.launch {
             emailFlow.collect { email ->
-                // The first emitted value is the one provided in the constructor arguments, and
-                // shouldn't trigger a lookup.
-                if (email == initialEmail && lookupJob == null) {
-                    // If it's a valid email, collect phone number
-                    if (email != null) {
-                        onStateChanged(SignUpState.InputtingPhoneOrName)
-                    }
-                    return@collect
-                }
-
                 lookupJob?.cancel()
 
                 if (email != null) {

--- a/link/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
@@ -95,7 +95,7 @@ internal class InlineSignupViewModel @Inject constructor(
 
     private var hasExpanded = false
 
-    private var debouncer = Debouncer(prefilledEmail)
+    private var debouncer = Debouncer()
 
     fun toggleExpanded() {
         _viewState.update { oldState ->
@@ -119,7 +119,7 @@ internal class InlineSignupViewModel @Inject constructor(
                     oldState.copy(
                         signUpState = signUpState,
                         userInput = when (signUpState) {
-                            SignUpState.InputtingEmail, SignUpState.VerifyingEmail -> null
+                            SignUpState.InputtingEmail, SignUpState.VerifyingEmail -> oldState.userInput
                             SignUpState.InputtingPhoneOrName ->
                                 mapToUserInput(
                                     email = consumerEmail.value,
@@ -183,7 +183,6 @@ internal class InlineSignupViewModel @Inject constructor(
                 } else {
                     _viewState.update { oldState ->
                         oldState.copy(
-                            userInput = null,
                             signUpState = SignUpState.InputtingPhoneOrName,
                             apiFailed = false
                         )
@@ -194,7 +193,6 @@ internal class InlineSignupViewModel @Inject constructor(
             onFailure = {
                 _viewState.update { oldState ->
                     oldState.copy(
-                        userInput = null,
                         signUpState = SignUpState.InputtingEmail,
                         apiFailed = it is APIConnectionException
                     )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When pre-filling the link inline flow from paymentsheet configuration, you couldn't actually complete the flow with a new account unless you removed your phone number and re-added it. We also wouldn't do a lookup for default emails, so it would look like a new account creation, even when it wasn't.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
link redesign
