### PR TITLE
Test analytics with network rule to provide end to end insights into correctness.

### DIFF
--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.networktesting
 
+import android.util.Log
 import com.stripe.android.networktesting.RequestMatchers.composite
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
@@ -58,7 +59,10 @@ internal class NetworkDispatcher : Dispatcher() {
             return capturedEntry.responseFactory(testRequest)
         }
 
-        throw RequestNotFoundException("$request not mocked\n${testRequest.bodyText}")
+        val exception = RequestNotFoundException("$request not mocked\n${testRequest.bodyText}")
+        Log.d("NetworkDispatcher", "Request not found.", exception)
+        android.os.Process.killProcess(android.os.Process.myPid())
+        throw exception
     }
 }
 

--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
@@ -61,7 +61,15 @@ internal class NetworkDispatcher : Dispatcher() {
 
         val exception = RequestNotFoundException("$request not mocked\n${testRequest.bodyText}")
         Log.d("NetworkDispatcher", "Request not found.", exception)
+
+        // Some places that make requests silently ignore failures and cause the thrown exception
+        // to be ignored (think analytics, and non critical request paths).
+        // Given these requests are typically not critical to the flow of the tests, sometimes the
+        // rest of the test will continue, even if a request was missed.
+        // Killing the process will ensure the test fails for a missing request even if the
+        // exception is silently ignored.
         android.os.Process.killProcess(android.os.Process.myPid())
+
         throw exception
     }
 }

--- a/network-testing/src/main/java/com/stripe/android/networktesting/RequestMatchers.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/RequestMatchers.kt
@@ -116,6 +116,12 @@ object RequestMatchers {
         }
     }
 
+    fun hasQueryParam(param: String): RequestMatcher {
+        return ToStringRequestMatcher("queryParam($param)") { request ->
+            request.queryParameterValues(param).size == 1
+        }
+    }
+
     fun composite(vararg matchers: RequestMatcher): RequestMatcher {
         val friendlyName = "composite(${matchers.joinToString { it.toString() }})"
         return ToStringRequestMatcher(friendlyName) { request ->

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
@@ -1,0 +1,90 @@
+package com.stripe.android.paymentsheet
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.stripe.android.core.networking.AnalyticsRequest
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.RequestMatcher
+import com.stripe.android.networktesting.RequestMatchers.hasQueryParam
+import com.stripe.android.networktesting.RequestMatchers.host
+import com.stripe.android.networktesting.RequestMatchers.method
+import com.stripe.android.networktesting.RequestMatchers.path
+import com.stripe.android.networktesting.RequestMatchers.query
+import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.paymentsheet.utils.assertCompleted
+import com.stripe.android.paymentsheet.utils.runPaymentSheetTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class PaymentSheetAnalyticsTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    private val page: PaymentSheetPage = PaymentSheetPage(composeTestRule)
+
+    @get:Rule
+    val networkRule = NetworkRule(
+        hostsToTrack = listOf(ApiRequest.API_HOST, AnalyticsRequest.HOST),
+    )
+
+    @Test
+    fun testSuccessfulCardPayment() = runPaymentSheetTest(
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("GET"),
+            path("/v1/elements/sessions"),
+        ) { response ->
+            response.testBodyFromFile("elements-sessions-requires_payment_method.json")
+        }
+
+        validateAnalyticsRequest(eventName = "mc_complete_init_default")
+        validateAnalyticsRequest(eventName = "mc_load_started")
+        validateAnalyticsRequest(eventName = "mc_load_succeeded")
+        validateAnalyticsRequest(eventName = "mc_complete_sheet_newpm_show")
+
+        testContext.presentPaymentSheet {
+            presentWithPaymentIntent(
+                paymentIntentClientSecret = "pi_example_secret_example",
+                configuration = null,
+            )
+        }
+
+        validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
+
+        page.fillOutCardDetails()
+
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("POST"),
+            path("/v1/payment_intents/pi_example/confirm"),
+        ) { response ->
+            response.testBodyFromFile("payment-intent-confirm.json")
+        }
+
+        validateAnalyticsRequest(eventName = "mc_confirm_button_tapped")
+        validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
+        validateAnalyticsRequest(eventName = "stripe_android.payment_intent_confirmation")
+        validateAnalyticsRequest(eventName = "mc_complete_payment_newpm_success", hasQueryParam("duration"))
+
+        page.clickPrimaryButton()
+    }
+
+    private fun validateAnalyticsRequest(
+        eventName: String,
+        vararg requestMatchers: RequestMatcher,
+    ) {
+        networkRule.enqueue(
+            host("q.stripe.com"),
+            method("GET"),
+            query("event", eventName),
+            *requestMatchers,
+        ) { response ->
+            response.status = "HTTP/1.1 200 OK"
+        }
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetBillingConfigurationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetBillingConfigurationTest.kt
@@ -29,13 +29,14 @@ internal class PaymentSheetBillingConfigurationTest {
 
     @Test
     fun testPayloadWithDefaultsAndOverrides() {
-        networkRule.enqueue(
-            method("POST"),
-            path("/v1/consumers/sessions/lookup"),
-        ) { response ->
-            response.setResponseCode(500)
+        repeat(2) {
+            networkRule.enqueue(
+                method("POST"),
+                path("/v1/consumers/sessions/lookup"),
+            ) { response ->
+                response.setResponseCode(500)
+            }
         }
-
         networkRule.enqueue(
             method("GET"),
             path("/v1/elements/sessions"),
@@ -105,11 +106,13 @@ internal class PaymentSheetBillingConfigurationTest {
 
     @Test
     fun testPayloadWithoutDefaults() {
-        networkRule.enqueue(
-            method("POST"),
-            path("/v1/consumers/sessions/lookup"),
-        ) { response ->
-            response.setResponseCode(500)
+        repeat(2) {
+            networkRule.enqueue(
+                method("POST"),
+                path("/v1/consumers/sessions/lookup"),
+            ) { response ->
+                response.setResponseCode(500)
+            }
         }
 
         networkRule.enqueue(

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequest.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequest.kt
@@ -27,7 +27,8 @@ data class AnalyticsRequest(
         query.takeIf { it.isNotEmpty() }
     ).joinToString("?")
 
-    internal companion object {
-        internal const val HOST = "https://q.stripe.com"
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    companion object {
+        const val HOST = "https://q.stripe.com"
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This change adds a test that confirms analytics behavior end to end in payment sheet. It also makes validation stricter, so if we can more easily test and verify requests. It also makes it possible to test other hosts (not just api.stripe.com).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Follow up to #7197 and #7195 to test an analytics flow that wasn't possible to test prior to this change.

