### PR TITLE
[FC] Fix - Back press navigation on first screen of the flow

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/Destination.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/Destination.kt
@@ -160,7 +160,7 @@ internal sealed class Destination(
 
     object ManualEntrySuccess : Destination(
         route = Pane.MANUAL_ENTRY_SUCCESS.value,
-        paramKeys = listOf(KEY_MICRODEPOSITS, KEY_LAST4),
+        paramKeys = listOf(KEY_REFERRER, KEY_MICRODEPOSITS, KEY_LAST4),
         screenBuilder = { ManualEntrySuccessScreen(it) }
     ) {
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -149,7 +149,7 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
         ) {
             BackHandler(true) {
                 viewModel.onBackClick(navController.currentDestination?.pane)
-                if (navController.popBackStack().not()) onBackPressedDispatcher.onBackPressed()
+                if (navController.popBackStack().not()) viewModel.onBackPressed()
             }
             NavHost(
                 navController,


### PR DESCRIPTION
# Summary
- After navigation refactor, clicking back when the back stack is empty triggers `onBackPressedDispatcher`
- That enters in a loop that triggers the back handler again, resulting in a crash
- Fix: just call `viewModel.onBackPressed` when the back stack is empty. That'll trigger the close logic properly.

# Testing
- Test clicking back on the first screen (consent)
