### PR TITLE
Make payment configuration lazy

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -42,14 +42,14 @@ internal class CustomerSheetViewModel @Inject constructor(
     // TODO (jameswoo) should the current view state be derived from backstack?
     private val backstack: Stack<CustomerSheetViewState>,
     private var savedPaymentSelection: PaymentSelection?,
-    private val paymentConfiguration: PaymentConfiguration,
+    private val paymentConfigurationProvider: Provider<PaymentConfiguration>,
     private val resources: Resources,
     private val configuration: CustomerSheet.Configuration,
     private val logger: Logger,
     private val stripeRepository: StripeRepository,
     private val customerAdapter: CustomerAdapter,
     private val lpmRepository: LpmRepository,
-    @Named(IS_LIVE_MODE) private val isLiveMode: Boolean,
+    @Named(IS_LIVE_MODE) private val isLiveModeProvider: () -> Boolean,
     private val formViewModelSubcomponentBuilderProvider: Provider<FormViewModelSubcomponent.Builder>,
 ) : ViewModel() {
 
@@ -136,7 +136,7 @@ internal class CustomerSheetViewModel @Inject constructor(
                     title = configuration.headerTextForSelectionScreen,
                     savedPaymentMethods = paymentMethods ?: emptyList(),
                     paymentSelection = paymentSelection,
-                    isLiveMode = isLiveMode,
+                    isLiveMode = isLiveModeProvider(),
                     isProcessing = false,
                     isEditing = false,
                     isGooglePayEnabled = configuration.googlePayEnabled,
@@ -172,7 +172,7 @@ internal class CustomerSheetViewModel @Inject constructor(
                 paymentMethodCode = paymentMethodCode,
                 formViewData = FormViewModel.ViewData(),
                 enabled = true,
-                isLiveMode = isLiveMode,
+                isLiveMode = isLiveModeProvider(),
                 isProcessing = false,
             )
         )
@@ -337,8 +337,8 @@ internal class CustomerSheetViewModel @Inject constructor(
         return stripeRepository.createPaymentMethod(
             paymentMethodCreateParams = createParams,
             options = ApiRequest.Options(
-                apiKey = paymentConfiguration.publishableKey,
-                stripeAccount = paymentConfiguration.stripeAccountId,
+                apiKey = paymentConfigurationProvider.get().publishableKey,
+                stripeAccount = paymentConfigurationProvider.get().stripeAccountId,
             )
         )
     }
@@ -362,8 +362,8 @@ internal class CustomerSheetViewModel @Inject constructor(
                         clientSecret = clientSecret,
                     ),
                     options = ApiRequest.Options(
-                        apiKey = paymentConfiguration.publishableKey,
-                        stripeAccount = paymentConfiguration.stripeAccountId,
+                        apiKey = paymentConfigurationProvider.get().publishableKey,
+                        stripeAccount = paymentConfigurationProvider.get().stripeAccountId,
                     ),
                 ).getOrThrow()
             }.onSuccess {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -11,16 +11,19 @@ import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.IS_LIVE_MODE
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
+import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.customersheet.CustomerSheetViewState
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.ui.core.forms.resources.LpmRepository
+import dagger.Lazy
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.Dispatchers
 import java.util.Stack
 import javax.inject.Named
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 @Module(
@@ -30,10 +33,36 @@ import kotlin.coroutines.CoroutineContext
 )
 internal class CustomerSheetViewModelModule {
 
+    /**
+     * Provides a non-singleton PaymentConfiguration.
+     *
+     * Should be fetched only when it's needed, to allow client to set the publishableKey and
+     * stripeAccountId in PaymentConfiguration any time before presenting Customer Sheet.
+     *
+     * Should always be injected with [Lazy] or [Provider].
+     */
     @Provides
     fun paymentConfiguration(application: Application): PaymentConfiguration {
         return PaymentConfiguration.getInstance(application)
     }
+
+    @Provides
+    @Named(PUBLISHABLE_KEY)
+    fun providePublishableKey(
+        paymentConfiguration: Provider<PaymentConfiguration>
+    ): () -> String = { paymentConfiguration.get().publishableKey }
+
+    @Provides
+    @Named(STRIPE_ACCOUNT_ID)
+    fun provideStripeAccountId(
+        paymentConfiguration: Provider<PaymentConfiguration>
+    ): () -> String? = { paymentConfiguration.get().stripeAccountId }
+
+    @Provides
+    @Named(IS_LIVE_MODE)
+    fun isLiveMode(
+        paymentConfiguration: Provider<PaymentConfiguration>
+    ): () -> Boolean = { paymentConfiguration.get().publishableKey.startsWith("pk_live") }
 
     @Provides
     fun resources(application: Application): Resources {
@@ -59,12 +88,6 @@ internal class CustomerSheetViewModelModule {
     }
 
     @Provides
-    @Named(PUBLISHABLE_KEY)
-    fun publishableKeyProvider(paymentConfiguration: PaymentConfiguration): () -> String {
-        return { paymentConfiguration.publishableKey }
-    }
-
-    @Provides
     @Named(PRODUCT_USAGE)
     fun provideProductUsageTokens() = setOf("CustomerSheet")
 
@@ -81,18 +104,12 @@ internal class CustomerSheetViewModelModule {
         LocaleListCompat.getAdjustedDefault().takeUnless { it.isEmpty }?.get(0)
 
     @Provides
-    @Named(IS_LIVE_MODE)
-    fun isLiveMode(paymentConfiguration: PaymentConfiguration): Boolean {
-        return paymentConfiguration.publishableKey.startsWith("pk_live")
-    }
-
-    @Provides
     fun backstack(
-        @Named(IS_LIVE_MODE) isLiveMode: Boolean
+        @Named(IS_LIVE_MODE) isLiveModeProvider: () -> Boolean
     ): Stack<CustomerSheetViewState> = Stack<CustomerSheetViewState>().apply {
         push(
             CustomerSheetViewState.Loading(
-                isLiveMode = isLiveMode
+                isLiveMode = isLiveModeProvider()
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/StripeCustomerAdapterComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/StripeCustomerAdapterComponent.kt
@@ -8,6 +8,7 @@ import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
+import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.customersheet.CustomerEphemeralKey
 import com.stripe.android.customersheet.CustomerEphemeralKeyProvider
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
@@ -22,10 +23,12 @@ import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import dagger.Binds
 import dagger.BindsInstance
 import dagger.Component
+import dagger.Lazy
 import dagger.Module
 import dagger.Provides
 import java.util.Calendar
 import javax.inject.Named
+import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -85,6 +88,14 @@ internal interface StripeCustomerAdapterModule {
             )
         }
 
+        /**
+         * Provides a non-singleton PaymentConfiguration.
+         *
+         * Should be fetched only when it's needed, to allow client to set the publishableKey and
+         * stripeAccountId in PaymentConfiguration any time before presenting Customer Sheet.
+         *
+         * Should always be injected with [Lazy] or [Provider].
+         */
         @Provides
         fun providePaymentConfiguration(appContext: Context): PaymentConfiguration {
             return PaymentConfiguration.getInstance(appContext)
@@ -92,9 +103,15 @@ internal interface StripeCustomerAdapterModule {
 
         @Provides
         @Named(PUBLISHABLE_KEY)
-        fun providePublishableKey(configuration: PaymentConfiguration): () -> String = {
-            configuration.publishableKey
-        }
+        fun providePublishableKey(
+            paymentConfiguration: Provider<PaymentConfiguration>
+        ): () -> String = { paymentConfiguration.get().publishableKey }
+
+        @Provides
+        @Named(STRIPE_ACCOUNT_ID)
+        fun provideStripeAccountId(
+            paymentConfiguration: Provider<PaymentConfiguration>
+        ): () -> String? = { paymentConfiguration.get().stripeAccountId }
 
         @Provides
         @Named(PRODUCT_USAGE)

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTestHelper.kt
@@ -83,14 +83,14 @@ object CustomerSheetTestHelper {
             application = application,
             backstack = backstack,
             savedPaymentSelection = savedPaymentSelection,
-            paymentConfiguration = paymentConfiguration,
+            paymentConfigurationProvider = { paymentConfiguration },
             formViewModelSubcomponentBuilderProvider = mockFormSubComponentBuilderProvider,
             resources = application.resources,
             stripeRepository = stripeRepository,
             customerAdapter = customerAdapter,
             lpmRepository = lpmRepository,
             configuration = configuration,
-            isLiveMode = isLiveMode,
+            isLiveModeProvider = { isLiveMode },
             logger = Logger.noop(),
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -58,29 +58,29 @@ class CustomerSheetViewModelTest {
     @Test
     fun `isLiveMode is true when publishable key is live`() {
         val viewModelModule = CustomerSheetViewModelModule()
-        var isLiveMode = viewModelModule.isLiveMode(
+        var isLiveMode = viewModelModule.isLiveMode {
             PaymentConfiguration(
                 publishableKey = "pk_test_123"
             )
-        )
+        }
 
-        assertThat(isLiveMode).isFalse()
+        assertThat(isLiveMode()).isFalse()
 
-        isLiveMode = viewModelModule.isLiveMode(
+        isLiveMode = viewModelModule.isLiveMode {
             PaymentConfiguration(
                 publishableKey = "pk_live_123"
             )
-        )
+        }
 
-        assertThat(isLiveMode).isTrue()
+        assertThat(isLiveMode()).isTrue()
 
-        isLiveMode = viewModelModule.isLiveMode(
+        isLiveMode = viewModelModule.isLiveMode {
             PaymentConfiguration(
                 publishableKey = "pk_test_51HvTI7Lu5o3livep6t5AgBSkMvWoTtA0nyA7pVYDqpfLkRtWun7qZTYCOHCReprfLM464yaBeF72UFfB7cY9WG4a00ZnDtiC2C"
             )
-        )
+        }
 
-        assertThat(isLiveMode).isFalse()
+        assertThat(isLiveMode()).isFalse()
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Make payment configuration lazy. This fixes an issue where `StripeCustomerAdapter` retrieves a payment configuration before it is initialized (when dagger constructs `CustomerApiRepository`)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Fixes an issue where payment configuration is being initialized for the first time in CustomerSheet.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

