### PR TITLE
Improve number fields accessibility in PaymentSheet

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/Accessibility.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/Accessibility.kt
@@ -1,0 +1,5 @@
+package com.stripe.android.ui.core
+
+internal fun String.asIndividualDigits(): String {
+    return toCharArray().joinToString(separator = " ")
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -15,6 +15,7 @@ import com.stripe.android.cards.StaticCardAccountRanges
 import com.stripe.android.model.AccountRange
 import com.stripe.android.model.CardBrand
 import com.stripe.android.stripecardscan.cardscan.CardScanSheetResult
+import com.stripe.android.ui.core.asIndividualDigits
 import com.stripe.android.uicore.elements.FieldError
 import com.stripe.android.uicore.elements.SectionFieldErrorController
 import com.stripe.android.uicore.elements.TextFieldController
@@ -77,7 +78,8 @@ internal class CardNumberEditableController constructor(
     override val rawFieldValue: Flow<String> =
         _fieldValue.map { cardTextFieldConfig.convertToRaw(it) }
 
-    override val contentDescription: Flow<String> = _fieldValue
+    // This makes the screen reader read out numbers digit by digit
+    override val contentDescription: Flow<String> = _fieldValue.map { it.asIndividualDigits() }
 
     override val cardBrandFlow = _fieldValue.map {
         accountRangeService.accountRange?.brand ?: CardBrand.getCardBrands(it).firstOrNull()

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberViewOnlyController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberViewOnlyController.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 import com.stripe.android.model.CardBrand
+import com.stripe.android.ui.core.asIndividualDigits
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.TextFieldIcon
 import com.stripe.android.uicore.elements.TextFieldState
@@ -41,7 +42,8 @@ internal class CardNumberViewOnlyController(
 
     override val rawFieldValue = fieldValue
 
-    override val contentDescription = fieldValue
+    // This makes the screen reader read out numbers digit by digit
+    override val contentDescription: Flow<String> = _fieldValue.map { it.asIndividualDigits() }
 
     override val cardBrandFlow = flowOf(
         initialValues[IdentifierSpec.CardBrand]?.let {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.autofill.AutofillType
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import com.stripe.android.model.CardBrand
+import com.stripe.android.ui.core.asIndividualDigits
 import com.stripe.android.uicore.elements.FieldError
 import com.stripe.android.uicore.elements.SectionFieldErrorController
 import com.stripe.android.uicore.elements.TextFieldController
@@ -50,7 +51,7 @@ class CvcController constructor(
         _fieldValue.map { cvcTextFieldConfig.convertToRaw(it) }
 
     // This makes the screen reader read out numbers digit by digit
-    override val contentDescription: Flow<String> = _fieldValue.map { it.replace("\\d".toRegex(), "$0 ") }
+    override val contentDescription: Flow<String> = _fieldValue.map { it.asIndividualDigits() }
 
     private val _fieldState = combine(cardBrandFlow, _fieldValue) { brand, fieldValue ->
         cvcTextFieldConfig.determineState(brand, fieldValue, brand.maxCvcLength)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request improves our accessibility support in PaymentSheet. Now, a screen reader will read out the entered card number as individual digits as opposed to a gigantic number.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
