### PR TITLE
Add ability to handle next actions

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSessionViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSessionViewModel.kt
@@ -20,6 +20,7 @@ internal class CustomerSessionViewModel(
         configuration: CustomerSheet.Configuration,
         customerAdapter: CustomerAdapter,
         callback: CustomerSheetResultCallback,
+        statusBarColor: () -> Int?,
     ): CustomerSessionComponent {
         val shouldCreateNewComponent = configuration != backingComponent?.configuration ||
             customerAdapter != backingComponent?.customerAdapter ||
@@ -31,6 +32,7 @@ internal class CustomerSessionViewModel(
                 .configuration(configuration)
                 .customerAdapter(customerAdapter)
                 .callback(callback)
+                .statusBarColor(statusBarColor)
                 .customerSessionViewModel(this)
                 .build()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -235,6 +235,7 @@ class CustomerSheet @Inject internal constructor(
                 lifecycleOwner = activity,
                 viewModelStoreOwner = activity,
                 activityResultRegistryOwner = activity,
+                statusBarColor = { activity.window.statusBarColor },
                 configuration = configuration,
                 customerAdapter = customerAdapter,
                 callback = callback,
@@ -260,6 +261,7 @@ class CustomerSheet @Inject internal constructor(
                 viewModelStoreOwner = fragment,
                 activityResultRegistryOwner = (fragment.host as? ActivityResultRegistryOwner)
                     ?: fragment.requireActivity(),
+                statusBarColor = { fragment.activity?.window?.statusBarColor },
                 configuration = configuration,
                 customerAdapter = customerAdapter,
                 callback = callback,
@@ -270,6 +272,7 @@ class CustomerSheet @Inject internal constructor(
             lifecycleOwner: LifecycleOwner,
             viewModelStoreOwner: ViewModelStoreOwner,
             activityResultRegistryOwner: ActivityResultRegistryOwner,
+            statusBarColor: () -> Int?,
             configuration: Configuration,
             customerAdapter: CustomerAdapter,
             callback: CustomerSheetResultCallback,
@@ -281,6 +284,7 @@ class CustomerSheet @Inject internal constructor(
                 configuration = configuration,
                 customerAdapter = customerAdapter,
                 callback = callback,
+                statusBarColor = statusBarColor,
             )
 
             val customerSheetComponent: CustomerSheetComponent =

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetActivity.kt
@@ -43,6 +43,11 @@ internal class CustomerSheetActivity : AppCompatActivity() {
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
+        viewModel.registerFromActivity(
+            activityResultCaller = this,
+            lifecycleOwner = this,
+        )
+
         setContent {
             StripeTheme {
                 val bottomSheetState = rememberBottomSheetState()

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetCompose.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetCompose.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import com.stripe.android.utils.rememberActivityOrNull
 
 /**
  * Creates a [CustomerSheet] that is remembered across compositions.
@@ -34,6 +35,7 @@ fun rememberCustomerSheet(
     }
 
     val lifecycleOwner = LocalLifecycleOwner.current
+    val activity = rememberActivityOrNull()
 
     return remember(configuration) {
         CustomerSheet.getInstance(
@@ -43,6 +45,7 @@ fun rememberCustomerSheet(
             configuration = configuration,
             customerAdapter = customerAdapter,
             callback = callback,
+            statusBarColor = { activity?.window?.statusBarColor },
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
@@ -46,6 +46,7 @@ internal sealed class CustomerSheetViewState(
         val primaryButtonVisible: Boolean,
         val primaryButtonLabel: String?,
         val errorMessage: String? = null,
+        val unconfirmedPaymentMethod: PaymentMethod? = null,
     ) : CustomerSheetViewState(
         savedPaymentMethods = savedPaymentMethods,
         isLiveMode = isLiveMode,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSessionComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSessionComponent.kt
@@ -45,6 +45,9 @@ internal interface CustomerSessionComponent {
         @BindsInstance
         fun callback(callback: CustomerSheetResultCallback): Builder
 
+        @BindsInstance
+        fun statusBarColor(statusBarColor: () -> Int?): Builder
+
         fun build(): CustomerSessionComponent
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -12,11 +12,16 @@ import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.IS_LIVE_MODE
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
+import com.stripe.android.core.injection.UIContext
 import com.stripe.android.customersheet.CustomerSheetViewState
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.paymentsheet.DefaultIntentConfirmationInterceptor
+import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
+import com.stripe.android.paymentsheet.injection.IS_FLOW_CONTROLLER
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.ui.core.forms.resources.LpmRepository
+import dagger.Binds
 import dagger.Lazy
 import dagger.Module
 import dagger.Provides
@@ -30,91 +35,107 @@ import kotlin.coroutines.CoroutineContext
         FormViewModelSubcomponent::class,
     ]
 )
-internal class CustomerSheetViewModelModule {
+internal interface CustomerSheetViewModelModule {
 
-    /**
-     * Provides a non-singleton PaymentConfiguration.
-     *
-     * Should be fetched only when it's needed, to allow client to set the publishableKey and
-     * stripeAccountId in PaymentConfiguration any time before presenting Customer Sheet.
-     *
-     * Should always be injected with [Lazy] or [Provider].
-     */
-    @Provides
-    fun paymentConfiguration(application: Application): PaymentConfiguration {
-        return PaymentConfiguration.getInstance(application)
-    }
+    @Binds
+    fun bindsIntentConfirmationInterceptor(
+        impl: DefaultIntentConfirmationInterceptor,
+    ): IntentConfirmationInterceptor
 
-    @Provides
-    @Named(PUBLISHABLE_KEY)
-    fun providePublishableKey(
-        paymentConfiguration: Provider<PaymentConfiguration>
-    ): () -> String = { paymentConfiguration.get().publishableKey }
+    @Suppress("TooManyFunctions")
+    companion object {
+        /**
+         * Provides a non-singleton PaymentConfiguration.
+         *
+         * Should be fetched only when it's needed, to allow client to set the publishableKey and
+         * stripeAccountId in PaymentConfiguration any time before presenting Customer Sheet.
+         *
+         * Should always be injected with [Lazy] or [Provider].
+         */
+        @Provides
+        fun paymentConfiguration(application: Application): PaymentConfiguration {
+            return PaymentConfiguration.getInstance(application)
+        }
 
-    @Provides
-    @Named(STRIPE_ACCOUNT_ID)
-    fun provideStripeAccountId(
-        paymentConfiguration: Provider<PaymentConfiguration>
-    ): () -> String? = { paymentConfiguration.get().stripeAccountId }
+        @Provides
+        @Named(PUBLISHABLE_KEY)
+        fun providePublishableKey(
+            paymentConfiguration: Provider<PaymentConfiguration>
+        ): () -> String = { paymentConfiguration.get().publishableKey }
 
-    @Provides
-    @Named(IS_LIVE_MODE)
-    fun isLiveMode(
-        paymentConfiguration: Provider<PaymentConfiguration>
-    ): () -> Boolean = { paymentConfiguration.get().publishableKey.startsWith("pk_live") }
+        @Provides
+        @Named(STRIPE_ACCOUNT_ID)
+        fun provideStripeAccountId(
+            paymentConfiguration: Provider<PaymentConfiguration>
+        ): () -> String? = { paymentConfiguration.get().stripeAccountId }
 
-    @Provides
-    fun resources(application: Application): Resources {
-        return application.resources
-    }
+        @Provides
+        @Named(IS_LIVE_MODE)
+        fun isLiveMode(
+            paymentConfiguration: Provider<PaymentConfiguration>
+        ): () -> Boolean = { paymentConfiguration.get().publishableKey.startsWith("pk_live") }
 
-    @Provides
-    fun context(application: Application): Context {
-        return application
-    }
+        @Provides
+        fun resources(application: Application): Resources {
+            return application.resources
+        }
 
-    @Provides
-    @IOContext
-    fun ioContext(): CoroutineContext {
-        return Dispatchers.IO
-    }
+        @Provides
+        fun context(application: Application): Context {
+            return application
+        }
 
-    @Provides
-    fun provideLpmRepository(resources: Resources): LpmRepository {
-        return LpmRepository.getInstance(
-            LpmRepository.LpmRepositoryArguments(resources)
+        @Provides
+        @IOContext
+        fun ioContext(): CoroutineContext {
+            return Dispatchers.IO
+        }
+
+        @Provides
+        @UIContext
+        fun uiContext(): CoroutineContext {
+            return Dispatchers.Main
+        }
+
+        @Provides
+        fun provideLpmRepository(resources: Resources): LpmRepository {
+            return LpmRepository.getInstance(
+                LpmRepository.LpmRepositoryArguments(resources)
+            )
+        }
+
+        @Provides
+        @Named(PRODUCT_USAGE)
+        fun provideProductUsageTokens() = setOf("CustomerSheet")
+
+        @Provides
+        @Named(ENABLE_LOGGING)
+        fun providesEnableLogging(): Boolean = BuildConfig.DEBUG
+
+        @Provides
+        fun provideLogger(@Named(ENABLE_LOGGING) enableLogging: Boolean) =
+            Logger.getInstance(enableLogging)
+
+        @Provides
+        fun provideLocale() =
+            LocaleListCompat.getAdjustedDefault().takeUnless { it.isEmpty }?.get(0)
+
+        @Provides
+        fun backstack(
+            @Named(IS_LIVE_MODE) isLiveModeProvider: () -> Boolean
+        ): List<CustomerSheetViewState> = listOf(
+            CustomerSheetViewState.Loading(
+                isLiveMode = isLiveModeProvider()
+            )
         )
-    }
 
-    @Provides
-    @Named(PRODUCT_USAGE)
-    fun provideProductUsageTokens() = setOf("CustomerSheet")
+        @Provides
+        @Named(IS_FLOW_CONTROLLER)
+        fun provideIsFlowController() = false
 
-    @Provides
-    @Named(ENABLE_LOGGING)
-    fun providesEnableLogging(): Boolean = BuildConfig.DEBUG
+        @Provides
+        fun savedPaymentSelection(): PaymentSelection? = savedPaymentSelection
 
-    @Provides
-    fun provideLogger(@Named(ENABLE_LOGGING) enableLogging: Boolean) =
-        Logger.getInstance(enableLogging)
-
-    @Provides
-    fun provideLocale() =
-        LocaleListCompat.getAdjustedDefault().takeUnless { it.isEmpty }?.get(0)
-
-    @Provides
-    fun backstack(
-        @Named(IS_LIVE_MODE) isLiveModeProvider: () -> Boolean
-    ): List<CustomerSheetViewState> = listOf(
-        CustomerSheetViewState.Loading(
-            isLiveMode = isLiveModeProvider()
-        )
-    )
-
-    @Provides
-    fun savedPaymentSelection(): PaymentSelection? = savedPaymentSelection
-
-    private companion object {
         private val savedPaymentSelection: PaymentSelection? = null
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -623,7 +623,8 @@ class CustomerAdapterTest {
                 googlePayEnabled = true
             ),
             customerAdapter = adapter,
-            callback = {}
+            callback = {},
+            statusBarColor = { null },
         )
 
         val result = adapter.retrieveSelectedPaymentOption()
@@ -653,7 +654,8 @@ class CustomerAdapterTest {
                 googlePayEnabled = false
             ),
             customerAdapter = adapter,
-            callback = {}
+            callback = {},
+            statusBarColor = { null },
         )
 
         val result = adapter.retrieveSelectedPaymentOption()

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSessionViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSessionViewModelTest.kt
@@ -45,6 +45,7 @@ class CustomerSessionViewModelTest {
                 setupIntentClientSecretProvider = null,
             ),
             callback = { },
+            statusBarColor = { null },
         )
 
         val component2 = viewModel.createCustomerSessionComponent(
@@ -64,6 +65,7 @@ class CustomerSessionViewModelTest {
                 setupIntentClientSecretProvider = null,
             ),
             callback = { },
+            statusBarColor = { null },
         )
 
         assertThat(component1).isNotEqualTo(component2)
@@ -79,6 +81,7 @@ class CustomerSessionViewModelTest {
             ),
             customerAdapter = customerAdapter,
             callback = callback,
+            statusBarColor = { null },
         )
 
         val component2 = viewModel.createCustomerSessionComponent(
@@ -87,6 +90,7 @@ class CustomerSessionViewModelTest {
             ),
             customerAdapter = customerAdapter,
             callback = callback,
+            statusBarColor = { null },
         )
 
         assertThat(component1).isNotEqualTo(component2)
@@ -102,12 +106,14 @@ class CustomerSessionViewModelTest {
             configuration = configuration,
             customerAdapter = customerAdapter,
             callback = callback,
+            statusBarColor = { null },
         )
 
         val component2 = viewModel.createCustomerSessionComponent(
             configuration = configuration,
             customerAdapter = customerAdapter,
             callback = callback,
+            statusBarColor = { null },
         )
 
         assertThat(component1).isEqualTo(component2)
@@ -126,6 +132,7 @@ class CustomerSessionViewModelTest {
             configuration = mock(),
             customerAdapter = mock(),
             callback = mock(),
+            statusBarColor = { null },
         )
 
         assertThat(component).isEqualTo(CustomerSessionViewModel.component)
@@ -137,6 +144,7 @@ class CustomerSessionViewModelTest {
             configuration = mock(),
             customerAdapter = mock(),
             callback = mock(),
+            statusBarColor = { null },
         )
 
         assertThat(component).isEqualTo(CustomerSessionViewModel.component)

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTestHelper.kt
@@ -116,7 +116,8 @@ object CustomerSheetTestHelper {
                 GooglePayRepository {
                     flowOf(isGooglePayAvailable)
                 }
-            }
+            },
+            statusBarColor = { null },
         ).apply {
             registerFromActivity(DummyActivityResultCaller(), TestLifecycleOwner())
         }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeStripeRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeStripeRepository.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.customersheet
 
 import com.stripe.android.core.networking.ApiRequest
-import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.SetupIntent
@@ -9,7 +8,7 @@ import com.stripe.android.testing.AbsFakeStripeRepository
 
 class FakeStripeRepository(
     private val createPaymentMethodResult: Result<PaymentMethod> = Result.failure(NotImplementedError()),
-    private val confirmSetupIntentResult: Result<SetupIntent> = Result.failure(NotImplementedError())
+    private val retrieveSetupIntent: Result<SetupIntent> = Result.failure(NotImplementedError())
 ) : AbsFakeStripeRepository() {
 
     override suspend fun createPaymentMethod(
@@ -19,11 +18,11 @@ class FakeStripeRepository(
         return createPaymentMethodResult
     }
 
-    override suspend fun confirmSetupIntent(
-        confirmSetupIntentParams: ConfirmSetupIntentParams,
+    override suspend fun retrieveSetupIntent(
+        clientSecret: String,
         options: ApiRequest.Options,
         expandFields: List<String>
     ): Result<SetupIntent> {
-        return confirmSetupIntentResult
+        return retrieveSetupIntent
     }
 }


### PR DESCRIPTION
# Summary

Add ability to handle next actions.

[3ds2.webm](https://github.com/stripe/stripe-android/assets/99316447/4d8afced-2a90-41d3-8eb7-3d70cfd4fc1b)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Some setup intents require next actions such as 3DS2, this PR adds the interceptor and payment launcher to handle these next actions.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

