### PR TITLE
Update release notes for 20.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+## 20.30.1 - 2023-09-11
+
+### Financial Connections
+* [FIXED][7290](https://github.com/stripe/stripe-android/pull/7290) Fixed an issue where attempting to go back on the first screen caused a crash since there is no other screen in the back stack.
+
 ## 20.30.0 - 2023-09-11
 
 ### PaymentSheet


### PR DESCRIPTION
# Summary
This pull request adds the release notes for version 20.30.1.

- [ ] Update README (version number is done by bindings)
- [x] Update CHANGELOG with any new features or breaking changes (be thorough when reviewing commit history)
- [ ] Update MIGRATING (if necessary)

# Changelog
[FIXED][7290](https://github.com/stripe/stripe-android/pull/7290) Fixed an issue where attempting to go back on the first screen caused a crash since there is no other screen in the back stack.
