### PR TITLE
Fix warnings in `Stripe` and `StripeKtx`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/Stripe.kt
+++ b/payments-core/src/main/java/com/stripe/android/Stripe.kt
@@ -1101,7 +1101,7 @@ class Stripe internal constructor(
         @Size(min = 1) sourceId: String,
         @Size(min = 1) clientSecret: String,
         stripeAccountId: String? = this.stripeAccountId
-    ): Source? {
+    ): Source {
         return runBlocking {
             stripeRepository.retrieveSource(
                 sourceId,
@@ -1110,7 +1110,7 @@ class Stripe internal constructor(
                     apiKey = publishableKey,
                     stripeAccount = stripeAccountId
                 )
-            ).getOrThrow()
+            ).getOrElse { throw StripeException.create(it) }
         }
     }
 
@@ -1666,7 +1666,7 @@ class Stripe internal constructor(
      * This function should only be called when the PaymentIntent is in the `requires_action` state
      * and `NextActionType` is VerifyWithMicrodeposits.
      *
-     * See the [Verify bank account with micro-despoits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
+     * See the [Verify bank account with micro-deposits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
      *
      * @param clientSecret The client secret of the PaymentIntent
      * @param firstAmount The amount, in cents of USD, equal to the value of the first micro-deposit
@@ -1701,7 +1701,7 @@ class Stripe internal constructor(
      * This function should only be called when the PaymentIntent is in the `requires_action` state
      * and `NextActionType` is VerifyWithMicrodeposits.
      *
-     * See the [Verify bank account with micro-despoits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
+     * See the [Verify bank account with micro-deposits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
      *
      * @param clientSecret The client secret of the PaymentIntent
      * @param descriptorCode A unique, 6-digit descriptor code that starts with SM that was sent as
@@ -1732,7 +1732,7 @@ class Stripe internal constructor(
      * This function should only be called when the SetupIntent is in the `requires_action` state
      * and `NextActionType` is VerifyWithMicrodeposits.
      *
-     * See the [Verify bank account with micro-despoits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
+     * See the [Verify bank account with micro-deposits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
      *
      * @param clientSecret The client secret of the SetupIntent
      * @param firstAmount The amount, in cents of USD, equal to the value of the first micro-deposit
@@ -1767,7 +1767,7 @@ class Stripe internal constructor(
      * This function should only be called when the SetupIntent is in the `requires_action` state
      * and `NextActionType` is VerifyWithMicrodeposits.
      *
-     * See the [Verify bank account with micro-despoits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
+     * See the [Verify bank account with micro-deposits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
      *
      * @param clientSecret The client secret of the SetupIntent
      * @param descriptorCode A unique, 6-digit descriptor code that starts with SM that was sent as

--- a/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
@@ -696,7 +696,7 @@ private inline fun <reified ApiObject : StripeModel> runApiRequest(
 /**
  * Get the [PaymentIntentResult] from [Intent] returned via
  * Activity#onActivityResult(int, int, Intent)}} for PaymentIntent automatic confirmation
- * (see [confirmPayment]) or manual confirmation (see [handleNextActionForPayment]})
+ * (see [Stripe.confirmPayment]) or manual confirmation (see [Stripe.handleNextActionForPayment]})
  *
  * @param requestCode [Int] code passed from Activity#onActivityResult
  * @param data [Intent] intent from Activity#onActivityResult
@@ -759,7 +759,7 @@ suspend fun Stripe.getSetupIntentResult(
 /**
  * Get the [Source] from [Intent] returned via
  * Activity#onActivityResult(int, int, Intent)}} for [Source] authentication.
- * (see [authenticateSource])
+ * (see [Stripe.authenticateSource])
  *
  * @param requestCode [Int] code passed from Activity#onActivityResult
  * @param data [Intent] intent from Activity#onActivityResult
@@ -810,14 +810,13 @@ internal inline fun <reified ApiObject : StripeModel> runApiRequest(
  * This function should only be called when the PaymentIntent is in the `requires_action` state
  * and `NextActionType` is VerifyWithMicrodeposits.
  *
- * See the [Verify bank account with micro-despoits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
+ * See the [Verify bank account with micro-deposits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
  *
  * @param clientSecret The client secret of the PaymentIntent
  * @param firstAmount The amount, in cents of USD, equal to the value of the first micro-deposit
  * sent to the bank account
  * @param secondAmount The amount, in cents of USD, equal to the value of the second micro-deposit
  * sent to the bank account
- * @param callback a [ApiResultCallback] to receive the result or error
  *
  * @return a [PaymentIntent] object
  *
@@ -854,12 +853,11 @@ suspend fun Stripe.verifyPaymentIntentWithMicrodeposits(
  * This function should only be called when the PaymentIntent is in the `requires_action` state
  * and `NextActionType` is VerifyWithMicrodeposits.
  *
- * See the [Verify bank account with micro-despoits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
+ * See the [Verify bank account with micro-deposits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
  *
  * @param clientSecret The client secret of the PaymentIntent
  * @param descriptorCode A unique, 6-digit descriptor code that starts with SM that was sent as
  * statement descriptor to the bank account
- * @param callback a [ApiResultCallback] to receive the result or error
  *
  * @return a [PaymentIntent] object
  *
@@ -894,14 +892,13 @@ suspend fun Stripe.verifyPaymentIntentWithMicrodeposits(
  * This function should only be called when the SetupIntent is in the `requires_action` state
  * and `NextActionType` is VerifyWithMicrodeposits.
  *
- * See the [Verify bank account with micro-despoits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
+ * See the [Verify bank account with micro-deposits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
  *
  * @param clientSecret The client secret of the SetupIntent
  * @param firstAmount The amount, in cents of USD, equal to the value of the first micro-deposit
  * sent to the bank account
  * @param secondAmount The amount, in cents of USD, equal to the value of the second micro-deposit
  * sent to the bank account
- * @param callback a [ApiResultCallback] to receive the result or error
  *
  * @return a [SetupIntent] object
  *
@@ -938,12 +935,11 @@ suspend fun Stripe.verifySetupIntentWithMicrodeposits(
  * This function should only be called when the SetupIntent is in the `requires_action` state
  * and `NextActionType` is VerifyWithMicrodeposits.
  *
- * See the [Verify bank account with micro-despoits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
+ * See the [Verify bank account with micro-deposits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
  *
  * @param clientSecret The client secret of the SetupIntent
  * @param descriptorCode A unique, 6-digit descriptor code that starts with SM that was sent as
  * statement descriptor to the bank account
- * @param callback a [ApiResultCallback] to receive the result or error
  *
  * @return a [SetupIntent] object
  *


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes some warnings in `Stripe` and `StripeKtx`:
- Tighten `retrieveSource()` from returning `Source?` to `Source`
- Fix incorrect method references in `StripeKtx` docs
- Remove `@param callback` from methods that don’t have a callback
- Fix typo in micro-deposits comments

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

💅

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
