### PR TITLE
Use `DurationProvider` in Link event reporter

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.analytics
 
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
+import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.PaymentSheet

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -7,6 +7,8 @@ import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
+import com.stripe.android.core.utils.DefaultDurationProvider
+import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.link.injection.LinkAnalyticsComponent
 import com.stripe.android.link.injection.LinkComponent
 import com.stripe.android.payments.core.injection.APP_NAME
@@ -16,9 +18,7 @@ import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PrefsRepository
-import com.stripe.android.paymentsheet.analytics.DefaultDurationProvider
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
-import com.stripe.android.paymentsheet.analytics.DurationProvider
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.flowcontroller.DefaultPaymentSelectionUpdater
 import com.stripe.android.paymentsheet.flowcontroller.PaymentSelectionUpdater

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeDurationProvider.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeDurationProvider.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.utils
 
-import com.stripe.android.paymentsheet.analytics.DurationProvider
+import com.stripe.android.core.utils.DurationProvider
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
@@ -1,21 +1,26 @@
-package com.stripe.android.paymentsheet.analytics
+package com.stripe.android.core.utils
 
 import android.os.SystemClock
+import androidx.annotation.RestrictTo
 import javax.inject.Inject
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
-internal interface DurationProvider {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+interface DurationProvider {
     fun start(key: Key)
     fun end(key: Key): Duration?
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     enum class Key {
         Loading,
         Checkout,
+        LinkSignup,
     }
 }
 
-internal class DefaultDurationProvider @Inject constructor() : DurationProvider {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class DefaultDurationProvider @Inject constructor() : DurationProvider {
 
     private val store = mutableMapOf<DurationProvider.Key, Long>()
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request makes `DefaultLinkEventReporter` use the `DurationProvider` to be in line with the PaymentSheet event reporter.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Consistency.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
