### PR TITLE
Add bancontact pi + sfu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## XX.XX.XX - 2023-XX-XX
+* [ADDED][7263](https://github.com/stripe/stripe-android/pull/7263) PaymentSheet now supports Bancontact PaymentIntent with setup for future usage.
 
 ## 20.29.1 - 2023-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## XX.XX.XX - 2023-XX-XX
-* [ADDED][7263](https://github.com/stripe/stripe-android/pull/7263) PaymentSheet now supports Bancontact PaymentIntent with setup for future usage.
+* [ADDED][7263](https://github.com/stripe/stripe-android/pull/7263) PaymentSheet now supports Bancontact SetupIntent and PaymentIntent with setup for future usage.
 
 ## 20.29.1 - 2023-08-31
 

--- a/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
@@ -82,30 +82,13 @@ internal val CardRequirement = PaymentMethodRequirements(
 
 internal val BancontactRequirement = PaymentMethodRequirements(
     piRequirements = emptySet(),
+    siRequirements = setOf(Delayed),
 
     /**
-     * Currently we will not support this PaymentMethod for use with PI w/SFU,
-     * or SI until there is a way of retrieving valid mandates associated with a customer PM.
-     *
-     * The reason we are excluding it is because after PI w/SFU set or PI
-     * is used, the payment method appears as a SEPA payment method attached
-     * to a customer.  Without this block the SEPA payment method would
-     * show in PaymentSheet.  If the user used this save payment method
-     * we would have no way to know if the existing mandate was valid or how
-     * to request the user to re-accept the mandate.
-     *
-     * SEPA Debit does support PI w/SFU and SI (both with and without a customer),
-     * and it is Delayed in this configuration.
+     * PM will be attached as a SEPA Debit payment method and have the requirements
+     * of that PaymentMethod.
      */
-    siRequirements = null,
-
-    /**
-     * This PM cannot be attached to a customer, it should be noted that it
-     * will be attached as a SEPA Debit payment method and have the requirements
-     * of that PaymentMethod, but for now SEPA is not supported either so we will
-     * call it false.
-     */
-    confirmPMFromCustomer = false
+    confirmPMFromCustomer = true,
 )
 
 internal val SofortRequirement = PaymentMethodRequirements(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
@@ -45,12 +45,14 @@ import com.stripe.android.ui.core.elements.AfterpayClearpayHeaderElement.Compani
 import com.stripe.android.ui.core.elements.CardBillingSpec
 import com.stripe.android.ui.core.elements.CardDetailsSectionSpec
 import com.stripe.android.ui.core.elements.ContactInformationSpec
+import com.stripe.android.ui.core.elements.EmailSpec
 import com.stripe.android.ui.core.elements.EmptyFormSpec
 import com.stripe.android.ui.core.elements.FormItemSpec
 import com.stripe.android.ui.core.elements.LayoutSpec
 import com.stripe.android.ui.core.elements.LpmSerializer
 import com.stripe.android.ui.core.elements.MandateTextSpec
 import com.stripe.android.ui.core.elements.SaveForFutureUseSpec
+import com.stripe.android.ui.core.elements.SepaMandateTextSpec
 import com.stripe.android.ui.core.elements.SharedDataSpec
 import com.stripe.android.ui.core.elements.transform
 import java.io.InputStream
@@ -259,18 +261,30 @@ class LpmRepository constructor(
                 LayoutSpec(sharedDataSpec.fields)
             }
         )
-        PaymentMethod.Type.Bancontact.code -> SupportedPaymentMethod(
-            code = "bancontact",
-            requiresMandate = true,
-            mandateRequirement = MandateRequirement.Always,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_bancontact,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_bancontact,
-            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
-            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
-            tintIconOnSelection = false,
-            requirement = BancontactRequirement,
-            formSpec = LayoutSpec(sharedDataSpec.fields)
-        )
+        PaymentMethod.Type.Bancontact.code -> {
+            val sfu = (stripeIntent as? PaymentIntent)?.setupFutureUsage != null
+            val localLayoutSpecs: List<FormItemSpec> = if (sfu) {
+                listOf(
+                    EmailSpec(),
+                    SepaMandateTextSpec()
+                )
+            } else {
+                emptyList()
+            }
+
+            SupportedPaymentMethod(
+                code = "bancontact",
+                requiresMandate = true,
+                mandateRequirement = MandateRequirement.Always,
+                displayNameResource = R.string.stripe_paymentsheet_payment_method_bancontact,
+                iconResource = R.drawable.stripe_ic_paymentsheet_pm_bancontact,
+                lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+                darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+                tintIconOnSelection = false,
+                requirement = BancontactRequirement,
+                formSpec = LayoutSpec(sharedDataSpec.fields + localLayoutSpecs)
+            )
+        }
         PaymentMethod.Type.Sofort.code -> SupportedPaymentMethod(
             code = "sofort",
             requiresMandate = true,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
@@ -262,8 +262,9 @@ class LpmRepository constructor(
             }
         )
         PaymentMethod.Type.Bancontact.code -> {
-            val sfu = (stripeIntent as? PaymentIntent)?.setupFutureUsage != null
-            val localLayoutSpecs: List<FormItemSpec> = if (sfu) {
+            val isSfu = (stripeIntent as? PaymentIntent)?.setupFutureUsage != null
+            val isSetupIntent = stripeIntent is SetupIntent
+            val localLayoutSpecs: List<FormItemSpec> = if (isSfu || isSetupIntent) {
                 listOf(
                     EmailSpec(),
                     SepaMandateTextSpec()

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/BaseLpmTest.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/BaseLpmTest.kt
@@ -40,7 +40,7 @@ internal open class BaseLpmTest {
         saveCheckboxValue = false,
         saveForFutureUseCheckboxVisible = false,
         useBrowser = null,
-        authorizationAction = AuthorizeAction.Authorize,
+        authorizationAction = AuthorizeAction.AuthorizePayment,
         merchantCountryCode = "GB",
     )
 

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/TestAuthorization.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/TestAuthorization.kt
@@ -59,7 +59,7 @@ class TestAuthorization {
         saveCheckboxValue = false,
         saveForFutureUseCheckboxVisible = false,
         useBrowser = Browser.Chrome,
-        authorizationAction = AuthorizeAction.Authorize,
+        authorizationAction = AuthorizeAction.AuthorizePayment,
         merchantCountryCode = "GB",
     )
 
@@ -67,7 +67,7 @@ class TestAuthorization {
     fun testAuthorizeSuccess() {
         testDriver.confirmNewOrGuestComplete(
             bancontactNewUser.copy(
-                authorizationAction = AuthorizeAction.Authorize,
+                authorizationAction = AuthorizeAction.AuthorizePayment,
             )
         )
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/TestBrowsers.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/TestBrowsers.kt
@@ -59,7 +59,7 @@ class TestBrowsers {
         saveCheckboxValue = false,
         saveForFutureUseCheckboxVisible = false,
         useBrowser = Browser.Chrome,
-        authorizationAction = AuthorizeAction.Authorize,
+        authorizationAction = AuthorizeAction.AuthorizePayment,
         merchantCountryCode = "GB",
     )
 

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/TestCustomers.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/TestCustomers.kt
@@ -52,7 +52,7 @@ class TestCustomers {
         saveCheckboxValue = false,
         saveForFutureUseCheckboxVisible = false,
         useBrowser = Browser.Chrome,
-        authorizationAction = AuthorizeAction.Authorize,
+        authorizationAction = AuthorizeAction.AuthorizePayment,
         merchantCountryCode = "GB",
     )
 

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/TestFieldPopulation.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/TestFieldPopulation.kt
@@ -94,7 +94,7 @@ class TestFieldPopulation {
         saveCheckboxValue = false,
         saveForFutureUseCheckboxVisible = false,
         useBrowser = Browser.Chrome,
-        authorizationAction = AuthorizeAction.Authorize,
+        authorizationAction = AuthorizeAction.AuthorizePayment,
         merchantCountryCode = "GB",
         supportedPaymentMethods = listOf(
             PaymentMethod.Type.Card.code,

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestBancontact.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestBancontact.kt
@@ -2,6 +2,7 @@ package com.stripe.android.lpm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BaseLpmTest
+import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.Automatic
 import com.stripe.android.test.core.DelayedPMs
 import com.stripe.android.test.core.IntentType
@@ -39,6 +40,7 @@ internal class TestBancontact : BaseLpmTest() {
                 delayed = DelayedPMs.On,
                 automatic = Automatic.On,
                 intentType = IntentType.Setup,
+                authorizationAction = AuthorizeAction.AuthorizeSetup,
             ),
         )
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestBancontact.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestBancontact.kt
@@ -33,6 +33,17 @@ internal class TestBancontact : BaseLpmTest() {
     }
 
     @Test
+    fun testBancontactSetup() {
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = bancontact.copy(
+                delayed = DelayedPMs.On,
+                automatic = Automatic.On,
+                intentType = IntentType.Setup,
+            ),
+        )
+    }
+
+    @Test
     fun testBancontactInCustomFlow() {
         testDriver.confirmCustom(
             testParameters = bancontact,

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestBancontact.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestBancontact.kt
@@ -2,6 +2,9 @@ package com.stripe.android.lpm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BaseLpmTest
+import com.stripe.android.test.core.Automatic
+import com.stripe.android.test.core.DelayedPMs
+import com.stripe.android.test.core.IntentType
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -15,6 +18,17 @@ internal class TestBancontact : BaseLpmTest() {
     fun testBancontact() {
         testDriver.confirmNewOrGuestComplete(
             testParameters = bancontact,
+        )
+    }
+
+    @Test
+    fun testBancontactSfu() {
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = bancontact.copy(
+                delayed = DelayedPMs.On,
+                automatic = Automatic.On,
+                intentType = IntentType.PayWithSetup,
+            ),
         )
     }
 

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCashApp.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCashApp.kt
@@ -14,7 +14,7 @@ internal class TestCashApp : BaseLpmTest() {
         paymentMethod = lpmRepository.fromCode("cashapp")!!,
         currency = Currency.USD,
         merchantCountryCode = "US",
-        authorizationAction = AuthorizeAction.Authorize,
+        authorizationAction = AuthorizeAction.AuthorizePayment,
         supportedPaymentMethods = listOf("card", "cashapp"),
     )
 

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestGrabPay.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestGrabPay.kt
@@ -14,7 +14,7 @@ internal class TestGrabPay : BaseLpmTest() {
         paymentMethod = lpmRepository.fromCode("grabpay")!!,
         currency = Currency.SGD,
         merchantCountryCode = "SG",
-        authorizationAction = AuthorizeAction.Authorize,
+        authorizationAction = AuthorizeAction.AuthorizePayment,
     )
 
     @Test

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
@@ -86,14 +86,18 @@ enum class Browser {
  */
 sealed interface AuthorizeAction {
 
-    abstract val text: String
+    val text: String
 
     object PollingSucceedsAfterDelay : AuthorizeAction {
         override val text: String = "POLLING SUCCEEDS AFTER DELAY"
     }
 
-    object Authorize : AuthorizeAction {
+    object AuthorizePayment : AuthorizeAction {
         override val text: String = "AUTHORIZE TEST PAYMENT"
+    }
+
+    object AuthorizeSetup : AuthorizeAction {
+        override val text: String = "AUTHORIZE TEST SETUP"
     }
 
     data class Fail(val expectedError: String) : AuthorizeAction {

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -15,8 +15,8 @@ import androidx.test.uiautomator.Until
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.model.CountryUtils
-import com.stripe.android.model.PaymentMethod.Type.CashAppPay
 import com.stripe.android.model.PaymentMethod.Type.Blik
+import com.stripe.android.model.PaymentMethod.Type.CashAppPay
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.R
 import com.stripe.android.paymentsheet.example.playground.model.InitializationType
@@ -154,11 +154,11 @@ class Selectors(
 
     fun browserWindow(browser: BrowserUI): UiObject? = browserWindow(device, browser)
 
-    fun blockUntilAuthorizationPageLoaded() {
+    fun blockUntilAuthorizationPageLoaded(isSetup: Boolean) {
         assertThat(
             device.wait(
                 Until.findObject(
-                    By.textContains("test payment page")
+                    By.textContains("test ${if (isSetup) "setup" else "payment"} page")
                 ),
                 HOOKS_PAGE_LOAD_TIMEOUT * 1000
             )
@@ -183,7 +183,7 @@ class Selectors(
         .getInstalledApplications(PackageManager.GET_META_DATA)
 
     val authorizeAction = when (testParameters.authorizationAction) {
-        is AuthorizeAction.Authorize -> {
+        is AuthorizeAction.AuthorizePayment, AuthorizeAction.AuthorizeSetup -> {
             object : UiAutomatorText(
                 label = testParameters.authorizationAction.text,
                 className = "android.widget.Button",

--- a/paymentsheet/src/test/resources/bancontact-support.csv
+++ b/paymentsheet/src/test/resources/bancontact-support.csv
@@ -1,49 +1,49 @@
 lpm, hasCustomer, allowsDelayedPayment, intentSetupFutureUsage, intentHasShipping, intentLpms, supportCustomerSavedCard, formExists, formType, supportsAdding
-bancontact, true, true, off_session, false, card/bancontact, false, false, not available, false
-bancontact, true, true, off_session, false, card/eps/bancontact, false, false, not available, false
+bancontact, true, true, off_session, false, card/bancontact, true, true, merchantRequiredSave, true
+bancontact, true, true, off_session, false, card/eps/bancontact, true, true, merchantRequiredSave, true
 bancontact, true, false, off_session, false, card/bancontact, false, false, not available, false
 bancontact, true, false, off_session, false, card/eps/bancontact, false, false, not available, false
-bancontact, true, true, on_session, false, card/bancontact, false, false, not available, false
-bancontact, true, true, on_session, false, card/eps/bancontact, false, false, not available, false
+bancontact, true, true, on_session, false, card/bancontact, true, true, merchantRequiredSave, true
+bancontact, true, true, on_session, false, card/eps/bancontact, true, true, merchantRequiredSave, true
 bancontact, true, false, on_session, false, card/bancontact, false, false, not available, false
 bancontact, true, false, on_session, false, card/eps/bancontact, false, false, not available, false
-bancontact, true, true, null, false, card/bancontact, false, true, oneTime, true
-bancontact, true, true, null, false, card/eps/bancontact, false, true, oneTime, true
-bancontact, true, false, null, false, card/bancontact, false, true, oneTime, true
-bancontact, true, false, null, false, card/eps/bancontact, false, true, oneTime, true
-bancontact, false, true, off_session, false, card/bancontact, false, false, not available, false
-bancontact, false, true, off_session, false, card/eps/bancontact, false, false, not available, false
+bancontact, true, true, null, false, card/bancontact, true, true, userSelectedSave, true
+bancontact, true, true, null, false, card/eps/bancontact, true, true, userSelectedSave, true
+bancontact, true, false, null, false, card/bancontact, true, true, oneTime, true
+bancontact, true, false, null, false, card/eps/bancontact, true, true, oneTime, true
+bancontact, false, true, off_session, false, card/bancontact, true, true, merchantRequiredSave, true
+bancontact, false, true, off_session, false, card/eps/bancontact, true, true, merchantRequiredSave, true
 bancontact, false, false, off_session, false, card/bancontact, false, false, not available, false
 bancontact, false, false, off_session, false, card/eps/bancontact, false, false, not available, false
-bancontact, false, true, on_session, false, card/bancontact, false, false, not available, false
-bancontact, false, true, on_session, false, card/eps/bancontact, false, false, not available, false
+bancontact, false, true, on_session, false, card/bancontact, true, true, merchantRequiredSave, true
+bancontact, false, true, on_session, false, card/eps/bancontact, true, true, merchantRequiredSave, true
 bancontact, false, false, on_session, false, card/bancontact, false, false, not available, false
 bancontact, false, false, on_session, false, card/eps/bancontact, false, false, not available, false
-bancontact, false, true, null, false, card/bancontact, false, true, oneTime, true
-bancontact, false, true, null, false, card/eps/bancontact, false, true, oneTime, true
-bancontact, false, false, null, false, card/bancontact, false, true, oneTime, true
-bancontact, false, false, null, false, card/eps/bancontact, false, true, oneTime, true
-bancontact, true, true, off_session, true, card/bancontact, false, false, not available, false
-bancontact, true, true, off_session, true, card/eps/bancontact, false, false, not available, false
+bancontact, false, true, null, false, card/bancontact, true, true, oneTime, true
+bancontact, false, true, null, false, card/eps/bancontact, true, true, oneTime, true
+bancontact, false, false, null, false, card/bancontact, true, true, oneTime, true
+bancontact, false, false, null, false, card/eps/bancontact, true, true, oneTime, true
+bancontact, true, true, off_session, true, card/bancontact, true, true, merchantRequiredSave, true
+bancontact, true, true, off_session, true, card/eps/bancontact, true, true, merchantRequiredSave, true
 bancontact, true, false, off_session, true, card/bancontact, false, false, not available, false
 bancontact, true, false, off_session, true, card/eps/bancontact, false, false, not available, false
-bancontact, true, true, on_session, true, card/bancontact, false, false, not available, false
-bancontact, true, true, on_session, true, card/eps/bancontact, false, false, not available, false
+bancontact, true, true, on_session, true, card/bancontact, true, true, merchantRequiredSave, true
+bancontact, true, true, on_session, true, card/eps/bancontact, true, true, merchantRequiredSave, true
 bancontact, true, false, on_session, true, card/bancontact, false, false, not available, false
 bancontact, true, false, on_session, true, card/eps/bancontact, false, false, not available, false
-bancontact, true, true, null, true, card/bancontact, false, true, oneTime, true
-bancontact, true, true, null, true, card/eps/bancontact, false, true, oneTime, true
-bancontact, true, false, null, true, card/bancontact, false, true, oneTime, true
-bancontact, true, false, null, true, card/eps/bancontact, false, true, oneTime, true
-bancontact, false, true, off_session, true, card/bancontact, false, false, not available, false
-bancontact, false, true, off_session, true, card/eps/bancontact, false, false, not available, false
+bancontact, true, true, null, true, card/bancontact, true, true, userSelectedSave, true
+bancontact, true, true, null, true, card/eps/bancontact, true, true, userSelectedSave, true
+bancontact, true, false, null, true, card/bancontact, true, true, oneTime, true
+bancontact, true, false, null, true, card/eps/bancontact, true, true, oneTime, true
+bancontact, false, true, off_session, true, card/bancontact, true, true, merchantRequiredSave, true
+bancontact, false, true, off_session, true, card/eps/bancontact, true, true, merchantRequiredSave, true
 bancontact, false, false, off_session, true, card/bancontact, false, false, not available, false
 bancontact, false, false, off_session, true, card/eps/bancontact, false, false, not available, false
-bancontact, false, true, on_session, true, card/bancontact, false, false, not available, false
-bancontact, false, true, on_session, true, card/eps/bancontact, false, false, not available, false
+bancontact, false, true, on_session, true, card/bancontact, true, true, merchantRequiredSave, true
+bancontact, false, true, on_session, true, card/eps/bancontact, true, true, merchantRequiredSave, true
 bancontact, false, false, on_session, true, card/bancontact, false, false, not available, false
 bancontact, false, false, on_session, true, card/eps/bancontact, false, false, not available, false
-bancontact, false, true, null, true, card/bancontact, false, true, oneTime, true
-bancontact, false, true, null, true, card/eps/bancontact, false, true, oneTime, true
-bancontact, false, false, null, true, card/bancontact, false, true, oneTime, true
-bancontact, false, false, null, true, card/eps/bancontact, false, true, oneTime, true
+bancontact, false, true, null, true, card/bancontact, true, true, oneTime, true
+bancontact, false, true, null, true, card/eps/bancontact, true, true, oneTime, true
+bancontact, false, false, null, true, card/bancontact, true, true, oneTime, true
+bancontact, false, false, null, true, card/eps/bancontact, true, true, oneTime, true


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Add bancontact si, pi + sfu

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

https://github.com/stripe/stripe-android/assets/99316447/3d034f98-e8e3-4811-930f-acf06aaffda3

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

* [ADDED][7263](https://github.com/stripe/stripe-android/pull/7263) PaymentSheet now supports Bancontact SetupIntent and PaymentIntent with setup for future usage.


