### PR TITLE
Use IO dispatcher in IntentConfirmationInterceptor

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
@@ -41,6 +41,7 @@ class DefaultIntentConfirmationInterceptorTest {
         val interceptor = DefaultIntentConfirmationInterceptor(
             context = context,
             stripeRepository = object : AbsFakeStripeRepository() {},
+            workContext = coroutineContext,
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
             isFlowController = false,
@@ -67,6 +68,7 @@ class DefaultIntentConfirmationInterceptorTest {
         val interceptor = DefaultIntentConfirmationInterceptor(
             context = context,
             stripeRepository = object : AbsFakeStripeRepository() {},
+            workContext = coroutineContext,
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
             isFlowController = false,
@@ -93,6 +95,7 @@ class DefaultIntentConfirmationInterceptorTest {
         val interceptor = DefaultIntentConfirmationInterceptor(
             context = context,
             stripeRepository = object : AbsFakeStripeRepository() {},
+            workContext = coroutineContext,
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
             isFlowController = false,
@@ -131,6 +134,7 @@ class DefaultIntentConfirmationInterceptorTest {
                     return Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
                 }
             },
+            workContext = coroutineContext,
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
             isFlowController = false,
@@ -168,6 +172,7 @@ class DefaultIntentConfirmationInterceptorTest {
                     return Result.failure(apiException)
                 }
             },
+            workContext = coroutineContext,
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
             isFlowController = false,
@@ -209,6 +214,7 @@ class DefaultIntentConfirmationInterceptorTest {
                     return Result.failure(apiException)
                 }
             },
+            workContext = coroutineContext,
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
             isFlowController = false,
@@ -236,6 +242,7 @@ class DefaultIntentConfirmationInterceptorTest {
         val interceptor = DefaultIntentConfirmationInterceptor(
             context = context,
             stripeRepository = mock(),
+            workContext = coroutineContext,
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
             isFlowController = false,
@@ -265,6 +272,7 @@ class DefaultIntentConfirmationInterceptorTest {
         val interceptor = DefaultIntentConfirmationInterceptor(
             context = context,
             stripeRepository = mock(),
+            workContext = coroutineContext,
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
             isFlowController = false,
@@ -306,6 +314,7 @@ class DefaultIntentConfirmationInterceptorTest {
                     )
                 }
             },
+            workContext = coroutineContext,
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
             isFlowController = false,
@@ -345,6 +354,7 @@ class DefaultIntentConfirmationInterceptorTest {
                     return Result.success(PaymentIntentFixtures.PI_SUCCEEDED)
                 }
             },
+            workContext = coroutineContext,
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
             isFlowController = false,
@@ -390,6 +400,7 @@ class DefaultIntentConfirmationInterceptorTest {
                     )
                 }
             },
+            workContext = coroutineContext,
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
             isFlowController = false,
@@ -432,6 +443,7 @@ class DefaultIntentConfirmationInterceptorTest {
                     return Result.success(PaymentIntentFixtures.PI_SUCCEEDED)
                 }
             },
+            workContext = coroutineContext,
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
             isFlowController = false,
@@ -477,6 +489,7 @@ class DefaultIntentConfirmationInterceptorTest {
         val interceptor = DefaultIntentConfirmationInterceptor(
             context = context,
             stripeRepository = stripeRepository,
+            workContext = coroutineContext,
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
             isFlowController = false,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request makes us use the IO dispatcher when invoking the `IntentConfirmationInterceptor`.

It resolves an issue that only became apparent when a user integrated from Java and called `Thread.sleep()` in the `CreateIntentCallback.onCreateIntent()`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Resolves https://github.com/stripe/stripe-android/issues/7170

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
