### PR TITLE
Expose extension functions on CustomerAdapter.Result

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
@@ -187,7 +187,9 @@ interface CustomerAdapter {
         val isSuccess: Boolean get() = value !is Failure
         val isFailure: Boolean get() = value is Failure
 
-        internal data class Failure(
+        @ExperimentalCustomerSheetApi
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        data class Failure internal constructor(
             val cause: Throwable,
             val displayMessage: String? = null
         )

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapterResultKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapterResultKtx.kt
@@ -1,14 +1,32 @@
 @file:Suppress("UNCHECKED_CAST")
+@file:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 
 package com.stripe.android.customersheet
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.core.exception.StripeException
 
-@OptIn(ExperimentalCustomerSheetApi::class)
-internal fun <T> CustomerAdapter.Result<T>.getOrNull(): T? =
+/**
+ * Returns the encapsulated value if this instance represents success or null if it is failure.
+ */
+@ExperimentalCustomerSheetApi
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun <T> CustomerAdapter.Result<T>.getOrNull(): T? =
     when {
         isFailure -> null
         else -> value as T
+    }
+
+/**
+ * Returns the encapsulated [CustomerAdapter.Result.Failure] if this instance represents failure or
+ * null if it is success.
+ */
+@ExperimentalCustomerSheetApi
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun <T> CustomerAdapter.Result<T>.failureOrNull(): CustomerAdapter.Result.Failure? =
+    when {
+        isFailure -> value as CustomerAdapter.Result.Failure
+        else -> null
     }
 
 @OptIn(ExperimentalCustomerSheetApi::class)
@@ -81,10 +99,3 @@ internal inline fun <R, T> CustomerAdapter.Result<T>.onFailure(
     }
     return this
 }
-
-@OptIn(ExperimentalCustomerSheetApi::class)
-internal fun<T> CustomerAdapter.Result<T>.failureOrNull(): CustomerAdapter.Result.Failure? =
-    when {
-        isFailure -> value as CustomerAdapter.Result.Failure
-        else -> null
-    }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -615,6 +615,38 @@ class CustomerAdapterTest {
             .isEqualTo(null)
     }
 
+    @Test
+    fun `CustomerAdapter result can get value or null`() {
+        val result = CustomerAdapter.Result.success("Hello")
+
+        assertThat(result.getOrNull())
+            .isEqualTo("Hello")
+
+        val nullResult = CustomerAdapter.Result.failure<String>(
+            cause = IllegalStateException("some exception"),
+            displayMessage = "testing"
+        )
+
+        assertThat(nullResult.getOrNull())
+            .isNull()
+    }
+
+    @Test
+    fun `CustomerAdapter result can get failure or null`() {
+        val nullFailure = CustomerAdapter.Result.success("Hello")
+
+        assertThat(nullFailure.failureOrNull())
+            .isNull()
+
+        val failure = CustomerAdapter.Result.failure<String>(
+            cause = IllegalStateException("some exception"),
+            displayMessage = "testing"
+        )
+
+        assertThat(failure.failureOrNull()?.displayMessage)
+            .isEqualTo("testing")
+    }
+
     private fun createAdapter(
         customerEphemeralKeyProvider: CustomerEphemeralKeyProvider =
             CustomerEphemeralKeyProvider {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Expose extension functions on CustomerAdapter.Result for retrieving values.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

While writing the documentation examples, I noticed that integrators would not be able to parse the results from the adapter if they override the methods.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
