### PR TITLE
[Breaking change] Use suspendable function instead of `Flow` in `GooglePayRepository`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
@@ -21,7 +21,6 @@ import com.stripe.android.model.SetupIntent
 import com.stripe.android.networking.PaymentAnalyticsEvent
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
@@ -136,7 +135,7 @@ class GooglePayLauncher internal constructor(
         lifecycleScope.launch {
             val repository = googlePayRepositoryFactory(config.environment)
             readyCallback.onReady(
-                repository.isReady().first().also {
+                repository.isReady().also {
                     isReady = it
                 }
             )

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
@@ -35,7 +35,6 @@ import com.stripe.android.utils.mapResult
 import com.stripe.android.utils.requireApplication
 import com.stripe.android.view.AuthActivityStarterHost
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
 
@@ -68,7 +67,7 @@ internal class GooglePayLauncherViewModel(
 
     @VisibleForTesting
     suspend fun isReadyToPay(): Boolean {
-        return googlePayRepository.isReady().first()
+        return googlePayRepository.isReady()
     }
 
     @VisibleForTesting

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -36,7 +36,6 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
@@ -199,7 +198,7 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
             lifecycleScope.launch {
                 val repository = googlePayRepositoryFactory(config.environment)
                 readyCallback.onReady(
-                    repository.isReady().first().also {
+                    repository.isReady().also {
                         isReady = it
                     }
                 )

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
@@ -26,7 +26,6 @@ import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLaun
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.utils.requireApplication
-import kotlinx.coroutines.flow.first
 import org.json.JSONObject
 import javax.inject.Inject
 
@@ -57,7 +56,7 @@ internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
 
     @VisibleForTesting
     suspend fun isReadyToPay(): Boolean {
-        return googlePayRepository.isReady().first()
+        return googlePayRepository.isReady()
     }
 
     @VisibleForTesting

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -43,7 +43,6 @@ import com.stripe.android.paymentsheet.utils.mapAsStateFlow
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -228,7 +227,7 @@ internal class CustomerSheetViewModel @Inject constructor(
                     } else {
                         GooglePayEnvironment.Test
                     }
-                ).isReady().first()
+                ).isReady()
 
                 transition(
                     to = CustomerSheetViewState.SelectPaymentMethod(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -31,7 +31,6 @@ import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.ui.core.forms.resources.LpmRepository.ServerSpecState
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Named
@@ -99,7 +98,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
                         GooglePayEnvironment.Test
                 }
             )
-        }?.isReady()?.first() ?: false
+        }?.isReady() ?: false
     }
 
     private suspend fun create(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTestHelper.kt
@@ -22,7 +22,6 @@ import com.stripe.android.uicore.address.AddressRepository
 import com.stripe.android.utils.DummyActivityResultCaller
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.flowOf
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -114,7 +113,7 @@ object CustomerSheetTestHelper {
             },
             googlePayRepositoryFactory = {
                 GooglePayRepository {
-                    flowOf(isGooglePayAvailable)
+                    isGooglePayAvailable
                 }
             },
             statusBarColor = { null },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -26,7 +26,6 @@ import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.FakeElementsSessionRepository
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
@@ -38,6 +37,7 @@ import org.mockito.kotlin.capture
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
@@ -80,17 +80,10 @@ internal class DefaultPaymentSheetLoaderTest {
     fun setup() {
         MockitoAnnotations.openMocks(this)
 
-        whenever(readyGooglePayRepository.isReady()).thenReturn(
-            flow {
-                emit(true)
-            }
-        )
-
-        whenever(unreadyGooglePayRepository.isReady()).thenReturn(
-            flow {
-                emit(false)
-            }
-        )
+        readyGooglePayRepository.stub {
+            onBlocking { readyGooglePayRepository.isReady() } doReturn true
+            onBlocking { unreadyGooglePayRepository.isReady() } doReturn false
+        }
     }
 
     @Test


### PR DESCRIPTION
# Summary
Replaces the usage of `Flow` with a suspendable function that returns the result.

# Motivation
All consumers of `isReady` from `GooglePayRepository` use the returned `Flow` as a single emitting source by consuming only the first result using `first()`. Since we are only expecting a single result every time, it is better to represent `isReady` as a single result suspendable function.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
