### PR TITLE
Add rounded corners to `BottomSheet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+### PaymentSheet
+* [CHANGED][7144](https://github.com/stripe/stripe-android/pull/7144) PaymentSheet now features rounded corners with the radius provided in `PaymentSheet.Shapes.cornerRadiusDp`.
+
 ## 20.28.3 - 2023-08-21
 
 ### Financial Connections

--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheet.kt
@@ -10,7 +10,9 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ModalBottomSheetDefaults
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetState
@@ -28,8 +30,10 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.stripe.android.paymentsheet.BuildConfig
+import com.stripe.android.uicore.stripeShapes
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 
@@ -164,6 +168,10 @@ internal fun BottomSheet(
             .statusBarsPadding()
             .imePadding(),
         sheetState = state.modalBottomSheetState,
+        sheetShape = RoundedCornerShape(
+            topStart = MaterialTheme.stripeShapes.cornerRadius.dp,
+            topEnd = MaterialTheme.stripeShapes.cornerRadius.dp,
+        ),
         sheetContent = {
             Box(modifier = Modifier.testTag(BottomSheetContentTestTag)) {
                 sheetContent()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds rounded corners to `BottomSheet` for a more modern look. We use the rounded corners value as provided in `PaymentSheet.Configuration` to nicely fit in with the merchant’s desired look.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

UX polish.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before | After |
| ------------- | ------------- |
| ![straight-corners](https://github.com/stripe/stripe-android/assets/110940675/b11a0e66-ed85-4834-ad5b-755eeda2f27b) | ![rounded-corners](https://github.com/stripe/stripe-android/assets/110940675/02d7d110-2e36-414b-a339-3c38085d3de7) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
