### PR TITLE
Update header text when wallets are shown in the SelectSavedPaymentMethods screen.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/HeaderTextFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/HeaderTextFactory.kt
@@ -13,13 +13,12 @@ internal class HeaderTextFactory(
     fun create(
         screen: PaymentSheetScreen,
         isWalletEnabled: Boolean,
-        isPaymentIntent: Boolean,
         types: List<PaymentMethodCode>,
     ): Int? {
         return if (isCompleteFlow) {
             when (screen) {
                 PaymentSheetScreen.SelectSavedPaymentMethods -> {
-                    if (isWalletEnabled && isPaymentIntent) {
+                    if (isWalletEnabled) {
                         null
                     } else {
                         R.string.stripe_paymentsheet_select_payment_method

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/HeaderTextFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/HeaderTextFactory.kt
@@ -20,7 +20,7 @@ internal class HeaderTextFactory(
             when (screen) {
                 PaymentSheetScreen.SelectSavedPaymentMethods -> {
                     if (isWalletEnabled && isPaymentIntent) {
-                        R.string.stripe_paymentsheet_pay_using
+                        null
                     } else {
                         R.string.stripe_paymentsheet_select_payment_method
                     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -423,7 +423,6 @@ internal abstract class BaseSheetViewModel(
             headerTextFactory.create(
                 screen = screen,
                 isWalletEnabled = isLinkAvailable || googlePayState is GooglePayState.Available,
-                isPaymentIntent = stripeIntent is PaymentIntent,
                 types = stripeIntent.paymentMethodTypes,
             )
         } else {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/HeaderTextFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/HeaderTextFactoryTest.kt
@@ -9,11 +9,10 @@ import com.stripe.android.R as StripeR
 class HeaderTextFactoryTest {
 
     @Test
-    fun `Shows the correct header in complete flow if in payment mode and showing wallets`() {
+    fun `Shows the correct header in complete flow and showing wallets`() {
         val resource = HeaderTextFactory(isCompleteFlow = true).create(
             screen = PaymentSheetScreen.SelectSavedPaymentMethods,
             isWalletEnabled = true,
-            isPaymentIntent = true,
             types = emptyList(),
         )
 
@@ -21,23 +20,10 @@ class HeaderTextFactoryTest {
     }
 
     @Test
-    fun `Shows the correct header in complete flow if not in payment mode`() {
-        val resource = HeaderTextFactory(isCompleteFlow = true).create(
-            screen = PaymentSheetScreen.SelectSavedPaymentMethods,
-            isWalletEnabled = true,
-            isPaymentIntent = false,
-            types = emptyList(),
-        )
-
-        assertThat(resource).isEqualTo(R.string.stripe_paymentsheet_select_payment_method)
-    }
-
-    @Test
     fun `Does not show a header on AddAnotherPaymentMethod screen`() {
         val resource = HeaderTextFactory(isCompleteFlow = true).create(
             screen = PaymentSheetScreen.AddAnotherPaymentMethod,
             isWalletEnabled = true,
-            isPaymentIntent = false,
             types = emptyList(),
         )
 
@@ -49,7 +35,6 @@ class HeaderTextFactoryTest {
         val resource = HeaderTextFactory(isCompleteFlow = true).create(
             screen = PaymentSheetScreen.AddFirstPaymentMethod,
             isWalletEnabled = false,
-            isPaymentIntent = false,
             types = emptyList(),
         )
 
@@ -61,7 +46,6 @@ class HeaderTextFactoryTest {
         val resource = HeaderTextFactory(isCompleteFlow = true).create(
             screen = PaymentSheetScreen.AddFirstPaymentMethod,
             isWalletEnabled = true,
-            isPaymentIntent = false,
             types = emptyList(),
         )
 
@@ -73,7 +57,6 @@ class HeaderTextFactoryTest {
         val resource = HeaderTextFactory(isCompleteFlow = false).create(
             screen = PaymentSheetScreen.SelectSavedPaymentMethods,
             isWalletEnabled = true,
-            isPaymentIntent = false,
             types = emptyList(),
         )
 
@@ -85,7 +68,6 @@ class HeaderTextFactoryTest {
         val resource = HeaderTextFactory(isCompleteFlow = false).create(
             screen = PaymentSheetScreen.AddFirstPaymentMethod,
             isWalletEnabled = false,
-            isPaymentIntent = false,
             types = listOf("card"),
         )
 
@@ -97,7 +79,6 @@ class HeaderTextFactoryTest {
         val resource = HeaderTextFactory(isCompleteFlow = false).create(
             screen = PaymentSheetScreen.AddFirstPaymentMethod,
             isWalletEnabled = false,
-            isPaymentIntent = false,
             types = listOf("card", "not_card"),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/HeaderTextFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/HeaderTextFactoryTest.kt
@@ -17,7 +17,7 @@ class HeaderTextFactoryTest {
             types = emptyList(),
         )
 
-        assertThat(resource).isEqualTo(R.string.stripe_paymentsheet_pay_using)
+        assertThat(resource).isNull()
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Don't show a header when wallets are showing with a payment intent. This was kinda weird because it (essentially) said pay using twice.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
link redesign bug bash

![wallets-pi](https://github.com/stripe/stripe-android/assets/116920913/09f53941-8911-4ffc-978d-86e4f286c065)
