### PR TITLE
Open redirect activity with singleTask launchMode

### DIFF
--- a/financial-connections/src/main/AndroidManifest.xml
+++ b/financial-connections/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <application>
         <activity
             android:name=".FinancialConnectionsSheetRedirectActivity"
+            android:launchMode="singleTask"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
# Summary

We started observing deep links not working on DuckDuckGo on Financial Connections: 

- On the SDK, our main activity (`FinancialConnectionsNativeActivity`) opens a browser to handle bank logins.
- DuckDuckGo is launched as new [task](https://developer.android.com/guide/components/activities/tasks-and-back-stack) (task == independent set of activities).
- When a deep link triggers to open back the SDK (`RedirectActivity`) it opens it on that new task.
- `RedirectActivity` relies on `singleTop` to restore the existing `FinancialConnectionsNativeActivity` and continue the flow. However, since the activity is in a new task, we're not able to reopen it, so it creates a new instance of it (instead of bringing the existing one to front and calling `onNewIntent`)

Result -> **the user stays in DuckDuckGo. (looks like deeplink didn't' trigger)**

![image](https://github.com/stripe/stripe-android/assets/99293320/102db774-4d31-4f61-aea8-11fcbbad1804)


# Solution
Solution: Open the activity observing deep links (`RedirectActivity`) with **singleTask launch mode**. 

This should ensure that **the activity opens in an existing task with the same affinity (same app by default)**

![image](https://github.com/stripe/stripe-android/assets/99293320/2c0a02a3-0b8b-4a4d-8cf8-c78474764be2)

# Testing

Tested this printing the `TaskId` of `FinancialConnectionsNativeActivity` and `RedirectActivity`. They have different ids before singleTask, but they share the same id now. `onNewIntent` gets triggered as expected, instead of a new `onCreate` from a new activity instance. 
 
