### PR TITLE
Use `Result<T>` for issuing and FPX endpoints

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -218,8 +218,8 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         verificationId: String,
         userOneTimeCode: String,
         requestOptions: ApiRequest.Options
-    ): String? {
-        TODO("Not yet implemented")
+    ): Result<String> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun updateIssuingCardPin(
@@ -228,14 +228,14 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         verificationId: String,
         userOneTimeCode: String,
         requestOptions: ApiRequest.Options
-    ) {
+    ): Throwable? {
         TODO("Not yet implemented")
     }
 
     override suspend fun getFpxBankStatus(
         options: ApiRequest.Options
-    ): BankStatuses {
-        TODO("Not yet implemented")
+    ): Result<BankStatuses> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun getCardMetadata(bin: Bin, options: ApiRequest.Options): CardMetadata {

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -40,7 +40,6 @@ import com.stripe.android.model.Stripe3ds2AuthResult
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.Token
 import com.stripe.android.model.TokenParams
-import org.json.JSONException
 import java.util.Locale
 
 /**
@@ -260,29 +259,14 @@ interface StripeRepository {
         requestOptions: ApiRequest.Options
     ): Result<Customer>
 
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        CardException::class,
-        JSONException::class
-    )
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun retrieveIssuingCardPin(
         cardId: String,
         verificationId: String,
         userOneTimeCode: String,
         requestOptions: ApiRequest.Options
-    ): String?
+    ): Result<String>
 
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        CardException::class
-    )
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun updateIssuingCardPin(
         cardId: String,
@@ -290,10 +274,10 @@ interface StripeRepository {
         verificationId: String,
         userOneTimeCode: String,
         requestOptions: ApiRequest.Options
-    )
+    ): Throwable?
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    suspend fun getFpxBankStatus(options: ApiRequest.Options): BankStatuses
+    suspend fun getFpxBankStatus(options: ApiRequest.Options): Result<BankStatuses>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun getCardMetadata(

--- a/payments-core/src/main/java/com/stripe/android/view/FpxViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/FpxViewModel.kt
@@ -19,11 +19,13 @@ internal class FpxViewModel internal constructor(
     internal var selectedPosition: Int? = null
 
     @JvmSynthetic
-    internal fun getFpxBankStatues() = liveData<BankStatuses> {
+    internal fun getFpxBankStatues() = liveData {
         emit(
-            runCatching {
-                stripeRepository.getFpxBankStatus(ApiRequest.Options(publishableKey))
-            }.getOrDefault(BankStatuses())
+            stripeRepository.getFpxBankStatus(
+                options = ApiRequest.Options(publishableKey),
+            ).getOrElse {
+                BankStatuses()
+            }
         )
     }
 

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -1112,7 +1112,7 @@ internal class StripeApiRepositoryTest {
     fun getFpxBankStatus_withFpxKey() = runTest {
         val fpxBankStatuses = stripeApiRepository.getFpxBankStatus(
             ApiRequest.Options(ApiKeyFixtures.FPX_PUBLISHABLE_KEY)
-        )
+        ).getOrThrow()
         assertThat(fpxBankStatuses.size())
             .isEqualTo(26)
     }
@@ -1124,7 +1124,7 @@ internal class StripeApiRepositoryTest {
                 apiKey = ApiKeyFixtures.FPX_PUBLISHABLE_KEY,
                 stripeAccount = "acct_1234"
             )
-        )
+        ).getOrThrow()
         assertThat(fpxBankStatuses.size())
             .isEqualTo(26)
     }

--- a/payments-core/src/test/java/com/stripe/android/view/FpxViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/FpxViewModelTest.kt
@@ -31,6 +31,8 @@ class FpxViewModelTest {
     }
 
     private class FakeStripeRepository : AbsFakeStripeRepository() {
-        override suspend fun getFpxBankStatus(options: ApiRequest.Options) = BankStatuses()
+        override suspend fun getFpxBankStatus(options: ApiRequest.Options): Result<BankStatuses> {
+            return Result.success(BankStatuses())
+        }
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates the issuing- and FPX-related method in StripeRepository to use `Result<T>` as their return type.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
