### PR TITLE
Add tracking for confirm button presses

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -79,7 +79,10 @@ internal class PaymentOptionsViewModel @Inject constructor(
         amountFlow = amount,
         selectionFlow = selection,
         customPrimaryButtonUiStateFlow = customPrimaryButtonUiState,
-        onClick = this::onUserSelection,
+        onClick = {
+            reportConfirmButtonPressed()
+            onUserSelection()
+        },
     )
 
     private val _paymentOptionResult = MutableSharedFlow<PaymentOptionResult>(replay = 1)
@@ -261,6 +264,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
 
     override fun handleConfirmUSBankAccount(paymentSelection: PaymentSelection.New.USBankAccount) {
         updateSelection(paymentSelection)
+        reportConfirmButtonPressed()
         onUserSelection()
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -119,7 +119,10 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         amountFlow = amount,
         selectionFlow = selection,
         customPrimaryButtonUiStateFlow = customPrimaryButtonUiState,
-        onClick = this::checkout,
+        onClick = {
+            reportConfirmButtonPressed()
+            checkout()
+        },
     )
 
     private val _paymentSheetResult = MutableSharedFlow<PaymentSheetResult>(replay = 1)
@@ -427,6 +430,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     override fun handleConfirmUSBankAccount(paymentSelection: PaymentSelection.New.USBankAccount) {
         updateSelection(paymentSelection)
+        reportConfirmButtonPressed()
         checkout()
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -134,6 +134,15 @@ internal class DefaultEventReporter @Inject internal constructor(
         )
     }
 
+    override fun onPressConfirmButton(currency: String?, isDecoupling: Boolean) {
+        fireEvent(
+            PaymentSheetEvent.PressConfirmButton(
+                currency = currency,
+                isDecoupled = isDecoupling,
+            )
+        )
+    }
+
     override fun onPaymentSuccess(
         paymentSelection: PaymentSelection?,
         currency: String?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -83,6 +83,14 @@ internal interface EventReporter {
     )
 
     /**
+     * The customer has pressed the confirm button.
+     */
+    fun onPressConfirmButton(
+        currency: String?,
+        isDecoupling: Boolean,
+    )
+
+    /**
      * Payment or setup have succeeded.
      */
     fun onPaymentSuccess(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -204,6 +204,16 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         )
     }
 
+    class PressConfirmButton(
+        currency: String?,
+        override val isDecoupled: Boolean,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = "mc_confirm_button_tapped"
+        override val additionalParams: Map<String, Any?> = mapOf(
+            FIELD_CURRENCY to currency,
+        )
+    }
+
     class Payment(
         mode: EventReporter.Mode,
         result: Result,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -274,6 +274,13 @@ internal abstract class BaseSheetViewModel(
         }
     }
 
+    protected fun reportConfirmButtonPressed() {
+        eventReporter.onPressConfirmButton(
+            currency = stripeIntent.value?.currency,
+            isDecoupling = stripeIntent.value?.clientSecret == null,
+        )
+    }
+
     protected fun setStripeIntent(stripeIntent: StripeIntent?) {
         _stripeIntent.value = stripeIntent
         supportedPaymentMethods = getPMsToAdd(stripeIntent, config, lpmRepository)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -56,6 +56,7 @@ import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddAnotherP
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.ui.GooglePayButton
+import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.PrimaryButtonAnimator
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
@@ -83,6 +84,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.stub
+import org.mockito.kotlin.verify
 import org.robolectric.annotation.Config
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -928,6 +930,36 @@ internal class PaymentSheetActivityTest {
             assertThat(layoutParams.gravity).isEqualTo(Gravity.CENTER_HORIZONTAL or Gravity.BOTTOM)
             assertThat(layoutParams.width).isEqualTo(750)
         }
+    }
+
+    @Test
+    fun `Send confirm pressed event when pressing primary button`() = runTest(testDispatcher) {
+        // Use only payment method type that doesn't require form input
+        val paymentIntent = PAYMENT_INTENT.copy(
+            amount = 9999,
+            currency = "CAD",
+            paymentMethodTypes = listOf("cashapp"),
+        )
+
+        val viewModel = createViewModel(
+            paymentIntent = paymentIntent,
+            paymentMethods = emptyList(),
+        )
+
+        val scenario = activityScenario(viewModel)
+
+        scenario.launch(intent).onActivity {
+            composeTestRule
+                .onNodeWithTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG)
+                .performClick()
+
+            composeTestRule.waitForIdle()
+        }
+
+        verify(eventReporter).onPressConfirmButton(
+            currency = "CAD",
+            isDecoupling = false,
+        )
     }
 
     private fun activityScenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -72,6 +72,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
@@ -1417,6 +1418,60 @@ internal class PaymentSheetViewModelTest {
         val viewModel = createViewModelForDeferredIntent()
         viewModel.onUserCancel()
         verify(eventReporter).onDismiss(isDecoupling = true)
+    }
+
+    @Test
+    fun `Sends confirm pressed event when fully confirming US bank account payment`() = runTest {
+        val newPaymentSelection = PaymentSelection.New.USBankAccount(
+            labelResource = "Test",
+            iconResource = 0,
+            bankName = "Test",
+            last4 = "Test",
+            financialConnectionsSessionId = "1234",
+            intentId = "1234",
+            paymentMethodCreateParams = mock(),
+            customerRequestedSave = mock(),
+        )
+
+        val viewModel = createViewModel()
+
+        viewModel.handleConfirmUSBankAccount(newPaymentSelection)
+
+        verify(eventReporter).onPressConfirmButton(
+            currency = "usd",
+            isDecoupling = false,
+        )
+    }
+
+    @Test
+    fun `Sends no confirm pressed event when opening US bank account auth flow`() = runTest {
+        val paymentIntent = PAYMENT_INTENT.copy(
+            amount = 9999,
+            currency = "CAD",
+            paymentMethodTypes = listOf("card", "us_bank_account"),
+        )
+
+        val viewModel = createViewModel(stripeIntent = paymentIntent)
+
+        // Mock the filled out US Bank Account form by updating the selection
+        val usBankAccount = PaymentSelection.New.USBankAccount(
+            labelResource = "Test",
+            iconResource = 0,
+            bankName = "Test",
+            last4 = "Test",
+            financialConnectionsSessionId = "1234",
+            intentId = "1234",
+            paymentMethodCreateParams = mock(),
+            customerRequestedSave = mock(),
+        )
+        viewModel.updateSelection(usBankAccount)
+
+        viewModel.checkout()
+
+        verify(eventReporter, never()).onPressConfirmButton(
+            currency = "usd",
+            isDecoupling = false,
+        )
     }
 
     private fun createViewModel(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds tracking for pressing the confirm button. For US bank accounts, we only send an event on the confirming press, not on the press that opens the auth flow.

(cc @porter-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Observability improvements.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
