### PR TITLE
Fix issue where card text field icon would steal focus

### DIFF
--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
@@ -327,9 +327,7 @@ internal fun TrailingIcon(
             contentDescription = trailingIcon.contentDescription?.let {
                 stringResource(trailingIcon.contentDescription)
             },
-            modifier = Modifier.clickable {
-                trailingIcon.onClick?.invoke()
-            }
+            modifier = Modifier.conditionallyClickable(trailingIcon.onClick),
         )
     } else {
         Image(
@@ -337,9 +335,13 @@ internal fun TrailingIcon(
             contentDescription = trailingIcon.contentDescription?.let {
                 stringResource(trailingIcon.contentDescription)
             },
-            modifier = Modifier.clickable {
-                trailingIcon.onClick?.invoke()
-            }
+            modifier = Modifier.conditionallyClickable(trailingIcon.onClick),
         )
+    }
+}
+
+private fun Modifier.conditionallyClickable(onClick: (() -> Unit)?): Modifier {
+    return clickable(enabled = onClick != null) {
+        onClick?.invoke()
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the trailing icon of the card number input field would steal the input focus. This seems to be an emulator-only issue, but is still annoying.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before | After |
| ------------- | ------------- |
| ![keyboard_issue](https://github.com/stripe/stripe-android/assets/110940675/f3ca47a8-502e-4d1e-ab64-603563100378) | ![keyboard_issue_fixed](https://github.com/stripe/stripe-android/assets/110940675/a2d6de6c-5975-4d38-85b8-f8ea4ce63637) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
