### PR TITLE
Update link logo color in inline flow.

### DIFF
--- a/link/src/main/java/com/stripe/android/link/theme/Color.kt
+++ b/link/src/main/java/com/stripe/android/link/theme/Color.kt
@@ -16,7 +16,7 @@ private val ActionGreen = Color(0xFF05A87F)
 private val ButtonLabel = Color(0xFF1D3944)
 private val ErrorText = Color(0xFFFF2F4C)
 private val ErrorBackground = Color(0x2EFE87A1)
-private val InlineLink = Color(0x33787880)
+private val InlineLink = Color(0x99787880)
 
 private val LightComponentBackground = Color.White
 private val LightComponentBorder = Color(0xFFE0E6EB)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Make the link logo in the inline flow darker.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
link redesign bug bash

![link-logo-inline](https://github.com/stripe/stripe-android/assets/116920913/c6ea3f8c-1924-4e4c-9dee-b764e4079a77)
