### PR TITLE
[FC] Bitrise: e2e test setup improvements

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,8 +5,8 @@ project_type: android
 trigger_map:
   - push_branch: 'master'
     pipeline: main-trigger-pipeline
-  - pull_request_source_branch: '*'
-    pipeline: main-trigger-pipeline
+  - pull_request_source_branch: 'carlosmuvi/retry-maestro-download'
+    workflow: maestro-financial-connections
 app:
   envs:
     - GRADLE_OPTS: -Dkotlin.incremental=false
@@ -57,6 +57,13 @@ workflows:
       - wait-for-android-emulator@1:
           inputs:
             - boot_timeout: 600
+      - android-build@1:
+          inputs:
+            - arguments: -PSTRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL=$STRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL
+            - module: financial-connections-example
+            - variant: release
+            - build_type: apk
+            - cache_level: all
       - script@1:
           title: Execute Maestro tests (release)
           inputs:
@@ -68,12 +75,12 @@ workflows:
           inputs:
             - webhook_url: $WEBHOOK_SLACK_CARLOSMUVI_MAESTRO
             - webhook_url_on_error: $WEBHOOK_SLACK_CARLOSMUVI_MAESTRO
-      - pagerduty@0:
-          inputs:
-            - event_description: Android E2E tests failing! $BITRISE_BUILD_URL
-            - integration_key: $AUX_PAGERDUTY_INTEGRATION_KEY
-          is_always_run: true
-          run_if: .IsBuildFailed
+#      - pagerduty@0:
+#          inputs:
+#            - event_description: Android E2E tests failing! $BITRISE_BUILD_URL
+#            - integration_key: $AUX_PAGERDUTY_INTEGRATION_KEY
+#          is_always_run: true
+#          run_if: .IsBuildFailed
       - custom-test-results-export@1:
           inputs:
             - search_pattern: '*/maestroReport.xml'
@@ -89,6 +96,13 @@ workflows:
       - wait-for-android-emulator@1:
           inputs:
             - boot_timeout: 600
+      - android-build@1:
+          inputs:
+            - arguments: -PSTRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL=$STRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL
+            - module: financial-connections-example
+            - variant: debug
+            - build_type: apk
+            - cache_level: all
       - script@1:
           title: Execute Maestro tests (debug)
           inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,8 +5,8 @@ project_type: android
 trigger_map:
   - push_branch: 'master'
     pipeline: main-trigger-pipeline
-  - pull_request_source_branch: 'carlosmuvi/retry-maestro-download'
-    workflow: maestro-financial-connections
+  - pull_request_source_branch: '*'
+    pipeline: main-trigger-pipeline
 app:
   envs:
     - GRADLE_OPTS: -Dkotlin.incremental=false
@@ -75,12 +75,12 @@ workflows:
           inputs:
             - webhook_url: $WEBHOOK_SLACK_CARLOSMUVI_MAESTRO
             - webhook_url_on_error: $WEBHOOK_SLACK_CARLOSMUVI_MAESTRO
-#      - pagerduty@0:
-#          inputs:
-#            - event_description: Android E2E tests failing! $BITRISE_BUILD_URL
-#            - integration_key: $AUX_PAGERDUTY_INTEGRATION_KEY
-#          is_always_run: true
-#          run_if: .IsBuildFailed
+      - pagerduty@0:
+          inputs:
+            - event_description: Android E2E tests failing! $BITRISE_BUILD_URL
+            - integration_key: $AUX_PAGERDUTY_INTEGRATION_KEY
+          is_always_run: true
+          run_if: .IsBuildFailed
       - custom-test-results-export@1:
           inputs:
             - search_pattern: '*/maestroReport.xml'

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -65,11 +65,11 @@ workflows:
             - build_type: apk
             - cache_level: all
       - script@1:
-          title: Execute Maestro tests (release)
+          title: Execute Maestro tests
           inputs:
             - content: |-
                 #!/usr/bin/env bash
-                bash ./scripts/execute_maestro_tests.sh release
+                bash ./scripts/execute_maestro_tests.sh
       - slack@3:
           is_always_run: true
           inputs:
@@ -104,11 +104,11 @@ workflows:
             - build_type: apk
             - cache_level: all
       - script@1:
-          title: Execute Maestro tests (debug)
+          title: Execute Maestro tests
           inputs:
             - content: |-
                 #!/usr/bin/env bash
-                bash ./scripts/execute_maestro_tests.sh debug
+                bash ./scripts/execute_maestro_tests.sh
       - slack@3:
           is_always_run: true
           inputs:

--- a/scripts/execute_maestro_tests.sh
+++ b/scripts/execute_maestro_tests.sh
@@ -1,52 +1,35 @@
 #!/usr/bin/env bash
 set -o pipefail
 set -x
+set -e
+
+export MAESTRO_VERSION=1.31.0
 
 # Retry mechanism for Maestro installation
 MAX_RETRIES=3
 RETRY_COUNT=0
 
-# Get the first command line argument as the parameter
-buildType=$1
+while [ "$RETRY_COUNT" -lt "$MAX_RETRIES" ]; do
+    curl -Ls "https://get.maestro.mobile.dev" | bash &&
+    export PATH="$PATH:$HOME/.maestro/bin" &&
+    maestro -v &&
+    break
 
-if [ "$buildType" == "debug" ]; then
-  task="installDebug"
-elif [ "$buildType" == "release" ]; then
-  task="installRelease"
-else
-  echo "Invalid parameter. Please use 'debug' or 'release'."
-  exit 1
-fi
-
-now=$(date +%F_%H-%M-%S)
-echo $now
-
-while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-    export MAESTRO_VERSION=1.30.4
-    curl -Ls "https://get.maestro.mobile.dev" | bash
-
-    if [ $? -eq 0 ]; then
-        # If successful, set PATH and break loop
-        export PATH="$PATH":"$HOME/.maestro/bin"
-        maestro -v
-        break
-    else
-        let RETRY_COUNT=RETRY_COUNT+1
-        echo "Attempt $RETRY_COUNT failed. Retrying..."
-        sleep 5
-    fi
+    let RETRY_COUNT=RETRY_COUNT+1
+    echo "Attempt $RETRY_COUNT failed. Retrying..."
+    sleep 5
 done
 
-if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
-    echo "Failed to download and install Maestro after $MAX_RETRIES attempts."
+if [ "$RETRY_COUNT" -eq "$MAX_RETRIES" ]; then
+    echo "Installation failed after $MAX_RETRIES attempts."
     exit 1
 fi
 
 # Create test results folder.
 mkdir -p /tmp/test_results
 
-# Compile and install APK.
-./gradlew -PSTRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL=$STRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL :financial-connections-example:$task
+# install APK.
+adb install $BITRISE_APK_PATH
 
 # Clear and start collecting logs
 maestro test -e APP_ID=com.stripe.android.financialconnections.example --format junit --output maestroReport.xml maestro/financial-connections/


### PR DESCRIPTION
# Summary

- Also uses the `android-build` step so that we fully benefit from gradle caching.
  - using `all` cache mode so that build and deps are both cached here. 
- Aditionally, we've started getting failures on e2e test executions due to curls erroring when downloading Maestro. 
  - Solution: Retry download if maestro download / install fails.

<img width="1536" alt="image" src="https://github.com/stripe/stripe-android/assets/99293320/32c6c176-6127-4292-be05-4d278b6f36d9">