### PR TITLE
Fix retrieve initial payment selection

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/playground/CustomerSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/playground/CustomerSheetPlaygroundActivity.kt
@@ -74,7 +74,7 @@ class CustomerSheetPlaygroundActivity : AppCompatActivity() {
                     callback = viewModel::onCustomerSheetResult,
                 )
 
-                LaunchedEffect(configurationState.isExistingCustomer) {
+                LaunchedEffect(viewState) {
                     val result = customerSheet.retrievePaymentOptionSelection()
                     viewModel.onCustomerSheetResult(result)
                 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Fix an issue where the initial payment selection was not being properly updated from the activity.

