### PR TITLE
Add maestro customer sheet tests

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -130,6 +130,31 @@ workflows:
             - search_pattern: '*/maestroReport.xml'
             - test_name: Maestro tests
       - deploy-to-bitrise-io@2: { }
+  maestro-customersheet:
+    before_run:
+      - start_emulator
+      - prepare_all
+    after_run:
+      - conclude_all
+    steps:
+      - wait-for-android-emulator@1:
+          inputs:
+            - boot_timeout: 600
+      - script-runner@0:
+          title: Execute Maestro tests
+          inputs:
+            - file_path: ./scripts/execute_maestro_customersheet_tests.sh
+      - slack@3:
+          is_always_run: true
+          run_if: .IsBuildFailed
+          inputs:
+            - webhook_url: $WEBHOOK_SLACK_ELEMENTS_MAESTRO
+            - webhook_url_on_error: $WEBHOOK_SLACK_ELEMENTS_MAESTRO
+      - custom-test-results-export@1:
+          inputs:
+            - search_pattern: '*/maestroReport.xml'
+            - test_name: Maestro tests
+      - deploy-to-bitrise-io@2: { }
   run-instrumentation-tests:
     before_run:
       - prepare_all

--- a/maestro/customersheet/NewCustomer-Card.yaml
+++ b/maestro/customersheet/NewCustomer-Card.yaml
@@ -1,0 +1,44 @@
+appId: com.stripe.android.paymentsheet.example
+---
+- launchApp
+- startRecording: /tmp/test_results/newcustomer-card
+# Android specific: Navigate to example
+- scrollUntilVisible:
+    element: "CustomerSheet Playground"
+- waitForAnimationToEnd:
+    timeout: 5000
+- tapOn: "CustomerSheet Playground"
+- waitForAnimationToEnd:
+    timeout: 5000
+- extendedWaitUntil:
+    visible: "Payment default"
+    timeout: 60000
+# Use a new customer
+- tapOn:
+    id: "CUSTOMER_SHEET_PLAYGROUND_EXISTING_CUSTOMER"
+- extendedWaitUntil:
+      visible: "Select"
+      timeout: 60000
+- tapOn: "Select"
+- extendedWaitUntil:
+      visible: "Manage your payment method"
+      timeout: 60000
+- tapOn:
+    id: "AddCard"
+- extendedWaitUntil:
+    visible: "Save a new payment method"
+    timeout: 60000
+# ENTER CARD DETAILS
+- runFlow:
+    file: ./card/subflow-card-details.yaml
+    env:
+      CARD_NUMBER: 4242424242424242
+- hideKeyboard
+- tapOn: "Save"
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible:
+    id: "PAYMENT_OPTION_CARD_TEST_TAG_····4242"
+- tapOn: "Confirm"
+- assertVisible: "····4242"
+- stopRecording

--- a/maestro/customersheet/NewCustomer-GooglePay.yaml
+++ b/maestro/customersheet/NewCustomer-GooglePay.yaml
@@ -1,0 +1,32 @@
+appId: com.stripe.android.paymentsheet.example
+---
+- launchApp
+- startRecording: /tmp/test_results/newcustomer-googlepay
+# Android specific: Navigate to example
+- scrollUntilVisible:
+    element: "CustomerSheet Playground"
+- waitForAnimationToEnd:
+    timeout: 5000
+- tapOn: "CustomerSheet Playground"
+- waitForAnimationToEnd:
+    timeout: 5000
+- extendedWaitUntil:
+    visible: "Payment default"
+    timeout: 60000
+# Use a new customer
+- tapOn:
+    id: "CUSTOMER_SHEET_PLAYGROUND_EXISTING_CUSTOMER"
+- extendedWaitUntil:
+      visible: "Select"
+      timeout: 60000
+- tapOn: "Select"
+- extendedWaitUntil:
+      visible: "Manage your payment method"
+      timeout: 60000
+- tapOn:
+    id: "PAYMENT_OPTION_CARD_TEST_TAG_Google Pay"
+- tapOn: "Confirm"
+- assertVisible:
+    text: "Google Pay"
+    index: 1
+- stopRecording

--- a/maestro/customersheet/card/subflow-card-details.yaml
+++ b/maestro/customersheet/card/subflow-card-details.yaml
@@ -1,0 +1,13 @@
+appId: com.stripe.android.paymentsheet.example
+---
+####### Enter card details #######
+- tapOn: "Card number"
+- inputText: ${CARD_NUMBER}
+- tapOn: "MM / YY"
+- inputText: "444"
+- tapOn: "CVC"
+- inputText: "444"
+- tapOn: "Country or region"
+- tapOn: "\U0001f1fa\U0001f1f8 United States"
+- tapOn: "ZIP code"
+- inputText: "44444"

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/playground/CustomerSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/playground/CustomerSheetPlaygroundActivity.kt
@@ -22,8 +22,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -233,6 +237,7 @@ class CustomerSheetPlaygroundActivity : AppCompatActivity() {
         }
     }
 
+    @OptIn(ExperimentalComposeUiApi::class)
     @Composable
     private fun ExistingCustomerSwitch(
         viewState: CustomerSheetPlaygroundViewState,
@@ -255,7 +260,10 @@ class CustomerSheetPlaygroundActivity : AppCompatActivity() {
                 checked = viewState.isExistingCustomer,
                 onCheckedChange = {
                     viewActionHandler(CustomerSheetPlaygroundViewAction.ToggleExistingCustomer)
-                }
+                },
+                modifier = Modifier
+                    .semantics { testTagsAsResourceId = true }
+                    .testTag("CUSTOMER_SHEET_PLAYGROUND_EXISTING_CUSTOMER")
             )
         }
     }

--- a/scripts/execute_maestro_customersheet_tests.sh
+++ b/scripts/execute_maestro_customersheet_tests.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -o pipefail
+set -x
+
+now=$(date +%F_%H-%M-%S)
+echo $now
+
+# Install Maestro
+export MAESTRO_VERSION=1.30.4; curl -Ls "https://get.maestro.mobile.dev" | bash
+export PATH="$PATH":"$HOME/.maestro/bin"
+maestro -v
+
+# Create test results folder.
+mkdir -p /tmp/test_results
+
+# Compile and install APK.
+./gradlew :paymentsheet-example:installDebug
+
+# Clear and start collecting logs
+maestro test --format junit --output maestroReport.xml maestro/customersheet


### PR DESCRIPTION
# Summary
Add maestro customer sheet tests.

- NewCustomer-Card tests adding a new card and confirming the selection.
- NewCustomer-GooglePay tests setting google pay as the selection.
