### PR TITLE
Set JVM memory for building to 4 GB

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,5 +18,7 @@ android.nonFinalResIds=true
 android.nonTransitiveRClass=true
 android.useAndroidX=true
 
+org.gradle.jvmargs=-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError
+
 # Update StripeSdkVersion.VERSION_NAME when publishing a new release
 VERSION_NAME=20.29.1


### PR DESCRIPTION
# Summary
Configure the JVM memory to 4 GB in `gradle.properties`.

# Motivation
Environment: MacBook M1 Max, 32 GB RAM, macOS Ventura 13.5.1

Currently when you freshly check out the project and try to build it directly, you get an Out of memory error:
```
Exception in thread "ForkJoinPool-1-worker-1" java.lang.OutOfMemoryError: Java heap space
```
After increasing the JVM memory in `gradle.properties`, the error is gone and the project can be built successfully.