### PR TITLE
[FC] Conditionally show manual entry on errors

### DIFF
--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -235,6 +235,7 @@ enum class Merchant(val flow: String) {
     PartnerM("partner_m"),
     PartnerF("partner_f"),
     PartnerD("partner_d"),
+    PlatformC("strash"),
     App2App("app2app"),
     Networking("networking"),
     NetworkingTestMode("networking_testmode"),

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAttachPaymentAccount.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAttachPaymentAccount.kt
@@ -5,9 +5,9 @@ import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.exception.AccountNumberRetrievalError
 import com.stripe.android.financialconnections.features.common.showManualEntryInErrors
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
-import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.LinkAccountSessionPaymentAccount
 import com.stripe.android.financialconnections.model.PaymentAccountParams
+import com.stripe.android.financialconnections.model.SynchronizeSessionResponse
 import com.stripe.android.financialconnections.repository.FinancialConnectionsAccountsRepository
 import com.stripe.android.financialconnections.utils.PollTimingOptions
 import com.stripe.android.financialconnections.utils.retryOnException
@@ -21,7 +21,7 @@ internal class PollAttachPaymentAccount @Inject constructor(
 ) {
 
     suspend operator fun invoke(
-        manifest: FinancialConnectionsSessionManifest,
+        sync: SynchronizeSessionResponse,
         // null, when attaching via manual entry.
         activeInstitution: FinancialConnectionsInstitution?,
         // null, if account should not be saved to Link user.
@@ -45,7 +45,7 @@ internal class PollAttachPaymentAccount @Inject constructor(
             ) {
                 throw e.toDomainException(
                     activeInstitution,
-                    manifest.showManualEntryInErrors()
+                    sync.showManualEntryInErrors()
                 )
             }
         }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAttachPaymentAccount.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAttachPaymentAccount.kt
@@ -3,7 +3,9 @@ package com.stripe.android.financialconnections.domain
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.exception.AccountNumberRetrievalError
+import com.stripe.android.financialconnections.features.common.showManualEntryInErrors
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
+import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.LinkAccountSessionPaymentAccount
 import com.stripe.android.financialconnections.model.PaymentAccountParams
 import com.stripe.android.financialconnections.repository.FinancialConnectionsAccountsRepository
@@ -19,7 +21,7 @@ internal class PollAttachPaymentAccount @Inject constructor(
 ) {
 
     suspend operator fun invoke(
-        allowManualEntry: Boolean,
+        manifest: FinancialConnectionsSessionManifest,
         // null, when attaching via manual entry.
         activeInstitution: FinancialConnectionsInstitution?,
         // null, if account should not be saved to Link user.
@@ -43,7 +45,7 @@ internal class PollAttachPaymentAccount @Inject constructor(
             ) {
                 throw e.toDomainException(
                     activeInstitution,
-                    allowManualEntry
+                    manifest.showManualEntryInErrors()
                 )
             }
         }
@@ -51,13 +53,13 @@ internal class PollAttachPaymentAccount @Inject constructor(
 
     private fun StripeException.toDomainException(
         institution: FinancialConnectionsInstitution?,
-        allowManualEntry: Boolean
+        showManualEntry: Boolean
     ): StripeException =
         when {
             institution == null -> this
             stripeError?.extraFields?.get("reason") == "account_number_retrieval_failed" ->
                 AccountNumberRetrievalError(
-                    allowManualEntry = allowManualEntry,
+                    allowManualEntry = showManualEntry,
                     institution = institution,
                     stripeException = this
                 )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAttachPaymentAccount.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAttachPaymentAccount.kt
@@ -59,7 +59,7 @@ internal class PollAttachPaymentAccount @Inject constructor(
             institution == null -> this
             stripeError?.extraFields?.get("reason") == "account_number_retrieval_failed" ->
                 AccountNumberRetrievalError(
-                    allowManualEntry = showManualEntry,
+                    showManualEntry = showManualEntry,
                     institution = institution,
                     stripeException = this
                 )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts.kt
@@ -9,8 +9,8 @@ import com.stripe.android.financialconnections.features.common.getBusinessName
 import com.stripe.android.financialconnections.model.FinancialConnectionsAuthorizationSession
 import com.stripe.android.financialconnections.features.common.showManualEntryInErrors
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
-import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.PartnerAccountsList
+import com.stripe.android.financialconnections.model.SynchronizeSessionResponse
 import com.stripe.android.financialconnections.repository.FinancialConnectionsAccountsRepository
 import com.stripe.android.financialconnections.utils.PollTimingOptions
 import com.stripe.android.financialconnections.utils.retryOnException
@@ -30,8 +30,9 @@ internal class PollAuthorizationSessionAccounts @Inject constructor(
 
     suspend operator fun invoke(
         canRetry: Boolean,
-        manifest: FinancialConnectionsSessionManifest
+        sync: SynchronizeSessionResponse
     ): PartnerAccountsList = try {
+        val manifest = requireNotNull(sync.manifest)
         val activeAuthSession = requireNotNull(manifest.activeAuthSession)
         retryOnException(
             PollTimingOptions(
@@ -56,10 +57,10 @@ internal class PollAuthorizationSessionAccounts @Inject constructor(
         }
     } catch (@Suppress("SwallowedException") e: StripeException) {
         throw e.toDomainException(
-            institution = manifest.activeInstitution,
-            businessName = manifest.getBusinessName(),
+            institution = sync.manifest.activeInstitution,
+            businessName = sync.manifest.getBusinessName(),
             canRetry = canRetry,
-            showManualEntry = manifest.showManualEntryInErrors()
+            showManualEntry = sync.manifest.showManualEntryInErrors()
         )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts.kt
@@ -47,7 +47,7 @@ internal class PollAuthorizationSessionAccounts @Inject constructor(
             if (accounts.data.isEmpty()) {
                 throw AccountLoadError(
                     institution = requireNotNull(manifest.activeInstitution),
-                    allowManualEntry = manifest.allowManualEntry,
+                    showManualEntry = sync.showManualEntryInErrors(),
                     canRetry = canRetry,
                     stripeException = APIException()
                 )
@@ -83,7 +83,7 @@ private fun StripeException.toDomainException(
             )
 
         else -> AccountLoadError(
-            allowManualEntry = showManualEntry,
+            showManualEntry = showManualEntry,
             institution = institution,
             canRetry = canRetry,
             stripeException = this

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts.kt
@@ -7,6 +7,7 @@ import com.stripe.android.financialconnections.exception.AccountLoadError
 import com.stripe.android.financialconnections.exception.AccountNoneEligibleForPaymentMethodError
 import com.stripe.android.financialconnections.features.common.getBusinessName
 import com.stripe.android.financialconnections.model.FinancialConnectionsAuthorizationSession
+import com.stripe.android.financialconnections.features.common.showManualEntryInErrors
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.PartnerAccountsList
@@ -58,7 +59,7 @@ internal class PollAuthorizationSessionAccounts @Inject constructor(
             institution = manifest.activeInstitution,
             businessName = manifest.getBusinessName(),
             canRetry = canRetry,
-            allowManualEntry = manifest.allowManualEntry
+            showManualEntry = manifest.showManualEntryInErrors()
         )
     }
 }
@@ -67,7 +68,7 @@ private fun StripeException.toDomainException(
     institution: FinancialConnectionsInstitution?,
     businessName: String?,
     canRetry: Boolean,
-    allowManualEntry: Boolean
+    showManualEntry: Boolean
 ): StripeException =
     when {
         institution == null -> this
@@ -81,7 +82,7 @@ private fun StripeException.toDomainException(
             )
 
         else -> AccountLoadError(
-            allowManualEntry = allowManualEntry,
+            allowManualEntry = showManualEntry,
             institution = institution,
             canRetry = canRetry,
             stripeException = this

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts.kt
@@ -6,8 +6,8 @@ import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.exception.AccountLoadError
 import com.stripe.android.financialconnections.exception.AccountNoneEligibleForPaymentMethodError
 import com.stripe.android.financialconnections.features.common.getBusinessName
-import com.stripe.android.financialconnections.model.FinancialConnectionsAuthorizationSession
 import com.stripe.android.financialconnections.features.common.showManualEntryInErrors
+import com.stripe.android.financialconnections.model.FinancialConnectionsAuthorizationSession
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
 import com.stripe.android.financialconnections.model.PartnerAccountsList
 import com.stripe.android.financialconnections.model.SynchronizeSessionResponse
@@ -60,7 +60,7 @@ internal class PollAuthorizationSessionAccounts @Inject constructor(
             institution = sync.manifest.activeInstitution,
             businessName = sync.manifest.getBusinessName(),
             canRetry = canRetry,
-            showManualEntry = sync.manifest.showManualEntryInErrors()
+            showManualEntry = sync.showManualEntryInErrors()
         )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PostAuthorizationSession.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PostAuthorizationSession.kt
@@ -8,7 +8,7 @@ import com.stripe.android.financialconnections.exception.InstitutionUnplannedDow
 import com.stripe.android.financialconnections.features.common.showManualEntryInErrors
 import com.stripe.android.financialconnections.model.FinancialConnectionsAuthorizationSession
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
-import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
+import com.stripe.android.financialconnections.model.SynchronizeSessionResponse
 import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
 import javax.inject.Inject
 import javax.inject.Named
@@ -27,11 +27,11 @@ internal class PostAuthorizationSession @Inject constructor(
 
     /**
      * @param institution selected institution to create a [FinancialConnectionsAuthorizationSession]
-     * @param allowManualEntry to build
+     * @param sync [SynchronizeSessionResponse]
      */
     suspend operator fun invoke(
         institution: FinancialConnectionsInstitution,
-        manifest: FinancialConnectionsSessionManifest
+        sync: SynchronizeSessionResponse,
     ): FinancialConnectionsAuthorizationSession {
         return try {
             repository.postAuthorizationSession(
@@ -42,7 +42,7 @@ internal class PostAuthorizationSession @Inject constructor(
         } catch (
             @Suppress("SwallowedException") e: StripeException
         ) {
-            throw e.toDomainException(manifest.showManualEntryInErrors(), institution)
+            throw e.toDomainException(sync.showManualEntryInErrors(), institution)
         }
     }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PostAuthorizationSession.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PostAuthorizationSession.kt
@@ -42,7 +42,10 @@ internal class PostAuthorizationSession @Inject constructor(
         } catch (
             @Suppress("SwallowedException") e: StripeException
         ) {
-            throw e.toDomainException(sync.showManualEntryInErrors(), institution)
+            throw e.toDomainException(
+                showManualEntry = sync.showManualEntryInErrors(),
+                institution = institution
+            )
         }
     }
 
@@ -56,13 +59,13 @@ internal class PostAuthorizationSession @Inject constructor(
             "true" -> when {
                 availableAt.isNullOrEmpty() -> InstitutionUnplannedDowntimeError(
                     institution = institution,
-                    allowManualEntry = showManualEntry,
+                    showManualEntry = showManualEntry,
                     stripeException = this
                 )
 
                 else -> InstitutionPlannedDowntimeError(
                     institution = institution,
-                    allowManualEntry = showManualEntry,
+                    showManualEntry = showManualEntry,
                     isToday = true,
                     backUpAt = availableAt.toLong().seconds.inWholeMilliseconds,
                     stripeException = this

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/AccountLoadError.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/AccountLoadError.kt
@@ -4,7 +4,7 @@ import com.stripe.android.core.exception.StripeException
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
 
 internal class AccountLoadError(
-    val allowManualEntry: Boolean,
+    val showManualEntry: Boolean,
     val canRetry: Boolean,
     val institution: FinancialConnectionsInstitution,
     stripeException: StripeException

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/AccountNumberRetrievalError.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/AccountNumberRetrievalError.kt
@@ -4,7 +4,7 @@ import com.stripe.android.core.exception.StripeException
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
 
 internal class AccountNumberRetrievalError(
-    val allowManualEntry: Boolean,
+    val showManualEntry: Boolean,
     val institution: FinancialConnectionsInstitution,
     stripeException: StripeException
 ) : FinancialConnectionsError(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/InstitutionPlannedDowntimeError.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/InstitutionPlannedDowntimeError.kt
@@ -5,7 +5,7 @@ import com.stripe.android.financialconnections.model.FinancialConnectionsInstitu
 
 internal class InstitutionPlannedDowntimeError(
     val institution: FinancialConnectionsInstitution,
-    val allowManualEntry: Boolean,
+    val showManualEntry: Boolean,
     val isToday: Boolean,
     val backUpAt: Long,
     stripeException: StripeException

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/InstitutionUnplannedDowntimeError.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/InstitutionUnplannedDowntimeError.kt
@@ -5,7 +5,7 @@ import com.stripe.android.financialconnections.model.FinancialConnectionsInstitu
 
 internal class InstitutionUnplannedDowntimeError(
     val institution: FinancialConnectionsInstitution,
-    val allowManualEntry: Boolean,
+    val showManualEntry: Boolean,
     stripeException: StripeException
 ) : FinancialConnectionsError(
     name = "InstitutionUnplannedDowntimeError",

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
@@ -15,7 +15,7 @@ import com.stripe.android.financialconnections.analytics.FinancialConnectionsEve
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.Error
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.PaneLoaded
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.PollAccountsSucceeded
-import com.stripe.android.financialconnections.domain.GetManifest
+import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.GoNext
 import com.stripe.android.financialconnections.domain.PollAuthorizationSessionAccounts
 import com.stripe.android.financialconnections.domain.SelectAccounts
@@ -38,7 +38,7 @@ internal class AccountPickerViewModel @Inject constructor(
     initialState: AccountPickerState,
     private val eventTracker: FinancialConnectionsAnalyticsTracker,
     private val selectAccounts: SelectAccounts,
-    private val getManifest: GetManifest,
+    private val getOrFetchSync: GetOrFetchSync,
     private val goNext: GoNext,
     private val navigationManager: NavigationManager,
     private val logger: Logger,
@@ -54,11 +54,12 @@ internal class AccountPickerViewModel @Inject constructor(
     private fun loadAccounts() {
         suspend {
             val state = awaitState()
-            val manifest = getManifest()
+            val sync = getOrFetchSync()
+            val manifest = sync.manifest
             val activeAuthSession = requireNotNull(manifest.activeAuthSession)
             val (partnerAccountList, millis) = measureTimeMillis {
                 pollAuthorizationSessionAccounts(
-                    manifest = manifest,
+                    sync = sync,
                     canRetry = state.canRetry
                 )
             }
@@ -182,7 +183,7 @@ internal class AccountPickerViewModel @Inject constructor(
         updateLocalCache: Boolean
     ) {
         suspend {
-            val manifest = getManifest()
+            val manifest = getOrFetchSync().manifest
             val accountsList: PartnerAccountsList = selectAccounts(
                 selectedAccountIds = selectedIds,
                 sessionId = requireNotNull(manifest.activeAuthSession).id,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
@@ -59,7 +59,7 @@ internal class AttachPaymentViewModel @Inject constructor(
             val id = accounts.first().linkedAccountId
             val (result, millis) = measureTimeMillis {
                 pollAttachPaymentAccount(
-                    allowManualEntry = manifest.allowManualEntry,
+                    manifest = manifest,
                     activeInstitution = activeInstitution,
                     consumerSessionClientSecret = consumerSession?.clientSecret,
                     params = PaymentAccountParams.LinkedAccount(requireNotNull(id))

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
@@ -13,7 +13,7 @@ import com.stripe.android.financialconnections.analytics.FinancialConnectionsEve
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.PollAttachPaymentsSucceeded
 import com.stripe.android.financialconnections.domain.GetCachedAccounts
 import com.stripe.android.financialconnections.domain.GetCachedConsumerSession
-import com.stripe.android.financialconnections.domain.GetManifest
+import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.GoNext
 import com.stripe.android.financialconnections.domain.PollAttachPaymentAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
@@ -34,7 +34,7 @@ internal class AttachPaymentViewModel @Inject constructor(
     private val eventTracker: FinancialConnectionsAnalyticsTracker,
     private val getCachedAccounts: GetCachedAccounts,
     private val navigationManager: NavigationManager,
-    private val getManifest: GetManifest,
+    private val getOrFetchSync: GetOrFetchSync,
     private val getCachedConsumerSession: GetCachedConsumerSession,
     private val goNext: GoNext,
     private val logger: Logger
@@ -43,14 +43,16 @@ internal class AttachPaymentViewModel @Inject constructor(
     init {
         logErrors()
         suspend {
-            val manifest = getManifest()
+            val sync = getOrFetchSync()
+            val manifest = requireNotNull(sync.manifest)
             AttachPaymentState.Payload(
                 businessName = manifest.businessName,
                 accountsCount = getCachedAccounts().size
             )
         }.execute { copy(payload = it) }
         suspend {
-            val manifest = getManifest()
+            val sync = getOrFetchSync()
+            val manifest = requireNotNull(sync.manifest)
             val consumerSession = getCachedConsumerSession()
             val authSession = requireNotNull(manifest.activeAuthSession)
             val activeInstitution = requireNotNull(manifest.activeInstitution)
@@ -59,7 +61,7 @@ internal class AttachPaymentViewModel @Inject constructor(
             val id = accounts.first().linkedAccountId
             val (result, millis) = measureTimeMillis {
                 pollAttachPaymentAccount(
-                    manifest = manifest,
+                    sync = sync,
                     activeInstitution = activeInstitution,
                     consumerSessionClientSecret = consumerSession?.clientSecret,
                     params = PaymentAccountParams.LinkedAccount(requireNotNull(id))

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ErrorContent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ErrorContent.kt
@@ -95,7 +95,7 @@ internal fun InstitutionUnplannedDowntimeErrorContent(
             stringResource(R.string.stripe_error_cta_select_another_bank),
             onSelectAnotherBank
         ),
-        secondaryCta = if (exception.allowManualEntry) {
+        secondaryCta = if (exception.showManualEntry) {
             Pair(
                 stringResource(R.string.stripe_error_cta_manual_entry),
                 onEnterDetailsManually
@@ -130,7 +130,7 @@ internal fun InstitutionPlannedDowntimeErrorContent(
             stringResource(R.string.stripe_error_cta_select_another_bank),
             onSelectAnotherBank
         ),
-        secondaryCta = if (exception.allowManualEntry) {
+        secondaryCta = if (exception.showManualEntry) {
             Pair(
                 stringResource(R.string.stripe_error_cta_manual_entry),
                 onEnterDetailsManually
@@ -175,7 +175,7 @@ internal fun NoAccountsAvailableErrorContent(
 ) {
     // primary and (optional) secondary button to show.
     val (primaryCta: Pair<Int, () -> Unit>, secondaryCta: Pair<Int, () -> Unit>?) = remember(
-        exception.allowManualEntry,
+        exception.showManualEntry,
         exception.canRetry
     ) {
         when {
@@ -184,7 +184,7 @@ internal fun NoAccountsAvailableErrorContent(
                 second = R.string.stripe_error_cta_select_another_bank to onSelectAnotherBank,
             )
 
-            exception.allowManualEntry -> Pair(
+            exception.showManualEntry -> Pair(
                 first = R.string.stripe_error_cta_manual_entry to onEnterDetailsManually,
                 second = R.string.stripe_error_cta_select_another_bank to onSelectAnotherBank,
             )
@@ -196,10 +196,10 @@ internal fun NoAccountsAvailableErrorContent(
         }
     }
     // description to show.
-    val description = remember(exception.allowManualEntry, exception.canRetry) {
+    val description = remember(exception.showManualEntry, exception.canRetry) {
         when {
             exception.canRetry -> R.string.stripe_accounts_error_desc_retry
-            exception.allowManualEntry -> R.string.stripe_accounts_error_desc_manualentry
+            exception.showManualEntry -> R.string.stripe_accounts_error_desc_manualentry
             else -> R.string.stripe_accounts_error_desc_no_retry
         }
     }
@@ -381,7 +381,7 @@ internal fun InstitutionPlannedDowntimeErrorContentPreview() {
                         logo = null,
                         mobileHandoffCapable = false
                     ),
-                    allowManualEntry = true,
+                    showManualEntry = true,
                     isToday = true,
                     backUpAt = 10000L,
                     stripeException = APIException()
@@ -412,7 +412,7 @@ internal fun NoAccountsAvailableErrorContentPreview() {
                         logo = null,
                         mobileHandoffCapable = false
                     ),
-                    allowManualEntry = true,
+                    showManualEntry = true,
                     stripeException = APIException(),
                     canRetry = true
                 ),

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ErrorContent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ErrorContent.kt
@@ -228,7 +228,7 @@ internal fun AccountNumberRetrievalErrorContent(
             R.string.stripe_attachlinkedpaymentaccount_error_title
         ),
         content = stringResource(
-            when (exception.allowManualEntry) {
+            when (exception.showManualEntry) {
                 true -> R.string.stripe_attachlinkedpaymentaccount_error_desc_manual_entry
                 false -> R.string.stripe_attachlinkedpaymentaccount_error_desc
             }
@@ -237,7 +237,7 @@ internal fun AccountNumberRetrievalErrorContent(
             stringResource(R.string.stripe_error_cta_select_another_bank),
             onSelectAnotherBank
         ),
-        secondaryCta = if (exception.allowManualEntry) {
+        secondaryCta = if (exception.showManualEntry) {
             Pair(
                 stringResource(R.string.stripe_error_cta_manual_entry),
                 onEnterDetailsManually

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ManifestExtensions.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ManifestExtensions.kt
@@ -24,4 +24,9 @@ internal fun FinancialConnectionsSessionManifest.getRedactedEmail(): String? =
         }
     }
 
+internal fun FinancialConnectionsSessionManifest.showManualEntryInErrors(): Boolean {
+    //TODO check experiment.
+    return allowManualEntry && false
+}
+
 private const val EMAIL_LENGTH = 15

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ManifestExtensions.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ManifestExtensions.kt
@@ -26,7 +26,7 @@ internal fun FinancialConnectionsSessionManifest.getRedactedEmail(): String? =
     }
 
 internal fun SynchronizeSessionResponse.showManualEntryInErrors(): Boolean {
-    return manifest.allowManualEntry && visual.reducedManualEntryProminenceForErrors.not()
+    return manifest.allowManualEntry && visual.reducedManualEntryProminenceInErrors.not()
 }
 
 private const val EMAIL_LENGTH = 15

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ManifestExtensions.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ManifestExtensions.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.financialconnections.features.common
 
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
+import com.stripe.android.financialconnections.model.SynchronizeSessionResponse
 
 /**
  * Get the business name from the manifest.
@@ -24,9 +25,8 @@ internal fun FinancialConnectionsSessionManifest.getRedactedEmail(): String? =
         }
     }
 
-internal fun FinancialConnectionsSessionManifest.showManualEntryInErrors(): Boolean {
-    //TODO check experiment.
-    return allowManualEntry && false
+internal fun SynchronizeSessionResponse.showManualEntryInErrors(): Boolean {
+    return manifest.allowManualEntry && visual.reducedManualEntryProminenceForErrors.not()
 }
 
 private const val EMAIL_LENGTH = 15

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerScreen.kt
@@ -281,4 +281,3 @@ private fun Title(
         onClickableTextClick = {}
     )
 }
-

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
@@ -10,7 +10,7 @@ import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.PaneLoaded
-import com.stripe.android.financialconnections.domain.GetManifest
+import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.GoNext
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Terminate
@@ -30,7 +30,7 @@ internal class ManualEntryViewModel @Inject constructor(
     private val nativeAuthFlowCoordinator: NativeAuthFlowCoordinator,
     private val pollAttachPaymentAccount: PollAttachPaymentAccount,
     private val eventTracker: FinancialConnectionsAnalyticsTracker,
-    private val getManifest: GetManifest,
+    private val getOrFetchSync: GetOrFetchSync,
     private val goNext: GoNext,
     private val logger: Logger
 ) : MavericksViewModel<ManualEntryState>(initialState) {
@@ -39,7 +39,8 @@ internal class ManualEntryViewModel @Inject constructor(
         observeAsyncs()
         observeInputs()
         suspend {
-            val manifest = getManifest()
+            val sync = getOrFetchSync()
+            val manifest = requireNotNull(sync.manifest)
             eventTracker.track(PaneLoaded(Pane.MANUAL_ENTRY))
             ManualEntryState.Payload(
                 verifyWithMicrodeposits = manifest.manualEntryUsesMicrodeposits,
@@ -123,9 +124,9 @@ internal class ManualEntryViewModel @Inject constructor(
     fun onSubmit() {
         suspend {
             val state = awaitState()
-            val manifest = getManifest()
+            val sync = getOrFetchSync()
             pollAttachPaymentAccount(
-                manifest = manifest,
+                sync = sync,
                 activeInstitution = null,
                 consumerSessionClientSecret = null,
                 params = PaymentAccountParams.BankAccount(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
@@ -125,7 +125,7 @@ internal class ManualEntryViewModel @Inject constructor(
             val state = awaitState()
             val manifest = getManifest()
             pollAttachPaymentAccount(
-                allowManualEntry = manifest.allowManualEntry,
+                manifest = manifest,
                 activeInstitution = null,
                 consumerSessionClientSecret = null,
                 params = PaymentAccountParams.BankAccount(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupScreen.kt
@@ -327,4 +327,3 @@ internal fun EmailSection(
         }
     }
 }
-

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
@@ -17,7 +17,7 @@ import com.stripe.android.financialconnections.analytics.FinancialConnectionsEve
 import com.stripe.android.financialconnections.di.APPLICATION_ID
 import com.stripe.android.financialconnections.domain.CancelAuthorizationSession
 import com.stripe.android.financialconnections.domain.CompleteAuthorizationSession
-import com.stripe.android.financialconnections.domain.GetManifest
+import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.GoNext
 import com.stripe.android.financialconnections.domain.PollAuthorizationSessionOAuthResults
 import com.stripe.android.financialconnections.domain.PostAuthSessionEvent
@@ -29,6 +29,7 @@ import com.stripe.android.financialconnections.features.partnerauth.PartnerAuthS
 import com.stripe.android.financialconnections.features.partnerauth.PartnerAuthState.ViewEffect.OpenUrl
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
+import com.stripe.android.financialconnections.model.SynchronizeSessionResponse
 import com.stripe.android.financialconnections.navigation.NavigationDirections
 import com.stripe.android.financialconnections.navigation.NavigationManager
 import com.stripe.android.financialconnections.presentation.WebAuthFlowState
@@ -48,7 +49,7 @@ internal class PartnerAuthViewModel @Inject constructor(
     @Named(APPLICATION_ID) private val applicationId: String,
     private val uriUtils: UriUtils,
     private val postAuthSessionEvent: PostAuthSessionEvent,
-    private val getManifest: GetManifest,
+    private val getOrFetchSync: GetOrFetchSync,
     private val goNext: GoNext,
     private val navigationManager: NavigationManager,
     private val pollAuthorizationSessionOAuthResults: PollAuthorizationSessionOAuthResults,
@@ -73,10 +74,11 @@ internal class PartnerAuthViewModel @Inject constructor(
         suspend {
             // if coming from a process kill, there should be a session
             // re-fetch the manifest and use its active auth session instead of creating a new one
-            val manifest: FinancialConnectionsSessionManifest = getManifest()
+            val sync: SynchronizeSessionResponse = getOrFetchSync()
+            val manifest: FinancialConnectionsSessionManifest = sync.manifest
             val authSession = manifest.activeAuthSession ?: createAuthorizationSession(
                 institution = requireNotNull(manifest.activeInstitution),
-                allowManualEntry = manifest.allowManualEntry
+                sync = sync
             )
             Payload(
                 authSession = authSession,
@@ -89,10 +91,11 @@ internal class PartnerAuthViewModel @Inject constructor(
     private fun createAuthSession() {
         suspend {
             val launchedEvent = Launched(Date())
-            val manifest: FinancialConnectionsSessionManifest = getManifest()
+            val sync: SynchronizeSessionResponse = getOrFetchSync()
+            val manifest: FinancialConnectionsSessionManifest = sync.manifest
             val authSession = createAuthorizationSession(
                 institution = requireNotNull(manifest.activeInstitution),
-                allowManualEntry = manifest.allowManualEntry
+                sync = sync
             )
             logger.debug("Created auth session ${authSession.id}")
             Payload(
@@ -146,7 +149,7 @@ internal class PartnerAuthViewModel @Inject constructor(
     }
 
     private suspend fun launchAuthInBrowser() {
-        kotlin.runCatching { requireNotNull(getManifest().activeAuthSession) }
+        kotlin.runCatching { requireNotNull(getOrFetchSync().manifest.activeAuthSession) }
             .onSuccess {
                 it.url
                     ?.replaceFirst("stripe-auth://native-redirect/$applicationId/", "")
@@ -185,7 +188,7 @@ internal class PartnerAuthViewModel @Inject constructor(
         val error = WebAuthFlowFailedException(message, reason)
         kotlin.runCatching {
             logger.debug("Auth failed, cancelling AuthSession")
-            val authSession = getManifest().activeAuthSession
+            val authSession = getOrFetchSync().manifest.activeAuthSession
             logger.error("Auth failed, cancelling AuthSession", error)
             when {
                 authSession != null -> {
@@ -205,7 +208,7 @@ internal class PartnerAuthViewModel @Inject constructor(
         kotlin.runCatching {
             logger.debug("Auth cancelled, cancelling AuthSession")
             setState { copy(authenticationStatus = Loading()) }
-            val authSession = requireNotNull(getManifest().activeAuthSession)
+            val authSession = requireNotNull(getOrFetchSync().manifest.activeAuthSession)
             val result = cancelAuthorizationSession(authSession.id)
             if (authSession.isOAuth) {
                 // For OAuth institutions, create a new session and navigate to its nextPane (prepane).
@@ -230,7 +233,7 @@ internal class PartnerAuthViewModel @Inject constructor(
     private suspend fun completeAuthorizationSession() {
         kotlin.runCatching {
             setState { copy(authenticationStatus = Loading()) }
-            val authSession = requireNotNull(getManifest().activeAuthSession)
+            val authSession = requireNotNull(getOrFetchSync().manifest.activeAuthSession)
             postAuthSessionEvent(authSession.id, AuthSessionEvent.Success(Date()))
             if (authSession.isOAuth) {
                 logger.debug("Web AuthFlow completed! waiting for oauth results")

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/SynchronizeSessionResponse.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/SynchronizeSessionResponse.kt
@@ -32,8 +32,8 @@ internal data class VisualUpdate(
     // Indicates whether the logo should be removed from most panes
     @SerialName("reduced_branding")
     val reducedBranding: Boolean,
-    @SerialName("reduced_manual_entry_prominence_for_errors")
-    val reducedManualEntryProminenceForErrors: Boolean,
+    @SerialName("reduce_manual_entry_prominence_in_errors")
+    val reducedManualEntryProminenceInErrors: Boolean,
     @SerialName("merchant_logo")
     val merchantLogos: List<String>
 ) : Parcelable

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/SynchronizeSessionResponse.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/SynchronizeSessionResponse.kt
@@ -32,6 +32,8 @@ internal data class VisualUpdate(
     // Indicates whether the logo should be removed from most panes
     @SerialName("reduced_branding")
     val reducedBranding: Boolean,
+    @SerialName("reduced_manual_entry_prominence_for_errors")
+    val reducedManualEntryProminenceForErrors: Boolean,
     @SerialName("merchant_logo")
     val merchantLogos: List<String>
 ) : Parcelable

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/ApiKeyFixtures.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/ApiKeyFixtures.kt
@@ -21,11 +21,14 @@ internal object ApiKeyFixtures {
     const val SUCCESS_URL = "stripe-auth://link-accounts/success"
     const val CANCEL_URL = "stripe-auth://link-accounts/cancel"
 
-    fun syncResponse() = SynchronizeSessionResponse(
-        manifest = sessionManifest(),
+    fun syncResponse(
+        manifest: FinancialConnectionsSessionManifest = sessionManifest()
+    ) = SynchronizeSessionResponse(
+        manifest = manifest,
         text = null,
         visual = VisualUpdate(
             reducedBranding = false,
+            reducedManualEntryProminenceForErrors = false,
             merchantLogos = emptyList()
         )
     )

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/ApiKeyFixtures.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/ApiKeyFixtures.kt
@@ -22,15 +22,18 @@ internal object ApiKeyFixtures {
     const val CANCEL_URL = "stripe-auth://link-accounts/cancel"
 
     fun syncResponse(
-        manifest: FinancialConnectionsSessionManifest = sessionManifest()
+        manifest: FinancialConnectionsSessionManifest = sessionManifest(),
+        visual: VisualUpdate = visual()
     ) = SynchronizeSessionResponse(
         manifest = manifest,
         text = null,
-        visual = VisualUpdate(
-            reducedBranding = false,
-            reducedManualEntryProminenceForErrors = false,
-            merchantLogos = emptyList()
-        )
+        visual = visual
+    )
+
+    fun visual() = VisualUpdate(
+        reducedBranding = false,
+        reducedManualEntryProminenceForErrors = false,
+        merchantLogos = emptyList()
     )
 
     fun financialConnectionsSessionNoAccounts() = FinancialConnectionsSession(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/ApiKeyFixtures.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/ApiKeyFixtures.kt
@@ -32,7 +32,7 @@ internal object ApiKeyFixtures {
 
     fun visual() = VisualUpdate(
         reducedBranding = false,
-        reducedManualEntryProminenceForErrors = false,
+        reducedManualEntryProminenceInErrors = false,
         merchantLogos = emptyList()
     )
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccountsTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccountsTest.kt
@@ -6,6 +6,7 @@ import com.stripe.android.financialconnections.ApiKeyFixtures.authorizationSessi
 import com.stripe.android.financialconnections.ApiKeyFixtures.institution
 import com.stripe.android.financialconnections.ApiKeyFixtures.partnerAccount
 import com.stripe.android.financialconnections.ApiKeyFixtures.sessionManifest
+import com.stripe.android.financialconnections.ApiKeyFixtures.syncResponse
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.exception.AccountLoadError
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
@@ -37,9 +38,11 @@ internal class PollAuthorizationSessionAccountsTest {
 
     @Test
     fun `test successful account polling`() = runTest {
-        val manifest: FinancialConnectionsSessionManifest = sessionManifest().copy(
-            activeAuthSession = authorizationSession(),
-            activeInstitution = institution()
+        val sync = syncResponse(
+            sessionManifest().copy(
+                activeAuthSession = authorizationSession(),
+                activeInstitution = institution()
+            )
         )
         val accountsList = PartnerAccountsList(
             data = listOf(
@@ -53,27 +56,29 @@ internal class PollAuthorizationSessionAccountsTest {
         whenever(repository.postAuthorizationSessionAccounts(any(), any()))
             .doReturn(accountsList)
 
-        val result = pollAuthorizationSessionAccounts.invoke(true, manifest)
+        val result = pollAuthorizationSessionAccounts.invoke(true, sync)
 
         assertEquals(accountsList, result)
         verify(repository).postAuthorizationSessionAccounts(
             configuration.financialConnectionsSessionClientSecret,
-            manifest.activeAuthSession!!.id
+            sync.manifest.activeAuthSession!!.id
         )
     }
 
     @Test
     fun `test reached too many failed account polling`() = runTest {
-        val manifest: FinancialConnectionsSessionManifest = sessionManifest().copy(
-            activeAuthSession = authorizationSession(),
-            activeInstitution = institution()
+        val sync = syncResponse(
+            sessionManifest().copy(
+                activeAuthSession = authorizationSession(),
+                activeInstitution = institution()
+            )
         )
 
         whenever(repository.postAuthorizationSessionAccounts(any(), any()))
             .thenAnswer { throw retryException() }
 
         val exception: Throwable? = runCatching {
-            pollAuthorizationSessionAccounts.invoke(true, manifest)
+            pollAuthorizationSessionAccounts.invoke(true, sync)
         }.exceptionOrNull()
 
         assertIs<AccountLoadError>(exception)
@@ -81,15 +86,17 @@ internal class PollAuthorizationSessionAccountsTest {
         // Retries 180 times
         verify(repository, times(180)).postAuthorizationSessionAccounts(
             configuration.financialConnectionsSessionClientSecret,
-            manifest.activeAuthSession!!.id
+            sync.manifest.activeAuthSession!!.id
         )
     }
 
     @Test
     fun `test empty account list retrieved`() = runTest {
-        val manifest: FinancialConnectionsSessionManifest = sessionManifest().copy(
-            activeAuthSession = authorizationSession(),
-            activeInstitution = institution()
+        val sync = syncResponse(
+            sessionManifest().copy(
+                activeAuthSession = authorizationSession(),
+                activeInstitution = institution()
+            )
         )
 
         val emptyList = PartnerAccountsList(
@@ -102,14 +109,14 @@ internal class PollAuthorizationSessionAccountsTest {
         whenever(repository.postAuthorizationSessionAccounts(any(), any())).doReturn(emptyList)
 
         val exception: Throwable? = runCatching {
-            pollAuthorizationSessionAccounts.invoke(true, manifest)
+            pollAuthorizationSessionAccounts.invoke(true, sync)
         }.exceptionOrNull()
 
         assertIs<AccountLoadError>(exception)
 
         verify(repository, times(1)).postAuthorizationSessionAccounts(
             configuration.financialConnectionsSessionClientSecret,
-            manifest.activeAuthSession!!.id
+            sync.manifest.activeAuthSession!!.id
         )
     }
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PostAuthorizationSessionTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PostAuthorizationSessionTest.kt
@@ -4,16 +4,20 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.financialconnections.ApiKeyFixtures
+import com.stripe.android.financialconnections.ApiKeyFixtures.sessionManifest
+import com.stripe.android.financialconnections.ApiKeyFixtures.syncResponse
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.di.APPLICATION_ID
 import com.stripe.android.financialconnections.exception.InstitutionPlannedDowntimeError
 import com.stripe.android.financialconnections.exception.InstitutionUnplannedDowntimeError
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
 import com.stripe.android.financialconnections.networking.FakeFinancialConnectionsManifestRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import java.util.Date
 
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class PostAuthorizationSessionTest {
 
     private val repository = FakeFinancialConnectionsManifestRepository()
@@ -36,6 +40,9 @@ internal class PostAuthorizationSessionTest {
 
     @Test
     fun `invoke - institution unplanned downtime maps to exception`() = runTest {
+        val sync = syncResponse(
+            sessionManifest().copy(allowManualEntry = true)
+        )
         repository.postAuthorizationSessionProvider = {
             throw APIException(
                 stripeError = StripeError(
@@ -51,7 +58,7 @@ internal class PostAuthorizationSessionTest {
         val result: Throwable = kotlin.runCatching {
             postAuthorizationSession(
                 institution = selectedInstitution,
-                allowManualEntry = true
+                sync = sync
             )
         }
             .exceptionOrNull()!!
@@ -64,6 +71,9 @@ internal class PostAuthorizationSessionTest {
     @Test
     fun `invoke - institution planned downtime maps to exception`() = runTest {
         val upTime = Date().time
+        val sync = syncResponse(
+            sessionManifest().copy(allowManualEntry = true)
+        )
         repository.postAuthorizationSessionProvider = {
             throw APIException(
                 stripeError = StripeError(
@@ -80,7 +90,7 @@ internal class PostAuthorizationSessionTest {
         val result: Throwable = kotlin.runCatching {
             postAuthorizationSession(
                 institution = selectedInstitution,
-                allowManualEntry = true
+                sync = sync
             )
         }
             .exceptionOrNull()!!
@@ -93,6 +103,9 @@ internal class PostAuthorizationSessionTest {
 
     @Test
     fun `invoke - unhandled exception does not map`() = runTest {
+        val sync = syncResponse(
+            sessionManifest().copy(allowManualEntry = true)
+        )
         val unhandledException = APIException(
             stripeError = StripeError(
                 extraFields = mapOf()
@@ -105,7 +118,7 @@ internal class PostAuthorizationSessionTest {
         val result: Throwable = kotlin.runCatching {
             postAuthorizationSession(
                 institution = selectedInstitution,
-                allowManualEntry = true
+                sync = sync
             )
         }
             .exceptionOrNull()!!

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModelTest.kt
@@ -7,8 +7,8 @@ import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.ApiKeyFixtures.authorizationSession
 import com.stripe.android.financialconnections.ApiKeyFixtures.partnerAccount
 import com.stripe.android.financialconnections.ApiKeyFixtures.partnerAccountList
-import com.stripe.android.financialconnections.ApiKeyFixtures.syncResponse
 import com.stripe.android.financialconnections.ApiKeyFixtures.sessionManifest
+import com.stripe.android.financialconnections.ApiKeyFixtures.syncResponse
 import com.stripe.android.financialconnections.TestFinancialConnectionsAnalyticsTracker
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.GoNext

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModelTest.kt
@@ -6,8 +6,9 @@ import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.ApiKeyFixtures
 import com.stripe.android.financialconnections.ApiKeyFixtures.partnerAccount
 import com.stripe.android.financialconnections.ApiKeyFixtures.partnerAccountList
+import com.stripe.android.financialconnections.ApiKeyFixtures.syncResponse
 import com.stripe.android.financialconnections.TestFinancialConnectionsAnalyticsTracker
-import com.stripe.android.financialconnections.domain.GetManifest
+import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.GoNext
 import com.stripe.android.financialconnections.domain.PollAuthorizationSessionAccounts
 import com.stripe.android.financialconnections.domain.SelectAccounts
@@ -30,7 +31,7 @@ internal class AccountPickerViewModelTest {
     val mavericksTestRule = MavericksTestRule()
 
     private val pollAuthorizationSessionAccounts = mock<PollAuthorizationSessionAccounts>()
-    private val getManifest = mock<GetManifest>()
+    private val getSync = mock<GetOrFetchSync>()
     private val goNext = mock<GoNext>()
     private val navigationManager = mock<NavigationManager>()
     private val selectAccounts = mock<SelectAccounts>()
@@ -42,7 +43,7 @@ internal class AccountPickerViewModelTest {
         initialState = state,
         eventTracker = eventTracker,
         selectAccounts = selectAccounts,
-        getManifest = getManifest,
+        getOrFetchSync = getSync,
         goNext = goNext,
         navigationManager = navigationManager,
         logger = Logger.noop(),
@@ -124,7 +125,7 @@ internal class AccountPickerViewModelTest {
         }
 
     private suspend fun givenManifestReturns(manifest: FinancialConnectionsSessionManifest) {
-        whenever(getManifest()).thenReturn(manifest)
+        whenever(getSync()).thenReturn(syncResponse(manifest))
     }
 
     private suspend fun givenPollAccountsReturns(
@@ -133,7 +134,7 @@ internal class AccountPickerViewModelTest {
         whenever(
             pollAuthorizationSessionAccounts(
                 canRetry = any(),
-                manifest = any()
+                sync = any()
             )
         ).thenReturn(response)
     }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/common/ManifestExtensionsKtTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/common/ManifestExtensionsKtTest.kt
@@ -1,0 +1,47 @@
+package com.stripe.android.financialconnections.features.common
+
+import com.stripe.android.financialconnections.ApiKeyFixtures.sessionManifest
+import com.stripe.android.financialconnections.ApiKeyFixtures.syncResponse
+import com.stripe.android.financialconnections.ApiKeyFixtures.visual
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import org.junit.Test
+
+class ManifestExtensionsKtTest {
+
+    @Test
+    fun `showManualEntryInErrors true when allowManualEntry is true and reducedManualEntryProminenceForErrors is false`() {
+        val syncObj = syncResponse(
+            sessionManifest().copy(allowManualEntry = true),
+            visual().copy(reducedManualEntryProminenceForErrors = false)
+        )
+        assertTrue(syncObj.showManualEntryInErrors())
+    }
+
+    @Test
+    fun `showManualEntryInErrors false when allowManualEntry is true and reducedManualEntryProminenceForErrors is true`() {
+        val syncObj = syncResponse(
+            sessionManifest().copy(allowManualEntry = true),
+            visual().copy(reducedManualEntryProminenceForErrors = true)
+        )
+        assertFalse(syncObj.showManualEntryInErrors())
+    }
+
+    @Test
+    fun `showManualEntryInErrors false when allowManualEntry is false and reducedManualEntryProminenceForErrors is false`() {
+        val syncObj = syncResponse(
+            sessionManifest().copy(allowManualEntry = false),
+            visual().copy(reducedManualEntryProminenceForErrors = false)
+        )
+        assertFalse(syncObj.showManualEntryInErrors())
+    }
+
+    @Test
+    fun `showManualEntryInErrors false when allowManualEntry is false and reducedManualEntryProminenceForErrors is true`() {
+        val syncObj = syncResponse(
+            sessionManifest().copy(allowManualEntry = false),
+            visual().copy(reducedManualEntryProminenceForErrors = true)
+        )
+        assertFalse(syncObj.showManualEntryInErrors())
+    }
+}

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/common/ManifestExtensionsKtTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/common/ManifestExtensionsKtTest.kt
@@ -13,7 +13,7 @@ class ManifestExtensionsKtTest {
     fun `showManualEntryInErrors true when allowManualEntry true and reducedManualEntry false`() {
         val syncObj = syncResponse(
             sessionManifest().copy(allowManualEntry = true),
-            visual().copy(reducedManualEntryProminenceForErrors = false)
+            visual().copy(reducedManualEntryProminenceInErrors = false)
         )
         assertTrue(syncObj.showManualEntryInErrors())
     }
@@ -22,7 +22,7 @@ class ManifestExtensionsKtTest {
     fun `showManualEntryInErrors false when allowManualEntry true and reducedManualEntry true`() {
         val syncObj = syncResponse(
             sessionManifest().copy(allowManualEntry = true),
-            visual().copy(reducedManualEntryProminenceForErrors = true)
+            visual().copy(reducedManualEntryProminenceInErrors = true)
         )
         assertFalse(syncObj.showManualEntryInErrors())
     }
@@ -31,7 +31,7 @@ class ManifestExtensionsKtTest {
     fun `showManualEntryInErrors false when allowManualEntry false and reducedManualEntry false`() {
         val syncObj = syncResponse(
             sessionManifest().copy(allowManualEntry = false),
-            visual().copy(reducedManualEntryProminenceForErrors = false)
+            visual().copy(reducedManualEntryProminenceInErrors = false)
         )
         assertFalse(syncObj.showManualEntryInErrors())
     }
@@ -40,7 +40,7 @@ class ManifestExtensionsKtTest {
     fun `showManualEntryInErrors false when allowManualEntry false and reducedManualEntry true`() {
         val syncObj = syncResponse(
             sessionManifest().copy(allowManualEntry = false),
-            visual().copy(reducedManualEntryProminenceForErrors = true)
+            visual().copy(reducedManualEntryProminenceInErrors = true)
         )
         assertFalse(syncObj.showManualEntryInErrors())
     }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/common/ManifestExtensionsKtTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/common/ManifestExtensionsKtTest.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 class ManifestExtensionsKtTest {
 
     @Test
-    fun `showManualEntryInErrors true when allowManualEntry is true and reducedManualEntryProminenceForErrors is false`() {
+    fun `showManualEntryInErrors true when allowManualEntry true and reducedManualEntry false`() {
         val syncObj = syncResponse(
             sessionManifest().copy(allowManualEntry = true),
             visual().copy(reducedManualEntryProminenceForErrors = false)
@@ -19,7 +19,7 @@ class ManifestExtensionsKtTest {
     }
 
     @Test
-    fun `showManualEntryInErrors false when allowManualEntry is true and reducedManualEntryProminenceForErrors is true`() {
+    fun `showManualEntryInErrors false when allowManualEntry true and reducedManualEntry true`() {
         val syncObj = syncResponse(
             sessionManifest().copy(allowManualEntry = true),
             visual().copy(reducedManualEntryProminenceForErrors = true)
@@ -28,7 +28,7 @@ class ManifestExtensionsKtTest {
     }
 
     @Test
-    fun `showManualEntryInErrors false when allowManualEntry is false and reducedManualEntryProminenceForErrors is false`() {
+    fun `showManualEntryInErrors false when allowManualEntry false and reducedManualEntry false`() {
         val syncObj = syncResponse(
             sessionManifest().copy(allowManualEntry = false),
             visual().copy(reducedManualEntryProminenceForErrors = false)
@@ -37,7 +37,7 @@ class ManifestExtensionsKtTest {
     }
 
     @Test
-    fun `showManualEntryInErrors false when allowManualEntry is false and reducedManualEntryProminenceForErrors is true`() {
+    fun `showManualEntryInErrors false when allowManualEntry false and reducedManualEntry true`() {
         val syncObj = syncResponse(
             sessionManifest().copy(allowManualEntry = false),
             visual().copy(reducedManualEntryProminenceForErrors = true)

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModelTest.kt
@@ -7,8 +7,9 @@ import com.airbnb.mvrx.withState
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.ApiKeyFixtures.sessionManifest
+import com.stripe.android.financialconnections.ApiKeyFixtures.syncResponse
 import com.stripe.android.financialconnections.TestFinancialConnectionsAnalyticsTracker
-import com.stripe.android.financialconnections.domain.GetManifest
+import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.GoNext
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Terminate
@@ -16,6 +17,7 @@ import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.
 import com.stripe.android.financialconnections.domain.PollAttachPaymentAccount
 import com.stripe.android.financialconnections.features.manualentry.ManualEntryState.Payload
 import com.stripe.android.financialconnections.model.ManualEntryMode
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -24,18 +26,19 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import kotlin.test.assertEquals
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ManualEntryViewModelTest {
     @get:Rule
     val mavericksTestRule = MavericksTestRule()
 
-    private val getManifest = mock<GetManifest>()
+    private val getSync = mock<GetOrFetchSync>()
     private val goNext = mock<GoNext>()
     private val pollAttachPaymentAccount = mock<PollAttachPaymentAccount>()
     private val eventTracker = TestFinancialConnectionsAnalyticsTracker()
     private val nativeAuthFlowCoordinator = mock<NativeAuthFlowCoordinator>()
 
     private fun buildViewModel() = ManualEntryViewModel(
-        getManifest = getManifest,
+        getOrFetchSync = getSync,
         goNext = goNext,
         logger = Logger.noop(),
         eventTracker = eventTracker,
@@ -46,8 +49,11 @@ class ManualEntryViewModelTest {
 
     @Test
     fun `init - when custom manual entry, Terminate events is emitted`() = runTest {
-        val manifest = sessionManifest().copy(manualEntryMode = ManualEntryMode.CUSTOM)
-        whenever(getManifest()).thenReturn(manifest)
+        val sync = syncResponse(
+            sessionManifest().copy(manualEntryMode = ManualEntryMode.CUSTOM)
+        )
+
+        whenever(getSync()).thenReturn(sync)
         whenever(nativeAuthFlowCoordinator()).thenReturn(MutableSharedFlow())
 
         nativeAuthFlowCoordinator().test {
@@ -61,7 +67,7 @@ class ManualEntryViewModelTest {
                     Success(
                         Payload(
                             customManualEntry = true,
-                            verifyWithMicrodeposits = manifest.manualEntryUsesMicrodeposits
+                            verifyWithMicrodeposits = sync.manifest.manualEntryUsesMicrodeposits
                         )
                     )
                 )

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeStateTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeStateTest.kt
@@ -21,7 +21,7 @@ internal class FinancialConnectionsSheetNativeStateTest {
                 args = args(
                     VisualUpdate(
                         reducedBranding = true,
-                        reducedManualEntryProminenceForErrors = false,
+                        reducedManualEntryProminenceInErrors = false,
                         merchantLogos = emptyList()
                     )
                 )
@@ -36,7 +36,7 @@ internal class FinancialConnectionsSheetNativeStateTest {
                 args = args(
                     VisualUpdate(
                         reducedBranding = false,
-                        reducedManualEntryProminenceForErrors = false,
+                        reducedManualEntryProminenceInErrors = false,
                         merchantLogos = emptyList()
                     )
                 )

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeStateTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeStateTest.kt
@@ -21,6 +21,7 @@ internal class FinancialConnectionsSheetNativeStateTest {
                 args = args(
                     VisualUpdate(
                         reducedBranding = true,
+                        reducedManualEntryProminenceForErrors = false,
                         merchantLogos = emptyList()
                     )
                 )
@@ -35,6 +36,7 @@ internal class FinancialConnectionsSheetNativeStateTest {
                 args = args(
                     VisualUpdate(
                         reducedBranding = false,
+                        reducedManualEntryProminenceForErrors = false,
                         merchantLogos = emptyList()
                     )
                 )


### PR DESCRIPTION
# Summary
- Parses `synchronize[visual][reduce_manual_entry_prominence_in_errors]`
- On error screens that used to check `sync.manifest.allowManualEntry`, we now also check the feature flag above (`sync.visual.reduceManualEntryOnErrors`.) 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# How to test:
