### PR TITLE
Fix scrolling to focused view in PaymentSheet and CustomerSheet

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheet.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
@@ -120,7 +121,9 @@ internal fun BottomSheet(
     }
 
     ModalBottomSheetLayout(
-        modifier = modifier.statusBarsPadding(),
+        modifier = modifier
+            .statusBarsPadding()
+            .imePadding(),
         sheetState = state.modalBottomSheetState,
         sheetContent = {
             sheetContent()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScaffold.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScaffold.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.ui
 
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Surface
@@ -31,7 +32,10 @@ internal fun PaymentSheetScaffold(
         }
     }
 
-    val elevation by animateDpAsState(targetValue = targetElevation)
+    val elevation by animateDpAsState(
+        targetValue = targetElevation,
+        label = "PaymentSheetTopBarElevation",
+    )
 
     Column(modifier = modifier) {
         // We need to set a z-index to make sure that the Surface's elevation shadow is rendered
@@ -40,6 +44,12 @@ internal fun PaymentSheetScaffold(
             topBar()
         }
 
-        content(Modifier.verticalScroll(scrollState))
+        content(
+            // We provide the IME padding before the vertical scroll modifier to make sure that the
+            // content moves up correctly if it's covered by the keyboard when it's being focused.
+            Modifier
+                .imePadding()
+                .verticalScroll(scrollState)
+        )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/EdgeToEdge.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/EdgeToEdge.kt
@@ -4,8 +4,6 @@ import android.view.View
 import android.view.WindowInsets
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.ime
-import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
@@ -44,10 +42,5 @@ internal fun View.requestApplyInsetsWhenAttached() {
 internal fun PaymentSheetContentPadding() {
     val bottomPadding = dimensionResource(R.dimen.stripe_paymentsheet_button_container_spacing_bottom)
     Spacer(modifier = Modifier.requiredHeight(bottomPadding))
-
-    Spacer(modifier = Modifier.windowInsetsBottomHeight(ComposeWindowInsets.ime))
-
-    if (!ComposeWindowInsets.isImeVisible) {
-        Spacer(modifier = Modifier.windowInsetsBottomHeight(ComposeWindowInsets.navigationBars))
-    }
+    Spacer(modifier = Modifier.windowInsetsBottomHeight(ComposeWindowInsets.navigationBars))
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where following the edge-to-edge changes, we no longer automatically scrolled to a focused view if the keyboard pushed it out of view.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

UX polish.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
