### PR TITLE
Add Sofort SetupIntent and PaymentIntent with SFU support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## XX.XX.XX - 2023-XX-XX
 * [ADDED][7269](https://github.com/stripe/stripe-android/pull/7269) PaymentSheet now supports Ideal with SetupIntent and PaymentIntent with setup for future usage.
 * [ADDED][7270](https://github.com/stripe/stripe-android/pull/7270) PaymentSheet now supports SEPA with SetupIntent and PaymentIntent with setup for future usage.
+* [ADDED][7272](https://github.com/stripe/stripe-android/pull/7272) PaymentSheet now supports Sofort with SetupIntent and PaymentIntent with setup for future usage.
 
 ## 20.29.2 - 2023-09-05
 * [ADDED][7263](https://github.com/stripe/stripe-android/pull/7263) PaymentSheet now supports Bancontact SetupIntent and PaymentIntent with setup for future usage.

--- a/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
@@ -93,30 +93,13 @@ internal val BancontactRequirement = PaymentMethodRequirements(
 
 internal val SofortRequirement = PaymentMethodRequirements(
     piRequirements = setOf(Delayed),
+    siRequirements = setOf(Delayed),
 
     /**
-     * Currently we will not support this PaymentMethod for use with PI w/SFU,
-     * or SI until there is a way of retrieving valid mandates associated with a customer PM.
-     *
-     * The reason we are excluding it is because after PI w/SFU set or PI
-     * is used, the payment method appears as a SEPA payment method attached
-     * to a customer.  Without this block the SEPA payment method would
-     * show in PaymentSheet.  If the user used this save payment method
-     * we would have no way to know if the existing mandate was valid or how
-     * to request the user to re-accept the mandate.
-     *
-     * SEPA Debit does support PI w/SFU and SI (both with and without a customer),
-     * and it is Delayed in this configuration.
+     * PM will be attached as a SEPA Debit payment method and have the requirements
+     * of that PaymentMethod.
      */
-    siRequirements = null,
-
-    /**
-     * This PM cannot be attached to a customer, it should be noted that it
-     * will be attached as a SEPA Debit payment method and have the requirements
-     * of that PaymentMethod, but for now SEPA is not supported either so we will
-     * call it false.
-     */
-    confirmPMFromCustomer = false
+    confirmPMFromCustomer = true,
 )
 
 internal val IdealRequirement = PaymentMethodRequirements(

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSofort.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSofort.kt
@@ -2,8 +2,12 @@ package com.stripe.android.lpm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BaseLpmTest
+import com.stripe.android.test.core.AuthorizeAction
+import com.stripe.android.test.core.Automatic
 import com.stripe.android.test.core.Currency
 import com.stripe.android.test.core.DelayedPMs
+import com.stripe.android.test.core.GooglePayState
+import com.stripe.android.test.core.IntentType
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -12,14 +16,38 @@ internal class TestSofort : BaseLpmTest() {
     private val sofort = newUser.copy(
         paymentMethod = lpmRepository.fromCode("sofort")!!,
         currency = Currency.EUR,
-        merchantCountryCode = "GB",
+        merchantCountryCode = "FR",
         delayed = DelayedPMs.On,
+        googlePayState = GooglePayState.Off,
     )
 
     @Test
     fun testSofort() {
         testDriver.confirmNewOrGuestComplete(
             testParameters = sofort,
+        )
+    }
+
+    @Test
+    fun testSofortSfu() {
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = sofort.copy(
+                delayed = DelayedPMs.On,
+                automatic = Automatic.On,
+                intentType = IntentType.PayWithSetup,
+            ),
+        )
+    }
+
+    @Test
+    fun testSofortSetup() {
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = sofort.copy(
+                delayed = DelayedPMs.On,
+                automatic = Automatic.On,
+                intentType = IntentType.Setup,
+                authorizationAction = AuthorizeAction.AuthorizeSetup,
+            ),
         )
     }
 

--- a/paymentsheet/src/test/resources/sofort-support.csv
+++ b/paymentsheet/src/test/resources/sofort-support.csv
@@ -1,49 +1,49 @@
 lpm, hasCustomer, allowsDelayedPayment, intentSetupFutureUsage, intentHasShipping, intentLpms, supportCustomerSavedCard, formExists, formType, supportsAdding
-sofort, true, true, off_session, false, card/sofort, false, false, not available, false
-sofort, true, true, off_session, false, card/eps/sofort, false, false, not available, false
+sofort, true, true, off_session, false, card/sofort, true, true, merchantRequiredSave, true
+sofort, true, true, off_session, false, card/eps/sofort, true, true, merchantRequiredSave, true
 sofort, true, false, off_session, false, card/sofort, false, false, not available, false
 sofort, true, false, off_session, false, card/eps/sofort, false, false, not available, false
-sofort, true, true, on_session, false, card/sofort, false, false, not available, false
-sofort, true, true, on_session, false, card/eps/sofort, false, false, not available, false
+sofort, true, true, on_session, false, card/sofort, true, true, merchantRequiredSave, true
+sofort, true, true, on_session, false, card/eps/sofort, true, true, merchantRequiredSave, true
 sofort, true, false, on_session, false, card/sofort, false, false, not available, false
 sofort, true, false, on_session, false, card/eps/sofort, false, false, not available, false
-sofort, true, true, null, false, card/sofort, false, true, oneTime, true
-sofort, true, true, null, false, card/eps/sofort, false, true, oneTime, true
+sofort, true, true, null, false, card/sofort, true, true, userSelectedSave, true
+sofort, true, true, null, false, card/eps/sofort, true, true, userSelectedSave, true
 sofort, true, false, null, false, card/sofort, false, false, not available, false
 sofort, true, false, null, false, card/eps/sofort, false, false, not available, false
-sofort, false, true, off_session, false, card/sofort, false, false, not available, false
-sofort, false, true, off_session, false, card/eps/sofort, false, false, not available, false
+sofort, false, true, off_session, false, card/sofort, true, true, merchantRequiredSave, true
+sofort, false, true, off_session, false, card/eps/sofort, true, true, merchantRequiredSave, true
 sofort, false, false, off_session, false, card/sofort, false, false, not available, false
 sofort, false, false, off_session, false, card/eps/sofort, false, false, not available, false
-sofort, false, true, on_session, false, card/sofort, false, false, not available, false
-sofort, false, true, on_session, false, card/eps/sofort, false, false, not available, false
+sofort, false, true, on_session, false, card/sofort, true, true, merchantRequiredSave, true
+sofort, false, true, on_session, false, card/eps/sofort, true, true, merchantRequiredSave, true
 sofort, false, false, on_session, false, card/sofort, false, false, not available, false
 sofort, false, false, on_session, false, card/eps/sofort, false, false, not available, false
-sofort, false, true, null, false, card/sofort, false, true, oneTime, true
-sofort, false, true, null, false, card/eps/sofort, false, true, oneTime, true
+sofort, false, true, null, false, card/sofort, true, true, oneTime, true
+sofort, false, true, null, false, card/eps/sofort, true, true, oneTime, true
 sofort, false, false, null, false, card/sofort, false, false, not available, false
 sofort, false, false, null, false, card/eps/sofort, false, false, not available, false
-sofort, true, true, off_session, true, card/sofort, false, false, not available, false
-sofort, true, true, off_session, true, card/eps/sofort, false, false, not available, false
+sofort, true, true, off_session, true, card/sofort, true, true, merchantRequiredSave, true
+sofort, true, true, off_session, true, card/eps/sofort, true, true, merchantRequiredSave, true
 sofort, true, false, off_session, true, card/sofort, false, false, not available, false
 sofort, true, false, off_session, true, card/eps/sofort, false, false, not available, false
-sofort, true, true, on_session, true, card/sofort, false, false, not available, false
-sofort, true, true, on_session, true, card/eps/sofort, false, false, not available, false
+sofort, true, true, on_session, true, card/sofort, true, true, merchantRequiredSave, true
+sofort, true, true, on_session, true, card/eps/sofort, true, true, merchantRequiredSave, true
 sofort, true, false, on_session, true, card/sofort, false, false, not available, false
 sofort, true, false, on_session, true, card/eps/sofort, false, false, not available, false
-sofort, true, true, null, true, card/sofort, false, true, oneTime, true
-sofort, true, true, null, true, card/eps/sofort, false, true, oneTime, true
+sofort, true, true, null, true, card/sofort, true, true, userSelectedSave, true
+sofort, true, true, null, true, card/eps/sofort, true, true, userSelectedSave, true
 sofort, true, false, null, true, card/sofort, false, false, not available, false
 sofort, true, false, null, true, card/eps/sofort, false, false, not available, false
-sofort, false, true, off_session, true, card/sofort, false, false, not available, false
-sofort, false, true, off_session, true, card/eps/sofort, false, false, not available, false
+sofort, false, true, off_session, true, card/sofort, true, true, merchantRequiredSave, true
+sofort, false, true, off_session, true, card/eps/sofort, true, true, merchantRequiredSave, true
 sofort, false, false, off_session, true, card/sofort, false, false, not available, false
 sofort, false, false, off_session, true, card/eps/sofort, false, false, not available, false
-sofort, false, true, on_session, true, card/sofort, false, false, not available, false
-sofort, false, true, on_session, true, card/eps/sofort, false, false, not available, false
+sofort, false, true, on_session, true, card/sofort, true, true, merchantRequiredSave, true
+sofort, false, true, on_session, true, card/eps/sofort, true, true, merchantRequiredSave, true
 sofort, false, false, on_session, true, card/sofort, false, false, not available, false
 sofort, false, false, on_session, true, card/eps/sofort, false, false, not available, false
-sofort, false, true, null, true, card/sofort, false, true, oneTime, true
-sofort, false, true, null, true, card/eps/sofort, false, true, oneTime, true
+sofort, false, true, null, true, card/sofort, true, true, oneTime, true
+sofort, false, true, null, true, card/eps/sofort, true, true, oneTime, true
 sofort, false, false, null, true, card/sofort, false, false, not available, false
 sofort, false, false, null, true, card/eps/sofort, false, false, not available, false


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Add Sofort SetupIntent and PaymentIntent with SFU support

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

* [ADDED][7272](https://github.com/stripe/stripe-android/pull/7272) PaymentSheet now supports Sofort with SetupIntent and PaymentIntent with setup for future usage.