### PR TITLE
Turn `ElementsSessionRepository` into an interface

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -23,6 +23,7 @@ import com.stripe.android.paymentsheet.flowcontroller.PaymentSelectionUpdater
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
+import com.stripe.android.paymentsheet.repositories.RealElementsSessionRepository
 import com.stripe.android.paymentsheet.state.DefaultLinkAccountStatusProvider
 import com.stripe.android.paymentsheet.state.DefaultPaymentSheetLoader
 import com.stripe.android.paymentsheet.state.LinkAccountStatusProvider
@@ -52,7 +53,7 @@ internal abstract class PaymentSheetCommonModule {
 
     @Binds
     abstract fun bindsStripeIntentRepository(
-        repository: ElementsSessionRepository.Api
+        impl: RealElementsSessionRepository,
     ): ElementsSessionRepository
 
     @Binds

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
@@ -122,7 +122,7 @@ internal class ElementsSessionRepositoryTest {
             )
         )
 
-        val session = ElementsSessionRepository.Api(
+        val session = RealElementsSessionRepository(
             stripeRepository,
             { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
@@ -151,7 +151,7 @@ internal class ElementsSessionRepositoryTest {
             Result.failure(endpointException)
         )
 
-        val session = ElementsSessionRepository.Api(
+        val session = RealElementsSessionRepository(
             stripeRepository,
             { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
@@ -170,7 +170,7 @@ internal class ElementsSessionRepositoryTest {
         assertThat(session.exceptionOrNull()).isEqualTo(endpointException)
     }
 
-    private fun createRepository() = ElementsSessionRepository.Api(
+    private fun createRepository() = RealElementsSessionRepository(
         stripeRepository,
         { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
         testDispatcher,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -21,10 +21,10 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.StripeIntentValidator
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
-import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.utils.FakeCustomerRepository
+import com.stripe.android.utils.FakeElementsSessionRepository
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -551,7 +551,7 @@ internal class DefaultPaymentSheetLoaderTest {
             googlePayRepositoryFactory = {
                 if (isGooglePayReady) readyGooglePayRepository else unreadyGooglePayRepository
             },
-            elementsSessionRepository = ElementsSessionRepository.Static(stripeIntent),
+            elementsSessionRepository = FakeElementsSessionRepository(stripeIntent),
             stripeIntentValidator = StripeIntentValidator(),
             customerRepository = customerRepo,
             lpmRepository = lpmRepository,

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.utils
+
+import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
+
+internal class FakeElementsSessionRepository(
+    private val stripeIntent: StripeIntent?,
+) : ElementsSessionRepository {
+
+    override suspend fun get(
+        initializationMode: PaymentSheet.InitializationMode,
+    ): Result<ElementsSession> {
+        return if (stripeIntent != null) {
+            Result.success(
+                ElementsSession(
+                    linkSettings = null,
+                    paymentMethodSpecs = null,
+                    stripeIntent = stripeIntent,
+                    merchantCountry = null,
+                )
+            )
+        } else {
+            Result.failure(RuntimeException())
+        }
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request turns `ElementsSessionRepository` from a sealed class into an interface. This allows us to more easily create a fake (such as [here](https://github.com/stripe/stripe-android/pull/7070)). The sealed class hierarchy was unnecessary from the beginning.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
