### PR TITLE
Fix bottom sheet for APIs below 30

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheet.kt
@@ -69,7 +69,11 @@ internal class BottomSheetState(
         // a CancellationException.
         keyboardHandler.dismiss()
         if (modalBottomSheetState.isVisible) {
-            modalBottomSheetState.hide()
+            repeatUntilSucceededOrLimit(10) {
+                // Hiding the bottom sheet can be interrupted.
+                // We keep trying until it's fully hidden.
+                modalBottomSheetState.hide()
+            }
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue on APIs below 30 where `WindowInsets.isImeVisible` seemingly always returns true, which resulted in our bottom sheet dismissal being broken. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
