### PR TITLE
Make retrieving of payment methods and the selected payment method async.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -14,6 +14,8 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentOptionFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.utils.AnimationConstants
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import javax.inject.Inject
 
 /**
@@ -79,10 +81,16 @@ class CustomerSheet @Inject internal constructor(
      * Retrieves the customer's saved payment option selection or null if the customer does not have
      * a persisted payment option selection.
      */
-    suspend fun retrievePaymentOptionSelection(): CustomerSheetResult {
+    suspend fun retrievePaymentOptionSelection(): CustomerSheetResult = coroutineScope {
         val adapter = CustomerSessionViewModel.component.customerAdapter
-        val selectedPaymentOption = adapter.retrieveSelectedPaymentOption()
-        val paymentMethods = adapter.retrievePaymentMethods()
+        val selectedPaymentOptionDeferred = async {
+            adapter.retrieveSelectedPaymentOption()
+        }
+        val paymentMethodsDeferred = async {
+            adapter.retrievePaymentMethods()
+        }
+        val selectedPaymentOption = selectedPaymentOptionDeferred.await()
+        val paymentMethods = paymentMethodsDeferred.await()
 
         val selection = selectedPaymentOption.mapCatching { paymentOption ->
             paymentOption?.toPaymentSelection {
@@ -92,7 +100,7 @@ class CustomerSheet @Inject internal constructor(
             }?.toPaymentOptionSelection(paymentOptionFactory)
         }
 
-        return selection.fold(
+        selection.fold(
             onSuccess = {
                 CustomerSheetResult.Selected(it)
             },

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -42,6 +42,7 @@ import com.stripe.android.paymentsheet.state.toInternal
 import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
 import com.stripe.android.paymentsheet.utils.mapAsStateFlow
 import com.stripe.android.ui.core.forms.resources.LpmRepository
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
@@ -184,11 +185,15 @@ internal class CustomerSheetViewModel @Inject constructor(
 
     private fun loadPaymentMethods() {
         viewModelScope.launch {
-            val paymentMethodsResult = customerAdapter.retrievePaymentMethods()
-            val selectedPaymentOption = customerAdapter.retrieveSelectedPaymentOption()
+            val paymentMethodsResult = async {
+                customerAdapter.retrievePaymentMethods()
+            }
+            val selectedPaymentOption = async {
+                customerAdapter.retrieveSelectedPaymentOption()
+            }
 
-            paymentMethodsResult.flatMap { paymentMethods ->
-                selectedPaymentOption.map { paymentOption ->
+            paymentMethodsResult.await().flatMap { paymentMethods ->
+                selectedPaymentOption.await().map { paymentOption ->
                     Pair(paymentMethods, paymentOption)
                 }
             }.map {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Make retrieving of payment methods and the selected payment method async.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We don't need to do these in sequence, they can be done in parallel. This doesn't have a large impact today, but in the future the selected payment method will (hopefully) be loaded from the server.
