### PR TITLE
Use `Result<T>` for fetching intents

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -44,7 +44,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         clientSecret: String,
         options: ApiRequest.Options,
         expandFields: List<String>
-    ): StripeIntent {
+    ): Result<StripeIntent> {
         TODO("Not yet implemented")
     }
 

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -67,7 +67,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
     override suspend fun refreshPaymentIntent(
         clientSecret: String,
         options: ApiRequest.Options
-    ): PaymentIntent? {
+    ): Result<PaymentIntent> {
         TODO("Not yet implemented")
     }
 

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -6514,7 +6514,7 @@ public final class com/stripe/android/networking/StripeRepository$DefaultImpls {
 	public static synthetic fun confirmSetupIntent$default (Lcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/model/ConfirmSetupIntentParams;Lcom/stripe/android/core/networking/ApiRequest$Options;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun retrievePaymentIntent$default (Lcom/stripe/android/networking/StripeRepository;Ljava/lang/String;Lcom/stripe/android/core/networking/ApiRequest$Options;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun retrieveSetupIntent$default (Lcom/stripe/android/networking/StripeRepository;Ljava/lang/String;Lcom/stripe/android/core/networking/ApiRequest$Options;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun retrieveStripeIntent$default (Lcom/stripe/android/networking/StripeRepository;Ljava/lang/String;Lcom/stripe/android/core/networking/ApiRequest$Options;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun retrieveStripeIntent-BWLJW6A$default (Lcom/stripe/android/networking/StripeRepository;Ljava/lang/String;Lcom/stripe/android/core/networking/ApiRequest$Options;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/stripe/android/payments/PaymentFlowResult$Unvalidated : android/os/Parcelable {

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -176,24 +176,28 @@ class StripeApiRepository @JvmOverloads internal constructor(
         clientSecret: String,
         options: ApiRequest.Options,
         expandFields: List<String>
-    ): StripeIntent {
+    ): Result<StripeIntent> {
         return when {
             PaymentIntent.ClientSecret.isMatch(clientSecret) -> {
-                requireNotNull(
-                    retrievePaymentIntent(clientSecret, options, expandFields)
-                ) {
-                    "Could not retrieve PaymentIntent."
+                runCatching {
+                    requireNotNull(
+                        retrievePaymentIntent(clientSecret, options, expandFields)
+                    ) {
+                        "Could not retrieve PaymentIntent."
+                    }
                 }
             }
             SetupIntent.ClientSecret.isMatch(clientSecret) -> {
-                requireNotNull(
-                    retrieveSetupIntent(clientSecret, options, expandFields)
-                ) {
-                    "Could not retrieve SetupIntent."
+                runCatching {
+                    requireNotNull(
+                        retrieveSetupIntent(clientSecret, options, expandFields)
+                    ) {
+                        "Could not retrieve SetupIntent."
+                    }
                 }
             }
             else -> {
-                error("Invalid client secret.")
+                Result.failure(IllegalStateException("Invalid client secret."))
             }
         }
     }

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -52,7 +52,7 @@ interface StripeRepository {
         clientSecret: String,
         options: ApiRequest.Options,
         expandFields: List<String> = emptyList()
-    ): StripeIntent
+    ): Result<StripeIntent>
 
     @Throws(
         AuthenticationException::class,

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -80,17 +80,11 @@ interface StripeRepository {
         expandFields: List<String> = emptyList()
     ): PaymentIntent?
 
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class
-    )
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun refreshPaymentIntent(
         clientSecret: String,
         options: ApiRequest.Options
-    ): PaymentIntent?
+    ): Result<PaymentIntent>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun cancelPaymentIntentSource(

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -324,12 +324,10 @@ internal class PaymentIntentFlowResultProcessor @Inject constructor(
         clientSecret: String,
         requestOptions: ApiRequest.Options,
         expandFields: List<String>
-    ): Result<PaymentIntent> = runCatching {
-        requireNotNull(
-            stripeRepository.refreshPaymentIntent(
-                clientSecret,
-                requestOptions,
-            )
+    ): Result<PaymentIntent> {
+        return stripeRepository.refreshPaymentIntent(
+            clientSecret,
+            requestOptions,
         )
     }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/RetrieveStripeIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/RetrieveStripeIntent.kt
@@ -15,8 +15,8 @@ internal class RetrieveStripeIntent @Inject constructor(
     suspend operator fun invoke(
         publishableKey: String,
         clientSecret: String
-    ): Result<StripeIntent> = kotlin.runCatching {
-        stripeRepository.retrieveStripeIntent(
+    ): Result<StripeIntent> {
+        return stripeRepository.retrieveStripeIntent(
             clientSecret = clientSecret,
             options = ApiRequest.Options(publishableKey)
         )

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -186,14 +186,11 @@ internal class PaymentLauncherViewModel @Inject constructor(
         if (hasStarted) return
         viewModelScope.launch {
             savedStateHandle.set(KEY_HAS_STARTED, true)
-            runCatching {
-                requireNotNull(
-                    stripeApiRepository.retrieveStripeIntent(
-                        clientSecret,
-                        apiRequestOptionsProvider.get()
-                    )
-                )
-            }.fold(
+
+            stripeApiRepository.retrieveStripeIntent(
+                clientSecret = clientSecret,
+                options = apiRequestOptionsProvider.get(),
+            ).fold(
                 onSuccess = { intent ->
                     authenticatorRegistry
                         .getAuthenticator(intent)

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -1566,14 +1566,13 @@ internal class StripeApiRepositoryTest {
     @Test
     fun `retrieveStripeIntent() with invalid client secret should throw exception`() =
         runTest {
-            val error = assertFailsWith<IllegalStateException> {
-                stripeApiRepository.retrieveStripeIntent(
-                    "invalid!",
-                    DEFAULT_OPTIONS
-                )
-            }
-            assertThat(error.message)
-                .isEqualTo("Invalid client secret.")
+            val error = stripeApiRepository.retrieveStripeIntent(
+                clientSecret = "invalid!",
+                options = DEFAULT_OPTIONS,
+            ).exceptionOrNull()
+
+            assertThat(error).isInstanceOf(IllegalStateException::class.java)
+            assertThat(error?.message).isEqualTo("Invalid client secret.")
         }
 
     @Test

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -1589,12 +1589,10 @@ internal class StripeApiRepositoryTest {
                     )
                 )
 
-            requireNotNull(
-                create().refreshPaymentIntent(
-                    clientSecret,
-                    ApiRequest.Options(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
-                )
-            )
+            create().refreshPaymentIntent(
+                clientSecret,
+                ApiRequest.Options(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
+            ).getOrThrow()
 
             verify(stripeNetworkClient).executeRequest(
                 argWhere<ApiRequest> {

--- a/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
@@ -105,7 +105,7 @@ internal class PaymentIntentFlowResultProcessorTest {
                 PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE
             )
             whenever(mockStripeRepository.refreshPaymentIntent(any(), any())).thenReturn(
-                PaymentIntentFixtures.PI_REFRESH_RESPONSE_WECHAT_PAY_SUCCESS
+                Result.success(PaymentIntentFixtures.PI_REFRESH_RESPONSE_WECHAT_PAY_SUCCESS)
             )
 
             val clientSecret = "pi_3JkCxKBNJ02ErVOj0kNqBMAZ_secret_bC6oXqo976LFM06Z9rlhmzUQq"
@@ -147,7 +147,7 @@ internal class PaymentIntentFlowResultProcessorTest {
                 PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE
             )
             whenever(mockStripeRepository.refreshPaymentIntent(any(), any())).thenReturn(
-                PaymentIntentFixtures.PI_REFRESH_RESPONSE_WECHAT_PAY_SUCCESS
+                Result.success(PaymentIntentFixtures.PI_REFRESH_RESPONSE_WECHAT_PAY_SUCCESS)
             )
 
             val clientSecret = "pi_3JkCxKBNJ02ErVOj0kNqBMAZ_secret_bC6oXqo976LFM06Z9rlhmzUQq"
@@ -187,7 +187,7 @@ internal class PaymentIntentFlowResultProcessorTest {
                 PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE
             )
             whenever(mockStripeRepository.refreshPaymentIntent(any(), any())).thenReturn(
-                PaymentIntentFixtures.PI_REFRESH_RESPONSE_REQUIRES_WECHAT_PAY_AUTHORIZE
+                Result.success(PaymentIntentFixtures.PI_REFRESH_RESPONSE_REQUIRES_WECHAT_PAY_AUTHORIZE)
             )
 
             val clientSecret = "pi_3JkCxKBNJ02ErVOj0kNqBMAZ_secret_bC6oXqo976LFM06Z9rlhmzUQq"

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/RetrieveStripeIntentTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/RetrieveStripeIntentTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.networking.StripeRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -26,7 +27,7 @@ class RetrieveStripeIntentTest {
             val publishableKey = "publishable_key"
             val clientSecret = "pi_1234_secret_5678"
             givenRetrieveStripeIntentReturns {
-                mock<PaymentIntent>()
+                Result.success(mock<PaymentIntent>())
             }
 
             // When
@@ -53,7 +54,7 @@ class RetrieveStripeIntentTest {
             val clientSecret = "pi_invalid"
             val expectedException = APIException()
             givenRetrieveStripeIntentReturns {
-                throw expectedException
+                Result.failure(expectedException)
             }
 
             // When
@@ -79,7 +80,7 @@ class RetrieveStripeIntentTest {
             val publishableKey = "publishable_key"
             val clientSecret = "seti_1234_secret_5678"
             givenRetrieveStripeIntentReturns {
-                mock<SetupIntent>()
+                Result.success(mock<SetupIntent>())
             }
 
             // When
@@ -105,7 +106,7 @@ class RetrieveStripeIntentTest {
             val clientSecret = "seti_invalid"
             val expectedException = APIException()
             givenRetrieveStripeIntentReturns {
-                throw expectedException
+                Result.failure(expectedException)
             }
 
             // When
@@ -125,7 +126,7 @@ class RetrieveStripeIntentTest {
     }
 
     private suspend fun givenRetrieveStripeIntentReturns(
-        intent: () -> StripeIntent
+        result: () -> Result<StripeIntent>
     ) {
         whenever(
             stripeRepository.retrieveStripeIntent(
@@ -133,6 +134,6 @@ class RetrieveStripeIntentTest {
                 any(),
                 any()
             )
-        ).thenAnswer { intent() }
+        ).doReturn(result())
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.PaymentIntentResult
 import com.stripe.android.SetupIntentResult
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.StripePaymentController.Companion.EXPAND_PAYMENT_METHOD
+import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.core.injection.Injectable
 import com.stripe.android.core.injection.Injector

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
@@ -154,12 +154,11 @@ class PaymentLauncherViewModelTest {
 
         whenever(
             stripeApiRepository.retrieveStripeIntent(
-                eq(CLIENT_SECRET),
-                eq(apiRequestOptions),
-                any()
+                clientSecret = eq(CLIENT_SECRET),
+                options = eq(apiRequestOptions),
+                expandFields = any(),
             )
-        )
-            .thenReturn(stripeIntent)
+        ).thenReturn(Result.success(stripeIntent))
 
         whenever(authenticatorRegistry.getAuthenticator(eq(stripeIntent)))
             .thenReturn(stripeIntentAuthenticator)
@@ -387,7 +386,7 @@ class PaymentLauncherViewModelTest {
                     eq(apiRequestOptions),
                     any()
                 )
-            ).thenReturn(null)
+            ).thenReturn(Result.failure(APIConnectionException()))
 
             val viewModel = createViewModel()
             viewModel.handleNextActionForStripeIntent(CLIENT_SECRET, authHost)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptor.kt
@@ -292,12 +292,10 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
     }
 
     private suspend fun retrieveStripeIntent(clientSecret: String): Result<StripeIntent> {
-        return runCatching {
-            stripeRepository.retrieveStripeIntent(
-                clientSecret = clientSecret,
-                options = requestOptions,
-            )
-        }
+        return stripeRepository.retrieveStripeIntent(
+            clientSecret = clientSecret,
+            options = requestOptions,
+        )
     }
 
     private fun createConfirmStep(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
@@ -205,8 +205,8 @@ class DefaultIntentConfirmationInterceptorTest {
                     clientSecret: String,
                     options: ApiRequest.Options,
                     expandFields: List<String>
-                ): StripeIntent {
-                    throw apiException
+                ): Result<StripeIntent> {
+                    return Result.failure(apiException)
                 }
             },
             publishableKeyProvider = { "pk" },
@@ -298,9 +298,11 @@ class DefaultIntentConfirmationInterceptorTest {
                     clientSecret: String,
                     options: ApiRequest.Options,
                     expandFields: List<String>,
-                ): StripeIntent {
-                    return PaymentIntentFixtures.PI_SUCCEEDED.copy(
-                        status = StripeIntent.Status.RequiresConfirmation,
+                ): Result<StripeIntent> {
+                    return Result.success(
+                        PaymentIntentFixtures.PI_SUCCEEDED.copy(
+                            status = StripeIntent.Status.RequiresConfirmation,
+                        )
                     )
                 }
             },
@@ -339,8 +341,8 @@ class DefaultIntentConfirmationInterceptorTest {
                     clientSecret: String,
                     options: ApiRequest.Options,
                     expandFields: List<String>
-                ): StripeIntent {
-                    return PaymentIntentFixtures.PI_SUCCEEDED
+                ): Result<StripeIntent> {
+                    return Result.success(PaymentIntentFixtures.PI_SUCCEEDED)
                 }
             },
             publishableKeyProvider = { "pk" },
@@ -380,9 +382,11 @@ class DefaultIntentConfirmationInterceptorTest {
                     clientSecret: String,
                     options: ApiRequest.Options,
                     expandFields: List<String>
-                ): StripeIntent {
-                    return PaymentIntentFixtures.PI_SUCCEEDED.copy(
-                        status = StripeIntent.Status.RequiresAction,
+                ): Result<StripeIntent> {
+                    return Result.success(
+                        PaymentIntentFixtures.PI_SUCCEEDED.copy(
+                            status = StripeIntent.Status.RequiresAction,
+                        )
                     )
                 }
             },
@@ -424,8 +428,8 @@ class DefaultIntentConfirmationInterceptorTest {
                     clientSecret: String,
                     options: ApiRequest.Options,
                     expandFields: List<String>
-                ): StripeIntent {
-                    return PaymentIntentFixtures.PI_SUCCEEDED
+                ): Result<StripeIntent> {
+                    return Result.success(PaymentIntentFixtures.PI_SUCCEEDED)
                 }
             },
             publishableKeyProvider = { "pk" },


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates the methods to retrieve a generic Stripe intent and to refresh a PaymentIntent to use `Result<T>` as their return type.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
