### PR TITLE
Inject `AnalyticsRequestExecutor` interface instead of implementation

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -99,8 +99,6 @@ constructor(
     private val authenticatorRegistry: PaymentAuthenticatorRegistry =
         DefaultPaymentAuthenticatorRegistry.createInstance(
             context,
-            stripeRepository,
-            analyticsRequestExecutor,
             paymentAnalyticsRequestFactory,
             enableLogging,
             workContext,

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -16,7 +16,6 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.BuildConfig
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.Injectable
@@ -32,8 +31,6 @@ import com.stripe.android.googlepaylauncher.injection.DaggerGooglePayPaymentMeth
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networking.PaymentAnalyticsEvent
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
-import com.stripe.android.networking.StripeApiRepository
-import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -76,14 +73,6 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
         setOf(PRODUCT_USAGE_TOKEN)
     ),
     analyticsRequestExecutor: AnalyticsRequestExecutor = DefaultAnalyticsRequestExecutor(),
-    stripeRepository: StripeRepository = StripeApiRepository(
-        context,
-        publishableKeyProvider,
-        logger = Logger.getInstance(enableLogging),
-        workContext = ioContext,
-        productUsageTokens = setOf(PRODUCT_USAGE_TOKEN),
-        paymentAnalyticsRequestFactory = paymentAnalyticsRequestFactory
-    )
 ) {
     private var isReady = false
 
@@ -91,11 +80,11 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
         .context(context)
         .ioContext(ioContext)
         .analyticsRequestFactory(paymentAnalyticsRequestFactory)
-        .stripeRepository(stripeRepository)
         .googlePayConfig(config)
         .enableLogging(enableLogging)
         .publishableKeyProvider(publishableKeyProvider)
         .stripeAccountIdProvider(stripeAccountIdProvider)
+        .productUsage(productUsage)
         .build()
 
     @InjectorKey

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherComponent.kt
@@ -9,7 +9,8 @@ import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherViewModel
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
-import com.stripe.android.networking.StripeRepository
+import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Named
@@ -24,7 +25,8 @@ import kotlin.coroutines.CoroutineContext
 @Component(
     modules = [
         GooglePayPaymentMethodLauncherModule::class,
-        CoreCommonModule::class
+        CoreCommonModule::class,
+        StripeRepositoryModule::class,
     ]
 )
 @SuppressWarnings("UnnecessaryAbstractClass")
@@ -43,9 +45,6 @@ internal abstract class GooglePayPaymentMethodLauncherComponent {
         fun analyticsRequestFactory(paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory): Builder
 
         @BindsInstance
-        fun stripeRepository(stripeRepository: StripeRepository): Builder
-
-        @BindsInstance
         fun googlePayConfig(config: GooglePayPaymentMethodLauncher.Config): Builder
 
         @BindsInstance
@@ -56,6 +55,9 @@ internal abstract class GooglePayPaymentMethodLauncherComponent {
 
         @BindsInstance
         fun stripeAccountIdProvider(@Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?): Builder
+
+        @BindsInstance
+        fun productUsage(@Named(PRODUCT_USAGE) productUsage: Set<String>): Builder
 
         fun build(): GooglePayPaymentMethodLauncherComponent
     }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.googlepaylauncher.injection
 
-import android.content.Context
 import com.stripe.android.googlepaylauncher.DefaultGooglePayRepository
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayRepository
@@ -25,7 +24,6 @@ internal abstract class GooglePayPaymentMethodLauncherModule {
         @Provides
         @Singleton
         fun providePaymentsClient(
-            context: Context,
             googlePayConfig: GooglePayPaymentMethodLauncher.Config,
             paymentsClientFactory: PaymentsClientFactory
         ) = paymentsClientFactory.create(googlePayConfig.environment)

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry.kt
@@ -14,11 +14,9 @@ import com.stripe.android.core.injection.Injectable
 import com.stripe.android.core.injection.Injector
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.core.model.StripeModel
-import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.model.Source
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
-import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2TransactionViewModelFactory
 import com.stripe.android.payments.core.injection.AuthenticationComponent
@@ -144,8 +142,6 @@ internal class DefaultPaymentAuthenticatorRegistry @Inject internal constructor(
     companion object {
         fun createInstance(
             context: Context,
-            stripeRepository: StripeRepository,
-            analyticsRequestExecutor: AnalyticsRequestExecutor,
             paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
             enableLogging: Boolean,
             workContext: CoroutineContext,
@@ -159,8 +155,6 @@ internal class DefaultPaymentAuthenticatorRegistry @Inject internal constructor(
                 WeakMapInjectorRegistry.nextKey(requireNotNull(PaymentAuthenticatorRegistry::class.simpleName))
             val component = DaggerAuthenticationComponent.builder()
                 .context(context)
-                .stripeRepository(stripeRepository)
-                .analyticsRequestExecutor(analyticsRequestExecutor)
                 .analyticsRequestFactory(paymentAnalyticsRequestFactory)
                 .enableLogging(enableLogging)
                 .workContext(workContext)

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
@@ -7,9 +7,7 @@ import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.InjectorKey
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.UIContext
-import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
-import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.authentication.DefaultPaymentAuthenticatorRegistry
 import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2TransactionViewModelFactory
 import dagger.BindsInstance
@@ -31,7 +29,8 @@ import kotlin.coroutines.CoroutineContext
         AuthenticationModule::class,
         Stripe3DSAuthenticatorModule::class,
         WeChatPayAuthenticatorModule::class,
-        CoreCommonModule::class
+        CoreCommonModule::class,
+        StripeRepositoryModule::class,
     ]
 )
 internal interface AuthenticationComponent {
@@ -43,12 +42,6 @@ internal interface AuthenticationComponent {
     interface Builder {
         @BindsInstance
         fun context(context: Context): Builder
-
-        @BindsInstance
-        fun stripeRepository(stripeRepository: StripeRepository): Builder
-
-        @BindsInstance
-        fun analyticsRequestExecutor(analyticsRequestExecutor: AnalyticsRequestExecutor): Builder
 
         @BindsInstance
         fun analyticsRequestFactory(paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory): Builder

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherComponent.kt
@@ -8,7 +8,6 @@ import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.injection.UIContext
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
-import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.authentication.PaymentAuthenticatorRegistry
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherViewModel
 import dagger.BindsInstance
@@ -21,7 +20,8 @@ import kotlin.coroutines.CoroutineContext
 @Component(
     modules = [
         PaymentLauncherModule::class,
-        CoreCommonModule::class
+        CoreCommonModule::class,
+        StripeRepositoryModule::class,
     ]
 )
 internal interface PaymentLauncherComponent {
@@ -43,9 +43,6 @@ internal interface PaymentLauncherComponent {
 
         @BindsInstance
         fun uiContext(@UIContext uiContext: CoroutineContext): Builder
-
-        @BindsInstance
-        fun stripeRepository(stripeRepository: StripeRepository): Builder
 
         @BindsInstance
         fun analyticsRequestFactory(paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory): Builder

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherModule.kt
@@ -6,9 +6,7 @@ import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.UIContext
-import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
-import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.DefaultReturnUrl
 import com.stripe.android.payments.core.authentication.DefaultPaymentAuthenticatorRegistry
 import com.stripe.android.payments.core.authentication.PaymentAuthenticatorRegistry
@@ -34,20 +32,16 @@ internal class PaymentLauncherModule {
     @Singleton
     fun providePaymentAuthenticatorRegistry(
         context: Context,
-        stripeRepository: StripeRepository,
         @Named(ENABLE_LOGGING) enableLogging: Boolean,
         @IOContext workContext: CoroutineContext,
         @UIContext uiContext: CoroutineContext,
         threeDs1IntentReturnUrlMap: MutableMap<String, String>,
-        defaultAnalyticsRequestExecutor: DefaultAnalyticsRequestExecutor,
         paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
         @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
         @Named(PRODUCT_USAGE) productUsage: Set<String>,
         @Named(IS_INSTANT_APP) isInstantApp: Boolean
     ): PaymentAuthenticatorRegistry = DefaultPaymentAuthenticatorRegistry.createInstance(
         context,
-        stripeRepository,
-        defaultAnalyticsRequestExecutor,
         paymentAnalyticsRequestFactory,
         enableLogging,
         workContext,

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherFactory.kt
@@ -7,7 +7,6 @@ import androidx.annotation.RestrictTo
 import androidx.fragment.app.Fragment
 import com.stripe.android.BuildConfig
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
-import com.stripe.android.networking.StripeApiRepository
 import kotlinx.coroutines.Dispatchers
 
 /**
@@ -65,11 +64,6 @@ class PaymentLauncherFactory(
             enableLogging = BuildConfig.DEBUG,
             ioContext = Dispatchers.IO,
             uiContext = Dispatchers.Main,
-            stripeRepository = StripeApiRepository(
-                context = context,
-                publishableKeyProvider = { publishableKey },
-                paymentAnalyticsRequestFactory = analyticsRequestFactory,
-            ),
             paymentAnalyticsRequestFactory = analyticsRequestFactory,
             productUsage = productUsage,
         )

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -19,8 +19,8 @@ import com.stripe.android.core.injection.Injector
 import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.core.injection.injectWithFallback
+import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.ApiRequest
-import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
@@ -59,7 +59,7 @@ internal class PaymentLauncherViewModel @Inject constructor(
     private val threeDs1IntentReturnUrlMap: MutableMap<String, String>,
     private val lazyPaymentIntentFlowResultProcessor: Lazy<PaymentIntentFlowResultProcessor>,
     private val lazySetupIntentFlowResultProcessor: Lazy<SetupIntentFlowResultProcessor>,
-    private val analyticsRequestExecutor: DefaultAnalyticsRequestExecutor,
+    private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
     @UIContext private val uiContext: CoroutineContext,
     private val savedStateHandle: SavedStateHandle,

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncher.kt
@@ -15,7 +15,6 @@ import com.stripe.android.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
-import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.authentication.PaymentAuthenticatorRegistry
 import com.stripe.android.payments.core.injection.DaggerPaymentLauncherComponent
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
@@ -40,7 +39,6 @@ class StripePaymentLauncher @AssistedInject internal constructor(
     @Named(ENABLE_LOGGING) private val enableLogging: Boolean,
     @IOContext ioContext: CoroutineContext,
     @UIContext uiContext: CoroutineContext,
-    stripeRepository: StripeRepository,
     paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
     @Named(PRODUCT_USAGE) private val productUsage: Set<String>
 ) : PaymentLauncher, Injector {
@@ -50,7 +48,6 @@ class StripePaymentLauncher @AssistedInject internal constructor(
             .enableLogging(enableLogging)
             .ioContext(ioContext)
             .uiContext(uiContext)
-            .stripeRepository(stripeRepository)
             .analyticsRequestFactory(paymentAnalyticsRequestFactory)
             .publishableKeyProvider(publishableKeyProvider)
             .stripeAccountIdProvider(stripeAccountIdProvider)

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
@@ -21,8 +21,8 @@ import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.core.injection.Injectable
 import com.stripe.android.core.injection.Injector
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
+import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.ApiRequest
-import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.PaymentIntent
@@ -78,7 +78,7 @@ class PaymentLauncherViewModelTest {
     private val paymentIntentFlowResultProcessor = mock<PaymentIntentFlowResultProcessor>()
     private val setupIntentFlowResultProcessor = mock<SetupIntentFlowResultProcessor>()
 
-    private val analyticsRequestExecutor = mock<DefaultAnalyticsRequestExecutor>()
+    private val analyticsRequestExecutor = mock<AnalyticsRequestExecutor>()
     private val analyticsRequestFactory = mock<PaymentAnalyticsRequestFactory>()
     private val uiContext = UnconfinedTestDispatcher()
     private val activityResultCaller = mock<ActivityResultCaller>()

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncherTest.kt
@@ -23,7 +23,6 @@ class StripePaymentLauncherTest {
         enableLogging = false,
         ioContext = mock(),
         uiContext = mock(),
-        stripeRepository = mock(),
         paymentAnalyticsRequestFactory = mock(),
         productUsage = mock(),
         statusBarColor = Color.RED,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request makes sure that we inject `AnalyticsRequestExecutor` instead of `DefaultAnalyticsRequestExecutor` in `PaymentLauncherViewModel`.

This is done in preparation for https://github.com/stripe/stripe-android/pull/7085, which removes the empty constructor of `DefaultAnalyticsRequestExecutor`, making it impossible to be mocked with `mock()`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
