### PR TITLE
Use CameraX in CIV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 * [ADDED][6912](https://github.com/stripe/stripe-android/pull/6912) `GooglePayPaymentMethodLauncher` can now be presented with an amount of type `Long`. The method to present with an `Int` has been deprecated.
 * [DEPRECATED][6912](https://github.com/stripe/stripe-android/pull/6912) `GooglePayLauncherContract` and `GooglePayPaymentMethodLauncherContract` have been deprecated and will be removed in a future release. Use `GooglePayLauncher` and `GooglePayPaymentMethodLauncher` directly instead.
 
+### StripeCardScan
+* [CHANGED][7057](https://github.com/stripe/stripe-android/pull/7057) Updated CIV to use CameraX by default instead of Camera1.
+
 ## 20.25.8 - 2023-06-26
 
 ### Financial Connections

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/camera/GetCameraAdapter.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/camera/GetCameraAdapter.kt
@@ -10,6 +10,7 @@ import com.stripe.android.camera.Camera1Adapter
 import com.stripe.android.camera.CameraAdapter
 import com.stripe.android.camera.CameraErrorListener
 import com.stripe.android.camera.CameraPreviewImage
+import com.stripe.android.camera.CameraXAdapter
 
 private const val LOG_TAG = "CameraSelector"
 
@@ -25,7 +26,7 @@ internal fun getCameraAdapter(
 ): CameraAdapter<CameraPreviewImage<Bitmap>> =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
         try {
-            Camera1Adapter(activity, previewView, minimumResolution, cameraErrorListener)
+            CameraXAdapter(activity, previewView, minimumResolution, cameraErrorListener)
         } catch (t: Throwable) {
             Log.w(LOG_TAG, "Unable to instantiate CameraX", t)
             Camera1Adapter(activity, previewView, minimumResolution, cameraErrorListener)


### PR DESCRIPTION
# Summary
Swap CIV to use CameraX by default with a fallback to Camera1

# Motivation
Camera1 is causing an intermittent crash in DD

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
