### PR TITLE
Update onCustomerSheetResult to default to Error

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -110,9 +110,10 @@ class CustomerSheet @Inject internal constructor(
         )
     }
 
-    private fun onCustomerSheetResult(result: InternalCustomerSheetResult?) {
-        requireNotNull(result)
-        callback.onCustomerSheetResult(result.toPublicResult(paymentOptionFactory))
+    private fun onCustomerSheetResult(result: InternalCustomerSheetResult) {
+        callback.onCustomerSheetResult(
+            result.toPublicResult(paymentOptionFactory)
+        )
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetContract.kt
@@ -5,13 +5,15 @@ import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
 
 internal class CustomerSheetContract :
-    ActivityResultContract<CustomerSheetContract.Args, InternalCustomerSheetResult?>() {
+    ActivityResultContract<CustomerSheetContract.Args, InternalCustomerSheetResult>() {
     override fun createIntent(context: Context, input: Args): Intent {
         return Intent(context, CustomerSheetActivity::class.java)
     }
 
-    override fun parseResult(resultCode: Int, intent: Intent?): InternalCustomerSheetResult? {
-        return InternalCustomerSheetResult.fromIntent(intent)
+    override fun parseResult(resultCode: Int, intent: Intent?): InternalCustomerSheetResult {
+        return InternalCustomerSheetResult.fromIntent(intent) ?: InternalCustomerSheetResult.Error(
+            IllegalArgumentException("Failed to retrieve a CustomerSheetResult")
+        )
     }
 
     internal object Args

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
@@ -56,6 +56,23 @@ internal class CustomerSheetActivityTest {
     }
 
     @Test
+    fun `Finish without result emits null result and contract parses error`() {
+        runActivityScenario {
+            activity.finish()
+            assertThat(
+                InternalCustomerSheetResult.fromIntent(scenario.getResult().resultData)
+            ).isEqualTo(
+                null
+            )
+            val result = contract.parseResult(
+                scenario.getResult().resultCode,
+                scenario.getResult().resultData,
+            )
+            assertThat(result).isInstanceOf(InternalCustomerSheetResult.Error::class.java)
+        }
+    }
+
+    @Test
     fun `Finish with cancel and payment selection on back press`() {
         runActivityScenario(
             viewState = createSelectPaymentMethodViewState(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Update onCustomerSheetResult to default to Error when the result is not set

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

React Native calls finish() manually to solve a particular use case. This change makes sure that calling finish without a result does not crash.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

