### PR TITLE
Make `PaymentSheetLoader` return `Result<T>` instead of custom type

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -26,7 +26,7 @@
     <ID>LongMethod:FormViewModelTest.kt$FormViewModelTest$@Test fun `Verify params are set when required address fields are complete`()</ID>
     <ID>LongMethod:PaymentOptionFactory.kt$PaymentOptionFactory$fun create(selection: PaymentSelection): PaymentOption</ID>
     <ID>LongMethod:PaymentSheetConfigurationKtx.kt$internal fun PaymentSheet.Appearance.parseAppearance()</ID>
-    <ID>LongMethod:PaymentSheetLoader.kt$DefaultPaymentSheetLoader$private suspend fun create( elementsSession: ElementsSession, config: PaymentSheet.Configuration?, isGooglePayReady: Boolean, ): PaymentSheetLoader.Result</ID>
+    <ID>LongMethod:PaymentSheetLoader.kt$DefaultPaymentSheetLoader$private suspend fun create( elementsSession: ElementsSession, config: PaymentSheet.Configuration?, isGooglePayReady: Boolean, ): PaymentSheetState.Full</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable internal fun USBankAccountForm( formArgs: FormArguments, sheetViewModel: BaseSheetViewModel, isProcessing: Boolean, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable private fun AccountDetailsForm( formArgs: FormArguments, isProcessing: Boolean, bankName: String?, last4: String?, saveForFutureUseElement: SaveForFutureUseElement, onRemoveAccount: () -> Unit, )</ID>
     <ID>MagicNumber:AutocompleteScreen.kt$0.07f</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -288,15 +288,15 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             paymentSheetLoader.load(args.initializationMode, args.config)
         }
 
-        when (result) {
-            is PaymentSheetLoader.Result.Success -> {
-                handlePaymentSheetStateLoaded(result.state)
-            }
-            is PaymentSheetLoader.Result.Failure -> {
+        result.fold(
+            onSuccess = { state ->
+                handlePaymentSheetStateLoaded(state)
+            },
+            onFailure = { error ->
                 setStripeIntent(null)
-                onFatal(result.throwable)
+                onFatal(error)
             }
-        }
+        )
     }
 
     private fun handlePaymentSheetStateLoaded(state: PaymentSheetState.Full) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
@@ -85,16 +85,17 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
         }
 
         AnalyticsRequestFactory.regenerateSessionId()
-        when (val result = paymentSheetLoader.load(initializationMode, configuration)) {
-            is PaymentSheetLoader.Result.Success -> {
+
+        paymentSheetLoader.load(initializationMode, configuration).fold(
+            onSuccess = { state ->
                 viewModel.previousConfigureRequest = configureRequest
-                onInitSuccess(result.state, configureRequest)
+                onInitSuccess(state, configureRequest)
                 onConfigured()
+            },
+            onFailure = { error ->
+                onConfigured(error = error)
             }
-            is PaymentSheetLoader.Result.Failure -> {
-                onConfigured(error = result.throwable)
-            }
-        }
+        )
     }
 
     private fun onInitSuccess(

--- a/paymentsheet/src/test/java/com/stripe/android/utils/DelayingPaymentSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/DelayingPaymentSheetLoader.kt
@@ -9,14 +9,14 @@ import kotlinx.coroutines.channels.Channel
 
 internal class DelayingPaymentSheetLoader : PaymentSheetLoader {
 
-    private val results = Channel<PaymentSheetLoader.Result>(capacity = 1)
+    private val results = Channel<Result<PaymentSheetState.Full>>(capacity = 1)
 
     fun enqueueSuccess(
         stripeIntent: StripeIntent = PaymentIntentFactory.create(),
     ) {
         enqueue(
-            PaymentSheetLoader.Result.Success(
-                state = PaymentSheetState.Full(
+            Result.success(
+                PaymentSheetState.Full(
                     stripeIntent = stripeIntent,
                     customerPaymentMethods = emptyList(),
                     config = null,
@@ -30,17 +30,17 @@ internal class DelayingPaymentSheetLoader : PaymentSheetLoader {
 
     fun enqueueFailure() {
         val error = RuntimeException("whoops")
-        enqueue(PaymentSheetLoader.Result.Failure(error))
+        enqueue(Result.failure<PaymentSheetState.Full>(error))
     }
 
-    private fun enqueue(result: PaymentSheetLoader.Result) {
+    private fun enqueue(result: Result<PaymentSheetState.Full>) {
         results.trySend(result)
     }
 
     override suspend fun load(
         initializationMode: PaymentSheet.InitializationMode,
         paymentSheetConfiguration: PaymentSheet.Configuration?
-    ): PaymentSheetLoader.Result {
+    ): Result<PaymentSheetState.Full> {
         return results.receive()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
@@ -31,13 +31,13 @@ internal class FakePaymentSheetLoader(
     override suspend fun load(
         initializationMode: PaymentSheet.InitializationMode,
         paymentSheetConfiguration: PaymentSheet.Configuration?
-    ): PaymentSheetLoader.Result {
+    ): Result<PaymentSheetState.Full> {
         delay(delay)
         return if (shouldFail) {
-            PaymentSheetLoader.Result.Failure(IllegalStateException("oh no"))
+            Result.failure(IllegalStateException("oh no"))
         } else {
-            PaymentSheetLoader.Result.Success(
-                state = PaymentSheetState.Full(
+            Result.success(
+                PaymentSheetState.Full(
                     config = paymentSheetConfiguration,
                     stripeIntent = stripeIntent,
                     customerPaymentMethods = customerPaymentMethods,

--- a/paymentsheet/src/test/java/com/stripe/android/utils/RelayingPaymentSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/RelayingPaymentSheetLoader.kt
@@ -9,14 +9,14 @@ import kotlinx.coroutines.channels.Channel
 
 internal class RelayingPaymentSheetLoader : PaymentSheetLoader {
 
-    private val results = Channel<PaymentSheetLoader.Result>(capacity = 1)
+    private val results = Channel<Result<PaymentSheetState.Full>>(capacity = 1)
 
     fun enqueueSuccess(
         stripeIntent: StripeIntent = PaymentIntentFactory.create(),
     ) {
         enqueue(
-            PaymentSheetLoader.Result.Success(
-                state = PaymentSheetState.Full(
+            Result.success(
+                PaymentSheetState.Full(
                     stripeIntent = stripeIntent,
                     customerPaymentMethods = emptyList(),
                     config = null,
@@ -30,17 +30,17 @@ internal class RelayingPaymentSheetLoader : PaymentSheetLoader {
 
     fun enqueueFailure() {
         val error = RuntimeException("whoops")
-        enqueue(PaymentSheetLoader.Result.Failure(error))
+        enqueue(Result.failure<PaymentSheetState.Full>(error))
     }
 
-    private fun enqueue(result: PaymentSheetLoader.Result) {
+    private fun enqueue(result: Result<PaymentSheetState.Full>) {
         results.trySend(result)
     }
 
     override suspend fun load(
         initializationMode: PaymentSheet.InitializationMode,
         paymentSheetConfiguration: PaymentSheet.Configuration?
-    ): PaymentSheetLoader.Result {
+    ): Result<PaymentSheetState.Full> {
         return results.receive()
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates `PaymentSheetLoader` to use `Result<PaymentSheetState.Full` instead of its own `Result` class as its return type.

This simplifies the error handling and prepares us for https://github.com/stripe/stripe-android/pull/7117.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
