### PR TITLE
Use `Result<T>` for cancelling intent sources

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -99,8 +99,8 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         setupIntentId: String,
         sourceId: String,
         options: ApiRequest.Options
-    ): SetupIntent? {
-        TODO("Not yet implemented")
+    ): Result<SetupIntent> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun createSource(

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -75,8 +75,8 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         paymentIntentId: String,
         sourceId: String,
         options: ApiRequest.Options
-    ): PaymentIntent? {
-        TODO("Not yet implemented")
+    ): Result<PaymentIntent> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun confirmSetupIntent(

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -455,18 +455,12 @@ class StripeApiRepository @JvmOverloads internal constructor(
     /**
      * Analytics event: [PaymentAnalyticsEvent.SetupIntentCancelSource]
      */
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class
-    )
     override suspend fun cancelSetupIntentSource(
         setupIntentId: String,
         sourceId: String,
         options: ApiRequest.Options
-    ): SetupIntent? {
-        return fetchStripeModel(
+    ): Result<SetupIntent> {
+        return fetchStripeModelResult(
             apiRequestFactory.createPost(
                 getCancelSetupIntentSourceUrl(setupIntentId),
                 options,

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -343,26 +343,20 @@ class StripeApiRepository @JvmOverloads internal constructor(
     /**
      * Analytics event: [PaymentAnalyticsEvent.PaymentIntentCancelSource]
      */
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class
-    )
     override suspend fun cancelPaymentIntentSource(
         paymentIntentId: String,
         sourceId: String,
         options: ApiRequest.Options
-    ): PaymentIntent? {
+    ): Result<PaymentIntent> {
         fireFraudDetectionDataRequest()
 
-        return fetchStripeModel(
-            apiRequestFactory.createPost(
-                getCancelPaymentIntentSourceUrl(paymentIntentId),
-                options,
-                mapOf("source" to sourceId)
+        return fetchStripeModelResult(
+            apiRequest = apiRequestFactory.createPost(
+                url = getCancelPaymentIntentSourceUrl(paymentIntentId),
+                options = options,
+                params = mapOf("source" to sourceId),
             ),
-            PaymentIntentJsonParser()
+            jsonParser = PaymentIntentJsonParser(),
         ) {
             fireAnalyticsRequest(PaymentAnalyticsEvent.PaymentIntentCancelSource)
         }

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -94,18 +94,12 @@ interface StripeRepository {
         options: ApiRequest.Options
     ): PaymentIntent?
 
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class
-    )
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun cancelPaymentIntentSource(
         paymentIntentId: String,
         sourceId: String,
         options: ApiRequest.Options
-    ): PaymentIntent?
+    ): Result<PaymentIntent>
 
     @Throws(
         AuthenticationException::class,

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -133,18 +133,12 @@ interface StripeRepository {
         expandFields: List<String> = emptyList()
     ): SetupIntent?
 
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class
-    )
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun cancelSetupIntentSource(
         setupIntentId: String,
         sourceId: String,
         options: ApiRequest.Options
-    ): SetupIntent?
+    ): Result<SetupIntent>
 
     @Throws(
         AuthenticationException::class,

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -408,13 +408,11 @@ internal class SetupIntentFlowResultProcessor @Inject constructor(
         stripeIntentId: String,
         requestOptions: ApiRequest.Options,
         sourceId: String
-    ): Result<SetupIntent> = runCatching {
-        requireNotNull(
-            stripeRepository.cancelSetupIntentSource(
-                stripeIntentId,
-                sourceId,
-                requestOptions
-            )
+    ): Result<SetupIntent> {
+        return stripeRepository.cancelSetupIntentSource(
+            setupIntentId = stripeIntentId,
+            sourceId = sourceId,
+            options = requestOptions,
         )
     }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -337,13 +337,11 @@ internal class PaymentIntentFlowResultProcessor @Inject constructor(
         stripeIntentId: String,
         requestOptions: ApiRequest.Options,
         sourceId: String
-    ): Result<PaymentIntent> = runCatching {
-        requireNotNull(
-            stripeRepository.cancelPaymentIntentSource(
-                stripeIntentId,
-                sourceId,
-                requestOptions
-            )
+    ): Result<PaymentIntent> {
+        return stripeRepository.cancelPaymentIntentSource(
+            paymentIntentId = stripeIntentId,
+            sourceId = sourceId,
+            options = requestOptions,
         )
     }
 

--- a/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -273,11 +273,11 @@ internal class StripePaymentControllerTest {
             paymentIntentId: String,
             sourceId: String,
             options: ApiRequest.Options
-        ): PaymentIntent {
+        ): Result<PaymentIntent> {
             cancelPaymentIntentArgs.add(
                 Triple(paymentIntentId, sourceId, options)
             )
-            return cancelPaymentIntentResponse
+            return Result.success(cancelPaymentIntentResponse)
         }
 
         override suspend fun cancelSetupIntentSource(

--- a/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -14,6 +14,7 @@ import com.stripe.android.model.AlipayAuthResult
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.Source
 import com.stripe.android.model.SourceFixtures
@@ -283,7 +284,7 @@ internal class StripePaymentControllerTest {
             setupIntentId: String,
             sourceId: String,
             options: ApiRequest.Options
-        ) = SetupIntentFixtures.CANCELLED
+        ): Result<SetupIntent> = Result.success(SetupIntentFixtures.CANCELLED)
 
         override suspend fun confirmPaymentIntent(
             confirmPaymentIntentParams: ConfirmPaymentIntentParams,

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
@@ -826,7 +826,7 @@ internal object PaymentIntentFixtures {
         }
                 """.trimIndent()
             )
-        )
+        )!!
     }
 
     val EXPANDED_PAYMENT_METHOD_JSON by lazy {

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -1141,21 +1141,19 @@ internal class StripeApiRepositoryTest {
     @Test
     fun cancelPaymentIntentSource_whenAlreadyCanceled_throwsInvalidRequestException() =
         runTest {
-            val exception = assertFailsWith<InvalidRequestException> {
-                stripeApiRepository.cancelPaymentIntentSource(
-                    "pi_1FejpSH8dsfnfKo38L276wr6",
-                    "src_1FejpbH8dsfnfKo3KR7EqCzJ",
-                    ApiRequest.Options(ApiKeyFixtures.FPX_PUBLISHABLE_KEY)
-                )
-            }
-            assertEquals(
+            val exception = stripeApiRepository.cancelPaymentIntentSource(
+                paymentIntentId = "pi_1FejpSH8dsfnfKo38L276wr6",
+                sourceId = "src_1FejpbH8dsfnfKo3KR7EqCzJ",
+                options = ApiRequest.Options(ApiKeyFixtures.FPX_PUBLISHABLE_KEY),
+            ).exceptionOrNull() as InvalidRequestException
+
+            assertThat(exception.message).isEqualTo(
                 "This PaymentIntent could be not be fulfilled via this session because" +
                     " a different payment method was attached to it. " +
                     "Another session could be attempting to fulfill this PaymentIntent." +
                     " Please complete that session or try again.",
-                exception.message
             )
-            assertEquals("payment_intent_unexpected_state", exception.stripeError?.code)
+            assertThat(exception.stripeError?.code).isEqualTo("payment_intent_unexpected_state")
         }
 
     @Test

--- a/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
@@ -49,12 +49,12 @@ internal class PaymentIntentFlowResultProcessorTest {
             )
             whenever(
                 mockStripeRepository.cancelPaymentIntentSource(
-                    any(),
-                    any(),
-                    any()
+                    paymentIntentId = any(),
+                    sourceId = any(),
+                    options = any(),
                 )
             ).thenReturn(
-                PaymentIntentFixtures.CANCELLED
+                Result.success(PaymentIntentFixtures.CANCELLED)
             )
 
             val paymentIntentResult = processor.processResult(
@@ -80,7 +80,7 @@ internal class PaymentIntentFlowResultProcessorTest {
             whenever(mockStripeRepository.retrievePaymentIntent(any(), any(), any()))
                 .thenReturn(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2)
             whenever(mockStripeRepository.cancelPaymentIntentSource(any(), any(), any()))
-                .thenReturn(PaymentIntentFixtures.PAYMENT_INTENT_WITH_CANCELED_3DS2_SOURCE)
+                .thenReturn(Result.success(PaymentIntentFixtures.PAYMENT_INTENT_WITH_CANCELED_3DS2_SOURCE))
 
             processor.processResult(
                 PaymentFlowResult.Unvalidated(

--- a/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
@@ -45,7 +45,7 @@ internal class SetupIntentFlowResultProcessorTest {
                 SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT
             )
             whenever(mockStripeRepository.cancelSetupIntentSource(any(), any(), any())).thenReturn(
-                SetupIntentFixtures.CANCELLED
+                Result.success(SetupIntentFixtures.CANCELLED)
             )
 
             val setupIntentResult = processor.processResult(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates the methods for canceling an intent source to using `Result<T>` as their return type.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
