### PR TITLE
Implement referrer_pane on pane launched events

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsEvent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsEvent.kt
@@ -23,7 +23,7 @@ internal sealed class FinancialConnectionsEvent(
     ) : FinancialConnectionsEvent(
         "pane.launched",
         mapOf(
-            "referrer" to referrer?.value,
+            "referrer_pane" to referrer?.value,
             "pane" to pane.value,
         ).filterNotNullValues()
     )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsEvent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsEvent.kt
@@ -18,10 +18,12 @@ internal sealed class FinancialConnectionsEvent(
     val eventName = if (includePrefix) "$EVENT_PREFIX.$name" else name
 
     class PaneLaunched(
-        pane: Pane
+        pane: Pane,
+        referrer: Pane?
     ) : FinancialConnectionsEvent(
         "pane.launched",
         mapOf(
+            "referrer" to referrer?.value,
             "pane" to pane.value,
         ).filterNotNullValues()
     )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
@@ -25,7 +25,8 @@ import com.stripe.android.financialconnections.features.consent.FinancialConnect
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.model.PartnerAccount
 import com.stripe.android.financialconnections.model.PartnerAccountsList
-import com.stripe.android.financialconnections.navigation.Destination
+import com.stripe.android.financialconnections.navigation.Destination.ManualEntry
+import com.stripe.android.financialconnections.navigation.Destination.Reset
 import com.stripe.android.financialconnections.navigation.NavigationManager
 import com.stripe.android.financialconnections.navigation.destination
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
@@ -100,7 +101,7 @@ internal class AccountPickerViewModel @Inject constructor(
                 businessName = manifest.businessName,
                 stripeDirect = manifest.isStripeDirect ?: false
             ).also {
-                eventTracker.track(PaneLoaded(Pane.ACCOUNT_PICKER))
+                eventTracker.track(PaneLoaded(PANE))
             }
         }.execute { copy(payload = it) }
     }
@@ -139,7 +140,7 @@ internal class AccountPickerViewModel @Inject constructor(
             onFail = {
                 eventTracker.logError(
                     logger = logger,
-                    pane = Pane.ACCOUNT_PICKER,
+                    pane = PANE,
                     extraMessage = "Error retrieving accounts",
                     error = it
                 )
@@ -150,7 +151,7 @@ internal class AccountPickerViewModel @Inject constructor(
             onFail = {
                 eventTracker.logError(
                     logger = logger,
-                    pane = Pane.ACCOUNT_PICKER,
+                    pane = PANE,
                     extraMessage = "Error selecting accounts",
                     error = it
                 )
@@ -211,7 +212,7 @@ internal class AccountPickerViewModel @Inject constructor(
 
     fun onSubmit() {
         viewModelScope.launch {
-            eventTracker.track(ClickLinkAccounts(Pane.ACCOUNT_PICKER))
+            eventTracker.track(ClickLinkAccounts(PANE))
         }
         withState { state ->
             state.payload()?.let {
@@ -233,7 +234,7 @@ internal class AccountPickerViewModel @Inject constructor(
                 sessionId = requireNotNull(manifest.activeAuthSession).id,
                 updateLocalCache = updateLocalCache
             )
-            navigationManager.tryNavigateTo(accountsList.nextPane.destination())
+            navigationManager.tryNavigateTo(accountsList.nextPane.destination(referrer = PANE))
             accountsList
         }.execute {
             copy(selectAccounts = it)
@@ -241,10 +242,10 @@ internal class AccountPickerViewModel @Inject constructor(
     }
 
     fun selectAnotherBank() =
-        navigationManager.tryNavigateTo(Destination.Reset())
+        navigationManager.tryNavigateTo(Reset(referrer = PANE))
 
     fun onEnterDetailsManually() =
-        navigationManager.tryNavigateTo(Destination.ManualEntry())
+        navigationManager.tryNavigateTo(ManualEntry(referrer = PANE))
 
     fun onLoadAccountsAgain() {
         setState { copy(canRetry = false) }
@@ -293,6 +294,8 @@ internal class AccountPickerViewModel @Inject constructor(
                 .build()
                 .viewModel
         }
+
+        private val PANE = Pane.ACCOUNT_PICKER
     }
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
@@ -18,7 +18,8 @@ import com.stripe.android.financialconnections.domain.PollAttachPaymentAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.model.LinkAccountSessionPaymentAccount
 import com.stripe.android.financialconnections.model.PaymentAccountParams
-import com.stripe.android.financialconnections.navigation.Destination
+import com.stripe.android.financialconnections.navigation.Destination.ManualEntry
+import com.stripe.android.financialconnections.navigation.Destination.Reset
 import com.stripe.android.financialconnections.navigation.NavigationManager
 import com.stripe.android.financialconnections.navigation.destination
 import com.stripe.android.financialconnections.repository.SaveToLinkWithStripeSucceededRepository
@@ -66,7 +67,7 @@ internal class AttachPaymentViewModel @Inject constructor(
                     params = PaymentAccountParams.LinkedAccount(requireNotNull(id))
                 ).also {
                     val nextPane = it.nextPane ?: Pane.SUCCESS
-                    navigationManager.tryNavigateTo(nextPane.destination())
+                    navigationManager.tryNavigateTo(nextPane.destination(referrer = PANE))
                 }
             }
             eventTracker.track(PollAttachPaymentsSucceeded(authSession.id, millis))
@@ -80,13 +81,13 @@ internal class AttachPaymentViewModel @Inject constructor(
             onFail = {
                 eventTracker.logError(
                     logger = logger,
-                    pane = Pane.ATTACH_LINKED_PAYMENT_ACCOUNT,
+                    pane = PANE,
                     extraMessage = "Error retrieving accounts to attach payment",
                     error = it
                 )
             },
             onSuccess = {
-                eventTracker.track(PaneLoaded(Pane.ATTACH_LINKED_PAYMENT_ACCOUNT))
+                eventTracker.track(PaneLoaded(PANE))
             }
         )
         onAsync(
@@ -98,7 +99,7 @@ internal class AttachPaymentViewModel @Inject constructor(
                 runCatching { saveToLinkWithStripeSucceeded.set(false) }
                 eventTracker.logError(
                     logger = logger,
-                    pane = Pane.ATTACH_LINKED_PAYMENT_ACCOUNT,
+                    pane = PANE,
                     extraMessage = "Error Attaching payment account",
                     error = it
                 )
@@ -107,10 +108,10 @@ internal class AttachPaymentViewModel @Inject constructor(
     }
 
     fun onEnterDetailsManually() =
-        navigationManager.tryNavigateTo(Destination.ManualEntry())
+        navigationManager.tryNavigateTo(ManualEntry(referrer = PANE))
 
     fun onSelectAnotherBank() =
-        navigationManager.tryNavigateTo(Destination.Reset())
+        navigationManager.tryNavigateTo(Reset(referrer = PANE))
 
     companion object : MavericksViewModelFactory<AttachPaymentViewModel, AttachPaymentState> {
 
@@ -126,6 +127,8 @@ internal class AttachPaymentViewModel @Inject constructor(
                 .build()
                 .viewModel
         }
+
+        private val PANE = Pane.ATTACH_LINKED_PAYMENT_ACCOUNT
     }
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentViewModel.kt
@@ -17,7 +17,7 @@ import com.stripe.android.financialconnections.features.consent.ConsentState.Vie
 import com.stripe.android.financialconnections.features.consent.ConsentState.ViewEffect.OpenUrl
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
-import com.stripe.android.financialconnections.navigation.Destination
+import com.stripe.android.financialconnections.navigation.Destination.ManualEntry
 import com.stripe.android.financialconnections.navigation.NavigationManager
 import com.stripe.android.financialconnections.navigation.destination
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
@@ -71,7 +71,7 @@ internal class ConsentViewModel @Inject constructor(
         suspend {
             eventTracker.track(ConsentAgree)
             val updatedManifest: FinancialConnectionsSessionManifest = acceptConsent()
-            navigationManager.tryNavigateTo(updatedManifest.nextPane.destination())
+            navigationManager.tryNavigateTo(updatedManifest.nextPane.destination(referrer = Pane.CONSENT))
         }.execute { copy(acceptConsent = it) }
     }
 
@@ -98,7 +98,7 @@ internal class ConsentViewModel @Inject constructor(
                     }
 
                     ConsentClickableText.MANUAL_ENTRY -> {
-                        navigationManager.tryNavigateTo(Destination.ManualEntry())
+                        navigationManager.tryNavigateTo(ManualEntry(referrer = Pane.CONSENT))
                     }
 
                     ConsentClickableText.LEGAL_DETAILS -> {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModel.kt
@@ -26,7 +26,8 @@ import com.stripe.android.financialconnections.features.institutionpicker.Instit
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.model.InstitutionResponse
-import com.stripe.android.financialconnections.navigation.Destination
+import com.stripe.android.financialconnections.navigation.Destination.ManualEntry
+import com.stripe.android.financialconnections.navigation.Destination.PartnerAuth
 import com.stripe.android.financialconnections.navigation.NavigationManager
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
 import com.stripe.android.financialconnections.utils.ConflatedJob
@@ -171,7 +172,7 @@ internal class InstitutionPickerViewModel @Inject constructor(
                 )
             }
             // navigate to next step
-            navigationManager.tryNavigateTo(Destination.PartnerAuth())
+            navigationManager.tryNavigateTo(PartnerAuth(referrer = Pane.INSTITUTION_PICKER))
         }.execute { this }
     }
 
@@ -200,7 +201,7 @@ internal class InstitutionPickerViewModel @Inject constructor(
     }
 
     fun onManualEntryClick() {
-        navigationManager.tryNavigateTo(Destination.ManualEntry())
+        navigationManager.tryNavigateTo(ManualEntry(referrer = Pane.INSTITUTION_PICKER))
     }
 
     fun onScrollChanged() {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
@@ -88,7 +88,7 @@ internal class LinkAccountPickerViewModel @Inject constructor(
             onFail = { error ->
                 logger.error("Error fetching payload", error)
                 eventTracker.track(Error(PANE, error))
-                navigationManager.tryNavigateTo(Destination.InstitutionPicker())
+                navigationManager.tryNavigateTo(Destination.InstitutionPicker(referrer = PANE))
             },
         )
         onAsync(
@@ -108,7 +108,7 @@ internal class LinkAccountPickerViewModel @Inject constructor(
     fun onNewBankAccountClick() = viewModelScope.launch {
         eventTracker.track(Click("click.new_account", PANE))
         val nextPane = awaitState().payload()?.nextPaneOnNewAccount ?: Pane.INSTITUTION_PICKER
-        navigationManager.tryNavigateTo(nextPane.destination())
+        navigationManager.tryNavigateTo(nextPane.destination(referrer = PANE))
     }
 
     fun onSelectAccountClick() = suspend {
@@ -143,7 +143,7 @@ internal class LinkAccountPickerViewModel @Inject constructor(
             else -> Unit
         }
         nextPane?.let {
-            navigationManager.tryNavigateTo(it.destination())
+            navigationManager.tryNavigateTo(it.destination(referrer = PANE))
         }
         Unit
     }.execute { copy(selectNetworkedAccountAsync = it) }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationViewModel.kt
@@ -29,6 +29,7 @@ import com.stripe.android.financialconnections.domain.UpdateLocalManifest
 import com.stripe.android.financialconnections.features.linkstepupverification.LinkStepUpVerificationState.Payload
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.navigation.Destination
+import com.stripe.android.financialconnections.navigation.Destination.InstitutionPicker
 import com.stripe.android.financialconnections.navigation.NavigationManager
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
 import com.stripe.android.model.ConsumerSession
@@ -72,7 +73,7 @@ internal class LinkStepUpVerificationViewModel @Inject constructor(
                 verificationType = VerificationType.EMAIL,
                 onConsumerNotFound = {
                     eventTracker.track(VerificationStepUpError(PANE, ConsumerNotFoundError))
-                    navigationManager.tryNavigateTo(Destination.InstitutionPicker())
+                    navigationManager.tryNavigateTo(InstitutionPicker(referrer = PANE))
                 },
                 onLookupError = { error ->
                     eventTracker.track(VerificationStepUpError(PANE, LookupConsumerSession))
@@ -110,7 +111,7 @@ internal class LinkStepUpVerificationViewModel @Inject constructor(
             },
             onFail = { error ->
                 logger.error("Error fetching payload", error)
-                eventTracker.track(Error(Pane.NETWORKING_LINK_VERIFICATION, error))
+                eventTracker.track(Error(PANE, error))
             },
         )
     }
@@ -149,7 +150,7 @@ internal class LinkStepUpVerificationViewModel @Inject constructor(
         updateLocalManifest { it.copy(activeInstitution = activeInstitution.data.firstOrNull()) }
         // Updates cached accounts with the one selected.
         updateCachedAccounts { listOf(selectedAccount) }
-        navigationManager.tryNavigateTo(Destination.Success())
+        navigationManager.tryNavigateTo(Destination.Success(referrer = PANE))
     }.execute { copy(confirmVerification = it) }
 
     fun onClickableTextClick(text: String) {
@@ -171,7 +172,7 @@ internal class LinkStepUpVerificationViewModel @Inject constructor(
                 verificationType = VerificationType.EMAIL,
                 onConsumerNotFound = {
                     eventTracker.track(VerificationStepUpError(PANE, ConsumerNotFoundError))
-                    navigationManager.tryNavigateTo(Destination.InstitutionPicker())
+                    navigationManager.tryNavigateTo(InstitutionPicker(referrer = PANE))
                 },
                 onLookupError = { error ->
                     eventTracker.track(VerificationStepUpError(PANE, LookupConsumerSession))

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
@@ -99,7 +99,7 @@ internal class ManualEntryViewModel @Inject constructor(
             ManualEntryState::linkPaymentAccount,
             onFail = {
                 logger.error("Error linking payment account", it)
-                eventTracker.track(FinancialConnectionsEvent.Error(Pane.MANUAL_ENTRY, it))
+                eventTracker.track(FinancialConnectionsEvent.Error(PANE, it))
             },
         )
     }
@@ -140,7 +140,7 @@ internal class ManualEntryViewModel @Inject constructor(
                     last4 = state.account.takeLast(4)
                 )
                 val destination = (it.nextPane ?: Pane.MANUAL_ENTRY_SUCCESS).destination
-                navigationManager.tryNavigateTo(destination(args))
+                navigationManager.tryNavigateTo(destination(PANE, args))
             }
         }.execute { copy(linkPaymentAccount = it) }
     }
@@ -160,6 +160,8 @@ internal class ManualEntryViewModel @Inject constructor(
                 .build()
                 .viewModel
         }
+
+        private val PANE = Pane.MANUAL_ENTRY
     }
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModel.kt
@@ -64,7 +64,7 @@ internal class NetworkingLinkLoginWarmupViewModel @Inject constructor(
 
     fun onContinueClick() = viewModelScope.launch {
         eventTracker.track(Click("click.continue", PANE))
-        navigationManager.tryNavigateTo(Destination.NetworkingLinkVerification())
+        navigationManager.tryNavigateTo(Destination.NetworkingLinkVerification(referrer = PANE))
     }
 
     fun onClickableTextClick(text: String) = when (text) {
@@ -80,7 +80,7 @@ internal class NetworkingLinkLoginWarmupViewModel @Inject constructor(
                     // skipping disables networking, which means
                     // we don't want the user to navigate back to
                     // the warm-up pane.
-                    it.nextPane.destination(),
+                    it.nextPane.destination(referrer = PANE),
                     popUpToCurrent = true,
                     inclusive = true
                 )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
@@ -24,7 +24,8 @@ import com.stripe.android.financialconnections.features.networkinglinksignup.Net
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.model.NetworkingLinkSignupPane
-import com.stripe.android.financialconnections.navigation.Destination
+import com.stripe.android.financialconnections.navigation.Destination.NetworkingSaveToLinkVerification
+import com.stripe.android.financialconnections.navigation.Destination.Success
 import com.stripe.android.financialconnections.navigation.NavigationManager
 import com.stripe.android.financialconnections.repository.SaveToLinkWithStripeSucceededRepository
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
@@ -109,7 +110,7 @@ internal class NetworkingLinkSignupViewModel @Inject constructor(
                 saveToLinkWithStripeSucceeded.set(false)
                 logger.error("Error saving account to Link", error)
                 eventTracker.track(Error(PANE, error))
-                navigationManager.tryNavigateTo(Destination.Success())
+                navigationManager.tryNavigateTo(Success(referrer = PANE))
             },
         )
         onAsync(
@@ -117,7 +118,7 @@ internal class NetworkingLinkSignupViewModel @Inject constructor(
             onSuccess = { consumerSession ->
                 if (consumerSession.exists) {
                     eventTracker.track(NetworkingReturningConsumer(PANE))
-                    navigationManager.tryNavigateTo(Destination.NetworkingSaveToLinkVerification())
+                    navigationManager.tryNavigateTo(NetworkingSaveToLinkVerification(referrer = PANE))
                 } else {
                     eventTracker.track(NetworkingNewConsumer(PANE))
                 }
@@ -159,7 +160,7 @@ internal class NetworkingLinkSignupViewModel @Inject constructor(
 
     fun onSkipClick() = viewModelScope.launch {
         eventTracker.track(Click(eventName = "click.not_now", pane = PANE))
-        navigationManager.tryNavigateTo(Destination.Success())
+        navigationManager.tryNavigateTo(Success(referrer = PANE))
     }
 
     fun onSaveAccount() {
@@ -175,7 +176,7 @@ internal class NetworkingLinkSignupViewModel @Inject constructor(
                 phoneNumber = phoneController.getE164PhoneNumber(state.validPhone!!),
                 selectedAccounts = selectedAccounts.map { it.id },
             ).also {
-                navigationManager.tryNavigateTo(Destination.Success())
+                navigationManager.tryNavigateTo(Success(referrer = PANE))
             }
         }.execute { copy(saveAccountToLink = it) }
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModel.kt
@@ -29,6 +29,7 @@ import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.model.NetworkedAccountsList
 import com.stripe.android.financialconnections.navigation.Destination
+import com.stripe.android.financialconnections.navigation.Destination.InstitutionPicker
 import com.stripe.android.financialconnections.navigation.NavigationManager
 import com.stripe.android.financialconnections.navigation.destination
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
@@ -66,7 +67,7 @@ internal class NetworkingLinkVerificationViewModel @Inject constructor(
                         verificationType = VerificationType.SMS,
                         onConsumerNotFound = {
                             analyticsTracker.track(VerificationError(PANE, ConsumerNotFoundError))
-                            navigationManager.tryNavigateTo(Destination.InstitutionPicker())
+                            navigationManager.tryNavigateTo(InstitutionPicker(referrer = PANE))
                         },
                         onLookupError = { error ->
                             analyticsTracker.track(VerificationError(PANE, LookupConsumerSession))
@@ -135,7 +136,7 @@ internal class NetworkingLinkVerificationViewModel @Inject constructor(
         logger.error("Error fetching networked accounts", error)
         analyticsTracker.track(Error(PANE, error))
         analyticsTracker.track(VerificationError(PANE, NetworkedAccountsRetrieveMethodError))
-        navigationManager.tryNavigateTo(updatedManifest.nextPane.destination())
+        navigationManager.tryNavigateTo(updatedManifest.nextPane.destination(referrer = PANE))
     }
 
     private suspend fun onNetworkedAccountsSuccess(
@@ -145,11 +146,11 @@ internal class NetworkingLinkVerificationViewModel @Inject constructor(
         if (accounts.data.isEmpty()) {
             // Networked user has no accounts
             analyticsTracker.track(VerificationSuccessNoAccounts(PANE))
-            navigationManager.tryNavigateTo(updatedManifest.nextPane.destination())
+            navigationManager.tryNavigateTo(updatedManifest.nextPane.destination(referrer = PANE))
         } else {
             // Networked user has linked accounts
             analyticsTracker.track(VerificationSuccess(PANE))
-            navigationManager.tryNavigateTo(Destination.LinkAccountPicker())
+            navigationManager.tryNavigateTo(Destination.LinkAccountPicker(referrer = PANE))
         }
     }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModel.kt
@@ -22,7 +22,7 @@ import com.stripe.android.financialconnections.domain.MarkLinkVerified
 import com.stripe.android.financialconnections.domain.SaveAccountToLink
 import com.stripe.android.financialconnections.domain.StartVerification
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
-import com.stripe.android.financialconnections.navigation.Destination
+import com.stripe.android.financialconnections.navigation.Destination.Success
 import com.stripe.android.financialconnections.navigation.NavigationManager
 import com.stripe.android.financialconnections.repository.SaveToLinkWithStripeSucceededRepository
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
@@ -86,14 +86,14 @@ internal class NetworkingSaveToLinkVerificationViewModel @Inject constructor(
             NetworkingSaveToLinkVerificationState::confirmVerification,
             onSuccess = {
                 saveToLinkWithStripeSucceeded.set(true)
-                navigationManager.tryNavigateTo(Destination.Success())
+                navigationManager.tryNavigateTo(Success(referrer = PANE))
             },
             onFail = { error ->
                 logger.error("Error confirming verification", error)
                 eventTracker.track(Error(PANE, error))
                 if (error !is OTPError) {
                     saveToLinkWithStripeSucceeded.set(false)
-                    navigationManager.tryNavigateTo(Destination.Success())
+                    navigationManager.tryNavigateTo(Success(referrer = PANE))
                 }
             },
         )
@@ -123,7 +123,7 @@ internal class NetworkingSaveToLinkVerificationViewModel @Inject constructor(
     }.execute { copy(confirmVerification = it) }
 
     fun onSkipClick() {
-        navigationManager.tryNavigateTo(Destination.Success())
+        navigationManager.tryNavigateTo(Success(referrer = PANE))
     }
 
     companion object :

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/reset/ResetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/reset/ResetViewModel.kt
@@ -33,9 +33,9 @@ internal class ResetViewModel @Inject constructor(
         suspend {
             val updatedManifest = linkMoreAccounts()
             nativeAuthFlowCoordinator().emit(ClearPartnerWebAuth)
-            eventTracker.track(PaneLoaded(Pane.RESET))
+            eventTracker.track(PaneLoaded(PANE))
             navigationManager.tryNavigateTo(
-                updatedManifest.nextPane.destination(),
+                updatedManifest.nextPane.destination(referrer = PANE),
                 popUpToCurrent = true,
                 inclusive = true
             )
@@ -47,7 +47,7 @@ internal class ResetViewModel @Inject constructor(
             ResetState::payload,
             onFail = { error ->
                 logger.error("Error linking more accounts", error)
-                eventTracker.track(Error(Pane.RESET, error))
+                eventTracker.track(Error(PANE, error))
             },
         )
     }
@@ -66,6 +66,8 @@ internal class ResetViewModel @Inject constructor(
                 .build()
                 .viewModel
         }
+
+        internal val PANE = Pane.RESET
     }
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/Destination.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/Destination.kt
@@ -62,13 +62,25 @@ internal sealed class Destination(
      *
      * @param args a map of arguments to be appended to the route
      */
-    abstract operator fun invoke(args: Map<String, String?> = emptyMap()): String
+    abstract operator fun invoke(
+        referrer: Pane?,
+        args: Map<String, String?> = emptyMap()
+    ): String
 
     sealed class NoArgumentsDestination(
         route: String,
         composable: @Composable (NavBackStackEntry) -> Unit
-    ) : Destination(route, emptyList(), composable) {
-        override operator fun invoke(args: Map<String, String?>): String = route
+    ) : Destination(
+        route = route,
+        paramKeys = listOf(KEY_REFERRER),
+        screenBuilder = composable
+    ) {
+        override operator fun invoke(
+            referrer: Pane?,
+            args: Map<String, String?>
+        ): String = route.appendParamValues(
+            KEY_REFERRER to referrer?.value
+        )
     }
 
     object InstitutionPicker : NoArgumentsDestination(
@@ -167,13 +179,18 @@ internal sealed class Destination(
         fun last4(backStackEntry: NavBackStackEntry): String? =
             backStackEntry.arguments?.getString(KEY_LAST4)
 
-        override fun invoke(args: Map<String, String?>): String = route.appendParamValues(
+        override fun invoke(
+            referrer: Pane?,
+            args: Map<String, String?>
+        ): String = route.appendParamValues(
+            KEY_REFERRER to referrer?.value,
             KEY_MICRODEPOSITS to args[KEY_MICRODEPOSITS],
             KEY_LAST4 to args[KEY_LAST4]
         )
     }
 
     companion object {
+        const val KEY_REFERRER = "referrer"
         const val KEY_MICRODEPOSITS = "microdeposits"
         const val KEY_LAST4 = "last4"
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/Destination.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/Destination.kt
@@ -50,7 +50,10 @@ internal sealed class Destination(
         var paneLaunchedTriggered by rememberSaveable { mutableStateOf(false) }
         if (!paneLaunchedTriggered) {
             LaunchedEffect(Unit) {
-                viewModel.onPaneLaunched(navBackStackEntry.destination.pane)
+                viewModel.onPaneLaunched(
+                    referrer = referrer(navBackStackEntry),
+                    pane = navBackStackEntry.destination.pane
+                )
                 paneLaunchedTriggered = true
             }
         }
@@ -190,6 +193,10 @@ internal sealed class Destination(
     }
 
     companion object {
+        private fun referrer(entry: NavBackStackEntry): Pane? = entry.arguments
+            ?.getString(KEY_REFERRER)
+            ?.let { value -> Pane.values().firstOrNull { it.value == value } }
+
         const val KEY_REFERRER = "referrer"
         const val KEY_MICRODEPOSITS = "microdeposits"
         const val KEY_LAST4 = "last4"

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -15,11 +15,11 @@ import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
-import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.AppBackgrounded
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.ClickNavBarBack
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.ClickNavBarClose
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.Complete
+import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.PaneLaunched
 import com.stripe.android.financialconnections.di.APPLICATION_ID
 import com.stripe.android.financialconnections.di.DaggerFinancialConnectionsSheetNativeComponent
 import com.stripe.android.financialconnections.di.FinancialConnectionsSheetNativeComponent
@@ -303,10 +303,13 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
         }
     }
 
-    fun onPaneLaunched(pane: Pane) {
+    fun onPaneLaunched(pane: Pane, referrer: Pane?) {
         viewModelScope.launch {
             eventTracker.track(
-                FinancialConnectionsEvent.PaneLaunched(pane)
+                PaneLaunched(
+                    referrer = referrer,
+                    pane = pane
+                )
             )
         }
     }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModelTest.kt
@@ -24,7 +24,7 @@ import com.stripe.android.financialconnections.model.NetworkedAccountsList
 import com.stripe.android.financialconnections.model.PartnerAccount
 import com.stripe.android.financialconnections.model.ReturningNetworkingUserAccountPicker
 import com.stripe.android.financialconnections.model.TextUpdate
-import com.stripe.android.financialconnections.navigation.Destination
+import com.stripe.android.financialconnections.navigation.Destination.LinkStepUpVerification
 import com.stripe.android.financialconnections.navigation.destination
 import com.stripe.android.financialconnections.utils.TestNavigationManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -116,8 +116,8 @@ class LinkAccountPickerViewModelTest {
         val viewModel = buildViewModel(LinkAccountPickerState())
         viewModel.onNewBankAccountClick()
 
-        val navigation = response.nextPaneOnAddAccount!!.destination
-        navigationManager.assertNavigatedTo(navigation)
+        val destination = response.nextPaneOnAddAccount!!.destination
+        navigationManager.assertNavigatedTo(destination, Pane.LINK_ACCOUNT_PICKER)
     }
 
     @Test
@@ -159,7 +159,7 @@ class LinkAccountPickerViewModelTest {
             assertThat(firstValue(null)).isEqualTo(listOf(selectedAccount))
         }
         val destination = accounts.data.first().nextPaneOnSelection!!.destination
-        navigationManager.assertNavigatedTo(destination)
+        navigationManager.assertNavigatedTo(destination, Pane.LINK_ACCOUNT_PICKER)
     }
 
     @Test
@@ -203,7 +203,7 @@ class LinkAccountPickerViewModelTest {
             }
             verifyNoInteractions(updateLocalManifest)
             verifyNoInteractions(selectNetworkedAccount)
-            navigationManager.assertNavigatedTo(Destination.LinkStepUpVerification)
+            navigationManager.assertNavigatedTo(LinkStepUpVerification, Pane.LINK_ACCOUNT_PICKER)
         }
 
     private fun twoAccounts() = NetworkedAccountsList(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationViewModelTest.kt
@@ -125,7 +125,10 @@ class LinkStepUpVerificationViewModelTest {
         onConsumerNotFoundCaptor.firstValue()
 
         assertThat(viewModel.awaitState().payload).isInstanceOf(Loading::class.java)
-        navigationManager.assertNavigatedTo(Destination.InstitutionPicker)
+        navigationManager.assertNavigatedTo(
+            destination = Destination.InstitutionPicker,
+            pane = Pane.LINK_STEP_UP_VERIFICATION
+        )
         eventTracker.assertContainsEvent(
             "linked_accounts.networking.verification.step_up.error",
             mapOf(
@@ -183,7 +186,10 @@ class LinkStepUpVerificationViewModelTest {
                 consumerSession.clientSecret,
                 selectedAccount.id
             )
-            navigationManager.assertNavigatedTo(Destination.Success)
+            navigationManager.assertNavigatedTo(
+                Destination.Success,
+                pane = Pane.LINK_STEP_UP_VERIFICATION
+            )
         }
 
     private suspend fun getManifestReturnsManifestWithEmail(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModelTest.kt
@@ -43,7 +43,10 @@ class NetworkingLinkLoginWarmupViewModelTest {
         val viewModel = buildViewModel(NetworkingLinkLoginWarmupState())
 
         viewModel.onContinueClick()
-        navigationManager.assertNavigatedTo(Destination.NetworkingLinkVerification)
+        navigationManager.assertNavigatedTo(
+            destination = Destination.NetworkingLinkVerification,
+            pane = Pane.NETWORKING_LINK_LOGIN_WARMUP
+        )
     }
 
     @Test
@@ -58,6 +61,9 @@ class NetworkingLinkLoginWarmupViewModelTest {
         viewModel.onClickableTextClick("skip_login")
 
         verify(disableNetworking).invoke()
-        navigationManager.assertNavigatedTo(expectedNextPane.destination)
+        navigationManager.assertNavigatedTo(
+            destination = expectedNextPane.destination,
+            pane = Pane.NETWORKING_LINK_LOGIN_WARMUP
+        )
     }
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModelTest.kt
@@ -14,6 +14,7 @@ import com.stripe.android.financialconnections.domain.GetManifest
 import com.stripe.android.financialconnections.domain.LookupConsumerAndStartVerification
 import com.stripe.android.financialconnections.domain.MarkLinkVerified
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane.INSTITUTION_PICKER
+import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane.NETWORKING_LINK_VERIFICATION
 import com.stripe.android.financialconnections.model.NetworkedAccountsList
 import com.stripe.android.financialconnections.navigation.Destination
 import com.stripe.android.financialconnections.navigation.destination
@@ -121,7 +122,10 @@ class NetworkingLinkVerificationViewModelTest {
         onConsumerNotFoundCaptor.firstValue()
 
         assertThat(viewModel.awaitState().payload).isInstanceOf(Loading::class.java)
-        navigationManager.assertNavigatedTo(Destination.InstitutionPicker)
+        navigationManager.assertNavigatedTo(
+            destination = Destination.InstitutionPicker,
+            pane = NETWORKING_LINK_VERIFICATION
+        )
 
         analyticsTracker.assertContainsEvent(
             "linked_accounts.networking.verification.error",
@@ -174,7 +178,11 @@ class NetworkingLinkVerificationViewModelTest {
             }
 
             verify(confirmVerification).sms(any(), eq("111111"))
-            navigationManager.assertNavigatedTo(linkVerifiedManifest.nextPane.destination)
+
+            navigationManager.assertNavigatedTo(
+                destination = linkVerifiedManifest.nextPane.destination,
+                pane = NETWORKING_LINK_VERIFICATION
+            )
         }
 
     @Test
@@ -218,6 +226,9 @@ class NetworkingLinkVerificationViewModelTest {
             }
 
             verify(confirmVerification).sms(any(), eq("111111"))
-            navigationManager.assertNavigatedTo(Destination.LinkAccountPicker)
+            navigationManager.assertNavigatedTo(
+                destination = Destination.LinkAccountPicker,
+                pane = NETWORKING_LINK_VERIFICATION
+            )
         }
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModelTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.financialconnections.domain.GetCachedConsumerSession
 import com.stripe.android.financialconnections.domain.MarkLinkVerified
 import com.stripe.android.financialconnections.domain.SaveAccountToLink
 import com.stripe.android.financialconnections.domain.StartVerification
+import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane.INSTITUTION_PICKER
 import com.stripe.android.financialconnections.navigation.Destination
 import com.stripe.android.financialconnections.repository.SaveToLinkWithStripeSucceededRepository
@@ -105,7 +106,10 @@ class NetworkingSaveToLinkVerificationViewModelTest {
                 "linked_accounts.networking.verification.success",
                 mapOf("pane" to "networking_save_to_link_verification")
             )
-            navigationManager.assertNavigatedTo(Destination.Success)
+            navigationManager.assertNavigatedTo(
+                destination = Destination.Success,
+                pane = Pane.NETWORKING_SAVE_TO_LINK_VERIFICATION
+            )
         }
 
     @Test
@@ -161,6 +165,9 @@ class NetworkingSaveToLinkVerificationViewModelTest {
 
         verifyNoInteractions(confirmVerification)
         verifyNoInteractions(saveAccountToLink)
-        navigationManager.assertNavigatedTo(Destination.Success)
+        navigationManager.assertNavigatedTo(
+            destination = Destination.Success,
+            pane = Pane.NETWORKING_SAVE_TO_LINK_VERIFICATION
+        )
     }
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/utils/TestNavigationManager.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/utils/TestNavigationManager.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.financialconnections.utils
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.navigation.Destination
 import com.stripe.android.financialconnections.navigation.NavigationIntent
 import com.stripe.android.financialconnections.navigation.NavigationManager
@@ -35,9 +36,13 @@ internal class TestNavigationManager : NavigationManager {
         )
     }
 
-    fun assertNavigatedTo(destination: Destination) {
+    fun assertNavigatedTo(
+        destination: Destination,
+        pane: Pane,
+        args: Map<String, String?> = emptyMap()
+    ) {
         val last: NavigationIntent = emittedIntents.last()
         assertIs<NavigationIntent.NavigateTo>(last)
-        assertThat(last.route).isEqualTo(destination.fullRoute)
+        assertThat(last.route).isEqualTo(destination(pane, args))
     }
 }


### PR DESCRIPTION
# Summary

Sends referrer_pane when navigating to a different screen, so that it can be logged when triggering the `pane.launched` event.

- Adds referrer_pane as the first "common argument" that any Destination has to provide on their route. 
- Reads referrer_pane from the navStackEntry and logs it.

# Motivation
https://jira.corp.stripe.com/browse/BANKCON-7284


# Testing

See some splunk [queries](https://splunk.corp.stripe.com/en-US/app/search/search?sid=1694116268.978970_16A88E4A-C308-4A39-B80F-1C1910B5BF26) including `referrer_pane` 

<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [X] Modified tests
- [ ] Manually verified
