### PR TITLE
Refactor the CustomerAdapter.Result to sealed class

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
@@ -179,35 +179,37 @@ interface CustomerAdapter {
 
     @ExperimentalCustomerSheetApi
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    @JvmInline
-    value class Result<out T> internal constructor(
-        internal val value: Any?
-    ) {
+    sealed class Result<T> {
 
-        val isSuccess: Boolean get() = value !is Failure
-        val isFailure: Boolean get() = value is Failure
+        @ExperimentalCustomerSheetApi
+        @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        val isFailure: Boolean get() = this is Failure
 
-        internal data class Failure(
+        @ExperimentalCustomerSheetApi
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        data class Success<T>(
+            val value: T
+        ) : Result<T>()
+
+        @ExperimentalCustomerSheetApi
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        data class Failure<T>(
             val cause: Throwable,
             val displayMessage: String? = null
-        )
+        ) : Result<T>()
 
         @ExperimentalCustomerSheetApi
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         companion object {
             @ExperimentalCustomerSheetApi
             @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-            fun <T> success(value: T): Result<T> {
-                return Result(value)
+            fun <T> success(value: T): Success<T> {
+                return Success(value)
             }
 
             @ExperimentalCustomerSheetApi
             @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-            fun <T> failure(cause: Throwable, displayMessage: String?): Result<T> {
-                return Result(createFailure(cause, displayMessage))
-            }
-
-            private fun createFailure(cause: Throwable, displayMessage: String? = null): Any {
+            fun <T> failure(cause: Throwable, displayMessage: String?): Failure<T> {
                 return Failure(cause, displayMessage)
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
@@ -182,18 +182,14 @@ interface CustomerAdapter {
     sealed class Result<T> {
 
         @ExperimentalCustomerSheetApi
-        @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        val isFailure: Boolean get() = this is Failure
-
-        @ExperimentalCustomerSheetApi
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        data class Success<T>(
+        class Success<T> internal constructor(
             val value: T
         ) : Result<T>()
 
         @ExperimentalCustomerSheetApi
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        data class Failure<T>(
+        class Failure<T> internal constructor(
             val cause: Throwable,
             val displayMessage: String? = null
         ) : Result<T>()

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -133,12 +133,8 @@ internal class CustomerSheetViewModel @Inject constructor(
                 }
             }
 
-            val failure = result.failureOrNull()
-            val errorMessage = if (result.isFailure) {
-                failure?.displayMessage ?: failure?.cause?.stripeErrorMessage(application)
-            } else {
-                null
-            }
+            val errorMessage = result.failureOrNull()?.displayMessage
+                ?: result.failureOrNull()?.cause?.stripeErrorMessage(application)
 
             originalPaymentSelection = paymentSelection
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -147,7 +147,7 @@ class CustomerAdapterTest {
             customerEphemeralKeyProvider = { error }
         )
         val result = adapter.retrievePaymentMethods()
-        assertThat((result.value as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat((result.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
             .isEqualTo("Merchant says cannot get customer")
     }
 
@@ -178,7 +178,7 @@ class CustomerAdapterTest {
             )
         )
         val result = adapter.attachPaymentMethod("pm_1234")
-        assertThat((result.value as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat((result.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
             .isEqualTo("Something went wrong")
     }
 
@@ -197,7 +197,7 @@ class CustomerAdapterTest {
             )
         )
         val result = adapter.attachPaymentMethod("pm_1234")
-        assertThat((result.value as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat((result.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
             .isEqualTo("Unable to attach payment method")
     }
 
@@ -230,7 +230,7 @@ class CustomerAdapterTest {
             )
         )
         val result = adapter.detachPaymentMethod("pm_1234")
-        assertThat((result.value as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat((result.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
             .isEqualTo("Something went wrong")
     }
 
@@ -249,7 +249,7 @@ class CustomerAdapterTest {
             )
         )
         val result = adapter.detachPaymentMethod("pm_1234")
-        assertThat((result.value as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat((result.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
             .isEqualTo("Unable to detach payment method")
     }
 
@@ -364,9 +364,9 @@ class CustomerAdapterTest {
         val result = adapter.setSelectedPaymentOption(
             paymentOption = CustomerAdapter.PaymentOption.StripeId("pm_1234")
         )
-        assertThat((result.value as CustomerAdapter.Result.Failure).cause.message)
+        assertThat((result.failureOrNull() as CustomerAdapter.Result.Failure).cause.message)
             .isEqualTo("Unable to persist payment option StripeId(id=pm_1234)")
-        assertThat(result.value.displayMessage)
+        assertThat(result.failureOrNull()!!.displayMessage)
             .isEqualTo("Something went wrong")
     }
 
@@ -438,7 +438,7 @@ class CustomerAdapterTest {
             },
         )
         val result = adapter.setupIntentClientSecretForCustomerAttach()
-        assertThat((result.value as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat((result.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
             .isEqualTo("Couldn't get client secret")
     }
 
@@ -507,18 +507,12 @@ class CustomerAdapterTest {
     @Test
     fun `CustomerAdapter Result can be created using success`() {
         val result: CustomerAdapter.Result<String> = CustomerAdapter.Result.success("Hello")
-        assertThat(result.value)
-            .isEqualTo("Hello")
         assertThat(result.getOrNull())
             .isEqualTo("Hello")
 
         var newResult = result.map { "world" }
-        assertThat(newResult.value)
+        assertThat(newResult.getOrNull())
             .isEqualTo("world")
-
-        newResult = newResult.mapCatching { "Hello world" }
-        assertThat(newResult.value)
-            .isEqualTo("Hello world")
 
         newResult = newResult.fold(
             onSuccess = {
@@ -531,7 +525,7 @@ class CustomerAdapterTest {
                 )
             }
         )
-        assertThat(newResult.value)
+        assertThat(newResult.getOrNull())
             .isEqualTo("Success")
     }
 
@@ -541,19 +535,13 @@ class CustomerAdapterTest {
             cause = IllegalStateException("Illegal state"),
             displayMessage = "This is display message",
         )
-        assertThat((result.value as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat((result.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
             .isEqualTo("This is display message")
         assertThat(result.getOrNull())
             .isNull()
 
         var newResult = result.map { "world" }
-        assertThat(newResult.isFailure).isTrue()
-        assertThat((newResult.value as CustomerAdapter.Result.Failure).displayMessage)
-            .isEqualTo("This is display message")
-
-        newResult = newResult.mapCatching { "Hello world" }
-        assertThat(newResult.isFailure).isTrue()
-        assertThat((newResult.value as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat((newResult.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
             .isEqualTo("This is display message")
 
         newResult = newResult.fold(
@@ -567,8 +555,7 @@ class CustomerAdapterTest {
                 )
             }
         )
-        assertThat(newResult.isFailure).isTrue()
-        assertThat((newResult.value as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat((newResult.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
             .isEqualTo("This is a new display message")
     }
 
@@ -580,19 +567,19 @@ class CustomerAdapterTest {
             ),
             displayMessage = "There was a problem with Stripe",
         )
-        assertThat((result.value as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat((result.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
             .isEqualTo("There was a problem with Stripe")
 
         var newResult = result.map {
             "New result"
         }
-        assertThat((newResult.value as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat((newResult.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
             .isEqualTo("There was a problem with Stripe")
 
         newResult = result.mapCatching {
             "New result"
         }
-        assertThat((newResult.value as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat((newResult.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
             .isEqualTo("There was a problem with Stripe")
 
         var stripeResult: CustomerAdapter.Result<String> = CustomerAdapter.Result.failure(
@@ -602,7 +589,7 @@ class CustomerAdapterTest {
             ),
             displayMessage = "There was a problem with Stripe",
         )
-        assertThat((stripeResult.value as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat((stripeResult.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
             .isEqualTo("There was a problem with Stripe")
 
         stripeResult = CustomerAdapter.Result.failure(
@@ -611,7 +598,7 @@ class CustomerAdapterTest {
             ),
             displayMessage = null,
         )
-        assertThat((stripeResult.value as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat((stripeResult.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
             .isEqualTo(null)
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -147,7 +147,7 @@ class CustomerAdapterTest {
             customerEphemeralKeyProvider = { error }
         )
         val result = adapter.retrievePaymentMethods()
-        assertThat((result.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat(result.failureOrNull()?.displayMessage)
             .isEqualTo("Merchant says cannot get customer")
     }
 
@@ -178,7 +178,7 @@ class CustomerAdapterTest {
             )
         )
         val result = adapter.attachPaymentMethod("pm_1234")
-        assertThat((result.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat(result.failureOrNull()?.displayMessage)
             .isEqualTo("Something went wrong")
     }
 
@@ -197,7 +197,7 @@ class CustomerAdapterTest {
             )
         )
         val result = adapter.attachPaymentMethod("pm_1234")
-        assertThat((result.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat(result.failureOrNull()?.displayMessage)
             .isEqualTo("Unable to attach payment method")
     }
 
@@ -230,7 +230,7 @@ class CustomerAdapterTest {
             )
         )
         val result = adapter.detachPaymentMethod("pm_1234")
-        assertThat((result.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat(result.failureOrNull()?.displayMessage)
             .isEqualTo("Something went wrong")
     }
 
@@ -249,7 +249,7 @@ class CustomerAdapterTest {
             )
         )
         val result = adapter.detachPaymentMethod("pm_1234")
-        assertThat((result.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat(result.failureOrNull()?.displayMessage)
             .isEqualTo("Unable to detach payment method")
     }
 
@@ -364,9 +364,9 @@ class CustomerAdapterTest {
         val result = adapter.setSelectedPaymentOption(
             paymentOption = CustomerAdapter.PaymentOption.StripeId("pm_1234")
         )
-        assertThat((result.failureOrNull() as CustomerAdapter.Result.Failure).cause.message)
+        assertThat(result.failureOrNull()?.cause?.message)
             .isEqualTo("Unable to persist payment option StripeId(id=pm_1234)")
-        assertThat(result.failureOrNull()!!.displayMessage)
+        assertThat(result.failureOrNull()?.displayMessage)
             .isEqualTo("Something went wrong")
     }
 
@@ -438,7 +438,7 @@ class CustomerAdapterTest {
             },
         )
         val result = adapter.setupIntentClientSecretForCustomerAttach()
-        assertThat((result.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat(result.failureOrNull()?.displayMessage)
             .isEqualTo("Couldn't get client secret")
     }
 
@@ -535,13 +535,13 @@ class CustomerAdapterTest {
             cause = IllegalStateException("Illegal state"),
             displayMessage = "This is display message",
         )
-        assertThat((result.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat(result.failureOrNull()?.displayMessage)
             .isEqualTo("This is display message")
         assertThat(result.getOrNull())
             .isNull()
 
         var newResult = result.map { "world" }
-        assertThat((newResult.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat(newResult.failureOrNull()?.displayMessage)
             .isEqualTo("This is display message")
 
         newResult = newResult.fold(
@@ -555,7 +555,7 @@ class CustomerAdapterTest {
                 )
             }
         )
-        assertThat((newResult.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat(newResult.failureOrNull()?.displayMessage)
             .isEqualTo("This is a new display message")
     }
 
@@ -567,29 +567,29 @@ class CustomerAdapterTest {
             ),
             displayMessage = "There was a problem with Stripe",
         )
-        assertThat((result.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat(result.failureOrNull()?.displayMessage)
             .isEqualTo("There was a problem with Stripe")
 
         var newResult = result.map {
             "New result"
         }
-        assertThat((newResult.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat(newResult.failureOrNull()?.displayMessage)
             .isEqualTo("There was a problem with Stripe")
 
         newResult = result.mapCatching {
             "New result"
         }
-        assertThat((newResult.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat(newResult.failureOrNull()?.displayMessage)
             .isEqualTo("There was a problem with Stripe")
 
-        var stripeResult: CustomerAdapter.Result<String> = CustomerAdapter.Result.failure(
+        var stripeResult = CustomerAdapter.Result.failure<String>(
             cause = APIException(
                 message = "Unlocalized message",
                 stripeError = null,
             ),
             displayMessage = "There was a problem with Stripe",
         )
-        assertThat((stripeResult.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat(stripeResult.failureOrNull()?.displayMessage)
             .isEqualTo("There was a problem with Stripe")
 
         stripeResult = CustomerAdapter.Result.failure(
@@ -598,7 +598,7 @@ class CustomerAdapterTest {
             ),
             displayMessage = null,
         )
-        assertThat((stripeResult.failureOrNull() as CustomerAdapter.Result.Failure).displayMessage)
+        assertThat(stripeResult.failureOrNull()?.displayMessage)
             .isEqualTo(null)
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Refactor the CustomerAdapter.Result to sealed class

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

When an integrator wants to override the default behavior of the CustomerAdapter, they need to know whether it was a success or failure and the underlying value.

Example:

```kotlin
val result = adapter.retrievePaymentMethods()
when (result) {
    is CustomerAdapter.Result.Failure -> TODO()
    is CustomerAdapter.Result.Success -> TODO()
}
```

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
