### PR TITLE
Remove test that validates server response.

### DIFF
--- a/payments-core/src/test/java/com/stripe/android/StripeTest.java
+++ b/payments-core/src/test/java/com/stripe/android/StripeTest.java
@@ -862,18 +862,6 @@ public class StripeTest {
     }
 
     @Test
-    public void createVisaCheckoutParams_whenUnactivated_throwsException() {
-        final SourceParams sourceParams = SourceParams.createVisaCheckoutParams(
-                UUID.randomUUID().toString()
-        );
-        final InvalidRequestException ex = assertThrows(
-                InvalidRequestException.class,
-                () -> defaultStripe.createSourceSynchronous(sourceParams)
-        );
-        assertEquals("visa_checkout must be activated before use.", ex.getMessage());
-    }
-
-    @Test
     public void createMasterpassParams_whenUnactivated_throwsException() {
         final SourceParams sourceParams = SourceParams.createMasterpassParams(
                 UUID.randomUUID().toString(),


### PR DESCRIPTION
This is slowly changing.

Expected :visa_checkout must be activated before use.
Actual   :visa_checkout has been deprecated. Please migrate to Secure Remote Commerce. https://stripe.com/docs/secure-remote-commerce

# Summary
<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Test has been flaking.
