### PR TITLE
[Identity] Add a selfie warmup screen

### DIFF
--- a/identity/res/drawable/stripe_selfie_warmup_icon.xml
+++ b/identity/res/drawable/stripe_selfie_warmup_icon.xml
@@ -1,0 +1,44 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="136dp"
+    android:height="136dp"
+    android:viewportWidth="136"
+    android:viewportHeight="136">
+  <path
+      android:pathData="M134,25.97V19.31C134,7.63 128.81,2 116.27,2H108.24M2,27.64V19.65C2,7.17 7.66,2 19.39,2H27.08M133.32,108.36V116.35C133.32,128.84 127.67,134 115.93,134H108.24M27.76,134H19.73C7.19,134 2,128.37 2,116.69L2,109.03"
+      android:strokeAlpha="0.3"
+      android:strokeWidth="3"
+      android:fillColor="#00000000"
+      android:strokeColor="@color/stripe_selfie_warmup_icon_tint"
+      android:fillAlpha="0.3"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M68,68m-40,0a40,40 0,1 1,80 0a40,40 0,1 1,-80 0"
+      android:strokeWidth="3.89189"
+      android:fillColor="#00000000"
+      android:strokeColor="@color/stripe_selfie_warmup_icon_tint"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M52.43,81.97C60.22,92.35 75.78,92.35 83.57,81.97"
+      android:strokeWidth="3.89189"
+      android:fillColor="#00000000"
+      android:strokeColor="@color/stripe_selfie_warmup_icon_tint"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M51.84,59.32V61.92"
+      android:strokeWidth="5.18919"
+      android:fillColor="#00000000"
+      android:strokeColor="@color/stripe_selfie_warmup_icon_tint"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M85.16,59.32V61.92"
+      android:strokeWidth="5.18919"
+      android:fillColor="#00000000"
+      android:strokeColor="@color/stripe_selfie_warmup_icon_tint"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M70.59,68.05V69.35C70.59,71.31 69.01,72.89 67.05,72.89V72.89"
+      android:strokeWidth="3.89189"
+      android:fillColor="#00000000"
+      android:strokeColor="@color/stripe_selfie_warmup_icon_tint"
+      android:strokeLineCap="round"/>
+</vector>

--- a/identity/res/values-night/colors.xml
+++ b/identity/res/values-night/colors.xml
@@ -3,4 +3,6 @@
     <color name="stripe_plus_icon_tint">#F7FAFC</color>
     <color name="stripe_privacy_policy_icon_tint">#F7FAFC</color>
     <color name="stripe_time_estimate_icon_tint">#F7FAFC</color>
+
+    <color name="stripe_selfie_warmup_icon_tint">#F7FAFC</color>
 </resources>

--- a/identity/res/values/colors.xml
+++ b/identity/res/values/colors.xml
@@ -11,4 +11,5 @@
 
     <color name="stripe_flash_mask_color">#FFFFFF</color>
 
+    <color name="stripe_selfie_warmup_icon_tint">#1A1B25</color>
 </resources>

--- a/identity/res/values/dimens.xml
+++ b/identity/res/values/dimens.xml
@@ -11,4 +11,5 @@
     <dimen name="stripe_camera_permission_title_text_size">28sp</dimen>
     <dimen name="stripe_error_title_text_size">28sp</dimen>
     <dimen name="stripe_upload_title_text_size">28sp</dimen>
+    <dimen name="stripe_selfie_warmup_title_text_size">28sp</dimen>
 </resources>

--- a/identity/res/values/totranslate.xml
+++ b/identity/res/values/totranslate.xml
@@ -10,4 +10,7 @@
 
     <string name="stripe_upload_a_photo">Upload a photo</string>
     <string name="stripe_upload_your_photo_id">Upload your photo ID</string>
+
+    <string name="stripe_selfie_warmup_title">Get ready to take a selfie</string>
+    <string name="stripe_selfie_warmup_body">A few photos will be taken automatically on the next step to verify it\'s you</string>
 </resources>

--- a/identity/src/main/java/com/stripe/android/identity/analytics/IdentityAnalyticsRequestFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/analytics/IdentityAnalyticsRequestFactory.kt
@@ -334,6 +334,7 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         const val SCREEN_NAME_FILE_UPLOAD_PASSPORT = "file_upload_passport"
         const val SCREEN_NAME_FILE_UPLOAD_ID = "file_upload_id"
         const val SCREEN_NAME_FILE_UPLOAD_DRIVER_LICENSE = "file_upload_driver_license"
+        const val SCREEN_NAME_SELFIE_WARMUP = "selfie_warmup"
         const val SCREEN_NAME_SELFIE = "selfie"
         const val SCREEN_NAME_CONFIRMATION = "confirmation"
         const val SCREEN_NAME_ERROR = "error"

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityNavGraph.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityNavGraph.kt
@@ -46,6 +46,7 @@ import com.stripe.android.identity.ui.IndividualWelcomeScreen
 import com.stripe.android.identity.ui.InitialLoadingScreen
 import com.stripe.android.identity.ui.OTPScreen
 import com.stripe.android.identity.ui.SelfieScanScreen
+import com.stripe.android.identity.ui.SelfieWarmupScreen
 import com.stripe.android.identity.ui.UploadScreen
 import com.stripe.android.identity.viewmodel.IdentityScanViewModel
 import com.stripe.android.identity.viewmodel.IdentityViewModel
@@ -154,6 +155,12 @@ internal fun IdentityNavGraph(
                     identityScanViewModel = identityScanViewModel,
                     backStackEntry = it,
                     route = PassportScanDestination.ROUTE.route
+                )
+            }
+            screen(SelfieWarmupDestination.ROUTE) {
+                SelfieWarmupScreen(
+                    navController = navController,
+                    identityViewModel = identityViewModel
                 )
             }
             screen(SelfieDestination.ROUTE) {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/NavControllerExt.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/NavControllerExt.kt
@@ -126,7 +126,7 @@ internal suspend fun NavController.navigateOnVerificationPageData(
     } else if (verificationPageData.isMissingBack()) {
         onMissingBack()
     } else if (verificationPageData.isMissingSelfie()) {
-        navigateTo(SelfieDestination)
+        navigateTo(SelfieWarmupDestination)
     } else if (verificationPageData.isMissingIndividualRequirements()) {
         navigateTo(IndividualDestination)
     } else {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/SelfieWarmupDestination.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/SelfieWarmupDestination.kt
@@ -1,0 +1,10 @@
+package com.stripe.android.identity.navigation
+
+internal object SelfieWarmupDestination : IdentityTopLevelDestination() {
+    private const val SELFIE_WARMUP = "SelfieWarmup"
+    val ROUTE = object : DestinationRoute() {
+        override val routeBase = SELFIE_WARMUP
+    }
+
+    override val destinationRoute = ROUTE
+}

--- a/identity/src/main/java/com/stripe/android/identity/ui/SelfieWarmupScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/SelfieWarmupScreen.kt
@@ -1,0 +1,107 @@
+package com.stripe.android.identity.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import com.stripe.android.identity.R
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
+import com.stripe.android.identity.navigation.SelfieDestination
+import com.stripe.android.identity.navigation.navigateTo
+import com.stripe.android.identity.viewmodel.IdentityViewModel
+
+@Composable
+@Suppress("LongMethod")
+internal fun SelfieWarmupScreen(
+    navController: NavController,
+    identityViewModel: IdentityViewModel
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(
+                vertical = dimensionResource(id = R.dimen.stripe_page_vertical_margin),
+                horizontal = dimensionResource(id = R.dimen.stripe_page_horizontal_margin)
+            )
+    ) {
+        ScreenTransitionLaunchedEffect(
+            identityViewModel = identityViewModel,
+            screenName = IdentityAnalyticsRequestFactory.SCREEN_NAME_SELFIE_WARMUP
+        )
+
+        var continueButtonState by remember {
+            mutableStateOf(LoadingButtonState.Idle)
+        }
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .testTag(SELFIE_WARMUP_CONTENT_TAG),
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.stripe_selfie_warmup_icon),
+                modifier = Modifier
+                    .size(140.dp)
+                    .align(Alignment.CenterHorizontally),
+                contentDescription = stringResource(id = R.string.stripe_description_exclamation)
+            )
+            Text(
+                text = stringResource(id = R.string.stripe_selfie_warmup_title),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        top = dimensionResource(id = R.dimen.stripe_item_vertical_margin)
+                    ),
+                fontSize = dimensionResource(id = R.dimen.stripe_selfie_warmup_title_text_size).value.sp,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center
+            )
+            Text(
+                text = stringResource(id = R.string.stripe_selfie_warmup_body),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        top = dimensionResource(id = R.dimen.stripe_item_vertical_margin),
+                    ),
+                textAlign = TextAlign.Center
+            )
+        }
+
+        LoadingButton(
+            modifier = Modifier.testTag(SELFIE_CONTINUE_BUTTON_TAG),
+            text = stringResource(id = R.string.stripe_kontinue).uppercase(),
+            state = continueButtonState
+        ) {
+            continueButtonState = LoadingButtonState.Loading
+            navController.navigateTo(SelfieDestination)
+        }
+    }
+}
+
+internal const val SELFIE_WARMUP_CONTENT_TAG = "SelfieWarmupContentTag"
+internal const val SELFIE_CONTINUE_BUTTON_TAG = "SelfieContinueButtonTag"

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
@@ -48,6 +48,7 @@ import com.stripe.android.identity.navigation.OTPDestination
 import com.stripe.android.identity.navigation.PassportScanDestination
 import com.stripe.android.identity.navigation.PassportUploadDestination
 import com.stripe.android.identity.navigation.SelfieDestination
+import com.stripe.android.identity.navigation.SelfieWarmupDestination
 import com.stripe.android.identity.navigation.navigateOnVerificationPageData
 import com.stripe.android.identity.navigation.navigateTo
 import com.stripe.android.identity.navigation.navigateToErrorScreenWithDefaultValues
@@ -1165,7 +1166,7 @@ internal class IdentityViewModel constructor(
         fromRoute: String
     ) {
         if (requireNotNull(verificationPage.value?.data).requireSelfie()) {
-            navController.navigateTo(SelfieDestination)
+            navController.navigateTo(SelfieWarmupDestination)
         } else {
             submitAndNavigate(navController, fromRoute)
         }

--- a/identity/src/test/java/com/stripe/android/identity/ui/SelfieScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/SelfieScreenTest.kt
@@ -190,9 +190,9 @@ class SelfieScreenTest {
         newDisplayState: IdentityScanState?,
         testBlock: ComposeContentTestRule.() -> Unit = {}
     ) {
-        newDisplayState?.let { newDisplayState ->
+        newDisplayState?.let { state ->
             displayStateChangedFlow.update {
-                newDisplayState to mock()
+                state to mock()
             }
         }
         composeTestRule.setContent {

--- a/identity/src/test/java/com/stripe/android/identity/ui/SelfieWarmupScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/SelfieWarmupScreenTest.kt
@@ -1,0 +1,51 @@
+package com.stripe.android.identity.ui
+
+import android.os.Build
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onChildAt
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.navigation.NavController
+import androidx.navigation.NavOptionsBuilder
+import com.stripe.android.identity.TestApplication
+import com.stripe.android.identity.navigation.SelfieDestination
+import com.stripe.android.identity.viewmodel.IdentityViewModel
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = TestApplication::class, sdk = [Build.VERSION_CODES.Q])
+class SelfieWarmupScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val mockNavController = mock<NavController>()
+    private val mockIdentityViewModel = mock<IdentityViewModel>()
+
+    @Test
+    fun verifyContentVisibleAndButtonClick() {
+        composeTestRule.setContent {
+            SelfieWarmupScreen(
+                navController = mockNavController,
+                identityViewModel = mockIdentityViewModel,
+            )
+        }
+
+        with(composeTestRule) {
+            onNodeWithTag(SELFIE_WARMUP_CONTENT_TAG).assertExists()
+
+            onNodeWithTag(SELFIE_CONTINUE_BUTTON_TAG).onChildAt(0).performClick()
+            verify(mockNavController).navigate(
+                eq(SelfieDestination.routeWithArgs),
+                any<NavOptionsBuilder.() -> Unit>()
+            )
+        }
+    }
+}

--- a/identity/src/test/java/com/stripe/android/identity/viewmodel/IdentityViewModelTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/viewmodel/IdentityViewModelTest.kt
@@ -41,7 +41,7 @@ import com.stripe.android.identity.navigation.ConsentDestination
 import com.stripe.android.identity.navigation.DocSelectionDestination
 import com.stripe.android.identity.navigation.ErrorDestination
 import com.stripe.android.identity.navigation.IdentityTopLevelDestination
-import com.stripe.android.identity.navigation.SelfieDestination
+import com.stripe.android.identity.navigation.SelfieWarmupDestination
 import com.stripe.android.identity.networking.IdentityModelFetcher
 import com.stripe.android.identity.networking.IdentityRepository
 import com.stripe.android.identity.networking.Resource
@@ -423,7 +423,7 @@ internal class IdentityViewModelTest {
     fun `postVerificationPageDataAndMaybeNavigate - missSelfie`() {
         testPostVerificationPageDataAndMaybeNavigate(
             VERIFICATION_PAGE_DATA_MISSING_SELFIE,
-            SelfieDestination
+            SelfieWarmupDestination
         )
     }
 
@@ -475,7 +475,7 @@ internal class IdentityViewModelTest {
             ConsentDestination.ROUTE.route
         )
         verify(mockController).navigate(
-            eq(SelfieDestination.routeWithArgs),
+            eq(SelfieWarmupDestination.routeWithArgs),
             any<NavOptionsBuilder.() -> Unit>()
         )
     }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Add a selfie warm up screen before starting scanning selfie

iOS: https://github.com/stripe/stripe-ios/pull/2856

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Better selfie experience


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Unit
- [x] Manual

# Screenshots
| Light  | Dark | Recording |
| ------------- | ------------- | ------------- |
| ![light](https://github.com/stripe/stripe-android/assets/79880926/cb6ac2d6-2c8b-4e2c-bbed-af29cdc65cec)  | ![dark](https://github.com/stripe/stripe-android/assets/79880926/b7d74827-8c8e-4bbe-ad8a-00ba821b71e2) | ![androidSelfieWarmup](https://github.com/stripe/stripe-android/assets/79880926/ec5dea42-c82d-4a70-94c8-8b7d01c3a1be)
 |




