### PR TITLE
Migrate to Dagger 2.48 for KSP support

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -27,7 +27,7 @@ ext.versions = [
         binaryCompatibilityValidator: '0.13.1',
         buildTools                  : "30.0.3",
         cameraX                     : '1.2.3',
-        dagger                      : '2.45',
+        dagger                      : '2.48',
         detekt                      : "1.22.0",
         diskLruCache                : '2.0.2',
         dokka                       : '1.9.0-dev-218',

--- a/financial-connections/build.gradle
+++ b/financial-connections/build.gradle
@@ -1,6 +1,5 @@
 apply from: configs.androidLibrary
 
-apply plugin: 'kotlin-kapt'
 apply plugin: 'checkstyle'
 apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
 apply plugin: 'kotlinx-serialization'
@@ -50,7 +49,7 @@ dependencies {
     debugImplementation libs.compose.uiTooling
     debugImplementation libs.showkase
 
-    kapt libs.daggerCompiler
+    ksp libs.daggerCompiler
 
     kspDebug libs.showkaseProcessor
 
@@ -79,7 +78,7 @@ dependencies {
     androidTestImplementation testLibs.espresso.intents
     androidTestImplementation testLibs.truth
 
-    kaptAndroidTest libs.showkaseProcessor
+    kspAndroidTest libs.showkaseProcessor
 
     androidTestUtil testLibs.testOrchestrator
 }

--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -2,7 +2,7 @@ apply from: configs.androidLibrary
 
 apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
-apply plugin: 'kotlin-kapt'
+apply plugin: 'com.google.devtools.ksp'
 
 dependencies {
     implementation project(":camera-core")
@@ -36,7 +36,7 @@ dependencies {
 
     debugImplementation libs.compose.uiTestManifest
 
-    kapt libs.daggerCompiler
+    ksp libs.daggerCompiler
 
     testImplementation testLibs.androidx.archCore
     testImplementation testLibs.androidx.composeUi

--- a/link/build.gradle
+++ b/link/build.gradle
@@ -1,6 +1,6 @@
 apply from: configs.androidLibrary
 
-apply plugin: 'kotlin-kapt'
+apply plugin: 'com.google.devtools.ksp'
 apply plugin: "org.jetbrains.kotlin.plugin.parcelize"
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 
@@ -19,7 +19,7 @@ dependencies {
     implementation libs.androidx.viewModel
     implementation libs.dagger
     implementation libs.material
-    kapt libs.daggerCompiler
+    ksp libs.daggerCompiler
 
     implementation libs.compose.activity
     implementation libs.compose.foundation

--- a/payment-method-messaging/build.gradle
+++ b/payment-method-messaging/build.gradle
@@ -1,6 +1,6 @@
 apply from: configs.androidLibrary
 
-apply plugin: 'kotlin-kapt'
+apply plugin: 'com.google.devtools.ksp'
 apply plugin: 'checkstyle'
 apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
 apply plugin: 'kotlinx-serialization'
@@ -37,7 +37,7 @@ dependencies {
     implementation libs.kotlin.coroutines
     implementation libs.kotlin.coroutinesAndroid
 
-    kapt libs.daggerCompiler
+    ksp libs.daggerCompiler
 
     testImplementation testLibs.androidx.archCore
     testImplementation testLibs.androidx.core

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -1,6 +1,6 @@
 apply from: configs.androidLibrary
 
-apply plugin: 'kotlin-kapt'
+apply plugin: 'com.google.devtools.ksp'
 apply plugin: 'checkstyle'
 apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
 
@@ -30,7 +30,7 @@ dependencies {
     // https://github.com/stripe/stripe-android/issues/3173#issuecomment-785176608
     implementation libs.stripe3ds2
 
-    kapt libs.daggerCompiler
+    ksp libs.daggerCompiler
 
     javadocDeps libs.androidx.annotation
     javadocDeps libs.androidx.appCompat

--- a/payments-ui-core/build.gradle
+++ b/payments-ui-core/build.gradle
@@ -1,6 +1,6 @@
 apply from: configs.androidLibrary
 
-apply plugin: 'kotlin-kapt'
+apply plugin: 'com.google.devtools.ksp'
 apply plugin: "org.jetbrains.kotlin.plugin.parcelize"
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 
@@ -18,7 +18,7 @@ dependencies {
     implementation libs.androidx.liveDataKtx
     implementation libs.material
     implementation libs.dagger
-    kapt libs.daggerCompiler
+    ksp libs.daggerCompiler
 
     implementation libs.compose.ui
     implementation libs.compose.foundation

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -1,6 +1,6 @@
 apply from: configs.androidLibrary
 
-apply plugin: 'kotlin-kapt'
+apply plugin: 'com.google.devtools.ksp'
 apply plugin: "org.jetbrains.kotlin.plugin.parcelize"
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'app.cash.paparazzi'
@@ -29,7 +29,7 @@ dependencies {
 
     // DI
     implementation libs.dagger
-    kapt libs.daggerCompiler
+    ksp libs.daggerCompiler
 
     // Compose
     implementation libs.compose.ui

--- a/stripe-core/build.gradle
+++ b/stripe-core/build.gradle
@@ -1,6 +1,6 @@
 apply from: configs.androidLibrary
 
-apply plugin: 'kotlin-kapt'
+apply plugin: 'com.google.devtools.ksp'
 apply plugin: 'checkstyle'
 apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
 apply plugin: 'kotlinx-serialization'
@@ -18,7 +18,7 @@ dependencies {
     implementation libs.kotlin.coroutinesAndroid
     implementation libs.kotlin.serialization
 
-    kapt libs.daggerCompiler
+    ksp libs.daggerCompiler
 
     testImplementation testLibs.androidx.archCore
     testImplementation testLibs.androidx.core

--- a/stripe-ui-core/build.gradle
+++ b/stripe-ui-core/build.gradle
@@ -1,6 +1,6 @@
 apply from: configs.androidLibrary
 
-apply plugin: 'kotlin-kapt'
+apply plugin: 'com.google.devtools.ksp'
 apply plugin: 'checkstyle'
 apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
@@ -47,7 +47,7 @@ dependencies {
 
     // DI
     implementation libs.dagger
-    kapt libs.daggerCompiler
+    ksp libs.daggerCompiler
 
     debugImplementation libs.compose.uiTestManifest
     debugImplementation libs.compose.uiTooling

--- a/stripecardscan/build.gradle
+++ b/stripecardscan/build.gradle
@@ -1,6 +1,5 @@
 apply from: configs.androidLibrary
 
-apply plugin: 'kotlin-kapt'
 apply plugin: "org.jetbrains.kotlin.plugin.parcelize"
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 


### PR DESCRIPTION
# Summary
Migrates usages of `Dagger` to use `KSP` rather than `Kapt` which is now supported with `Dagger` `2.48`.

# Motivation
Kotlin Symbol Processing (`KSP`) is a Kotlin-first alternative to Kotlin Annotation Processing Tool (`Kapt`). `KSP` analyzes Kotlin code up to 2x faster and can reduce compilation time by 25%. Google now recommends the usage of `KSP`. `Kapt` will no longer release improvements and be solely in maintenance mode. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

Locally around a 26% improvement to build time to the `paymentsheet-example` app (1m25s on `Kapt`, 1m3s on `KSP`). I ran through all the example applications to test for any bugs or crashes and wasn't able to produce any while walking through all the flows.

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
