### PR TITLE
Add `network_type` to analytics events

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
@@ -10,6 +10,7 @@ import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
+import com.stripe.android.core.networking.NetworkTypeDetector
 import com.stripe.android.core.networking.StripeNetworkClient
 import com.stripe.android.core.utils.ContextUtils.packageInfo
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
@@ -129,6 +130,7 @@ internal object FinancialConnectionsSheetSharedModule {
         packageManager = application.packageManager,
         packageName = application.packageName.orEmpty(),
         packageInfo = application.packageInfo,
-        publishableKeyProvider = { publishableKey }
+        publishableKeyProvider = { publishableKey },
+        networkTypeProvider = NetworkTypeDetector(application)::invoke,
     )
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/analytics/DefaultConnectionsEventReportTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/analytics/DefaultConnectionsEventReportTest.kt
@@ -29,7 +29,8 @@ class DefaultConnectionsEventReportTest {
         packageManager = application.packageManager,
         packageName = application.packageName.orEmpty(),
         packageInfo = application.packageManager.getPackageInfo(application.packageName, 0),
-        publishableKeyProvider = { ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY }
+        publishableKeyProvider = { ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY },
+        networkTypeProvider = { "5G" },
     )
 
     private val eventReporter = DefaultFinancialConnectionsEventReporter(

--- a/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsRequestFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsRequestFactory.kt
@@ -9,6 +9,7 @@ import androidx.annotation.VisibleForTesting
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.AnalyticsRequestFactory
+import com.stripe.android.core.networking.NetworkTypeDetector
 import com.stripe.android.core.utils.ContextUtils.packageInfo
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.Source
@@ -27,12 +28,14 @@ class PaymentAnalyticsRequestFactory @VisibleForTesting internal constructor(
     packageInfo: PackageInfo?,
     packageName: String,
     publishableKeyProvider: Provider<String>,
-    internal val defaultProductUsageTokens: Set<String> = emptySet()
+    networkTypeProvider: Provider<String?>,
+    internal val defaultProductUsageTokens: Set<String> = emptySet(),
 ) : AnalyticsRequestFactory(
     packageManager,
     packageInfo,
     packageName,
-    publishableKeyProvider
+    publishableKeyProvider,
+    networkTypeProvider,
 ) {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     constructor(
@@ -49,11 +52,11 @@ class PaymentAnalyticsRequestFactory @VisibleForTesting internal constructor(
         context: Context,
         publishableKeyProvider: Provider<String>
     ) : this(
-        context.applicationContext.packageManager,
-        context.applicationContext.packageInfo,
-        context.applicationContext.packageName.orEmpty(),
-        publishableKeyProvider,
-        emptySet()
+        packageManager = context.applicationContext.packageManager,
+        packageInfo = context.applicationContext.packageInfo,
+        packageName = context.applicationContext.packageName.orEmpty(),
+        publishableKeyProvider = publishableKeyProvider,
+        networkTypeProvider = NetworkTypeDetector(context)::invoke,
     )
 
     @Inject
@@ -62,11 +65,12 @@ class PaymentAnalyticsRequestFactory @VisibleForTesting internal constructor(
         @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
         @Named(PRODUCT_USAGE) defaultProductUsageTokens: Set<String>
     ) : this(
-        context.applicationContext.packageManager,
-        context.applicationContext.packageInfo,
-        context.applicationContext.packageName.orEmpty(),
-        publishableKeyProvider,
-        defaultProductUsageTokens
+        packageManager = context.applicationContext.packageManager,
+        packageInfo = context.applicationContext.packageInfo,
+        packageName = context.applicationContext.packageName.orEmpty(),
+        publishableKeyProvider = publishableKeyProvider,
+        networkTypeProvider = NetworkTypeDetector(context)::invoke,
+        defaultProductUsageTokens = defaultProductUsageTokens,
     )
 
     @JvmSynthetic

--- a/payments-core/src/test/java/com/stripe/android/PaymentAnalyticsRequestFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentAnalyticsRequestFactoryTest.kt
@@ -121,7 +121,8 @@ class PaymentAnalyticsRequestFactoryTest {
                 "product_usage" to ATTRIBUTION.toList(),
                 "source_type" to "card",
                 "is_development" to true,
-                "session_id" to AnalyticsRequestFactory.sessionId
+                "session_id" to AnalyticsRequestFactory.sessionId,
+                "network_type" to "2G",
             )
         )
     }
@@ -186,10 +187,11 @@ class PaymentAnalyticsRequestFactoryTest {
         }
 
         val factory = PaymentAnalyticsRequestFactory(
-            packageManager,
-            packageInfo,
-            packageName,
-            { API_KEY }
+            packageManager = packageManager,
+            packageInfo = packageInfo,
+            packageName = packageName,
+            publishableKeyProvider = { API_KEY },
+            networkTypeProvider = { "5G" },
         )
         val params = factory.createTokenCreation(
             ATTRIBUTION,
@@ -205,8 +207,8 @@ class PaymentAnalyticsRequestFactoryTest {
         assertNotNull(params[AnalyticsFields.OS_RELEASE])
         assertNotNull(params[AnalyticsFields.OS_NAME])
         assertEquals(versionCode, params[AnalyticsFields.APP_VERSION])
-        assertThat(params[AnalyticsFields.APP_NAME])
-            .isEqualTo(BuildConfig.LIBRARY_PACKAGE_NAME)
+        assertThat(params[AnalyticsFields.APP_NAME]).isEqualTo(BuildConfig.LIBRARY_PACKAGE_NAME)
+        assertThat(params[AnalyticsFields.NETWORK_TYPE]).isEqualTo("5G")
 
         assertEquals(StripeSdkVersion.VERSION_NAME, params[AnalyticsFields.BINDINGS_VERSION])
         assertEquals(expectedEventName, params[AnalyticsFields.EVENT])
@@ -300,7 +302,7 @@ class PaymentAnalyticsRequestFactoryTest {
                 )
             )
         assertThat(analyticsRequest.url)
-            .isEqualTo("https://q.stripe.com?publishable_key=pk_abc123&app_version=0&bindings_version=$sdkVersion&os_version=30&session_id=${AnalyticsRequestFactory.sessionId}&os_release=11&device_type=robolectric_robolectric_robolectric&source_type=card&app_name=com.stripe.android.test&analytics_ua=analytics.stripe_android-1.0&os_name=REL&event=stripe_android.payment_method_creation&is_development=true")
+            .isEqualTo("https://q.stripe.com?publishable_key=pk_abc123&app_version=0&bindings_version=$sdkVersion&os_version=30&session_id=${AnalyticsRequestFactory.sessionId}&os_release=11&device_type=robolectric_robolectric_robolectric&source_type=card&app_name=com.stripe.android.test&analytics_ua=analytics.stripe_android-1.0&os_name=REL&network_type=2G&event=stripe_android.payment_method_creation&is_development=true")
     }
 
     @Test
@@ -375,7 +377,8 @@ class PaymentAnalyticsRequestFactoryTest {
             AnalyticsFields.SESSION_ID,
             PaymentAnalyticsRequestFactory.FIELD_PRODUCT_USAGE,
             PaymentAnalyticsRequestFactory.FIELD_SOURCE_TYPE,
-            PaymentAnalyticsRequestFactory.FIELD_TOKEN_TYPE
+            PaymentAnalyticsRequestFactory.FIELD_TOKEN_TYPE,
+            AnalyticsFields.NETWORK_TYPE,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.injection
 import android.content.Context
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.networking.AnalyticsRequestFactory
+import com.stripe.android.core.networking.NetworkTypeDetector
 import com.stripe.android.core.utils.ContextUtils.packageInfo
 import com.stripe.android.paymentsheet.addresselement.AddressElementActivityContract
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
@@ -44,7 +45,8 @@ internal class AddressElementViewModelModule {
         packageManager = context.packageManager,
         packageName = context.packageName.orEmpty(),
         packageInfo = context.packageInfo,
-        publishableKeyProvider = { publishableKey }
+        publishableKeyProvider = { publishableKey },
+        networkTypeProvider = NetworkTypeDetector(context)::invoke,
     )
 
     @Provides

--- a/stripe-core/detekt-baseline.xml
+++ b/stripe-core/detekt-baseline.xml
@@ -4,6 +4,7 @@
   <CurrentIssues>
     <ID>EmptyFunctionBlock:DefaultStripeNetworkClientTest.kt$DefaultStripeNetworkClientTest.FailingConnection${ }</ID>
     <ID>EmptyFunctionBlock:DefaultStripeNetworkClientTest.kt$DefaultStripeNetworkClientTest.ResponseCodeOverrideConnection${ }</ID>
+    <ID>MagicNumber:NetworkTypeDetector.kt$NetworkTypeDetector$19</ID>
     <ID>MagicNumber:StripeJsonUtils.kt$StripeJsonUtils$3</ID>
     <ID>MaxLineLength:QueryStringFactoryTest.kt$QueryStringFactoryTest$"colors[]=blue&amp;colors[]=green&amp;empty_list=&amp;person[age]=45&amp;person[city]=San Francisco&amp;person[wishes]=&amp;person[friends][]=Alice&amp;person[friends][]=Bob"</ID>
     <ID>MaxLineLength:RequestHeadersFactoriesTest.kt$RequestHeadersFactoriesTest$.</ID>

--- a/stripe-core/src/main/AndroidManifest.xml
+++ b/stripe-core/src/main/AndroidManifest.xml
@@ -1,2 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+</manifest>

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsFields.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsFields.kt
@@ -21,4 +21,5 @@ object AnalyticsFields {
     const val OS_VERSION = "os_version"
     const val PUBLISHABLE_KEY = "publishable_key"
     const val SESSION_ID = "session_id"
+    const val NETWORK_TYPE = "network_type"
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
@@ -15,7 +15,8 @@ open class AnalyticsRequestFactory(
     private val packageManager: PackageManager?,
     private val packageInfo: PackageInfo?,
     private val packageName: String,
-    private val publishableKeyProvider: Provider<String>
+    private val publishableKeyProvider: Provider<String>,
+    private val networkTypeProvider: Provider<String?>,
 ) {
     /**
      * Builds an Analytics request for the given [AnalyticsEvent],
@@ -56,8 +57,13 @@ open class AnalyticsRequestFactory(
         AnalyticsFields.DEVICE_TYPE to DEVICE_TYPE,
         AnalyticsFields.BINDINGS_VERSION to StripeSdkVersion.VERSION_NAME,
         AnalyticsFields.IS_DEVELOPMENT to BuildConfig.DEBUG,
-        AnalyticsFields.SESSION_ID to sessionId
-    )
+        AnalyticsFields.SESSION_ID to sessionId,
+    ) + networkType()
+
+    private fun networkType(): Map<String, String> {
+        val networkType = networkTypeProvider.get() ?: return emptyMap()
+        return mapOf(AnalyticsFields.NETWORK_TYPE to networkType)
+    }
 
     internal fun appDataParams(): Map<String, Any> {
         return when {

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/NetworkTypeDetector.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/NetworkTypeDetector.kt
@@ -1,0 +1,80 @@
+package com.stripe.android.core.networking
+
+import android.content.Context
+import android.content.Context.CONNECTIVITY_SERVICE
+import android.net.ConnectivityManager
+import android.telephony.TelephonyManager
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class NetworkTypeDetector private constructor(
+    private val connectivityManager: ConnectivityManager,
+) {
+
+    constructor(context: Context) : this(
+        connectivityManager = context.getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager,
+    )
+
+    @Suppress("DEPRECATION")
+    operator fun invoke(): String? {
+        val networkInfo = connectivityManager.activeNetworkInfo
+
+        if (networkInfo == null || !networkInfo.isConnected) {
+            return null
+        }
+
+        val networkType = when (networkInfo.type) {
+            ConnectivityManager.TYPE_WIFI -> NetworkType.WiFi
+            ConnectivityManager.TYPE_MOBILE -> determineMobileNetworkType(networkInfo.subtype)
+            else -> NetworkType.Unknown
+        }
+
+        return networkType.value
+    }
+
+    private fun determineMobileNetworkType(subtype: Int): NetworkType {
+        return when (subtype) {
+            TelephonyManager.NETWORK_TYPE_GPRS,
+            TelephonyManager.NETWORK_TYPE_EDGE,
+            TelephonyManager.NETWORK_TYPE_CDMA,
+            TelephonyManager.NETWORK_TYPE_1xRTT,
+            TelephonyManager.NETWORK_TYPE_IDEN,
+            TelephonyManager.NETWORK_TYPE_GSM -> {
+                NetworkType.Mobile2G
+            }
+            TelephonyManager.NETWORK_TYPE_UMTS,
+            TelephonyManager.NETWORK_TYPE_EVDO_0,
+            TelephonyManager.NETWORK_TYPE_EVDO_A,
+            TelephonyManager.NETWORK_TYPE_HSDPA,
+            TelephonyManager.NETWORK_TYPE_HSUPA,
+            TelephonyManager.NETWORK_TYPE_HSPA,
+            TelephonyManager.NETWORK_TYPE_EVDO_B,
+            TelephonyManager.NETWORK_TYPE_EHRPD,
+            TelephonyManager.NETWORK_TYPE_HSPAP,
+            TelephonyManager.NETWORK_TYPE_TD_SCDMA -> {
+                NetworkType.Mobile3G
+            }
+            TelephonyManager.NETWORK_TYPE_LTE,
+            TelephonyManager.NETWORK_TYPE_IWLAN,
+            // This is for the non-exposed TelephonyManager.NETWORK_TYPE_LTE_CA
+            19 -> {
+                NetworkType.Mobile4G
+            }
+            TelephonyManager.NETWORK_TYPE_NR -> {
+                NetworkType.Mobile5G
+            }
+            else -> {
+                NetworkType.Unknown
+            }
+        }
+    }
+
+    private enum class NetworkType(val value: String) {
+        WiFi("Wi-Fi"),
+        Mobile2G("2G"),
+        Mobile3G("3G"),
+        Mobile4G("4G"),
+        Mobile5G("5G"),
+        Unknown("unknown"),
+    }
+}

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestFactoryTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestFactoryTest.kt
@@ -1,10 +1,8 @@
 package com.stripe.android.core.networking
 
-import android.content.Context
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.os.Build
-import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.BuildConfig
 import com.stripe.android.core.exception.APIException
@@ -18,8 +16,6 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class AnalyticsRequestFactoryTest : TestCase() {
 
-    private val context = ApplicationProvider.getApplicationContext<Context>()
-
     private val packageManager = mock<PackageManager>()
     private val packageName = "com.stripe.android.test"
     private val apiKey = "pk_abc123"
@@ -28,15 +24,6 @@ class AnalyticsRequestFactoryTest : TestCase() {
         override val eventName: String = "randomEvent"
     }
 
-    val factory = AnalyticsRequestFactory(
-        context.applicationContext.packageManager,
-        runCatching {
-            context.applicationContext.packageManager.getPackageInfo(packageName, 0)
-        }.getOrNull(),
-        context.applicationContext.packageName.orEmpty(),
-        { apiKey }
-    )
-
     @Test
     fun `when publishable key is unavailable, create params with undefined key`() {
         val exception = APIException(RuntimeException())
@@ -44,7 +31,8 @@ class AnalyticsRequestFactoryTest : TestCase() {
             mock(),
             null,
             packageName,
-            { throw exception }
+            { throw exception },
+            { "5G" },
         )
 
         val params = factory.createRequest(mockEvent, emptyMap()).params
@@ -68,7 +56,8 @@ class AnalyticsRequestFactoryTest : TestCase() {
             packageManager,
             packageInfo,
             packageName,
-            { apiKey }
+            { apiKey },
+            { "5G" },
         )
         val params = factory.createRequest(mockEvent, emptyMap()).params
 
@@ -92,7 +81,8 @@ class AnalyticsRequestFactoryTest : TestCase() {
             mock(),
             null,
             packageName,
-            { apiKey }
+            { apiKey },
+            { "5G" },
         )
         assertThat(factory.appDataParams()).isEmpty()
     }
@@ -103,7 +93,8 @@ class AnalyticsRequestFactoryTest : TestCase() {
             null,
             null,
             "",
-            { apiKey }
+            { apiKey },
+            { "5G" },
         )
         assertThat(factory.appDataParams()).isEmpty()
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds logging of the current network type (`unknown`, `Wi-Fi`, `2G`, `3G`, `4G` or `5G`) to all PaymentSheet events.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
