### PR TITLE
[Identity] Show alert dialog to cancel when falling back to document consent

### DIFF
--- a/identity/detekt-baseline.xml
+++ b/identity/detekt-baseline.xml
@@ -25,6 +25,7 @@
     <ID>LongMethod:IDNumberSection.kt$@Composable internal fun IDNumberSection( enabled: Boolean, idNumberCountries: List&lt;Country>, countryNotListedText: String, navController: NavController, onIdNumberCollected: (Resource&lt;IdNumberParam>) -> Unit )</ID>
     <ID>LongMethod:IdentityActivity.kt$IdentityActivity$override fun onCreate(savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:IdentityNavGraph.kt$@Composable internal fun IdentityNavGraph( navController: NavHostController = rememberNavController(), identityViewModel: IdentityViewModel, fallbackUrlLauncher: FallbackUrlLauncher, appSettingsOpenable: AppSettingsOpenable, cameraPermissionEnsureable: CameraPermissionEnsureable, verificationFlowFinishable: VerificationFlowFinishable, identityScanViewModelFactory: IdentityScanViewModel.IdentityScanViewModelFactory, onTopBarNavigationClick: () -> Unit, topBarState: IdentityTopBarState, onNavControllerCreated: (NavController) -> Unit )</ID>
+    <ID>LongMethod:IdentityOnBackPressedHandler.kt$IdentityOnBackPressedHandler$override fun handleOnBackPressed()</ID>
     <ID>LongMethod:IdentityViewModel.kt$IdentityViewModel$internal fun uploadScanResult( result: IdentityAggregator.FinalResult, verificationPage: VerificationPage, targetScanType: IdentityScanState.ScanType? )</ID>
     <ID>LongMethod:IdentityViewModel.kt$IdentityViewModel$private fun uploadDocumentImagesAndNotify( imageFile: File, filePurpose: StripeFilePurpose, uploadMethod: UploadMethod, scores: List&lt;Float>? = null, isHighRes: Boolean, isFront: Boolean, scanType: IdentityScanState.ScanType, compressionQuality: Float )</ID>
     <ID>LongMethod:IdentityViewModel.kt$IdentityViewModel$suspend fun postVerificationPageDataForDocSelection( type: CollectedDataParam.Type, navController: NavController, viewLifecycleOwner: LifecycleOwner, cameraPermissionEnsureable: CameraPermissionEnsureable )</ID>
@@ -56,6 +57,7 @@
     <ID>MagicNumber:IDNumberSection.kt$USIDConfig.&lt;no name provided>$4</ID>
     <ID>MagicNumber:OTPScreen.kt$4</ID>
     <ID>MagicNumber:RoundToMaxDecimals.kt$10</ID>
+    <ID>MatchingDeclarationName:AlertUtils.kt$AlertButton</ID>
     <ID>MatchingDeclarationName:ComposeLoadingButton.kt$LoadingButtonState</ID>
     <ID>MaxLineLength:DefaultIdentityRepositoryTest.kt$DefaultIdentityRepositoryTest$fun</ID>
     <ID>MaxLineLength:IDDetectorTransitionerTest.kt$IDDetectorTransitionerTest$fun</ID>

--- a/identity/res/values/totranslate.xml
+++ b/identity/res/values/totranslate.xml
@@ -10,4 +10,8 @@
 
     <string name="stripe_upload_a_photo">Upload a photo</string>
     <string name="stripe_upload_your_photo_id">Upload your photo ID</string>
+
+    <string name="stripe_identity_confirm_cancel">Are you sure you want to cancel?</string>
+    <string name="stripe_identity_yes">Yes</string>
+    <string name="stripe_identity_no">No</string>
 </resources>

--- a/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
@@ -196,6 +196,7 @@ internal class IdentityActivity :
                     onBackPressedCallback =
                         IdentityOnBackPressedHandler(
                             this,
+                            this,
                             navController,
                             identityViewModel
                         )

--- a/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
@@ -10,7 +10,6 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
-import androidx.appcompat.app.AlertDialog
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -38,6 +37,8 @@ import com.stripe.android.identity.navigation.IndividualWelcomeDestination
 import com.stripe.android.identity.navigation.navigateToFinalErrorScreen
 import com.stripe.android.identity.ui.IdentityTheme
 import com.stripe.android.identity.ui.IdentityTopBarState
+import com.stripe.android.identity.utils.AlertButton
+import com.stripe.android.identity.utils.showAlertDialog
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import javax.inject.Inject
 import javax.inject.Provider
@@ -231,12 +232,13 @@ internal class IdentityActivity :
      * [CameraPermissionCheckingActivity.requestCameraPermission].
      */
     override fun showPermissionRationaleDialog() {
-        val builder = AlertDialog.Builder(this)
-        builder.setMessage(R.string.stripe_camera_permission_rationale)
-            .setPositiveButton(R.string.stripe_ok) { _, _ ->
+        showAlertDialog(
+            this,
+            R.string.stripe_camera_permission_rationale,
+            positiveButton = AlertButton(R.string.stripe_ok) { _, _ ->
                 requestCameraPermission()
             }
-        builder.show()
+        )
     }
 
     // This should have neve been invoked as PERMISSION_RATIONALE_SHOWN is never written.

--- a/identity/src/main/java/com/stripe/android/identity/IdentityOnBackPressedHandler.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityOnBackPressedHandler.kt
@@ -1,7 +1,9 @@
 package com.stripe.android.identity
 
+import android.content.Context
 import android.os.Bundle
 import androidx.activity.OnBackPressedCallback
+import androidx.appcompat.app.AlertDialog
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
@@ -19,6 +21,7 @@ import com.stripe.android.identity.viewmodel.IdentityViewModel
  * Handles back button behavior based on current navigation status.
  */
 internal class IdentityOnBackPressedHandler(
+    private val context: Context,
     private val verificationFlowFinishable: VerificationFlowFinishable,
     private val navController: NavController,
     private val identityViewModel: IdentityViewModel
@@ -37,8 +40,7 @@ internal class IdentityOnBackPressedHandler(
             return
         }
         if (navController.previousBackStackEntry?.destination?.route == InitialLoadingDestination.ROUTE.route ||
-            navController.previousBackStackEntry?.destination?.route == DebugDestination.ROUTE.route ||
-            destination?.route == ConsentDestination.ROUTE.route
+            navController.previousBackStackEntry?.destination?.route == DebugDestination.ROUTE.route
         ) {
             finishWithCancelResult(
                 identityViewModel,
@@ -46,6 +48,8 @@ internal class IdentityOnBackPressedHandler(
                 destination?.route?.routeToScreenName()
                     ?: IdentityAnalyticsRequestFactory.SCREEN_NAME_UNKNOWN
             )
+        } else if (destination?.route == ConsentDestination.ROUTE.route) {
+            showAboutToCancelAlert()
         } else {
             when (destination?.route) {
                 ConfirmationDestination.ROUTE.route -> {
@@ -82,6 +86,21 @@ internal class IdentityOnBackPressedHandler(
                 }
             }
         }
+    }
+
+    private fun showAboutToCancelAlert() {
+        val builder = AlertDialog.Builder(context)
+        builder.setMessage(R.string.stripe_identity_confirm_cancel)
+            .setPositiveButton(R.string.stripe_identity_yes) { _, _ ->
+                finishWithCancelResult(
+                    identityViewModel,
+                    verificationFlowFinishable,
+                    destination?.route?.routeToScreenName()
+                        ?: IdentityAnalyticsRequestFactory.SCREEN_NAME_UNKNOWN
+                )
+            }.setNegativeButton(R.string.stripe_identity_no) { _, _ ->
+            }
+        builder.show()
     }
 
     private fun finishWithCancelResult(

--- a/identity/src/main/java/com/stripe/android/identity/IdentityOnBackPressedHandler.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityOnBackPressedHandler.kt
@@ -3,7 +3,6 @@ package com.stripe.android.identity
 import android.content.Context
 import android.os.Bundle
 import androidx.activity.OnBackPressedCallback
-import androidx.appcompat.app.AlertDialog
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
@@ -15,6 +14,8 @@ import com.stripe.android.identity.navigation.InitialLoadingDestination
 import com.stripe.android.identity.navigation.clearDataAndNavigateUp
 import com.stripe.android.identity.navigation.routeToScreenName
 import com.stripe.android.identity.networking.models.VerificationPage.Companion.requireSelfie
+import com.stripe.android.identity.utils.AlertButton
+import com.stripe.android.identity.utils.showAlertDialog
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 
 /**
@@ -49,7 +50,21 @@ internal class IdentityOnBackPressedHandler(
                     ?: IdentityAnalyticsRequestFactory.SCREEN_NAME_UNKNOWN
             )
         } else if (destination?.route == ConsentDestination.ROUTE.route) {
-            showAboutToCancelAlert()
+            showAlertDialog(
+                context,
+                R.string.stripe_identity_confirm_cancel,
+                positiveButton = AlertButton(
+                    R.string.stripe_identity_yes
+                ) { _, _ ->
+                    finishWithCancelResult(
+                        identityViewModel,
+                        verificationFlowFinishable,
+                        destination?.route?.routeToScreenName()
+                            ?: IdentityAnalyticsRequestFactory.SCREEN_NAME_UNKNOWN
+                    )
+                },
+                negativeButton = AlertButton(R.string.stripe_identity_no)
+            )
         } else {
             when (destination?.route) {
                 ConfirmationDestination.ROUTE.route -> {
@@ -86,21 +101,6 @@ internal class IdentityOnBackPressedHandler(
                 }
             }
         }
-    }
-
-    private fun showAboutToCancelAlert() {
-        val builder = AlertDialog.Builder(context)
-        builder.setMessage(R.string.stripe_identity_confirm_cancel)
-            .setPositiveButton(R.string.stripe_identity_yes) { _, _ ->
-                finishWithCancelResult(
-                    identityViewModel,
-                    verificationFlowFinishable,
-                    destination?.route?.routeToScreenName()
-                        ?: IdentityAnalyticsRequestFactory.SCREEN_NAME_UNKNOWN
-                )
-            }.setNegativeButton(R.string.stripe_identity_no) { _, _ ->
-            }
-        builder.show()
     }
 
     private fun finishWithCancelResult(

--- a/identity/src/main/java/com/stripe/android/identity/utils/AlertUtils.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/AlertUtils.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.identity.utils
+
+import android.content.Context
+import android.content.DialogInterface.OnClickListener
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AlertDialog
+
+internal data class AlertButton(
+    @StringRes val buttonRes: Int,
+    val onClickListener: OnClickListener? = null
+)
+
+internal fun showAlertDialog(
+    context: Context,
+    @StringRes titleRes: Int,
+    positiveButton: AlertButton? = null,
+    negativeButton: AlertButton? = null
+) {
+    val builder = AlertDialog.Builder(context)
+    builder.setMessage(titleRes)
+    positiveButton?.let {
+        builder.setPositiveButton(positiveButton.buttonRes, positiveButton.onClickListener)
+    }
+    negativeButton?.let {
+        builder.setNegativeButton(negativeButton.buttonRes, negativeButton.onClickListener)
+    }
+    builder.show()
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When clicking back on document consent when falling back to document in phoneV, show an alert dialog to confirm cancelation

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Better user experience


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![cancelDialogBefore](https://github.com/stripe/stripe-android/assets/79880926/dccd4d89-2428-4a35-aa88-884c811cafdf)  | ![cancelDialogAfter](https://github.com/stripe/stripe-android/assets/79880926/90f182ee-922d-48ec-a0fe-c1de34547474) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
