### PR TITLE
Better abstract ConnectionFactory connection opener.

### DIFF
--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
@@ -9,6 +9,8 @@ import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 import java.io.OutputStream
+import java.net.HttpURLConnection
+import java.net.URL
 import javax.net.ssl.HttpsURLConnection
 
 class NetworkRule private constructor(
@@ -65,26 +67,33 @@ private class NetworkStatement(
     }
 
     private fun setup() {
-        ConnectionFactory.Default.testHostCustomization = lambda@{ request ->
-            val requestHost = request.url.hostFromUrl()
-            if (!hostsToTrack.contains(requestHost)) {
-                throw RequestNotFoundException(
-                    "Test request attempted to reach a non test endpoint. " +
-                        "Url: ${request.url}"
-                )
-            }
+        ConnectionFactory.Default.connectionOpener = ::connectionOpener
+    }
 
-            return@lambda DelegatingStripeRequest(
-                request,
-                request.url.replace(
-                    "https://$requestHost",
-                    mockWebServer.baseUrl.toString().removeSuffix("/")
-                )
+    private fun connectionOpener(
+        request: StripeRequest,
+        callback: HttpURLConnection.(request: StripeRequest) -> Unit
+    ): HttpURLConnection {
+        val requestHost = request.url.hostFromUrl()
+        if (!hostsToTrack.contains(requestHost)) {
+            throw RequestNotFoundException(
+                "Test request attempted to reach a non test endpoint. " +
+                    "Url: ${request.url}"
             )
         }
-        ConnectionFactory.Default.testConnectionCustomization = lambda@{ insecureConnection ->
-            val connection = insecureConnection as? HttpsURLConnection ?: return@lambda
-            connection.sslSocketFactory = mockWebServer.clientSocketFactory()
+
+        val delegatingRequest = DelegatingStripeRequest(
+            request,
+            request.url.replace(
+                "https://$requestHost",
+                mockWebServer.baseUrl.toString().removeSuffix("/")
+            )
+        )
+        return (URL(delegatingRequest.url).openConnection() as HttpURLConnection).apply {
+            if (this is HttpsURLConnection) {
+                sslSocketFactory = mockWebServer.clientSocketFactory()
+            }
+            callback(delegatingRequest)
         }
     }
 
@@ -101,8 +110,7 @@ private class NetworkStatement(
 
     private fun tearDown() {
         mockWebServer.dispatcher.clear()
-        ConnectionFactory.Default.testConnectionCustomization = null
-        ConnectionFactory.Default.testHostCustomization = null
+        ConnectionFactory.Default.connectionOpener = ConnectionFactory.Default::defaultConnectionOpener
     }
 }
 

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/ConnectionFactory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/ConnectionFactory.kt
@@ -29,14 +29,17 @@ interface ConnectionFactory {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     object Default : ConnectionFactory {
         @Volatile
-        var connectionOpener: ((
-            request: StripeRequest,
-            callback: HttpURLConnection.(request: StripeRequest) -> Unit
-        ) -> HttpURLConnection) = ::defaultConnectionOpener
+        var connectionOpener: (
+            (
+                request: StripeRequest,
+                callback: HttpURLConnection.(request: StripeRequest) -> Unit
+            ) -> HttpURLConnection
+        ) = ::defaultConnectionOpener
 
         fun defaultConnectionOpener(
             request: StripeRequest,
-            callback: HttpURLConnection.(request: StripeRequest) -> Unit): HttpURLConnection {
+            callback: HttpURLConnection.(request: StripeRequest) -> Unit
+        ): HttpURLConnection {
             return (URL(request.url).openConnection() as HttpURLConnection).apply {
                 callback(request)
             }

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/ConnectionFactory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/ConnectionFactory.kt
@@ -61,8 +61,10 @@ interface ConnectionFactory {
             )
         }
 
-        private fun openConnectionAndApplyFields(request: StripeRequest): HttpURLConnection {
-            return connectionOpener(request) {
+        private fun openConnectionAndApplyFields(
+            originalRequest: StripeRequest
+        ): HttpURLConnection {
+            return connectionOpener(originalRequest) { request ->
                 connectTimeout = CONNECT_TIMEOUT
                 readTimeout = READ_TIMEOUT
                 useCaches = request.shouldCache

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/ConnectionFactory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/ConnectionFactory.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.core.networking
 
 import androidx.annotation.RestrictTo
-import com.stripe.android.core.BuildConfig
 import com.stripe.android.core.exception.InvalidRequestException
 import java.io.File
 import java.io.IOException
@@ -30,10 +29,18 @@ interface ConnectionFactory {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     object Default : ConnectionFactory {
         @Volatile
-        var testConnectionCustomization: ((HttpURLConnection) -> Unit)? = null
+        var connectionOpener: ((
+            request: StripeRequest,
+            callback: HttpURLConnection.(request: StripeRequest) -> Unit
+        ) -> HttpURLConnection) = ::defaultConnectionOpener
 
-        @Volatile
-        var testHostCustomization: ((StripeRequest) -> StripeRequest)? = null
+        fun defaultConnectionOpener(
+            request: StripeRequest,
+            callback: HttpURLConnection.(request: StripeRequest) -> Unit): HttpURLConnection {
+            return (URL(request.url).openConnection() as HttpURLConnection).apply {
+                callback(request)
+            }
+        }
 
         @Throws(IOException::class, InvalidRequestException::class)
         @JvmSynthetic
@@ -52,31 +59,22 @@ interface ConnectionFactory {
         }
 
         private fun openConnectionAndApplyFields(request: StripeRequest): HttpURLConnection {
-            val actualRequest = if (BuildConfig.DEBUG) {
-                testHostCustomization?.invoke(request) ?: request
-            } else {
-                request
-            }
-            return (URL(actualRequest.url).openConnection() as HttpURLConnection).apply {
-                if (BuildConfig.DEBUG) {
-                    testConnectionCustomization?.invoke(this)
-                }
-
+            return connectionOpener(request) {
                 connectTimeout = CONNECT_TIMEOUT
                 readTimeout = READ_TIMEOUT
-                useCaches = actualRequest.shouldCache
-                requestMethod = actualRequest.method.code
+                useCaches = request.shouldCache
+                requestMethod = request.method.code
 
-                actualRequest.headers.forEach { (key, value) ->
+                request.headers.forEach { (key, value) ->
                     setRequestProperty(key, value)
                 }
 
-                if (StripeRequest.Method.POST == actualRequest.method) {
+                if (StripeRequest.Method.POST == request.method) {
                     doOutput = true
-                    actualRequest.postHeaders?.forEach { (key, value) ->
+                    request.postHeaders?.forEach { (key, value) ->
                         setRequestProperty(key, value)
                     }
-                    outputStream.use { output -> actualRequest.writePostBody(output) }
+                    outputStream.use { output -> request.writePostBody(output) }
                 }
             }
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Refactor ConnectionFactory.Default to make connection opening configurable.
This allows easy testing, as well as proxy enablement in the example app.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We were using 2 fields to do one thing, now it's all done in one. It also makes reading the connection factory code much easier, as well as enables a lot more powerful customizations for tests and proxy configuration.

You can enable a proxy in the example app by doing something like this: 

```
class ProxyConnectionOpener(
    private val ipAddress: String
) : ConnectionFactory.ConnectionOpener {
    override fun open(
        request: StripeRequest,
        callback: HttpURLConnection.(request: StripeRequest) -> Unit
    ): HttpURLConnection {
        val socketAddress = InetSocketAddress.createUnresolved(ipAddress, 8888)
        val proxy = Proxy(Proxy.Type.HTTP, socketAddress)

        return (URL(request.url).openConnection(proxy) as HttpURLConnection).apply {
            (this as? HttpsURLConnection)?.let { connection ->
                connection.sslSocketFactory = trustAllSocketFactory()
            }
            callback(request)
        }
    }

    @SuppressLint("CustomX509TrustManager", "TrustAllX509TrustManager")
    private fun trustAllSocketFactory(): SSLSocketFactory {
        val trustAllCerts = arrayOf<TrustManager>(
            object : X509TrustManager {
                override fun checkClientTrusted(
                    chain: Array<out X509Certificate>?,
                    authType: String?
                ) {
                }

                override fun checkServerTrusted(
                    chain: Array<out X509Certificate>?,
                    authType: String?
                ) {
                }

                override fun getAcceptedIssuers(): Array<X509Certificate> {
                    return emptyArray()
                }
            })

        val sslContext = SSLContext.getInstance("SSL")
        sslContext.init(null, trustAllCerts, SecureRandom())
        return sslContext.socketFactory
    }
}
```
