### PR TITLE
Use `Result<T>` for retrieveCardMetadata

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -396,7 +396,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
     override suspend fun retrieveCardMetadata(
         cardNumber: String,
         requestOptions: ApiRequest.Options
-    ): CardMetadata? {
+    ): Result<CardMetadata> {
         TODO("Not yet implemented")
     }
 

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -360,7 +360,7 @@ interface StripeRepository {
     suspend fun retrieveCardMetadata(
         cardNumber: String,
         requestOptions: ApiRequest.Options
-    ): CardMetadata?
+    ): Result<CardMetadata>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun buildPaymentUserAgent(attribution: Set<String> = emptySet()): String

--- a/payments-core/src/test/java/com/stripe/android/StripeKtxTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripeKtxTest.kt
@@ -586,9 +586,11 @@ internal class StripeKtxTest {
     @Test
     fun `Verify retrievePossibleCardBrands passes card number on to repository`() = runTest {
         whenever(mockApiRepository.retrieveCardMetadata(any(), any())).thenReturn(
-            CardMetadata(
-                bin = mock(),
-                accountRanges = listOf()
+            Result.success(
+                CardMetadata(
+                    bin = mock(),
+                    accountRanges = listOf()
+                )
             )
         )
 
@@ -601,13 +603,16 @@ internal class StripeKtxTest {
     }
 
     @Test
-    fun `Verify retrievePossibleCardBrands throws an error when less than 6 characters`() = runTest {
+    fun `Verify retrievePossibleCardBrands throws an error if repository returns failure`() = runTest {
+        whenever(mockApiRepository.retrieveCardMetadata(any(), any())).thenReturn(
+            Result.failure(InvalidRequestException(message = "cardNumber cannot be less than 6 characters"))
+        )
+
         val error = assertFailsWith<InvalidRequestException> {
             stripe.retrievePossibleBrands("4242")
         }
 
-        assertThat(error.message)
-            .isEqualTo("cardNumber cannot be less than 6 characters")
+        assertThat(error.message).isEqualTo("cardNumber cannot be less than 6 characters")
     }
 
     private inline fun <reified ApiObject : StripeModel, reified CreateAPIParam : StripeParamsModel, reified RepositoryParam : StripeParamsModel>

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -2226,6 +2226,18 @@ internal class StripeApiRepositoryTest {
         }
     }
 
+    @Test
+    fun `Verify that retrieveCardMetadata returns failure for BINs that are too short`() = runTest {
+        val repository = create()
+
+        val exception = repository.retrieveCardMetadata(
+            cardNumber = "4242 4",
+            requestOptions = DEFAULT_OPTIONS,
+        ).exceptionOrNull()
+
+        assertThat(exception).isInstanceOf(InvalidRequestException::class.java)
+    }
+
     /**
      * Helper DSL to validate nested params.
      */


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates the final method in `StripeRepository` to return `Result<T>` 🥳

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
