### PR TITLE
Fix incorrect show event reporting

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -287,14 +287,14 @@ internal class PaymentOptionsViewModel @Inject constructor(
         )
     }
 
-    override fun transitionToFirstScreen() {
+    override fun determineInitialBackStack(): List<PaymentSheetScreen> {
         val target = if (args.state.hasPaymentOptions) {
             SelectSavedPaymentMethods
         } else {
             AddFirstPaymentMethod
         }
 
-        val initialBackStack = buildList {
+        return buildList {
             add(target)
 
             if (target is SelectSavedPaymentMethods && newPaymentSelection != null) {
@@ -304,9 +304,6 @@ internal class PaymentOptionsViewModel @Inject constructor(
                 add(PaymentSheetScreen.AddAnotherPaymentMethod)
             }
         }
-
-        backStack.value = initialBackStack
-        reportNavigationEvent(initialBackStack.last())
     }
 
     internal class Factory(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -618,13 +618,14 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     override fun onError(error: String?) = resetViewState(error)
 
-    override fun transitionToFirstScreen() {
-        val target = if (paymentMethods.value.isNullOrEmpty()) {
-            PaymentSheetScreen.AddFirstPaymentMethod
-        } else {
+    override fun determineInitialBackStack(): List<PaymentSheetScreen> {
+        val hasPaymentMethods = !paymentMethods.value.isNullOrEmpty()
+        val target = if (hasPaymentMethods) {
             PaymentSheetScreen.SelectSavedPaymentMethods
+        } else {
+            PaymentSheetScreen.AddFirstPaymentMethod
         }
-        transitionTo(target)
+        return listOf(target)
     }
 
     internal class Factory(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DurationProvider.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DurationProvider.kt
@@ -1,0 +1,31 @@
+package com.stripe.android.paymentsheet.analytics
+
+import android.os.SystemClock
+import javax.inject.Inject
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+internal interface DurationProvider {
+    fun start(key: Key)
+    fun end(key: Key): Duration?
+
+    enum class Key {
+        Checkout,
+    }
+}
+
+internal class DefaultDurationProvider @Inject constructor() : DurationProvider {
+
+    private val store = mutableMapOf<DurationProvider.Key, Long>()
+
+    override fun start(key: DurationProvider.Key) {
+        val startTime = SystemClock.uptimeMillis()
+        store[key] = startTime
+    }
+
+    override fun end(key: DurationProvider.Key): Duration? {
+        val startTime = store.remove(key) ?: return null
+        val duration = SystemClock.uptimeMillis() - startTime
+        return duration.milliseconds
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -16,7 +16,9 @@ import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PrefsRepository
+import com.stripe.android.paymentsheet.analytics.DefaultDurationProvider
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
+import com.stripe.android.paymentsheet.analytics.DurationProvider
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.flowcontroller.DefaultPaymentSelectionUpdater
 import com.stripe.android.paymentsheet.flowcontroller.PaymentSelectionUpdater
@@ -43,6 +45,9 @@ import kotlin.coroutines.CoroutineContext
     ],
 )
 internal abstract class PaymentSheetCommonModule {
+
+    @Binds
+    abstract fun bindsDurationProvider(impl: DefaultDurationProvider): DurationProvider
 
     @Binds
     abstract fun bindsEventReporter(eventReporter: DefaultEventReporter): EventReporter

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -242,21 +242,26 @@ internal abstract class BaseSheetViewModel(
         }
     }
 
-    abstract fun transitionToFirstScreen()
-
-    protected fun transitionTo(target: PaymentSheetScreen) {
-        clearErrorMessages()
-        backStack.update { (it - PaymentSheetScreen.Loading) + target }
-        reportNavigationEvent(target)
+    protected fun transitionToFirstScreen() {
+        val initialBackStack = determineInitialBackStack()
+        backStack.value = initialBackStack
+        reportPaymentSheetShown(initialBackStack.first())
     }
+
+    abstract fun determineInitialBackStack(): List<PaymentSheetScreen>
 
     fun transitionToAddPaymentScreen() {
         transitionTo(AddAnotherPaymentMethod)
     }
 
-    protected fun reportNavigationEvent(currentScreen: PaymentSheetScreen) {
+    private fun transitionTo(target: PaymentSheetScreen) {
+        clearErrorMessages()
+        backStack.update { (it - PaymentSheetScreen.Loading) + target }
+    }
+
+    private fun reportPaymentSheetShown(currentScreen: PaymentSheetScreen) {
         when (currentScreen) {
-            PaymentSheetScreen.Loading -> {
+            PaymentSheetScreen.Loading, AddAnotherPaymentMethod -> {
                 // Nothing to do here
             }
             PaymentSheetScreen.SelectSavedPaymentMethods -> {
@@ -266,8 +271,7 @@ internal abstract class BaseSheetViewModel(
                     isDecoupling = stripeIntent.value?.clientSecret == null,
                 )
             }
-            AddFirstPaymentMethod,
-            AddAnotherPaymentMethod -> {
+            AddFirstPaymentMethod -> {
                 eventReporter.onShowNewPaymentOptionForm(
                     linkEnabled = linkHandler.isLinkEnabled.value == true,
                     currency = stripeIntent.value?.currency,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -127,7 +127,6 @@ internal class PaymentOptionsViewModelTest {
         )
 
         viewModel.currentScreen.test {
-            viewModel.transitionToFirstScreen()
             assertThat(awaitItem()).isEqualTo(SelectSavedPaymentMethods)
         }
     }
@@ -144,7 +143,6 @@ internal class PaymentOptionsViewModelTest {
         )
 
         viewModel.currentScreen.test {
-            viewModel.transitionToFirstScreen()
             assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.AddAnotherPaymentMethod)
 
             viewModel.handleBackPressed()
@@ -270,7 +268,6 @@ internal class PaymentOptionsViewModelTest {
         )
 
         viewModel.currentScreen.test {
-            viewModel.transitionToFirstScreen()
             assertThat(awaitItem()).isEqualTo(AddFirstPaymentMethod)
         }
     }
@@ -287,7 +284,6 @@ internal class PaymentOptionsViewModelTest {
             )
 
             viewModel.currentScreen.test {
-                viewModel.transitionToFirstScreen()
                 assertThat(awaitItem()).isEqualTo(SelectSavedPaymentMethods)
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -74,6 +74,7 @@ import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -985,13 +986,13 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `Sends correct event when navigating to AddAnotherPaymentMethod screen`() = runTest {
+    fun `Sends no event when navigating to AddAnotherPaymentMethod screen`() = runTest {
         val viewModel = createViewModel(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
             customerPaymentMethods = PaymentMethodFixtures.createCards(1),
         )
 
-        val receiver = viewModel.currentScreen.testIn(this)
+        verify(eventReporter).onInit(configuration = anyOrNull(), isDecoupling = any())
 
         verify(eventReporter).onShowExistingPaymentOptions(
             linkEnabled = eq(false),
@@ -1001,13 +1002,7 @@ internal class PaymentSheetViewModelTest {
 
         viewModel.transitionToAddPaymentScreen()
 
-        verify(eventReporter).onShowNewPaymentOptionForm(
-            linkEnabled = eq(false),
-            currency = eq("usd"),
-            isDecoupling = eq(false),
-        )
-
-        receiver.cancelAndIgnoreRemainingEvents()
+        verifyNoMoreInteractions(eventReporter)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeDurationProvider.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeDurationProvider.kt
@@ -1,0 +1,26 @@
+package com.stripe.android.utils
+
+import com.stripe.android.paymentsheet.analytics.DurationProvider
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+internal class FakeDurationProvider(
+    private val originalDuration: Duration = 1.seconds,
+) : DurationProvider {
+
+    private var overrideDuration: Duration? = null
+
+    fun enqueueDuration(duration: Duration?) {
+        overrideDuration = duration
+    }
+
+    override fun start(key: DurationProvider.Key) {
+        // Nothing to do here
+    }
+
+    override fun end(key: DurationProvider.Key): Duration {
+        val result = overrideDuration ?: originalDuration
+        overrideDuration = null
+        return result
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where we incorrectly called `eventReporter.onShowExistingPaymentOptions()` and `eventReporter.onShowNewPaymentOptionForm()`. This also has an impact on the duration that we calculate for the whole checkout flow.

Here in more details:
1. We used to send `sheet_savedpm_show` whenever we navigated to the SPM screen, and `sheet_newpm_show` whenever we navigated to the payment method form screen. The latter would also be sent when pressing the `Add` button in the SPM screen, resulting in two events being called in some flows.
2. This is a deviation from iOS, where we only send either `sheet_savedpm_show` or `sheet_newpm_show` at the time that PaymentSheet is being launched. We don’t send any events on navigation there.
3. The behavior on Android doesn’t only cause more events to be sent, it also results in an incorrect `duration` value, as we reset `paymentSheetShownMillis` when either of the two events is sent.

To align the behavior with iOS, we change the following:
1. We rename `reportNavigationEvent` to `reportPaymentSheetShown` and only call it once.
2. We don’t report any event when we navigate to the `Add another payment method` screen.
3. We add a new `DurationProvider` that keeps track of time with the `SystemClock` instead of `System.currentTimeMillis()`, making us more resilient against device time changes.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Reliable reporting.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
