### PR TITLE
Add `error_message` to payment failed event

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -35,6 +35,7 @@ import com.stripe.android.payments.paymentlauncher.StripePaymentLauncher
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
 import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
 import com.stripe.android.paymentsheet.extensions.registerPollingAuthenticator
 import com.stripe.android.paymentsheet.extensions.unregisterPollingAuthenticator
 import com.stripe.android.paymentsheet.injection.DaggerPaymentSheetLauncherComponent
@@ -548,6 +549,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     paymentSelection = selection.value,
                     currency = stripeIntent.currency,
                     isDecoupling = isDecoupling,
+                    error = PaymentSheetConfirmationError.Stripe(paymentResult.throwable),
                 )
 
                 resetViewState(
@@ -578,6 +580,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     paymentSelection = PaymentSelection.GooglePay,
                     currency = stripeIntent.value?.currency,
                     isDecoupling = isDecoupling,
+                    error = PaymentSheetConfirmationError.GooglePay(result.errorCode),
                 )
                 onError(
                     when (result.errorCode) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -177,6 +177,7 @@ internal class DefaultEventReporter @Inject internal constructor(
         paymentSelection: PaymentSelection?,
         currency: String?,
         isDecoupling: Boolean,
+        error: PaymentSheetConfirmationError,
     ) {
         val duration = durationProvider.end(DurationProvider.Key.Checkout)
 
@@ -185,7 +186,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 mode = mode,
                 paymentSelection = paymentSelection,
                 duration = duration,
-                result = PaymentSheetEvent.Payment.Result.Failure,
+                result = PaymentSheetEvent.Payment.Result.Failure(error),
                 currency = currency,
                 isDecoupled = isDecoupling,
                 deferredIntentConfirmationType = null,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -107,6 +107,7 @@ internal interface EventReporter {
         paymentSelection: PaymentSelection?,
         currency: String?,
         isDecoupling: Boolean,
+        error: PaymentSheetConfirmationError,
     )
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetConfirmationError.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetConfirmationError.kt
@@ -1,0 +1,37 @@
+package com.stripe.android.paymentsheet.analytics
+
+import com.stripe.android.core.exception.APIConnectionException
+import com.stripe.android.core.exception.APIException
+import com.stripe.android.core.exception.InvalidRequestException
+import com.stripe.android.core.exception.StripeException
+
+internal sealed class PaymentSheetConfirmationError : Throwable() {
+
+    abstract val analyticsValue: String
+
+    data class Stripe(override val cause: Throwable) : PaymentSheetConfirmationError() {
+
+        override val analyticsValue: String
+            get() = StripeException.create(cause).analyticsValue
+    }
+
+    data class GooglePay(val errorCode: Int) : PaymentSheetConfirmationError() {
+
+        override val analyticsValue: String
+            get() = "googlePay_$errorCode"
+    }
+
+    object InvalidState : PaymentSheetConfirmationError() {
+
+        override val analyticsValue: String
+            get() = "invalidState"
+    }
+}
+
+internal val StripeException.analyticsValue: String
+    get() = when (this) {
+        is APIException -> "apiError"
+        is APIConnectionException -> "connectionError"
+        is InvalidRequestException -> "invalidRequestError"
+        else -> "unknown"
+    }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -41,6 +41,7 @@ import com.stripe.android.paymentsheet.PaymentSheetResultCallback
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
 import com.stripe.android.paymentsheet.extensions.registerPollingAuthenticator
 import com.stripe.android.paymentsheet.extensions.unregisterPollingAuthenticator
 import com.stripe.android.paymentsheet.intercept
@@ -371,14 +372,15 @@ internal class DefaultFlowController @Inject internal constructor(
                             state
                         )
                     },
-                    onFailure = {
+                    onFailure = { error ->
                         eventReporter.onPaymentFailure(
                             paymentSelection = PaymentSelection.GooglePay,
                             currency = viewModel.state?.stripeIntent?.currency,
                             isDecoupling = isDecoupling,
+                            error = PaymentSheetConfirmationError.InvalidState,
                         )
                         paymentResultCallback.onPaymentSheetResult(
-                            PaymentSheetResult.Failed(it)
+                            PaymentSheetResult.Failed(error)
                         )
                     }
                 )
@@ -388,6 +390,7 @@ internal class DefaultFlowController @Inject internal constructor(
                     paymentSelection = PaymentSelection.GooglePay,
                     currency = viewModel.state?.stripeIntent?.currency,
                     isDecoupling = isDecoupling,
+                    error = PaymentSheetConfirmationError.GooglePay(googlePayResult.errorCode),
                 )
                 paymentResultCallback.onPaymentSheetResult(
                     PaymentSheetResult.Failed(
@@ -422,14 +425,15 @@ internal class DefaultFlowController @Inject internal constructor(
                         state
                     )
                 },
-                onFailure = {
+                onFailure = { error ->
                     eventReporter.onPaymentFailure(
                         paymentSelection = PaymentSelection.Link,
                         currency = viewModel.state?.stripeIntent?.currency,
                         isDecoupling = isDecoupling,
+                        error = PaymentSheetConfirmationError.InvalidState,
                     )
                     paymentResultCallback.onPaymentSheetResult(
-                        PaymentSheetResult.Failed(it)
+                        PaymentSheetResult.Failed(error)
                     )
                 }
             )
@@ -498,6 +502,7 @@ internal class DefaultFlowController @Inject internal constructor(
                     paymentSelection = viewModel.paymentSelection,
                     currency = viewModel.state?.stripeIntent?.currency,
                     isDecoupling = isDecoupling,
+                    error = PaymentSheetConfirmationError.Stripe(paymentResult.throwable),
                 )
             }
             else -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoadingException.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoadingException.kt
@@ -1,11 +1,9 @@
 package com.stripe.android.paymentsheet.state
 
-import com.stripe.android.core.exception.APIConnectionException
-import com.stripe.android.core.exception.APIException
-import com.stripe.android.core.exception.InvalidRequestException
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentsheet.analytics.analyticsValue
 import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException.Unknown
 
 internal sealed class PaymentSheetLoadingException : Throwable() {
@@ -73,12 +71,7 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
     ) : PaymentSheetLoadingException() {
 
         override val type: String
-            get() = when (StripeException.create(cause)) {
-                is APIException -> "apiError"
-                is APIConnectionException -> "connectionError"
-                is InvalidRequestException -> "invalidRequestError"
-                else -> "unknown"
-            }
+            get() = StripeException.create(cause).analyticsValue
 
         override val message: String? = cause.message
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -39,6 +39,7 @@ import com.stripe.android.paymentsheet.PaymentSheet.InitializationMode
 import com.stripe.android.paymentsheet.PaymentSheetViewModel.CheckoutIdentifier
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.model.SavedSelection
@@ -501,15 +502,18 @@ internal class PaymentSheetViewModelTest {
     fun `onPaymentResult() with non-success outcome should report failure event`() = runTest {
         val viewModel = createViewModel()
         val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        val error = APIException()
+
         viewModel.updateSelection(selection)
 
         viewModel.stripeIntent.test {
-            viewModel.onPaymentResult(PaymentResult.Failed(Throwable()))
+            viewModel.onPaymentResult(PaymentResult.Failed(error))
             verify(eventReporter)
                 .onPaymentFailure(
                     paymentSelection = selection,
                     currency = "usd",
                     isDecoupling = false,
+                    error = PaymentSheetConfirmationError.Stripe(error),
                 )
 
             val stripeIntent = awaitItem()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -4,6 +4,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.model.PaymentMethodFixtures
@@ -204,13 +205,16 @@ class DefaultEventReporterTest {
             paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
             currency = "usd",
             isDecoupling = false,
+            error = PaymentSheetConfirmationError.Stripe(APIException())
         )
+
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
                 req.params["event"] == "mc_complete_payment_savedpm_failure" &&
                     req.params["duration"] == 0.456f &&
                     req.params["currency"] == "usd" &&
-                    req.params["locale"] == "en_US"
+                    req.params["locale"] == "en_US" &&
+                    req.params["error_message"] == "apiError"
             }
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.analytics
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.exception.APIException
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.model.PaymentDetailsFixtures
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
@@ -277,7 +278,9 @@ class PaymentSheetEventTest {
                 mock()
             ),
             duration = 1.milliseconds,
-            result = PaymentSheetEvent.Payment.Result.Failure,
+            result = PaymentSheetEvent.Payment.Result.Failure(
+                error = PaymentSheetConfirmationError.Stripe(APIException()),
+            ),
             currency = "usd",
             isDecoupled = false,
             deferredIntentConfirmationType = null,
@@ -295,6 +298,7 @@ class PaymentSheetEventTest {
                 "duration" to 0.001F,
                 "is_decoupled" to false,
                 "selected_lpm" to "card",
+                "error_message" to "apiError",
             )
         )
     }
@@ -305,7 +309,9 @@ class PaymentSheetEventTest {
             mode = EventReporter.Mode.Complete,
             paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
             duration = 1.milliseconds,
-            result = PaymentSheetEvent.Payment.Result.Failure,
+            result = PaymentSheetEvent.Payment.Result.Failure(
+                error = PaymentSheetConfirmationError.Stripe(APIException()),
+            ),
             currency = "usd",
             isDecoupled = false,
             deferredIntentConfirmationType = null,
@@ -323,6 +329,7 @@ class PaymentSheetEventTest {
                 "duration" to 0.001F,
                 "is_decoupled" to false,
                 "selected_lpm" to "card",
+                "error_message" to "apiError",
             )
         )
     }
@@ -333,7 +340,9 @@ class PaymentSheetEventTest {
             mode = EventReporter.Mode.Complete,
             paymentSelection = PaymentSelection.GooglePay,
             duration = 1.milliseconds,
-            result = PaymentSheetEvent.Payment.Result.Failure,
+            result = PaymentSheetEvent.Payment.Result.Failure(
+                error = PaymentSheetConfirmationError.Stripe(APIException()),
+            ),
             currency = "usd",
             isDecoupled = false,
             deferredIntentConfirmationType = null,
@@ -351,6 +360,7 @@ class PaymentSheetEventTest {
                 "duration" to 0.001F,
                 "is_decoupled" to false,
                 "selected_lpm" to "google_pay",
+                "error_message" to "apiError",
             )
         )
     }
@@ -361,7 +371,9 @@ class PaymentSheetEventTest {
             mode = EventReporter.Mode.Complete,
             paymentSelection = PaymentSelection.Link,
             duration = 1.milliseconds,
-            result = PaymentSheetEvent.Payment.Result.Failure,
+            result = PaymentSheetEvent.Payment.Result.Failure(
+                error = PaymentSheetConfirmationError.Stripe(APIException()),
+            ),
             currency = "usd",
             isDecoupled = false,
             deferredIntentConfirmationType = null,
@@ -379,6 +391,7 @@ class PaymentSheetEventTest {
                 "duration" to 0.001F,
                 "is_decoupled" to false,
                 "selected_lpm" to "link",
+                "error_message" to "apiError",
             )
         )
     }
@@ -395,7 +408,9 @@ class PaymentSheetEventTest {
                 )
             ),
             duration = 1.milliseconds,
-            result = PaymentSheetEvent.Payment.Result.Failure,
+            result = PaymentSheetEvent.Payment.Result.Failure(
+                error = PaymentSheetConfirmationError.Stripe(APIException()),
+            ),
             currency = "usd",
             isDecoupled = false,
             deferredIntentConfirmationType = null,
@@ -412,6 +427,7 @@ class PaymentSheetEventTest {
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
+                "error_message" to "apiError",
             )
         )
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request populates the `error_message` field for the payment failed event.

Possible values are
- `apiError`, `connectionError`, `invalidRequestError`, and `unknown` (same as the load errors)
- `invalidState` for wrong local assertions
- `googlePay_{code}` for Google Pay errors

(cc @porter-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Observability improvements

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
