### PR TITLE
Fix invalid setup intent handling

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -474,7 +474,8 @@ internal class CustomerSheetViewModel @Inject constructor(
                 )
                 updateViewState<CustomerSheetViewState.AddPaymentMethod> {
                     it.copy(
-                        errorMessage = displayMessage,
+                        errorMessage = displayMessage ?: cause.stripeErrorMessage(application),
+                        enabled = true,
                         isProcessing = false,
                     )
                 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -727,13 +727,13 @@ class CustomerSheetViewModelTest {
             customerAdapter = FakeCustomerAdapter(
                 canCreateSetupIntents = true,
                 onSetupIntentClientSecretForCustomerAttach = {
-                    CustomerAdapter.Result.success("seti_123")
+                    CustomerAdapter.Result.success("invalid setup intent")
                 },
             ),
             stripeRepository = FakeStripeRepository(
                 createPaymentMethodResult = Result.success(CARD_PAYMENT_METHOD),
                 retrieveSetupIntent = Result.failure(
-                    APIException(stripeError = StripeError(message = "Could not attach payment method."))
+                    IllegalArgumentException("Invalid setup intent")
                 ),
             ),
         )
@@ -747,7 +747,8 @@ class CustomerSheetViewModelTest {
             assertThat(awaitViewState<AddPaymentMethod>().isProcessing).isTrue()
 
             viewState = awaitViewState()
-            assertThat(viewState.errorMessage).isEqualTo("Could not attach payment method.")
+            assertThat(viewState.errorMessage).isEqualTo("Something went wrong")
+            assertThat(viewState.enabled).isTrue()
             assertThat(viewState.isProcessing).isFalse()
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Fix an issue where an invalid setup intent would not show an error in Customer Sheet. This was happening because the call `stripeRepository.retrieveSetupIntent(...)` was returning an `IllegalArgumentException`. Our display message handling (in `onFailure`) assumed that the exception is a `StripeException`. 

The fix here is to see if displayMessage is null, if so, we fallback to the default error message.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

