### PR TITLE
Use two decimal places for LAK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### PaymentSheet
 * [CHANGED][7144](https://github.com/stripe/stripe-android/pull/7144) PaymentSheet now features rounded corners with the radius provided in `PaymentSheet.Shapes.cornerRadiusDp`.
+* [FIXED][7190](https://github.com/stripe/stripe-android/pull/7190) Fixed an issue where amounts in Laotian Kip were displayed incorrectly.
 
 ## 20.28.3 - 2023-08-21
 

--- a/payments-core/src/main/java/com/stripe/android/PayWithGoogleUtils.kt
+++ b/payments-core/src/main/java/com/stripe/android/PayWithGoogleUtils.kt
@@ -1,5 +1,6 @@
 package com.stripe.android
 
+import com.stripe.android.uicore.format.CurrencyFormatter
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
 import java.util.Currency
@@ -36,7 +37,7 @@ object PayWithGoogleUtils {
      */
     @JvmStatic
     fun getPriceString(price: Long, currency: Currency): String {
-        val fractionDigits = currency.defaultFractionDigits
+        val fractionDigits = CurrencyFormatter.getDefaultDecimalDigits(currency)
         val totalLength = price.toString().length
         val builder = StringBuilder()
 

--- a/payments-core/src/test/java/com/stripe/android/PayWithGoogleUtilsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PayWithGoogleUtilsTest.kt
@@ -66,4 +66,11 @@ class PayWithGoogleUtilsTest {
         val bigPrice = getPriceString(20000000L, Currency.getInstance("GBP"))
         assertThat(bigPrice).isEqualTo("200000.00")
     }
+
+    @Test
+    fun getPriceString_whenLocaleWithWrongSystemDecimalDigits_returnsExpectedValue() {
+        // Currency.defaultFractionDigits returns an incorrect value for LAK
+        val priceString = getPriceString(2_000_000L, Currency.getInstance("LAK"))
+        assertThat(priceString).isEqualTo("20000.00")
+    }
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/format/CurrencyFormatter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/format/CurrencyFormatter.kt
@@ -11,10 +11,9 @@ import kotlin.math.pow
 object CurrencyFormatter {
 
     private const val MAJOR_UNIT_BASE = 10.0
-    private val SERVER_DECIMAL_DIGITS =
-        mapOf(
-            setOf("UGX", "AFN", "ALL", "AMD", "COP", "IDR", "ISK", "PKR", "LBP", "MMK") to 2
-        )
+    private val SERVER_DECIMAL_DIGITS = mapOf(
+        setOf("UGX", "AFN", "ALL", "AMD", "COP", "IDR", "ISK", "PKR", "LBP", "MMK", "LAK") to 2,
+    )
 
     fun format(
         amount: Long,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/format/CurrencyFormatter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/format/CurrencyFormatter.kt
@@ -70,7 +70,7 @@ object CurrencyFormatter {
         return currencyFormat.format(majorUnitAmount)
     }
 
-    private fun getDefaultDecimalDigits(currency: Currency): Int {
+    fun getDefaultDecimalDigits(currency: Currency): Int {
         /**
          * Handle special cases where the client's default fractional digits for a given currency
          * don't match the Stripe backend's assumption.

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/format/CurrencyFormatterTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/format/CurrencyFormatterTest.kt
@@ -229,6 +229,13 @@ class CurrencyFormatterTest {
         assertThat(formattedAmount).isEqualTo("MMK50.99")
     }
 
+    @Test
+    fun `Treats LAK as a two-decimal currency`() {
+        val currency = Currency.getInstance("LAK")
+        val formattedAmount = CurrencyFormatter.format(5099L, currency)
+        assertThat(formattedAmount).isEqualTo("LAK50.99")
+    }
+
     companion object {
         val LOCALE_ICELAND_LANGUAGE_ONLY = Locale("IS")
         val LOCALE_AUSTRALIA_LANGUAGE_COUNTRY = Locale("en-AU", "AU")


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the Laotian Kip was formatted incorrectly.

To fix this, I added `LAK` to the special cases in `CurrencyFormatter` and also made `PayWithGoogleUtils` use that class to determine the amount of decimal places. This makes sure that PaymentSheet and Google Pay display the same values.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[RUN_MOBILESDK-2548](https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2548)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
