### PR TITLE
Remove publishable key from CustomerRepository

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.testing
 
 import com.stripe.android.cards.Bin
-import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.model.StripeFile
 import com.stripe.android.core.model.StripeFileParams
 import com.stripe.android.core.networking.ApiRequest
@@ -153,7 +152,6 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         TODO("Not yet implemented")
     }
 
-    @Throws(APIException::class)
     override suspend fun attachPaymentMethod(
         customerId: String,
         productUsageTokens: Set<String>,
@@ -163,7 +161,6 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         TODO("Not yet implemented")
     }
 
-    @Throws(APIException::class)
     override suspend fun detachPaymentMethod(
         productUsageTokens: Set<String>,
         paymentMethodId: String,
@@ -172,7 +169,6 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         TODO("Not yet implemented")
     }
 
-    @Throws(APIException::class)
     override suspend fun getPaymentMethods(
         listPaymentMethodsParams: ListPaymentMethodsParams,
         productUsageTokens: Set<String>,

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -156,7 +156,6 @@ abstract class AbsFakeStripeRepository : StripeRepository {
     @Throws(APIException::class)
     override suspend fun attachPaymentMethod(
         customerId: String,
-        publishableKey: String,
         productUsageTokens: Set<String>,
         paymentMethodId: String,
         requestOptions: ApiRequest.Options
@@ -166,7 +165,6 @@ abstract class AbsFakeStripeRepository : StripeRepository {
 
     @Throws(APIException::class)
     override suspend fun detachPaymentMethod(
-        publishableKey: String,
         productUsageTokens: Set<String>,
         paymentMethodId: String,
         requestOptions: ApiRequest.Options
@@ -177,7 +175,6 @@ abstract class AbsFakeStripeRepository : StripeRepository {
     @Throws(APIException::class)
     override suspend fun getPaymentMethods(
         listPaymentMethodsParams: ListPaymentMethodsParams,
-        publishableKey: String,
         productUsageTokens: Set<String>,
         requestOptions: ApiRequest.Options
     ): Result<List<PaymentMethod>> {

--- a/payments-core/src/main/java/com/stripe/android/CustomerSessionOperationExecutor.kt
+++ b/payments-core/src/main/java/com/stripe/android/CustomerSessionOperationExecutor.kt
@@ -73,7 +73,6 @@ internal class CustomerSessionOperationExecutor(
             is EphemeralOperation.Customer.AttachPaymentMethod -> {
                 val result = stripeRepository.attachPaymentMethod(
                     customerId = ephemeralKey.objectId,
-                    publishableKey = publishableKey,
                     productUsageTokens = operation.productUsage,
                     paymentMethodId = operation.paymentMethodId,
                     requestOptions = ApiRequest.Options(ephemeralKey.secret, stripeAccountId),
@@ -93,7 +92,6 @@ internal class CustomerSessionOperationExecutor(
             }
             is EphemeralOperation.Customer.DetachPaymentMethod -> {
                 val result = stripeRepository.detachPaymentMethod(
-                    publishableKey = publishableKey,
                     productUsageTokens = operation.productUsage,
                     paymentMethodId = operation.paymentMethodId,
                     requestOptions = ApiRequest.Options(ephemeralKey.secret, stripeAccountId),
@@ -120,7 +118,6 @@ internal class CustomerSessionOperationExecutor(
                         endingBefore = operation.endingBefore,
                         startingAfter = operation.startingAfter,
                     ),
-                    publishableKey = publishableKey,
                     productUsageTokens = operation.productUsage,
                     requestOptions = ApiRequest.Options(ephemeralKey.secret, stripeAccountId),
                 )

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -633,7 +633,6 @@ class StripeApiRepository @JvmOverloads internal constructor(
      */
     override suspend fun attachPaymentMethod(
         customerId: String,
-        publishableKey: String,
         productUsageTokens: Set<String>,
         paymentMethodId: String,
         requestOptions: ApiRequest.Options
@@ -665,7 +664,6 @@ class StripeApiRepository @JvmOverloads internal constructor(
         CardException::class
     )
     override suspend fun detachPaymentMethod(
-        publishableKey: String,
         productUsageTokens: Set<String>,
         paymentMethodId: String,
         requestOptions: ApiRequest.Options
@@ -690,7 +688,6 @@ class StripeApiRepository @JvmOverloads internal constructor(
      */
     override suspend fun getPaymentMethods(
         listPaymentMethodsParams: ListPaymentMethodsParams,
-        publishableKey: String,
         productUsageTokens: Set<String>,
         requestOptions: ApiRequest.Options
     ): Result<List<PaymentMethod>> {

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -145,7 +145,6 @@ interface StripeRepository {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun attachPaymentMethod(
         customerId: String,
-        publishableKey: String,
         productUsageTokens: Set<String>,
         paymentMethodId: String,
         requestOptions: ApiRequest.Options
@@ -153,7 +152,6 @@ interface StripeRepository {
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun detachPaymentMethod(
-        publishableKey: String,
         productUsageTokens: Set<String>,
         paymentMethodId: String,
         requestOptions: ApiRequest.Options
@@ -162,7 +160,6 @@ interface StripeRepository {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun getPaymentMethods(
         listPaymentMethodsParams: ListPaymentMethodsParams,
-        publishableKey: String,
         productUsageTokens: Set<String>,
         requestOptions: ApiRequest.Options
     ): Result<List<PaymentMethod>>

--- a/payments-core/src/test/java/com/stripe/android/CustomerSessionOperationExecutorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/CustomerSessionOperationExecutorTest.kt
@@ -45,7 +45,6 @@ internal class CustomerSessionOperationExecutorTest {
             object : AbsFakeStripeRepository() {
                 override suspend fun attachPaymentMethod(
                     customerId: String,
-                    publishableKey: String,
                     productUsageTokens: Set<String>,
                     paymentMethodId: String,
                     requestOptions: ApiRequest.Options
@@ -79,7 +78,6 @@ internal class CustomerSessionOperationExecutorTest {
             object : AbsFakeStripeRepository() {
                 override suspend fun attachPaymentMethod(
                     customerId: String,
-                    publishableKey: String,
                     productUsageTokens: Set<String>,
                     paymentMethodId: String,
                     requestOptions: ApiRequest.Options

--- a/payments-core/src/test/java/com/stripe/android/CustomerSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/CustomerSessionTest.kt
@@ -103,29 +103,26 @@ internal class CustomerSessionTest {
 
             whenever(
                 stripeRepository.attachPaymentMethod(
-                    any(),
-                    eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
-                    any(),
-                    any(),
-                    any()
+                    customerId = any(),
+                    productUsageTokens = any(),
+                    paymentMethodId = any(),
+                    requestOptions = any()
                 )
             ).thenReturn(Result.success(PAYMENT_METHOD))
 
             whenever(
                 stripeRepository.detachPaymentMethod(
-                    eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
-                    any(),
-                    any(),
-                    any()
+                    productUsageTokens = any(),
+                    paymentMethodId = any(),
+                    requestOptions = any()
                 )
             ).thenReturn(Result.success(PAYMENT_METHOD))
 
             whenever(
                 stripeRepository.getPaymentMethods(
-                    any(),
-                    eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
-                    any(),
-                    any()
+                    listPaymentMethodsParams = any(),
+                    productUsageTokens = any(),
+                    requestOptions = any()
                 )
             ).thenReturn(Result.success(listOf(PAYMENT_METHOD)))
 
@@ -165,11 +162,10 @@ internal class CustomerSessionTest {
         idleLooper()
 
         verify(stripeRepository).attachPaymentMethod(
-            any(),
-            eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
-            eq(DEFAULT_PRODUCT_USAGE),
-            any(),
-            any()
+            customerId = any(),
+            productUsageTokens = eq(DEFAULT_PRODUCT_USAGE),
+            paymentMethodId = any(),
+            requestOptions = any()
         )
     }
 
@@ -569,11 +565,10 @@ internal class CustomerSessionTest {
 
         assertNotNull(FIRST_CUSTOMER.id)
         verify(stripeRepository).attachPaymentMethod(
-            eq(FIRST_CUSTOMER.id.orEmpty()),
-            eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
-            eq(expectedProductUsage),
-            eq("pm_abc123"),
-            requestOptionsArgumentCaptor.capture()
+            customerId = eq(FIRST_CUSTOMER.id.orEmpty()),
+            productUsageTokens = eq(expectedProductUsage),
+            paymentMethodId = eq("pm_abc123"),
+            requestOptions = requestOptionsArgumentCaptor.capture()
         )
         assertEquals(
             EphemeralKeyFixtures.FIRST.secret,
@@ -640,10 +635,9 @@ internal class CustomerSessionTest {
 
         assertNotNull(FIRST_CUSTOMER.id)
         verify(stripeRepository).detachPaymentMethod(
-            eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
-            eq(expectedProductUsage),
-            eq("pm_abc123"),
-            requestOptionsArgumentCaptor.capture()
+            productUsageTokens = eq(expectedProductUsage),
+            paymentMethodId = eq("pm_abc123"),
+            requestOptions = requestOptionsArgumentCaptor.capture()
         )
         assertEquals(
             EphemeralKeyFixtures.FIRST.secret,
@@ -705,15 +699,14 @@ internal class CustomerSessionTest {
 
         assertNotNull(FIRST_CUSTOMER.id)
         verify(stripeRepository).getPaymentMethods(
-            eq(
+            listPaymentMethodsParams = eq(
                 ListPaymentMethodsParams(
                     customerId = FIRST_CUSTOMER.id.orEmpty(),
                     paymentMethodType = PaymentMethod.Type.Card
                 )
             ),
-            eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
-            eq(expectedProductUsage),
-            requestOptionsArgumentCaptor.capture()
+            productUsageTokens = eq(expectedProductUsage),
+            requestOptions = requestOptionsArgumentCaptor.capture()
         )
         assertEquals(
             EphemeralKeyFixtures.FIRST.secret,
@@ -765,11 +758,10 @@ internal class CustomerSessionTest {
 
         whenever(
             stripeRepository.attachPaymentMethod(
-                any(),
-                eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
-                any(),
-                any(),
-                any()
+                customerId = any(),
+                productUsageTokens = any(),
+                paymentMethodId = any(),
+                requestOptions = any()
             )
         ).thenReturn(
             Result.failure(APIException(statusCode = 404, message = "The payment method is invalid"))
@@ -777,10 +769,9 @@ internal class CustomerSessionTest {
 
         whenever(
             stripeRepository.detachPaymentMethod(
-                eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
-                any(),
-                any(),
-                any()
+                productUsageTokens = any(),
+                paymentMethodId = any(),
+                requestOptions = any()
             )
         ).thenReturn(
             Result.failure(APIException(statusCode = 404, message = "The payment method does not exist"))
@@ -788,10 +779,9 @@ internal class CustomerSessionTest {
 
         whenever(
             stripeRepository.getPaymentMethods(
-                any(),
-                eq(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY),
-                any(),
-                any()
+                listPaymentMethodsParams = any(),
+                productUsageTokens = any(),
+                requestOptions = any()
             )
         ).thenReturn(
             Result.failure(APIException(statusCode = 404, message = "The payment method does not exist"))

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -1031,13 +1031,12 @@ internal class StripeApiRepositoryTest {
         val stripeApiRepository = create()
         val paymentMethods = stripeApiRepository
             .getPaymentMethods(
-                ListPaymentMethodsParams(
+                listPaymentMethodsParams = ListPaymentMethodsParams(
                     "cus_123",
                     PaymentMethod.Type.Card
                 ),
-                DEFAULT_OPTIONS.apiKey,
-                emptySet(),
-                ApiRequest.Options(ApiKeyFixtures.FAKE_EPHEMERAL_KEY)
+                productUsageTokens = emptySet(),
+                requestOptions = ApiRequest.Options(ApiKeyFixtures.FAKE_EPHEMERAL_KEY)
             ).getOrThrow()
         assertThat(paymentMethods)
             .hasSize(3)
@@ -1089,13 +1088,12 @@ internal class StripeApiRepositoryTest {
         val stripeApiRepository = create()
         val paymentMethods = stripeApiRepository
             .getPaymentMethods(
-                ListPaymentMethodsParams(
+                listPaymentMethodsParams = ListPaymentMethodsParams(
                     "cus_123",
                     PaymentMethod.Type.Card
                 ),
-                DEFAULT_OPTIONS.apiKey,
-                emptySet(),
-                ApiRequest.Options(ApiKeyFixtures.FAKE_EPHEMERAL_KEY)
+                productUsageTokens = emptySet(),
+                requestOptions = ApiRequest.Options(ApiKeyFixtures.FAKE_EPHEMERAL_KEY)
             ).getOrThrow()
         assertThat(paymentMethods)
             .isEmpty()

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -22,7 +22,6 @@ import com.stripe.android.paymentsheet.injection.IS_FLOW_CONTROLLER
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import dagger.Binds
-import dagger.Lazy
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.Dispatchers

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/StripeCustomerAdapterComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/StripeCustomerAdapterComponent.kt
@@ -23,7 +23,6 @@ import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import dagger.Binds
 import dagger.BindsInstance
 import dagger.Component
-import dagger.Lazy
 import dagger.Module
 import dagger.Provides
 import java.util.Calendar

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
@@ -57,7 +57,6 @@ internal class CustomerApiRepository @Inject constructor(
                         customerId = customerConfig.id,
                         paymentMethodType = paymentMethodType,
                     ),
-                    publishableKey = lazyPaymentConfig.get().publishableKey,
                     productUsageTokens = productUsageTokens,
                     requestOptions = ApiRequest.Options(
                         apiKey = customerConfig.ephemeralKeySecret,
@@ -91,7 +90,6 @@ internal class CustomerApiRepository @Inject constructor(
         paymentMethodId: String
     ): Result<PaymentMethod> =
         stripeRepository.detachPaymentMethod(
-            publishableKey = lazyPaymentConfig.get().publishableKey,
             productUsageTokens = productUsageTokens,
             paymentMethodId = paymentMethodId,
             requestOptions = ApiRequest.Options(
@@ -108,7 +106,6 @@ internal class CustomerApiRepository @Inject constructor(
     ): Result<PaymentMethod> =
         stripeRepository.attachPaymentMethod(
             customerId = customerConfig.id,
-            publishableKey = lazyPaymentConfig.get().publishableKey,
             productUsageTokens = productUsageTokens,
             paymentMethodId = paymentMethodId,
             requestOptions = ApiRequest.Options(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
@@ -53,15 +53,14 @@ internal class CustomerRepositoryTest {
             )
 
             verify(stripeRepository).getPaymentMethods(
-                eq(
+                listPaymentMethodsParams = eq(
                     ListPaymentMethodsParams(
                         customerId = "customer_id",
                         paymentMethodType = PaymentMethod.Type.Card
                     )
                 ),
-                anyString(),
-                any(),
-                any()
+                productUsageTokens = any(),
+                requestOptions = any()
             )
         }
 
@@ -235,10 +234,9 @@ internal class CustomerRepositoryTest {
         val repository = mock<StripeRepository>()
         whenever(
             repository.getPaymentMethods(
-                any(),
-                anyString(),
-                any(),
-                any()
+                listPaymentMethodsParams = any(),
+                productUsageTokens = any(),
+                requestOptions = any()
             )
         )
             .doReturn(Result.failure(InvalidParameterException("Request Failed")))
@@ -253,7 +251,6 @@ internal class CustomerRepositoryTest {
             onBlocking {
                 getPaymentMethods(
                     listPaymentMethodsParams = any(),
-                    publishableKey = anyString(),
                     productUsageTokens = any(),
                     requestOptions = any(),
                 )
@@ -267,7 +264,6 @@ internal class CustomerRepositoryTest {
         stripeRepository.stub {
             onBlocking {
                 detachPaymentMethod(
-                    publishableKey = anyString(),
                     productUsageTokens = any(),
                     paymentMethodId = anyString(),
                     requestOptions = any(),
@@ -283,7 +279,6 @@ internal class CustomerRepositoryTest {
             onBlocking {
                 attachPaymentMethod(
                     customerId = anyString(),
-                    publishableKey = anyString(),
                     productUsageTokens = any(),
                     paymentMethodId = anyString(),
                     requestOptions = any(),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

- Remove the publishableKey argument from CustomerRepository constructor.
- Remove the publishableKey argument from several StripeRepository methods as they were not used.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Simplify the StripeRepository API

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

