### PR TITLE
Add support for `Bacs Debit` configs & specs

### DIFF
--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -100,6 +100,38 @@ public final class com/stripe/android/ui/core/elements/AuBankAccountNumberSpec$C
 public final class com/stripe/android/ui/core/elements/AuBecsDebitMandateElementUIKt {
 }
 
+public final class com/stripe/android/ui/core/elements/BacsDebitAccountNumberSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/BacsDebitAccountNumberSpec$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/ui/core/elements/BacsDebitAccountNumberSpec;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/ui/core/elements/BacsDebitAccountNumberSpec;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/BacsDebitAccountNumberSpec$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/BacsDebitSortCodeSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/BacsDebitSortCodeSpec$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/ui/core/elements/BacsDebitSortCodeSpec;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/ui/core/elements/BacsDebitSortCodeSpec;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/BacsDebitSortCodeSpec$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/stripe/android/ui/core/elements/BlikSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/BlikSpec$$serializer;

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -100,35 +100,35 @@ public final class com/stripe/android/ui/core/elements/AuBankAccountNumberSpec$C
 public final class com/stripe/android/ui/core/elements/AuBecsDebitMandateElementUIKt {
 }
 
-public final class com/stripe/android/ui/core/elements/BacsDebitAccountNumberSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final class com/stripe/android/ui/core/elements/BacsDebitBankAccountSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field $stable I
-	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/BacsDebitAccountNumberSpec$$serializer;
+	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/BacsDebitBankAccountSpec$$serializer;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/ui/core/elements/BacsDebitAccountNumberSpec;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/ui/core/elements/BacsDebitBankAccountSpec;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/ui/core/elements/BacsDebitAccountNumberSpec;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/ui/core/elements/BacsDebitBankAccountSpec;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/stripe/android/ui/core/elements/BacsDebitAccountNumberSpec$Companion {
+public final class com/stripe/android/ui/core/elements/BacsDebitBankAccountSpec$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/stripe/android/ui/core/elements/BacsDebitSortCodeSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final class com/stripe/android/ui/core/elements/BacsDebitConfirmSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field $stable I
-	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/BacsDebitSortCodeSpec$$serializer;
+	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/BacsDebitConfirmSpec$$serializer;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/ui/core/elements/BacsDebitSortCodeSpec;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/ui/core/elements/BacsDebitConfirmSpec;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/ui/core/elements/BacsDebitSortCodeSpec;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/ui/core/elements/BacsDebitConfirmSpec;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/stripe/android/ui/core/elements/BacsDebitSortCodeSpec$Companion {
+public final class com/stripe/android/ui/core/elements/BacsDebitConfirmSpec$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/payments-ui-core/res/values/strings.xml
+++ b/payments-ui-core/res/values/strings.xml
@@ -4,6 +4,8 @@
   <string name="stripe_afterpay_clearpay_message"><![CDATA[Pay in <num_installments/> interest-free payments of <installment_price/> with <img/>]]></string>
   <!-- Text for back button -->
   <string name="stripe_back">Back</string>
+  <!-- Section title for Bacs bank account fields -->
+  <string name="stripe_bacs_bank_account_title">Bank account</string>
   <!-- Label for Bacs account number field -->
   <string name="stripe_bacs_account_number">Account number</string>
   <!-- BECS Debit Widget - account number field - incomplete error message -->
@@ -12,6 +14,8 @@
   <string name="stripe_bacs_sort_code">Sort code</string>
   <!-- An error message displayed when the customer's Bacs sort code is incomplete. -->
   <string name="stripe_bacs_sort_code_incomplete">Your sort code is incomplete.</string>
+  <!-- Label for confirmation checkbox for bacs mandate. -->
+  <string name="stripe_bacs_confirm_mandate_label">I understand that Stripe will be collecting Direct Debits on behalf of %s and confirm that I am the account holder and the only person required to authorise debits from this account.</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Billing address</string>
   <!-- Label for BLIK code number field on form -->

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitAccountNumberConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitAccountNumberConfig.kt
@@ -1,0 +1,61 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+import androidx.annotation.StringRes
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
+import com.stripe.android.ui.core.R
+import com.stripe.android.uicore.elements.TextFieldConfig
+import com.stripe.android.uicore.elements.TextFieldIcon
+import com.stripe.android.uicore.elements.TextFieldState
+import com.stripe.android.uicore.elements.TextFieldStateConstants
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class BacsDebitAccountNumberConfig : TextFieldConfig {
+    override val capitalization: KeyboardCapitalization = KeyboardCapitalization.None
+
+    override val debugLabel: String = DEBUG_LABEL
+
+    @StringRes
+    override val label: Int = R.string.stripe_bacs_account_number
+
+    override val placeHolder: String
+        get() = PLACEHOLDER
+
+    override val keyboard: KeyboardType = KeyboardType.NumberPassword
+
+    override val visualTransformation: VisualTransformation = VisualTransformation.None
+
+    override val trailingIcon: StateFlow<TextFieldIcon?> = MutableStateFlow(null)
+
+    override val loading: StateFlow<Boolean> = MutableStateFlow(false)
+
+    override fun determineState(input: String): TextFieldState {
+        return when {
+            input.isBlank() -> TextFieldStateConstants.Error.Blank
+            input.length < LENGTH -> TextFieldStateConstants.Error.Incomplete(
+                R.string.stripe_bacs_account_number_incomplete
+            )
+            else -> TextFieldStateConstants.Valid.Full
+        }
+    }
+
+    override fun filter(userTyped: String): String {
+        return userTyped.filter { character ->
+            character.isDigit()
+        }.take(LENGTH)
+    }
+
+    override fun convertToRaw(displayName: String): String = displayName
+
+    override fun convertFromRaw(rawValue: String): String = rawValue
+
+    private companion object {
+        const val LENGTH = 8
+        const val DEBUG_LABEL = "bacs_debit_account_number"
+        const val PLACEHOLDER = "00012345"
+    }
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitBankAccountSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitBankAccountSpec.kt
@@ -1,0 +1,36 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.ui.core.R
+import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.SimpleTextElement
+import com.stripe.android.uicore.elements.SimpleTextFieldController
+import kotlinx.serialization.Serializable
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+@Serializable
+class BacsDebitBankAccountSpec : FormItemSpec() {
+    override val apiPath: IdentifierSpec = IdentifierSpec()
+
+    fun transform(
+        initialValues: Map<IdentifierSpec, String?>
+    ) = createSectionElement(
+        listOf(
+            SimpleTextElement(
+                IdentifierSpec.Generic("bacs_debit[sort_code]"),
+                SimpleTextFieldController(
+                    BacsDebitSortCodeConfig(),
+                    initialValue = initialValues[this.apiPath]
+                )
+            ),
+            SimpleTextElement(
+                IdentifierSpec.Generic("bacs_debit[account_number"),
+                SimpleTextFieldController(
+                    BacsDebitAccountNumberConfig(),
+                    initialValue = initialValues[this.apiPath]
+                )
+            )
+        ),
+        R.string.stripe_bacs_bank_account_title
+    )
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitBankAccountSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitBankAccountSpec.kt
@@ -24,7 +24,7 @@ class BacsDebitBankAccountSpec : FormItemSpec() {
                 )
             ),
             SimpleTextElement(
-                IdentifierSpec.Generic("bacs_debit[account_number"),
+                IdentifierSpec.Generic("bacs_debit[account_number]"),
                 SimpleTextFieldController(
                     BacsDebitAccountNumberConfig(),
                     initialValue = initialValues[this.apiPath]

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitConfirmSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitConfirmSpec.kt
@@ -1,0 +1,25 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.ui.core.R
+import com.stripe.android.uicore.elements.CheckboxFieldController
+import com.stripe.android.uicore.elements.CheckboxFieldElement
+import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.serialization.Serializable
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+@Serializable
+class BacsDebitConfirmSpec : FormItemSpec() {
+    override val apiPath: IdentifierSpec = IdentifierSpec.Generic("")
+
+    fun transform(merchantName: String) = CheckboxFieldElement(
+        apiPath,
+        CheckboxFieldController(
+            labelResource = CheckboxFieldController.LabelResource(
+                R.string.stripe_bacs_confirm_mandate_label,
+                merchantName
+            ),
+            debugTag = "BACS_MANDATE_CHECKBOX"
+        )
+    )
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitConfirmSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitConfirmSpec.kt
@@ -10,7 +10,10 @@ import kotlinx.serialization.Serializable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 @Serializable
 class BacsDebitConfirmSpec : FormItemSpec() {
-    override val apiPath: IdentifierSpec = IdentifierSpec.Generic("")
+    override val apiPath: IdentifierSpec = IdentifierSpec(
+        v1 = "bacs_debit[confirmed]",
+        ignoreField = true
+    )
 
     fun transform(merchantName: String) = CheckboxFieldElement(
         apiPath,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitSortCodeConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitSortCodeConfig.kt
@@ -1,0 +1,61 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+import androidx.annotation.StringRes
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
+import com.stripe.android.ui.core.R
+import com.stripe.android.uicore.elements.TextFieldConfig
+import com.stripe.android.uicore.elements.TextFieldIcon
+import com.stripe.android.uicore.elements.TextFieldState
+import com.stripe.android.uicore.elements.TextFieldStateConstants
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class BacsDebitSortCodeConfig : TextFieldConfig {
+    override val capitalization: KeyboardCapitalization = KeyboardCapitalization.None
+
+    override val debugLabel: String = DEBUG_LABEL
+
+    @StringRes
+    override val label: Int = R.string.stripe_bacs_sort_code
+
+    override val placeHolder: String
+        get() = PLACEHOLDER
+
+    override val keyboard: KeyboardType = KeyboardType.NumberPassword
+
+    override val visualTransformation: VisualTransformation = BacsDebitSortCodeVisualTransformation
+
+    override val trailingIcon: StateFlow<TextFieldIcon?> = MutableStateFlow(null)
+
+    override val loading: StateFlow<Boolean> = MutableStateFlow(false)
+
+    override fun determineState(input: String): TextFieldState {
+        return when {
+            input.isBlank() -> TextFieldStateConstants.Error.Blank
+            input.length < LENGTH -> TextFieldStateConstants.Error.Incomplete(
+                R.string.stripe_bacs_sort_code_incomplete
+            )
+            else -> TextFieldStateConstants.Valid.Full
+        }
+    }
+
+    override fun filter(userTyped: String): String {
+        return userTyped.filter { character ->
+            character.isDigit()
+        }.take(LENGTH)
+    }
+
+    override fun convertToRaw(displayName: String): String = displayName
+
+    override fun convertFromRaw(rawValue: String): String = rawValue
+
+    private companion object {
+        const val LENGTH = 6
+        const val DEBUG_LABEL = "bacs_debit_sort_code"
+        const val PLACEHOLDER = "10-80-00"
+    }
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitSortCodeVisualTransformation.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitSortCodeVisualTransformation.kt
@@ -1,0 +1,59 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+
+internal object BacsDebitSortCodeVisualTransformation : VisualTransformation {
+    private const val SEPARATOR = '-'
+
+    override fun filter(text: AnnotatedString): TransformedText {
+        val internalText = text.text
+        val transformedText = format(internalText)
+
+        return TransformedText(
+            text = AnnotatedString(transformedText),
+            offsetMapping = SortCodeOffsetMapping
+        )
+    }
+
+    private fun format(text: String): String {
+        val split = text.chunked(size = 2)
+
+        return buildString {
+            split.forEachIndexed { index, splitText ->
+                append(splitText)
+
+                if (index != split.size - 1) {
+                    append(SEPARATOR)
+                }
+            }
+        }
+    }
+
+    private object SortCodeOffsetMapping : OffsetMapping {
+        private const val DIVISIBLE = 2
+
+        override fun originalToTransformed(offset: Int): Int {
+            return when (offset) {
+                0 -> 0
+                else -> {
+                    val newOffset = offset + offset / DIVISIBLE
+
+                    return when (offset % DIVISIBLE) {
+                        0 -> newOffset - 1
+                        else -> newOffset
+                    }
+                }
+            }
+        }
+
+        override fun transformedToOriginal(offset: Int): Int {
+            return when (offset) {
+                0 -> 0
+                else -> offset - offset / (DIVISIBLE + 1)
+            }
+        }
+    }
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitSortCodeVisualTransformation.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitSortCodeVisualTransformation.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 
 internal object BacsDebitSortCodeVisualTransformation : VisualTransformation {
-    private const val SEPARATOR = '-'
+    private const val SEPARATOR = "-"
 
     override fun filter(text: AnnotatedString): TransformedText {
         val internalText = text.text
@@ -19,17 +19,7 @@ internal object BacsDebitSortCodeVisualTransformation : VisualTransformation {
     }
 
     private fun format(text: String): String {
-        val split = text.chunked(size = 2)
-
-        return buildString {
-            split.forEachIndexed { index, splitText ->
-                append(splitText)
-
-                if (index != split.size - 1) {
-                    append(SEPARATOR)
-                }
-            }
-        }
+        return text.chunked(size = 2).joinToString(separator = SEPARATOR)
     }
 
     private object SortCodeOffsetMapping : OffsetMapping {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
@@ -8,6 +8,8 @@ import com.stripe.android.ui.core.elements.AffirmTextSpec
 import com.stripe.android.ui.core.elements.AfterpayClearpayTextSpec
 import com.stripe.android.ui.core.elements.AuBankAccountNumberSpec
 import com.stripe.android.ui.core.elements.AuBecsDebitMandateTextSpec
+import com.stripe.android.ui.core.elements.BacsDebitBankAccountSpec
+import com.stripe.android.ui.core.elements.BacsDebitConfirmSpec
 import com.stripe.android.ui.core.elements.BlikSpec
 import com.stripe.android.ui.core.elements.BoletoTaxIdSpec
 import com.stripe.android.ui.core.elements.BsbSpec
@@ -73,6 +75,8 @@ class TransformSpecToElements(
                 is EmptyFormSpec -> EmptyFormElement()
                 is MandateTextSpec -> it.transform(merchantName)
                 is AuBecsDebitMandateTextSpec -> it.transform(merchantName)
+                is BacsDebitBankAccountSpec -> it.transform(initialValues)
+                is BacsDebitConfirmSpec -> it.transform(merchantName)
                 is CardDetailsSectionSpec -> it.transform(
                     context = context,
                     isEligibleForCardBrandChoice = isEligibleForCardBrandChoice,

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/BacsDebitAccountNumberConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/BacsDebitAccountNumberConfigTest.kt
@@ -3,7 +3,7 @@ package com.stripe.android.ui.core.elements
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.uicore.elements.TextFieldStateConstants
 import org.junit.Test
 
@@ -12,54 +12,54 @@ class BacsDebitAccountNumberConfigTest {
 
     @Test
     fun `verify config uses proper visual transformation, keyboard capitalization, and keyboard type`() {
-        Truth.assertThat(
+        assertThat(
             bacsDebitAccountNumberConfig.visualTransformation
         ).isEqualTo(VisualTransformation.None)
 
-        Truth.assertThat(
+        assertThat(
             bacsDebitAccountNumberConfig.capitalization
         ).isEqualTo(KeyboardCapitalization.None)
 
-        Truth.assertThat(
+        assertThat(
             bacsDebitAccountNumberConfig.keyboard
         ).isEqualTo(KeyboardType.NumberPassword)
     }
 
     @Test
     fun `verify only numbers are allowed in the field`() {
-        Truth.assertThat(
+        assertThat(
             bacsDebitAccountNumberConfig.filter("12345ewgh6789")
         ).isEqualTo("12345678")
     }
 
     @Test
     fun `verify limits input to accepted length`() {
-        Truth.assertThat(
+        assertThat(
             bacsDebitAccountNumberConfig.filter("1234567899999")
         ).isEqualTo("12345678")
     }
 
     @Test
     fun `verify blank account number returns blank state`() {
-        Truth.assertThat(
+        assertThat(
             bacsDebitAccountNumberConfig.determineState("")
         ).isEqualTo(TextFieldStateConstants.Error.Blank)
     }
 
     @Test
     fun `verify incomplete account number is in incomplete state`() {
-        Truth.assertThat(
+        assertThat(
             bacsDebitAccountNumberConfig.determineState("123")
         ).isInstanceOf(TextFieldStateConstants.Error.Incomplete::class.java)
 
-        Truth.assertThat(
+        assertThat(
             bacsDebitAccountNumberConfig.determineState("123456")
         ).isInstanceOf(TextFieldStateConstants.Error.Incomplete::class.java)
     }
 
     @Test
     fun `verify valid account number is in valid state`() {
-        Truth.assertThat(
+        assertThat(
             bacsDebitAccountNumberConfig.determineState("65398764")
         ).isInstanceOf(TextFieldStateConstants.Valid.Full::class.java)
     }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/BacsDebitAccountNumberConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/BacsDebitAccountNumberConfigTest.kt
@@ -1,0 +1,66 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
+import com.google.common.truth.Truth
+import com.stripe.android.uicore.elements.TextFieldStateConstants
+import org.junit.Test
+
+class BacsDebitAccountNumberConfigTest {
+    private val bacsDebitAccountNumberConfig = BacsDebitAccountNumberConfig()
+
+    @Test
+    fun `verify config uses proper visual transformation, keyboard capitalization, and keyboard type`() {
+        Truth.assertThat(
+            bacsDebitAccountNumberConfig.visualTransformation
+        ).isEqualTo(VisualTransformation.None)
+
+        Truth.assertThat(
+            bacsDebitAccountNumberConfig.capitalization
+        ).isEqualTo(KeyboardCapitalization.None)
+
+        Truth.assertThat(
+            bacsDebitAccountNumberConfig.keyboard
+        ).isEqualTo(KeyboardType.NumberPassword)
+    }
+
+    @Test
+    fun `verify only numbers are allowed in the field`() {
+        Truth.assertThat(
+            bacsDebitAccountNumberConfig.filter("12345ewgh6789")
+        ).isEqualTo("12345678")
+    }
+
+    @Test
+    fun `verify limits input to accepted length`() {
+        Truth.assertThat(
+            bacsDebitAccountNumberConfig.filter("1234567899999")
+        ).isEqualTo("12345678")
+    }
+
+    @Test
+    fun `verify blank account number returns blank state`() {
+        Truth.assertThat(
+            bacsDebitAccountNumberConfig.determineState("")
+        ).isEqualTo(TextFieldStateConstants.Error.Blank)
+    }
+
+    @Test
+    fun `verify incomplete account number is in incomplete state`() {
+        Truth.assertThat(
+            bacsDebitAccountNumberConfig.determineState("123")
+        ).isInstanceOf(TextFieldStateConstants.Error.Incomplete::class.java)
+
+        Truth.assertThat(
+            bacsDebitAccountNumberConfig.determineState("123456")
+        ).isInstanceOf(TextFieldStateConstants.Error.Incomplete::class.java)
+    }
+
+    @Test
+    fun `verify valid account number is in valid state`() {
+        Truth.assertThat(
+            bacsDebitAccountNumberConfig.determineState("65398764")
+        ).isInstanceOf(TextFieldStateConstants.Valid.Full::class.java)
+    }
+}

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/BacsDebitSortCodeConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/BacsDebitSortCodeConfigTest.kt
@@ -2,7 +2,7 @@ package com.stripe.android.ui.core.elements
 
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.uicore.elements.TextFieldStateConstants
 import org.junit.Test
 
@@ -11,54 +11,54 @@ class BacsDebitSortCodeConfigTest {
 
     @Test
     fun `verify config uses proper visual transformation, keyboard capitalization, and keyboard type`() {
-        Truth.assertThat(
+        assertThat(
             bacsDebitSortCodeConfig.visualTransformation
         ).isEqualTo(BacsDebitSortCodeVisualTransformation)
 
-        Truth.assertThat(
+        assertThat(
             bacsDebitSortCodeConfig.capitalization
         ).isEqualTo(KeyboardCapitalization.None)
 
-        Truth.assertThat(
+        assertThat(
             bacsDebitSortCodeConfig.keyboard
         ).isEqualTo(KeyboardType.NumberPassword)
     }
 
     @Test
     fun `verify only numbers are allowed in the field`() {
-        Truth.assertThat(
+        assertThat(
             bacsDebitSortCodeConfig.filter("12345hell6789")
         ).isEqualTo("123456")
     }
 
     @Test
     fun `verify limits input to accepted length`() {
-        Truth.assertThat(
+        assertThat(
             bacsDebitSortCodeConfig.filter("1234567899999")
         ).isEqualTo("123456")
     }
 
     @Test
     fun `verify blank sort code returns blank state`() {
-        Truth.assertThat(
+        assertThat(
             bacsDebitSortCodeConfig.determineState("")
         ).isEqualTo(TextFieldStateConstants.Error.Blank)
     }
 
     @Test
     fun `verify incomplete sort code is in incomplete state`() {
-        Truth.assertThat(
+        assertThat(
             bacsDebitSortCodeConfig.determineState("123")
         ).isInstanceOf(TextFieldStateConstants.Error.Incomplete::class.java)
 
-        Truth.assertThat(
+        assertThat(
             bacsDebitSortCodeConfig.determineState("12345")
         ).isInstanceOf(TextFieldStateConstants.Error.Incomplete::class.java)
     }
 
     @Test
     fun `verify valid sort code is in valid state`() {
-        Truth.assertThat(
+        assertThat(
             bacsDebitSortCodeConfig.determineState("653987")
         ).isInstanceOf(TextFieldStateConstants.Valid.Full::class.java)
     }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/BacsDebitSortCodeConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/BacsDebitSortCodeConfigTest.kt
@@ -1,0 +1,65 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import com.google.common.truth.Truth
+import com.stripe.android.uicore.elements.TextFieldStateConstants
+import org.junit.Test
+
+class BacsDebitSortCodeConfigTest {
+    private val bacsDebitSortCodeConfig = BacsDebitSortCodeConfig()
+
+    @Test
+    fun `verify config uses proper visual transformation, keyboard capitalization, and keyboard type`() {
+        Truth.assertThat(
+            bacsDebitSortCodeConfig.visualTransformation
+        ).isEqualTo(BacsDebitSortCodeVisualTransformation)
+
+        Truth.assertThat(
+            bacsDebitSortCodeConfig.capitalization
+        ).isEqualTo(KeyboardCapitalization.None)
+
+        Truth.assertThat(
+            bacsDebitSortCodeConfig.keyboard
+        ).isEqualTo(KeyboardType.NumberPassword)
+    }
+
+    @Test
+    fun `verify only numbers are allowed in the field`() {
+        Truth.assertThat(
+            bacsDebitSortCodeConfig.filter("12345hell6789")
+        ).isEqualTo("123456")
+    }
+
+    @Test
+    fun `verify limits input to accepted length`() {
+        Truth.assertThat(
+            bacsDebitSortCodeConfig.filter("1234567899999")
+        ).isEqualTo("123456")
+    }
+
+    @Test
+    fun `verify blank sort code returns blank state`() {
+        Truth.assertThat(
+            bacsDebitSortCodeConfig.determineState("")
+        ).isEqualTo(TextFieldStateConstants.Error.Blank)
+    }
+
+    @Test
+    fun `verify incomplete sort code is in incomplete state`() {
+        Truth.assertThat(
+            bacsDebitSortCodeConfig.determineState("123")
+        ).isInstanceOf(TextFieldStateConstants.Error.Incomplete::class.java)
+
+        Truth.assertThat(
+            bacsDebitSortCodeConfig.determineState("12345")
+        ).isInstanceOf(TextFieldStateConstants.Error.Incomplete::class.java)
+    }
+
+    @Test
+    fun `verify valid sort code is in valid state`() {
+        Truth.assertThat(
+            bacsDebitSortCodeConfig.determineState("653987")
+        ).isInstanceOf(TextFieldStateConstants.Valid.Full::class.java)
+    }
+}

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/BacsDebitSortCodeVisualTransformationTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/BacsDebitSortCodeVisualTransformationTest.kt
@@ -1,0 +1,114 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.compose.ui.text.AnnotatedString
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class BacsDebitSortCodeVisualTransformationTest {
+    private val transformation = BacsDebitSortCodeVisualTransformation
+
+    @Test
+    fun `on no characters, should format & offset properly`() {
+        val transformedText = transformation.filter(AnnotatedString(""))
+
+        assertThat(transformedText.text.text).isEqualTo("")
+
+        assertThat(
+            transformedText.offsetMapping.originalToTransformed(offset = 0)
+        ).isEqualTo(0)
+
+        assertThat(
+            transformedText.offsetMapping.transformedToOriginal(offset = 0)
+        ).isEqualTo(0)
+    }
+
+    @Test
+    fun `on 1 character, should format & offset properly`() {
+        val transformedText = transformation.filter(AnnotatedString("1"))
+
+        assertThat(transformedText.text.text).isEqualTo("1")
+
+        assertThat(
+            transformedText.offsetMapping.originalToTransformed(offset = 1)
+        ).isEqualTo(1)
+
+        assertThat(
+            transformedText.offsetMapping.transformedToOriginal(offset = 1)
+        ).isEqualTo(1)
+    }
+
+    @Test
+    fun `on 2 characters, should format & offset properly`() {
+        val transformedText = transformation.filter(AnnotatedString("12"))
+
+        assertThat(transformedText.text.text).isEqualTo("12")
+
+        assertThat(
+            transformedText.offsetMapping.originalToTransformed(offset = 2)
+        ).isEqualTo(2)
+
+        assertThat(
+            transformedText.offsetMapping.transformedToOriginal(offset = 2)
+        ).isEqualTo(2)
+    }
+
+    @Test
+    fun `on 3 characters, should format & offset properly`() {
+        val transformedText = transformation.filter(AnnotatedString("123"))
+
+        assertThat(transformedText.text.text).isEqualTo("12-3")
+
+        assertThat(
+            transformedText.offsetMapping.originalToTransformed(offset = 3)
+        ).isEqualTo(4)
+
+        assertThat(
+            transformedText.offsetMapping.transformedToOriginal(offset = 4)
+        ).isEqualTo(3)
+    }
+
+    @Test
+    fun `on 4 characters, should format & offset properly`() {
+        val transformedText = transformation.filter(AnnotatedString("1234"))
+
+        assertThat(transformedText.text.text).isEqualTo("12-34")
+
+        assertThat(
+            transformedText.offsetMapping.originalToTransformed(offset = 4)
+        ).isEqualTo(5)
+
+        assertThat(
+            transformedText.offsetMapping.transformedToOriginal(offset = 5)
+        ).isEqualTo(4)
+    }
+
+    @Test
+    fun `on 5 characters, should format & offset properly`() {
+        val transformedText = transformation.filter(AnnotatedString("12345"))
+
+        assertThat(transformedText.text.text).isEqualTo("12-34-5")
+
+        assertThat(
+            transformedText.offsetMapping.originalToTransformed(offset = 5)
+        ).isEqualTo(7)
+
+        assertThat(
+            transformedText.offsetMapping.transformedToOriginal(offset = 7)
+        ).isEqualTo(5)
+    }
+
+    @Test
+    fun `on 6 characters, should format & offset properly`() {
+        val transformedText = transformation.filter(AnnotatedString("123456"))
+
+        assertThat(transformedText.text.text).isEqualTo("12-34-56")
+
+        assertThat(
+            transformedText.offsetMapping.originalToTransformed(offset = 6)
+        ).isEqualTo(8)
+
+        assertThat(
+            transformedText.offsetMapping.transformedToOriginal(offset = 8)
+        ).isEqualTo(6)
+    }
+}


### PR DESCRIPTION
# Summary
Add `BacsDebitSortCodeConfig` & `BacsDebitAccountNumberConfig` to handle sort code & account number field mapping respectively. Both are wrapped with a `BacsDebitBankAccountSpec`.

These fields are required to properly support `Bacs Direct Debit`.

# Motivation
These field configurations are required to properly support `Bacs Direct Debit`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
N/A

# Changelog
N/A
