### PR TITLE
Only use fallback error messages for non-Spain Spanish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+### PaymentSheet
+* [FIXED][7147](https://github.com/stripe/stripe-android/pull/7147) Fixed an issue where we displayed incorrect error messages for some languages.
+
 ## 20.28.1 - 2023-08-09
 
 ### PaymentSheet

--- a/payments-core/src/test/java/com/stripe/android/StripeErrorMappingTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripeErrorMappingTest.kt
@@ -1,0 +1,61 @@
+package com.stripe.android
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.StripeError
+import com.stripe.android.networking.withLocalizedMessage
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.Locale
+
+@RunWith(RobolectricTestRunner::class)
+class StripeErrorMappingTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `Uses backend message for non-Spanish locale`() {
+        withLocale(Locale.US) {
+            val error = StripeError(
+                code = "incorrect_number",
+                message = "The backend message",
+            )
+            val updatedError = error.withLocalizedMessage(context)
+            assertThat(updatedError).isEqualTo(error)
+        }
+    }
+
+    @Test
+    fun `Uses backend message for Spanish locale from Spain`() {
+        withLocale(Locale("es", "es")) {
+            val error = StripeError(
+                code = "incorrect_number",
+                message = "The backend message",
+            )
+            val updatedError = error.withLocalizedMessage(context)
+            assertThat(updatedError).isEqualTo(error)
+        }
+    }
+
+    @Test
+    fun `Uses client message for Spanish locale from outside Spain`() {
+        withLocale(Locale("es", "ar")) {
+            val error = StripeError(
+                code = "incorrect_number",
+                message = "The backend message",
+            )
+            val updatedError = error.withLocalizedMessage(context)
+            assertThat(updatedError).isNotEqualTo(error)
+        }
+    }
+
+    private inline fun <T> withLocale(locale: Locale, block: () -> T): T {
+        val original = Locale.getDefault()
+        Locale.setDefault(locale)
+        val result = block()
+        Locale.setDefault(original)
+        return result
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/StripeTest.java
+++ b/payments-core/src/test/java/com/stripe/android/StripeTest.java
@@ -1038,7 +1038,7 @@ public class StripeTest {
                 CardException.class,
                 () -> defaultStripe.createCardTokenSynchronous(cardParams)
         );
-        assertEquals("Your card's number is invalid.", cardException.getMessage());
+        assertEquals("Your card number is incorrect.", cardException.getMessage());
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request restricts our error message fallback logic to Spanish locales that aren’t Spain itself.

Our backend is unable to provide translated error messages for some language tags. As a solution, we started using client error messages a while ago. However, these error messages aren’t in line with the Web and iOS messages and lack some detail.

Therefore, we now only use the client error messages for the “problematic” languages. As of right now, the only languages for which we are aware of this issue are Spanish languages outside of Spain, such as in Argentina or Chile.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Resolves https://github.com/stripe/stripe-android/issues/7043

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

[FIXED] Fixed an issue where we displayed incorrect error messages for some languages.
