### PR TITLE
Fix Google Pay button padding issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+### PaymentSheet
+* [FIXED][6992](https://github.com/stripe/stripe-android/pull/6992) Fixed an issue where incorrect padding was set on the Google Pay button.
+
 ## 20.27.0 - 2023-07-10
 
 ### PaymentSheet

--- a/paymentsheet/res/layout/stripe_google_pay_button.xml
+++ b/paymentsheet/res/layout/stripe_google_pay_button.xml
@@ -4,16 +4,14 @@
         android:id="@+id/google_pay_button_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/stripe_paymentsheet_googlepay_button_margin_horizontal"
         android:clipToPadding="false"
         android:paddingTop="2sp"
         android:contentDescription="@string/stripe_google_pay">
+
         <com.stripe.android.paymentsheet.ui.PrimaryButton
             android:id="@+id/google_pay_primary_button"
             android:layout_width="match_parent"
             android:layout_height="@dimen/stripe_paymentsheet_googlepay_button_height"
-            android:layout_marginTop="@dimen/stripe_paymentsheet_googlepay_button_margin"
-            android:layout_marginHorizontal="@dimen/stripe_paymentsheet_googlepay_button_margin"
             android:visibility="invisible" />
 
         <com.google.android.gms.wallet.button.PayButton
@@ -22,4 +20,3 @@
             android:layout_height="wrap_content" />
     </RelativeLayout>
 </merge>
-

--- a/paymentsheet/res/values/dimens.xml
+++ b/paymentsheet/res/values/dimens.xml
@@ -16,8 +16,6 @@
     <dimen name="stripe_paymentsheet_primary_button_height">48dp</dimen>
     <dimen name="stripe_paymentsheet_googlepay_button_height">48dp</dimen>
     <dimen name="stripe_paymentsheet_googlepay_button_margin">16dp</dimen>
-    <dimen name="stripe_paymentsheet_googlepay_button_margin_horizontal">-16dp</dimen>
-    <dimen name="stripe_paymentsheet_googlepay_button_bottom_padding">14dp</dimen>
     <dimen name="stripe_paymentsheet_card_elevation">2dp</dimen>
     <dimen name="stripe_paymentsheet_paymentoption_card_height">25dp</dimen>
     <dimen name="stripe_paymentsheet_paymentoption_card_width">35dp</dimen>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/GooglePayButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/GooglePayButton.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
-import androidx.core.view.updatePadding
 import com.google.android.gms.wallet.button.ButtonConstants
 import com.google.android.gms.wallet.button.ButtonOptions
 import com.stripe.android.GooglePayJsonFactory
@@ -153,10 +152,6 @@ internal class GooglePayButton @JvmOverloads constructor(
     }
 
     private fun onStartProcessing() {
-        val padding = context.resources.getDimensionPixelSize(
-            R.dimen.stripe_paymentsheet_googlepay_button_bottom_padding
-        )
-        viewBinding.googlePayButtonLayout.updatePadding(bottom = padding)
         viewBinding.googlePayPrimaryButton.isVisible = true
         viewBinding.googlePayPaymentButton.isVisible = false
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -163,6 +164,8 @@ internal fun Wallet(
         }
 
         state.link?.let { link ->
+            Spacer(modifier = Modifier.requiredHeight(8.dp))
+
             LinkButton(
                 email = link.email,
                 enabled = state.buttonsEnabled,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -164,7 +164,9 @@ internal fun Wallet(
         }
 
         state.link?.let { link ->
-            Spacer(modifier = Modifier.requiredHeight(8.dp))
+            if (state.googlePay != null) {
+                Spacer(modifier = Modifier.requiredHeight(8.dp))
+            }
 
             LinkButton(
                 email = link.email,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where incorrect padding was applied to the Google Pay button.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Resolves https://github.com/stripe/stripe-android/issues/6940

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

[Fixed] Fixed an issue where incorrect padding was set on the Google Pay button.
