### PR TITLE
Update `PostalCodeConfig` to internally determine validation & settings

### DIFF
--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
@@ -28,7 +28,7 @@ class PostalCodeConfigTest {
     @Test
     fun `verify Other config uses proper keyboard capitalization & keyboard type`() {
         with(createConfigForCountry("UK")) {
-            Truth.assertThat(capitalization).isEqualTo(KeyboardCapitalization.Words)
+            Truth.assertThat(capitalization).isEqualTo(KeyboardCapitalization.Characters)
             Truth.assertThat(keyboard).isEqualTo(KeyboardType.Text)
         }
     }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.ui.core.elements
 
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
 import com.google.common.truth.Truth
 import com.stripe.android.core.R
 import com.stripe.android.uicore.elements.PostalCodeConfig
@@ -7,6 +9,29 @@ import com.stripe.android.uicore.elements.TextFieldState
 import org.junit.Test
 
 class PostalCodeConfigTest {
+    @Test
+    fun `verify US config uses proper keyboard capitalization & keyboard type`() {
+        with(createConfigForCountry("US")) {
+            Truth.assertThat(capitalization).isEqualTo(KeyboardCapitalization.None)
+            Truth.assertThat(keyboard).isEqualTo(KeyboardType.NumberPassword)
+        }
+    }
+
+    @Test
+    fun `verify CA config uses proper keyboard capitalization & keyboard type`() {
+        with(createConfigForCountry("CA")) {
+            Truth.assertThat(capitalization).isEqualTo(KeyboardCapitalization.Characters)
+            Truth.assertThat(keyboard).isEqualTo(KeyboardType.Text)
+        }
+    }
+
+    @Test
+    fun `verify Other config uses proper keyboard capitalization & keyboard type`() {
+        with(createConfigForCountry("UK")) {
+            Truth.assertThat(capitalization).isEqualTo(KeyboardCapitalization.Words)
+            Truth.assertThat(keyboard).isEqualTo(KeyboardType.Text)
+        }
+    }
 
     @Test
     fun `verify US postal codes`() {
@@ -16,7 +41,7 @@ class PostalCodeConfigTest {
             Truth.assertThat(determineStateForInput("12345").isValid()).isTrue()
             Truth.assertThat(determineStateForInput("12345").isFull()).isTrue()
             Truth.assertThat(determineStateForInput("abcde").isValid()).isFalse()
-            Truth.assertThat(determineStateForInput("abcde").isFull()).isTrue()
+            Truth.assertThat(determineStateForInput("abcde").isFull()).isFalse()
         }
     }
 
@@ -51,11 +76,20 @@ class PostalCodeConfigTest {
     }
 
     @Test
-    fun `invalid postal codes emit error`() {
+    fun `invalid US postal codes emit error`() {
         with(createConfigForCountry("US")) {
             Truth.assertThat(determineStateForInput("").getError()).isNull()
             Truth.assertThat(determineStateForInput("1234").getError()).isNotNull()
             Truth.assertThat(determineStateForInput("12345").getError()).isNull()
+        }
+    }
+
+    @Test
+    fun `invalid CA postal codes emit error`() {
+        with(createConfigForCountry("CA")) {
+            Truth.assertThat(determineStateForInput("").getError()).isNull()
+            Truth.assertThat(determineStateForInput("1N8E8R").getError()).isNotNull()
+            Truth.assertThat(determineStateForInput("141124").getError()).isNotNull()
         }
     }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/TransformAddressToElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/TransformAddressToElement.kt
@@ -307,8 +307,6 @@ private fun FieldType.toConfig(
     return when (this) {
         FieldType.PostalCode -> PostalCodeConfig(
             label = label,
-            capitalization = capitalization,
-            keyboard = keyboardType,
             country = countryCode
         )
         else -> SimpleTextFieldConfig(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PostalCodeConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PostalCodeConfig.kt
@@ -19,8 +19,8 @@ class PostalCodeConfig(
 
     override val capitalization: KeyboardCapitalization = when (format) {
         CountryPostalFormat.US -> KeyboardCapitalization.None
-        CountryPostalFormat.CA -> KeyboardCapitalization.Characters
-        CountryPostalFormat.Other -> KeyboardCapitalization.Words
+        CountryPostalFormat.CA,
+        CountryPostalFormat.Other -> KeyboardCapitalization.Characters
     }
 
     override val keyboard: KeyboardType = when (format) {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PostalCodeConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PostalCodeConfig.kt
@@ -12,12 +12,22 @@ import kotlin.math.max
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class PostalCodeConfig(
     @StringRes override val label: Int,
-    override val capitalization: KeyboardCapitalization = KeyboardCapitalization.Words,
-    override val keyboard: KeyboardType = KeyboardType.Text,
     override val trailingIcon: MutableStateFlow<TextFieldIcon?> = MutableStateFlow(null),
     private val country: String
 ) : TextFieldConfig {
     private val format = CountryPostalFormat.forCountry(country)
+
+    override val capitalization: KeyboardCapitalization = when (format) {
+        CountryPostalFormat.US -> KeyboardCapitalization.None
+        CountryPostalFormat.CA -> KeyboardCapitalization.Characters
+        CountryPostalFormat.Other -> KeyboardCapitalization.Words
+    }
+
+    override val keyboard: KeyboardType = when (format) {
+        CountryPostalFormat.US -> KeyboardType.NumberPassword
+        CountryPostalFormat.CA,
+        CountryPostalFormat.Other -> KeyboardType.Text
+    }
 
     override val debugLabel: String = "postal_code_text"
     override val visualTransformation: VisualTransformation =
@@ -54,14 +64,13 @@ class PostalCodeConfig(
         override fun isBlank(): Boolean = input.isBlank()
     }
 
-    override fun filter(userTyped: String): String =
-        if (
-            setOf(KeyboardType.Number, KeyboardType.NumberPassword).contains(keyboard)
-        ) {
-            userTyped.filter { it.isDigit() }
-        } else {
-            userTyped
+    override fun filter(userTyped: String): String {
+        return when (format) {
+            CountryPostalFormat.US -> userTyped.filter { it.isDigit() }
+            CountryPostalFormat.CA -> userTyped.filter { it.isLetterOrDigit() }.uppercase()
+            CountryPostalFormat.Other -> userTyped
         }.dropLast(max(0, userTyped.length - format.maximumLength))
+    }
 
     override fun convertToRaw(displayName: String) = displayName
 


### PR DESCRIPTION
# Summary
Updates `PostalCodeConfig` to build raw values by `PostalCodeFormat`.
- In `US`, use only digits,
- In `CA`, user digits and letters & capitalize letters. 

# Motivation
Resolves https://github.com/stripe/stripe-android/issues/7044

Allows valid postal codes entered in complete lowercase to be considered valid by card providers who except postal codes to be provided completely in uppercase despite lowercase postal codes being valid. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
