### PR TITLE
Add support for validating the host in NetworkRule tests.

### DIFF
--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
@@ -89,6 +89,7 @@ private class NetworkStatement(
     private fun tearDown() {
         mockWebServer.dispatcher.clear()
         ConnectionFactory.Default.testConnectionCustomization = null
+        ConnectionFactory.Default.testHostCustomization = null
     }
 }
 

--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
@@ -2,10 +2,13 @@ package com.stripe.android.networktesting
 
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.ConnectionFactory
+import com.stripe.android.core.networking.StripeRequest
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.mockwebserver.MockResponse
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
+import java.io.OutputStream
 import javax.net.ssl.HttpsURLConnection
 
 class NetworkRule : TestRule {
@@ -50,14 +53,22 @@ private class NetworkStatement(
     }
 
     private fun setup() {
-        ApiRequest.apiTestHost = mockWebServer.baseUrl.toString().removeSuffix("/")
-        ConnectionFactory.Default.testConnectionCustomization = lambda@{ insecureConnection ->
-            if (mockWebServer.baseUrl.host != insecureConnection.url.host) {
+        ConnectionFactory.Default.testHostCustomization = lambda@{ request ->
+            if (!request.url.startsWith(ApiRequest.API_HOST)) {
                 throw RequestNotFoundException(
                     "Test request attempted to reach a non test endpoint. " +
-                        "Url: ${insecureConnection.url}"
+                        "Url: ${request.url}"
                 )
             }
+
+            return@lambda DelegatingStripeRequest(
+                request, request.url.replace(
+                    ApiRequest.API_HOST,
+                    mockWebServer.baseUrl.toString().removeSuffix("/")
+                )
+            )
+        }
+        ConnectionFactory.Default.testConnectionCustomization = lambda@{ insecureConnection ->
             val connection = insecureConnection as? HttpsURLConnection ?: return@lambda
             connection.sslSocketFactory = mockWebServer.clientSocketFactory()
         }
@@ -77,6 +88,37 @@ private class NetworkStatement(
     private fun tearDown() {
         mockWebServer.dispatcher.clear()
         ConnectionFactory.Default.testConnectionCustomization = null
-        ApiRequest.apiTestHost = null
+    }
+}
+
+private class DelegatingStripeRequest(
+    private val original: StripeRequest,
+    private val testUrl: String,
+) : StripeRequest() {
+
+    private val originalHost: String = original.url.toHttpUrl().host
+
+    override val method: Method
+        get() = original.method
+
+    override val mimeType: MimeType
+        get() = original.mimeType
+
+    override val retryResponseCodes: Iterable<Int>
+        get() = original.retryResponseCodes
+
+    override val url: String
+        get() = testUrl
+
+    override val headers: Map<String, String>
+        get() = original.headers.plus(Pair("original-host", originalHost))
+
+    override var postHeaders: Map<String, String>? = original.postHeaders
+
+    override val shouldCache: Boolean
+        get() = original.shouldCache
+
+    override fun writePostBody(outputStream: OutputStream) {
+        original.writePostBody(outputStream)
     }
 }

--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
@@ -62,7 +62,8 @@ private class NetworkStatement(
             }
 
             return@lambda DelegatingStripeRequest(
-                request, request.url.replace(
+                request,
+                request.url.replace(
                     ApiRequest.API_HOST,
                     mockWebServer.baseUrl.toString().removeSuffix("/")
                 )

--- a/network-testing/src/main/java/com/stripe/android/networktesting/RequestMatchers.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/RequestMatchers.kt
@@ -14,6 +14,10 @@ private class ToStringRequestMatcher(
 }
 
 object RequestMatchers {
+    fun host(host: String): RequestMatcher {
+        return header("original-host", host)
+    }
+
     fun header(key: String, value: String): RequestMatcher {
         return ToStringRequestMatcher("header($key, $value)") { request ->
             request.headers[key] == value

--- a/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
@@ -171,21 +171,18 @@ class ConsumersApiServiceImplTest {
 
     @Test
     fun testConsumerSessionLookupUrl() {
-        ApiRequest.apiTestHost = null
         assertThat("https://api.stripe.com/v1/consumers/sessions/lookup")
             .isEqualTo(ConsumersApiServiceImpl.consumerSessionLookupUrl)
     }
 
     @Test
     fun testStartConsumerVerificationUrl() {
-        ApiRequest.apiTestHost = null
         assertThat("https://api.stripe.com/v1/consumers/sessions/start_verification")
             .isEqualTo(ConsumersApiServiceImpl.startConsumerVerificationUrl)
     }
 
     @Test
     fun testConfirmConsumerVerificationUrl() {
-        ApiRequest.apiTestHost = null
         assertThat("https://api.stripe.com/v1/consumers/sessions/confirm_verification")
             .isEqualTo(ConsumersApiServiceImpl.confirmConsumerVerificationUrl)
     }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
+import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.not
 import com.stripe.android.networktesting.RequestMatchers.path
@@ -31,6 +32,7 @@ internal class PaymentSheetTest {
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
+            host("api.stripe.com"),
             method("GET"),
             path("/v1/elements/sessions"),
         ) { response ->

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/ApiRequest.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/ApiRequest.kt
@@ -195,12 +195,6 @@ data class ApiRequest internal constructor(
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
-        @Volatile
-        var apiTestHost: String? = null
-
-        val API_HOST: String
-            get() {
-                return apiTestHost ?: "https://api.stripe.com"
-            }
+        const val API_HOST = "https://api.stripe.com"
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Rewrite requests when using network rule to be able to validate the host of the original request.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
First step in adding support for validating q.stripe.com requests.
