### PR TITLE
Fix issue with showing confirm button when editing in `CustomerSheet`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -337,6 +337,10 @@ internal class CustomerSheetViewModel @Inject constructor(
         // error source is when the payment methods cannot be loaded
         when (paymentSelection) {
             is PaymentSelection.GooglePay, is PaymentSelection.Saved -> {
+                if (viewState.value.isEditing) {
+                    return
+                }
+
                 updateViewState<CustomerSheetViewState.SelectPaymentMethod> {
                     it.copy(
                         paymentSelection = paymentSelection,


### PR DESCRIPTION
# Summary
Fix issue with showing confirm button when editing in `CustomerSheet`. Occurs when selecting an "enabled" payment method.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screen recordings
| Before  | After |
| ------------- | ------------- |
| <video src="https://github.com/stripe/stripe-android/assets/141707240/2881f505-65d7-4fcd-8ef3-72ce7839416b" />  | <video src="https://github.com/stripe/stripe-android/assets/141707240/86c283f7-a3fe-45b4-9424-5f04aff01c57" /> |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
