### PR TITLE
Remove unnecessary authorizationAction.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestBancontact.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestBancontact.kt
@@ -2,7 +2,6 @@ package com.stripe.android.lpm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BaseLpmTest
-import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.Automatic
 import com.stripe.android.test.core.DelayedPMs
 import com.stripe.android.test.core.IntentType
@@ -40,7 +39,6 @@ internal class TestBancontact : BaseLpmTest() {
                 delayed = DelayedPMs.On,
                 automatic = Automatic.On,
                 intentType = IntentType.Setup,
-                authorizationAction = AuthorizeAction.AuthorizeSetup,
             ),
         )
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCashApp.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCashApp.kt
@@ -61,7 +61,6 @@ internal class TestCashApp : BaseLpmTest() {
         testDriver.confirmNewOrGuestComplete(
             testParameters = cashApp.copy(
                 intentType = IntentType.Setup,
-                authorizationAction = AuthorizeAction.AuthorizeSetup,
             ),
         )
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestIdeal.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestIdeal.kt
@@ -2,7 +2,6 @@ package com.stripe.android.lpm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BaseLpmTest
-import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.Automatic
 import com.stripe.android.test.core.DelayedPMs
 import com.stripe.android.test.core.IntentType
@@ -40,7 +39,6 @@ internal class TestIdeal : BaseLpmTest() {
                 delayed = DelayedPMs.On,
                 automatic = Automatic.On,
                 intentType = IntentType.Setup,
-                authorizationAction = AuthorizeAction.AuthorizeSetup,
             ),
         )
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSofort.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSofort.kt
@@ -2,7 +2,6 @@ package com.stripe.android.lpm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BaseLpmTest
-import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.Automatic
 import com.stripe.android.test.core.Currency
 import com.stripe.android.test.core.DelayedPMs
@@ -46,7 +45,6 @@ internal class TestSofort : BaseLpmTest() {
                 delayed = DelayedPMs.On,
                 automatic = Automatic.On,
                 intentType = IntentType.Setup,
-                authorizationAction = AuthorizeAction.AuthorizeSetup,
             ),
         )
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -427,7 +427,7 @@ class PlaygroundTestDriver(
                     assertThat(browserWindow(selectedBrowser)?.exists()).isTrue()
 
                     blockUntilAuthorizationPageLoaded(
-                        isSetup = testParameters.authorizationAction is AuthorizeAction.AuthorizeSetup
+                        isSetup = testParameters.intentType == IntentType.Setup
                     )
                 }
 
@@ -437,7 +437,8 @@ class PlaygroundTestDriver(
                     } else if (!authorizeAction.exists()) {
                         // Buttons aren't showing the same way each time in the web page.
                         object : UiAutomatorText(
-                            label = requireNotNull(testParameters.authorizationAction).text,
+                            label = requireNotNull(testParameters.authorizationAction)
+                                .text(testParameters.intentType),
                             className = "android.widget.TextView",
                             device = device
                         ) {}.click()
@@ -453,7 +454,6 @@ class PlaygroundTestDriver(
                         }
                     }
                     is AuthorizeAction.AuthorizePayment -> {}
-                    is AuthorizeAction.AuthorizeSetup -> {}
                     is AuthorizeAction.PollingSucceedsAfterDelay -> {
                         waitForPollingToFinish()
                     }
@@ -496,7 +496,6 @@ class PlaygroundTestDriver(
 
         val isDone = testParameters.authorizationAction in setOf(
             AuthorizeAction.AuthorizePayment,
-            AuthorizeAction.AuthorizeSetup,
             AuthorizeAction.PollingSucceedsAfterDelay,
             AuthorizeAction.DisplayQrCode,
             null

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
@@ -86,36 +86,38 @@ enum class Browser {
  */
 sealed interface AuthorizeAction {
 
-    val text: String
+    fun text(intentType: IntentType): String
+
     val requiresBrowser: Boolean
 
     object PollingSucceedsAfterDelay : AuthorizeAction {
-        override val text: String = "POLLING SUCCEEDS AFTER DELAY"
+        override fun text(intentType: IntentType): String = "POLLING SUCCEEDS AFTER DELAY"
         override val requiresBrowser: Boolean = false
     }
 
     object AuthorizePayment : AuthorizeAction {
-        override val text: String = "AUTHORIZE TEST PAYMENT"
-        override val requiresBrowser: Boolean = true
-    }
-
-    object AuthorizeSetup : AuthorizeAction {
-        override val text: String = "AUTHORIZE TEST SETUP"
+        override fun text(intentType: IntentType): String {
+            return if (intentType == IntentType.Setup) {
+                "AUTHORIZE TEST SETUP"
+            } else {
+                "AUTHORIZE TEST PAYMENT"
+            }
+        }
         override val requiresBrowser: Boolean = true
     }
 
     object DisplayQrCode : AuthorizeAction {
-        override val text: String = "Display QR code"
+        override fun text(intentType: IntentType): String = "Display QR code"
         override val requiresBrowser: Boolean = false
     }
 
     data class Fail(val expectedError: String) : AuthorizeAction {
-        override val text: String = "FAIL TEST PAYMENT"
+        override fun text(intentType: IntentType): String = "FAIL TEST PAYMENT"
         override val requiresBrowser: Boolean = true
     }
 
     object Cancel : AuthorizeAction {
-        override val text: String = ""
+        override fun text(intentType: IntentType): String = ""
         override val requiresBrowser: Boolean = true
     }
 }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -186,9 +186,9 @@ class Selectors(
         .getInstalledApplications(PackageManager.GET_META_DATA)
 
     val authorizeAction = when (testParameters.authorizationAction) {
-        is AuthorizeAction.AuthorizePayment, AuthorizeAction.AuthorizeSetup -> {
+        is AuthorizeAction.AuthorizePayment -> {
             object : UiAutomatorText(
-                label = testParameters.authorizationAction.text,
+                label = testParameters.authorizationAction.text(testParameters.intentType),
                 className = "android.widget.Button",
                 device = device
             ) {
@@ -207,7 +207,7 @@ class Selectors(
         }
         is AuthorizeAction.Cancel -> {
             object : UiAutomatorText(
-                label = testParameters.authorizationAction.text,
+                label = testParameters.authorizationAction.text(testParameters.intentType),
                 className = "android.widget.Button",
                 device = device
             ) {
@@ -218,7 +218,7 @@ class Selectors(
         }
         is AuthorizeAction.Fail -> {
             object : UiAutomatorText(
-                label = testParameters.authorizationAction.text,
+                label = testParameters.authorizationAction.text(testParameters.intentType),
                 className = "android.widget.Button",
                 device = device
             ) {}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This caused confusion where there were 2 sources of truth (IntentType, AuthorizationAction) making it easy to get wrong. This unifies the configuration.
