### PR TITLE
Attempt to fix robolectric build issues.

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -19,10 +19,10 @@ pipelines:
 stages:
   stage-trigger-run-all:
     workflows:
-      - check: { }
+#      - check: { }
       - test: { }
-      - run-instrumentation-tests: { }
-      - run-paymentsheet-end-to-end-tests: { }
+#      - run-instrumentation-tests: { }
+#      - run-paymentsheet-end-to-end-tests: { }
 
 workflows:
   check:
@@ -173,6 +173,7 @@ workflows:
       - git-clone@8: { }
       - cache-pull@2: { }
       - script-runner@0:
+          # Maven doesn't like java 17, so running it before.
           run_if: '{{getenv "NEEDS_ROBOLECTRIC" | ne ""}}'
           title: Download robolectric dependencies
           inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -168,6 +168,10 @@ workflows:
           run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
       - git-clone@8: { }
       - cache-pull@2: { }
+      - script-runner@0:
+          title: Download robolectric dependencies
+          inputs:
+            - file_path: ./scripts/download_robolectric.sh
       - set-java-version@1:
           inputs:
             - set_java_version: 17
@@ -177,10 +181,6 @@ workflows:
       - script@1:
           inputs:
             - content: echo "STRIPE_EXAMPLE_BACKEND_URL=$STRIPE_EXAMPLE_BACKEND_URL" >> ~/.gradle/gradle.properties; echo "STRIPE_EXAMPLE_PUBLISHABLE_KEY=$STRIPE_EXAMPLE_PUBLISHABLE_KEY" >> ~/.gradle/gradle.properties
-      - script-runner@0:
-          title: Download robolectric dependencies
-          inputs:
-            - file_path: ./scripts/download_robolectric.sh
   conclude_all:
     steps:
       - script-runner@0:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -177,6 +177,10 @@ workflows:
       - script@1:
           inputs:
             - content: echo "STRIPE_EXAMPLE_BACKEND_URL=$STRIPE_EXAMPLE_BACKEND_URL" >> ~/.gradle/gradle.properties; echo "STRIPE_EXAMPLE_PUBLISHABLE_KEY=$STRIPE_EXAMPLE_PUBLISHABLE_KEY" >> ~/.gradle/gradle.properties
+      - script-runner@0:
+          title: Download robolectric dependencies
+          inputs:
+            - file_path: ./scripts/download_robolectric.sh
   conclude_all:
     steps:
       - script-runner@0:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -38,7 +38,7 @@ workflows:
     envs:
       - opts:
           is_expand: false
-          NEEDS_ROBOLECTRIC: true
+        NEEDS_ROBOLECTRIC: true
     before_run:
       - prepare_all
     after_run:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -19,10 +19,10 @@ pipelines:
 stages:
   stage-trigger-run-all:
     workflows:
- #      - check: { }
+      - check: { }
       - test: { }
-#      - run-instrumentation-tests: { }
-#      - run-paymentsheet-end-to-end-tests: { }
+      - run-instrumentation-tests: { }
+      - run-paymentsheet-end-to-end-tests: { }
 
 workflows:
   check:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -19,7 +19,7 @@ pipelines:
 stages:
   stage-trigger-run-all:
     workflows:
-#      - check: { }
+ #      - check: { }
       - test: { }
 #      - run-instrumentation-tests: { }
 #      - run-paymentsheet-end-to-end-tests: { }

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -35,6 +35,10 @@ workflows:
           inputs:
             - content: ./gradlew ktlint detekt lintRelease apiCheck verifyReleaseResources
   test:
+    envs:
+      - opts:
+          is_expand: false
+          NEEDS_ROBOLECTRIC: true
     before_run:
       - prepare_all
     after_run:
@@ -169,6 +173,7 @@ workflows:
       - git-clone@8: { }
       - cache-pull@2: { }
       - script-runner@0:
+          run_if: '{{getenv "NEEDS_ROBOLECTRIC" | ne ""}}'
           title: Download robolectric dependencies
           inputs:
             - file_path: ./scripts/download_robolectric.sh

--- a/scripts/download_robolectric.sh
+++ b/scripts/download_robolectric.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e # Fail on error.
+
+declare -a robolectric_versions=("10-robolectric-5803371-i4" "11-robolectric-6757853-i4" "13-robolectric-9030017-i4" "4.1.2_r1-robolectric-r1-i4" "9-robolectric-4913185-2-i4")
+
+for i in ${robolectric_versions[@]}; do
+  eval "mvn dependency:get -Dartifact=org.robolectric:android-all-instrumented:${i}"
+done

--- a/scripts/download_robolectric.sh
+++ b/scripts/download_robolectric.sh
@@ -2,6 +2,11 @@
 
 set -e # Fail on error.
 
+# To get this list run the following commands.
+# rm -rf ~/.m2/repository/org/robolectric/android-all-instrumented
+# ./gradlew testDebugUnitTest
+# ls ~/.m2/repository/org/robolectric/android-all-instrumented/
+# The resulting list of versions should be added below.
 declare -a robolectric_versions=("10-robolectric-5803371-i4" "11-robolectric-6757853-i4" "13-robolectric-9030017-i4" "4.1.2_r1-robolectric-r1-i4" "9-robolectric-4913185-2-i4")
 
 for i in ${robolectric_versions[@]}; do

--- a/scripts/download_robolectric.sh
+++ b/scripts/download_robolectric.sh
@@ -5,5 +5,5 @@ set -e # Fail on error.
 declare -a robolectric_versions=("10-robolectric-5803371-i4" "11-robolectric-6757853-i4" "13-robolectric-9030017-i4" "4.1.2_r1-robolectric-r1-i4" "9-robolectric-4913185-2-i4")
 
 for i in ${robolectric_versions[@]}; do
-  eval "mvn dependency:get -Dartifact=org.robolectric:android-all-instrumented:${i}"
+  mvn dependency:get -Dartifact=org.robolectric:android-all-instrumented:${i}
 done


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We were having lots of flakes running unit tests because robolectric was failing to download while running the tests. This change prefetches the robolectric dependencies so they can be used locally rather than downloading the during the test run.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Flakey tests.
