### PR TITLE
Add `SetupIntent` & `PaymentIntent` w/ `SetupFutureUsage` support for BECS Direct Debit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [ADDED][7269](https://github.com/stripe/stripe-android/pull/7269) PaymentSheet now supports Ideal with SetupIntent and PaymentIntent with setup for future usage.
 * [ADDED][7270](https://github.com/stripe/stripe-android/pull/7270) PaymentSheet now supports SEPA with SetupIntent and PaymentIntent with setup for future usage.
 * [ADDED][7272](https://github.com/stripe/stripe-android/pull/7272) PaymentSheet now supports Sofort with SetupIntent and PaymentIntent with setup for future usage.
+* [ADDED][7273](https://github.com/stripe/stripe-android/pull/7273) PaymentSheet now supports BECS Direct Debit with SetupIntent and PaymentIntent with setup for future usage.
 
 ## 20.29.2 - 2023-09-05
 * [ADDED][7263](https://github.com/stripe/stripe-android/pull/7263) PaymentSheet now supports Bancontact SetupIntent and PaymentIntent with setup for future usage.

--- a/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
@@ -217,8 +217,8 @@ internal val MobilePayRequirement = PaymentMethodRequirements(
  */
 internal val AuBecsDebitRequirement = PaymentMethodRequirements(
     piRequirements = setOf(Delayed),
-    siRequirements = null,
-    confirmPMFromCustomer = null
+    siRequirements = setOf(Delayed),
+    confirmPMFromCustomer = true
 )
 
 internal val ZipRequirement = PaymentMethodRequirements(

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestAuBecsDD.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestAuBecsDD.kt
@@ -2,8 +2,10 @@ package com.stripe.android.lpm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BaseLpmTest
+import com.stripe.android.test.core.Automatic
 import com.stripe.android.test.core.Currency
 import com.stripe.android.test.core.DelayedPMs
+import com.stripe.android.test.core.IntentType
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -28,6 +30,28 @@ internal class TestAuBecsDD : BaseLpmTest() {
     fun testAuBecsDDInCustomFlow() {
         testDriver.confirmCustom(
             testParameters = auBecsDD,
+        )
+    }
+
+    @Test
+    fun testAuBecsDDSfu() {
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = auBecsDD.copy(
+                delayed = DelayedPMs.On,
+                automatic = Automatic.On,
+                intentType = IntentType.PayWithSetup,
+            ),
+        )
+    }
+
+    @Test
+    fun testAuBecsDDSetup() {
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = auBecsDD.copy(
+                delayed = DelayedPMs.On,
+                automatic = Automatic.On,
+                intentType = IntentType.Setup,
+            ),
         )
     }
 }

--- a/paymentsheet/src/test/resources/au_becs_debit-support.csv
+++ b/paymentsheet/src/test/resources/au_becs_debit-support.csv
@@ -1,49 +1,49 @@
 lpm, hasCustomer, allowsDelayedPayment, intentSetupFutureUsage, intentHasShipping, intentLpms, supportCustomerSavedCard, formExists, formType, supportsAdding
-au_becs_debit, true, true, off_session, false, card/au_becs_debit, false, false, not available, false
-au_becs_debit, true, true, off_session, false, card/eps/au_becs_debit, false, false, not available, false
+au_becs_debit, true, true, off_session, false, card/au_becs_debit, true, true, merchantRequiredSave, true
+au_becs_debit, true, true, off_session, false, card/eps/au_becs_debit, true, true, merchantRequiredSave, true
 au_becs_debit, true, false, off_session, false, card/au_becs_debit, false, false, not available, false
 au_becs_debit, true, false, off_session, false, card/eps/au_becs_debit, false, false, not available, false
-au_becs_debit, true, true, on_session, false, card/au_becs_debit, false, false, not available, false
-au_becs_debit, true, true, on_session, false, card/eps/au_becs_debit, false, false, not available, false
+au_becs_debit, true, true, on_session, false, card/au_becs_debit, true, true, merchantRequiredSave, true
+au_becs_debit, true, true, on_session, false, card/eps/au_becs_debit, true, true, merchantRequiredSave, true
 au_becs_debit, true, false, on_session, false, card/au_becs_debit, false, false, not available, false
 au_becs_debit, true, false, on_session, false, card/eps/au_becs_debit, false, false, not available, false
-au_becs_debit, true, true, null, false, card/au_becs_debit, false, true, oneTime, true
-au_becs_debit, true, true, null, false, card/eps/au_becs_debit, false, true, oneTime, true
+au_becs_debit, true, true, null, false, card/au_becs_debit, true, true, userSelectedSave, true
+au_becs_debit, true, true, null, false, card/eps/au_becs_debit, true, true, userSelectedSave, true
 au_becs_debit, true, false, null, false, card/au_becs_debit, false, false, not available, false
 au_becs_debit, true, false, null, false, card/eps/au_becs_debit, false, false, not available, false
-au_becs_debit, false, true, off_session, false, card/au_becs_debit, false, false, not available, false
-au_becs_debit, false, true, off_session, false, card/eps/au_becs_debit, false, false, not available, false
+au_becs_debit, false, true, off_session, false, card/au_becs_debit, true, true, merchantRequiredSave, true
+au_becs_debit, false, true, off_session, false, card/eps/au_becs_debit, true, true, merchantRequiredSave, true
 au_becs_debit, false, false, off_session, false, card/au_becs_debit, false, false, not available, false
 au_becs_debit, false, false, off_session, false, card/eps/au_becs_debit, false, false, not available, false
-au_becs_debit, false, true, on_session, false, card/au_becs_debit, false, false, not available, false
-au_becs_debit, false, true, on_session, false, card/eps/au_becs_debit, false, false, not available, false
+au_becs_debit, false, true, on_session, false, card/au_becs_debit, true, true, merchantRequiredSave, true
+au_becs_debit, false, true, on_session, false, card/eps/au_becs_debit, true, true, merchantRequiredSave, true
 au_becs_debit, false, false, on_session, false, card/au_becs_debit, false, false, not available, false
 au_becs_debit, false, false, on_session, false, card/eps/au_becs_debit, false, false, not available, false
-au_becs_debit, false, true, null, false, card/au_becs_debit, false, true, oneTime, true
-au_becs_debit, false, true, null, false, card/eps/au_becs_debit, false, true, oneTime, true
+au_becs_debit, false, true, null, false, card/au_becs_debit, true, true, oneTime, true
+au_becs_debit, false, true, null, false, card/eps/au_becs_debit, true, true, oneTime, true
 au_becs_debit, false, false, null, false, card/au_becs_debit, false, false, not available, false
 au_becs_debit, false, false, null, false, card/eps/au_becs_debit, false, false, not available, false
-au_becs_debit, true, true, off_session, true, card/au_becs_debit, false, false, not available, false
-au_becs_debit, true, true, off_session, true, card/eps/au_becs_debit, false, false, not available, false
+au_becs_debit, true, true, off_session, true, card/au_becs_debit, true, true, merchantRequiredSave, true
+au_becs_debit, true, true, off_session, true, card/eps/au_becs_debit, true, true, merchantRequiredSave, true
 au_becs_debit, true, false, off_session, true, card/au_becs_debit, false, false, not available, false
 au_becs_debit, true, false, off_session, true, card/eps/au_becs_debit, false, false, not available, false
-au_becs_debit, true, true, on_session, true, card/au_becs_debit, false, false, not available, false
-au_becs_debit, true, true, on_session, true, card/eps/au_becs_debit, false, false, not available, false
+au_becs_debit, true, true, on_session, true, card/au_becs_debit, true, true, merchantRequiredSave, true
+au_becs_debit, true, true, on_session, true, card/eps/au_becs_debit, true, true, merchantRequiredSave, true
 au_becs_debit, true, false, on_session, true, card/au_becs_debit, false, false, not available, false
 au_becs_debit, true, false, on_session, true, card/eps/au_becs_debit, false, false, not available, false
-au_becs_debit, true, true, null, true, card/au_becs_debit, false, true, oneTime, true
-au_becs_debit, true, true, null, true, card/eps/au_becs_debit, false, true, oneTime, true
+au_becs_debit, true, true, null, true, card/au_becs_debit, true, true, userSelectedSave, true
+au_becs_debit, true, true, null, true, card/eps/au_becs_debit, true, true, userSelectedSave, true
 au_becs_debit, true, false, null, true, card/au_becs_debit, false, false, not available, false
 au_becs_debit, true, false, null, true, card/eps/au_becs_debit, false, false, not available, false
-au_becs_debit, false, true, off_session, true, card/au_becs_debit, false, false, not available, false
-au_becs_debit, false, true, off_session, true, card/eps/au_becs_debit, false, false, not available, false
+au_becs_debit, false, true, off_session, true, card/au_becs_debit, true, true, merchantRequiredSave, true
+au_becs_debit, false, true, off_session, true, card/eps/au_becs_debit, true, true, merchantRequiredSave, true
 au_becs_debit, false, false, off_session, true, card/au_becs_debit, false, false, not available, false
 au_becs_debit, false, false, off_session, true, card/eps/au_becs_debit, false, false, not available, false
-au_becs_debit, false, true, on_session, true, card/au_becs_debit, false, false, not available, false
-au_becs_debit, false, true, on_session, true, card/eps/au_becs_debit, false, false, not available, false
+au_becs_debit, false, true, on_session, true, card/au_becs_debit, true, true, merchantRequiredSave, true
+au_becs_debit, false, true, on_session, true, card/eps/au_becs_debit, true, true, merchantRequiredSave, true
 au_becs_debit, false, false, on_session, true, card/au_becs_debit, false, false, not available, false
 au_becs_debit, false, false, on_session, true, card/eps/au_becs_debit, false, false, not available, false
-au_becs_debit, false, true, null, true, card/au_becs_debit, false, true, oneTime, true
-au_becs_debit, false, true, null, true, card/eps/au_becs_debit, false, true, oneTime, true
+au_becs_debit, false, true, null, true, card/au_becs_debit, true, true, oneTime, true
+au_becs_debit, false, true, null, true, card/eps/au_becs_debit, true, true, oneTime, true
 au_becs_debit, false, false, null, true, card/au_becs_debit, false, false, not available, false
 au_becs_debit, false, false, null, true, card/eps/au_becs_debit, false, false, not available, false


### PR DESCRIPTION
# Summary
Add `SetupIntent` & `PaymentIntent` w/ `SetupFutureUsage` support for BECS Direct Debit.

# Motivation
LPM sprint

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
