### PR TITLE
Update test devices for BrowserStack tests

### DIFF
--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -188,7 +188,7 @@ def executeTests(appUrl, testUrl, isNightly):
         devices = [
             "Google Pixel 7-13.0",
             "Samsung Galaxy S22-12.0",
-            "Google Pixel 2-8.0",
+            "Google Pixel 5-11.0",
         ]
     else:
         devices = [


### PR DESCRIPTION
Attempt at fixing flaky browserstack tests for Pixel 2, custom flow tests. I think the issue is in the `launchCustom` method, where we call:

```
Espresso.onIdle()
selectors.composeTestRule.waitForIdle()
```

This is the only difference between `launchCustom` and `launchComplete`, but we don't see any flaky tests in `launchComplete`.

I think the problem could be that the Android OS handles compose differently on lower versions, and that is why it is flaking on these lines. The suggested fix is to change the OS version to test on, since the issue isn't with the implementation of PaymentSheet, but how we are testing it.