### PR TITLE
Fix an issue where we would show exception types and implementation details to buyers.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -13,7 +13,7 @@ import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.StripeIntentResult
-import com.stripe.android.core.exception.APIException
+import com.stripe.android.core.exception.LocalStripeException
 import com.stripe.android.core.injection.Injectable
 import com.stripe.android.core.injection.Injector
 import com.stripe.android.core.injection.UIContext
@@ -237,17 +237,17 @@ internal class PaymentLauncherViewModel @Inject constructor(
                     PaymentResult.Completed
                 StripeIntentResult.Outcome.FAILED ->
                     PaymentResult.Failed(
-                        APIException(message = stripeIntentResult.failureMessage)
+                        LocalStripeException(message = stripeIntentResult.failureMessage)
                     )
                 StripeIntentResult.Outcome.CANCELED ->
                     PaymentResult.Canceled
                 StripeIntentResult.Outcome.TIMEDOUT ->
                     PaymentResult.Failed(
-                        APIException(message = TIMEOUT_ERROR + stripeIntentResult.failureMessage)
+                        LocalStripeException(message = TIMEOUT_ERROR + stripeIntentResult.failureMessage)
                     )
                 else ->
                     PaymentResult.Failed(
-                        APIException(message = UNKNOWN_ERROR + stripeIntentResult.failureMessage)
+                        LocalStripeException(message = UNKNOWN_ERROR + stripeIntentResult.failureMessage)
                     )
             }
         )

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -237,17 +237,17 @@ internal class PaymentLauncherViewModel @Inject constructor(
                     PaymentResult.Completed
                 StripeIntentResult.Outcome.FAILED ->
                     PaymentResult.Failed(
-                        LocalStripeException(message = stripeIntentResult.failureMessage)
+                        LocalStripeException(displayMessage = stripeIntentResult.failureMessage)
                     )
                 StripeIntentResult.Outcome.CANCELED ->
                     PaymentResult.Canceled
                 StripeIntentResult.Outcome.TIMEDOUT ->
                     PaymentResult.Failed(
-                        LocalStripeException(message = TIMEOUT_ERROR + stripeIntentResult.failureMessage)
+                        LocalStripeException(displayMessage = TIMEOUT_ERROR + stripeIntentResult.failureMessage)
                     )
                 else ->
                     PaymentResult.Failed(
-                        LocalStripeException(message = UNKNOWN_ERROR + stripeIntentResult.failureMessage)
+                        LocalStripeException(displayMessage = UNKNOWN_ERROR + stripeIntentResult.failureMessage)
                     )
             }
         )

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
@@ -33,12 +33,18 @@ internal class PaymentSheetPage(
             .performClick()
     }
 
-    fun waitForText(text: String) {
+    fun waitForText(text: String, substring: Boolean = false) {
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
             composeTestRule
-                .onAllNodes(hasText(text))
+                .onAllNodes(hasText(text, substring = substring))
                 .fetchSemanticsNodes().isNotEmpty()
         }
+    }
+
+    fun assertNoText(text: String, substring: Boolean = false) {
+        composeTestRule
+            .onAllNodes(hasText(text, substring = substring))
+            .fetchSemanticsNodes().isEmpty()
     }
 
     fun addPaymentMethod() {

--- a/paymentsheet/src/androidTest/resources/payment-intent-confirm-insufficient-funds.json
+++ b/paymentsheet/src/androidTest/resources/payment-intent-confirm-insufficient-funds.json
@@ -1,0 +1,155 @@
+{
+  "error": {
+    "charge": "ch_3Ni2nGLu5o3P18Zp0hHEq8M3",
+    "code": "card_declined",
+    "decline_code": "insufficient_funds",
+    "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+    "message": "Your card has insufficient funds.",
+    "payment_intent": {
+      "id": "pi_example",
+      "object": "payment_intent",
+      "amount": 5099,
+      "amount_details": {
+        "tip": {}
+      },
+      "automatic_payment_methods": {
+        "allow_redirects": "always",
+        "enabled": true
+      },
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "client_secret": "pi_example_secret_example",
+      "confirmation_method": "automatic",
+      "created": 1692742282,
+      "currency": "usd",
+      "description": null,
+      "last_payment_error": {
+        "charge": "ch_3Ni2nGLu5o3P18Zp0hHEq8M3",
+        "code": "card_declined",
+        "decline_code": "insufficient_funds",
+        "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+        "message": "Your card has insufficient funds.",
+        "payment_method": {
+          "id": "pm_1MUXVpLu5o3P18ZpS2NCqb2F",
+          "object": "payment_method",
+          "billing_details": {
+            "address": {
+              "city": "South San Francisco",
+              "country": "US",
+              "line1": "354 Oyster Point Blvd",
+              "line2": null,
+              "postal_code": "94080",
+              "state": "CA"
+            },
+            "email": "email@email.com",
+            "name": "Jenny Rosen",
+            "phone": "+18008675309"
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": null
+            },
+            "country": "US",
+            "exp_month": 12,
+            "exp_year": 2034,
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "9995",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1692742304,
+          "customer": null,
+          "livemode": false,
+          "type": "card"
+        },
+        "type": "card_error"
+      },
+      "livemode": false,
+      "next_action": null,
+      "payment_method": null,
+      "payment_method_options": {
+        "us_bank_account": {
+          "verification_method": "automatic"
+        }
+      },
+      "payment_method_types": [
+        "card",
+        "acss_debit",
+        "afterpay_clearpay",
+        "alipay",
+        "klarna",
+        "link",
+        "us_bank_account",
+        "wechat_pay",
+        "affirm",
+        "cashapp"
+      ],
+      "processing": null,
+      "receipt_email": null,
+      "setup_future_usage": null,
+      "shipping": null,
+      "source": null,
+      "status": "requires_payment_method"
+    },
+    "payment_method": {
+      "id": "pm_1MUXVpLu5o3P18ZpS2NCqb2F",
+      "object": "payment_method",
+      "billing_details": {
+        "address": {
+          "city": "South San Francisco",
+          "country": "US",
+          "line1": "354 Oyster Point Blvd",
+          "line2": null,
+          "postal_code": "94080",
+          "state": "CA"
+        },
+        "email": "email@email.com",
+        "name": "Jenny Rosen",
+        "phone": "+18008675309"
+      },
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": null,
+          "address_postal_code_check": null,
+          "cvc_check": null
+        },
+        "country": "US",
+        "exp_month": 12,
+        "exp_year": 2034,
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "9995",
+        "networks": {
+          "available": [
+            "visa"
+          ],
+          "preferred": null
+        },
+        "three_d_secure_usage": {
+          "supported": true
+        },
+        "wallet": null
+      },
+      "created": 1692742304,
+      "customer": null,
+      "livemode": false,
+      "type": "card"
+    },
+    "request_log_url": "https://dashboard.stripe.com/test/logs/req_EqLBV1aambW25P?t=1692742304",
+    "type": "card_error"
+  }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/exception/ExceptionKt.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/exception/ExceptionKt.kt
@@ -5,6 +5,7 @@ import com.stripe.android.core.exception.LocalStripeException
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.paymentsheet.R
 
+@Suppress("ReturnCount")
 internal fun Throwable?.stripeErrorMessage(context: Context): String {
     (this as? StripeException)?.stripeError?.message?.let {
         return it

--- a/paymentsheet/src/main/java/com/stripe/android/common/exception/ExceptionKt.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/exception/ExceptionKt.kt
@@ -10,7 +10,7 @@ internal fun Throwable?.stripeErrorMessage(context: Context): String {
     (this as? StripeException)?.stripeError?.message?.let {
         return it
     }
-    (this as? LocalStripeException)?.message?.let {
+    (this as? LocalStripeException)?.displayMessage?.let {
         return it
     }
     return context.resources.getString(R.string.stripe_something_went_wrong)

--- a/paymentsheet/src/main/java/com/stripe/android/common/exception/ExceptionKt.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/exception/ExceptionKt.kt
@@ -1,11 +1,16 @@
 package com.stripe.android.common.exception
 
 import android.content.Context
+import com.stripe.android.core.exception.LocalStripeException
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.paymentsheet.R
 
 internal fun Throwable?.stripeErrorMessage(context: Context): String {
-    return (this as? StripeException)?.stripeError?.message
-        ?: (this as? StripeException)?.message
-        ?: context.resources.getString(R.string.stripe_something_went_wrong)
+    (this as? StripeException)?.stripeError?.message?.let {
+        return it
+    }
+    (this as? LocalStripeException)?.message?.let {
+        return it
+    }
+    return context.resources.getString(R.string.stripe_something_went_wrong)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/exception/ExceptionKt.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/exception/ExceptionKt.kt
@@ -6,5 +6,6 @@ import com.stripe.android.paymentsheet.R
 
 internal fun Throwable?.stripeErrorMessage(context: Context): String {
     return (this as? StripeException)?.stripeError?.message
+        ?: (this as? StripeException)?.message
         ?: context.resources.getString(R.string.stripe_something_went_wrong)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.ui
 
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -28,7 +27,6 @@ import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.uicore.image.StripeImageLoader
 import kotlinx.coroutines.flow.Flow
 
-@OptIn(ExperimentalAnimationApi::class)
 @Composable
 internal fun PaymentElement(
     sheetViewModel: BaseSheetViewModel,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -24,6 +24,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.io.IOException
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertFailsWith
 
@@ -169,11 +170,7 @@ class CustomerAdapterTest {
         val adapter = createAdapter(
             customerRepository = FakeCustomerRepository(
                 onAttachPaymentMethod = {
-                    Result.failure(
-                        APIException(
-                            message = "could not attach payment method",
-                        )
-                    )
+                    Result.failure(IOException("could not attach payment method"))
                 }
             )
         )
@@ -221,11 +218,7 @@ class CustomerAdapterTest {
         val adapter = createAdapter(
             customerRepository = FakeCustomerRepository(
                 onDetachPaymentMethod = {
-                    Result.failure(
-                        APIException(
-                            message = "could not detach payment method",
-                        )
-                    )
+                    Result.failure(IOException("could not detach payment method"))
                 }
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -24,7 +24,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.io.IOException
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertFailsWith
 
@@ -170,7 +169,11 @@ class CustomerAdapterTest {
         val adapter = createAdapter(
             customerRepository = FakeCustomerRepository(
                 onAttachPaymentMethod = {
-                    Result.failure(IOException("could not attach payment method"))
+                    Result.failure(
+                        APIException(
+                            message = "could not attach payment method",
+                        )
+                    )
                 }
             )
         )
@@ -218,7 +221,11 @@ class CustomerAdapterTest {
         val adapter = createAdapter(
             customerRepository = FakeCustomerRepository(
                 onDetachPaymentMethod = {
-                    Result.failure(IOException("could not detach payment method"))
+                    Result.failure(
+                        APIException(
+                            message = "could not detach payment method",
+                        )
+                    )
                 }
             )
         )

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/LocalStripeException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/LocalStripeException.kt
@@ -4,7 +4,7 @@ import androidx.annotation.RestrictTo
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class LocalStripeException(
-    message: String?
+    val displayMessage: String?
 ) : StripeException(
-    message = message
+    message = displayMessage
 )

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/LocalStripeException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/LocalStripeException.kt
@@ -1,0 +1,10 @@
+package com.stripe.android.core.exception
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class LocalStripeException(
+    message: String?
+) : StripeException(
+    message = message
+)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Before this change, we would show something along the lines of "IOException during API request to Stripe (https://api.stripe.com...) unexpected end of stream..." to buyers, now we ONLY show messages intended to be displayed to buyers.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Better error messages for buyers.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
