### PR TITLE
Expand `error_message` to include network and server errors

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoadingException.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoadingException.kt
@@ -74,8 +74,8 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
 
         override val type: String
             get() = when (StripeException.create(cause)) {
-                is APIException -> "serverError"
-                is APIConnectionException -> "networkError"
+                is APIException -> "apiError"
+                is APIConnectionException -> "connectionError"
                 is InvalidRequestException -> "invalidRequestError"
                 else -> "unknown"
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoadingException.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoadingException.kt
@@ -1,5 +1,9 @@
 package com.stripe.android.paymentsheet.state
 
+import com.stripe.android.core.exception.APIConnectionException
+import com.stripe.android.core.exception.APIException
+import com.stripe.android.core.exception.InvalidRequestException
+import com.stripe.android.core.exception.StripeException
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException.Unknown
@@ -67,7 +71,15 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
     data class Unknown(
         override val cause: Throwable,
     ) : PaymentSheetLoadingException() {
-        override val type: String = "unknown"
+
+        override val type: String
+            get() = when (StripeException.create(cause)) {
+                is APIException -> "serverError"
+                is APIConnectionException -> "networkError"
+                is InvalidRequestException -> "invalidRequestError"
+                else -> "unknown"
+            }
+
         override val message: String? = cause.message
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -1,8 +1,10 @@
 package com.stripe.android.paymentsheet.analytics
 
 import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
@@ -10,12 +12,15 @@ import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.utils.FakeDurationProvider
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.json.JSONException
 import org.junit.runner.RunWith
 import org.mockito.kotlin.argWhere
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
+import java.io.IOException
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -237,5 +242,47 @@ class DefaultEventReporterTest {
             durationProvider,
             testDispatcher
         )
+    }
+
+    @Test
+    fun `Send correct error_message for server errors`() {
+        completeEventReporter.onLoadFailed(
+            isDecoupling = false,
+            error = JSONException("Server did something bad"),
+        )
+
+        val argumentCaptor = argumentCaptor<AnalyticsRequest>()
+        verify(analyticsRequestExecutor).executeAsync(argumentCaptor.capture())
+
+        val errorType = argumentCaptor.firstValue.params["error_message"] as String
+        assertThat(errorType).isEqualTo("serverError")
+    }
+
+    @Test
+    fun `Send correct error_message for network errors`() {
+        completeEventReporter.onLoadFailed(
+            isDecoupling = false,
+            error = IOException("Internet no good"),
+        )
+
+        val argumentCaptor = argumentCaptor<AnalyticsRequest>()
+        verify(analyticsRequestExecutor).executeAsync(argumentCaptor.capture())
+
+        val errorType = argumentCaptor.firstValue.params["error_message"] as String
+        assertThat(errorType).isEqualTo("networkError")
+    }
+
+    @Test
+    fun `Send correct error_message for invalid requests`() {
+        completeEventReporter.onLoadFailed(
+            isDecoupling = false,
+            error = IllegalArgumentException("This ain't valid"),
+        )
+
+        val argumentCaptor = argumentCaptor<AnalyticsRequest>()
+        verify(analyticsRequestExecutor).executeAsync(argumentCaptor.capture())
+
+        val errorType = argumentCaptor.firstValue.params["error_message"] as String
+        assertThat(errorType).isEqualTo("invalidRequestError")
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -255,7 +255,7 @@ class DefaultEventReporterTest {
         verify(analyticsRequestExecutor).executeAsync(argumentCaptor.capture())
 
         val errorType = argumentCaptor.firstValue.params["error_message"] as String
-        assertThat(errorType).isEqualTo("serverError")
+        assertThat(errorType).isEqualTo("apiError")
     }
 
     @Test
@@ -269,7 +269,7 @@ class DefaultEventReporterTest {
         verify(analyticsRequestExecutor).executeAsync(argumentCaptor.capture())
 
         val errorType = argumentCaptor.firstValue.params["error_message"] as String
-        assertThat(errorType).isEqualTo("networkError")
+        assertThat(errorType).isEqualTo("connectionError")
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request expands what we send as `error_message` if the load operation fails. We now send `connectionError`, `apiError` or `invalidRequestError`.

(cc @porter-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Observability improvements

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
