### PR TITLE
[Identity] Stop camera early to remove the blurriness

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/ui/CameraScreenLaunchedEffect.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/CameraScreenLaunchedEffect.kt
@@ -84,7 +84,6 @@ internal fun CameraScreenLaunchedEffect(
                     }
                 )
             }
-            identityScanViewModel.stopScan(lifecycleOwner)
 
             // Upload success result
             if (finalResult.identityState is IdentityScanState.Finished) {

--- a/identity/src/main/java/com/stripe/android/identity/ui/DocumenetScanScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/DocumenetScanScreen.kt
@@ -163,6 +163,7 @@ internal fun DocumentScanScreen(
                     cameraManager.toggleFound()
                 }
                 is IdentityScanState.Finished -> {
+                    identityScanViewModel.stopScan(lifecycleOwner)
                     cameraManager.toggleFinished()
                 }
                 else -> {} // no-op

--- a/identity/src/main/java/com/stripe/android/identity/ui/SelfieScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/SelfieScreen.kt
@@ -186,6 +186,12 @@ internal fun SelfieScanScreen(
             identityViewModel.resetSelfieUploadedState()
         }
 
+        LaunchedEffect(newDisplayState) {
+            if (newDisplayState is IdentityScanState.Finished) {
+                identityScanViewModel.stopScan(lifecycleOwner)
+            }
+        }
+
         CameraScreenLaunchedEffect(
             identityViewModel = identityViewModel,
             identityScanViewModel = identityScanViewModel,

--- a/identity/src/test/java/com/stripe/android/identity/ui/CameraScreenLaunchedEffectTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/CameraScreenLaunchedEffectTest.kt
@@ -142,7 +142,6 @@ class CameraScreenLaunchedEffectTest {
                     eq(IdentityAnalyticsRequestFactory.TYPE_SELFIE)
                 )
             }
-            verify(mockIdentityScanViewModel).stopScan(any())
 
             verify(mockIdentityViewModel).updateAnalyticsState(
                 argWhere { block ->
@@ -175,7 +174,6 @@ class CameraScreenLaunchedEffectTest {
                     eq(IdentityAnalyticsRequestFactory.TYPE_SELFIE)
                 )
             }
-            verify(mockIdentityScanViewModel).stopScan(any())
 
             verify(mockIdentityAnalyticsRequestFactory).selfieTimeout()
 
@@ -213,7 +211,6 @@ class CameraScreenLaunchedEffectTest {
                     eq(IdentityAnalyticsRequestFactory.TYPE_DOCUMENT)
                 )
             }
-            verify(mockIdentityScanViewModel).stopScan(any())
 
             verify(mockIdentityViewModel).updateAnalyticsState(
                 argWhere { block ->
@@ -248,7 +245,6 @@ class CameraScreenLaunchedEffectTest {
                     eq(IdentityAnalyticsRequestFactory.TYPE_DOCUMENT)
                 )
             }
-            verify(mockIdentityScanViewModel).stopScan(any())
 
             verify(mockIdentityAnalyticsRequestFactory).documentTimeout(
                 eq(IdentityScanState.ScanType.ID_FRONT)
@@ -287,7 +283,6 @@ class CameraScreenLaunchedEffectTest {
                     eq(IdentityAnalyticsRequestFactory.TYPE_DOCUMENT)
                 )
             }
-            verify(mockIdentityScanViewModel).stopScan(any())
 
             verify(mockIdentityViewModel).updateAnalyticsState(
                 argWhere { block ->
@@ -322,7 +317,6 @@ class CameraScreenLaunchedEffectTest {
                     eq(IdentityAnalyticsRequestFactory.TYPE_DOCUMENT)
                 )
             }
-            verify(mockIdentityScanViewModel).stopScan(any())
 
             verify(mockIdentityAnalyticsRequestFactory).documentTimeout(
                 eq(IdentityScanState.ScanType.ID_BACK)

--- a/identity/src/test/java/com/stripe/android/identity/ui/DocumentScanScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/DocumentScanScreenTest.kt
@@ -123,6 +123,7 @@ class DocumentScanScreenTest {
             displayState = mock<IdentityScanState.Finished>(),
             targetScanType = IdentityScanState.ScanType.ID_FRONT
         ) {
+            verify(mockIdentityScanViewModel).stopScan(any())
             onNodeWithTag(SCAN_TITLE_TAG).assertTextEquals(context.getString(R.string.stripe_front_of_id))
             onNodeWithTag(SCAN_MESSAGE_TAG).assertTextEquals(context.getString(R.string.stripe_scanned))
             onNodeWithTag(CHECK_MARK_TAG).assertExists()

--- a/identity/src/test/java/com/stripe/android/identity/ui/SelfieScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/SelfieScreenTest.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -158,6 +159,7 @@ class SelfieScreenTest {
             on { transitioner } doReturn faceDetectorTransitioner
         }
         testSelfieScanScreen(finishedState) {
+            verify(mockIdentityScanViewModel).stopScan(any())
             onNodeWithTag(SELFIE_SCAN_TITLE_TAG)
                 .assertTextEquals(context.getString(R.string.stripe_selfie_captures))
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Call `identityScanViewModel.stopScan` in a separate `LaunchedEffect` instead of calling it from `CameraScreenLaunchedEffect`.

Otherwise this is called after the UI(the checkmark) gets updated and there's a delay between the final UI states and camera freezes, making it possible to get a blurry image if the camera is still moving afterwards.


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix blurriness of camera


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![cameraBefore](https://github.com/stripe/stripe-android/assets/79880926/b223d6c9-9c40-4276-b777-3438698c887f)  | ![cameraAfter](https://github.com/stripe/stripe-android/assets/79880926/19429b18-fa07-4137-9cd2-1923514694b1) |





# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
