### PR TITLE
Use `Result<T>` for source/PM/token create calls

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -106,8 +106,8 @@ abstract class AbsFakeStripeRepository : StripeRepository {
     override suspend fun createSource(
         sourceParams: SourceParams,
         options: ApiRequest.Options
-    ): Source? {
-        TODO("Not yet implemented")
+    ): Result<Source> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun retrieveSource(
@@ -121,15 +121,15 @@ abstract class AbsFakeStripeRepository : StripeRepository {
     override suspend fun createPaymentMethod(
         paymentMethodCreateParams: PaymentMethodCreateParams,
         options: ApiRequest.Options
-    ): PaymentMethod? {
-        TODO("Not yet implemented")
+    ): Result<PaymentMethod> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun createToken(
         tokenParams: TokenParams,
         options: ApiRequest.Options
-    ): Token? {
-        TODO("Not yet implemented")
+    ): Result<Token> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun addCustomerSource(

--- a/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
@@ -98,15 +98,15 @@ suspend fun Stripe.createPaymentMethod(
     paymentMethodCreateParams: PaymentMethodCreateParams,
     idempotencyKey: String? = null,
     stripeAccountId: String? = this.stripeAccountId
-): PaymentMethod = runApiRequest {
-    stripeRepository.createPaymentMethod(
+): PaymentMethod {
+    return stripeRepository.createPaymentMethod(
         paymentMethodCreateParams,
         ApiRequest.Options(
             apiKey = publishableKey,
             stripeAccount = stripeAccountId,
             idempotencyKey = idempotencyKey
         )
-    )
+    ).getOrElse { throw StripeException.create(it) }
 }
 
 /**
@@ -137,15 +137,15 @@ suspend fun Stripe.createSource(
     sourceParams: SourceParams,
     idempotencyKey: String? = null,
     stripeAccountId: String? = this.stripeAccountId
-): Source = runApiRequest {
-    stripeRepository.createSource(
+): Source {
+    return stripeRepository.createSource(
         sourceParams,
         ApiRequest.Options(
             apiKey = publishableKey,
             stripeAccount = stripeAccountId,
             idempotencyKey = idempotencyKey
         )
-    )
+    ).getOrElse { throw StripeException.create(it) }
 }
 
 /**
@@ -176,14 +176,11 @@ suspend fun Stripe.createAccountToken(
     accountParams: AccountParams,
     idempotencyKey: String? = null,
     stripeAccountId: String? = this.stripeAccountId
-): Token = runApiRequest {
-    stripeRepository.createToken(
-        accountParams,
-        ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId,
-            idempotencyKey = idempotencyKey
-        )
+): Token {
+    return createTokenOrThrow(
+        tokenParams = accountParams,
+        stripeAccountId = stripeAccountId,
+        idempotencyKey = idempotencyKey,
     )
 }
 
@@ -215,14 +212,11 @@ suspend fun Stripe.createBankAccountToken(
     bankAccountTokenParams: BankAccountTokenParams,
     idempotencyKey: String? = null,
     stripeAccountId: String? = this.stripeAccountId
-): Token = runApiRequest {
-    stripeRepository.createToken(
-        bankAccountTokenParams,
-        ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId,
-            idempotencyKey = idempotencyKey
-        )
+): Token {
+    return createTokenOrThrow(
+        tokenParams = bankAccountTokenParams,
+        stripeAccountId = stripeAccountId,
+        idempotencyKey = idempotencyKey,
     )
 }
 
@@ -254,14 +248,11 @@ suspend fun Stripe.createPiiToken(
     personalId: String,
     idempotencyKey: String? = null,
     stripeAccountId: String? = this.stripeAccountId
-): Token = runApiRequest {
-    stripeRepository.createToken(
-        PiiTokenParams(personalId),
-        ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId,
-            idempotencyKey = idempotencyKey
-        )
+): Token {
+    return createTokenOrThrow(
+        tokenParams = PiiTokenParams(personalId),
+        stripeAccountId = stripeAccountId,
+        idempotencyKey = idempotencyKey,
     )
 }
 
@@ -295,14 +286,11 @@ suspend fun Stripe.createCardToken(
     cardParams: CardParams,
     idempotencyKey: String? = null,
     stripeAccountId: String? = this.stripeAccountId
-): Token = runApiRequest {
-    stripeRepository.createToken(
-        cardParams,
-        ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId,
-            idempotencyKey = idempotencyKey
-        )
+): Token {
+    return createTokenOrThrow(
+        tokenParams = cardParams,
+        stripeAccountId = stripeAccountId,
+        idempotencyKey = idempotencyKey,
     )
 }
 
@@ -333,14 +321,11 @@ suspend fun Stripe.createCvcUpdateToken(
     @Size(min = 3, max = 4) cvc: String,
     idempotencyKey: String? = null,
     stripeAccountId: String? = this.stripeAccountId
-): Token = runApiRequest {
-    stripeRepository.createToken(
-        CvcTokenParams(cvc),
-        ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId,
-            idempotencyKey = idempotencyKey
-        )
+): Token {
+    return createTokenOrThrow(
+        tokenParams = CvcTokenParams(cvc),
+        stripeAccountId = stripeAccountId,
+        idempotencyKey = idempotencyKey,
     )
 }
 
@@ -373,14 +358,11 @@ suspend fun Stripe.createPersonToken(
     params: PersonTokenParams,
     idempotencyKey: String? = null,
     stripeAccountId: String? = this.stripeAccountId
-): Token = runApiRequest {
-    stripeRepository.createToken(
-        params,
-        ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId,
-            idempotencyKey = idempotencyKey
-        )
+): Token {
+    return createTokenOrThrow(
+        tokenParams = params,
+        stripeAccountId = stripeAccountId,
+        idempotencyKey = idempotencyKey,
     )
 }
 

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
@@ -104,11 +104,7 @@ internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
 
         val params = PaymentMethodCreateParams.createFromGooglePay(paymentDataJson)
 
-        return runCatching {
-            requireNotNull(
-                stripeRepository.createPaymentMethod(params, requestOptions)
-            )
-        }.fold(
+        return stripeRepository.createPaymentMethod(params, requestOptions).fold(
             onSuccess = {
                 GooglePayPaymentMethodLauncher.Result.Completed(it)
             },

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -10,7 +10,6 @@ import com.stripe.android.core.model.StripeFile
 import com.stripe.android.core.model.StripeFileParams
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.StripeResponse
-import com.stripe.android.exception.CardException
 import com.stripe.android.model.BankStatuses
 import com.stripe.android.model.CardMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
@@ -133,17 +132,11 @@ interface StripeRepository {
         options: ApiRequest.Options
     ): Result<SetupIntent>
 
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class
-    )
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun createSource(
         sourceParams: SourceParams,
         options: ApiRequest.Options
-    ): Source?
+    ): Result<Source>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun retrieveSource(
@@ -152,30 +145,17 @@ interface StripeRepository {
         options: ApiRequest.Options
     ): Result<Source>
 
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class
-    )
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun createPaymentMethod(
         paymentMethodCreateParams: PaymentMethodCreateParams,
         options: ApiRequest.Options
-    ): PaymentMethod?
+    ): Result<PaymentMethod>
 
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        CardException::class
-    )
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun createToken(
         tokenParams: TokenParams,
         options: ApiRequest.Options
-    ): Token?
+    ): Result<Token>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun addCustomerSource(

--- a/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
@@ -29,9 +29,9 @@ internal class PaymentMethodEndToEndTest {
         val paymentMethod =
             Stripe(context, ApiKeyFixtures.BACS_PUBLISHABLE_KEY)
                 .createPaymentMethodSynchronous(params)
-        assertThat(paymentMethod?.type)
+        assertThat(paymentMethod.type)
             .isEqualTo(PaymentMethod.Type.BacsDebit)
-        assertThat(paymentMethod?.bacsDebit)
+        assertThat(paymentMethod.bacsDebit)
             .isEqualTo(
                 PaymentMethod.BacsDebit(
                     fingerprint = "UkSG0HfCGxxrja1H",
@@ -47,9 +47,9 @@ internal class PaymentMethodEndToEndTest {
         val paymentMethod =
             Stripe(context, ApiKeyFixtures.SOFORT_PUBLISHABLE_KEY)
                 .createPaymentMethodSynchronous(params)
-        assertThat(paymentMethod?.type)
+        assertThat(paymentMethod.type)
             .isEqualTo(PaymentMethod.Type.Sofort)
-        assertThat(paymentMethod?.sofort)
+        assertThat(paymentMethod.sofort)
             .isEqualTo(
                 PaymentMethod.Sofort(
                     country = "DE"
@@ -63,7 +63,7 @@ internal class PaymentMethodEndToEndTest {
         val paymentMethod =
             Stripe(context, ApiKeyFixtures.P24_PUBLISHABLE_KEY)
                 .createPaymentMethodSynchronous(params)
-        assertThat(paymentMethod?.type)
+        assertThat(paymentMethod.type)
             .isEqualTo(PaymentMethod.Type.P24)
     }
 
@@ -73,7 +73,7 @@ internal class PaymentMethodEndToEndTest {
         val paymentMethod =
             Stripe(context, ApiKeyFixtures.BANCONTACT_PUBLISHABLE_KEY)
                 .createPaymentMethodSynchronous(params)
-        assertThat(paymentMethod?.type)
+        assertThat(paymentMethod.type)
             .isEqualTo(PaymentMethod.Type.Bancontact)
     }
 
@@ -99,7 +99,7 @@ internal class PaymentMethodEndToEndTest {
         val paymentMethod =
             Stripe(context, ApiKeyFixtures.NETBANKING_PUBLISHABLE_KEY)
                 .createPaymentMethodSynchronous(params)
-        assertThat(paymentMethod?.type)
+        assertThat(paymentMethod.type)
             .isEqualTo(PaymentMethod.Type.Netbanking)
     }
 
@@ -111,8 +111,8 @@ internal class PaymentMethodEndToEndTest {
                 context,
                 ApiKeyFixtures.US_BANK_ACCOUNT_PUBLISHABLE_KEY
             ).createPaymentMethodSynchronous(params)
-        assertThat(paymentMethod?.type).isEqualTo(PaymentMethod.Type.USBankAccount)
-        assertThat(paymentMethod?.usBankAccount).isEqualTo(
+        assertThat(paymentMethod.type).isEqualTo(PaymentMethod.Type.USBankAccount)
+        assertThat(paymentMethod.usBankAccount).isEqualTo(
             PaymentMethod.USBankAccount(
                 accountHolderType = PaymentMethod.USBankAccount.USBankAccountHolderType.INDIVIDUAL,
                 accountType = PaymentMethod.USBankAccount.USBankAccountType.CHECKING,
@@ -139,7 +139,7 @@ internal class PaymentMethodEndToEndTest {
                 context,
                 ApiKeyFixtures.US_BANK_ACCOUNT_PUBLISHABLE_KEY
             ).createPaymentMethodSynchronous(params)
-        assertThat(paymentMethod?.type)
+        assertThat(paymentMethod.type)
             .isEqualTo(PaymentMethod.Type.USBankAccount)
     }
 
@@ -166,7 +166,7 @@ internal class PaymentMethodEndToEndTest {
         val paymentMethod =
             Stripe(context, ApiKeyFixtures.GIROPAY_PUBLISHABLE_KEY)
                 .createPaymentMethodSynchronous(params)
-        assertThat(paymentMethod?.type)
+        assertThat(paymentMethod.type)
             .isEqualTo(PaymentMethod.Type.Giropay)
     }
 
@@ -191,7 +191,7 @@ internal class PaymentMethodEndToEndTest {
         val paymentMethod =
             Stripe(context, ApiKeyFixtures.EPS_PUBLISHABLE_KEY)
                 .createPaymentMethodSynchronous(params)
-        assertThat(paymentMethod?.type)
+        assertThat(paymentMethod.type)
             .isEqualTo(PaymentMethod.Type.Eps)
     }
 
@@ -216,7 +216,7 @@ internal class PaymentMethodEndToEndTest {
         val paymentMethod =
             Stripe(context, ApiKeyFixtures.UPI_PUBLISHABLE_KEY)
                 .createPaymentMethodSynchronous(params)
-        assertThat(paymentMethod?.type)
+        assertThat(paymentMethod.type)
             .isEqualTo(PaymentMethod.Type.Upi)
     }
 
@@ -227,7 +227,7 @@ internal class PaymentMethodEndToEndTest {
         )
         val paymentMethod = Stripe(context, ApiKeyFixtures.OXXO_PUBLISHABLE_KEY)
             .createPaymentMethodSynchronous(params)
-        assertThat(paymentMethod?.type)
+        assertThat(paymentMethod.type)
             .isEqualTo(PaymentMethod.Type.Oxxo)
     }
 
@@ -270,7 +270,7 @@ internal class PaymentMethodEndToEndTest {
         val paymentMethod =
             Stripe(context, ApiKeyFixtures.ALIPAY_PUBLISHABLE_KEY)
                 .createPaymentMethodSynchronous(params)
-        assertThat(paymentMethod?.type)
+        assertThat(paymentMethod.type)
             .isEqualTo(PaymentMethod.Type.Alipay)
     }
 
@@ -286,8 +286,8 @@ internal class PaymentMethodEndToEndTest {
         val paymentMethod = repository.createPaymentMethod(
             params,
             ApiRequest.Options(ApiKeyFixtures.GRABPAY_PUBLISHABLE_KEY)
-        )
-        assertThat(paymentMethod?.type)
+        ).getOrThrow()
+        assertThat(paymentMethod.type)
             .isEqualTo(PaymentMethod.Type.GrabPay)
     }
 
@@ -300,9 +300,8 @@ internal class PaymentMethodEndToEndTest {
         ).createPaymentMethod(
             PaymentMethodCreateParams.createPayPal(),
             ApiRequest.Options(ApiKeyFixtures.PAYPAL_PUBLISHABLE_KEY)
-        )
+        ).getOrThrow()
 
-        requireNotNull(paymentMethod)
         assertThat(paymentMethod.type)
             .isEqualTo(PaymentMethod.Type.PayPal)
     }
@@ -315,7 +314,7 @@ internal class PaymentMethodEndToEndTest {
                     billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS
                 )
             )
-        assertThat(paymentMethod?.type)
+        assertThat(paymentMethod.type)
             .isEqualTo(PaymentMethod.Type.AfterpayClearpay)
     }
 
@@ -367,7 +366,7 @@ internal class PaymentMethodEndToEndTest {
         val paymentMethod =
             Stripe(context, ApiKeyFixtures.BLIK_PUBLISHABLE_KEY)
                 .createPaymentMethodSynchronous(params)
-        assertThat(paymentMethod?.type)
+        assertThat(paymentMethod.type)
             .isEqualTo(PaymentMethod.Type.Blik)
     }
 
@@ -381,7 +380,7 @@ internal class PaymentMethodEndToEndTest {
                 betas = setOf(StripeApiBeta.WeChatPayV1)
             )
                 .createPaymentMethodSynchronous(params)
-        assertThat(paymentMethod?.type)
+        assertThat(paymentMethod.type)
             .isEqualTo(PaymentMethod.Type.WeChatPay)
     }
 
@@ -425,7 +424,7 @@ internal class PaymentMethodEndToEndTest {
             Stripe(context, ApiKeyFixtures.KLARNA_PUBLISHABLE_KEY)
                 .createPaymentMethodSynchronous(params)
 
-        assertThat(paymentMethod?.type).isEqualTo(PaymentMethod.Type.Klarna)
+        assertThat(paymentMethod.type).isEqualTo(PaymentMethod.Type.Klarna)
     }
 
     @Test
@@ -436,7 +435,7 @@ internal class PaymentMethodEndToEndTest {
                     billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS
                 )
             )
-        assertThat(paymentMethod?.type)
+        assertThat(paymentMethod.type)
             .isEqualTo(PaymentMethod.Type.Affirm)
     }
 
@@ -446,6 +445,6 @@ internal class PaymentMethodEndToEndTest {
         val params = PaymentMethodCreateParamsFixtures.CASH_APP_PAY
 
         val paymentMethod = stripe.createPaymentMethodSynchronous(params)
-        assertThat(paymentMethod?.type).isEqualTo(PaymentMethod.Type.CashAppPay)
+        assertThat(paymentMethod.type).isEqualTo(PaymentMethod.Type.CashAppPay)
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/PaymentSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentSessionTest.kt
@@ -364,8 +364,8 @@ class PaymentSessionTest {
         override suspend fun createPaymentMethod(
             paymentMethodCreateParams: PaymentMethodCreateParams,
             options: ApiRequest.Options
-        ): PaymentMethod {
-            return PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        ): Result<PaymentMethod> {
+            return Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         }
 
         override suspend fun setDefaultCustomerSource(

--- a/payments-core/src/test/java/com/stripe/android/StripeKtxTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripeKtxTest.kt
@@ -63,13 +63,6 @@ internal class StripeKtxTest {
         )
 
     @Test
-    fun `When repository returns null then createPaymentMethod should throw InvalidRequestException`(): Unit =
-        `Given repository returns null when calling createAPI then throws InvalidRequestException`(
-            mockApiRepository::createPaymentMethod,
-            stripe::createPaymentMethod
-        )
-
-    @Test
     fun `When repository returns correct value then createSource should Succeed`(): Unit =
         `Given repository returns non-empty value when calling createAPI then returns correct result`(
             mockApiRepository::createSource,
@@ -79,13 +72,6 @@ internal class StripeKtxTest {
     @Test
     fun `When repository throws exception then createSource should throw same exception`(): Unit =
         `Given repository throws exception when calling createAPI then throws same exception`(
-            mockApiRepository::createSource,
-            stripe::createSource
-        )
-
-    @Test
-    fun `When repository returns null then createSource should throw InvalidRequestException`(): Unit =
-        `Given repository returns null when calling createAPI then throws InvalidRequestException`(
             mockApiRepository::createSource,
             stripe::createSource
         )
@@ -105,13 +91,6 @@ internal class StripeKtxTest {
         )
 
     @Test
-    fun `When repository returns null then createAccountToken should throw InvalidRequestException`(): Unit =
-        `Given repository returns null when calling createAPI then throws InvalidRequestException`(
-            mockApiRepository::createToken,
-            stripe::createAccountToken
-        )
-
-    @Test
     fun `When repository returns correct value then createBankAccountToken should Succeed`(): Unit =
         `Given repository returns non-empty value when calling createAPI then returns correct result`(
             mockApiRepository::createToken,
@@ -121,13 +100,6 @@ internal class StripeKtxTest {
     @Test
     fun `When repository throws exception then createBankAccountToken should throw same exception`(): Unit =
         `Given repository throws exception when calling createAPI then throws same exception`(
-            mockApiRepository::createToken,
-            stripe::createBankAccountToken
-        )
-
-    @Test
-    fun `When repository returns null then createBankAccountToken should throw InvalidRequestException`(): Unit =
-        `Given repository returns null when calling createAPI then throws InvalidRequestException`(
             mockApiRepository::createToken,
             stripe::createBankAccountToken
         )
@@ -147,13 +119,6 @@ internal class StripeKtxTest {
         )
 
     @Test
-    fun `When repository returns null then createPiiToken should throw InvalidRequestException`(): Unit =
-        `Given repository returns null when calling createAPI with String param then throws InvalidRequestException`(
-            mockApiRepository::createToken,
-            stripe::createPiiToken
-        )
-
-    @Test
     fun `When repository returns correct value then createCardToken should Succeed`(): Unit =
         `Given repository returns non-empty value when calling createAPI then returns correct result`(
             mockApiRepository::createToken,
@@ -163,13 +128,6 @@ internal class StripeKtxTest {
     @Test
     fun `When repository throws exception then createCardToken should throw same exception`(): Unit =
         `Given repository throws exception when calling createAPI then throws same exception`(
-            mockApiRepository::createToken,
-            stripe::createCardToken
-        )
-
-    @Test
-    fun `When repository returns null then createCardToken should throw InvalidRequestException`(): Unit =
-        `Given repository returns null when calling createAPI then throws InvalidRequestException`(
             mockApiRepository::createToken,
             stripe::createCardToken
         )
@@ -189,13 +147,6 @@ internal class StripeKtxTest {
         )
 
     @Test
-    fun `When repository returns null then createCvcUpdateToken should throw InvalidRequestException`(): Unit =
-        `Given repository returns null when calling createAPI with String param then throws InvalidRequestException`(
-            mockApiRepository::createToken,
-            stripe::createCvcUpdateToken
-        )
-
-    @Test
     fun `When repository returns correct value then createPersonToken should Succeed`(): Unit =
         `Given repository returns non-empty value when calling createAPI then returns correct result`(
             mockApiRepository::createToken,
@@ -205,13 +156,6 @@ internal class StripeKtxTest {
     @Test
     fun `When repository throws exception then createPersonToken should throw same exception`(): Unit =
         `Given repository throws exception when calling createAPI then throws same exception`(
-            mockApiRepository::createToken,
-            stripe::createPersonToken
-        )
-
-    @Test
-    fun `When repository returns null then createPersonToken should throw InvalidRequestException`(): Unit =
-        `Given repository returns null when calling createAPI then throws InvalidRequestException`(
             mockApiRepository::createToken,
             stripe::createPersonToken
         )
@@ -695,14 +639,14 @@ internal class StripeKtxTest {
 
     private inline fun <reified ApiObject : StripeModel, reified CreateAPIParam : StripeParamsModel, reified RepositoryParam : StripeParamsModel>
     `Given repository returns non-empty value when calling createAPI then returns correct result`(
-        crossinline repositoryBlock: suspend (RepositoryParam, ApiRequest.Options) -> ApiObject?,
+        crossinline repositoryBlock: suspend (RepositoryParam, ApiRequest.Options) -> Result<ApiObject>,
         crossinline createApiInvocationBlock: suspend (CreateAPIParam, String?, String?) -> ApiObject
     ) = runTest {
         val expectedApiObj = mock<ApiObject>()
 
         whenever(
             repositoryBlock(any(), any())
-        ).thenReturn(expectedApiObj)
+        ).thenReturn(Result.success(expectedApiObj))
 
         val actualObj = createApiInvocationBlock(
             mock(),
@@ -715,12 +659,12 @@ internal class StripeKtxTest {
 
     private inline fun <reified CreateAPIParam : StripeParamsModel, reified RepositoryParam : StripeParamsModel>
     `Given repository throws exception when calling createAPI then throws same exception`(
-        crossinline repositoryBlock: suspend (RepositoryParam, ApiRequest.Options) -> StripeModel?,
+        crossinline repositoryBlock: suspend (RepositoryParam, ApiRequest.Options) -> Result<StripeModel>,
         crossinline createApiInvocationBlock: suspend (CreateAPIParam, String?, String?) -> StripeModel
     ): Unit = runTest {
         whenever(
             repositoryBlock(any(), any())
-        ).thenThrow(mock<AuthenticationException>())
+        ).thenReturn(Result.failure(mock<AuthenticationException>()))
 
         assertFailsWith<AuthenticationException> {
             createApiInvocationBlock(
@@ -731,34 +675,16 @@ internal class StripeKtxTest {
         }
     }
 
-    private inline fun <reified ApiObject : StripeModel, reified CreateAPIParam : StripeParamsModel, reified RepositoryParam : StripeParamsModel>
-    `Given repository returns null when calling createAPI then throws InvalidRequestException`(
-        crossinline repositoryBlock: suspend (RepositoryParam, ApiRequest.Options) -> ApiObject?,
-        crossinline createApiInvocationBlock: suspend (CreateAPIParam, String?, String?) -> ApiObject
-    ): Unit = runTest {
-        whenever(
-            repositoryBlock(any(), any())
-        ).thenReturn(null)
-
-        assertFailsWithMessage<InvalidRequestException>("Failed to parse ${ApiObject::class.java.simpleName}.") {
-            createApiInvocationBlock(
-                mock(),
-                TEST_IDEMPOTENCY_KEY,
-                TEST_STRIPE_ACCOUNT_ID
-            )
-        }
-    }
-
     private inline fun <reified ApiObject : StripeModel, reified RepositoryParam : StripeParamsModel>
     `Given repository returns non-empty value when calling createAPI with String param then returns correct result`(
-        crossinline repositoryBlock: suspend (RepositoryParam, ApiRequest.Options) -> ApiObject?,
+        crossinline repositoryBlock: suspend (RepositoryParam, ApiRequest.Options) -> Result<ApiObject>,
         crossinline createApiInvocationBlock: suspend (String, String?, String?) -> ApiObject
     ) = runTest {
         val expectedApiObj = mock<ApiObject>()
 
         whenever(
             repositoryBlock(any(), any())
-        ).thenReturn(expectedApiObj)
+        ).thenReturn(Result.success(expectedApiObj))
 
         val actualObj = createApiInvocationBlock(
             "param1",
@@ -771,32 +697,14 @@ internal class StripeKtxTest {
 
     private inline fun <reified RepositoryParam : StripeParamsModel>
     `Given repository throws exception when calling createAPI with String param then throws same exception`(
-        crossinline repositoryBlock: suspend (RepositoryParam, ApiRequest.Options) -> StripeModel?,
+        crossinline repositoryBlock: suspend (RepositoryParam, ApiRequest.Options) -> Result<StripeModel>,
         crossinline createApiInvocationBlock: suspend (String, String?, String?) -> StripeModel
     ): Unit = runTest {
         whenever(
             repositoryBlock(any(), any())
-        ).thenThrow(mock<AuthenticationException>())
+        ).thenReturn(Result.failure(mock<AuthenticationException>()))
 
         assertFailsWith<AuthenticationException> {
-            createApiInvocationBlock(
-                "param1",
-                TEST_IDEMPOTENCY_KEY,
-                TEST_STRIPE_ACCOUNT_ID
-            )
-        }
-    }
-
-    private inline fun <reified ApiObject : StripeModel, reified RepositoryParam : Any>
-    `Given repository returns null when calling createAPI with String param then throws InvalidRequestException`(
-        crossinline repositoryBlock: suspend (RepositoryParam, ApiRequest.Options) -> ApiObject?,
-        crossinline createApiInvocationBlock: suspend (String, String?, String?) -> ApiObject
-    ): Unit = runTest {
-        whenever(
-            repositoryBlock(any(), any())
-        ).thenReturn(null)
-
-        assertFailsWithMessage<InvalidRequestException>("Failed to parse ${ApiObject::class.java.simpleName}.") {
             createApiInvocationBlock(
                 "param1",
                 TEST_IDEMPOTENCY_KEY,

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
@@ -242,8 +242,8 @@ class GooglePayPaymentMethodLauncherViewModelTest {
         override suspend fun createPaymentMethod(
             paymentMethodCreateParams: PaymentMethodCreateParams,
             options: ApiRequest.Options
-        ): PaymentMethod {
-            return PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        ): Result<PaymentMethod> {
+            return Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         }
     }
 

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -1162,12 +1162,12 @@ internal class StripeApiRepositoryTest {
             whenever(stripeNetworkClient.executeRequest(any<ApiRequest>()))
                 .thenAnswer { throw UnknownHostException() }
 
-            assertFailsWith<APIConnectionException> {
-                create().createSource(
-                    SourceParams.createCardParams(CARD_PARAMS),
-                    DEFAULT_OPTIONS
-                )
-            }
+            val exception = create().createSource(
+                sourceParams = SourceParams.createCardParams(CARD_PARAMS),
+                options = DEFAULT_OPTIONS,
+            ).exceptionOrNull()
+
+            assertThat(exception).isInstanceOf(APIConnectionException::class.java)
         }
 
     @Test

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -323,17 +323,13 @@ internal class CustomerSheetViewModel @Inject constructor(
     private suspend fun createPaymentMethod(
         createParams: PaymentMethodCreateParams
     ): Result<PaymentMethod> {
-        return kotlin.runCatching {
-            requireNotNull(
-                stripeRepository.createPaymentMethod(
-                    paymentMethodCreateParams = createParams,
-                    options = ApiRequest.Options(
-                        apiKey = paymentConfiguration.publishableKey,
-                        stripeAccount = paymentConfiguration.stripeAccountId,
-                    )
-                )
+        return stripeRepository.createPaymentMethod(
+            paymentMethodCreateParams = createParams,
+            options = ApiRequest.Options(
+                apiKey = paymentConfiguration.publishableKey,
+                stripeAccount = paymentConfiguration.stripeAccountId,
             )
-        }
+        )
     }
 
     private fun attachPaymentMethodToCustomer(paymentMethod: PaymentMethod) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptor.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet
 import android.content.Context
 import com.stripe.android.ConfirmStripeIntentParamsFactory
 import com.stripe.android.R
-import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.networking.ApiRequest
@@ -229,12 +228,10 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
     private suspend fun createPaymentMethod(
         params: PaymentMethodCreateParams,
     ): Result<PaymentMethod> {
-        return runCatching {
-            stripeRepository.createPaymentMethod(
-                paymentMethodCreateParams = params,
-                options = requestOptions,
-            ) ?: throw APIException(message = "Couldn't parse response when creating payment method")
-        }
+        return stripeRepository.createPaymentMethod(
+            paymentMethodCreateParams = params,
+            options = requestOptions,
+        )
     }
 
     private suspend fun handleDeferredIntentCreationFromPaymentMethod(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -9,7 +9,7 @@ import com.stripe.android.core.exception.APIException
 import com.stripe.android.customersheet.CustomerSheetTestHelper.createViewModel
 import com.stripe.android.customersheet.injection.CustomerSheetViewModelModule
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.forms.FormViewModel
@@ -80,12 +80,12 @@ class CustomerSheetViewModelTest {
             customerAdapter = FakeCustomerAdapter(
                 paymentMethods = CustomerAdapter.Result.success(
                     listOf(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                        CARD_PAYMENT_METHOD
                     )
                 ),
                 selectedPaymentOption = CustomerAdapter.Result.success(
                     CustomerAdapter.PaymentOption.fromId(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!
+                        CARD_PAYMENT_METHOD.id!!
                     )
                 )
             )
@@ -96,10 +96,10 @@ class CustomerSheetViewModelTest {
                     CustomerSheetViewState.SelectPaymentMethod(
                         title = null,
                         savedPaymentMethods = listOf(
-                            PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                            CARD_PAYMENT_METHOD,
                         ),
                         paymentSelection = PaymentSelection.Saved(
-                            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                            paymentMethod = CARD_PAYMENT_METHOD,
                         ),
                         isLiveMode = false,
                         isProcessing = false,
@@ -186,12 +186,12 @@ class CustomerSheetViewModelTest {
             customerAdapter = FakeCustomerAdapter(
                 paymentMethods = CustomerAdapter.Result.success(
                     listOf(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                        CARD_PAYMENT_METHOD
                     )
                 ),
                 selectedPaymentOption = CustomerAdapter.Result.success(
                     CustomerAdapter.PaymentOption.fromId(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!
+                        CARD_PAYMENT_METHOD.id!!
                     )
                 )
             )
@@ -219,12 +219,12 @@ class CustomerSheetViewModelTest {
             customerAdapter = FakeCustomerAdapter(
                 paymentMethods = CustomerAdapter.Result.success(
                     listOf(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                        CARD_PAYMENT_METHOD
                     )
                 ),
                 selectedPaymentOption = CustomerAdapter.Result.success(
                     CustomerAdapter.PaymentOption.fromId(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!
+                        CARD_PAYMENT_METHOD.id!!
                     )
                 )
             )
@@ -244,7 +244,7 @@ class CustomerSheetViewModelTest {
             customerAdapter = FakeCustomerAdapter(
                 paymentMethods = CustomerAdapter.Result.success(
                     listOf(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                        CARD_PAYMENT_METHOD
                     )
                 ),
                 selectedPaymentOption = CustomerAdapter.Result.success(null)
@@ -263,7 +263,7 @@ class CustomerSheetViewModelTest {
             customerAdapter = FakeCustomerAdapter(
                 paymentMethods = CustomerAdapter.Result.success(
                     listOf(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                        CARD_PAYMENT_METHOD
                     )
                 ),
                 selectedPaymentOption = CustomerAdapter.Result.success(null)
@@ -277,7 +277,7 @@ class CustomerSheetViewModelTest {
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnItemSelected(
                     selection = PaymentSelection.Saved(
-                        paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                        paymentMethod = CARD_PAYMENT_METHOD
                     )
                 )
             )
@@ -297,7 +297,7 @@ class CustomerSheetViewModelTest {
             customerAdapter = FakeCustomerAdapter(
                 paymentMethods = CustomerAdapter.Result.success(
                     listOf(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                        CARD_PAYMENT_METHOD
                     )
                 ),
                 selectedPaymentOption = CustomerAdapter.Result.success(null)
@@ -329,7 +329,7 @@ class CustomerSheetViewModelTest {
             customerAdapter = FakeCustomerAdapter(
                 paymentMethods = CustomerAdapter.Result.success(
                     listOf(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                        CARD_PAYMENT_METHOD
                     )
                 ),
                 selectedPaymentOption = CustomerAdapter.Result.success(null)
@@ -355,7 +355,7 @@ class CustomerSheetViewModelTest {
             customerAdapter = FakeCustomerAdapter(
                 paymentMethods = CustomerAdapter.Result.success(
                     listOf(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                        CARD_PAYMENT_METHOD
                     )
                 ),
                 selectedPaymentOption = CustomerAdapter.Result.success(null)
@@ -425,12 +425,12 @@ class CustomerSheetViewModelTest {
             customerAdapter = FakeCustomerAdapter(
                 paymentMethods = CustomerAdapter.Result.success(
                     listOf(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                        CARD_PAYMENT_METHOD
                     )
                 ),
                 selectedPaymentOption = CustomerAdapter.Result.success(
                     CustomerAdapter.PaymentOption.fromId(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!
+                        CARD_PAYMENT_METHOD.id!!
                     )
                 )
             )
@@ -442,7 +442,7 @@ class CustomerSheetViewModelTest {
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnItemRemoved(
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                    CARD_PAYMENT_METHOD
                 )
             )
 
@@ -458,7 +458,7 @@ class CustomerSheetViewModelTest {
             customerAdapter = FakeCustomerAdapter(
                 paymentMethods = CustomerAdapter.Result.success(
                     listOf(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                        CARD_PAYMENT_METHOD
                     )
                 ),
                 onDetachPaymentMethod = {
@@ -480,7 +480,7 @@ class CustomerSheetViewModelTest {
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnItemRemoved(
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                    CARD_PAYMENT_METHOD
                 )
             )
 
@@ -497,12 +497,12 @@ class CustomerSheetViewModelTest {
             customerAdapter = FakeCustomerAdapter(
                 paymentMethods = CustomerAdapter.Result.success(
                     listOf(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                        CARD_PAYMENT_METHOD
                     )
                 ),
                 selectedPaymentOption = CustomerAdapter.Result.success(
                     CustomerAdapter.PaymentOption.fromId(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!
+                        CARD_PAYMENT_METHOD.id!!
                     )
                 )
             )
@@ -524,12 +524,12 @@ class CustomerSheetViewModelTest {
             customerAdapter = FakeCustomerAdapter(
                 paymentMethods = CustomerAdapter.Result.success(
                     listOf(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                        CARD_PAYMENT_METHOD
                     )
                 ),
                 selectedPaymentOption = CustomerAdapter.Result.success(
                     CustomerAdapter.PaymentOption.fromId(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!
+                        CARD_PAYMENT_METHOD.id!!
                     )
                 ),
                 onSetSelectedPaymentOption = {
@@ -588,9 +588,7 @@ class CustomerSheetViewModelTest {
                 )
             ),
             stripeRepository = FakeStripeRepository(
-                onCreatePaymentMethod = {
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD
-                }
+                createPaymentMethodResult = Result.success(CARD_PAYMENT_METHOD),
             )
         )
 
@@ -622,13 +620,9 @@ class CustomerSheetViewModelTest {
                 )
             ),
             stripeRepository = FakeStripeRepository(
-                onCreatePaymentMethod = {
-                    throw APIException(
-                        stripeError = StripeError(
-                            message = "Could not create payment method."
-                        )
-                    )
-                }
+                createPaymentMethodResult = Result.failure(
+                    APIException(stripeError = StripeError(message = "Could not create payment method."))
+                ),
             )
         )
 
@@ -679,9 +673,7 @@ class CustomerSheetViewModelTest {
                 },
             ),
             stripeRepository = FakeStripeRepository(
-                onCreatePaymentMethod = {
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD
-                },
+                createPaymentMethodResult = Result.success(CARD_PAYMENT_METHOD),
                 onConfirmSetupIntent = {
                     SetupIntentFixtures.SI_SUCCEEDED
                 }
@@ -700,7 +692,7 @@ class CustomerSheetViewModelTest {
             val newViewState = awaitItem() as CustomerSheetViewState.SelectPaymentMethod
             assertThat(newViewState.errorMessage).isNull()
             assertThat(newViewState.isProcessing).isFalse()
-            assertThat(newViewState.savedPaymentMethods.contains(PaymentMethodFixtures.CARD_PAYMENT_METHOD))
+            assertThat(newViewState.savedPaymentMethods.contains(CARD_PAYMENT_METHOD))
         }
     }
 
@@ -735,14 +727,12 @@ class CustomerSheetViewModelTest {
             customerAdapter = FakeCustomerAdapter(
                 canCreateSetupIntents = false,
                 onAttachPaymentMethod = {
-                    CustomerAdapter.Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+                    CustomerAdapter.Result.success(CARD_PAYMENT_METHOD)
                 },
                 onSetupIntentClientSecretForCustomerAttach = null,
             ),
             stripeRepository = FakeStripeRepository(
-                onCreatePaymentMethod = {
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD
-                },
+                createPaymentMethodResult = Result.success(CARD_PAYMENT_METHOD),
             ),
         )
 
@@ -758,7 +748,7 @@ class CustomerSheetViewModelTest {
             val newViewState = awaitItem() as CustomerSheetViewState.SelectPaymentMethod
             assertThat(newViewState.errorMessage).isNull()
             assertThat(newViewState.isProcessing).isFalse()
-            assertThat(newViewState.savedPaymentMethods.contains(PaymentMethodFixtures.CARD_PAYMENT_METHOD))
+            assertThat(newViewState.savedPaymentMethods.contains(CARD_PAYMENT_METHOD))
         }
     }
 
@@ -785,9 +775,7 @@ class CustomerSheetViewModelTest {
                 },
             ),
             stripeRepository = FakeStripeRepository(
-                onCreatePaymentMethod = {
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD
-                },
+                createPaymentMethodResult = Result.success(CARD_PAYMENT_METHOD),
                 onConfirmSetupIntent = {
                     throw APIException(
                         stripeError = StripeError(
@@ -833,9 +821,7 @@ class CustomerSheetViewModelTest {
                 onSetupIntentClientSecretForCustomerAttach = null,
             ),
             stripeRepository = FakeStripeRepository(
-                onCreatePaymentMethod = {
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD
-                },
+                createPaymentMethodResult = Result.success(CARD_PAYMENT_METHOD),
             ),
         )
 
@@ -884,9 +870,7 @@ class CustomerSheetViewModelTest {
                 },
             ),
             stripeRepository = FakeStripeRepository(
-                onCreatePaymentMethod = {
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD
-                },
+                createPaymentMethodResult = Result.success(CARD_PAYMENT_METHOD),
             ),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeStripeRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeStripeRepository.kt
@@ -8,16 +8,15 @@ import com.stripe.android.model.SetupIntent
 import com.stripe.android.testing.AbsFakeStripeRepository
 
 class FakeStripeRepository(
-    private val onCreatePaymentMethod:
-        ((paymentMethodCreateParams: PaymentMethodCreateParams) -> PaymentMethod)? = null,
-    private val onConfirmSetupIntent:
-        (() -> SetupIntent?)? = null
+    private val createPaymentMethodResult: Result<PaymentMethod> = Result.failure(NotImplementedError()),
+    private val onConfirmSetupIntent: (() -> SetupIntent?)? = null,
 ) : AbsFakeStripeRepository() {
+
     override suspend fun createPaymentMethod(
         paymentMethodCreateParams: PaymentMethodCreateParams,
         options: ApiRequest.Options
-    ): PaymentMethod? {
-        return onCreatePaymentMethod?.invoke(paymentMethodCreateParams)
+    ): Result<PaymentMethod> {
+        return createPaymentMethodResult
     }
 
     override suspend fun confirmSetupIntent(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
@@ -127,8 +127,8 @@ class DefaultIntentConfirmationInterceptorTest {
                 override suspend fun createPaymentMethod(
                     paymentMethodCreateParams: PaymentMethodCreateParams,
                     options: ApiRequest.Options
-                ): PaymentMethod {
-                    return PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                ): Result<PaymentMethod> {
+                    return Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
                 }
             },
             publishableKeyProvider = { "pk" },
@@ -164,8 +164,8 @@ class DefaultIntentConfirmationInterceptorTest {
                 override suspend fun createPaymentMethod(
                     paymentMethodCreateParams: PaymentMethodCreateParams,
                     options: ApiRequest.Options
-                ): PaymentMethod? {
-                    throw apiException
+                ): Result<PaymentMethod> {
+                    return Result.failure(apiException)
                 }
             },
             publishableKeyProvider = { "pk" },


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates the creation-related methods in `StripeRepository` to use `Result<T>` as their return type. As a consequence, some tests are no longer applicable and are being removed as part of this work.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
