### PR TITLE
Update maestro to use record

### DIFF
--- a/maestro/paymentsheet/FlowController-Deferred-PaymentIntent-Card.yaml
+++ b/maestro/paymentsheet/FlowController-Deferred-PaymentIntent-Card.yaml
@@ -1,6 +1,7 @@
 appId: com.stripe.android.paymentsheet.example
 ---
 - launchApp
+- startRecording: /tmp/test_results/flowcontroller-deferred-paymentintent-card
 # Android specific: Navigate to example
 - tapOn: "FlowController with server-side confirmation"
 - waitForAnimationToEnd:
@@ -18,7 +19,9 @@ appId: com.stripe.android.paymentsheet.example
     env:
         CARD_NUMBER: 4242424242424242
 - scroll
-- tapOn: "Continue"
+- tapOn:
+    id: "com.stripe.android.paymentsheet.example:id/primary_button"
 - tapOn: "Buy"
 - assertVisible: ".*Success.*"
 - tapOn: "Finish"
+- stopRecording

--- a/maestro/paymentsheet/FlowController-PaymentIntent-Card.yaml
+++ b/maestro/paymentsheet/FlowController-PaymentIntent-Card.yaml
@@ -1,6 +1,7 @@
 appId: com.stripe.android.paymentsheet.example
 ---
 - launchApp
+- startRecording: /tmp/test_results/flowcontroller-paymentintent-card
 # Android specific: Navigate to example
 - tapOn: "FlowController"
 - extendedWaitUntil:
@@ -16,7 +17,9 @@ appId: com.stripe.android.paymentsheet.example
     env:
         CARD_NUMBER: 4242424242424242
 - scroll
-- tapOn: "Continue"
+- tapOn:
+    id: "com.stripe.android.paymentsheet.example:id/primary_button"
 - tapOn: "Buy"
 - assertVisible: ".*Success.*"
 - tapOn: "Finish"
+- stopRecording

--- a/maestro/paymentsheet/PaymentSheet-Deferred-PaymentIntent-Card.yaml
+++ b/maestro/paymentsheet/PaymentSheet-Deferred-PaymentIntent-Card.yaml
@@ -1,6 +1,7 @@
 appId: com.stripe.android.paymentsheet.example
 ---
 - launchApp
+- startRecording: /tmp/test_results/paymentsheet-deferred-paymentintent-card
 # Android specific: Navigate to example
 - tapOn: "PaymentSheet with server-side confirmation"
 - waitForAnimationToEnd:
@@ -15,6 +16,8 @@ appId: com.stripe.android.paymentsheet.example
     env:
         CARD_NUMBER: 4242424242424242
 - scroll
-- tapOn: "Pay.*"
+- tapOn:
+    id: "com.stripe.android.paymentsheet.example:id/primary_button"
 - assertVisible: ".*Success.*"
 - tapOn: "Finish"
+- stopRecording

--- a/maestro/paymentsheet/PaymentSheet-PaymentIntent-AddressElement-Card.yaml
+++ b/maestro/paymentsheet/PaymentSheet-PaymentIntent-AddressElement-Card.yaml
@@ -1,6 +1,7 @@
 appId: com.stripe.android.paymentsheet.example
 ---
 - launchApp
+- startRecording: /tmp/test_results/paymentsheet-paymentintent-addresselement-card
 - scroll
 # Android specific: Navigate to example
 - waitForAnimationToEnd:
@@ -31,5 +32,7 @@ appId: com.stripe.android.paymentsheet.example
     env:
         CARD_NUMBER: 4242424242424242
 - scroll
-- tapOn: "Pay.*"
+- tapOn:
+    id: "com.stripe.android.paymentsheet.example:id/primary_button"
 - assertVisible: ".*Success.*"
+- stopRecording

--- a/maestro/paymentsheet/PaymentSheet-PaymentIntent-Card-3DS2.yaml
+++ b/maestro/paymentsheet/PaymentSheet-PaymentIntent-Card-3DS2.yaml
@@ -1,6 +1,7 @@
 appId: com.stripe.android.paymentsheet.example
 ---
 - launchApp
+- startRecording: /tmp/test_results/paymentsheet-paymentintent-card-3ds2
 # Android specific: Navigate to example
 - tapOn: "PaymentSheet"
 - waitForAnimationToEnd:
@@ -15,7 +16,8 @@ appId: com.stripe.android.paymentsheet.example
     env:
         CARD_NUMBER: 4000000000003220
 - scroll
-- tapOn: "Pay.*"
+- tapOn:
+    id: "com.stripe.android.paymentsheet.example:id/primary_button"
 ####### Bypass Chrome on-boarding screen #######
 - runFlow:
       file: ../common/subflow-skip-chrome-welcome.yaml
@@ -32,3 +34,4 @@ appId: com.stripe.android.paymentsheet.example
     visible: ".*Success.*"
     timeout: 60000
 - tapOn: "Finish"
+- stopRecording

--- a/maestro/paymentsheet/PaymentSheet-PaymentIntent-Card.yaml
+++ b/maestro/paymentsheet/PaymentSheet-PaymentIntent-Card.yaml
@@ -1,6 +1,7 @@
 appId: com.stripe.android.paymentsheet.example
 ---
 - launchApp
+- startRecording: /tmp/test_results/paymentsheet-paymentintent-card
 # Android specific: Navigate to example
 - tapOn: "PaymentSheet"
 - waitForAnimationToEnd:
@@ -15,6 +16,8 @@ appId: com.stripe.android.paymentsheet.example
     env:
         CARD_NUMBER: 4242424242424242
 - scroll
-- tapOn: "Pay.*"
+- tapOn:
+    id: "com.stripe.android.paymentsheet.example:id/primary_button"
 - assertVisible: ".*Success.*"
 - tapOn: "Finish"
+- stopRecording

--- a/scripts/execute_maestro_paymentsheet_tests.sh
+++ b/scripts/execute_maestro_paymentsheet_tests.sh
@@ -6,35 +6,15 @@ now=$(date +%F_%H-%M-%S)
 echo $now
 
 # Install Maestro
-export MAESTRO_VERSION=1.21.3; curl -Ls "https://get.maestro.mobile.dev" | bash
+export MAESTRO_VERSION=1.30.4; curl -Ls "https://get.maestro.mobile.dev" | bash
 export PATH="$PATH":"$HOME/.maestro/bin"
 maestro -v
+
+# Create test results folder.
+mkdir -p /tmp/test_results
 
 # Compile and install APK.
 ./gradlew :paymentsheet-example:installDebug
 
-# Start screen record (adb screenrecord has a 3 min limit). Can append more recordings as needed.
-adb shell "screenrecord /sdcard/$now-1.mp4; screenrecord /sdcard/$now-2.mp4" &
-
-# Store the process ID
-childpid=$!
-
 # Clear and start collecting logs
 maestro test --format junit --output maestroReport.xml maestro/paymentsheet
-result=$?
-
-# Wait for the recording process to finish
-kill -2 "$childpid"
-wait "$childpid"
-
-# Sleep for a short duration to allow the process to finalize the video file
-sleep 3
-
-# Pull the video file from the device
-mkdir -p /tmp/test_results
-cd /tmp/test_results
-adb logcat -d > /tmp/test_results/log.txt
-adb pull "/sdcard/$now-1.mp4" || true
-adb pull "/sdcard/$now-2.mp4" || true
-
-exit "$result"


### PR DESCRIPTION
# Summary
 - Update maestro to use record. Rather than use adb to record videos at an unknown length, the record feature in maestro allows us to start and end when we need to (when the test starts and ends)
 - Update the maestro tests to tap on the primary button, rather than Link UI which sometimes contains the word "Pay"

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

