### PR TITLE
Add event for payment method type selection

### DIFF
--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     testImplementation testLibs.espresso.core
 
     androidTestImplementation project(':network-testing')
+    androidTestImplementation project(':payments-core-testing')
 
     androidTestImplementation libs.places
     androidTestImplementation testLibs.androidx.composeUi
@@ -93,6 +94,9 @@ dependencies {
     androidTestImplementation (testLibs.espresso.contrib) {
         exclude group: 'org.checkerframework', module: 'checker'
     }
+    androidTestImplementation testLibs.mockito.core
+    androidTestImplementation testLibs.mockito.inline
+    androidTestImplementation testLibs.mockito.kotlin
     androidTestImplementation testLibs.truth
 
     androidTestUtil testLibs.testOrchestrator

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.analytics
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.utils.DurationProvider
+import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -100,6 +101,20 @@ internal class DefaultEventReporter @Inject internal constructor(
                 linkEnabled = linkEnabled,
                 currency = currency,
                 isDecoupled = isDecoupling,
+            )
+        )
+    }
+
+    override fun onSelectPaymentMethod(
+        code: PaymentMethodCode,
+        currency: String?,
+        isDecoupling: Boolean
+    ) {
+        fireEvent(
+            PaymentSheetEvent.SelectPaymentMethod(
+                code = code,
+                isDecoupled = isDecoupling,
+                currency = currency,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -108,7 +108,7 @@ internal class DefaultEventReporter @Inject internal constructor(
     override fun onSelectPaymentMethod(
         code: PaymentMethodCode,
         currency: String?,
-        isDecoupling: Boolean
+        isDecoupling: Boolean,
     ) {
         fireEvent(
             PaymentSheetEvent.SelectPaymentMethod(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.analytics
 
 import androidx.annotation.Keep
+import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -59,6 +60,15 @@ internal interface EventReporter {
      */
     fun onShowNewPaymentOptionForm(
         linkEnabled: Boolean,
+        currency: String?,
+        isDecoupling: Boolean,
+    )
+
+    /**
+     * The customer has selected one of the available payment methods in the payment method form.
+     */
+    fun onSelectPaymentMethod(
+        code: PaymentMethodCode,
         currency: String?,
         isDecoupling: Boolean,
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -179,6 +179,18 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         )
     }
 
+    class SelectPaymentMethod(
+        code: String,
+        currency: String?,
+        override val isDecoupled: Boolean,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = "mc_carousel_payment_method_tapped"
+        override val additionalParams: Map<String, Any?> = mapOf(
+            FIELD_CURRENCY to currency,
+            FIELD_SELECTED_LPM to code,
+        )
+    }
+
     class SelectPaymentOption(
         mode: EventReporter.Mode,
         paymentSelection: PaymentSelection?,
@@ -293,6 +305,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_DURATION = "duration"
         const val FIELD_LINK_ENABLED = "link_enabled"
         const val FIELD_CURRENCY = "currency"
+        const val FIELD_SELECTED_LPM = "selected_lpm"
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -61,6 +61,10 @@ internal fun AddPaymentMethod(
         arguments.showCheckbox,
     )
 
+    LaunchedEffect(selectedPaymentMethodCode) {
+        sheetViewModel.reportLpmSelected(selectedPaymentMethodCode)
+    }
+
     LaunchedEffect(arguments) {
         showCheckboxFlow.emit(arguments.showCheckbox)
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -61,10 +61,6 @@ internal fun AddPaymentMethod(
         arguments.showCheckbox,
     )
 
-    LaunchedEffect(selectedPaymentMethodCode) {
-        sheetViewModel.reportLpmSelected(selectedPaymentMethodCode)
-    }
-
     LaunchedEffect(arguments) {
         showCheckboxFlow.emit(arguments.showCheckbox)
     }
@@ -102,6 +98,7 @@ internal fun AddPaymentMethod(
                 onItemSelectedListener = { selectedLpm ->
                     if (selectedItem != selectedLpm) {
                         selectedPaymentMethodCode = selectedLpm.code
+                        sheetViewModel.reportPaymentMethodTypeSelected(selectedLpm.code)
                     }
                 },
                 onLinkSignupStateChanged = { _, inlineSignupViewState ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -290,6 +290,21 @@ internal abstract class BaseSheetViewModel(
         eventReporter.onDismiss(isDecoupling = isDecoupling)
     }
 
+    fun reportLpmSelected(code: PaymentMethodCode) {
+        eventReporter.onSelectPaymentMethod(
+            code = code,
+            isDecoupling = stripeIntent.value?.clientSecret == null,
+            currency = stripeIntent.value?.currency,
+        )
+    }
+
+    protected fun reportConfirmButtonPressed() {
+        eventReporter.onPressConfirmButton(
+            isDecoupling = stripeIntent.value?.clientSecret == null,
+            currency = stripeIntent.value?.currency,
+        )
+    }
+
     abstract fun clearErrorMessages()
 
     fun updatePrimaryButtonForLinkSignup(viewState: InlineSignupViewState) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -290,16 +290,9 @@ internal abstract class BaseSheetViewModel(
         eventReporter.onDismiss(isDecoupling = isDecoupling)
     }
 
-    fun reportLpmSelected(code: PaymentMethodCode) {
+    fun reportPaymentMethodTypeSelected(code: PaymentMethodCode) {
         eventReporter.onSelectPaymentMethod(
             code = code,
-            isDecoupling = stripeIntent.value?.clientSecret == null,
-            currency = stripeIntent.value?.currency,
-        )
-    }
-
-    protected fun reportConfirmButtonPressed() {
-        eventReporter.onPressConfirmButton(
             isDecoupling = stripeIntent.value?.clientSecret == null,
             currency = stripeIntent.value?.currency,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeFormViewModelSubcomponentBuilder.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeFormViewModelSubcomponentBuilder.kt
@@ -1,0 +1,58 @@
+package com.stripe.android.utils
+
+import android.content.Context
+import com.stripe.android.paymentsheet.forms.FormViewModel
+import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
+import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
+import com.stripe.android.ui.core.forms.resources.LpmRepository
+import com.stripe.android.uicore.address.AddressRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import javax.inject.Provider
+
+internal fun formViewModelSubcomponentBuilder(
+    context: Context,
+    lpmRepository: LpmRepository,
+): Provider<FormViewModelSubcomponent.Builder> {
+    val formViewModelProvider: (FormArguments, Flow<Boolean>) -> FormViewModel = { args, showCheckbox ->
+        FormViewModel(
+            context = context,
+            formArguments = args,
+            lpmRepository = lpmRepository,
+            addressRepository = AddressRepository(context.resources, Dispatchers.Unconfined),
+            showCheckboxFlow = showCheckbox,
+        )
+    }
+
+    val mockFormSubComponentBuilderProvider = mock<Provider<FormViewModelSubcomponent.Builder>>()
+
+    val mockFormBuilder = object : FormViewModelSubcomponent.Builder {
+
+        private lateinit var formArguments: FormArguments
+        private lateinit var showCheckboxFlow: Flow<Boolean>
+
+        override fun formArguments(args: FormArguments): FormViewModelSubcomponent.Builder {
+            formArguments = args
+            return this
+        }
+
+        override fun showCheckboxFlow(
+            saveForFutureUseVisibleFlow: Flow<Boolean>,
+        ): FormViewModelSubcomponent.Builder {
+            showCheckboxFlow = saveForFutureUseVisibleFlow
+            return this
+        }
+
+        override fun build(): FormViewModelSubcomponent {
+            return mock {
+                on { viewModel } doReturn formViewModelProvider(formArguments, showCheckboxFlow)
+            }
+        }
+    }
+
+    whenever(mockFormSubComponentBuilderProvider.get()).thenReturn(mockFormBuilder)
+    return mockFormSubComponentBuilderProvider
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds an event for when a user selects a payment method type in the payment method form. We send the selected type as `selected_lpm`.

(cc @porter-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Observability.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
