### PR TITLE
Fix primary button visibility when no payment method selected

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -220,7 +220,7 @@ internal class CustomerSheetViewModel @Inject constructor(
             val isEditing = !it.isEditing
             it.copy(
                 isEditing = isEditing,
-                primaryButtonVisible = !isEditing,
+                primaryButtonVisible = !isEditing && originalPaymentSelection != it.paymentSelection,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarState.kt
@@ -21,7 +21,7 @@ internal object PaymentSheetTopBarStateFactory {
 
     fun create(
         screen: PaymentSheetScreen,
-        paymentMethods: List<PaymentMethod>?,
+        paymentMethods: List<PaymentMethod>,
         isLiveMode: Boolean,
         isProcessing: Boolean,
         isEditing: Boolean,
@@ -50,7 +50,7 @@ internal object PaymentSheetTopBarStateFactory {
             icon = icon,
             contentDescription = contentDescription,
             showTestModeLabel = !isLiveMode,
-            showEditMenu = showOptionsMenu && !paymentMethods.isNullOrEmpty(),
+            showEditMenu = showOptionsMenu && paymentMethods.isNotEmpty(),
             editMenuLabel = editMenuLabel,
             isEnabled = !isProcessing,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -204,9 +204,16 @@ internal abstract class BaseSheetViewModel(
         paymentMethods,
         stripeIntent.map { it?.isLiveMode ?: true },
         processing,
-        editing,
-        PaymentSheetTopBarStateFactory::create,
-    ).stateIn(
+        editing
+    ) { currentScreen, paymentMethods, isLiveMode, isProcessing, isEditing ->
+        PaymentSheetTopBarStateFactory.create(
+            screen = currentScreen,
+            paymentMethods = paymentMethods ?: emptyList(),
+            isLiveMode = isLiveMode,
+            isProcessing = isProcessing,
+            isEditing = isEditing,
+        )
+    }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(),
         initialValue = PaymentSheetTopBarStateFactory.createDefault(),

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -1070,7 +1070,15 @@ class CustomerSheetViewModelTest {
             )
 
             viewState = awaitItem() as CustomerSheetViewState.SelectPaymentMethod
-            assertThat((viewState).primaryButtonVisible)
+            assertThat(viewState.primaryButtonVisible)
+                .isFalse()
+
+            viewModel.handleViewAction(
+                CustomerSheetViewAction.OnEditPressed
+            )
+
+            viewState = awaitItem() as CustomerSheetViewState.SelectPaymentMethod
+            assertThat(viewState.primaryButtonVisible)
                 .isFalse()
 
             viewModel.handleViewAction(
@@ -1082,7 +1090,7 @@ class CustomerSheetViewModelTest {
             )
 
             viewState = awaitItem() as CustomerSheetViewState.SelectPaymentMethod
-            assertThat((viewState).primaryButtonVisible)
+            assertThat(viewState.primaryButtonVisible)
                 .isTrue()
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Fix an issue, when there is no initial payment selection, creating and then removing the newly added card (which selects the newly added card) would keep the primary button visible.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

