### PR TITLE
Prefer saving card to customer over Link.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
@@ -17,7 +17,6 @@ internal object FormArgumentsFactory {
         merchantName: String,
         amount: Amount? = null,
         newLpm: PaymentSelection.New?,
-        isShowingLinkInlineSignup: Boolean = false,
     ): FormArguments {
         val layoutFormDescriptor = paymentMethod.getPMAddForm(stripeIntent, config)
 
@@ -45,7 +44,7 @@ internal object FormArgumentsFactory {
 
         return FormArguments(
             paymentMethodCode = paymentMethod.code,
-            showCheckbox = layoutFormDescriptor.showCheckbox && !isShowingLinkInlineSignup,
+            showCheckbox = layoutFormDescriptor.showCheckbox,
             showCheckboxControlledFields = showCheckboxControlledFields,
             merchantName = merchantName,
             amount = amount,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -51,14 +51,15 @@ internal fun AddPaymentMethod(
         }
     }
 
+    val arguments = remember(selectedItem) {
+        sheetViewModel.createFormArguments(selectedItem)
+    }
+
     val showLinkInlineSignup = sheetViewModel.showLinkInlineSignupView(
         selectedPaymentMethodCode,
-        linkAccountStatus
+        linkAccountStatus,
+        arguments.showCheckbox,
     )
-
-    val arguments = remember(selectedItem, showLinkInlineSignup) {
-        sheetViewModel.createFormArguments(selectedItem, showLinkInlineSignup)
-    }
 
     LaunchedEffect(arguments) {
         showCheckboxFlow.emit(arguments.showCheckbox)
@@ -126,7 +127,8 @@ private val BaseSheetViewModel.initiallySelectedPaymentMethodType: PaymentMethod
 
 private fun BaseSheetViewModel.showLinkInlineSignupView(
     paymentMethodCode: String,
-    linkAccountStatus: AccountStatus?
+    linkAccountStatus: AccountStatus?,
+    showSaveToCustomerCheckbox: Boolean,
 ): Boolean {
     val validStatusStates = setOf(
         AccountStatus.Verified,
@@ -135,10 +137,11 @@ private fun BaseSheetViewModel.showLinkInlineSignupView(
         AccountStatus.SignedOut,
     )
     val linkInlineSelectionValid = linkHandler.linkInlineSelection.value != null
-    return linkHandler.isLinkEnabled.value == true && stripeIntent.value
+    val ableToShowLink = linkHandler.isLinkEnabled.value == true && stripeIntent.value
         ?.linkFundingSources?.contains(PaymentMethod.Type.Card.code) == true &&
         paymentMethodCode == PaymentMethod.Type.Card.code &&
         (linkAccountStatus in validStatusStates || linkInlineSelectionValid)
+    return !showSaveToCustomerCheckbox && ableToShowLink
 }
 
 internal fun FormFieldValues.transformToPaymentMethodCreateParams(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -445,7 +445,6 @@ internal abstract class BaseSheetViewModel(
 
     fun createFormArguments(
         selectedItem: LpmRepository.SupportedPaymentMethod,
-        showLinkInlineSignup: Boolean
     ): FormArguments = FormArgumentsFactory.create(
         paymentMethod = selectedItem,
         stripeIntent = requireNotNull(stripeIntent.value),
@@ -453,7 +452,6 @@ internal abstract class BaseSheetViewModel(
         merchantName = merchantName,
         amount = amount.value,
         newLpm = newPaymentSelection,
-        isShowingLinkInlineSignup = showLinkInlineSignup
     )
 
     fun handleBackPressed() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -904,7 +904,6 @@ internal class PaymentSheetViewModelTest {
 
         val observedArgs = viewModel.createFormArguments(
             selectedItem = LpmRepository.HardcodedCard,
-            showLinkInlineSignup = false,
         )
 
         assertThat(observedArgs).isEqualTo(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We found that preferring Link over the customer object caused merchants to turn Link off. 
Long term we will find a solution to support both, but short term we will just prefer the customer checkbox when both are available. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
link redesign
