### PR TITLE
Finish `Result<T>` migration with some polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## XX.XX.XX - 2023-XX-XX
 
 ### Payments
-*[FIXED][6977](https://github.com/stripe/stripe-android/pull/6977) Fixed an issue where `Stripe.retrievePossibleBrands()` returned incorrect results.
+*[CHANGED] The return type for several methods in `Stripe` has changed from `T?` (nullable) to `T` to better reflect possible behavior. These methods continue to be throwing and should be wrapped in a `try/catch` block.
+*[FIXED][6977](https://github.com/stripe/stripe-android/pull/6977) Fixed an issue where `Stripe.retrievePossibleBrands()` returned incorrect results. 
 
 ## 20.27.2 - 2023-07-18
 

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -53,7 +53,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         options: ApiRequest.Options,
         expandFields: List<String>
     ): Result<PaymentIntent> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun retrievePaymentIntent(
@@ -76,7 +76,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         sourceId: String,
         options: ApiRequest.Options
     ): Result<PaymentIntent> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun confirmSetupIntent(
@@ -84,7 +84,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         options: ApiRequest.Options,
         expandFields: List<String>
     ): Result<SetupIntent> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun retrieveSetupIntent(
@@ -100,14 +100,14 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         sourceId: String,
         options: ApiRequest.Options
     ): Result<SetupIntent> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun createSource(
         sourceParams: SourceParams,
         options: ApiRequest.Options
     ): Result<Source> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun retrieveSource(
@@ -115,21 +115,21 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         clientSecret: String,
         options: ApiRequest.Options
     ): Result<Source> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun createPaymentMethod(
         paymentMethodCreateParams: PaymentMethodCreateParams,
         options: ApiRequest.Options
     ): Result<PaymentMethod> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun createToken(
         tokenParams: TokenParams,
         options: ApiRequest.Options
     ): Result<Token> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun addCustomerSource(
@@ -140,7 +140,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         sourceType: String,
         requestOptions: ApiRequest.Options
     ): Result<Source> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun deleteCustomerSource(
@@ -150,7 +150,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         sourceId: String,
         requestOptions: ApiRequest.Options
     ): Result<Source> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     @Throws(APIException::class)
@@ -161,7 +161,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         paymentMethodId: String,
         requestOptions: ApiRequest.Options
     ): Result<PaymentMethod> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     @Throws(APIException::class)
@@ -171,7 +171,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         paymentMethodId: String,
         requestOptions: ApiRequest.Options
     ): Result<PaymentMethod> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     @Throws(APIException::class)
@@ -181,7 +181,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         productUsageTokens: Set<String>,
         requestOptions: ApiRequest.Options
     ): Result<List<PaymentMethod>> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun setDefaultCustomerSource(
@@ -192,7 +192,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         sourceType: String,
         requestOptions: ApiRequest.Options
     ): Result<Customer> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun setCustomerShippingInfo(
@@ -202,7 +202,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         shippingInformation: ShippingInformation,
         requestOptions: ApiRequest.Options
     ): Result<Customer> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun retrieveCustomer(
@@ -210,7 +210,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         productUsageTokens: Set<String>,
         requestOptions: ApiRequest.Options
     ): Result<Customer> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun retrieveIssuingCardPin(
@@ -219,7 +219,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         userOneTimeCode: String,
         requestOptions: ApiRequest.Options
     ): Result<String> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun updateIssuingCardPin(
@@ -235,7 +235,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
     override suspend fun getFpxBankStatus(
         options: ApiRequest.Options
     ): Result<BankStatuses> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun getCardMetadata(bin: Bin, options: ApiRequest.Options): Result<CardMetadata> {
@@ -246,34 +246,34 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         authParams: Stripe3ds2AuthParams,
         requestOptions: ApiRequest.Options
     ): Result<Stripe3ds2AuthResult> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun complete3ds2Auth(
         sourceId: String,
         requestOptions: ApiRequest.Options
     ): Result<Stripe3ds2AuthResult> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun createFile(
         fileParams: StripeFileParams,
         requestOptions: ApiRequest.Options
     ): Result<StripeFile> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun retrieveObject(
         url: String,
         requestOptions: ApiRequest.Options
     ): Result<StripeResponse<String>> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun createRadarSession(
         requestOptions: ApiRequest.Options
     ): Result<RadarSession> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun consumerSignUp(
@@ -286,7 +286,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         consentAction: ConsumerSignUpConsentAction,
         requestOptions: ApiRequest.Options
     ): Result<ConsumerSession> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun createPaymentDetails(
@@ -294,7 +294,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         paymentDetailsCreateParams: ConsumerPaymentDetailsCreateParams,
         requestOptions: ApiRequest.Options
     ): Result<ConsumerPaymentDetails> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun attachFinancialConnectionsSessionToPaymentIntent(
@@ -304,7 +304,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         requestOptions: ApiRequest.Options,
         expandFields: List<String>
     ): Result<PaymentIntent> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun attachFinancialConnectionsSessionToSetupIntent(
@@ -314,14 +314,14 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         requestOptions: ApiRequest.Options,
         expandFields: List<String>
     ): Result<SetupIntent> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun createFinancialConnectionsSessionForDeferredPayments(
         params: CreateFinancialConnectionsSessionForDeferredPaymentParams,
         requestOptions: ApiRequest.Options
     ): Result<FinancialConnectionsSession> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun createPaymentIntentFinancialConnectionsSession(
@@ -329,7 +329,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         params: CreateFinancialConnectionsSessionParams,
         requestOptions: ApiRequest.Options
     ): Result<FinancialConnectionsSession> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun createSetupIntentFinancialConnectionsSession(
@@ -337,7 +337,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         params: CreateFinancialConnectionsSessionParams,
         requestOptions: ApiRequest.Options
     ): Result<FinancialConnectionsSession> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun verifyPaymentIntentWithMicrodeposits(
@@ -346,7 +346,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         secondAmount: Int,
         requestOptions: ApiRequest.Options
     ): Result<PaymentIntent> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun verifyPaymentIntentWithMicrodeposits(
@@ -354,7 +354,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         descriptorCode: String,
         requestOptions: ApiRequest.Options
     ): Result<PaymentIntent> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun verifySetupIntentWithMicrodeposits(
@@ -363,7 +363,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         secondAmount: Int,
         requestOptions: ApiRequest.Options
     ): Result<SetupIntent> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun verifySetupIntentWithMicrodeposits(
@@ -371,7 +371,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         descriptorCode: String,
         requestOptions: ApiRequest.Options
     ): Result<SetupIntent> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun retrievePaymentMethodMessage(
@@ -383,14 +383,14 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         logoColor: String,
         requestOptions: ApiRequest.Options
     ): Result<PaymentMethodMessage> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun retrieveElementsSession(
         params: ElementsSessionParams,
         options: ApiRequest.Options
     ): Result<ElementsSession> {
-        return Result.failure(NotImplementedError())
+        TODO("Not yet implemented")
     }
 
     override suspend fun retrieveCardMetadata(

--- a/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
@@ -30,6 +30,7 @@ import com.stripe.android.model.Source
 import com.stripe.android.model.SourceParams
 import com.stripe.android.model.Token
 import com.stripe.android.model.WeChatPayNextAction
+import com.stripe.android.utils.mapResult
 
 /**
  * Confirm and authenticate a [PaymentIntent] using the Alipay SDK
@@ -59,14 +60,16 @@ suspend fun Stripe.confirmAlipayPayment(
     authenticator: AlipayAuthenticator,
     stripeAccountId: String? = this.stripeAccountId
 ): PaymentIntentResult {
-    return paymentController.confirmAndAuthenticateAlipay(
-        confirmPaymentIntentParams,
-        authenticator,
-        ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId
+    return runApiRequest {
+        paymentController.confirmAndAuthenticateAlipay(
+            confirmPaymentIntentParams,
+            authenticator,
+            ApiRequest.Options(
+                apiKey = publishableKey,
+                stripeAccount = stripeAccountId
+            )
         )
-    ).getOrElse { throw StripeException.create(it) }
+    }
 }
 
 /**
@@ -98,14 +101,16 @@ suspend fun Stripe.createPaymentMethod(
     idempotencyKey: String? = null,
     stripeAccountId: String? = this.stripeAccountId
 ): PaymentMethod {
-    return stripeRepository.createPaymentMethod(
-        paymentMethodCreateParams,
-        ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId,
-            idempotencyKey = idempotencyKey
+    return runApiRequest {
+        stripeRepository.createPaymentMethod(
+            paymentMethodCreateParams,
+            ApiRequest.Options(
+                apiKey = publishableKey,
+                stripeAccount = stripeAccountId,
+                idempotencyKey = idempotencyKey
+            )
         )
-    ).getOrElse { throw StripeException.create(it) }
+    }
 }
 
 /**
@@ -137,14 +142,16 @@ suspend fun Stripe.createSource(
     idempotencyKey: String? = null,
     stripeAccountId: String? = this.stripeAccountId
 ): Source {
-    return stripeRepository.createSource(
-        sourceParams,
-        ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId,
-            idempotencyKey = idempotencyKey
+    return runApiRequest {
+        stripeRepository.createSource(
+            sourceParams,
+            ApiRequest.Options(
+                apiKey = publishableKey,
+                stripeAccount = stripeAccountId,
+                idempotencyKey = idempotencyKey
+            )
         )
-    ).getOrElse { throw StripeException.create(it) }
+    }
 }
 
 /**
@@ -396,14 +403,16 @@ suspend fun Stripe.createFile(
     idempotencyKey: String? = null,
     stripeAccountId: String? = this.stripeAccountId
 ): StripeFile {
-    return stripeRepository.createFile(
-        fileParams,
-        ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId,
-            idempotencyKey = idempotencyKey
+    return runApiRequest {
+        stripeRepository.createFile(
+            fileParams,
+            ApiRequest.Options(
+                apiKey = publishableKey,
+                stripeAccount = stripeAccountId,
+                idempotencyKey = idempotencyKey
+            )
         )
-    ).getOrElse { throw StripeException.create(it) }
+    }
 }
 
 /**
@@ -425,12 +434,14 @@ suspend fun Stripe.createFile(
     APIException::class
 )
 suspend fun Stripe.createRadarSession(): RadarSession {
-    return stripeRepository.createRadarSession(
-        ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId,
+    return runApiRequest {
+        stripeRepository.createRadarSession(
+            ApiRequest.Options(
+                apiKey = publishableKey,
+                stripeAccount = stripeAccountId,
+            )
         )
-    ).getOrElse { throw StripeException.create(it) }
+    }
 }
 
 /**
@@ -462,14 +473,16 @@ suspend fun Stripe.retrievePaymentIntent(
     stripeAccountId: String? = this.stripeAccountId,
     expand: List<String> = emptyList(),
 ): PaymentIntent {
-    return stripeRepository.retrievePaymentIntent(
-        clientSecret,
-        ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId
-        ),
-        expand,
-    ).getOrElse { throw StripeException.create(it) }
+    return runApiRequest {
+        stripeRepository.retrievePaymentIntent(
+            clientSecret,
+            ApiRequest.Options(
+                apiKey = publishableKey,
+                stripeAccount = stripeAccountId
+            ),
+            expand,
+        )
+    }
 }
 
 /**
@@ -501,14 +514,16 @@ suspend fun Stripe.retrieveSetupIntent(
     stripeAccountId: String? = this.stripeAccountId,
     expand: List<String> = emptyList(),
 ): SetupIntent {
-    return stripeRepository.retrieveSetupIntent(
-        clientSecret,
-        ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId
-        ),
-        expand,
-    ).getOrElse { throw StripeException.create(it) }
+    return runApiRequest {
+        stripeRepository.retrieveSetupIntent(
+            clientSecret,
+            ApiRequest.Options(
+                apiKey = publishableKey,
+                stripeAccount = stripeAccountId
+            ),
+            expand,
+        )
+    }
 }
 
 /**
@@ -540,14 +555,16 @@ suspend fun Stripe.retrieveSource(
     @Size(min = 1) clientSecret: String,
     stripeAccountId: String? = this.stripeAccountId
 ): Source {
-    return stripeRepository.retrieveSource(
-        sourceId,
-        clientSecret,
-        ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId
+    return runApiRequest {
+        stripeRepository.retrieveSource(
+            sourceId,
+            clientSecret,
+            ApiRequest.Options(
+                apiKey = publishableKey,
+                stripeAccount = stripeAccountId
+            )
         )
-    ).getOrElse { throw StripeException.create(it) }
+    }
 }
 
 /**
@@ -578,15 +595,17 @@ suspend fun Stripe.confirmSetupIntent(
     idempotencyKey: String? = null,
     expand: List<String> = emptyList(),
 ): SetupIntent {
-    return stripeRepository.confirmSetupIntent(
-        confirmSetupIntentParams,
-        ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId,
-            idempotencyKey = idempotencyKey
-        ),
-        expand,
-    ).getOrElse { throw StripeException.create(it) }
+    return runApiRequest {
+        stripeRepository.confirmSetupIntent(
+            confirmSetupIntentParams,
+            ApiRequest.Options(
+                apiKey = publishableKey,
+                stripeAccount = stripeAccountId,
+                idempotencyKey = idempotencyKey
+            ),
+            expand,
+        )
+    }
 }
 
 /**
@@ -609,13 +628,15 @@ suspend fun Stripe.confirmWeChatPayPayment(
     confirmPaymentIntentParams: ConfirmPaymentIntentParams,
     stripeAccountId: String? = this.stripeAccountId
 ): WeChatPayNextAction {
-    return paymentController.confirmWeChatPay(
-        confirmPaymentIntentParams,
-        ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId
+    return runApiRequest {
+        paymentController.confirmWeChatPay(
+            confirmPaymentIntentParams,
+            ApiRequest.Options(
+                apiKey = publishableKey,
+                stripeAccount = stripeAccountId
+            )
         )
-    ).getOrElse { throw StripeException.create(it) }
+    }
 }
 
 /**
@@ -644,14 +665,16 @@ suspend fun Stripe.confirmPaymentIntent(
     confirmPaymentIntentParams: ConfirmPaymentIntentParams,
     idempotencyKey: String? = null
 ): PaymentIntent {
-    return stripeRepository.confirmPaymentIntent(
-        confirmPaymentIntentParams,
-        ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId,
-            idempotencyKey = idempotencyKey
+    return runApiRequest {
+        stripeRepository.confirmPaymentIntent(
+            confirmPaymentIntentParams,
+            ApiRequest.Options(
+                apiKey = publishableKey,
+                stripeAccount = stripeAccountId,
+                idempotencyKey = idempotencyKey
+            )
         )
-    ).getOrElse { throw StripeException.create(it) }
+    }
 }
 
 /**
@@ -660,13 +683,10 @@ suspend fun Stripe.confirmPaymentIntent(
  * @return the result if the API result and JSON parsing are successful; otherwise, throw an exception.
  */
 private inline fun <reified ApiObject : StripeModel> runApiRequest(
-    block: () -> ApiObject?
-): ApiObject =
-    runCatching {
-        requireNotNull(block()) {
-            "Failed to parse ${ApiObject::class.java.simpleName}."
-        }
-    }.getOrElse { throw StripeException.create(it) }
+    block: () -> Result<ApiObject>,
+): ApiObject {
+    return block().getOrElse { throw StripeException.create(it) }
+}
 
 /**
  * Get the [PaymentIntentResult] from [Intent] returned via
@@ -696,7 +716,7 @@ suspend fun Stripe.getPaymentIntentResult(
             requestCode,
             data
         )
-    ) { paymentController.getPaymentIntentResult(data).getOrThrow() }
+    ) { paymentController.getPaymentIntentResult(data) }
 }
 
 /**
@@ -728,7 +748,7 @@ suspend fun Stripe.getSetupIntentResult(
             requestCode,
             data
         )
-    ) { paymentController.getSetupIntentResult(data).getOrThrow() }
+    ) { paymentController.getSetupIntentResult(data) }
 }
 
 /**
@@ -759,7 +779,7 @@ suspend fun Stripe.getAuthenticateSourceResult(
             requestCode,
             data
         )
-    ) { paymentController.getAuthenticateSourceResult(data).getOrThrow() }
+    ) { paymentController.getAuthenticateSourceResult(data) }
 }
 
 /**
@@ -770,14 +790,18 @@ suspend fun Stripe.getAuthenticateSourceResult(
  */
 internal inline fun <reified ApiObject : StripeModel> runApiRequest(
     isValidParam: Boolean,
-    block: () -> ApiObject
-): ApiObject =
-    runCatching {
+    block: () -> Result<ApiObject>,
+): ApiObject {
+    return runCatching {
         require(isValidParam) {
             "Incorrect requestCode and data for ${ApiObject::class.java.simpleName}."
         }
+    }.mapResult {
         block()
-    }.getOrElse { throw StripeException.create(it) }
+    }.getOrElse {
+        throw StripeException.create(it)
+    }
+}
 
 /**
  * Suspend function to verify a customer's bank account with micro-deposits
@@ -811,15 +835,17 @@ suspend fun Stripe.verifyPaymentIntentWithMicrodeposits(
     firstAmount: Int,
     secondAmount: Int
 ): PaymentIntent {
-    return stripeRepository.verifyPaymentIntentWithMicrodeposits(
-        clientSecret = clientSecret,
-        firstAmount = firstAmount,
-        secondAmount = secondAmount,
-        requestOptions = ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId
+    return runApiRequest {
+        stripeRepository.verifyPaymentIntentWithMicrodeposits(
+            clientSecret = clientSecret,
+            firstAmount = firstAmount,
+            secondAmount = secondAmount,
+            requestOptions = ApiRequest.Options(
+                apiKey = publishableKey,
+                stripeAccount = stripeAccountId
+            )
         )
-    ).getOrElse { throw StripeException.create(it) }
+    }
 }
 
 /**
@@ -851,14 +877,16 @@ suspend fun Stripe.verifyPaymentIntentWithMicrodeposits(
     clientSecret: String,
     descriptorCode: String
 ): PaymentIntent {
-    return stripeRepository.verifyPaymentIntentWithMicrodeposits(
-        clientSecret = clientSecret,
-        descriptorCode = descriptorCode,
-        requestOptions = ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId
+    return runApiRequest {
+        stripeRepository.verifyPaymentIntentWithMicrodeposits(
+            clientSecret = clientSecret,
+            descriptorCode = descriptorCode,
+            requestOptions = ApiRequest.Options(
+                apiKey = publishableKey,
+                stripeAccount = stripeAccountId
+            )
         )
-    ).getOrElse { throw StripeException.create(it) }
+    }
 }
 
 /**
@@ -893,15 +921,17 @@ suspend fun Stripe.verifySetupIntentWithMicrodeposits(
     firstAmount: Int,
     secondAmount: Int
 ): SetupIntent {
-    return stripeRepository.verifySetupIntentWithMicrodeposits(
-        clientSecret = clientSecret,
-        firstAmount = firstAmount,
-        secondAmount = secondAmount,
-        requestOptions = ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId
+    return runApiRequest {
+        stripeRepository.verifySetupIntentWithMicrodeposits(
+            clientSecret = clientSecret,
+            firstAmount = firstAmount,
+            secondAmount = secondAmount,
+            requestOptions = ApiRequest.Options(
+                apiKey = publishableKey,
+                stripeAccount = stripeAccountId
+            )
         )
-    ).getOrElse { throw StripeException.create(it) }
+    }
 }
 
 /**
@@ -933,14 +963,16 @@ suspend fun Stripe.verifySetupIntentWithMicrodeposits(
     clientSecret: String,
     descriptorCode: String
 ): SetupIntent {
-    return stripeRepository.verifySetupIntentWithMicrodeposits(
-        clientSecret = clientSecret,
-        descriptorCode = descriptorCode,
-        requestOptions = ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId
+    return runApiRequest {
+        stripeRepository.verifySetupIntentWithMicrodeposits(
+            clientSecret = clientSecret,
+            descriptorCode = descriptorCode,
+            requestOptions = ApiRequest.Options(
+                apiKey = publishableKey,
+                stripeAccount = stripeAccountId
+            )
         )
-    ).getOrElse { throw StripeException.create(it) }
+    }
 }
 
 /**
@@ -960,14 +992,16 @@ suspend fun Stripe.verifySetupIntentWithMicrodeposits(
 suspend fun Stripe.retrievePossibleBrands(
     cardNumber: String
 ): PossibleBrands {
-    return stripeRepository.retrieveCardMetadata(
-        cardNumber = cardNumber,
-        requestOptions = ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId
-        )
-    ).map { metadata ->
-        val brands = metadata.accountRanges.map { it.brand }
-        PossibleBrands(brands = brands.distinct())
-    }.getOrElse { throw StripeException.create(it) }
+    return runApiRequest {
+        stripeRepository.retrieveCardMetadata(
+            cardNumber = cardNumber,
+            requestOptions = ApiRequest.Options(
+                apiKey = publishableKey,
+                stripeAccount = stripeAccountId
+            )
+        ).map { metadata ->
+            val brands = metadata.accountRanges.map { it.brand }
+            PossibleBrands(brands = brands.distinct())
+        }
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request finishes off the `Result<T>` migration, including:
1. Reverting to using throwing `TODO()` calls in the abstract fake repository
2. Creating a new `runApiRequest` wrapper that works with `Result<T>`
3. Adding release notes about some `T? -> T` changes

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

[CHANGED] The return type for several methods in `Stripe` has changed from `T?` (nullable) to `T` to better reflect possible behavior. These methods continue to be throwing and should be wrapped in a `try/catch` block.
