### PR TITLE
Remove unnecessary coroutine scope in CustomerSheetActivity

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetActivity.kt
@@ -11,7 +11,6 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.common.ui.BottomSheet
@@ -19,7 +18,6 @@ import com.stripe.android.common.ui.rememberBottomSheetState
 import com.stripe.android.customersheet.ui.CustomerSheetScreen
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.utils.AnimationConstants
-import kotlinx.coroutines.launch
 
 internal class CustomerSheetActivity : AppCompatActivity() {
 
@@ -48,7 +46,6 @@ internal class CustomerSheetActivity : AppCompatActivity() {
         setContent {
             StripeTheme {
                 val bottomSheetState = rememberBottomSheetState()
-                val coroutineScope = rememberCoroutineScope()
 
                 val viewState by viewModel.viewState.collectAsState()
                 val result by viewModel.result.collectAsState()
@@ -61,9 +58,7 @@ internal class CustomerSheetActivity : AppCompatActivity() {
                 }
 
                 BackHandler {
-                    coroutineScope.launch {
-                        viewModel.handleViewAction(CustomerSheetViewAction.OnBackPressed)
-                    }
+                    viewModel.handleViewAction(CustomerSheetViewAction.OnBackPressed)
                 }
 
                 BottomSheet(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request removes an unnecessary coroutine scope from `CustomerSheetActivity`. This was necessary when we called `bottomSheetState.hide()` inline, but now that we’re delegating to the view model, it’s no longer needed.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
