### PR TITLE
Fix incorrect navigation bar padding in BottomSheet

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheet.kt
@@ -4,12 +4,8 @@ import android.os.Build
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.MaterialTheme
@@ -176,7 +172,6 @@ internal fun BottomSheet(
             Box(modifier = Modifier.testTag(BottomSheetContentTestTag)) {
                 sheetContent()
             }
-            Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.systemBars))
         },
         content = {},
     )

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -5,8 +5,6 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
@@ -150,9 +148,7 @@ internal fun AddCard(
     val horizontalPadding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
 
     Column(
-        modifier = modifier
-            .padding(horizontal = horizontalPadding)
-            .verticalScroll(rememberScrollState())
+        modifier = modifier.padding(horizontal = horizontalPadding),
     ) {
         H4Text(
             text = stringResource(id = R.string.stripe_paymentsheet_save_a_new_payment_method),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreen.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.ui
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -38,14 +37,13 @@ internal fun PaymentOptionsScreen(
                 toggleEditing = viewModel::toggleEditing,
             )
         },
-        content = { scrollModifier ->
-            PaymentOptionsScreenContent(viewModel, scrollModifier)
+        content = {
+            PaymentOptionsScreenContent(viewModel)
         },
         modifier = modifier,
     )
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun PaymentOptionsScreenContent(
     viewModel: PaymentOptionsViewModel,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScaffold.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScaffold.kt
@@ -2,7 +2,11 @@ package com.stripe.android.paymentsheet.ui
 
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Surface
@@ -17,7 +21,7 @@ import androidx.compose.ui.zIndex
 @Composable
 internal fun PaymentSheetScaffold(
     topBar: @Composable () -> Unit,
-    content: @Composable (Modifier) -> Unit,
+    content: @Composable () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
@@ -44,12 +48,15 @@ internal fun PaymentSheetScaffold(
             topBar()
         }
 
-        content(
-            // We provide the IME padding before the vertical scroll modifier to make sure that the
-            // content moves up correctly if it's covered by the keyboard when it's being focused.
-            Modifier
+        // We provide the IME padding before the vertical scroll modifier to make sure that the
+        // content moves up correctly if it's covered by the keyboard when it's being focused.
+        Column(
+            modifier = Modifier
                 .imePadding()
                 .verticalScroll(scrollState)
-        )
+        ) {
+            content()
+            Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
+        }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -54,12 +54,9 @@ internal fun PaymentSheetScreen(
                 toggleEditing = viewModel::toggleEditing,
             )
         },
-        content = { scrollModifier ->
+        content = {
             if (contentVisible) {
-                PaymentSheetScreenContent(
-                    viewModel = viewModel,
-                    modifier = scrollModifier,
-                )
+                PaymentSheetScreenContent(viewModel = viewModel)
             } else {
                 Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
             }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the `BottomSheet` content wouldn’t be correctly padded against the navigation bar. This issue only occurred if the content was scrollable.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
