### PR TITLE
[Identity] Add Laplacian blur detector for document scanning

### DIFF
--- a/identity/detekt-baseline.xml
+++ b/identity/detekt-baseline.xml
@@ -8,7 +8,6 @@
     <ID>CyclomaticComplexMethod:IdentityViewModel.kt$IdentityViewModel$fun updateNewScanType(scanType: IdentityScanState.ScanType)</ID>
     <ID>CyclomaticComplexMethod:OTPScreen.kt$@Composable internal fun OTPScreen( navController: NavController, identityViewModel: IdentityViewModel, otpViewModelFactory: ViewModelProvider.Factory = OTPViewModel.Factory( identityRepository = identityViewModel.identityRepository, verificationArgs = identityViewModel.verificationArgs ) )</ID>
     <ID>CyclomaticComplexMethod:UploadScreen.kt$@Composable internal fun UploadScreen( navController: NavController, identityViewModel: IdentityViewModel, collectedDataParamType: CollectedDataParam.Type, route: String, @StringRes titleRes: Int, @StringRes contextRes: Int, frontInfo: DocumentUploadSideInfo, backInfo: DocumentUploadSideInfo?, shouldShowTakePhoto: Boolean, shouldShowChoosePhoto: Boolean )</ID>
-    <ID>FunctionOnlyReturningConstant:FaceDetectorTransitioner.kt$FaceDetectorTransitioner$private fun isFaceFocused(): Boolean</ID>
     <ID>LargeClass:IdentityViewModel.kt$IdentityViewModel : AndroidViewModel</ID>
     <ID>LargeClass:IdentityViewModelTest.kt$IdentityViewModelTest</ID>
     <ID>LongMethod:AddressSection.kt$@Composable internal fun AddressSection( enabled: Boolean, identityViewModel: IdentityViewModel, addressCountries: List&lt;Country>, addressNotListedText: String, navController: NavController, onAddressCollected: (Resource&lt;RequiredInternationalAddress>) -> Unit )</ID>
@@ -67,12 +66,13 @@
     <ID>MaxLineLength:InjectableActivityScenario.kt$InjectableActivityScenario$?:</ID>
     <ID>MaxLineLength:VerificationPage.kt$VerificationPage$* A VerificationPage contains the static content and initial state that is required for Stripe Identity's native mobile SDKs to render the verification flow.</ID>
     <ID>MaxLineLength:VerificationPageData.kt$VerificationPageData$* VerificationPageData contains the state of a verification, including what information needs to be collected to complete the verification flow.</ID>
-    <ID>MaximumLineLength:com.stripe.android.identity.camera.IdentityScanFlow.kt:34</ID>
+    <ID>MaximumLineLength:com.stripe.android.identity.camera.IdentityScanFlow.kt:35</ID>
     <ID>ReturnCount:AddressSection.kt$private fun isValidAddress(addressMap: Map&lt;IdentifierSpec, FormFieldEntry>): Boolean</ID>
     <ID>ReturnCount:IDNumberSection.kt$BRVisualTransformation.&lt;no name provided>$override fun originalToTransformed(offset: Int): Int</ID>
     <ID>ReturnCount:IDNumberSection.kt$BRVisualTransformation.&lt;no name provided>$override fun transformedToOriginal(offset: Int): Int</ID>
     <ID>SwallowedException:IdentityTheme.kt$e: ReflectiveOperationException</ID>
     <ID>ThrowsCount:DefaultIdentityRepository.kt$DefaultIdentityRepository$private suspend fun &lt;Response : StripeModel> executeRequestWithModelJsonParser( request: StripeRequest, responseJsonParser: ModelJsonParser&lt;Response>, onSuccessExecutionTimeBlock: (Long) -> Unit = {} ): Response</ID>
+    <ID>TooGenericExceptionCaught:LaplacianBlurDetector.kt$LaplacianBlurDetector$e: Exception</ID>
     <ID>TooManyFunctions:DefaultIdentityRepository.kt$DefaultIdentityRepository : IdentityRepository</ID>
     <ID>TooManyFunctions:IdentityAnalyticsRequestFactory.kt$IdentityAnalyticsRequestFactory</ID>
     <ID>TooManyFunctions:IdentityRepository.kt$IdentityRepository</ID>

--- a/identity/src/main/java/com/stripe/android/identity/analytics/AnalyticsState.kt
+++ b/identity/src/main/java/com/stripe/android/identity/analytics/AnalyticsState.kt
@@ -16,5 +16,7 @@ internal data class AnalyticsState(
     val docBackUploadType: DocumentUploadParam.UploadMethod? = null,
     val docFrontModelScore: Float? = null,
     val docBackModelScore: Float? = null,
-    val selfieModelScore: Float? = null
+    val selfieModelScore: Float? = null,
+    val docFrontBlurScore: Float? = null,
+    val docBackBlurScore: Float? = null
 ) : Parcelable

--- a/identity/src/main/java/com/stripe/android/identity/analytics/IdentityAnalyticsRequestFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/analytics/IdentityAnalyticsRequestFactory.kt
@@ -63,7 +63,9 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         docBackUploadType: DocumentUploadParam.UploadMethod? = null,
         docFrontModelScore: Float? = null,
         docBackModelScore: Float? = null,
-        selfieModelScore: Float? = null
+        selfieModelScore: Float? = null,
+        docFrontBlurScore: Float? = null,
+        docBackBlurScore: Float? = null
     ) = requestFactory.createRequest(
         eventName = EVENT_VERIFICATION_SUCCEEDED,
         additionalParams = additionalParamWithEventMetadata(
@@ -77,7 +79,9 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
             PARAM_DOC_BACK_UPLOAD_TYPE to docBackUploadType?.name,
             PARAM_DOC_FRONT_MODEL_SCORE to docFrontModelScore,
             PARAM_DOC_BACK_MODEL_SCORE to docBackModelScore,
-            PARAM_SELFIE_MODEL_SCORE to selfieModelScore
+            PARAM_SELFIE_MODEL_SCORE to selfieModelScore,
+            PARAM_DOC_FRONT_BLUR_SCORE to docFrontBlurScore,
+            PARAM_DOC_BACK_BLUR_SCORE to docBackBlurScore
         )
     )
 
@@ -304,6 +308,8 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         const val PARAM_DOC_FRONT_MODEL_SCORE = "doc_front_model_score"
         const val PARAM_DOC_BACK_MODEL_SCORE = "doc_back_model_score"
         const val PARAM_SELFIE_MODEL_SCORE = "selfie_model_score"
+        const val PARAM_DOC_FRONT_BLUR_SCORE = "doc_front_blur_score"
+        const val PARAM_DOC_BACK_BLUR_SCORE = "doc_back_blur_score"
         const val PARAM_LAST_SCREEN_NAME = "last_screen_name"
         const val PARAM_ERROR = "error"
         const val PARAM_EXCEPTION = "exception"

--- a/identity/src/main/java/com/stripe/android/identity/camera/IdentityAggregator.kt
+++ b/identity/src/main/java/com/stripe/android/identity/camera/IdentityAggregator.kt
@@ -43,7 +43,9 @@ internal class IdentityAggregator(
             IDDetectorTransitioner(
                 timeout = verificationPage.documentCapture.autocaptureTimeout.milliseconds,
                 iouThreshold = verificationPage.documentCapture.motionBlurMinIou,
-                timeRequired = verificationPage.documentCapture.motionBlurMinDuration
+                timeRequired = verificationPage.documentCapture.motionBlurMinDuration,
+                blurThreshold = verificationPage.documentCapture.blurThreshold
+                    ?: IDDetectorTransitioner.DEFAULT_BLUR_THRESHOLD
             )
         }
     ),

--- a/identity/src/main/java/com/stripe/android/identity/camera/IdentityScanFlow.kt
+++ b/identity/src/main/java/com/stripe/android/identity/camera/IdentityScanFlow.kt
@@ -17,6 +17,7 @@ import com.stripe.android.identity.ml.FaceDetectorAnalyzer
 import com.stripe.android.identity.ml.IDDetectorAnalyzer
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.states.LaplacianBlurDetector
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
@@ -35,7 +36,8 @@ internal class IdentityScanFlow(
     private val idDetectorModelFile: File,
     private val faceDetectorModelFile: File?,
     private val verificationPage: VerificationPage,
-    private val modelPerformanceTracker: ModelPerformanceTracker
+    private val modelPerformanceTracker: ModelPerformanceTracker,
+    private val laplacianBlurDetector: LaplacianBlurDetector
 ) : ScanFlow<IdentityScanState.ScanType, CameraPreviewImage<Bitmap>> {
     private var aggregator: IdentityAggregator? = null
 
@@ -103,7 +105,8 @@ internal class IdentityScanFlow(
                         IDDetectorAnalyzer.Factory(
                             idDetectorModelFile,
                             verificationPage.documentCapture.models.idDetectorMinScore,
-                            modelPerformanceTracker
+                            modelPerformanceTracker,
+                            laplacianBlurDetector
                         )
                     }
                 )

--- a/identity/src/main/java/com/stripe/android/identity/ml/IDDetectorAnalyzer.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ml/IDDetectorAnalyzer.kt
@@ -7,6 +7,7 @@ import com.stripe.android.camera.framework.image.size
 import com.stripe.android.camera.framework.util.maxAspectRatioInSize
 import com.stripe.android.identity.analytics.ModelPerformanceTracker
 import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.states.LaplacianBlurDetector
 import com.stripe.android.identity.utils.roundToMaxDecimals
 import com.stripe.android.mlcore.base.InterpreterOptionsWrapper
 import com.stripe.android.mlcore.base.InterpreterWrapper
@@ -24,7 +25,8 @@ import java.io.File
 internal class IDDetectorAnalyzer(
     modelFile: File,
     private val idDetectorMinScore: Float,
-    private val modelPerformanceTracker: ModelPerformanceTracker
+    private val modelPerformanceTracker: ModelPerformanceTracker,
+    private val laplacianBlurDetector: LaplacianBlurDetector,
 ) :
     Analyzer<AnalyzerInput, IdentityScanState, AnalyzerOutput> {
 
@@ -106,14 +108,16 @@ internal class IDDetectorAnalyzer(
             bestScore,
             LIST_OF_INDICES.map {
                 categories[bestIndex][it].roundToMaxDecimals(2)
-            }
+            },
+            laplacianBlurDetector.calculateBlurOutput(croppedImage)
         )
     }
 
     internal class Factory(
         private val modelFile: File,
         private val idDetectorMinScore: Float,
-        private val modelPerformanceTracker: ModelPerformanceTracker
+        private val modelPerformanceTracker: ModelPerformanceTracker,
+        private val laplacianBlurDetector: LaplacianBlurDetector
     ) : AnalyzerFactory<
             AnalyzerInput,
             IdentityScanState,
@@ -124,7 +128,8 @@ internal class IDDetectorAnalyzer(
             return IDDetectorAnalyzer(
                 modelFile,
                 idDetectorMinScore,
-                modelPerformanceTracker
+                modelPerformanceTracker,
+                laplacianBlurDetector
             )
         }
     }

--- a/identity/src/main/java/com/stripe/android/identity/ml/ModelIO.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ml/ModelIO.kt
@@ -39,7 +39,8 @@ internal data class IDDetectorOutput(
     val boundingBox: BoundingBox,
     val category: Category,
     val resultScore: Float,
-    val allScores: List<Float>
+    val allScores: List<Float>,
+    val blurScore: Float
 ) : AnalyzerOutput
 
 /**

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentDocumentCapturePage.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentDocumentCapturePage.kt
@@ -29,5 +29,7 @@ internal data class VerificationPageStaticContentDocumentCapturePage(
     @SerialName("motion_blur_min_duration")
     val motionBlurMinDuration: Int,
     @SerialName("motion_blur_min_iou")
-    val motionBlurMinIou: Float
+    val motionBlurMinIou: Float,
+    @SerialName("blur_threshold")
+    val blurThreshold: Float? = null
 ) : Parcelable

--- a/identity/src/main/java/com/stripe/android/identity/states/FaceDetectorTransitioner.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/FaceDetectorTransitioner.kt
@@ -235,7 +235,6 @@ internal class FaceDetectorTransitioner(
 
     private fun isFaceValid(analyzerOutput: FaceDetectorOutput) =
         isFaceCentered(analyzerOutput.boundingBox) &&
-            isFaceFocused() &&
             isFaceAwayFromEdges(analyzerOutput.boundingBox) &&
             isFaceCoverageOK(analyzerOutput.boundingBox) &&
             isFaceScoreOverThreshold(analyzerOutput.resultScore)
@@ -249,13 +248,6 @@ internal class FaceDetectorTransitioner(
             selfieCapturePage.maxCenteredThresholdY &&
             abs(1 - (boundingBox.left + boundingBox.left + boundingBox.width)) <
                 selfieCapturePage.maxCenteredThresholdX
-    }
-
-    /**
-     * TODO(ccen) Decide blur detection algorithm
-     */
-    private fun isFaceFocused(): Boolean {
-        return true
     }
 
     private fun isFaceAwayFromEdges(boundingBox: BoundingBox): Boolean {

--- a/identity/src/main/java/com/stripe/android/identity/states/LaplacianBlurDetector.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/LaplacianBlurDetector.kt
@@ -1,0 +1,158 @@
+package com.stripe.android.identity.states
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.renderscript.Allocation
+import android.renderscript.Element
+import android.renderscript.RenderScript
+import android.renderscript.ScriptIntrinsicBlur
+import android.renderscript.ScriptIntrinsicColorMatrix
+import android.renderscript.ScriptIntrinsicConvolve3x3
+import android.util.Log
+import javax.inject.Inject
+
+/**
+ * Detector to determine if an image is blurry based on variance of the laplacian method.
+ */
+internal class LaplacianBlurDetector @Inject constructor(context: Context) {
+
+    private val renderScript by lazy {
+        RenderScript.create(context)
+    }
+
+    /**
+     * Calculate the blur score of an image with laplacian method, return DEFAULT_SCORE if
+     * error occurs.
+     *
+     * @param sourceBitmap original image bitmap
+     *
+     * @return The most luminous greyscale color value from 0x00 to 0xFF, scaled from 0 to 1.
+     *         The higher the value, the more prominent the laplacian edge, the less blurry.
+     */
+    @Suppress("LongMethod")
+    fun calculateBlurOutput(sourceBitmap: Bitmap): Float {
+        try {
+            // First apply a soft blur to smoothen out visual artifacts
+            val smootherBitmap = Bitmap.createBitmap(
+                sourceBitmap.width,
+                sourceBitmap.height,
+                sourceBitmap.config
+            )
+            val blurIntrinsic =
+                ScriptIntrinsicBlur.create(renderScript, Element.RGBA_8888(renderScript))
+            val source = Allocation.createFromBitmap(
+                renderScript,
+                sourceBitmap,
+                Allocation.MipmapControl.MIPMAP_NONE,
+                Allocation.USAGE_SHARED
+            )
+            val blurTargetAllocation = Allocation.createFromBitmap(
+                renderScript,
+                smootherBitmap,
+                Allocation.MipmapControl.MIPMAP_NONE,
+                Allocation.USAGE_SHARED
+            )
+            blurIntrinsic.apply {
+                setRadius(1f)
+                setInput(source)
+                forEach(blurTargetAllocation)
+            }
+            blurTargetAllocation.copyTo(smootherBitmap)
+
+            // Greyscale so we're only dealing with white <--> black pixels, this is so we only need to
+            // detect pixel luminosity
+            val greyscaleBitmap = Bitmap.createBitmap(
+                sourceBitmap.width,
+                sourceBitmap.height,
+                sourceBitmap.config
+            )
+            val smootherInput = Allocation.createFromBitmap(
+                renderScript,
+                smootherBitmap,
+                Allocation.MipmapControl.MIPMAP_NONE,
+                Allocation.USAGE_SHARED
+            )
+            val greyscaleTargetAllocation = Allocation.createFromBitmap(
+                renderScript,
+                greyscaleBitmap,
+                Allocation.MipmapControl.MIPMAP_NONE,
+                Allocation.USAGE_SHARED
+            )
+
+            // Inverts and greyscales the image
+            val colorIntrinsic = ScriptIntrinsicColorMatrix.create(renderScript)
+            colorIntrinsic.setGreyscale()
+            colorIntrinsic.forEach(smootherInput, greyscaleTargetAllocation)
+            greyscaleTargetAllocation.copyTo(greyscaleBitmap)
+
+            // Run edge detection algorithm using a laplacian matrix convolution
+            // Apply 3x3 convolution to detect edges
+            val edgesBitmap = Bitmap.createBitmap(
+                sourceBitmap.width,
+                sourceBitmap.height,
+                sourceBitmap.config
+            )
+            val greyscaleInput = Allocation.createFromBitmap(
+                renderScript,
+                greyscaleBitmap,
+                Allocation.MipmapControl.MIPMAP_NONE,
+                Allocation.USAGE_SHARED
+            )
+            val edgesTargetAllocation = Allocation.createFromBitmap(
+                renderScript,
+                edgesBitmap,
+                Allocation.MipmapControl.MIPMAP_NONE,
+                Allocation.USAGE_SHARED
+            )
+
+            val convolve =
+                ScriptIntrinsicConvolve3x3.create(renderScript, Element.U8_4(renderScript))
+            convolve.setInput(greyscaleInput)
+            convolve.setCoefficients(CLASSIC_MATRIX) // Or use others
+            convolve.forEach(edgesTargetAllocation)
+            edgesTargetAllocation.copyTo(edgesBitmap)
+
+            // Scale the score from 0~255(0xFF)
+            return mostLuminousIntensityFromBitmap(edgesBitmap).toFloat() / COLOR_MAX
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to calculate blur score. $e")
+            return DEFAULT_SCORE
+        }
+    }
+
+    /**
+     * Resolves the most luminous color pixel in a given greyscale bitmap.
+     *
+     * @param bitmap Source greyscale bitmap, with same RGB channel value.
+     * @return The most luminous color in bitmap, ranging from 0x00 to 0xFF.
+     */
+    private fun mostLuminousIntensityFromBitmap(bitmap: Bitmap): Int {
+        bitmap.setHasAlpha(false)
+        val pixels = IntArray(bitmap.height * bitmap.width)
+        bitmap.getPixels(pixels, 0, bitmap.width, 0, 0, bitmap.width, bitmap.height)
+        var maxIntensity = -1
+        for (pixel in pixels) {
+            // Since this is a greyscale bitmap, its RGB channel has the same value.
+            // Retrieving the Red channel for comparison.
+            val intensity = Color.red(pixel)
+
+            if (intensity > maxIntensity) {
+                maxIntensity = intensity
+            }
+        }
+        return maxIntensity
+    }
+
+    companion object {
+        private const val TAG = "LaplacianBlurDetector"
+        private val CLASSIC_MATRIX = floatArrayOf(
+            -1.0f, -1.0f, -1.0f,
+            -1.0f, 8.0f, -1.0f,
+            -1.0f, -1.0f, -1.0f
+        )
+
+        private const val DEFAULT_SCORE = 1.0f
+        private const val COLOR_MAX = 0xFF
+    }
+}

--- a/identity/src/main/java/com/stripe/android/identity/states/LaplacianBlurDetector.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/LaplacianBlurDetector.kt
@@ -114,7 +114,7 @@ internal class LaplacianBlurDetector @Inject constructor(context: Context) {
             edgesTargetAllocation.copyTo(edgesBitmap)
 
             // Scale the score from 0~255(0xFF)
-            return mostLuminousIntensityFromBitmap(edgesBitmap).toFloat() / COLOR_MAX
+            return mostLuminousIntensityFromGreyscaleBitmap(edgesBitmap).toFloat() / COLOR_MAX
         } catch (e: Exception) {
             Log.e(TAG, "Failed to calculate blur score. $e")
             return DEFAULT_SCORE
@@ -127,7 +127,7 @@ internal class LaplacianBlurDetector @Inject constructor(context: Context) {
      * @param bitmap Source greyscale bitmap, with same RGB channel value.
      * @return The most luminous color in bitmap, ranging from 0x00 to 0xFF.
      */
-    private fun mostLuminousIntensityFromBitmap(bitmap: Bitmap): Int {
+    private fun mostLuminousIntensityFromGreyscaleBitmap(bitmap: Bitmap): Int {
         bitmap.setHasAlpha(false)
         val pixels = IntArray(bitmap.height * bitmap.width)
         bitmap.getPixels(pixels, 0, bitmap.width, 0, 0, bitmap.width, bitmap.height)

--- a/identity/src/main/java/com/stripe/android/identity/ui/CameraScreenLaunchedEffect.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/CameraScreenLaunchedEffect.kt
@@ -96,11 +96,17 @@ internal fun CameraScreenLaunchedEffect(
                     is IDDetectorOutput -> {
                         if (finalResult.identityState.type.isFront()) {
                             identityViewModel.updateAnalyticsState { oldState ->
-                                oldState.copy(docFrontModelScore = finalResult.result.resultScore)
+                                oldState.copy(
+                                    docFrontModelScore = finalResult.result.resultScore,
+                                    docFrontBlurScore = finalResult.result.blurScore
+                                )
                             }
                         } else if (finalResult.identityState.type.isBack()) {
                             identityViewModel.updateAnalyticsState { oldState ->
-                                oldState.copy(docBackModelScore = finalResult.result.resultScore)
+                                oldState.copy(
+                                    docBackModelScore = finalResult.result.resultScore,
+                                    docBackBlurScore = finalResult.result.blurScore
+                                )
                             }
                         }
                     }

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/CameraViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/CameraViewModel.kt
@@ -17,6 +17,7 @@ import com.stripe.android.identity.ml.FaceDetectorOutput
 import com.stripe.android.identity.ml.IDDetectorAnalyzer
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.states.LaplacianBlurDetector
 import com.stripe.android.identity.utils.SingleLiveEvent
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -32,6 +33,7 @@ import kotlin.coroutines.CoroutineContext
  */
 internal open class CameraViewModel(
     private val modelPerformanceTracker: ModelPerformanceTracker,
+    private val laplacianBlurDetector: LaplacianBlurDetector,
     @UIContext private val uiContext: CoroutineContext
 ) :
     ViewModel(),
@@ -60,7 +62,8 @@ internal open class CameraViewModel(
             idDetectorModelFile,
             faceDetectorModelFile,
             verificationPage,
-            modelPerformanceTracker
+            modelPerformanceTracker,
+            laplacianBlurDetector
         )
     }
 

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityScanViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityScanViewModel.kt
@@ -10,6 +10,7 @@ import com.stripe.android.core.injection.UIContext
 import com.stripe.android.identity.analytics.ModelPerformanceTracker
 import com.stripe.android.identity.camera.IdentityCameraManager
 import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.states.LaplacianBlurDetector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import java.lang.ref.WeakReference
@@ -19,9 +20,10 @@ import kotlin.coroutines.CoroutineContext
 internal class IdentityScanViewModel(
     private val context: WeakReference<Context>,
     modelPerformanceTracker: ModelPerformanceTracker,
+    laplacianBlurDetector: LaplacianBlurDetector,
     @UIContext private val uiContext: CoroutineContext
 ) :
-    CameraViewModel(modelPerformanceTracker, uiContext) {
+    CameraViewModel(modelPerformanceTracker, laplacianBlurDetector, uiContext) {
 
     /**
      * StateFlow to keep track of current target scan type.
@@ -61,6 +63,7 @@ internal class IdentityScanViewModel(
     internal class IdentityScanViewModelFactory @Inject constructor(
         private val context: Context,
         private val modelPerformanceTracker: ModelPerformanceTracker,
+        private val laplacianBlurDetector: LaplacianBlurDetector,
         @UIContext private val uiContext: CoroutineContext,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
@@ -68,6 +71,7 @@ internal class IdentityScanViewModel(
             return IdentityScanViewModel(
                 WeakReference(context),
                 modelPerformanceTracker,
+                laplacianBlurDetector,
                 uiContext
             ) as T
         }

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
@@ -1261,7 +1261,9 @@ internal class IdentityViewModel constructor(
                         docBackUploadType = latestState.docBackUploadType,
                         docFrontModelScore = latestState.docFrontModelScore,
                         docBackModelScore = latestState.docBackModelScore,
-                        selfieModelScore = latestState.selfieModelScore
+                        selfieModelScore = latestState.selfieModelScore,
+                        docFrontBlurScore = latestState.docFrontBlurScore,
+                        docBackBlurScore = latestState.docBackBlurScore
                     )
                 )
             }

--- a/identity/src/test/java/com/stripe/android/identity/ui/CameraScreenLaunchedEffectTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/CameraScreenLaunchedEffectTest.kt
@@ -196,7 +196,8 @@ class CameraScreenLaunchedEffectTest {
                     boundingBox = mock(),
                     category = mock(),
                     resultScore = ID_FRONT_SCORE,
-                    allScores = mock()
+                    allScores = mock(),
+                    blurScore = 1.0f
                 ),
                 identityState = IdentityScanState.Finished(
                     type = IdentityScanState.ScanType.ID_FRONT,
@@ -230,7 +231,8 @@ class CameraScreenLaunchedEffectTest {
                     boundingBox = mock(),
                     category = mock(),
                     resultScore = ID_FRONT_SCORE,
-                    allScores = mock()
+                    allScores = mock(),
+                    blurScore = 1.0f
                 ),
                 identityState = IdentityScanState.TimeOut(
                     type = IdentityScanState.ScanType.ID_FRONT,
@@ -268,7 +270,8 @@ class CameraScreenLaunchedEffectTest {
                     boundingBox = mock(),
                     category = mock(),
                     resultScore = ID_BACK_SCORE,
-                    allScores = mock()
+                    allScores = mock(),
+                    blurScore = 1.0f
                 ),
                 identityState = IdentityScanState.Finished(
                     type = IdentityScanState.ScanType.ID_BACK,
@@ -302,7 +305,8 @@ class CameraScreenLaunchedEffectTest {
                     boundingBox = mock(),
                     category = mock(),
                     resultScore = ID_BACK_SCORE,
-                    allScores = mock()
+                    allScores = mock(),
+                    blurScore = 1.0f
                 ),
                 identityState = IdentityScanState.TimeOut(
                     type = IdentityScanState.ScanType.ID_BACK,

--- a/identity/src/test/java/com/stripe/android/identity/ui/CameraScreenLaunchedEffectTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/CameraScreenLaunchedEffectTest.kt
@@ -195,9 +195,9 @@ class CameraScreenLaunchedEffectTest {
                 result = IDDetectorOutput(
                     boundingBox = mock(),
                     category = mock(),
-                    resultScore = ID_FRONT_SCORE,
+                    resultScore = ID_FRONT_MODEL_SCORE,
                     allScores = mock(),
-                    blurScore = 1.0f
+                    blurScore = ID_FRONT_BLUR_SCORE
                 ),
                 identityState = IdentityScanState.Finished(
                     type = IdentityScanState.ScanType.ID_FRONT,
@@ -215,7 +215,9 @@ class CameraScreenLaunchedEffectTest {
 
             verify(mockIdentityViewModel).updateAnalyticsState(
                 argWhere { block ->
-                    block(AnalyticsState()).docFrontModelScore == ID_FRONT_SCORE
+                    val state = block(AnalyticsState())
+                    state.docFrontModelScore == ID_FRONT_MODEL_SCORE &&
+                        state.docFrontBlurScore == ID_FRONT_BLUR_SCORE
                 }
             )
         }
@@ -230,9 +232,9 @@ class CameraScreenLaunchedEffectTest {
                 result = IDDetectorOutput(
                     boundingBox = mock(),
                     category = mock(),
-                    resultScore = ID_FRONT_SCORE,
+                    resultScore = ID_FRONT_MODEL_SCORE,
                     allScores = mock(),
-                    blurScore = 1.0f
+                    blurScore = ID_FRONT_BLUR_SCORE
                 ),
                 identityState = IdentityScanState.TimeOut(
                     type = IdentityScanState.ScanType.ID_FRONT,
@@ -269,9 +271,9 @@ class CameraScreenLaunchedEffectTest {
                 result = IDDetectorOutput(
                     boundingBox = mock(),
                     category = mock(),
-                    resultScore = ID_BACK_SCORE,
+                    resultScore = ID_BACK_MODEL_SCORE,
                     allScores = mock(),
-                    blurScore = 1.0f
+                    blurScore = ID_BACK_BLUR_SCORE
                 ),
                 identityState = IdentityScanState.Finished(
                     type = IdentityScanState.ScanType.ID_BACK,
@@ -289,7 +291,9 @@ class CameraScreenLaunchedEffectTest {
 
             verify(mockIdentityViewModel).updateAnalyticsState(
                 argWhere { block ->
-                    block(AnalyticsState()).docBackModelScore == ID_BACK_SCORE
+                    val state = block(AnalyticsState())
+                    state.docBackModelScore == ID_BACK_MODEL_SCORE &&
+                        state.docBackBlurScore == ID_BACK_BLUR_SCORE
                 }
             )
         }
@@ -304,7 +308,7 @@ class CameraScreenLaunchedEffectTest {
                 result = IDDetectorOutput(
                     boundingBox = mock(),
                     category = mock(),
-                    resultScore = ID_BACK_SCORE,
+                    resultScore = ID_BACK_MODEL_SCORE,
                     allScores = mock(),
                     blurScore = 1.0f
                 ),
@@ -352,7 +356,9 @@ class CameraScreenLaunchedEffectTest {
 
     private companion object {
         const val FACE_SCORE = 123f
-        const val ID_FRONT_SCORE = 456f
-        const val ID_BACK_SCORE = 789f
+        const val ID_FRONT_MODEL_SCORE = 456f
+        const val ID_BACK_MODEL_SCORE = 789f
+        const val ID_FRONT_BLUR_SCORE = 0.1f
+        const val ID_BACK_BLUR_SCORE = 0.2f
     }
 }

--- a/identity/src/test/java/com/stripe/android/identity/viewmodel/IdentityViewModelTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/viewmodel/IdentityViewModelTest.kt
@@ -1081,7 +1081,8 @@ internal class IdentityViewModelTest {
                 boundingBox = BOUNDING_BOX,
                 category = mock(),
                 resultScore = 0.8f,
-                allScores = ALL_SCORES
+                allScores = ALL_SCORES,
+                blurScore = 1.0f
             ),
             identityState = mock<IdentityScanState.Finished>()
         )


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Implement a laplacian blurriness detector for document scan. 

Note: ATM we will not really block any image, but upload the blurscore(laplaican variance) to server(using 0 as the blur threshod). Later we analyze historical blur data and experience different blur threshold from server.

iOS: https://github.com/stripe/stripe-ios/pull/2873

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
The detector would check the blurriness of captured document image on client side and reduce the high blur error rate on server side.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Manually tested on Pixel 5, samsung z flip

