### PR TITLE
Improve invalid input handling for dates and card numbers

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberConfig.kt
@@ -23,11 +23,17 @@ internal class CardNumberConfig : CardDetailsTextFieldConfig {
         return if (number.isBlank()) {
             TextFieldStateConstants.Error.Blank
         } else if (brand == CardBrand.Unknown) {
-            TextFieldStateConstants.Error.Invalid(StripeR.string.stripe_invalid_card_number)
+            TextFieldStateConstants.Error.Invalid(
+                errorMessageResId = StripeR.string.stripe_invalid_card_number,
+                preventMoreInput = true,
+            )
         } else if (isDigitLimit && number.length < numberAllowedDigits) {
             TextFieldStateConstants.Error.Incomplete(StripeR.string.stripe_invalid_card_number)
         } else if (!luhnValid) {
-            TextFieldStateConstants.Error.Invalid(StripeR.string.stripe_invalid_card_number)
+            TextFieldStateConstants.Error.Invalid(
+                errorMessageResId = StripeR.string.stripe_invalid_card_number,
+                preventMoreInput = true,
+            )
         } else if (isDigitLimit && number.length == numberAllowedDigits) {
             TextFieldStateConstants.Valid.Full
         } else {

--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -218,9 +218,10 @@ public final class com/stripe/android/uicore/elements/TextFieldStateConstants$Er
 
 public final class com/stripe/android/uicore/elements/TextFieldStateConstants$Error$Invalid : com/stripe/android/uicore/elements/TextFieldStateConstants$Error {
 	public static final field $stable I
-	public fun <init> (I[Ljava/lang/Object;)V
-	public synthetic fun <init> (I[Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (I[Ljava/lang/Object;Z)V
+	public synthetic fun <init> (I[Ljava/lang/Object;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun isBlank ()Z
+	public fun isFull ()Z
 	public fun shouldShowError (Z)Z
 }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldStateConstants.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldStateConstants.kt
@@ -38,10 +38,12 @@ class TextFieldStateConstants {
 
         class Invalid(
             @StringRes override val errorMessageResId: Int,
-            override val formatArgs: Array<out Any>? = null
+            override val formatArgs: Array<out Any>? = null,
+            private val preventMoreInput: Boolean = false,
         ) : Error(errorMessageResId, formatArgs) {
             override fun shouldShowError(hasFocus: Boolean): Boolean = true
             override fun isBlank(): Boolean = false
+            override fun isFull(): Boolean = preventMoreInput
         }
 
         object Blank : Error(R.string.stripe_blank_and_required) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request improves how we handle invalid card number and date inputs.

Previously, an invalid text field state wouldn’t prevent further input. For instance, this made it possible to end up with `3 / 21111` in the expiry date field.

Now, we mark the text field as “full” when we encounter a non-recoverable input where no further input can fix the problem.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

UX polish.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screen recordings

<details><summary>Before</summary>
<p>

[invalid_input_before.webm](https://github.com/stripe/stripe-android/assets/110940675/3cebf611-fc5a-4367-bfd4-98b0cdce836f)

</p>
</details>

<details><summary>After</summary>
<p>

[invalid_input_after.webm](https://github.com/stripe/stripe-android/assets/110940675/d23b4208-d65d-4645-860b-06ed038074e5)

</p>
</details>

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
