### PR TITLE
Add loading analytics events for PaymentSheet

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -26,7 +26,7 @@
     <ID>LongMethod:FormViewModelTest.kt$FormViewModelTest$@Test fun `Verify params are set when required address fields are complete`()</ID>
     <ID>LongMethod:PaymentOptionFactory.kt$PaymentOptionFactory$fun create(selection: PaymentSelection): PaymentOption</ID>
     <ID>LongMethod:PaymentSheetConfigurationKtx.kt$internal fun PaymentSheet.Appearance.parseAppearance()</ID>
-    <ID>LongMethod:PaymentSheetLoader.kt$DefaultPaymentSheetLoader$private suspend fun create( stripeIntent: StripeIntent, customerConfig: PaymentSheet.CustomerConfiguration?, config: PaymentSheet.Configuration?, isGooglePayReady: Boolean, merchantCountry: String?, ): PaymentSheetLoader.Result</ID>
+    <ID>LongMethod:PaymentSheetLoader.kt$DefaultPaymentSheetLoader$private suspend fun create( elementsSession: ElementsSession, config: PaymentSheet.Configuration?, isGooglePayReady: Boolean, ): PaymentSheetLoader.Result</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable internal fun USBankAccountForm( formArgs: FormArguments, sheetViewModel: BaseSheetViewModel, isProcessing: Boolean, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable private fun AccountDetailsForm( formArgs: FormArguments, isProcessing: Boolean, bankName: String?, last4: String?, saveForFutureUseElement: SaveForFutureUseElement, onRemoveAccount: () -> Unit, )</ID>
     <ID>MagicNumber:AutocompleteScreen.kt$0.07f</ID>
@@ -72,7 +72,9 @@
     <ID>ReturnCount:AddressUtils.kt$internal fun CharSequence.levenshtein(other: CharSequence): Int</ID>
     <ID>ThrowsCount:PaymentSheetConfigurationKtx.kt$internal fun PaymentSheet.Configuration.validate()</ID>
     <ID>TooManyFunctions:CustomerSheetViewModelModule.kt$CustomerSheetViewModelModule</ID>
+    <ID>TooManyFunctions:DefaultEventReporter.kt$DefaultEventReporter : EventReporter</ID>
     <ID>TooManyFunctions:DefaultFlowController.kt$DefaultFlowController : FlowController</ID>
+    <ID>TooManyFunctions:EventReporter.kt$EventReporter</ID>
     <ID>TooManyFunctions:PaymentOption.kt$DelegateDrawable : Drawable</ID>
     <ID>TooManyFunctions:PaymentOptionsViewModel.kt$PaymentOptionsViewModel : BaseSheetViewModel</ID>
     <ID>TooManyFunctions:PaymentSheetViewModel.kt$PaymentSheetViewModel : BaseSheetViewModel</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -188,6 +188,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     }
 
     override fun onUserCancel() {
+        reportDismiss(isDecoupling)
         _paymentOptionResult.tryEmit(
             PaymentOptionResult.Canceled(
                 mostRecentError = mostRecentError,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -606,6 +606,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     override fun onUserCancel() {
+        reportDismiss(isDecoupling)
         _paymentSheetResult.tryEmit(PaymentSheetResult.Canceled)
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -34,12 +34,36 @@ internal class DefaultEventReporter @Inject internal constructor(
         )
     }
 
+    override fun onLoadStarted(isDecoupling: Boolean) {
+        durationProvider.start(DurationProvider.Key.Loading)
+        fireEvent(PaymentSheetEvent.LoadStarted(isDecoupling))
+    }
+
+    override fun onLoadSucceeded(isDecoupling: Boolean) {
+        val duration = durationProvider.end(DurationProvider.Key.Loading)
+        fireEvent(
+            PaymentSheetEvent.LoadSucceeded(
+                duration = duration,
+                isDecoupled = isDecoupling,
+            )
+        )
+    }
+
+    override fun onLoadFailed(isDecoupling: Boolean) {
+        val duration = durationProvider.end(DurationProvider.Key.Loading)
+        fireEvent(
+            PaymentSheetEvent.LoadFailed(
+                duration = duration,
+                isDecoupled = isDecoupling,
+            )
+        )
+    }
+
     override fun onDismiss(
         isDecoupling: Boolean,
     ) {
         fireEvent(
             PaymentSheetEvent.Dismiss(
-                mode = mode,
                 isDecoupled = isDecoupling,
             )
         )
@@ -110,7 +134,7 @@ internal class DefaultEventReporter @Inject internal constructor(
             PaymentSheetEvent.Payment(
                 mode = mode,
                 paymentSelection = realSelection,
-                durationMillis = duration?.inWholeMilliseconds,
+                duration = duration,
                 result = PaymentSheetEvent.Payment.Result.Success,
                 currency = currency,
                 isDecoupled = deferredIntentConfirmationType != null,
@@ -130,7 +154,7 @@ internal class DefaultEventReporter @Inject internal constructor(
             PaymentSheetEvent.Payment(
                 mode = mode,
                 paymentSelection = paymentSelection,
-                durationMillis = duration?.inWholeMilliseconds,
+                duration = duration,
                 result = PaymentSheetEvent.Payment.Result.Failure,
                 currency = currency,
                 isDecoupled = isDecoupling,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DurationProvider.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DurationProvider.kt
@@ -10,6 +10,7 @@ internal interface DurationProvider {
     fun end(key: Key): Duration?
 
     enum class Key {
+        Loading,
         Checkout,
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -7,49 +7,99 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 
 internal interface EventReporter {
 
+    /**
+     * PaymentSheet has been instantiated or FlowController has finished its configuration.
+     */
     fun onInit(
         configuration: PaymentSheet.Configuration?,
         isDecoupling: Boolean,
     )
 
+    /**
+     * PaymentSheet or FlowController have started loading.
+     */
+    fun onLoadStarted(
+        isDecoupling: Boolean,
+    )
+
+    /**
+     * PaymentSheet or FlowController have successfully loaded the information required to be
+     * rendered.
+     */
+    fun onLoadSucceeded(
+        isDecoupling: Boolean,
+    )
+
+    /**
+     * PaymentSheet or FlowController have failed to load.
+     */
+    fun onLoadFailed(
+        isDecoupling: Boolean,
+    )
+
+    /**
+     * PaymentSheet has been dismissed by pressing the close button.
+     */
     fun onDismiss(
         isDecoupling: Boolean,
     )
 
+    /**
+     * PaymentSheet is now being displayed and its first screen shows the customer's saved payment
+     * methods.
+     */
     fun onShowExistingPaymentOptions(
         linkEnabled: Boolean,
         currency: String?,
         isDecoupling: Boolean,
     )
 
+    /**
+     * PaymentSheet is now being displayed and its first screen shows the payment method form.
+     */
     fun onShowNewPaymentOptionForm(
         linkEnabled: Boolean,
         currency: String?,
         isDecoupling: Boolean,
     )
 
+    /**
+     * The customer has selected one of their existing payment methods.
+     */
     fun onSelectPaymentOption(
         paymentSelection: PaymentSelection,
         currency: String?,
         isDecoupling: Boolean,
     )
 
+    /**
+     * Payment or setup have succeeded.
+     */
     fun onPaymentSuccess(
         paymentSelection: PaymentSelection?,
         currency: String?,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
     )
 
+    /**
+     * Payment or setup have failed.
+     */
     fun onPaymentFailure(
         paymentSelection: PaymentSelection?,
         currency: String?,
         isDecoupling: Boolean,
     )
 
+    /**
+     * The client was unable to parse the response from LUXE.
+     */
     fun onLpmSpecFailure(
         isDecoupling: Boolean,
     )
 
+    /**
+     * The user has auto-filled a text field.
+     */
     fun onAutofill(
         type: String,
         isDecoupling: Boolean,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -286,6 +286,10 @@ internal abstract class BaseSheetViewModel(
         }
     }
 
+    protected fun reportDismiss(isDecoupling: Boolean) {
+        eventReporter.onDismiss(isDecoupling = isDecoupling)
+    }
+
     abstract fun clearErrorMessages()
 
     fun updatePrimaryButtonForLinkSignup(viewState: InlineSignupViewState) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -492,6 +492,24 @@ internal class PaymentOptionsViewModelTest {
         }
     }
 
+    @Test
+    fun `Sends dismiss event when the user cancels the flow with non-deferred intent`() = runTest {
+        val viewModel = createViewModel()
+        viewModel.onUserCancel()
+        verify(eventReporter).onDismiss(isDecoupling = false)
+    }
+
+    @Test
+    fun `Sends dismiss event when the user cancels the flow with deferred intent`() = runTest {
+        val deferredIntentArgs = PAYMENT_OPTION_CONTRACT_ARGS.copy(
+            state = PAYMENT_OPTION_CONTRACT_ARGS.state.copy(stripeIntent = DEFERRED_PAYMENT_INTENT),
+        )
+
+        val viewModel = createViewModel(args = deferredIntentArgs)
+        viewModel.onUserCancel()
+        verify(eventReporter).onDismiss(isDecoupling = true)
+    }
+
     private fun createViewModel(
         args: PaymentOptionContract.Args = PAYMENT_OPTION_CONTRACT_ARGS,
         linkState: LinkState? = args.state.linkState,
@@ -525,6 +543,7 @@ internal class PaymentOptionsViewModelTest {
 
     private companion object {
         private val PAYMENT_INTENT = PaymentIntentFactory.create()
+        private val DEFERRED_PAYMENT_INTENT = PAYMENT_INTENT.copy(clientSecret = null)
         private val SELECTION_SAVED_PAYMENT_METHOD = PaymentSelection.Saved(
             PaymentMethodFixtures.CARD_PAYMENT_METHOD
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1405,6 +1405,20 @@ internal class PaymentSheetViewModelTest {
         )
     }
 
+    @Test
+    fun `Sends dismiss event when the user cancels the flow with non-deferred intent`() = runTest {
+        val viewModel = createViewModel()
+        viewModel.onUserCancel()
+        verify(eventReporter).onDismiss(isDecoupling = false)
+    }
+
+    @Test
+    fun `Sends dismiss event when the user cancels the flow with deferred intent`() = runTest {
+        val viewModel = createViewModelForDeferredIntent()
+        viewModel.onUserCancel()
+        verify(eventReporter).onDismiss(isDecoupling = true)
+    }
+
     private fun createViewModel(
         args: PaymentSheetContractV2.Args = ARGS_CUSTOMER_WITH_GOOGLEPAY,
         stripeIntent: StripeIntent = PAYMENT_INTENT,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
 
 @RunWith(RobolectricTestRunner::class)
 class PaymentSheetEventTest {
@@ -58,7 +59,7 @@ class PaymentSheetEventTest {
                 mock(),
                 mock()
             ),
-            durationMillis = 1L,
+            duration = 1.milliseconds,
             result = PaymentSheetEvent.Payment.Result.Success,
             currency = "usd",
             isDecoupled = false,
@@ -86,7 +87,7 @@ class PaymentSheetEventTest {
         val savedPMEvent = PaymentSheetEvent.Payment(
             mode = EventReporter.Mode.Complete,
             paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
-            durationMillis = 1L,
+            duration = 1.milliseconds,
             result = PaymentSheetEvent.Payment.Result.Success,
             currency = "usd",
             isDecoupled = false,
@@ -114,7 +115,7 @@ class PaymentSheetEventTest {
         val googlePayEvent = PaymentSheetEvent.Payment(
             mode = EventReporter.Mode.Complete,
             paymentSelection = PaymentSelection.GooglePay,
-            durationMillis = 1L,
+            duration = 1.milliseconds,
             result = PaymentSheetEvent.Payment.Result.Success,
             currency = "usd",
             isDecoupled = false,
@@ -142,7 +143,7 @@ class PaymentSheetEventTest {
         val linkEvent = PaymentSheetEvent.Payment(
             mode = EventReporter.Mode.Complete,
             paymentSelection = PaymentSelection.Link,
-            durationMillis = 1L,
+            duration = 1.milliseconds,
             result = PaymentSheetEvent.Payment.Result.Success,
             currency = "usd",
             isDecoupled = false,
@@ -176,7 +177,7 @@ class PaymentSheetEventTest {
                     mock()
                 )
             ),
-            durationMillis = 1L,
+            duration = 1.milliseconds,
             result = PaymentSheetEvent.Payment.Result.Success,
             currency = "usd",
             isDecoupled = false,
@@ -208,7 +209,7 @@ class PaymentSheetEventTest {
                 mock(),
                 mock()
             ),
-            durationMillis = 1L,
+            duration = 1.milliseconds,
             result = PaymentSheetEvent.Payment.Result.Failure,
             currency = "usd",
             isDecoupled = false,
@@ -236,7 +237,7 @@ class PaymentSheetEventTest {
         val savedPMEvent = PaymentSheetEvent.Payment(
             mode = EventReporter.Mode.Complete,
             paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
-            durationMillis = 1L,
+            duration = 1.milliseconds,
             result = PaymentSheetEvent.Payment.Result.Failure,
             currency = "usd",
             isDecoupled = false,
@@ -264,7 +265,7 @@ class PaymentSheetEventTest {
         val googlePayEvent = PaymentSheetEvent.Payment(
             mode = EventReporter.Mode.Complete,
             paymentSelection = PaymentSelection.GooglePay,
-            durationMillis = 1L,
+            duration = 1.milliseconds,
             result = PaymentSheetEvent.Payment.Result.Failure,
             currency = "usd",
             isDecoupled = false,
@@ -292,7 +293,7 @@ class PaymentSheetEventTest {
         val linkEvent = PaymentSheetEvent.Payment(
             mode = EventReporter.Mode.Complete,
             paymentSelection = PaymentSelection.Link,
-            durationMillis = 1L,
+            duration = 1.milliseconds,
             result = PaymentSheetEvent.Payment.Result.Failure,
             currency = "usd",
             isDecoupled = false,
@@ -326,7 +327,7 @@ class PaymentSheetEventTest {
                     mock()
                 )
             ),
-            durationMillis = 1L,
+            duration = 1.milliseconds,
             result = PaymentSheetEvent.Payment.Result.Failure,
             currency = "usd",
             isDecoupled = false,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds new analytics events for PaymentSheet and FlowController:
1. Loading started
2. Loading succeeded or failed
3. Sheet dismissed (this was previously implemented, but never called)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Observability improvements.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
