### PR TITLE
Fix issue with wrong selection on cancel

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -98,9 +98,9 @@ internal class CustomerSheetViewModelModule {
     }
 
     @Provides
-    fun originalPaymentSelection(): PaymentSelection? = originalPaymentSelection
+    fun savedPaymentSelection(): PaymentSelection? = savedPaymentSelection
 
     private companion object {
-        private val originalPaymentSelection: PaymentSelection? = null
+        private val savedPaymentSelection: PaymentSelection? = null
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
@@ -62,6 +62,9 @@ internal class CustomerSheetActivityTest {
                 paymentSelection = PaymentSelection.Saved(
                     PaymentMethodFixtures.CARD_PAYMENT_METHOD
                 )
+            ),
+            savedPaymentSelection = PaymentSelection.Saved(
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD
             )
         ) {
             composeTestRule.waitForIdle()
@@ -173,11 +176,13 @@ internal class CustomerSheetActivityTest {
 
     private fun activityScenario(
         viewState: CustomerSheetViewState,
+        savedPaymentSelection: PaymentSelection?,
     ): InjectableActivityScenario<CustomerSheetActivity> {
         val viewModel = createViewModel(
             backstack = Stack<CustomerSheetViewState>().apply {
                 push(viewState)
-            }
+            },
+            savedPaymentSelection = savedPaymentSelection,
         )
 
         return injectableActivityScenario {
@@ -191,10 +196,12 @@ internal class CustomerSheetActivityTest {
         viewState: CustomerSheetViewState = CustomerSheetViewState.Loading(
             isLiveMode = false,
         ),
+        savedPaymentSelection: PaymentSelection? = null,
         testBlock: CustomerSheetTestData.() -> Unit,
     ) {
         activityScenario(
             viewState = viewState,
+            savedPaymentSelection = savedPaymentSelection,
         )
             .launchForResult(intent)
             .use { injectableActivityScenario ->

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTestHelper.kt
@@ -41,7 +41,7 @@ object CustomerSheetTestHelper {
         backstack: Stack<CustomerSheetViewState> = Stack<CustomerSheetViewState>().apply {
             push(CustomerSheetViewState.Loading(isLiveMode))
         },
-        originalPaymentSelection: PaymentSelection? = null,
+        savedPaymentSelection: PaymentSelection? = null,
         customerAdapter: CustomerAdapter = FakeCustomerAdapter(),
         stripeRepository: StripeRepository = FakeStripeRepository(),
         paymentConfiguration: PaymentConfiguration = PaymentConfiguration(
@@ -82,7 +82,7 @@ object CustomerSheetTestHelper {
         return CustomerSheetViewModel(
             application = application,
             backstack = backstack,
-            originalPaymentSelection = originalPaymentSelection,
+            savedPaymentSelection = savedPaymentSelection,
             paymentConfiguration = paymentConfiguration,
             formViewModelSubcomponentBuilderProvider = mockFormSubComponentBuilderProvider,
             resources = application.resources,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Fix issue with wrong selection on cancel. When there is an initial selection and user selects a different payment method, but doesn't confirm, canceling would select that payment method.

Renamed `originalPaymentSelection` to `savedPaymentSelection`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
