### PR TITLE
Update ordering of payment methods

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -114,15 +114,20 @@ internal class CustomerSheetViewModel @Inject constructor(
                 Pair(paymentMethods, selection)
             }
 
-            val paymentMethods = result.getOrNull()?.first?.toMutableList()
+            var paymentMethods = result.getOrNull()?.first
+            val paymentSelection = result.getOrNull()?.second
 
-            val paymentSelection = result.getOrNull()?.second?.apply {
-                // The order of the payment method carousel should be as follows:
-                // Add card, Google Pay (if enabled), selected PM, additional PMs
+            paymentSelection?.apply {
                 val selectedPaymentMethod = (this as? PaymentSelection.Saved)?.paymentMethod
-                paymentMethods?.remove(selectedPaymentMethod)
-                selectedPaymentMethod?.let {
-                    paymentMethods?.add(0, selectedPaymentMethod)
+                // The order of the payment methods should be selected PM and then any additional PMs
+                // The carousel always starts with Add and Google Pay (if enabled)
+                paymentMethods = paymentMethods?.sortedWith { left, right ->
+                    // We only care to move the selected payment method, all others stay in the order they were before
+                    when {
+                        left.id == selectedPaymentMethod?.id -> -1
+                        right.id == selectedPaymentMethod?.id -> 1
+                        else -> 0
+                    }
                 }
             }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -959,6 +959,52 @@ class CustomerSheetViewModelTest {
         }
     }
 
+    @Test
+    fun `When there is a payment selection, the selected PM should be first in the list`() = runTest {
+        val viewModel = createViewModel(
+            customerAdapter = FakeCustomerAdapter(
+                paymentMethods = CustomerAdapter.Result.success(
+                    listOf(
+                        PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_1"),
+                        PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_2"),
+                        PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_3"),
+                    )
+                ),
+                selectedPaymentOption = CustomerAdapter.Result.success(
+                    CustomerAdapter.PaymentOption.fromId("pm_3")
+                )
+            )
+        )
+
+        viewModel.viewState.test {
+            val viewState = awaitItem() as CustomerSheetViewState.SelectPaymentMethod
+            assertThat(viewState.savedPaymentMethods.indexOfFirst { it.id == "pm_3" }).isEqualTo(0)
+        }
+    }
+
+    @Test
+    fun `When there is no payment selection, the order of the payment methods is preserved`() = runTest {
+        val viewModel = createViewModel(
+            customerAdapter = FakeCustomerAdapter(
+                paymentMethods = CustomerAdapter.Result.success(
+                    listOf(
+                        PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_1"),
+                        PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_2"),
+                        PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_3"),
+                    )
+                ),
+                selectedPaymentOption = CustomerAdapter.Result.success(null)
+            )
+        )
+
+        viewModel.viewState.test {
+            val viewState = awaitItem() as CustomerSheetViewState.SelectPaymentMethod
+            assertThat(viewState.savedPaymentMethods.indexOfFirst { it.id == "pm_1" }).isEqualTo(0)
+            assertThat(viewState.savedPaymentMethods.indexOfFirst { it.id == "pm_2" }).isEqualTo(1)
+            assertThat(viewState.savedPaymentMethods.indexOfFirst { it.id == "pm_3" }).isEqualTo(2)
+        }
+    }
+
     private fun buildBackstack(vararg states: CustomerSheetViewState): Stack<CustomerSheetViewState> {
         return Stack<CustomerSheetViewState>().apply {
             states.forEach {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Update ordering of payment methods. The selected payment method should always come after the add card, google play card (if enabled).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Match iOS behavior

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |


https://github.com/stripe/stripe-android/assets/99316447/d693107b-cb75-4939-bcc0-06afce35397c

