### PR TITLE
Respect corner radius in `LinkInlineSignup`

### DIFF
--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
@@ -51,7 +51,6 @@ import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.R
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.theme.linkColors
-import com.stripe.android.link.theme.linkShapes
 import com.stripe.android.link.ui.ErrorMessage
 import com.stripe.android.link.ui.ErrorText
 import com.stripe.android.link.ui.LinkTerms
@@ -67,6 +66,7 @@ import com.stripe.android.uicore.elements.TextFieldSection
 import com.stripe.android.uicore.elements.menu.Checkbox
 import com.stripe.android.uicore.getBorderStroke
 import com.stripe.android.uicore.stripeColors
+import com.stripe.android.uicore.stripeShapes
 
 @Preview
 @Composable
@@ -164,23 +164,20 @@ internal fun LinkInlineSignup(
                 modifier = modifier
                     .border(
                         border = MaterialTheme.getBorderStroke(isSelected = false),
-                        shape = MaterialTheme.linkShapes.small
+                        shape = MaterialTheme.stripeShapes.roundedCornerShape,
                     )
                     .background(
                         color = MaterialTheme.stripeColors.component,
-                        shape = MaterialTheme.linkShapes.small
+                        shape = MaterialTheme.stripeShapes.roundedCornerShape,
                     )
             ) {
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .clip(MaterialTheme.linkShapes.small)
+                        .clip(MaterialTheme.stripeShapes.roundedCornerShape)
                 ) {
                     Column(
-                        modifier = Modifier
-                            .clickable {
-                                toggleExpanded()
-                            }
+                        modifier = Modifier.clickable { toggleExpanded() },
                     ) {
                         Row(
                             modifier = Modifier

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/StripeTheme.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/StripeTheme.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.TextStyle
@@ -60,7 +61,11 @@ data class StripeShapes(
     val cornerRadius: Float,
     val borderStrokeWidth: Float,
     val borderStrokeWidthSelected: Float
-)
+) {
+
+    val roundedCornerShape: Shape
+        get() = RoundedCornerShape(size = cornerRadius.dp)
+}
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class StripeTypography(
@@ -359,16 +364,19 @@ fun DefaultStripeTheme(
     }
 }
 
+@Suppress("UnusedReceiverParameter")
 val MaterialTheme.stripeColors: StripeColors
     @Composable
     @ReadOnlyComposable
     get() = LocalColors.current
 
+@Suppress("UnusedReceiverParameter")
 val MaterialTheme.stripeShapes: StripeShapes
     @Composable
     @ReadOnlyComposable
     get() = LocalShapes.current
 
+@Suppress("UnusedReceiverParameter")
 val MaterialTheme.stripeTypography: StripeTypography
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Composable


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates `LinkInlineSignup` to respect the corner radius provided in `PaymentSheet.Appearance`. Previously, it used a hardcoded value from the Link theme, which was intended for use within the Link UI surface (which no longer exists) as opposed to within PaymentSheet.

(cc @jaynewstrom-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

UX polish.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before | After |
| ------------- | ------------- |
| ![Screenshot_1692139050](https://github.com/stripe/stripe-android/assets/110940675/68aecaa9-1609-4be5-89ac-dd6efb141a11) | ![Screenshot_1692139182](https://github.com/stripe/stripe-android/assets/110940675/5dd18b67-1078-47ac-bffc-b8964f58ab7f) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
