### PR TITLE
Fix sepa payment method form ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   * [7269](https://github.com/stripe/stripe-android/pull/7269) iDEAL
   * [7270](https://github.com/stripe/stripe-android/pull/7270) SEPA
   * [7272](https://github.com/stripe/stripe-android/pull/7272) Sofort
+* [FIXED][7283](https://github.com/stripe/stripe-android/pull/7283) Fixed an issue where Bancontact SetupIntent or PaymentIntent with setup for future usage would show the mandate text in the middle of the form. 
 
 ## 20.29.2 - 2023-09-05
 

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -22,19 +22,19 @@ public final class com/stripe/android/ui/core/Amount$Creator : android/os/Parcel
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/ui/core/BillingDetailsCollectionConfiguration$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/ui/core/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
 	public static final field DEBUG Z
 	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
 	public fun <init> ()V
-}
-
-public final class com/stripe/android/ui/core/CardBillingDetailsCollectionConfiguration$Creator : android/os/Parcelable$Creator {
-	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/CardBillingDetailsCollectionConfiguration;
-	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/ui/core/CardBillingDetailsCollectionConfiguration;
-	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/ui/core/FieldValuesToParamsMapConverter$Companion {
@@ -651,6 +651,22 @@ public final class com/stripe/android/ui/core/elements/SaveForFutureUseSpec$$ser
 }
 
 public final class com/stripe/android/ui/core/elements/SaveForFutureUseSpec$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/SepaMandateTextSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/SepaMandateTextSpec$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/ui/core/elements/SepaMandateTextSpec;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/ui/core/elements/SepaMandateTextSpec;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/SepaMandateTextSpec$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/payments-ui-core/detekt-baseline.xml
+++ b/payments-ui-core/detekt-baseline.xml
@@ -5,12 +5,12 @@
     <ID>ConstructorParameterNaming:CardNumberElement.kt$CardNumberElement$val _identifier: IdentifierSpec</ID>
     <ID>ConstructorParameterNaming:CvcElement.kt$CvcElement$val _identifier: IdentifierSpec</ID>
     <ID>CyclomaticComplexMethod:FormItemSpec.kt$FormItemSpecSerializer$override fun selectDeserializer(element: JsonElement): DeserializationStrategy&lt;out FormItemSpec></ID>
-    <ID>CyclomaticComplexMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, cardBillingDetailsCollectionConfiguration: CardBillingDetailsCollectionConfiguration, )</ID>
+    <ID>CyclomaticComplexMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration, )</ID>
     <ID>CyclomaticComplexMethod:TransformGoogleToStripeAddress.kt$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun Place.transformGoogleToStripeAddress( context: Context ): com.stripe.android.model.Address</ID>
     <ID>CyclomaticComplexMethod:TransformSpecToElements.kt$TransformSpecToElements$fun transform(list: List&lt;FormItemSpec>): List&lt;FormElement></ID>
     <ID>EmptyFunctionBlock:CardNumberViewOnlyController.kt$CardNumberViewOnlyController${}</ID>
     <ID>ForbiddenComment:Menu.kt$// TODO: Make sure this gets the rounded corner values</ID>
-    <ID>LongMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, cardBillingDetailsCollectionConfiguration: CardBillingDetailsCollectionConfiguration, )</ID>
+    <ID>LongMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration, )</ID>
     <ID>LongMethod:Menu.kt$@Suppress("ModifierParameter") @Composable internal fun DropdownMenuContent( expandedStates: MutableTransitionState&lt;Boolean>, transformOriginState: MutableState&lt;TransformOrigin>, initialFirstVisibleItemIndex: Int, modifier: Modifier = Modifier, content: LazyListScope.() -> Unit )</ID>
     <ID>LongMethod:TransformGoogleToStripeAddress.kt$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun Place.transformGoogleToStripeAddress( context: Context ): com.stripe.android.model.Address</ID>
     <ID>LongMethod:TransformGoogleToStripeAddressTest.kt$TransformGoogleToStripeAddressTest$@Test fun `test JP address`()</ID>
@@ -65,7 +65,6 @@
     <ID>ReturnCount:IbanConfig.kt$IbanConfig$override fun determineState(input: String): TextFieldState</ID>
     <ID>SpreadOperator:BsbElementUI.kt$( it.errorMessage, *args )</ID>
     <ID>SpreadOperator:MandateTextUI.kt$(element.stringResId, *element.args.toTypedArray())</ID>
-    <ID>TooGenericExceptionCaught:LpmSerializer.kt$LpmSerializer$e: Exception</ID>
     <ID>TooGenericExceptionCaught:PlacesClientProxy.kt$DefaultPlacesClientProxy$e: Exception</ID>
     <ID>UtilityClassWithPublicConstructor:FieldValuesToParamsMapConverter.kt$FieldValuesToParamsMapConverter</ID>
   </CurrentIssues>

--- a/payments-ui-core/src/main/assets/lpms.json
+++ b/payments-ui-core/src/main/assets/lpms.json
@@ -189,6 +189,10 @@
       {
         "type": "placeholder",
         "for": "billing_address"
+      },
+      {
+        "type": "placeholder",
+        "for": "sepa_mandate"
       }
     ],
     "next_action_spec": {
@@ -233,6 +237,10 @@
       {
         "type": "placeholder",
         "for": "billing_address_without_country"
+      },
+      {
+        "type": "placeholder",
+        "for": "sepa_mandate"
       }
     ],
     "next_action_spec": {
@@ -275,6 +283,10 @@
       {
         "type": "placeholder",
         "for": "billing_address"
+      },
+      {
+        "type": "placeholder",
+        "for": "sepa_mandate"
       }
     ],
     "next_action_spec": {

--- a/payments-ui-core/src/main/assets/lpms.json
+++ b/payments-ui-core/src/main/assets/lpms.json
@@ -263,6 +263,18 @@
         "api_path": {
           "v1": "billing_details[name]"
         }
+      },
+      {
+        "type": "placeholder",
+        "for": "email"
+      },
+      {
+        "type": "placeholder",
+        "for": "phone"
+      },
+      {
+        "type": "placeholder",
+        "for": "billing_address"
       }
     ],
     "next_action_spec": {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/BillingDetailsCollectionConfiguration.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/BillingDetailsCollectionConfiguration.kt
@@ -6,7 +6,7 @@ import kotlinx.parcelize.Parcelize
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Parcelize
-data class CardBillingDetailsCollectionConfiguration(
+data class BillingDetailsCollectionConfiguration(
     val collectName: Boolean = false,
     val collectEmail: Boolean = false,
     val collectPhone: Boolean = false,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingAddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingAddressElement.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
-import com.stripe.android.ui.core.CardBillingDetailsCollectionConfiguration
+import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.uicore.address.AddressRepository
 import com.stripe.android.uicore.address.FieldType
 import com.stripe.android.uicore.elements.AddressElement
@@ -30,8 +30,8 @@ class CardBillingAddressElement(
     ),
     sameAsShippingElement: SameAsShippingElement?,
     shippingValuesMap: Map<IdentifierSpec, String?>?,
-    private val collectionMode: CardBillingDetailsCollectionConfiguration.AddressCollectionMode =
-        CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+    private val collectionMode: BillingDetailsCollectionConfiguration.AddressCollectionMode =
+        BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
 ) : AddressElement(
     identifier,
     addressRepository,
@@ -47,15 +47,15 @@ class CardBillingAddressElement(
     val hiddenIdentifiers: Flow<Set<IdentifierSpec>> =
         countryDropdownFieldController.rawFieldValue.map { countryCode ->
             when (collectionMode) {
-                CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Never -> {
+                BillingDetailsCollectionConfiguration.AddressCollectionMode.Never -> {
                     FieldType.values()
                         .map { it.identifierSpec }
                         .toSet()
                 }
-                CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Full -> {
+                BillingDetailsCollectionConfiguration.AddressCollectionMode.Full -> {
                     emptySet()
                 }
-                CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic -> {
+                BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic -> {
                     when (countryCode) {
                         "US", "GB", "CA" -> {
                             FieldType.values()

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingSpec.kt
@@ -2,7 +2,7 @@ package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.CountryUtils
-import com.stripe.android.ui.core.CardBillingDetailsCollectionConfiguration
+import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.address.AddressRepository
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -20,15 +20,15 @@ data class CardBillingSpec(
     @SerialName("allowed_country_codes")
     val allowedCountryCodes: Set<String> = CountryUtils.supportedBillingCountries,
     @SerialName("collection_mode")
-    val collectionMode: CardBillingDetailsCollectionConfiguration.AddressCollectionMode =
-        CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+    val collectionMode: BillingDetailsCollectionConfiguration.AddressCollectionMode =
+        BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
 ) : FormItemSpec() {
     fun transform(
         initialValues: Map<IdentifierSpec, String?>,
         addressRepository: AddressRepository,
         shippingValues: Map<IdentifierSpec, String?>?,
     ): SectionElement? {
-        if (collectionMode == CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Never) {
+        if (collectionMode == BillingDetailsCollectionConfiguration.AddressCollectionMode.Never) {
             return null
         }
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PlaceholderSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PlaceholderSpec.kt
@@ -31,6 +31,9 @@ data class PlaceholderSpec(
         @SerialName("billing_address_without_country")
         BillingAddressWithoutCountry,
 
+        @SerialName("sepa_mandate")
+        SepaMandate,
+
         @SerialName("unknown")
         Unknown,
     }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SepaMandateTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SepaMandateTextSpec.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Transient
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Serializable
-internal data class SepaMandateTextSpec(
+data class SepaMandateTextSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("sepa_mandate"),
     @StringRes

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
@@ -54,6 +54,7 @@ import com.stripe.android.ui.core.elements.MandateTextSpec
 import com.stripe.android.ui.core.elements.SaveForFutureUseSpec
 import com.stripe.android.ui.core.elements.SharedDataSpec
 import com.stripe.android.ui.core.elements.transform
+import com.stripe.android.uicore.elements.IdentifierSpec
 import java.io.InputStream
 
 /**
@@ -236,7 +237,12 @@ class LpmRepository constructor(
             darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
             tintIconOnSelection = false,
             requirement = BancontactRequirement,
-            formSpec = LayoutSpec(sharedDataSpec.fields)
+            formSpec = LayoutSpec(sharedDataSpec.fields),
+            placeholderOverrideList = if (stripeIntent.requiresMandate()) {
+                listOf(IdentifierSpec.Name, IdentifierSpec.Email)
+            } else {
+                emptyList()
+            }
         )
         PaymentMethod.Type.Sofort.code -> SupportedPaymentMethod(
             code = "sofort",
@@ -247,7 +253,12 @@ class LpmRepository constructor(
             darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
             tintIconOnSelection = false,
             requirement = SofortRequirement,
-            formSpec = LayoutSpec(sharedDataSpec.fields)
+            formSpec = LayoutSpec(sharedDataSpec.fields),
+            placeholderOverrideList = if (stripeIntent.requiresMandate()) {
+                listOf(IdentifierSpec.Name, IdentifierSpec.Email)
+            } else {
+                emptyList()
+            }
         )
         PaymentMethod.Type.Ideal.code -> {
             SupportedPaymentMethod(
@@ -259,7 +270,12 @@ class LpmRepository constructor(
                 darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
                 tintIconOnSelection = false,
                 requirement = IdealRequirement,
-                formSpec = LayoutSpec(sharedDataSpec.fields)
+                formSpec = LayoutSpec(sharedDataSpec.fields),
+                placeholderOverrideList = if (stripeIntent.requiresMandate()) {
+                    listOf(IdentifierSpec.Name, IdentifierSpec.Email)
+                } else {
+                    emptyList()
+                }
             )
         }
         PaymentMethod.Type.SepaDebit.code -> SupportedPaymentMethod(
@@ -575,7 +591,12 @@ class LpmRepository constructor(
         /**
          * This describes how the UI should look.
          */
-        val formSpec: LayoutSpec
+        val formSpec: LayoutSpec,
+
+        /**
+         * This forces the UI to render the required fields
+         */
+        val placeholderOverrideList: List<IdentifierSpec> = emptyList()
     ) {
         /**
          * Returns true if the payment method supports confirming from a saved

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/resources/LpmRepositoryTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/resources/LpmRepositoryTest.kt
@@ -8,7 +8,7 @@ import com.stripe.android.model.PaymentMethod.Type.CashAppPay
 import com.stripe.android.model.PaymentMethod.Type.USBankAccount
 import com.stripe.android.paymentsheet.forms.Delayed
 import com.stripe.android.testing.PaymentIntentFactory
-import com.stripe.android.ui.core.CardBillingDetailsCollectionConfiguration
+import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.CardBillingSpec
 import com.stripe.android.ui.core.elements.CardDetailsSectionSpec
@@ -388,11 +388,11 @@ class LpmRepositoryTest {
             }
          ]
             """.trimIndent(),
-            CardBillingDetailsCollectionConfiguration(
+            BillingDetailsCollectionConfiguration(
                 collectName = true,
                 collectEmail = true,
                 collectPhone = false,
-                address = CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
             )
         )
 
@@ -415,7 +415,7 @@ class LpmRepositoryTest {
 
         val addressSpec = card.formSpec.items[2] as CardBillingSpec
         assertThat(addressSpec.collectionMode)
-            .isEqualTo(CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Full)
+            .isEqualTo(BillingDetailsCollectionConfiguration.AddressCollectionMode.Full)
     }
 
     @Test

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -2,6 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
+    <ID>CyclomaticComplexMethod:PlaceholderHelper.kt$PlaceholderHelper$@VisibleForTesting internal fun specForPlaceholderField( field: PlaceholderField, placeholderOverrideList: List&lt;IdentifierSpec>, requiresMandate: Boolean, configuration: PaymentSheet.BillingDetailsCollectionConfiguration, )</ID>
     <ID>EmptyFunctionBlock:PrimaryButtonAnimator.kt$PrimaryButtonAnimator.&lt;no name provided>${ }</ID>
     <ID>ForbiddenComment:PaymentOptionFactory.kt$PaymentOptionFactory$// TODO: Should use labelResource paymentMethodCreateParams or extension function</ID>
     <ID>FunctionNaming:PaymentOptionUi.kt$@Preview(name = "Payment option in editing mode") @Composable private fun PaymentOptionUi_Editing()</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
@@ -55,6 +55,7 @@ internal object FormArgumentsFactory {
             billingDetailsCollectionConfiguration = config?.billingDetailsCollectionConfiguration
                 ?: PaymentSheet.BillingDetailsCollectionConfiguration(),
             isEligibleForCardBrandChoice = isEligibleForCardBrandChoice,
+            requiresMandate = paymentMethod.requiresMandate,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
@@ -56,6 +56,7 @@ internal object FormArgumentsFactory {
                 ?: PaymentSheet.BillingDetailsCollectionConfiguration(),
             isEligibleForCardBrandChoice = isEligibleForCardBrandChoice,
             requiresMandate = paymentMethod.requiresMandate,
+            requiredFields = paymentMethod.placeholderOverrideList,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
@@ -7,8 +7,8 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.addresselement.toIdentifierMap
-import com.stripe.android.paymentsheet.forms.BillingDetailsHelpers.connectBillingDetailsFields
-import com.stripe.android.paymentsheet.forms.BillingDetailsHelpers.specsForConfiguration
+import com.stripe.android.paymentsheet.forms.PlaceholderHelper.connectBillingDetailsFields
+import com.stripe.android.paymentsheet.forms.PlaceholderHelper.specsForConfiguration
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
@@ -73,6 +73,7 @@ internal class FormViewModel @Inject internal constructor(
         if (formArguments.paymentMethodCode != PaymentMethod.Type.Card.code) {
             specs = specsForConfiguration(
                 configuration = formArguments.billingDetailsCollectionConfiguration,
+                requiresMandate = formArguments.requiresMandate,
                 specs = specs,
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
@@ -73,6 +73,7 @@ internal class FormViewModel @Inject internal constructor(
         if (formArguments.paymentMethodCode != PaymentMethod.Type.Card.code) {
             specs = specsForConfiguration(
                 configuration = formArguments.billingDetailsCollectionConfiguration,
+                placeholderOverrideList = formArguments.requiredFields,
                 requiresMandate = formArguments.requiresMandate,
                 specs = specs,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArguments.kt
@@ -24,6 +24,7 @@ internal data class FormArguments(
     val billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration =
         PaymentSheet.BillingDetailsCollectionConfiguration(),
     val requiresMandate: Boolean = false,
+    val requiredFields: List<IdentifierSpec> = emptyList()
 ) : Parcelable
 
 internal fun FormArguments.getInitialValuesMap(): Map<IdentifierSpec, String?> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArguments.kt
@@ -23,6 +23,7 @@ internal data class FormArguments(
     val initialPaymentMethodCreateParams: PaymentMethodCreateParams? = null,
     val billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration =
         PaymentSheet.BillingDetailsCollectionConfiguration(),
+    val requiresMandate: Boolean = false,
 ) : Parcelable
 
 internal fun FormArguments.getInitialValuesMap(): Map<IdentifierSpec, String?> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -26,7 +26,7 @@ import com.stripe.android.paymentsheet.model.getSupportedSavedCustomerPMs
 import com.stripe.android.paymentsheet.model.requireValidOrThrow
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
-import com.stripe.android.ui.core.CardBillingDetailsCollectionConfiguration
+import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -227,12 +227,12 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         return elementsSessionRepository.get(initializationMode).mapCatching { elementsSession ->
             val billingDetailsCollectionConfig =
                 configuration?.billingDetailsCollectionConfiguration?.toInternal()
-                    ?: CardBillingDetailsCollectionConfiguration()
+                    ?: BillingDetailsCollectionConfiguration()
 
             val didParseServerResponse = lpmRepository.update(
                 stripeIntent = elementsSession.stripeIntent,
                 serverLpmSpecs = elementsSession.paymentMethodSpecs,
-                cardBillingDetailsCollectionConfiguration = billingDetailsCollectionConfig,
+                billingDetailsCollectionConfiguration = billingDetailsCollectionConfig,
             )
 
             if (!didParseServerResponse) {
@@ -370,20 +370,20 @@ private fun PaymentMethod.toPaymentSelection(): PaymentSelection.Saved {
 }
 
 internal fun PaymentSheet.BillingDetailsCollectionConfiguration.toInternal():
-    CardBillingDetailsCollectionConfiguration {
-    return CardBillingDetailsCollectionConfiguration(
+    BillingDetailsCollectionConfiguration {
+    return BillingDetailsCollectionConfiguration(
         collectName = name == Always,
         collectEmail = email == Always,
         collectPhone = phone == Always,
         address = when (address) {
             PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic -> {
-                CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
+                BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
             }
             PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never -> {
-                CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Never
+                BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
             }
             PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full -> {
-                CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Full
+                BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
             }
         },
     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -12,7 +12,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.COMPOSE_FRAGMENT_ARGS
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
-import com.stripe.android.ui.core.CardBillingDetailsCollectionConfiguration
+import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.AddressSpec
 import com.stripe.android.ui.core.elements.CardDetailsSectionElement
@@ -727,11 +727,11 @@ internal class FormViewModelTest {
                 attachDefaultsToPaymentMethod = false,
             )
 
-            val internalBillingDetailsCollectionConfig = CardBillingDetailsCollectionConfiguration(
+            val internalBillingDetailsCollectionConfig = BillingDetailsCollectionConfiguration(
                 collectName = true,
                 collectEmail = true,
                 collectPhone = true,
-                address = CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
             )
 
             val args = COMPOSE_FRAGMENT_ARGS.copy(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/PlaceholderHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/PlaceholderHelperTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.ui.core.elements.NameSpec
 import com.stripe.android.ui.core.elements.PhoneSpec
 import com.stripe.android.ui.core.elements.PlaceholderSpec
 import com.stripe.android.ui.core.elements.PlaceholderSpec.PlaceholderField
+import com.stripe.android.ui.core.elements.SepaMandateTextSpec
 import com.stripe.android.ui.core.elements.SimpleTextSpec
 import com.stripe.android.uicore.elements.IdentifierSpec
 import org.junit.Test
@@ -32,11 +33,14 @@ class PlaceholderHelperTest {
 
         val specs = specsForConfiguration(
             configuration = billingDetailsCollectionConfiguration,
+            placeholderOverrideList = emptyList(),
+            requiresMandate = false,
             specs = listOf(
                 NameSpec(),
                 EmailSpec(),
                 PhoneSpec(),
                 AddressSpec(),
+                SepaMandateTextSpec(),
             ),
         )
         assertThat(specs).isEmpty()
@@ -54,6 +58,8 @@ class PlaceholderHelperTest {
 
         val specs = specsForConfiguration(
             configuration = billingDetailsCollectionConfiguration,
+            placeholderOverrideList = emptyList(),
+            requiresMandate = false,
             specs = listOf(
                 PlaceholderSpec(field = PlaceholderSpec.PlaceholderField.Name),
                 PlaceholderSpec(field = PlaceholderSpec.PlaceholderField.Email),
@@ -76,6 +82,8 @@ class PlaceholderHelperTest {
 
         val specs = specsForConfiguration(
             configuration = billingDetailsCollectionConfiguration,
+            placeholderOverrideList = emptyList(),
+            requiresMandate = false,
             specs = listOf(
                 NameSpec(),
                 PlaceholderSpec(
@@ -114,32 +122,42 @@ class PlaceholderHelperTest {
 
         assertThat(
             specForPlaceholderField(
-                PlaceholderField.Name,
-                billingDetailsCollectionConfiguration,
+                field = PlaceholderField.Name,
+                placeholderOverrideList = emptyList(),
+                requiresMandate = false,
+                configuration = billingDetailsCollectionConfiguration,
             )
         ).isEqualTo(NameSpec())
         assertThat(
             specForPlaceholderField(
-                PlaceholderField.Email,
-                billingDetailsCollectionConfiguration,
+                field = PlaceholderField.Email,
+                placeholderOverrideList = emptyList(),
+                requiresMandate = false,
+                configuration = billingDetailsCollectionConfiguration,
             )
         ).isEqualTo(EmailSpec())
         assertThat(
             specForPlaceholderField(
-                PlaceholderField.Phone,
-                billingDetailsCollectionConfiguration,
+                field = PlaceholderField.Phone,
+                placeholderOverrideList = emptyList(),
+                requiresMandate = false,
+                configuration = billingDetailsCollectionConfiguration,
             )
         ).isEqualTo(PhoneSpec())
         assertThat(
             specForPlaceholderField(
-                PlaceholderField.BillingAddress,
-                billingDetailsCollectionConfiguration,
+                field = PlaceholderField.BillingAddress,
+                placeholderOverrideList = emptyList(),
+                requiresMandate = false,
+                configuration = billingDetailsCollectionConfiguration,
             )
         ).isEqualTo(AddressSpec())
         assertThat(
             specForPlaceholderField(
-                PlaceholderField.BillingAddressWithoutCountry,
-                billingDetailsCollectionConfiguration,
+                field = PlaceholderField.BillingAddressWithoutCountry,
+                placeholderOverrideList = emptyList(),
+                requiresMandate = false,
+                configuration = billingDetailsCollectionConfiguration,
             )
         ).isEqualTo(AddressSpec(hideCountry = true))
     }
@@ -156,32 +174,42 @@ class PlaceholderHelperTest {
 
         assertThat(
             specForPlaceholderField(
-                PlaceholderField.Name,
-                billingDetailsCollectionConfiguration,
+                field = PlaceholderField.Name,
+                placeholderOverrideList = emptyList(),
+                requiresMandate = false,
+                configuration = billingDetailsCollectionConfiguration,
             )
         ).isNull()
         assertThat(
             specForPlaceholderField(
-                PlaceholderField.Email,
-                billingDetailsCollectionConfiguration,
+                field = PlaceholderField.Email,
+                placeholderOverrideList = emptyList(),
+                requiresMandate = false,
+                configuration = billingDetailsCollectionConfiguration,
             )
         ).isNull()
         assertThat(
             specForPlaceholderField(
-                PlaceholderField.Phone,
-                billingDetailsCollectionConfiguration,
+                field = PlaceholderField.Phone,
+                placeholderOverrideList = emptyList(),
+                requiresMandate = false,
+                configuration = billingDetailsCollectionConfiguration,
             )
         ).isNull()
         assertThat(
             specForPlaceholderField(
-                PlaceholderField.BillingAddress,
-                billingDetailsCollectionConfiguration,
+                field = PlaceholderField.BillingAddress,
+                placeholderOverrideList = emptyList(),
+                requiresMandate = false,
+                configuration = billingDetailsCollectionConfiguration,
             )
         ).isNull()
         assertThat(
             specForPlaceholderField(
-                PlaceholderField.BillingAddressWithoutCountry,
-                billingDetailsCollectionConfiguration,
+                field = PlaceholderField.BillingAddressWithoutCountry,
+                placeholderOverrideList = emptyList(),
+                requiresMandate = false,
+                configuration = billingDetailsCollectionConfiguration,
             )
         ).isNull()
     }
@@ -273,6 +301,80 @@ class PlaceholderHelperTest {
             PlaceholderField.Name,
             PlaceholderField.Email,
             PlaceholderField.Phone,
+        )
+    }
+
+    @Test
+    fun `Test requires mandate`() {
+        assertThat(
+            specForPlaceholderField(
+                field = PlaceholderField.SepaMandate,
+                placeholderOverrideList = emptyList(),
+                requiresMandate = false,
+                configuration = PaymentSheet.BillingDetailsCollectionConfiguration(),
+            )
+        ).isNull()
+        assertThat(
+            specForPlaceholderField(
+                field = PlaceholderField.SepaMandate,
+                placeholderOverrideList = emptyList(),
+                requiresMandate = true,
+                configuration = PaymentSheet.BillingDetailsCollectionConfiguration(),
+            )
+        ).isInstanceOf(
+            SepaMandateTextSpec::class.java
+        )
+    }
+
+    @Test
+    fun `Test overrideable placeholders`() {
+        val billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+            name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+            email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+            phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+            address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+            attachDefaultsToPaymentMethod = false,
+        )
+
+        assertThat(
+            specForPlaceholderField(
+                field = PlaceholderField.Name,
+                placeholderOverrideList = listOf(IdentifierSpec.Name),
+                requiresMandate = false,
+                configuration = billingDetailsCollectionConfiguration,
+            )
+        ).isInstanceOf(
+            NameSpec::class.java
+        )
+        assertThat(
+            specForPlaceholderField(
+                field = PlaceholderField.Email,
+                placeholderOverrideList = listOf(IdentifierSpec.Email),
+                requiresMandate = false,
+                configuration = billingDetailsCollectionConfiguration,
+            )
+        ).isInstanceOf(
+            EmailSpec::class.java
+        )
+        assertThat(
+            specForPlaceholderField(
+                field = PlaceholderField.Phone,
+                placeholderOverrideList = listOf(IdentifierSpec.Phone),
+                requiresMandate = false,
+                configuration = billingDetailsCollectionConfiguration,
+            )
+        ).isInstanceOf(
+            PhoneSpec::class.java
+        )
+        assertThat(
+            specForPlaceholderField(
+                field = PlaceholderField.BillingAddress,
+                placeholderOverrideList = listOf(IdentifierSpec.Generic("billing_details[address]")),
+                requiresMandate = false,
+                configuration = billingDetailsCollectionConfiguration,
+            )
+        ).isInstanceOf(
+            AddressSpec::class.java
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/PlaceholderHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/PlaceholderHelperTest.kt
@@ -2,9 +2,9 @@ package com.stripe.android.paymentsheet.forms
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.forms.BillingDetailsHelpers.removeCorrespondingPlaceholder
-import com.stripe.android.paymentsheet.forms.BillingDetailsHelpers.specForPlaceholderField
-import com.stripe.android.paymentsheet.forms.BillingDetailsHelpers.specsForConfiguration
+import com.stripe.android.paymentsheet.forms.PlaceholderHelper.removeCorrespondingPlaceholder
+import com.stripe.android.paymentsheet.forms.PlaceholderHelper.specForPlaceholderField
+import com.stripe.android.paymentsheet.forms.PlaceholderHelper.specsForConfiguration
 import com.stripe.android.ui.core.elements.AddressSpec
 import com.stripe.android.ui.core.elements.EmailSpec
 import com.stripe.android.ui.core.elements.NameSpec
@@ -19,7 +19,7 @@ import org.robolectric.RobolectricTestRunner
 import com.stripe.android.R as StripeR
 
 @RunWith(RobolectricTestRunner::class)
-class BillingDetailsHelpersTest {
+class PlaceholderHelperTest {
     @Test
     fun `Test unused elements are removed`() {
         val billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Fix sepa payment method form ui. This is the client side fix to the server side updates to the lpm specs.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots

[sepalpms.webm](https://github.com/stripe/stripe-android/assets/99316447/2bfbdd16-fc93-4f3a-9b7a-8657b493aaeb)

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

* [FIXED][]() Fixed an issue where Bancontact SetupIntent or PaymentIntent with setup for future usage would show the mandate text in the middle of the form. 

