### PR TITLE
Don't show the Link inline checkbox for existing link users when passed in by the merchant.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -132,8 +132,6 @@ private fun BaseSheetViewModel.showLinkInlineSignupView(
 ): Boolean {
     val validStatusStates = setOf(
         AccountStatus.Verified,
-        AccountStatus.NeedsVerification,
-        AccountStatus.VerificationStarted,
         AccountStatus.SignedOut,
     )
     val linkInlineSelectionValid = linkHandler.linkInlineSelection.value != null


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This hides the inline checkbox for existing users (when the users email was passed in via the merchant).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
link redesign bug bash
