### PR TITLE
Fix duplicate `DurationProvider` instances

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -48,9 +48,6 @@ import kotlin.coroutines.CoroutineContext
 internal abstract class PaymentSheetCommonModule {
 
     @Binds
-    abstract fun bindsDurationProvider(impl: DefaultDurationProvider): DurationProvider
-
-    @Binds
     abstract fun bindsEventReporter(eventReporter: DefaultEventReporter): EventReporter
 
     @Binds
@@ -131,6 +128,12 @@ internal abstract class PaymentSheetCommonModule {
         ): String {
             val application = appContext as Application
             return application.applicationInfo.loadLabel(application.packageManager).toString()
+        }
+
+        @Provides
+        @Singleton
+        fun provideDurationProvider(): DurationProvider {
+            return DefaultDurationProvider.instance
         }
     }
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
@@ -2,7 +2,6 @@ package com.stripe.android.core.utils
 
 import android.os.SystemClock
 import androidx.annotation.RestrictTo
-import javax.inject.Inject
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -20,18 +19,25 @@ interface DurationProvider {
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class DefaultDurationProvider @Inject constructor() : DurationProvider {
+class DefaultDurationProvider private constructor() : DurationProvider {
 
     private val store = mutableMapOf<DurationProvider.Key, Long>()
 
     override fun start(key: DurationProvider.Key) {
-        val startTime = SystemClock.uptimeMillis()
-        store[key] = startTime
+        if (key !in store) {
+            val startTime = SystemClock.uptimeMillis()
+            store[key] = startTime
+        }
     }
 
     override fun end(key: DurationProvider.Key): Duration? {
         val startTime = store.remove(key) ?: return null
         val duration = SystemClock.uptimeMillis() - startTime
         return duration.milliseconds
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    companion object {
+        val instance = DefaultDurationProvider()
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes two issues with `DurationProvider`:

1. With our DI structure, we ended up with multiple `EventReporter` instances, which all pulled in their own `DurationProvider` dependencies. This resulted in no duration being reported in the custom flow.
2. **This is to be discussed**: The existing implementation basically reset the checkout timer if the customer re-opened PaymentSheet in the custom flow. Now, we keep the original start timestamp.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
