### PR TITLE
Support Google Pay button type configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## XX.XX.XX - 2023-XX-XX
 
 ### PaymentSheet
+* [ADDED][7249](https://github.com/stripe/stripe-android/pull/7249) PaymentSheet now supports configuring the Google Pay button type.
 * [FIXED][7584](https://github.com/stripe/stripe-android/pull/7584) Fixed an issue where PaymentSheet would render with a lightened surface color in dark mode.
 * [FIXED][7635](https://github.com/stripe/stripe-android/pull/7635) Fixed an issue where PaymentSheet wouldn't accept valid Mexican phone numbers.
 * [CHANGED][7627](https://github.com/stripe/stripe-android/pull/7627) Updated the experimental CustomerSheet.Configuration to require a merchant name.

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -688,17 +688,20 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfigu
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)V
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)V
-	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType;)V
+	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/Long;
 	public final fun component5 ()Ljava/lang/String;
-	public final fun copy (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
+	public final fun component6 ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType;
+	public final fun copy (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType;)Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAmount ()Ljava/lang/Long;
+	public final fun getButtonType ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType;
 	public final fun getCountryCode ()Ljava/lang/String;
 	public final fun getCurrencyCode ()Ljava/lang/String;
 	public final fun getEnvironment ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;
@@ -706,6 +709,19 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfigu
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType : java/lang/Enum {
+	public static final field Book Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType;
+	public static final field Buy Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType;
+	public static final field Checkout Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType;
+	public static final field Donate Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType;
+	public static final field Order Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType;
+	public static final field Pay Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType;
+	public static final field Plain Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType;
+	public static final field Subscribe Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType;
+	public static fun values ()[Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType;
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Creator : android/os/Parcelable$Creator {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/ui/GooglePayButtonTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/ui/GooglePayButtonTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import com.google.android.gms.wallet.button.ButtonConstants.ButtonType
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.paymentsheet.MainActivity
@@ -31,6 +32,7 @@ class GooglePayButtonTest {
                 billingAddressParameters = GooglePayJsonFactory.BillingAddressParameters(),
                 onPressed = { didCallOnPressed = true },
                 modifier = Modifier.testTag(testTag),
+                buttonType = ButtonType.PAY
             )
         }
 
@@ -57,6 +59,7 @@ class GooglePayButtonTest {
                 billingAddressParameters = GooglePayJsonFactory.BillingAddressParameters(),
                 onPressed = { didCallOnPressed = true },
                 modifier = Modifier.testTag(testTag),
+                buttonType = ButtonType.PAY
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -1116,6 +1116,9 @@ class PaymentSheet internal constructor(
      * @param label An optional label to display with the amount. Google Pay may or may not display
      * this label depending on its own internal logic. Defaults to a generic label if none is
      * provided.
+     * @param buttonType The Google Pay button type to use. Set to "Pay" by default. See
+     * [Google's documentation](https://developers.google.com/android/reference/com/google/android/gms/wallet/Wallet.WalletOptions#environment)
+     * for more information on button types.
      */
     @Parcelize
     data class GooglePayConfiguration @JvmOverloads constructor(
@@ -1124,11 +1127,60 @@ class PaymentSheet internal constructor(
         val currencyCode: String? = null,
         val amount: Long? = null,
         val label: String? = null,
+        val buttonType: ButtonType = ButtonType.Pay
     ) : Parcelable {
 
         enum class Environment {
             Production,
             Test,
+        }
+
+        @Suppress("MaxLineLength")
+        /**
+         * Google Pay button type options
+         *
+         * See [Google's documentation](https://developers.google.com/pay/api/android/reference/request-objects#ButtonOptions) for more information on button types.
+         */
+        enum class ButtonType {
+            /**
+             * Displays "Buy with" alongside the Google Pay logo.
+             */
+            Buy,
+
+            /**
+             * Displays "Book with" alongside the Google Pay logo.
+             */
+            Book,
+
+            /**
+             * Displays "Checkout with" alongside the Google Pay logo.
+             */
+            Checkout,
+
+            /**
+             * Displays "Donate with" alongside the Google Pay logo.
+             */
+            Donate,
+
+            /**
+             * Displays "Order with" alongside the Google Pay logo.
+             */
+            Order,
+
+            /**
+             * Displays "Pay with" alongside the Google Pay logo.
+             */
+            Pay,
+
+            /**
+             * Displays "Subscribe with" alongside the Google Pay logo.
+             */
+            Subscribe,
+
+            /**
+             * Displays only the Google Pay logo.
+             */
+            Plain
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -40,6 +40,7 @@ import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
 import com.stripe.android.paymentsheet.injection.DaggerPaymentSheetLauncherComponent
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.injection.PaymentSheetViewModelModule
+import com.stripe.android.paymentsheet.model.GooglePayButtonType
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.model.currency
@@ -161,6 +162,19 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     private var deferredIntentConfirmationType: DeferredIntentConfirmationType? = null
 
+    private val googlePayButtonType: GooglePayButtonType =
+        when (args.config.googlePay?.buttonType) {
+            PaymentSheet.GooglePayConfiguration.ButtonType.Buy -> GooglePayButtonType.Buy
+            PaymentSheet.GooglePayConfiguration.ButtonType.Book -> GooglePayButtonType.Book
+            PaymentSheet.GooglePayConfiguration.ButtonType.Checkout -> GooglePayButtonType.Checkout
+            PaymentSheet.GooglePayConfiguration.ButtonType.Donate -> GooglePayButtonType.Donate
+            PaymentSheet.GooglePayConfiguration.ButtonType.Order -> GooglePayButtonType.Order
+            PaymentSheet.GooglePayConfiguration.ButtonType.Subscribe -> GooglePayButtonType.Subscribe
+            PaymentSheet.GooglePayConfiguration.ButtonType.Plain -> GooglePayButtonType.Plain
+            PaymentSheet.GooglePayConfiguration.ButtonType.Pay,
+            null -> GooglePayButtonType.Pay
+        }
+
     @VisibleForTesting
     internal val googlePayLauncherConfig: GooglePayPaymentMethodLauncher.Config? =
         args.googlePayConfig?.let { config ->
@@ -213,6 +227,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             buttonsEnabled = buttonsEnabled,
             paymentMethodTypes = paymentMethodTypes,
             googlePayLauncherConfig = googlePayLauncherConfig,
+            googlePayButtonType = googlePayButtonType,
             screen = stack.last(),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/GooglePayButtonType.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/GooglePayButtonType.kt
@@ -1,0 +1,14 @@
+package com.stripe.android.paymentsheet.model
+
+import com.google.android.gms.wallet.button.ButtonConstants
+
+internal enum class GooglePayButtonType(val value: Int) {
+    Buy(ButtonConstants.ButtonType.BUY),
+    Book(ButtonConstants.ButtonType.BOOK),
+    Checkout(ButtonConstants.ButtonType.CHECKOUT),
+    Donate(ButtonConstants.ButtonType.DONATE),
+    Order(ButtonConstants.ButtonType.ORDER),
+    Pay(ButtonConstants.ButtonType.PAY),
+    Subscribe(ButtonConstants.ButtonType.SUBSCRIBE),
+    Plain(ButtonConstants.ButtonType.PLAIN)
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/WalletsState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/WalletsState.kt
@@ -6,6 +6,7 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher.BillingAddressConfig
 import com.stripe.android.model.PaymentMethod.Type.Card
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.model.GooglePayButtonType
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 
@@ -22,6 +23,7 @@ internal data class WalletsState(
 
     data class GooglePay(
         val buttonState: PaymentSheetViewState?,
+        val buttonType: GooglePayButtonType,
         val allowCreditCards: Boolean,
         val billingAddressParameters: GooglePayJsonFactory.BillingAddressParameters?,
     )
@@ -33,6 +35,7 @@ internal data class WalletsState(
             linkEmail: String?,
             googlePayState: GooglePayState,
             googlePayButtonState: PaymentSheetViewState?,
+            googlePayButtonType: GooglePayButtonType,
             buttonsEnabled: Boolean,
             paymentMethodTypes: List<String>,
             googlePayLauncherConfig: GooglePayPaymentMethodLauncher.Config?,
@@ -47,6 +50,7 @@ internal data class WalletsState(
             val googlePay = GooglePay(
                 buttonState = googlePayButtonState,
                 allowCreditCards = googlePayLauncherConfig?.allowCreditCards ?: false,
+                buttonType = googlePayButtonType,
                 billingAddressParameters = googlePayLauncherConfig?.let {
                     GooglePayJsonFactory.BillingAddressParameters(
                         isRequired = it.billingAddressConfig.isRequired,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/GooglePayButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/GooglePayButton.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import com.google.android.gms.wallet.button.ButtonConstants
+import com.google.android.gms.wallet.button.ButtonConstants.ButtonType
 import com.google.android.gms.wallet.button.ButtonOptions
 import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.paymentsheet.R
@@ -28,6 +29,7 @@ import org.json.JSONArray
 internal fun GooglePayButton(
     state: PrimaryButton.State?,
     allowCreditCards: Boolean,
+    @ButtonType buttonType: Int,
     billingAddressParameters: GooglePayJsonFactory.BillingAddressParameters?,
     isEnabled: Boolean,
     onPressed: () -> Unit,
@@ -46,6 +48,7 @@ internal fun GooglePayButton(
                 googlePayButton.initialize(
                     cornerRadius = cornerRadius,
                     allowCreditCards = allowCreditCards,
+                    buttonType = buttonType,
                     billingAddressParameters = billingAddressParameters
                 )
             }
@@ -78,7 +81,8 @@ internal class GooglePayButton @JvmOverloads constructor(
     fun initialize(
         cornerRadius: Int,
         allowCreditCards: Boolean,
-        billingAddressParameters: GooglePayJsonFactory.BillingAddressParameters?
+        @ButtonType buttonType: Int,
+        billingAddressParameters: GooglePayJsonFactory.BillingAddressParameters?,
     ) {
         initializePrimaryButton()
         val isDark = context.isSystemDarkTheme()
@@ -97,7 +101,7 @@ internal class GooglePayButton @JvmOverloads constructor(
                     ButtonConstants.ButtonTheme.DARK
                 }
             )
-            setButtonType(ButtonConstants.ButtonType.PAY)
+            setButtonType(buttonType)
             setAllowedPaymentMethods(allowedPaymentMethods)
             setCornerRadius(
                 // Corner radius of 0 is undefined in Google Pay

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -153,6 +153,7 @@ internal fun Wallet(
             GooglePayButton(
                 state = googlePay.buttonState?.convert(),
                 allowCreditCards = googlePay.allowCreditCards,
+                buttonType = googlePay.buttonType.value,
                 billingAddressParameters = googlePay.billingAddressParameters,
                 isEnabled = state.buttonsEnabled,
                 onPressed = onGooglePayPressed,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -46,6 +46,7 @@ import com.stripe.android.paymentsheet.PaymentSheetViewModel.CheckoutIdentifier
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
+import com.stripe.android.paymentsheet.model.GooglePayButtonType
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.model.SavedSelection
@@ -751,6 +752,49 @@ internal class PaymentSheetViewModelTest {
         val viewModel = createViewModel(ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP)
         assertThat(viewModel.googlePayLauncherConfig)
             .isNotNull()
+    }
+
+    @Test
+    fun `'buttonType' from 'GooglePayConfiguration' should be parsed to proper 'GooglePayButtonType'`() = runTest {
+        testButtonTypeParsedToProperGooglePayButtonType(
+            PaymentSheet.GooglePayConfiguration.ButtonType.Plain,
+            GooglePayButtonType.Plain
+        )
+
+        testButtonTypeParsedToProperGooglePayButtonType(
+            PaymentSheet.GooglePayConfiguration.ButtonType.Pay,
+            GooglePayButtonType.Pay
+        )
+
+        testButtonTypeParsedToProperGooglePayButtonType(
+            PaymentSheet.GooglePayConfiguration.ButtonType.Book,
+            GooglePayButtonType.Book
+        )
+
+        testButtonTypeParsedToProperGooglePayButtonType(
+            PaymentSheet.GooglePayConfiguration.ButtonType.Buy,
+            GooglePayButtonType.Buy
+        )
+
+        testButtonTypeParsedToProperGooglePayButtonType(
+            PaymentSheet.GooglePayConfiguration.ButtonType.Donate,
+            GooglePayButtonType.Donate
+        )
+
+        testButtonTypeParsedToProperGooglePayButtonType(
+            PaymentSheet.GooglePayConfiguration.ButtonType.Checkout,
+            GooglePayButtonType.Checkout
+        )
+
+        testButtonTypeParsedToProperGooglePayButtonType(
+            PaymentSheet.GooglePayConfiguration.ButtonType.Order,
+            GooglePayButtonType.Order
+        )
+
+        testButtonTypeParsedToProperGooglePayButtonType(
+            PaymentSheet.GooglePayConfiguration.ButtonType.Subscribe,
+            GooglePayButtonType.Subscribe
+        )
     }
 
     @Test
@@ -1902,6 +1946,26 @@ internal class PaymentSheetViewModelTest {
             args = args.copy(initializationMode = InitializationMode.DeferredIntent(intentConfig)),
             stripeIntent = deferredIntent,
         )
+    }
+
+    private suspend fun testButtonTypeParsedToProperGooglePayButtonType(
+        buttonType: PaymentSheet.GooglePayConfiguration.ButtonType,
+        googlePayButtonType: GooglePayButtonType
+    ) {
+        val viewModel = createViewModel(
+            isGooglePayReady = true,
+            args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.copy(
+                    googlePay = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.googlePayConfig?.copy(
+                        buttonType = buttonType
+                    )
+                )
+            )
+        )
+
+        viewModel.walletsState.test {
+            assertThat(awaitItem()?.googlePay?.buttonType).isEqualTo(googlePayButtonType)
+        }
     }
 
     private companion object {


### PR DESCRIPTION
# Summary
Supports configuring the button type for Google Pay within `PaymentSheet`.

[MOBILE_APIREVIEW-56](https://jira.corp.stripe.com/browse/MOBILE_APIREVIEW-56)

Added all current supported button types:
- `Buy`
- `Book`
- `Checkout`
- `Donate`
- `Order`
- `Subscribe`
- `Plain`

# Motivation
`PaymentSheet` currently hardcodes the `Pay` button type option for Google Pay. Merchants however may want to deliberately specify the purchase type being made with Google Pay. We already support [Apple Pay button types](https://github.com/stripe/stripe-ios/blob/dd9e4b4c4bf7cceffc8ba661cbe2ec2430b3ce4a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift#L198) in Stripe iOS, we should do the same for Google Pay on Android.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![1000001361](https://github.com/stripe/stripe-android/assets/141707240/04322147-2fe4-45e8-8c29-eb18b8d4a7e5) | ![1000001362](https://github.com/stripe/stripe-android/assets/141707240/e990b83e-2b15-4d15-96ec-ea92f5c9ba9a) |
|  | ![1000001363](https://github.com/stripe/stripe-android/assets/141707240/4d371d7c-bb64-459d-859d-f3b3c00ef486) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
[ADDED][7249](https://github.com/stripe/stripe-android/pull/7249) PaymentSheet now supports configuring Google Pay button type.
