### PR TITLE
Add `amount` and `label` to `GooglePayLauncher` and `GooglePayConfiguration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### PaymentSheet
 * [ADDED][7302](https://github.com/stripe/stripe-android/pull/7302) PaymentSheet now supports Alma for PaymentIntents in private beta.
+* [ADDED][7191](https://github.com/stripe/stripe-android/pull/7191) `PaymentSheet.GooglePayConfiguration` now takes an optional `amount` and `label`. The `amount` will be displayed in Google Pay for SetupIntents, while `label` will be displayed for both PaymentIntents and SetupIntents.
+
+### Payments
+* [ADDED][7191](https://github.com/stripe/stripe-android/pull/7191) `GooglePayLauncher` now takes an optional `label` when presenting Google Pay for PaymentIntents, and an optional `amount` and `label` when presenting for SetupIntents.
+* [ADDED][7191](https://github.com/stripe/stripe-android/pull/7191) `GooglePayPaymentMethodLauncher` now takes an optional `label` when presenting Google Pay.
 
 ## 20.30.2 - 2023-09-13
 
@@ -37,13 +42,6 @@
 
 ### PaymentSheet
 * [ADDED][7263](https://github.com/stripe/stripe-android/pull/7263) PaymentSheet now supports Bancontact SetupIntent and PaymentIntent with setup for future usage.
-
-### PaymentSheet
-* [ADDED][7191](https://github.com/stripe/stripe-android/pull/7191) `PaymentSheet.GooglePayConfiguration` now takes an optional `amount` and `label`. The `amount` will be displayed in Google Pay for SetupIntents, while `label` will be displayed for both PaymentIntents and SetupIntents.
-
-### Payments
-* [ADDED][7191](https://github.com/stripe/stripe-android/pull/7191) `GooglePayLauncher` now takes an optional `label` when presenting Google Pay for PaymentIntents, and an optional `amount` and `label` when presenting for SetupIntents.
-* [ADDED][7191](https://github.com/stripe/stripe-android/pull/7191) `GooglePayPaymentMethodLauncher` now takes an optional `label` when presenting Google Pay.
 
 ## 20.29.1 - 2023-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@
 ### PaymentSheet
 * [ADDED][7263](https://github.com/stripe/stripe-android/pull/7263) PaymentSheet now supports Bancontact SetupIntent and PaymentIntent with setup for future usage.
 
+### PaymentSheet
+* [ADDED][7191](https://github.com/stripe/stripe-android/pull/7191) `PaymentSheet.GooglePayConfiguration` now takes an optional `amount` and `label`. The `amount` will be displayed in Google Pay for SetupIntents, while `label` will be displayed for both PaymentIntents and SetupIntents.
+
+### Payments
+* [ADDED][7191](https://github.com/stripe/stripe-android/pull/7191) `GooglePayLauncher` now takes an optional `label` when presenting Google Pay for PaymentIntents, and an optional `amount` and `label` when presenting for SetupIntents.
+* [ADDED][7191](https://github.com/stripe/stripe-android/pull/7191) `GooglePayPaymentMethodLauncher` now takes an optional `label` when presenting Google Pay.
+
 ## 20.29.1 - 2023-08-31
 
 ### PaymentSheet

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -1267,6 +1267,7 @@ public abstract class com/stripe/android/googlepaylauncher/GooglePayLauncherCont
 public final class com/stripe/android/googlepaylauncher/GooglePayLauncherContract$PaymentIntentArgs : com/stripe/android/googlepaylauncher/GooglePayLauncherContract$Args {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;)V
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun copy (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Ljava/lang/String;)Lcom/stripe/android/googlepaylauncher/GooglePayLauncherContract$PaymentIntentArgs;
@@ -1289,6 +1290,8 @@ public final class com/stripe/android/googlepaylauncher/GooglePayLauncherContrac
 public final class com/stripe/android/googlepaylauncher/GooglePayLauncherContract$SetupIntentArgs : com/stripe/android/googlepaylauncher/GooglePayLauncherContract$Args {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Ljava/lang/String;Ljava/lang/Long;)V
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun copy (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)Lcom/stripe/android/googlepaylauncher/GooglePayLauncherContract$SetupIntentArgs;

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -1096,7 +1096,12 @@ public final class com/stripe/android/googlepaylauncher/GooglePayLauncher {
 	public fun <init> (Landroidx/activity/ComponentActivity;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$ReadyCallback;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$ResultCallback;)V
 	public fun <init> (Landroidx/fragment/app/Fragment;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$ReadyCallback;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$ResultCallback;)V
 	public final fun presentForPaymentIntent (Ljava/lang/String;)V
+	public final fun presentForPaymentIntent (Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun presentForPaymentIntent$default (Lcom/stripe/android/googlepaylauncher/GooglePayLauncher;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public final fun presentForSetupIntent (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun presentForSetupIntent (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)V
+	public final fun presentForSetupIntent (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)V
+	public static synthetic fun presentForSetupIntent$default (Lcom/stripe/android/googlepaylauncher/GooglePayLauncher;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILjava/lang/Object;)V
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayLauncher$BillingAddressConfig : android/os/Parcelable {
@@ -1262,9 +1267,10 @@ public abstract class com/stripe/android/googlepaylauncher/GooglePayLauncherCont
 public final class com/stripe/android/googlepaylauncher/GooglePayLauncherContract$PaymentIntentArgs : com/stripe/android/googlepaylauncher/GooglePayLauncherContract$Args {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;)V
-	public final fun copy (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;)Lcom/stripe/android/googlepaylauncher/GooglePayLauncherContract$PaymentIntentArgs;
-	public static synthetic fun copy$default (Lcom/stripe/android/googlepaylauncher/GooglePayLauncherContract$PaymentIntentArgs;Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;ILjava/lang/Object;)Lcom/stripe/android/googlepaylauncher/GooglePayLauncherContract$PaymentIntentArgs;
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Ljava/lang/String;)Lcom/stripe/android/googlepaylauncher/GooglePayLauncherContract$PaymentIntentArgs;
+	public static synthetic fun copy$default (Lcom/stripe/android/googlepaylauncher/GooglePayLauncherContract$PaymentIntentArgs;Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/googlepaylauncher/GooglePayLauncherContract$PaymentIntentArgs;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -1283,9 +1289,10 @@ public final class com/stripe/android/googlepaylauncher/GooglePayLauncherContrac
 public final class com/stripe/android/googlepaylauncher/GooglePayLauncherContract$SetupIntentArgs : com/stripe/android/googlepaylauncher/GooglePayLauncherContract$Args {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Ljava/lang/String;)V
-	public final fun copy (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Ljava/lang/String;)Lcom/stripe/android/googlepaylauncher/GooglePayLauncherContract$SetupIntentArgs;
-	public static synthetic fun copy$default (Lcom/stripe/android/googlepaylauncher/GooglePayLauncherContract$SetupIntentArgs;Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/googlepaylauncher/GooglePayLauncherContract$SetupIntentArgs;
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)Lcom/stripe/android/googlepaylauncher/GooglePayLauncherContract$SetupIntentArgs;
+	public static synthetic fun copy$default (Lcom/stripe/android/googlepaylauncher/GooglePayLauncherContract$SetupIntentArgs;Ljava/lang/String;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/googlepaylauncher/GooglePayLauncherContract$SetupIntentArgs;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -1350,8 +1357,9 @@ public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLa
 	public final fun present (Ljava/lang/String;ILjava/lang/String;)V
 	public final fun present (Ljava/lang/String;J)V
 	public final fun present (Ljava/lang/String;JLjava/lang/String;)V
+	public final fun present (Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;)V
 	public static synthetic fun present$default (Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher;Ljava/lang/String;ILjava/lang/String;ILjava/lang/Object;)V
-	public static synthetic fun present$default (Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher;Ljava/lang/String;JLjava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun present$default (Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$BillingAddressConfig : android/os/Parcelable {

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
@@ -152,8 +152,14 @@ class GooglePayLauncher internal constructor(
      * object.
      *
      * @param clientSecret the PaymentIntent's [client secret](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret)
+     * @param label An optional label to display with the amount. If none is provided, Google Pay
+     * will display a generic pay label.
      */
-    fun presentForPaymentIntent(clientSecret: String) {
+    @JvmOverloads
+    fun presentForPaymentIntent(
+        clientSecret: String,
+        label: String? = null,
+    ) {
         check(isReady) {
             "presentForPaymentIntent() may only be called when Google Pay is available on this device."
         }
@@ -161,7 +167,8 @@ class GooglePayLauncher internal constructor(
         activityResultLauncher.launch(
             GooglePayLauncherContract.PaymentIntentArgs(
                 clientSecret = clientSecret,
-                config = config
+                config = config,
+                label = label,
             )
         )
     }
@@ -175,10 +182,18 @@ class GooglePayLauncher internal constructor(
      *
      * @param clientSecret the SetupIntent's [client secret](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-client_secret)
      * @param currencyCode The ISO 4217 alphabetic currency code.
+     * @param amount An optional amount to display. If none is provided, this method launches Google
+     * Pay with an amount of 0. Google Pay may or may not display this price depending on its own
+     * internal logic.
+     * @param label An optional label to display with the amount. If none is provided, Google Pay
+     * will display a generic pay label.
      */
+    @JvmOverloads
     fun presentForSetupIntent(
         clientSecret: String,
-        currencyCode: String
+        currencyCode: String,
+        amount: Long? = null,
+        label: String? = null,
     ) {
         check(isReady) {
             "presentForSetupIntent() may only be called when Google Pay is available on this device."
@@ -188,7 +203,9 @@ class GooglePayLauncher internal constructor(
             GooglePayLauncherContract.SetupIntentArgs(
                 clientSecret = clientSecret,
                 config = config,
-                currencyCode = currencyCode
+                currencyCode = currencyCode,
+                amount = amount,
+                label = label,
             )
         )
     }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
@@ -152,8 +152,9 @@ class GooglePayLauncher internal constructor(
      * object.
      *
      * @param clientSecret the PaymentIntent's [client secret](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret)
-     * @param label An optional label to display with the amount. If none is provided, Google Pay
-     * will display a generic pay label.
+     * @param label An optional label to display with the amount. Google Pay may or may not display
+     * this label depending on its own internal logic. Defaults to a generic label if none is
+     * provided.
      */
     @JvmOverloads
     fun presentForPaymentIntent(
@@ -182,11 +183,11 @@ class GooglePayLauncher internal constructor(
      *
      * @param clientSecret the SetupIntent's [client secret](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-client_secret)
      * @param currencyCode The ISO 4217 alphabetic currency code.
-     * @param amount An optional amount to display. If none is provided, this method launches Google
-     * Pay with an amount of 0. Google Pay may or may not display this price depending on its own
-     * internal logic.
-     * @param label An optional label to display with the amount. If none is provided, Google Pay
-     * will display a generic pay label.
+     * @param amount An optional amount to display. Google Pay may or may not display this amount
+     * depending on its own internal logic. Defaults to 0 if none is provided.
+     * @param label An optional label to display with the amount. Google Pay may or may not display
+     * this label depending on its own internal logic. Defaults to a generic label if none is
+     * provided.
      */
     @JvmOverloads
     fun presentForSetupIntent(

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherContract.kt
@@ -37,7 +37,8 @@ class GooglePayLauncherContract :
     @Parcelize
     data class PaymentIntentArgs(
         override val clientSecret: String,
-        override val config: GooglePayLauncher.Config
+        override val config: GooglePayLauncher.Config,
+        internal val label: String? = null,
     ) : Args()
 
     /**
@@ -47,7 +48,9 @@ class GooglePayLauncherContract :
     data class SetupIntentArgs(
         override val clientSecret: String,
         override val config: GooglePayLauncher.Config,
-        internal val currencyCode: String
+        internal val currencyCode: String,
+        internal val amount: Long? = null,
+        internal val label: String? = null,
     ) : Args()
 
     sealed class Args : Parcelable {

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherContract.kt
@@ -35,7 +35,7 @@ class GooglePayLauncherContract :
      * Args for launching [GooglePayLauncherContract] to confirm a [PaymentIntent].
      */
     @Parcelize
-    data class PaymentIntentArgs(
+    data class PaymentIntentArgs @JvmOverloads constructor(
         override val clientSecret: String,
         override val config: GooglePayLauncher.Config,
         internal val label: String? = null,
@@ -45,7 +45,7 @@ class GooglePayLauncherContract :
      * Args for launching [GooglePayLauncherContract] to confirm a [SetupIntent].
      */
     @Parcelize
-    data class SetupIntentArgs(
+    data class SetupIntentArgs @JvmOverloads constructor(
         override val clientSecret: String,
         override val config: GooglePayLauncher.Config,
         internal val currencyCode: String,

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
@@ -84,6 +84,7 @@ internal class GooglePayLauncherViewModel(
                     createTransactionInfo(
                         stripeIntent = intent,
                         currencyCode = intent.currency.orEmpty(),
+                        label = args.label,
                     )
                 }
             }
@@ -95,6 +96,8 @@ internal class GooglePayLauncherViewModel(
                     createTransactionInfo(
                         stripeIntent = intent,
                         currencyCode = args.currencyCode,
+                        amount = args.amount,
+                        label = args.label,
                     )
                 }
             }
@@ -123,7 +126,9 @@ internal class GooglePayLauncherViewModel(
     @VisibleForTesting
     internal fun createTransactionInfo(
         stripeIntent: StripeIntent,
-        currencyCode: String
+        currencyCode: String,
+        amount: Long? = null,
+        label: String? = null,
     ): GooglePayJsonFactory.TransactionInfo {
         return when (stripeIntent) {
             is PaymentIntent -> {
@@ -134,7 +139,7 @@ internal class GooglePayLauncherViewModel(
                     transactionId = stripeIntent.id,
                     totalPrice = stripeIntent.amount,
                     totalPriceLabel = null,
-                    checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.CompleteImmediatePurchase
+                    checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.CompleteImmediatePurchase,
                 )
             }
             is SetupIntent -> {
@@ -143,9 +148,9 @@ internal class GooglePayLauncherViewModel(
                     totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Estimated,
                     countryCode = args.config.merchantCountryCode,
                     transactionId = stripeIntent.id,
-                    totalPrice = 0L,
-                    totalPriceLabel = null,
-                    checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.Default
+                    totalPrice = amount ?: 0L,
+                    totalPriceLabel = label,
+                    checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.Default,
                 )
             }
         }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -247,12 +247,15 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
      * @param transactionId A unique ID that identifies a transaction attempt. Merchants may use an
      * existing ID or generate a specific one for Google Pay transaction attempts.
      * This field is required when you send callbacks to the Google Transaction Events API.
+     * @param label An optional label to display with the amount. If none is provided, Google Pay
+     * will display a generic label.
      */
     @JvmOverloads
     fun present(
         currencyCode: String,
         amount: Long = 0L,
-        transactionId: String? = null
+        transactionId: String? = null,
+        label: String? = null,
     ) {
         check(skipReadyCheck || isReady) {
             "present() may only be called when Google Pay is available on this device."
@@ -263,6 +266,7 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
                 config = config,
                 currencyCode = currencyCode,
                 amount = amount,
+                label = label,
                 transactionId = transactionId,
                 injectionParams = GooglePayPaymentMethodLauncherContractV2.Args.InjectionParams(
                     injectorKey,

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -247,8 +247,9 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
      * @param transactionId A unique ID that identifies a transaction attempt. Merchants may use an
      * existing ID or generate a specific one for Google Pay transaction attempts.
      * This field is required when you send callbacks to the Google Transaction Events API.
-     * @param label An optional label to display with the amount. If none is provided, Google Pay
-     * will display a generic label.
+     * @param label An optional label to display with the amount. Google Pay may or may not display
+     * this label depending on its own internal logic. Defaults to a generic label if none is
+     * provided.
      */
     @JvmOverloads
     fun present(

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2.kt
@@ -46,16 +46,26 @@ class GooglePayPaymentMethodLauncherContractV2 :
         internal val config: GooglePayPaymentMethodLauncher.Config,
         internal val currencyCode: String,
         internal val amount: Long,
+        internal val label: String? = null,
         internal val transactionId: String? = null,
-        internal val injectionParams: InjectionParams? = null
+        internal val injectionParams: InjectionParams? = null,
     ) : Parcelable {
+
         @JvmOverloads
         constructor(
             config: GooglePayPaymentMethodLauncher.Config,
             currencyCode: String,
             amount: Long,
-            transactionId: String? = null
-        ) : this(config, currencyCode, amount, transactionId, null)
+            transactionId: String? = null,
+            label: String? = null,
+        ) : this(
+            config = config,
+            currencyCode = currencyCode,
+            amount = amount,
+            label = label,
+            transactionId = transactionId,
+            injectionParams = null,
+        )
 
         internal fun toBundle() = bundleOf(EXTRA_ARGS to this)
 

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
@@ -83,7 +83,7 @@ internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
             countryCode = args.config.merchantCountryCode,
             transactionId = args.transactionId,
             totalPrice = args.amount,
-            totalPriceLabel = null,
+            totalPriceLabel = args.label,
             checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.Default
         )
     }

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
@@ -164,11 +164,12 @@ class GooglePayPaymentMethodLauncherViewModelTest {
 
             val factory = GooglePayPaymentMethodLauncherViewModel.Factory(
                 GooglePayPaymentMethodLauncherContractV2.Args(
-                    mock(),
-                    "usd",
-                    1099,
-                    null,
-                    GooglePayPaymentMethodLauncherContractV2.Args.InjectionParams(
+                    config = mock(),
+                    currencyCode = "usd",
+                    amount = 1099,
+                    label = null,
+                    transactionId = null,
+                    injectionParams = GooglePayPaymentMethodLauncherContractV2.Args.InjectionParams(
                         injectorKey,
                         emptySet(),
                         false,
@@ -201,15 +202,16 @@ class GooglePayPaymentMethodLauncherViewModelTest {
 
             val factory = GooglePayPaymentMethodLauncherViewModel.Factory(
                 GooglePayPaymentMethodLauncherContractV2.Args(
-                    GooglePayPaymentMethodLauncher.Config(
+                    config = GooglePayPaymentMethodLauncher.Config(
                         GooglePayEnvironment.Test,
                         "US",
                         "merchant"
                     ),
-                    "usd",
-                    1099,
-                    null,
-                    GooglePayPaymentMethodLauncherContractV2.Args.InjectionParams(
+                    currencyCode = "usd",
+                    amount = 1099,
+                    label = null,
+                    transactionId = null,
+                    injectionParams = GooglePayPaymentMethodLauncherContractV2.Args.InjectionParams(
                         DUMMY_INJECTOR_KEY,
                         productUsage,
                         false,

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -679,19 +679,24 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$FlowController$R
 public final class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;)V
-	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAmount ()Ljava/lang/Long;
 	public final fun getCountryCode ()Ljava/lang/String;
 	public final fun getCurrencyCode ()Ljava/lang/String;
 	public final fun getEnvironment ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;
+	public final fun getLabel ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -679,8 +679,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$FlowController$R
 public final class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)V
-	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)V
 	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -679,6 +679,9 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$FlowController$R
 public final class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;)V
+	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)V
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)V
 	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -1037,33 +1037,45 @@ class PaymentSheet internal constructor(
         val ephemeralKeySecret: String
     ) : Parcelable
 
+    /**
+     * @param environment The Google Pay environment to use. See
+     * [Google's documentation](https://developers.google.com/android/reference/com/google/android/gms/wallet/Wallet.WalletOptions#environment)
+     * for more information.
+     * @param countryCode The two-letter ISO 3166 code of the country of your business, e.g. "US".
+     * See your account's country value [here](https://dashboard.stripe.com/settings/account).
+     * @param currencyCode The three-letter ISO 4217 alphabetic currency code, e.g. "USD" or "EUR".
+     * Required in order to support Google Pay when processing a Setup Intent.
+     * @param amount An optional amount to display for setup intents. If none is provided, this
+     * method launches Google Pay with an amount of 0. Google Pay may or may not display this price
+     * depending on its own internal logic.
+     * @param label An optional label to display with the amount. If none is provided, Google Pay
+     * will display a generic label.
+     */
     @Parcelize
     data class GooglePayConfiguration(
-        /**
-         * The Google Pay environment to use.
-         *
-         * See [Google's documentation](https://developers.google.com/android/reference/com/google/android/gms/wallet/Wallet.WalletOptions#environment) for more information.
-         */
         val environment: Environment,
-        /**
-         * The two-letter ISO 3166 code of the country of your business, e.g. "US".
-         * See your account's country value [here](https://dashboard.stripe.com/settings/account).
-         */
         val countryCode: String,
-        /**
-         * The three-letter ISO 4217 alphabetic currency code, e.g. "USD" or "EUR".
-         * Required in order to support Google Pay when processing a Setup Intent.
-         */
-        val currencyCode: String? = null
+        val currencyCode: String? = null,
+        val amount: Long? = null,
+        val label: String? = null,
     ) : Parcelable {
+
         constructor(
             environment: Environment,
-            countryCode: String
-        ) : this(environment, countryCode, null)
+            countryCode: String,
+            amount: Long? = null,
+            label: String? = null,
+        ) : this(
+            environment = environment,
+            countryCode = countryCode,
+            currencyCode = null,
+            amount = amount,
+            label = label,
+        )
 
         enum class Environment {
             Production,
-            Test
+            Test,
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -1052,7 +1052,7 @@ class PaymentSheet internal constructor(
      * provided.
      */
     @Parcelize
-    data class GooglePayConfiguration(
+    data class GooglePayConfiguration @JvmOverloads constructor(
         val environment: Environment,
         val countryCode: String,
         val currencyCode: String? = null,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -1045,11 +1045,11 @@ class PaymentSheet internal constructor(
      * See your account's country value [here](https://dashboard.stripe.com/settings/account).
      * @param currencyCode The three-letter ISO 4217 alphabetic currency code, e.g. "USD" or "EUR".
      * Required in order to support Google Pay when processing a Setup Intent.
-     * @param amount An optional amount to display for setup intents. If none is provided, this
-     * method launches Google Pay with an amount of 0. Google Pay may or may not display this price
-     * depending on its own internal logic.
-     * @param label An optional label to display with the amount. If none is provided, Google Pay
-     * will display a generic label.
+     * @param amount An optional amount to display for setup intents. Google Pay may or may not
+     * display this amount depending on its own internal logic. Defaults to 0 if none is provided.
+     * @param label An optional label to display with the amount. Google Pay may or may not display
+     * this label depending on its own internal logic. Defaults to a generic label if none is
+     * provided.
      */
     @Parcelize
     data class GooglePayConfiguration(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -1060,19 +1060,6 @@ class PaymentSheet internal constructor(
         val label: String? = null,
     ) : Parcelable {
 
-        constructor(
-            environment: Environment,
-            countryCode: String,
-            amount: Long? = null,
-            label: String? = null,
-        ) : this(
-            environment = environment,
-            countryCode = countryCode,
-            currencyCode = null,
-            amount = amount,
-            label = label,
-        )
-
         enum class Environment {
             Production,
             Test,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -374,7 +374,10 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 googlePayPaymentMethodLauncher?.present(
                     currencyCode = (stripeIntent as? PaymentIntent)?.currency
                         ?: args.googlePayConfig?.currencyCode.orEmpty(),
-                    amount = (stripeIntent as? PaymentIntent)?.amount ?: 0L,
+                    amount = when (stripeIntent) {
+                        is PaymentIntent -> stripeIntent.amount ?: 0L
+                        is SetupIntent -> args.googlePayConfig?.amount ?: 0L
+                    },
                     transactionId = stripeIntent.id,
                     label = args.googlePayConfig?.label,
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -375,7 +375,8 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     currencyCode = (stripeIntent as? PaymentIntent)?.currency
                         ?: args.googlePayConfig?.currencyCode.orEmpty(),
                     amount = (stripeIntent as? PaymentIntent)?.amount ?: 0L,
-                    transactionId = stripeIntent.id
+                    transactionId = stripeIntent.id,
+                    label = args.googlePayConfig?.label,
                 )
             }
         } else {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -551,7 +551,8 @@ internal class DefaultFlowController @Inject internal constructor(
             currencyCode = (state.stripeIntent as? PaymentIntent)?.currency
                 ?: googlePayConfig.currencyCode.orEmpty(),
             amount = (state.stripeIntent as? PaymentIntent)?.amount ?: 0L,
-            transactionId = state.stripeIntent.id
+            transactionId = state.stripeIntent.id,
+            label = googlePayConfig.label,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -20,12 +20,10 @@ internal object PaymentSheetFixtures {
     internal const val MERCHANT_DISPLAY_NAME = "Merchant, Inc."
     internal const val CLIENT_SECRET = "pi_1234_secret_1234"
     internal const val DIFFERENT_CLIENT_SECRET = "pi_4321_secret_4321"
+    internal const val SETUP_CLIENT_SECRET = "seti_1234_secret_4321"
 
-    internal val PAYMENT_INTENT_CLIENT_SECRET = PaymentIntentClientSecret(
-        CLIENT_SECRET
-    )
-
-    internal val SETUP_INTENT_CLIENT_SECRET = PaymentIntentClientSecret("seti_1234_secret_4321")
+    internal val PAYMENT_INTENT_CLIENT_SECRET = PaymentIntentClientSecret(CLIENT_SECRET)
+    internal val SETUP_INTENT_CLIENT_SECRET = PaymentIntentClientSecret(SETUP_CLIENT_SECRET)
 
     internal val CONFIG_MINIMUM = PaymentSheet.Configuration(
         merchantDisplayName = MERCHANT_DISPLAY_NAME

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1599,6 +1599,7 @@ internal class PaymentSheetViewModelTest {
         val viewModel = createViewModel(
             args = args,
             isGooglePayReady = true,
+            stripeIntent = SETUP_INTENT,
         )
 
         viewModel.setupGooglePay(
@@ -1685,5 +1686,6 @@ internal class PaymentSheetViewModelTest {
         private val PAYMENT_METHODS = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
 
         val PAYMENT_INTENT = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
+        val SETUP_INTENT = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
+import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.model.Address
@@ -130,6 +131,10 @@ internal class PaymentSheetViewModelTest {
     }
     private val paymentLauncherFactory = mock<StripePaymentLauncherAssistedFactory> {
         on { create(any(), any(), anyOrNull(), any()) } doReturn paymentLauncher
+    }
+    private val googlePayLauncher = mock<GooglePayPaymentMethodLauncher>()
+    private val googlePayLauncherFactory = mock<GooglePayPaymentMethodLauncherFactory> {
+        on { create(any(), any(), any(), any(), any()) } doReturn googlePayLauncher
     }
     private val fakeIntentConfirmationInterceptor = FakeIntentConfirmationInterceptor()
 
@@ -1537,6 +1542,80 @@ internal class PaymentSheetViewModelTest {
         )
     }
 
+    @Test
+    fun `Launches Google Pay with custom label if provided for payment intent`() {
+        val expectedLabel = "My custom label"
+        val expectedAmount = 1099L
+
+        val args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
+            config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config?.copy(
+                googlePay = PaymentSheet.GooglePayConfiguration(
+                    environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                    countryCode = "CA",
+                    currencyCode = "CAD",
+                    amount = 12345,
+                    label = expectedLabel,
+                )
+            )
+        )
+
+        val viewModel = createViewModel(
+            args = args,
+            isGooglePayReady = true,
+        )
+
+        viewModel.setupGooglePay(
+            lifecycleScope = mock(),
+            activityResultLauncher = mock(),
+        )
+
+        viewModel.checkoutWithGooglePay()
+
+        verify(googlePayLauncher).present(
+            currencyCode = any(),
+            amount = eq(expectedAmount),
+            transactionId = anyOrNull(),
+            label = eq(expectedLabel),
+        )
+    }
+
+    @Test
+    fun `Launches Google Pay with custom label and amount if provided for setup intent`() {
+        val expectedLabel = "My custom label"
+        val expectedAmount = 1234L
+
+        val args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
+            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config?.copy(
+                googlePay = PaymentSheet.GooglePayConfiguration(
+                    environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                    countryCode = "CA",
+                    currencyCode = "CAD",
+                    amount = expectedAmount,
+                    label = expectedLabel,
+                )
+            )
+        )
+
+        val viewModel = createViewModel(
+            args = args,
+            isGooglePayReady = true,
+        )
+
+        viewModel.setupGooglePay(
+            lifecycleScope = mock(),
+            activityResultLauncher = mock(),
+        )
+
+        viewModel.checkoutWithGooglePay()
+
+        verify(googlePayLauncher).present(
+            currencyCode = any(),
+            amount = eq(expectedAmount),
+            transactionId = anyOrNull(),
+            label = eq(expectedLabel),
+        )
+    }
+
     private fun createViewModel(
         args: PaymentSheetContractV2.Args = ARGS_CUSTOMER_WITH_GOOGLEPAY,
         stripeIntent: StripeIntent = PAYMENT_INTENT,
@@ -1553,11 +1632,11 @@ internal class PaymentSheetViewModelTest {
             linkConfigurationCoordinator = linkConfigurationCoordinator,
         ) { linkHandler, linkInteractor, savedStateHandle ->
             PaymentSheetViewModel(
-                application,
-                args,
-                eventReporter,
-                { paymentConfiguration },
-                FakePaymentSheetLoader(
+                application = application,
+                args = args,
+                eventReporter = eventReporter,
+                lazyPaymentConfig = { paymentConfiguration },
+                paymentSheetLoader = FakePaymentSheetLoader(
                     stripeIntent = stripeIntent,
                     shouldFail = shouldFailLoad,
                     linkState = linkState,
@@ -1565,13 +1644,13 @@ internal class PaymentSheetViewModelTest {
                     delay = delay,
                     isGooglePayAvailable = isGooglePayReady,
                 ),
-                customerRepository,
-                prefsRepository,
-                lpmRepository,
+                customerRepository = customerRepository,
+                prefsRepository = prefsRepository,
+                lpmRepository = lpmRepository,
                 paymentLauncherFactory = paymentLauncherFactory,
-                mock(),
-                Logger.noop(),
-                testDispatcher,
+                googlePayPaymentMethodLauncherFactory = googlePayLauncherFactory,
+                logger = Logger.noop(),
+                workContext = testDispatcher,
                 savedStateHandle = savedStateHandle,
                 linkHandler = linkHandler,
                 linkConfigurationCoordinator = linkInteractor,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -1337,6 +1337,76 @@ internal class DefaultFlowControllerTest {
         )
     }
 
+    @Test
+    fun `Launches Google Pay with custom label if provided for payment intent`() = runTest {
+        val expectedLabel = "My custom label"
+        val expectedAmount = 1099L
+
+        val flowController = createFlowController()
+
+        flowController.configureExpectingSuccess(
+            clientSecret = PaymentSheetFixtures.CLIENT_SECRET,
+            configuration = PaymentSheet.Configuration(
+                merchantDisplayName = "My merchant",
+                googlePay = PaymentSheet.GooglePayConfiguration(
+                    environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                    countryCode = "CA",
+                    currencyCode = "CAD",
+                    amount = 1234L,
+                    label = expectedLabel,
+                )
+            )
+        )
+
+        flowController.onPaymentOptionResult(
+            PaymentOptionResult.Succeeded(PaymentSelection.GooglePay)
+        )
+
+        flowController.confirm()
+
+        verify(googlePayPaymentMethodLauncher).present(
+            currencyCode = any(),
+            amount = eq(expectedAmount),
+            transactionId = anyOrNull(),
+            label = eq(expectedLabel),
+        )
+    }
+
+    @Test
+    fun `Launches Google Pay with custom label and amount if provided for setup intent`() = runTest {
+        val expectedLabel = "My custom label"
+        val expectedAmount = 1099L
+
+        val flowController = createFlowController()
+
+        flowController.configureExpectingSuccess(
+            clientSecret = PaymentSheetFixtures.SETUP_CLIENT_SECRET,
+            configuration = PaymentSheet.Configuration(
+                merchantDisplayName = "My merchant",
+                googlePay = PaymentSheet.GooglePayConfiguration(
+                    environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                    countryCode = "CA",
+                    currencyCode = "CAD",
+                    amount = expectedAmount,
+                    label = expectedLabel,
+                )
+            )
+        )
+
+        flowController.onPaymentOptionResult(
+            PaymentOptionResult.Succeeded(PaymentSelection.GooglePay)
+        )
+
+        flowController.confirm()
+
+        verify(googlePayPaymentMethodLauncher).present(
+            currencyCode = any(),
+            amount = eq(expectedAmount),
+            transactionId = anyOrNull(),
+            label = eq(expectedLabel),
+        )
+    }
+
     private fun createAndConfigureFlowControllerForDeferredIntent(
         paymentIntent: PaymentIntent = PaymentIntentFixtures.PI_SUCCEEDED,
     ): DefaultFlowController {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds support for providing a custom amount (for setup intents) and a custom label when opening the Google Pay bottom sheet.

For `GooglePayLauncher`, we add both properties to `presentForSetupIntent()` and the label property to `presentForPaymentIntent()`.

For `GooglePayPaymentMethodLauncher`, we add the label property to `present()`, as the amount property already exists.

For `PaymentSheet.GooglePayConfiguration`, we add both properties to the constructor. We also remove one redundant constructor.

(cc @charliecruzan-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[MOBILE_APIREVIEW-53](https://jira.corp.stripe.com/browse/MOBILE_APIREVIEW-53)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
