### PR TITLE
Fix primary button visibility issue with selected payment method

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -41,6 +41,7 @@ internal class CustomerSheetViewModel @Inject constructor(
     private val application: Application,
     // TODO (jameswoo) should the current view state be derived from backstack?
     private val backstack: Stack<CustomerSheetViewState>,
+    private var originalPaymentSelection: PaymentSelection?,
     private val paymentConfiguration: PaymentConfiguration,
     private val resources: Resources,
     private val configuration: CustomerSheet.Configuration,
@@ -63,8 +64,6 @@ internal class CustomerSheetViewModel @Inject constructor(
             .filterIsInstance<CustomerSheetViewState.SelectPaymentMethod>()
             .firstOrNull()
             ?.paymentSelection
-
-    private var originalPaymentSelection: PaymentSelection? = null
 
     init {
         lpmRepository.initializeWithCardSpec(
@@ -252,7 +251,7 @@ internal class CustomerSheetViewModel @Inject constructor(
                             }
 
                             removedPaymentSelection
-                        },
+                        } ?: originalPaymentSelection,
                     )
                 }
             }.onFailure { cause, displayMessage ->

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -14,6 +14,7 @@ import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.customersheet.CustomerSheetViewState
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import dagger.Module
 import dagger.Provides
@@ -94,5 +95,12 @@ internal class CustomerSheetViewModelModule {
                 isLiveMode = isLiveMode
             )
         )
+    }
+
+    @Provides
+    fun originalPaymentSelection(): PaymentSelection? = originalPaymentSelection
+
+    private companion object {
+        private val originalPaymentSelection: PaymentSelection? = null
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarState.kt
@@ -21,7 +21,7 @@ internal object PaymentSheetTopBarStateFactory {
 
     fun create(
         screen: PaymentSheetScreen,
-        paymentMethods: List<PaymentMethod>,
+        paymentMethods: List<PaymentMethod>?,
         isLiveMode: Boolean,
         isProcessing: Boolean,
         isEditing: Boolean,
@@ -50,7 +50,7 @@ internal object PaymentSheetTopBarStateFactory {
             icon = icon,
             contentDescription = contentDescription,
             showTestModeLabel = !isLiveMode,
-            showEditMenu = showOptionsMenu && paymentMethods.isNotEmpty(),
+            showEditMenu = isEditing || showOptionsMenu && !paymentMethods.isNullOrEmpty(),
             editMenuLabel = editMenuLabel,
             isEnabled = !isProcessing,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -204,16 +204,9 @@ internal abstract class BaseSheetViewModel(
         paymentMethods,
         stripeIntent.map { it?.isLiveMode ?: true },
         processing,
-        editing
-    ) { currentScreen, paymentMethods, isLiveMode, isProcessing, isEditing ->
-        PaymentSheetTopBarStateFactory.create(
-            screen = currentScreen,
-            paymentMethods = paymentMethods ?: emptyList(),
-            isLiveMode = isLiveMode,
-            isProcessing = isProcessing,
-            isEditing = isEditing,
-        )
-    }.stateIn(
+        editing,
+        PaymentSheetTopBarStateFactory::create,
+    ).stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(),
         initialValue = PaymentSheetTopBarStateFactory.createDefault(),

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTestHelper.kt
@@ -8,6 +8,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.forms.resources.LpmRepository
@@ -40,6 +41,7 @@ object CustomerSheetTestHelper {
         backstack: Stack<CustomerSheetViewState> = Stack<CustomerSheetViewState>().apply {
             push(CustomerSheetViewState.Loading(isLiveMode))
         },
+        originalPaymentSelection: PaymentSelection? = null,
         customerAdapter: CustomerAdapter = FakeCustomerAdapter(),
         stripeRepository: StripeRepository = FakeStripeRepository(),
         paymentConfiguration: PaymentConfiguration = PaymentConfiguration(
@@ -80,6 +82,7 @@ object CustomerSheetTestHelper {
         return CustomerSheetViewModel(
             application = application,
             backstack = backstack,
+            originalPaymentSelection = originalPaymentSelection,
             paymentConfiguration = paymentConfiguration,
             formViewModelSubcomponentBuilderProvider = mockFormSubComponentBuilderProvider,
             resources = application.resources,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Fix an issue where initially there is a payment selection, create a new payment method, then remove the newly created payment method, the initial payment selection should be selected again and the primary button should not be visible.

Fix an issue where the DONE edit button would disappear after removing the last payment method in the carousel.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
