### PR TITLE
Enable Cash App Pay for SI and PI+SFU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,17 @@
 ## XX.XX.XX - 2023-XX-XX
 
 ### PaymentSheet
-
-* [ADDED][7269](https://github.com/stripe/stripe-android/pull/7269) PaymentSheet now supports Ideal with SetupIntent and PaymentIntent with setup for future usage.
-* [ADDED][7270](https://github.com/stripe/stripe-android/pull/7270) PaymentSheet now supports SEPA with SetupIntent and PaymentIntent with setup for future usage.
-* [ADDED][7272](https://github.com/stripe/stripe-android/pull/7272) PaymentSheet now supports Sofort with SetupIntent and PaymentIntent with setup for future usage.
-* [ADDED][7273](https://github.com/stripe/stripe-android/pull/7273) PaymentSheet now supports BECS Direct Debit with SetupIntent and PaymentIntent with setup for future usage.
-* [ADDED][7274](https://github.com/stripe/stripe-android/pull/7274) PaymentSheet now supports Alipay for PaymentIntents.
+* [ADDED] PaymentSheet now supports the following payment methods for SetupIntents and PaymentIntents with setup for future usage:
+  * [7274](https://github.com/stripe/stripe-android/pull/7274) Alipay
+  * [7273](https://github.com/stripe/stripe-android/pull/7273) BECS Direct Debit
+  * [7264](https://github.com/stripe/stripe-android/pull/7264) Cash App Pay
+  * [7269](https://github.com/stripe/stripe-android/pull/7269) iDEAL
+  * [7270](https://github.com/stripe/stripe-android/pull/7270) SEPA
+  * [7272](https://github.com/stripe/stripe-android/pull/7272) Sofort
 
 ## 20.29.2 - 2023-09-05
+
+### PaymentSheet
 * [ADDED][7263](https://github.com/stripe/stripe-android/pull/7263) PaymentSheet now supports Bancontact SetupIntent and PaymentIntent with setup for future usage.
 
 ## 20.29.1 - 2023-08-31

--- a/payments-ui-core/detekt-baseline.xml
+++ b/payments-ui-core/detekt-baseline.xml
@@ -64,6 +64,7 @@
     <ID>ReturnCount:CardNumberVisualTransformation.kt$CardNumberVisualTransformation.&lt;no name provided>$override fun transformedToOriginal(offset: Int): Int</ID>
     <ID>ReturnCount:IbanConfig.kt$IbanConfig$override fun determineState(input: String): TextFieldState</ID>
     <ID>SpreadOperator:BsbElementUI.kt$( it.errorMessage, *args )</ID>
+    <ID>SpreadOperator:MandateTextUI.kt$(element.stringResId, *element.args.toTypedArray())</ID>
     <ID>TooGenericExceptionCaught:LpmSerializer.kt$LpmSerializer$e: Exception</ID>
     <ID>TooGenericExceptionCaught:PlacesClientProxy.kt$DefaultPlacesClientProxy$e: Exception</ID>
     <ID>UtilityClassWithPublicConstructor:FieldValuesToParamsMapConverter.kt$FieldValuesToParamsMapConverter</ID>

--- a/payments-ui-core/res/values/strings.xml
+++ b/payments-ui-core/res/values/strings.xml
@@ -55,6 +55,8 @@
   <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
   <!-- PayPal mandate text -->
   <string name="stripe_paypal_mandate">By confirming your payment with PayPal, you allow %s to charge your PayPal account for future payments in accordance with their terms.</string>
+  <!-- CashAppPay mandate text -->
+  <string name="stripe_cash_app_pay_mandate">By continuing, you authorize %1$s to debit your Cash App account for this payment and future payments in accordance with %2$s\'s terms, until this authorization is revoked. You can change this anytime in your Cash App Settings.</string>
   <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
   <string name="stripe_save_for_future_payments_with_merchant_name">Save for future %s payments</string>
   <!-- Button title to open camera to scan credit/debit card -->

--- a/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
@@ -59,7 +59,7 @@ data class PaymentMethodRequirements(
 
     /**
      * This indicates if the payment method can be confirmed when attached to a customer
-     * and only the Payment Method id is available.  This also implies that the PaymentMethod
+     * and only the Payment Method id is available. This also implies that the PaymentMethod
      * is internally supported in the SDK so it can be parsed in the customer repository requests.
      *  - Null means that it is not supported, or that it is attached as a different type
      *  - false means that it is supported by the payment method, but not currently enabled
@@ -250,8 +250,8 @@ internal val BlikRequirement = PaymentMethodRequirements(
 
 internal val CashAppPayRequirement = PaymentMethodRequirements(
     piRequirements = emptySet(),
-    siRequirements = null,
-    confirmPMFromCustomer = false,
+    siRequirements = emptySet(),
+    confirmPMFromCustomer = true,
 )
 
 internal val GrabPayRequirement = PaymentMethodRequirements(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CashAppPayMandateTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CashAppPayMandateTextSpec.kt
@@ -1,0 +1,27 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+import androidx.annotation.StringRes
+import com.stripe.android.ui.core.R
+import com.stripe.android.uicore.elements.FormElement
+import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Serializable
+internal data class CashAppPayMandateTextSpec(
+    @SerialName("api_path")
+    override val apiPath: IdentifierSpec = IdentifierSpec.Generic("cashapp_mandate"),
+    @StringRes
+    val stringResId: Int = R.string.stripe_cash_app_pay_mandate,
+) : FormItemSpec() {
+
+    @Transient
+    private val mandateTextSpec = MandateTextSpec(apiPath, stringResId)
+
+    fun transform(merchantName: String): FormElement {
+        return mandateTextSpec.transform(merchantName, merchantName)
+    }
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextElement.kt
@@ -12,9 +12,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 data class MandateTextElement(
     override val identifier: IdentifierSpec,
     val stringResId: Int,
-    val merchantName: String?,
+    val args: List<String>,
     override val controller: InputController? = null
 ) : FormElement {
+
     override fun getFormFieldValueFlow(): Flow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
         MutableStateFlow(emptyList())
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextSpec.kt
@@ -18,12 +18,12 @@ data class MandateTextSpec(
     @StringRes
     val stringResId: Int
 ) : FormItemSpec() {
-    fun transform(merchantName: String): FormElement =
-        // It could be argued that the static text should have a controller, but
-        // since it doesn't provide a form field we leave it out for now
-        MandateTextElement(
-            this.apiPath,
-            this.stringResId,
-            merchantName
+
+    fun transform(vararg args: String): FormElement {
+        return MandateTextElement(
+            identifier = apiPath,
+            stringResId = stringResId,
+            args = args.toList(),
         )
+    }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextUI.kt
@@ -17,7 +17,7 @@ fun MandateTextUI(
     element: MandateTextElement
 ) {
     Text(
-        text = stringResource(element.stringResId, element.merchantName ?: ""),
+        text = stringResource(element.stringResId, *element.args.toTypedArray()),
         style = MaterialTheme.typography.body2,
         color = MaterialTheme.stripeColors.subtitle,
         modifier = Modifier

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
@@ -12,6 +12,7 @@ import com.stripe.android.ui.core.elements.BlikSpec
 import com.stripe.android.ui.core.elements.BsbSpec
 import com.stripe.android.ui.core.elements.CardBillingSpec
 import com.stripe.android.ui.core.elements.CardDetailsSectionSpec
+import com.stripe.android.ui.core.elements.CashAppPayMandateTextSpec
 import com.stripe.android.ui.core.elements.ContactInformationSpec
 import com.stripe.android.ui.core.elements.CountrySpec
 import com.stripe.android.ui.core.elements.DropdownSpec
@@ -102,8 +103,8 @@ class TransformSpecToElements(
                 is UpiSpec -> it.transform()
                 is BlikSpec -> it.transform()
                 is ContactInformationSpec -> it.transform(initialValues)
-                is PlaceholderSpec ->
-                    error("Placeholders should be processed before calling transform.")
+                is PlaceholderSpec -> error("Placeholders should be processed before calling transform.")
+                is CashAppPayMandateTextSpec -> it.transform(merchantName)
             }
         }.takeUnless { it.isEmpty() } ?: listOf(EmptyFormElement())
 }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCashApp.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCashApp.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BaseLpmTest
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.Currency
+import com.stripe.android.test.core.IntentType
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -41,6 +42,26 @@ internal class TestCashApp : BaseLpmTest() {
         testDriver.confirmNewOrGuestComplete(
             testParameters = cashApp.copy(
                 authorizationAction = AuthorizeAction.Cancel,
+            ),
+        )
+    }
+
+    @Test
+    fun testCashAppPayWithSfu() {
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = cashApp.copy(
+                intentType = IntentType.PayWithSetup,
+                authorizationAction = AuthorizeAction.AuthorizePayment,
+            ),
+        )
+    }
+
+    @Test
+    fun testCashAppPayWithSetupIntent() {
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = cashApp.copy(
+                intentType = IntentType.Setup,
+                authorizationAction = AuthorizeAction.AuthorizeSetup,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -204,14 +204,20 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             PaymentMethod.Type.fromCode(it.code)
         }
 
-        return customerRepository.getPaymentMethods(
+        val paymentMethods = customerRepository.getPaymentMethods(
             customerConfig = customerConfig,
             types = paymentMethodTypes,
             silentlyFail = true,
-        ).getOrDefault(emptyList()).filter { paymentMethod ->
-            paymentMethod.hasExpectedDetails() &&
-                // PayPal isn't supported yet as a saved payment method (backend limitation).
-                paymentMethod.type != PaymentMethod.Type.PayPal
+        ).getOrDefault(emptyList())
+
+        return paymentMethods.filter { paymentMethod ->
+            paymentMethod.hasExpectedDetails()
+        }.filter { paymentMethod ->
+            // PayPal isn't supported yet as a saved payment method (backend limitation).
+            paymentMethod.type != PaymentMethod.Type.PayPal
+        }.filter { paymentMethod ->
+            // CashAppPay isn't supported yet as a saved payment method (backend limitation).
+            paymentMethod.type != PaymentMethod.Type.CashAppPay
         }
     }
 

--- a/paymentsheet/src/test/resources/cashapp-support.csv
+++ b/paymentsheet/src/test/resources/cashapp-support.csv
@@ -1,49 +1,49 @@
 lpm, hasCustomer, allowsDelayedPayment, intentSetupFutureUsage, intentHasShipping, intentLpms, supportCustomerSavedCard, formExists, formType, supportsAdding
-cashapp, true, true, off_session, false, card/cashapp, false, false, not available, false
-cashapp, true, true, off_session, false, card/eps/cashapp, false, false, not available, false
-cashapp, true, false, off_session, false, card/cashapp, false, false, not available, false
-cashapp, true, false, off_session, false, card/eps/cashapp, false, false, not available, false
-cashapp, true, true, on_session, false, card/cashapp, false, false, not available, false
-cashapp, true, true, on_session, false, card/eps/cashapp, false, false, not available, false
-cashapp, true, false, on_session, false, card/cashapp, false, false, not available, false
-cashapp, true, false, on_session, false, card/eps/cashapp, false, false, not available, false
-cashapp, true, true, null, false, card/cashapp, false, true, oneTime, true
-cashapp, true, true, null, false, card/eps/cashapp, false, true, oneTime, true
-cashapp, true, false, null, false, card/cashapp, false, true, oneTime, true
-cashapp, true, false, null, false, card/eps/cashapp, false, true, oneTime, true
-cashapp, false, true, off_session, false, card/cashapp, false, false, not available, false
-cashapp, false, true, off_session, false, card/eps/cashapp, false, false, not available, false
-cashapp, false, false, off_session, false, card/cashapp, false, false, not available, false
-cashapp, false, false, off_session, false, card/eps/cashapp, false, false, not available, false
-cashapp, false, true, on_session, false, card/cashapp, false, false, not available, false
-cashapp, false, true, on_session, false, card/eps/cashapp, false, false, not available, false
-cashapp, false, false, on_session, false, card/cashapp, false, false, not available, false
-cashapp, false, false, on_session, false, card/eps/cashapp, false, false, not available, false
-cashapp, false, true, null, false, card/cashapp, false, true, oneTime, true
-cashapp, false, true, null, false, card/eps/cashapp, false, true, oneTime, true
-cashapp, false, false, null, false, card/cashapp, false, true, oneTime, true
-cashapp, false, false, null, false, card/eps/cashapp, false, true, oneTime, true
-cashapp, true, true, off_session, true, card/cashapp, false, false, not available, false
-cashapp, true, true, off_session, true, card/eps/cashapp, false, false, not available, false
-cashapp, true, false, off_session, true, card/cashapp, false, false, not available, false
-cashapp, true, false, off_session, true, card/eps/cashapp, false, false, not available, false
-cashapp, true, true, on_session, true, card/cashapp, false, false, not available, false
-cashapp, true, true, on_session, true, card/eps/cashapp, false, false, not available, false
-cashapp, true, false, on_session, true, card/cashapp, false, false, not available, false
-cashapp, true, false, on_session, true, card/eps/cashapp, false, false, not available, false
-cashapp, true, true, null, true, card/cashapp, false, true, oneTime, true
-cashapp, true, true, null, true, card/eps/cashapp, false, true, oneTime, true
-cashapp, true, false, null, true, card/cashapp, false, true, oneTime, true
-cashapp, true, false, null, true, card/eps/cashapp, false, true, oneTime, true
-cashapp, false, true, off_session, true, card/cashapp, false, false, not available, false
-cashapp, false, true, off_session, true, card/eps/cashapp, false, false, not available, false
-cashapp, false, false, off_session, true, card/cashapp, false, false, not available, false
-cashapp, false, false, off_session, true, card/eps/cashapp, false, false, not available, false
-cashapp, false, true, on_session, true, card/cashapp, false, false, not available, false
-cashapp, false, true, on_session, true, card/eps/cashapp, false, false, not available, false
-cashapp, false, false, on_session, true, card/cashapp, false, false, not available, false
-cashapp, false, false, on_session, true, card/eps/cashapp, false, false, not available, false
-cashapp, false, true, null, true, card/cashapp, false, true, oneTime, true
-cashapp, false, true, null, true, card/eps/cashapp, false, true, oneTime, true
-cashapp, false, false, null, true, card/cashapp, false, true, oneTime, true
-cashapp, false, false, null, true, card/eps/cashapp, false, true, oneTime, true
+cashapp, true, true, off_session, false, card/cashapp, true, true, merchantRequiredSave, true
+cashapp, true, true, off_session, false, card/eps/cashapp, true, true, merchantRequiredSave, true
+cashapp, true, false, off_session, false, card/cashapp, true, true, merchantRequiredSave, true
+cashapp, true, false, off_session, false, card/eps/cashapp, true, true, merchantRequiredSave, true
+cashapp, true, true, on_session, false, card/cashapp, true, true, merchantRequiredSave, true
+cashapp, true, true, on_session, false, card/eps/cashapp, true, true, merchantRequiredSave, true
+cashapp, true, false, on_session, false, card/cashapp, true, true, merchantRequiredSave, true
+cashapp, true, false, on_session, false, card/eps/cashapp, true, true, merchantRequiredSave, true
+cashapp, true, true, null, false, card/cashapp, true, true, userSelectedSave, true
+cashapp, true, true, null, false, card/eps/cashapp, true, true, userSelectedSave, true
+cashapp, true, false, null, false, card/cashapp, true, true, userSelectedSave, true
+cashapp, true, false, null, false, card/eps/cashapp, true, true, userSelectedSave, true
+cashapp, false, true, off_session, false, card/cashapp, true, true, merchantRequiredSave, true
+cashapp, false, true, off_session, false, card/eps/cashapp, true, true, merchantRequiredSave, true
+cashapp, false, false, off_session, false, card/cashapp, true, true, merchantRequiredSave, true
+cashapp, false, false, off_session, false, card/eps/cashapp, true, true, merchantRequiredSave, true
+cashapp, false, true, on_session, false, card/cashapp, true, true, merchantRequiredSave, true
+cashapp, false, true, on_session, false, card/eps/cashapp, true, true, merchantRequiredSave, true
+cashapp, false, false, on_session, false, card/cashapp, true, true, merchantRequiredSave, true
+cashapp, false, false, on_session, false, card/eps/cashapp, true, true, merchantRequiredSave, true
+cashapp, false, true, null, false, card/cashapp, true, true, oneTime, true
+cashapp, false, true, null, false, card/eps/cashapp, true, true, oneTime, true
+cashapp, false, false, null, false, card/cashapp, true, true, oneTime, true
+cashapp, false, false, null, false, card/eps/cashapp, true, true, oneTime, true
+cashapp, true, true, off_session, true, card/cashapp, true, true, merchantRequiredSave, true
+cashapp, true, true, off_session, true, card/eps/cashapp, true, true, merchantRequiredSave, true
+cashapp, true, false, off_session, true, card/cashapp, true, true, merchantRequiredSave, true
+cashapp, true, false, off_session, true, card/eps/cashapp, true, true, merchantRequiredSave, true
+cashapp, true, true, on_session, true, card/cashapp, true, true, merchantRequiredSave, true
+cashapp, true, true, on_session, true, card/eps/cashapp, true, true, merchantRequiredSave, true
+cashapp, true, false, on_session, true, card/cashapp, true, true, merchantRequiredSave, true
+cashapp, true, false, on_session, true, card/eps/cashapp, true, true, merchantRequiredSave, true
+cashapp, true, true, null, true, card/cashapp, true, true, userSelectedSave, true
+cashapp, true, true, null, true, card/eps/cashapp, true, true, userSelectedSave, true
+cashapp, true, false, null, true, card/cashapp, true, true, userSelectedSave, true
+cashapp, true, false, null, true, card/eps/cashapp, true, true, userSelectedSave, true
+cashapp, false, true, off_session, true, card/cashapp, true, true, merchantRequiredSave, true
+cashapp, false, true, off_session, true, card/eps/cashapp, true, true, merchantRequiredSave, true
+cashapp, false, false, off_session, true, card/cashapp, true, true, merchantRequiredSave, true
+cashapp, false, false, off_session, true, card/eps/cashapp, true, true, merchantRequiredSave, true
+cashapp, false, true, on_session, true, card/cashapp, true, true, merchantRequiredSave, true
+cashapp, false, true, on_session, true, card/eps/cashapp, true, true, merchantRequiredSave, true
+cashapp, false, false, on_session, true, card/cashapp, true, true, merchantRequiredSave, true
+cashapp, false, false, on_session, true, card/eps/cashapp, true, true, merchantRequiredSave, true
+cashapp, false, true, null, true, card/cashapp, true, true, oneTime, true
+cashapp, false, true, null, true, card/eps/cashapp, true, true, oneTime, true
+cashapp, false, false, null, true, card/cashapp, true, true, oneTime, true
+cashapp, false, false, null, true, card/eps/cashapp, true, true, oneTime, true


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request enables the usage of Cash App Pay for setup intents and payment intents with SFU.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
