### PR TITLE
Fix issue with BottomSheet's onDismissed callback

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -30,6 +30,7 @@
     <ID>LongMethod:USBankAccountForm.kt$@Composable private fun AccountDetailsForm( formArgs: FormArguments, isProcessing: Boolean, bankName: String?, last4: String?, saveForFutureUseElement: SaveForFutureUseElement, onRemoveAccount: () -> Unit, )</ID>
     <ID>MagicNumber:AutocompleteScreen.kt$0.07f</ID>
     <ID>MagicNumber:BaseSheetActivity.kt$BaseSheetActivity$30</ID>
+    <ID>MagicNumber:BottomSheet.kt$BottomSheetState$10</ID>
     <ID>MagicNumber:GooglePayButton.kt$GooglePayButton$0.5f</ID>
     <ID>MagicNumber:PaymentMethodsUI.kt$.3f</ID>
     <ID>MagicNumber:PaymentMethodsUI.kt$.4f</ID>
@@ -70,7 +71,6 @@
     <ID>NestedBlockDepth:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest$private fun generatePaymentIntentScenarios(): List&lt;PaymentIntentTestInput></ID>
     <ID>ReturnCount:AddressUtils.kt$internal fun CharSequence.levenshtein(other: CharSequence): Int</ID>
     <ID>ThrowsCount:PaymentSheetConfigurationKtx.kt$internal fun PaymentSheet.Configuration.validate()</ID>
-    <ID>TooGenericExceptionThrown:CustomerSheetViewModelTest.kt$CustomerSheetViewModelTest$throw Exception("Cannot confirm setup intent")</ID>
     <ID>TooManyFunctions:CustomerSheetViewModelModule.kt$CustomerSheetViewModelModule</ID>
     <ID>TooManyFunctions:DefaultFlowController.kt$DefaultFlowController : FlowController</ID>
     <ID>TooManyFunctions:PaymentOption.kt$DelegateDrawable : Drawable</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheet.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.first
 @OptIn(ExperimentalMaterialApi::class)
 internal class BottomSheetState(
     val modalBottomSheetState: ModalBottomSheetState,
+    val keyboardHandler: BottomSheetKeyboardHandler,
 ) {
 
     private var dismissalType: DismissalType? = null
@@ -42,11 +43,12 @@ internal class BottomSheetState(
 
     suspend fun awaitDismissal(): DismissalType {
         snapshotFlow { modalBottomSheetState.isVisible }.first { isVisible -> !isVisible }
-        return dismissalType ?: DismissalType.Programmatically
+        return dismissalType ?: DismissalType.SwipedDownByUser
     }
 
     suspend fun hide() {
         dismissalType = DismissalType.Programmatically
+        keyboardHandler.dismissAndWait()
         modalBottomSheetState.hide()
     }
 
@@ -68,8 +70,13 @@ internal fun rememberBottomSheetState(
         animationSpec = tween(),
     )
 
+    val keyboardHandler = rememberBottomSheetKeyboardHandler()
+
     return remember {
-        BottomSheetState(modalBottomSheetState)
+        BottomSheetState(
+            modalBottomSheetState = modalBottomSheetState,
+            keyboardHandler = keyboardHandler,
+        )
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheet.kt
@@ -53,7 +53,9 @@ internal class BottomSheetState(
 
     suspend fun hide() {
         dismissalType = DismissalType.Programmatically
-        keyboardHandler.dismissAndWait()
+        // We dismiss the keyboard before we dismiss the sheet. This looks cleaner and prevents
+        // a CancellationException.
+        keyboardHandler.dismiss()
         modalBottomSheetState.hide()
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheetKeyboardHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheetKeyboardHandler.kt
@@ -1,0 +1,41 @@
+package com.stripe.android.common.ui
+
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.isImeVisible
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.SoftwareKeyboardController
+import kotlinx.coroutines.flow.first
+
+@OptIn(ExperimentalComposeUiApi::class)
+internal class BottomSheetKeyboardHandler(
+    private val keyboardController: SoftwareKeyboardController?,
+    private val isKeyboardVisible: State<Boolean>,
+) {
+
+    suspend fun dismissAndWait() {
+        keyboardController?.hide()
+
+        if (isKeyboardVisible.value) {
+            awaitKeyboardDismissed()
+        }
+    }
+
+    private suspend fun awaitKeyboardDismissed() {
+        snapshotFlow { isKeyboardVisible.value }.first { !it }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class, ExperimentalComposeUiApi::class)
+@Composable
+internal fun rememberBottomSheetKeyboardHandler(): BottomSheetKeyboardHandler {
+    val isImeVisible = WindowInsets.isImeVisible
+    val isImeVisibleState = rememberUpdatedState(isImeVisible)
+    val keyboardController = LocalSoftwareKeyboardController.current
+    return BottomSheetKeyboardHandler(keyboardController, isImeVisibleState)
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheetKeyboardHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheetKeyboardHandler.kt
@@ -19,9 +19,8 @@ internal class BottomSheetKeyboardHandler(
 ) {
 
     suspend fun dismissAndWait() {
-        keyboardController?.hide()
-
         if (isKeyboardVisible.value) {
+            keyboardController?.hide()
             awaitKeyboardDismissed()
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheetKeyboardHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheetKeyboardHandler.kt
@@ -18,7 +18,7 @@ internal class BottomSheetKeyboardHandler(
     private val isKeyboardVisible: State<Boolean>,
 ) {
 
-    suspend fun dismissAndWait() {
+    suspend fun dismiss() {
         if (isKeyboardVisible.value) {
             keyboardController?.hide()
             awaitKeyboardDismissed()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
@@ -53,6 +53,7 @@ internal class AddressElementActivity : ComponentActivity() {
         starterArgs.config?.appearance?.parseAppearance()
 
         setContent {
+            val coroutineScope = rememberCoroutineScope()
             val navController = rememberAnimatedNavController()
             viewModel.navigator.navigationController = navController
 
@@ -66,8 +67,6 @@ internal class AddressElementActivity : ComponentActivity() {
             BackHandler {
                 viewModel.navigator.onBack()
             }
-
-            val coroutineScope = rememberCoroutineScope()
 
             viewModel.navigator.onDismiss = { result ->
                 coroutineScope.launch {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
@@ -69,10 +69,10 @@ internal class AddressElementActivity : ComponentActivity() {
 
             val coroutineScope = rememberCoroutineScope()
 
-            viewModel.navigator.onDismiss = {
-                setResult(it)
+            viewModel.navigator.onDismiss = { result ->
                 coroutineScope.launch {
                     bottomSheetState.hide()
+                    setResult(result)
                     finish()
                 }
             }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes two issues:
1. The `BottomSheet`’s `onDismissed` was called even if the sheet was dismissed programmatically, when it should only be called if the sheet is dismissed by the user.
2. The animations to show and hide the sheet were sometimes interrupted (meaning that `show()` and `hide()` would throw a `CancellationException`), which prevented `onDismissed()` from being called at the correct time.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Properly working bottom sheet.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
