### PR TITLE
Automatically set locale and decoupling on PS events

### DIFF
--- a/payments-core/src/test/java/com/stripe/android/PaymentAnalyticsRequestFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentAnalyticsRequestFactoryTest.kt
@@ -123,6 +123,7 @@ class PaymentAnalyticsRequestFactoryTest {
                 "is_development" to true,
                 "session_id" to AnalyticsRequestFactory.sessionId,
                 "network_type" to "2G",
+                "locale" to "en_US",
             )
         )
     }
@@ -302,7 +303,7 @@ class PaymentAnalyticsRequestFactoryTest {
                 )
             )
         assertThat(analyticsRequest.url)
-            .isEqualTo("https://q.stripe.com?publishable_key=pk_abc123&app_version=0&bindings_version=$sdkVersion&os_version=30&session_id=${AnalyticsRequestFactory.sessionId}&os_release=11&device_type=robolectric_robolectric_robolectric&source_type=card&app_name=com.stripe.android.test&analytics_ua=analytics.stripe_android-1.0&os_name=REL&network_type=2G&event=stripe_android.payment_method_creation&is_development=true")
+            .isEqualTo("https://q.stripe.com?publishable_key=pk_abc123&app_version=0&bindings_version=$sdkVersion&os_version=30&session_id=${AnalyticsRequestFactory.sessionId}&os_release=11&device_type=robolectric_robolectric_robolectric&source_type=card&locale=en_US&app_name=com.stripe.android.test&analytics_ua=analytics.stripe_android-1.0&os_name=REL&network_type=2G&event=stripe_android.payment_method_creation&is_development=true")
     }
 
     @Test
@@ -379,6 +380,7 @@ class PaymentAnalyticsRequestFactoryTest {
             PaymentAnalyticsRequestFactory.FIELD_SOURCE_TYPE,
             PaymentAnalyticsRequestFactory.FIELD_TOKEN_TYPE,
             AnalyticsFields.NETWORK_TYPE,
+            AnalyticsFields.LOCALE,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -187,8 +187,8 @@ internal class DefaultEventReporter @Inject internal constructor(
         CoroutineScope(workContext).launch {
             analyticsRequestExecutor.executeAsync(
                 paymentAnalyticsRequestFactory.createRequest(
-                    event,
-                    event.additionalParams
+                    event = event,
+                    additionalParams = event.params,
                 )
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -6,7 +6,6 @@ import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.uicore.StripeThemeDefaults
-import java.util.Locale
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 
@@ -249,7 +248,6 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         isDecoupled: Boolean,
     ): Map<String, Any?> = mapOf(
         FIELD_IS_DECOUPLED to isDecoupled,
-        FIELD_LOCALE to Locale.getDefault().toString(),
     )
 
     internal companion object {
@@ -293,7 +291,6 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_COLLECT_PHONE = "phone"
         const val FIELD_COLLECT_ADDRESS = "address"
         const val FIELD_DURATION = "duration"
-        const val FIELD_LOCALE = "locale"
         const val FIELD_LINK_ENABLED = "link_enabled"
         const val FIELD_CURRENCY = "currency"
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -23,14 +23,14 @@ class PaymentSheetEventTest {
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
             isDecoupled = false,
         )
+
         assertThat(
             event.eventName
         ).isEqualTo(
             "mc_complete_init_customer_googlepay"
         )
-        assertThat(
-            event.additionalParams
-        ).containsEntry("locale", "en_US")
+
+        assertThat(event.params).containsEntry("is_decoupled", false)
     }
 
     @Test
@@ -40,14 +40,14 @@ class PaymentSheetEventTest {
             configuration = PaymentSheetFixtures.CONFIG_MINIMUM,
             isDecoupled = false,
         )
+
         assertThat(
             event.eventName
         ).isEqualTo(
             "mc_complete_init_default"
         )
-        assertThat(
-            event.additionalParams
-        ).containsEntry("locale", "en_US")
+
+        assertThat(event.params).containsEntry("is_decoupled", false)
     }
 
     @Test
@@ -71,10 +71,9 @@ class PaymentSheetEventTest {
             "mc_complete_payment_newpm_success"
         )
         assertThat(
-            newPMEvent.additionalParams
+            newPMEvent.params
         ).isEqualTo(
             mapOf(
-                "locale" to "en_US",
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
@@ -99,10 +98,9 @@ class PaymentSheetEventTest {
             "mc_complete_payment_savedpm_success"
         )
         assertThat(
-            savedPMEvent.additionalParams
+            savedPMEvent.params
         ).isEqualTo(
             mapOf(
-                "locale" to "en_US",
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
@@ -127,10 +125,9 @@ class PaymentSheetEventTest {
             "mc_complete_payment_googlepay_success"
         )
         assertThat(
-            googlePayEvent.additionalParams
+            googlePayEvent.params
         ).isEqualTo(
             mapOf(
-                "locale" to "en_US",
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
@@ -155,10 +152,9 @@ class PaymentSheetEventTest {
             "mc_complete_payment_link_success"
         )
         assertThat(
-            linkEvent.additionalParams
+            linkEvent.params
         ).isEqualTo(
             mapOf(
-                "locale" to "en_US",
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
@@ -189,10 +185,9 @@ class PaymentSheetEventTest {
             "mc_complete_payment_link_success"
         )
         assertThat(
-            inlineLinkEvent.additionalParams
+            inlineLinkEvent.params
         ).isEqualTo(
             mapOf(
-                "locale" to "en_US",
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
@@ -221,10 +216,9 @@ class PaymentSheetEventTest {
             "mc_complete_payment_newpm_failure"
         )
         assertThat(
-            newPMEvent.additionalParams
+            newPMEvent.params
         ).isEqualTo(
             mapOf(
-                "locale" to "en_US",
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
@@ -249,10 +243,9 @@ class PaymentSheetEventTest {
             "mc_complete_payment_savedpm_failure"
         )
         assertThat(
-            savedPMEvent.additionalParams
+            savedPMEvent.params
         ).isEqualTo(
             mapOf(
-                "locale" to "en_US",
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
@@ -277,10 +270,9 @@ class PaymentSheetEventTest {
             "mc_complete_payment_googlepay_failure"
         )
         assertThat(
-            googlePayEvent.additionalParams
+            googlePayEvent.params
         ).isEqualTo(
             mapOf(
-                "locale" to "en_US",
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
@@ -305,10 +297,9 @@ class PaymentSheetEventTest {
             "mc_complete_payment_link_failure"
         )
         assertThat(
-            linkEvent.additionalParams
+            linkEvent.params
         ).isEqualTo(
             mapOf(
-                "locale" to "en_US",
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
@@ -339,10 +330,9 @@ class PaymentSheetEventTest {
             "mc_complete_payment_link_failure"
         )
         assertThat(
-            inlineLinkEvent.additionalParams
+            inlineLinkEvent.params
         ).isEqualTo(
             mapOf(
-                "locale" to "en_US",
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
@@ -364,10 +354,9 @@ class PaymentSheetEventTest {
             "mc_custom_paymentoption_googlepay_select"
         )
         assertThat(
-            event.additionalParams
+            event.params
         ).isEqualTo(
             mapOf(
-                "locale" to "en_US",
                 "currency" to "usd",
                 "is_decoupled" to false,
             )
@@ -414,11 +403,10 @@ class PaymentSheetEventTest {
                 mode = EventReporter.Mode.Complete,
                 configuration = PaymentSheetFixtures.CONFIG_MINIMUM,
                 isDecoupled = false,
-            ).additionalParams
+            ).params
         ).isEqualTo(
             mapOf(
                 "mpe_config" to expectedConfigMap,
-                "locale" to "en_US",
                 "is_decoupled" to false,
             )
         )
@@ -464,11 +452,10 @@ class PaymentSheetEventTest {
                 mode = EventReporter.Mode.Complete,
                 configuration = PaymentSheetFixtures.CONFIG_WITH_EVERYTHING,
                 isDecoupled = false,
-            ).additionalParams
+            ).params
         ).isEqualTo(
             mapOf(
                 "mpe_config" to expectedConfigMap,
-                "locale" to "en_US",
                 "is_decoupled" to false,
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -17,7 +17,7 @@ import kotlin.time.Duration.Companion.milliseconds
 class PaymentSheetEventTest {
 
     @Test
-    fun `Init event with full config should return expected toString()`() {
+    fun `Init event with full config should return expected params`() {
         val event = PaymentSheetEvent.Init(
             mode = EventReporter.Mode.Complete,
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
@@ -30,11 +30,45 @@ class PaymentSheetEventTest {
             "mc_complete_init_customer_googlepay"
         )
 
-        assertThat(event.params).containsEntry("is_decoupled", false)
+        val expectedConfig = mapOf(
+            "customer" to true,
+            "googlepay" to true,
+            "primary_button_color" to false,
+            "default_billing_details" to false,
+            "allows_delayed_payment_methods" to false,
+            "appearance" to mapOf(
+                "colorsLight" to false,
+                "colorsDark" to false,
+                "corner_radius" to false,
+                "border_width" to false,
+                "font" to false,
+                "size_scale_factor" to false,
+                "primary_button" to mapOf(
+                    "colorsLight" to false,
+                    "colorsDark" to false,
+                    "corner_radius" to false,
+                    "border_width" to false,
+                    "font" to false,
+                ),
+                "usage" to false,
+            ),
+            "billing_details_collection_configuration" to mapOf(
+                "attach_defaults" to false,
+                "name" to "Automatic",
+                "email" to "Automatic",
+                "phone" to "Automatic",
+                "address" to "Automatic",
+            ),
+        )
+
+        assertThat(event.params).run {
+            containsEntry("is_decoupled", false)
+            containsEntry("mpe_config", expectedConfig)
+        }
     }
 
     @Test
-    fun `Init event with minimum config should return expected toString()`() {
+    fun `Init event with minimum config should return expected params`() {
         val event = PaymentSheetEvent.Init(
             mode = EventReporter.Mode.Complete,
             configuration = PaymentSheetFixtures.CONFIG_MINIMUM,
@@ -47,7 +81,41 @@ class PaymentSheetEventTest {
             "mc_complete_init_default"
         )
 
-        assertThat(event.params).containsEntry("is_decoupled", false)
+        val expectedConfig = mapOf(
+            "customer" to false,
+            "googlepay" to false,
+            "primary_button_color" to false,
+            "default_billing_details" to false,
+            "allows_delayed_payment_methods" to false,
+            "appearance" to mapOf(
+                "colorsLight" to false,
+                "colorsDark" to false,
+                "corner_radius" to false,
+                "border_width" to false,
+                "font" to false,
+                "size_scale_factor" to false,
+                "primary_button" to mapOf(
+                    "colorsLight" to false,
+                    "colorsDark" to false,
+                    "corner_radius" to false,
+                    "border_width" to false,
+                    "font" to false,
+                ),
+                "usage" to false,
+            ),
+            "billing_details_collection_configuration" to mapOf(
+                "attach_defaults" to false,
+                "name" to "Automatic",
+                "email" to "Automatic",
+                "phone" to "Automatic",
+                "address" to "Automatic",
+            ),
+        )
+
+        assertThat(event.params).run {
+            containsEntry("is_decoupled", false)
+            containsEntry("mpe_config", expectedConfig)
+        }
     }
 
     @Test

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsFields.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsFields.kt
@@ -22,4 +22,5 @@ object AnalyticsFields {
     const val PUBLISHABLE_KEY = "publishable_key"
     const val SESSION_ID = "session_id"
     const val NETWORK_TYPE = "network_type"
+    const val LOCALE = "locale"
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
@@ -7,6 +7,7 @@ import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.core.BuildConfig
 import com.stripe.android.core.version.StripeSdkVersion
+import java.util.Locale
 import java.util.UUID
 import javax.inject.Provider
 
@@ -58,6 +59,7 @@ open class AnalyticsRequestFactory(
         AnalyticsFields.BINDINGS_VERSION to StripeSdkVersion.VERSION_NAME,
         AnalyticsFields.IS_DEVELOPMENT to BuildConfig.DEBUG,
         AnalyticsFields.SESSION_ID to sessionId,
+        AnalyticsFields.LOCALE to Locale.getDefault().toString(),
     ) + networkType()
 
     private fun networkType(): Map<String, String> {

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestFactoryTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestFactoryTest.kt
@@ -12,6 +12,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
+import java.util.Locale
 
 @RunWith(RobolectricTestRunner::class)
 class AnalyticsRequestFactoryTest : TestCase() {
@@ -104,4 +105,38 @@ class AnalyticsRequestFactoryTest : TestCase() {
         assertThat(AnalyticsRequestFactory.ANALYTICS_UA)
             .isEqualTo("analytics.stripe_android-1.0")
     }
+
+    @Test
+    fun `Adds correct locale to request`() {
+        val locales = listOf(Locale.US, Locale.CANADA, Locale.GERMANY)
+
+        val factory = AnalyticsRequestFactory(
+            packageManager = null,
+            packageInfo = null,
+            packageName = "",
+            publishableKeyProvider = { apiKey },
+            networkTypeProvider = { "5G" },
+        )
+
+        val event = object : AnalyticsEvent {
+            override val eventName: String = "test_event"
+        }
+
+        for (locale in locales) {
+            withLocale(locale) {
+                val request = factory.createRequest(
+                    event = event,
+                    additionalParams = emptyMap(),
+                )
+                assertThat(request.params).containsEntry("locale", locale.toString())
+            }
+        }
+    }
+}
+
+private fun withLocale(locale: Locale, block: () -> Unit) {
+    val original = Locale.getDefault()
+    Locale.setDefault(locale)
+    block()
+    Locale.setDefault(original)
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request makes it so that we automatically set the `locale` and `is_decoupled` values for each analytics event.

Previously, we required both values to be set explicitly for each event. Now, we include `is_decoupled` in `PaymentSheetEvent.standardParams` and `locale` in `AnalyticsRequestFactory.standardParams`.

(cc @porter-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

More consistent logging.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
