### PR TITLE
Use `Result<T>` for 3DS2 endpoints

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -245,15 +245,15 @@ abstract class AbsFakeStripeRepository : StripeRepository {
     override suspend fun start3ds2Auth(
         authParams: Stripe3ds2AuthParams,
         requestOptions: ApiRequest.Options
-    ): Stripe3ds2AuthResult? {
-        TODO("Not yet implemented")
+    ): Result<Stripe3ds2AuthResult> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun complete3ds2Auth(
         sourceId: String,
         requestOptions: ApiRequest.Options
-    ): Stripe3ds2AuthResult? {
-        TODO("Not yet implemented")
+    ): Result<Stripe3ds2AuthResult> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun createFile(

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -305,13 +305,13 @@ interface StripeRepository {
     suspend fun start3ds2Auth(
         authParams: Stripe3ds2AuthParams,
         requestOptions: ApiRequest.Options
-    ): Stripe3ds2AuthResult?
+    ): Result<Stripe3ds2AuthResult>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun complete3ds2Auth(
         sourceId: String,
         requestOptions: ApiRequest.Options
-    ): Stripe3ds2AuthResult?
+    ): Result<Stripe3ds2AuthResult>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun createFile(

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2ChallengeResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2ChallengeResultProcessor.kt
@@ -141,13 +141,11 @@ internal class DefaultStripe3ds2ChallengeResultProcessor @Inject constructor(
         requestOptions: ApiRequest.Options,
         remainingRetries: Int = MAX_RETRIES
     ): Boolean {
-        return runCatching {
-            // complete3ds2Auth() result can be ignored
-            stripeRepository.complete3ds2Auth(
-                challengeResult.intentData.sourceId,
-                requestOptions
-            )
-        }.fold(
+        // complete3ds2Auth() result can be ignored
+        return stripeRepository.complete3ds2Auth(
+            challengeResult.intentData.sourceId,
+            requestOptions
+        ).fold(
             onSuccess = {
                 val attemptedRetries = MAX_RETRIES - remainingRetries
                 logger.debug(

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt
@@ -111,14 +111,12 @@ internal class Stripe3ds2TransactionViewModel @Inject constructor(
         )
 
         val timeout = args.config.timeout
-        return runCatching {
-            perform3ds2AuthenticationRequest(
-                transaction,
-                stripe3ds2Fingerprint,
-                threeDS2RequestOptions,
-                timeout
-            )
-        }.fold(
+        return perform3ds2AuthenticationRequest(
+            transaction,
+            stripe3ds2Fingerprint,
+            threeDS2RequestOptions,
+            timeout
+        ).fold(
             onSuccess = { authResult ->
                 on3ds2AuthSuccess(
                     authResult,
@@ -145,7 +143,7 @@ internal class Stripe3ds2TransactionViewModel @Inject constructor(
         stripe3ds2Fingerprint: Stripe3ds2Fingerprint,
         requestOptions: ApiRequest.Options,
         timeout: Int
-    ) = withContext(workContext) {
+    ): Result<Stripe3ds2AuthResult> = withContext(workContext) {
         val areqParams = transaction.createAuthenticationRequestParameters()
 
         val authParams = Stripe3ds2AuthParams(
@@ -162,11 +160,9 @@ internal class Stripe3ds2TransactionViewModel @Inject constructor(
             returnUrl = null
         )
 
-        requireNotNull(
-            stripeRepository.start3ds2Auth(
-                authParams,
-                requestOptions
-            )
+        stripeRepository.start3ds2Auth(
+            authParams,
+            requestOptions
         )
     }
 

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -474,13 +474,10 @@ internal class StripeApiRepositoryTest {
                 "stripe://payment-auth-return"
             )
 
-            val invalidRequestException =
-                assertFailsWith<InvalidRequestException> {
-                    stripeApiRepository.start3ds2Auth(
-                        authParams,
-                        DEFAULT_OPTIONS
-                    )
-                }
+            val invalidRequestException = stripeApiRepository.start3ds2Auth(
+                authParams,
+                DEFAULT_OPTIONS
+            ).exceptionOrNull() as InvalidRequestException
 
             assertEquals("source", invalidRequestException.stripeError?.param)
             assertEquals("resource_missing", invalidRequestException.stripeError?.code)
@@ -489,13 +486,11 @@ internal class StripeApiRepositoryTest {
     @Test
     fun complete3ds2Auth_withInvalidSource_shouldThrowInvalidRequestException() =
         runTest {
-            val invalidRequestException =
-                assertFailsWith<InvalidRequestException> {
-                    stripeApiRepository.complete3ds2Auth(
-                        "src_123",
-                        DEFAULT_OPTIONS
-                    )
-                }
+            val invalidRequestException = stripeApiRepository.complete3ds2Auth(
+                "src_123",
+                DEFAULT_OPTIONS
+            ).exceptionOrNull() as InvalidRequestException
+
             assertThat(invalidRequestException.statusCode)
                 .isEqualTo(HttpURLConnection.HTTP_NOT_FOUND)
             assertEquals("source", invalidRequestException.stripeError?.param)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates the 3DS2-related method in `StripeRepository` to use `Result<T>` as their return type.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
