### PR TITLE
Add konbini to PaymentSheet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### PaymentSheet
 * [ADDED][7302](https://github.com/stripe/stripe-android/pull/7302) PaymentSheet now supports Alma for PaymentIntents in private beta.
 * [ADDED][7191](https://github.com/stripe/stripe-android/pull/7191) `PaymentSheet.GooglePayConfiguration` now takes an optional `amount` and `label`. The `amount` will be displayed in Google Pay for SetupIntents, while `label` will be displayed for both PaymentIntents and SetupIntents.
+* [ADDED][7308](https://github.com/stripe/stripe-android/pull/7308) PaymentSheet now supports Konbini for PaymentIntents.
 
 ### Payments
 * [ADDED][7191](https://github.com/stripe/stripe-android/pull/7191) `GooglePayLauncher` now takes an optional `label` when presenting Google Pay for PaymentIntents, and an optional `amount` and `label` when presenting for SetupIntents.

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -3789,6 +3789,7 @@ public final class com/stripe/android/model/PaymentMethod$Type : java/lang/Enum,
 	public static final field GrabPay Lcom/stripe/android/model/PaymentMethod$Type;
 	public static final field Ideal Lcom/stripe/android/model/PaymentMethod$Type;
 	public static final field Klarna Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field Konbini Lcom/stripe/android/model/PaymentMethod$Type;
 	public static final field Link Lcom/stripe/android/model/PaymentMethod$Type;
 	public static final field MobilePay Lcom/stripe/android/model/PaymentMethod$Type;
 	public static final field Netbanking Lcom/stripe/android/model/PaymentMethod$Type;
@@ -4521,6 +4522,14 @@ public final class com/stripe/android/model/PaymentMethodOptionsParams$Card$Crea
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodOptionsParams$Card;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodOptionsParams$Card;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethodOptionsParams$Konbini$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodOptionsParams$Konbini;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodOptionsParams$Konbini;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
@@ -6043,6 +6052,14 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$DisplayB
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/model/StripeIntent$NextActionData$DisplayKonbiniDetails$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/StripeIntent$NextActionData$DisplayKonbiniDetails;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/StripeIntent$NextActionData$DisplayKonbiniDetails;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/model/StripeIntent$NextActionData$DisplayOxxoDetails : com/stripe/android/model/StripeIntent$NextActionData {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
@@ -6244,6 +6261,7 @@ public final class com/stripe/android/model/StripeIntent$NextActionType : java/l
 	public static final field BlikAuthorize Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field CashAppRedirect Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field DisplayBoletoDetails Lcom/stripe/android/model/StripeIntent$NextActionType;
+	public static final field DisplayKonbiniDetails Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field DisplayOxxoDetails Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field RedirectToUrl Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field UpiAwaitNotification Lcom/stripe/android/model/StripeIntent$NextActionType;

--- a/payments-core/src/main/java/com/stripe/android/ConfirmStripeIntentParamsFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/ConfirmStripeIntentParamsFactory.kt
@@ -102,6 +102,9 @@ internal class ConfirmPaymentIntentParamsFactory(
                 PaymentMethod.Type.Blik.code -> {
                     optionsParams
                 }
+                PaymentMethod.Type.Konbini.code -> {
+                    optionsParams
+                }
                 PaymentMethod.Type.Link.code -> {
                     null
                 }

--- a/payments-core/src/main/java/com/stripe/android/StripeIntentResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripeIntentResult.kt
@@ -97,6 +97,7 @@ abstract class StripeIntentResult<out T : StripeIntent> internal constructor(
             StripeIntent.NextActionType.BlikAuthorize,
             StripeIntent.NextActionType.DisplayOxxoDetails,
             StripeIntent.NextActionType.DisplayBoletoDetails,
+            StripeIntent.NextActionType.DisplayKonbiniDetails,
             StripeIntent.NextActionType.UpiAwaitNotification,
             StripeIntent.NextActionType.VerifyWithMicrodeposits -> {
                 true

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -174,6 +174,9 @@ constructor(
             is StripeIntent.NextActionData.DisplayBoletoDetails -> {
                 StripeIntent.NextActionType.DisplayBoletoDetails
             }
+            is StripeIntent.NextActionData.DisplayKonbiniDetails -> {
+                StripeIntent.NextActionType.DisplayKonbiniDetails
+            }
             is StripeIntent.NextActionData.VerifyWithMicrodeposits -> {
                 StripeIntent.NextActionType.VerifyWithMicrodeposits
             }

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -390,6 +390,13 @@ constructor(
             isVoucher = true,
             requiresMandate = false,
             hasDelayedSettlement = true,
+        ),
+        Konbini(
+            code = "konbini",
+            isReusable = false,
+            isVoucher = true,
+            requiresMandate = false,
+            hasDelayedSettlement = true,
         );
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
+import androidx.annotation.RestrictTo
 import kotlinx.parcelize.Parcelize
 
 sealed class PaymentMethodOptionsParams(
@@ -70,6 +71,22 @@ sealed class PaymentMethodOptionsParams(
 
         internal companion object {
             const val PARAM_CODE = "code"
+        }
+    }
+
+    @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class Konbini(
+        private val confirmationNumber: String
+    ) : PaymentMethodOptionsParams(PaymentMethod.Type.Konbini) {
+        override fun createTypeParams(): List<Pair<String, Any?>> {
+            return listOf(
+                PARAM_CONFIRMATION_NUMBER to confirmationNumber
+            )
+        }
+
+        internal companion object {
+            const val PARAM_CONFIRMATION_NUMBER = "confirmation_number"
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/model/SetupIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/SetupIntent.kt
@@ -128,6 +128,9 @@ data class SetupIntent internal constructor(
             is StripeIntent.NextActionData.DisplayBoletoDetails -> {
                 StripeIntent.NextActionType.DisplayBoletoDetails
             }
+            is StripeIntent.NextActionData.DisplayKonbiniDetails -> {
+                StripeIntent.NextActionType.DisplayKonbiniDetails
+            }
             is StripeIntent.NextActionData.VerifyWithMicrodeposits -> {
                 StripeIntent.NextActionType.VerifyWithMicrodeposits
             }

--- a/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -96,7 +96,8 @@ sealed interface StripeIntent : StripeModel {
         VerifyWithMicrodeposits("verify_with_microdeposits"),
         UpiAwaitNotification("upi_await_notification"),
         CashAppRedirect("cashapp_handle_redirect_or_display_qr_code"),
-        DisplayBoletoDetails("boleto_display_details");
+        DisplayBoletoDetails("boleto_display_details"),
+        DisplayKonbiniDetails("konbini_display_details");
 
         @Keep
         override fun toString(): String {
@@ -191,6 +192,15 @@ sealed interface StripeIntent : StripeModel {
         @Parcelize
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         data class DisplayBoletoDetails(
+            /**
+             * URL of a webpage containing the voucher for this payment.
+             */
+            val hostedVoucherUrl: String? = null,
+        ) : NextActionData()
+
+        @Parcelize
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        data class DisplayKonbiniDetails(
             /**
              * URL of a webpage containing the voucher for this payment.
              */

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/NextActionDataParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/NextActionDataParser.kt
@@ -19,6 +19,7 @@ internal class NextActionDataParser : ModelJsonParser<StripeIntent.NextActionDat
         val parser = when (nextActionType) {
             StripeIntent.NextActionType.DisplayOxxoDetails -> DisplayOxxoDetailsJsonParser()
             StripeIntent.NextActionType.DisplayBoletoDetails -> DisplayBoletoDetailsJsonParser()
+            StripeIntent.NextActionType.DisplayKonbiniDetails -> DisplayKonbiniDetailsJsonParser()
             StripeIntent.NextActionType.RedirectToUrl -> RedirectToUrlParser()
             StripeIntent.NextActionType.UseStripeSdk -> SdkDataJsonParser()
             StripeIntent.NextActionType.AlipayRedirect -> AlipayRedirectParser()
@@ -57,6 +58,21 @@ internal class NextActionDataParser : ModelJsonParser<StripeIntent.NextActionDat
             json: JSONObject
         ): StripeIntent.NextActionData.DisplayBoletoDetails {
             return StripeIntent.NextActionData.DisplayBoletoDetails(
+                hostedVoucherUrl = optString(json, FIELD_HOSTED_VOUCHER_URL)
+            )
+        }
+
+        private companion object {
+            private const val FIELD_HOSTED_VOUCHER_URL = "hosted_voucher_url"
+        }
+    }
+
+    private class DisplayKonbiniDetailsJsonParser :
+        ModelJsonParser<StripeIntent.NextActionData.DisplayKonbiniDetails> {
+        override fun parse(
+            json: JSONObject
+        ): StripeIntent.NextActionData.DisplayKonbiniDetails {
+            return StripeIntent.NextActionData.DisplayKonbiniDetails(
                 hostedVoucherUrl = optString(json, FIELD_HOSTED_VOUCHER_URL)
             )
         }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/KonbiniAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/KonbiniAuthenticator.kt
@@ -8,12 +8,12 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * [PaymentAuthenticator] for [NextActionData.DisplayBoletoDetails], redirects to
+ * [PaymentAuthenticator] for [NextActionData.DisplayKonbiniDetails], redirects to
  * [WebIntentAuthenticator] or [NoOpIntentAuthenticator] based on whether if there is a
  * hostedVoucherUrl set.
  */
 @Singleton
-internal class BoletoAuthenticator @Inject constructor(
+internal class KonbiniAuthenticator @Inject constructor(
     private val webIntentAuthenticator: WebIntentAuthenticator,
     private val noOpIntentAuthenticator: NoOpIntentAuthenticator
 ) : PaymentAuthenticator<StripeIntent>() {
@@ -22,7 +22,7 @@ internal class BoletoAuthenticator @Inject constructor(
         authenticatable: StripeIntent,
         requestOptions: ApiRequest.Options
     ) {
-        (authenticatable.nextActionData as NextActionData.DisplayBoletoDetails).let { detailsData ->
+        (authenticatable.nextActionData as NextActionData.DisplayKonbiniDetails).let { detailsData ->
             if (detailsData.hostedVoucherUrl == null) {
                 noOpIntentAuthenticator.authenticate(
                     host,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
@@ -91,6 +91,13 @@ internal class WebIntentAuthenticator @Inject constructor(
                 returnUrl = null
                 shouldCancelIntentOnUserNavigation = false
             }
+            is StripeIntent.NextActionData.DisplayKonbiniDetails -> {
+                // nextActionData.hostedVoucherUrl will never be null as AuthenticatorRegistry won't direct it here
+                authUrl = nextActionData.hostedVoucherUrl.takeIf { it!!.isNotEmpty() }
+                    ?: throw IllegalArgumentException("null hostedVoucherUrl for DisplayKonbiniDetails")
+                returnUrl = null
+                shouldCancelIntentOnUserNavigation = false
+            }
             is StripeIntent.NextActionData.CashAppRedirect -> {
                 authUrl = nextActionData.mobileAuthUrl
                 returnUrl = defaultReturnUrl.value

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationModule.kt
@@ -8,6 +8,7 @@ import com.stripe.android.model.StripeIntent.NextActionData
 import com.stripe.android.payments.DefaultReturnUrl
 import com.stripe.android.payments.core.authentication.BoletoAuthenticator
 import com.stripe.android.payments.core.authentication.DefaultPaymentAuthenticatorRegistry
+import com.stripe.android.payments.core.authentication.KonbiniAuthenticator
 import com.stripe.android.payments.core.authentication.OxxoAuthenticator
 import com.stripe.android.payments.core.authentication.PaymentAuthenticator
 import com.stripe.android.payments.core.authentication.WebIntentAuthenticator
@@ -55,6 +56,14 @@ internal abstract class AuthenticationModule {
     @IntentAuthenticatorKey(NextActionData.DisplayOxxoDetails::class)
     abstract fun bindsOxxoAuthenticator(
         oxxoAuthenticator: OxxoAuthenticator
+    ): PaymentAuthenticator<StripeIntent>
+
+    @IntentAuthenticatorMap
+    @Binds
+    @IntoMap
+    @IntentAuthenticatorKey(NextActionData.DisplayKonbiniDetails::class)
+    abstract fun bindsKonbiniAuthenticator(
+        konbiniAuthenticator: KonbiniAuthenticator
     ): PaymentAuthenticator<StripeIntent>
 
     @IntentAuthenticatorMap

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -461,6 +461,22 @@ public final class com/stripe/android/ui/core/elements/KlarnaCountrySpec$Compani
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/KonbiniConfirmationNumberSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/KonbiniConfirmationNumberSpec$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/ui/core/elements/KonbiniConfirmationNumberSpec;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/ui/core/elements/KonbiniConfirmationNumberSpec;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/KonbiniConfirmationNumberSpec$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/stripe/android/ui/core/elements/LayoutSpec$Companion {
 	public final fun create ()Lcom/stripe/android/ui/core/elements/LayoutSpec;
 	public final fun create ([Lcom/stripe/android/ui/core/elements/FormItemSpec;)Lcom/stripe/android/ui/core/elements/LayoutSpec;

--- a/payments-ui-core/res/drawable/stripe_ic_paymentsheet_pm_konbini.xml
+++ b/payments-ui-core/res/drawable/stripe_ic_paymentsheet_pm_konbini.xml
@@ -1,0 +1,36 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="m4.867,6a2.227,2.227 45,0 1,1.16 -1.867c0.547,-0.4 0.72,-0.533 0.72,-0.88s-0.173,-0.587 -0.493,-0.587 -0.533,0.24 -0.587,0.573l-0.813,0a1.333,1.333 0,0 1,1.4 -1.24c1,0 1.333,0.6 1.333,1.187s-0.227,0.813 -0.92,1.36c-0.48,0.333 -0.667,0.56 -0.733,0.733l1.813,0l-0.107,0.72z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="m9.893,6l0,-0.88l-1.773,0l0,-0.747l1.627,-2.293l0.92,0l0,2.347l0.467,0l0,0.693l-0.467,0l0,0.88zM9.893,3.733c0,-0.427 0,-0.667 0,-0.92a17.107,17.107 0,0 1,-1.04 1.613l1.027,0z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="m12,1.333l0,5.333l-8,0l0,-5.333zM12,0l-8,0a1.333,1.333 0,0 0,-1.333 1.333l0,5.333a1.333,1.333 0,0 0,1.333 1.333l8,0a1.333,1.333 0,0 0,1.333 -1.333l0,-5.333a1.333,1.333 0,0 0,-1.333 -1.333z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="m10.667,10.667l0,4l-5.333,0l0,-4zM10.667,9.333l-5.333,0a1.333,1.333 0,0 0,-1.333 1.333l0,4a1.333,1.333 0,0 0,1.333 1.333l5.333,0a1.333,1.333 0,0 0,1.333 -1.333l0,-4a1.333,1.333 0,0 0,-1.333 -1.333z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="m7.333,10l1.333,0l0,5.187l-1.333,0z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="m1.093,5.333l2.707,0l0,2.667l-2.707,0z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="m1.093,2.667l2.52,0l0,1.36l-2.52,0z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="m12.413,2.667l2.52,0l0,1.36l-2.52,0z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="m12.133,5.333l2.987,0l0,2.667l-2.987,0z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="m14.667,1.333l-2.667,0l0,1.333l2.667,0l0,12l-13.333,0l0,-12l2.667,0l0,-1.333l-2.667,0a1.333,1.333 0,0 0,-1.333 1.333l0,12a1.333,1.333 0,0 0,1.333 1.333l13.333,0a1.333,1.333 0,0 0,1.333 -1.333l0,-12a1.333,1.333 0,0 0,-1.333 -1.333z" />
+</vector>

--- a/payments-ui-core/res/values/donottranslate.xml
+++ b/payments-ui-core/res/values/donottranslate.xml
@@ -17,7 +17,6 @@
     <string name="stripe_paymentsheet_payment_method_grabpay">GrabPay</string>
     <string name="stripe_paymentsheet_payment_method_fpx">FPX Bank</string>
     <string name="stripe_paymentsheet_payment_method_boleto">Boleto</string>
-    <string name="stripe_paymentsheet_payment_method_konbini">Konbini</string>
 
     <string name="stripe_paymentsheet_payment_method_affirm">Affirm</string>
     <string name="stripe_paymentsheet_payment_method_revolut_pay">Revolut Pay</string>

--- a/payments-ui-core/res/values/donottranslate.xml
+++ b/payments-ui-core/res/values/donottranslate.xml
@@ -17,6 +17,7 @@
     <string name="stripe_paymentsheet_payment_method_grabpay">GrabPay</string>
     <string name="stripe_paymentsheet_payment_method_fpx">FPX Bank</string>
     <string name="stripe_paymentsheet_payment_method_boleto">Boleto</string>
+    <string name="stripe_paymentsheet_payment_method_konbini">Konbini</string>
 
     <string name="stripe_paymentsheet_payment_method_affirm">Affirm</string>
     <string name="stripe_paymentsheet_payment_method_revolut_pay">Revolut Pay</string>

--- a/payments-ui-core/res/values/strings.xml
+++ b/payments-ui-core/res/values/strings.xml
@@ -18,8 +18,6 @@
   <string name="stripe_blik_code">BLIK code</string>
   <!-- Label for Boleto Payment method Tax ID -->
   <string name="stripe_boleto_tax_id_label">CPF/CNPJ</string>
-  <!-- Label for Konbini Confirmation Number -->
-  <string name="stripe_konbini_confirmation_number_label">Phone</string>
   <!-- Cash App mandate text -->
   <string name="stripe_cash_app_pay_mandate">By continuing, you authorize %1$s to debit your Cash App account for this payment and future payments in accordance with %2$s\'s terms, until this authorization is revoked. You can change this anytime in your Cash App Settings.</string>
   <!-- Title for the contact information section -->
@@ -79,4 +77,8 @@
   <string name="stripe_setup_button_label">Set up</string>
   <!-- Label for UPI ID number field on form -->
   <string name="stripe_upi_id_label">UPI ID</string>
+  <!-- Label for Konbini Payment Method -->
+  <string name="stripe_paymentsheet_payment_method_konbini">Konbini</string>
+  <!-- Label for Konbini Confirmation Number -->
+  <string name="stripe_konbini_confirmation_number_label">Phone</string>
 </resources>

--- a/payments-ui-core/res/values/strings.xml
+++ b/payments-ui-core/res/values/strings.xml
@@ -18,6 +18,8 @@
   <string name="stripe_blik_code">BLIK code</string>
   <!-- Label for Boleto Payment method Tax ID -->
   <string name="stripe_boleto_tax_id_label">CPF/CNPJ</string>
+  <!-- Label for Konbini Confirmation Number -->
+  <string name="stripe_konbini_confirmation_number_label">Phone</string>
   <!-- Cash App mandate text -->
   <string name="stripe_cash_app_pay_mandate">By continuing, you authorize %1$s to debit your Cash App account for this payment and future payments in accordance with %2$s\'s terms, until this authorization is revoked. You can change this anytime in your Cash App Settings.</string>
   <!-- Title for the contact information section -->

--- a/payments-ui-core/src/main/assets/lpms.json
+++ b/payments-ui-core/src/main/assets/lpms.json
@@ -1065,5 +1065,26 @@
         "allowed_country_codes": ["BR"]
       }
     ]
+  },
+  {
+    "type": "konbini",
+    "async": false,
+    "fields": [
+      {
+        "type": "name",
+        "api_path": {
+          "v1": "billing_details[name]"
+        }
+      },
+      {
+        "type": "email",
+        "api_path": {
+          "v1": "billing_details[email]"
+        }
+      },
+      {
+        "type": "konbini_confirmation_number"
+      }
+    ]
   }
 ]

--- a/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
@@ -293,5 +293,5 @@ internal val BoletoRequirement = PaymentMethodRequirements(
 internal val KonbiniRequirement = PaymentMethodRequirements(
     piRequirements = setOf(Delayed),
     siRequirements = null,
-    confirmPMFromCustomer = true,
+    confirmPMFromCustomer = null,
 )

--- a/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
@@ -292,6 +292,6 @@ internal val BoletoRequirement = PaymentMethodRequirements(
 
 internal val KonbiniRequirement = PaymentMethodRequirements(
     piRequirements = setOf(Delayed),
-    siRequirements = setOf(Delayed),
+    siRequirements = null,
     confirmPMFromCustomer = true,
 )

--- a/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
@@ -289,3 +289,9 @@ internal val BoletoRequirement = PaymentMethodRequirements(
     siRequirements = setOf(Delayed),
     confirmPMFromCustomer = true,
 )
+
+internal val KonbiniRequirement = PaymentMethodRequirements(
+    piRequirements = setOf(Delayed),
+    siRequirements = setOf(Delayed),
+    confirmPMFromCustomer = true,
+)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
@@ -40,6 +40,7 @@ class FieldValuesToParamsMapConverter {
         /**
          * This function will convert fieldValuePairs to PaymentMethodOptionsParams.
          */
+        @Suppress("ReturnCount")
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         fun transformToPaymentMethodOptionsParams(
             fieldValuePairs: Map<IdentifierSpec, FormFieldEntry>,
@@ -51,6 +52,11 @@ class FieldValuesToParamsMapConverter {
                     return PaymentMethodOptionsParams.Blik(
                         blikCode
                     )
+                }
+            } else if (code == PaymentMethod.Type.Konbini.code) {
+                val confirmationNumber = fieldValuePairs[IdentifierSpec.KonbiniConfirmationNumber]?.value
+                if (confirmationNumber != null) {
+                    return PaymentMethodOptionsParams.Konbini(confirmationNumber)
                 }
             }
             return null

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/FormItemSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/FormItemSpec.kt
@@ -43,6 +43,7 @@ object FormItemSpecSerializer :
             "au_becs_account_number" -> AuBankAccountNumberSpec.serializer()
             "au_becs_mandate" -> AuBecsDebitMandateTextSpec.serializer()
             "boleto_tax_id" -> BoletoTaxIdSpec.serializer()
+            "konbini_confirmation_number" -> KonbiniConfirmationNumberSpec.serializer()
             "country" -> CountrySpec.serializer()
             "selector" -> DropdownSpec.serializer()
             "email" -> EmailSpec.serializer()

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/KonbiniConfirmationNumberSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/KonbiniConfirmationNumberSpec.kt
@@ -1,0 +1,26 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.ui.core.R
+import com.stripe.android.uicore.elements.FormElement
+import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+
+@Serializable
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+class KonbiniConfirmationNumberSpec : FormItemSpec() {
+    override val apiPath: IdentifierSpec = IdentifierSpec.KonbiniConfirmationNumber
+
+    @Transient
+    private val simpleTextSpec = SimpleTextSpec(
+        apiPath,
+        R.string.stripe_konbini_confirmation_number_label,
+        keyboardType = KeyboardType.Phone,
+        showOptionalLabel = true,
+    )
+
+    fun transform(initialValues: Map<IdentifierSpec, String?>): FormElement {
+        return simpleTextSpec.transform(initialValues)
+    }
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
@@ -24,6 +24,7 @@ import com.stripe.android.ui.core.elements.FormItemSpec
 import com.stripe.android.ui.core.elements.IbanSpec
 import com.stripe.android.ui.core.elements.KlarnaCountrySpec
 import com.stripe.android.ui.core.elements.KlarnaHeaderStaticTextSpec
+import com.stripe.android.ui.core.elements.KonbiniConfirmationNumberSpec
 import com.stripe.android.ui.core.elements.LayoutSpec
 import com.stripe.android.ui.core.elements.MandateTextSpec
 import com.stripe.android.ui.core.elements.NameSpec
@@ -101,6 +102,7 @@ class TransformSpecToElements(
                     shippingValues,
                 )
                 is BoletoTaxIdSpec -> it.transform(initialValues)
+                is KonbiniConfirmationNumberSpec -> it.transform(initialValues)
                 is SepaMandateTextSpec -> it.transform(merchantName)
                 is UpiSpec -> it.transform()
                 is BlikSpec -> it.transform()

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
@@ -31,6 +31,7 @@ import com.stripe.android.paymentsheet.forms.GiropayRequirement
 import com.stripe.android.paymentsheet.forms.GrabPayRequirement
 import com.stripe.android.paymentsheet.forms.IdealRequirement
 import com.stripe.android.paymentsheet.forms.KlarnaRequirement
+import com.stripe.android.paymentsheet.forms.KonbiniRequirement
 import com.stripe.android.paymentsheet.forms.MobilePayRequirement
 import com.stripe.android.paymentsheet.forms.OxxoRequirement
 import com.stripe.android.paymentsheet.forms.P24Requirement
@@ -576,6 +577,17 @@ class LpmRepository constructor(
             darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
             tintIconOnSelection = false,
             requirement = BoletoRequirement,
+            formSpec = LayoutSpec(sharedDataSpec.fields),
+        )
+        PaymentMethod.Type.Konbini.code -> SupportedPaymentMethod(
+            code = "konbini",
+            requiresMandate = false,
+            displayNameResource = R.string.stripe_paymentsheet_payment_method_konbini,
+            iconResource = R.drawable.stripe_ic_paymentsheet_pm_konbini,
+            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+            tintIconOnSelection = false,
+            requirement = KonbiniRequirement,
             formSpec = LayoutSpec(sharedDataSpec.fields),
         )
         else -> null

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestKonbini.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestKonbini.kt
@@ -1,0 +1,38 @@
+package com.stripe.android.lpm
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.stripe.android.BaseLpmTest
+import com.stripe.android.test.core.AuthorizeAction
+import com.stripe.android.test.core.Billing
+import com.stripe.android.test.core.Currency
+import com.stripe.android.test.core.Customer
+import com.stripe.android.test.core.DelayedPMs
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class TestKonbini : BaseLpmTest() {
+    private val konbini = newUser.copy(
+        customer = Customer.Guest,
+        paymentMethod = lpmRepository.fromCode("konbini")!!,
+        currency = Currency.JPY,
+        merchantCountryCode = "JP",
+        delayed = DelayedPMs.On,
+        billing = Billing.Off,
+        authorizationAction = AuthorizeAction.DisplayQrCode,
+    )
+
+    @Test
+    fun testKonbini() {
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = konbini,
+        )
+    }
+
+    @Test
+    fun testKonbiniInCustomFlow() {
+        testDriver.confirmCustom(
+            testParameters = konbini,
+        )
+    }
+}

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
@@ -146,6 +146,7 @@ enum class Currency {
     MYR,
     BRL,
     MXN,
+    JPY,
 }
 
 /**

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/EspressoText.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/EspressoText.kt
@@ -2,12 +2,23 @@ package com.stripe.android.test.core.ui
 
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.ViewActions.scrollTo
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withText
 
-open class EspressoText(private val text: String) {
+open class EspressoText(text: String) {
+    private val interaction = onView(withText(text))
 
     fun click() {
-        onView(withText(text))
-            .perform(ViewActions.click())
+        val isNotVisible = runCatching {
+            interaction.check(matches(isCompletelyDisplayed()))
+        }.isFailure
+
+        if (isNotVisible) {
+            interaction.perform(scrollTo())
+        }
+
+        interaction.perform(ViewActions.click())
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
@@ -646,9 +646,7 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
         if (viewBinding.shippingAddressCountriesGroup.checkedRadioButtonId ==
             viewBinding.shippingAddressCountriesPartialButton.id
         ) {
-            builder.allowedCountries(
-                setOf("US", "CA", "AU", "GB", "FR", "JP", "KR", "BR")
-            )
+            builder.allowedCountries(stripeSupportedCurrencies.toSet())
         }
         val phone = when (viewBinding.shippingAddressPhoneRadioGroup.checkedRadioButtonId) {
             viewBinding.shippingAddressPhoneRequiredButton.id -> {
@@ -882,7 +880,7 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
                 /**
                  * Modify this list if you want to change the countries displayed in the playground.
                  */
-                country.code.value in setOf("US", "GB", "AU", "FR", "IN", "SG", "MY", "MX", "BR")
+                country.code.value in setOf("US", "GB", "AU", "FR", "IN", "SG", "MY", "MX", "BR", "JP")
             }.map { country ->
                 /**
                  * Modify this statement to change the default currency associated with each
@@ -916,6 +914,9 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
                     "BR" -> {
                         country to "BRL"
                     }
+                    "JP" -> {
+                        country to "JPY"
+                    }
                     else -> {
                         country to "USD"
                     }
@@ -935,6 +936,7 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
             "MYR",
             "MXN",
             "BRL",
+            "JPY"
         )
     }
 }

--- a/paymentsheet/src/test/resources/konbini-support.csv
+++ b/paymentsheet/src/test/resources/konbini-support.csv
@@ -7,8 +7,8 @@ konbini, true, true, on_session, false, card/konbini, false, false, not availabl
 konbini, true, true, on_session, false, card/eps/konbini, false, false, not available, false
 konbini, true, false, on_session, false, card/konbini, false, false, not available, false
 konbini, true, false, on_session, false, card/eps/konbini, false, false, not available, false
-konbini, true, true, null, false, card/konbini, true, true, oneTime, true
-konbini, true, true, null, false, card/eps/konbini, true, true, oneTime, true
+konbini, true, true, null, false, card/konbini, false, true, oneTime, true
+konbini, true, true, null, false, card/eps/konbini, false, true, oneTime, true
 konbini, true, false, null, false, card/konbini, false, false, not available, false
 konbini, true, false, null, false, card/eps/konbini, false, false, not available, false
 konbini, false, true, off_session, false, card/konbini, false, false, not available, false
@@ -19,8 +19,8 @@ konbini, false, true, on_session, false, card/konbini, false, false, not availab
 konbini, false, true, on_session, false, card/eps/konbini, false, false, not available, false
 konbini, false, false, on_session, false, card/konbini, false, false, not available, false
 konbini, false, false, on_session, false, card/eps/konbini, false, false, not available, false
-konbini, false, true, null, false, card/konbini, true, true, oneTime, true
-konbini, false, true, null, false, card/eps/konbini, true, true, oneTime, true
+konbini, false, true, null, false, card/konbini, false, true, oneTime, true
+konbini, false, true, null, false, card/eps/konbini, false, true, oneTime, true
 konbini, false, false, null, false, card/konbini, false, false, not available, false
 konbini, false, false, null, false, card/eps/konbini, false, false, not available, false
 konbini, true, true, off_session, true, card/konbini, false, false, not available, false
@@ -31,8 +31,8 @@ konbini, true, true, on_session, true, card/konbini, false, false, not available
 konbini, true, true, on_session, true, card/eps/konbini, false, false, not available, false
 konbini, true, false, on_session, true, card/konbini, false, false, not available, false
 konbini, true, false, on_session, true, card/eps/konbini, false, false, not available, false
-konbini, true, true, null, true, card/konbini, true, true, oneTime, true
-konbini, true, true, null, true, card/eps/konbini, true, true, oneTime, true
+konbini, true, true, null, true, card/konbini, false, true, oneTime, true
+konbini, true, true, null, true, card/eps/konbini, false, true, oneTime, true
 konbini, true, false, null, true, card/konbini, false, false, not available, false
 konbini, true, false, null, true, card/eps/konbini, false, false, not available, false
 konbini, false, true, off_session, true, card/konbini, false, false, not available, false
@@ -43,7 +43,7 @@ konbini, false, true, on_session, true, card/konbini, false, false, not availabl
 konbini, false, true, on_session, true, card/eps/konbini, false, false, not available, false
 konbini, false, false, on_session, true, card/konbini, false, false, not available, false
 konbini, false, false, on_session, true, card/eps/konbini, false, false, not available, false
-konbini, false, true, null, true, card/konbini, true, true, oneTime, true
-konbini, false, true, null, true, card/eps/konbini, true, true, oneTime, true
+konbini, false, true, null, true, card/konbini, false, true, oneTime, true
+konbini, false, true, null, true, card/eps/konbini, false, true, oneTime, true
 konbini, false, false, null, true, card/konbini, false, false, not available, false
 konbini, false, false, null, true, card/eps/konbini, false, false, not available, false

--- a/paymentsheet/src/test/resources/konbini-support.csv
+++ b/paymentsheet/src/test/resources/konbini-support.csv
@@ -1,0 +1,49 @@
+lpm, hasCustomer, allowsDelayedPayment, intentSetupFutureUsage, intentHasShipping, intentLpms, supportCustomerSavedCard, formExists, formType, supportsAdding
+konbini, true, true, off_session, false, card/konbini, true, true, merchantRequiredSave, true
+konbini, true, true, off_session, false, card/eps/konbini, true, true, merchantRequiredSave, true
+konbini, true, false, off_session, false, card/konbini, false, false, not available, false
+konbini, true, false, off_session, false, card/eps/konbini, false, false, not available, false
+konbini, true, true, on_session, false, card/konbini, true, true, merchantRequiredSave, true
+konbini, true, true, on_session, false, card/eps/konbini, true, true, merchantRequiredSave, true
+konbini, true, false, on_session, false, card/konbini, false, false, not available, false
+konbini, true, false, on_session, false, card/eps/konbini, false, false, not available, false
+konbini, true, true, null, false, card/konbini, true, true, userSelectedSave, true
+konbini, true, true, null, false, card/eps/konbini, true, true, userSelectedSave, true
+konbini, true, false, null, false, card/konbini, false, false, not available, false
+konbini, true, false, null, false, card/eps/konbini, false, false, not available, false
+konbini, false, true, off_session, false, card/konbini, true, true, merchantRequiredSave, true
+konbini, false, true, off_session, false, card/eps/konbini, true, true, merchantRequiredSave, true
+konbini, false, false, off_session, false, card/konbini, false, false, not available, false
+konbini, false, false, off_session, false, card/eps/konbini, false, false, not available, false
+konbini, false, true, on_session, false, card/konbini, true, true, merchantRequiredSave, true
+konbini, false, true, on_session, false, card/eps/konbini, true, true, merchantRequiredSave, true
+konbini, false, false, on_session, false, card/konbini, false, false, not available, false
+konbini, false, false, on_session, false, card/eps/konbini, false, false, not available, false
+konbini, false, true, null, false, card/konbini, true, true, oneTime, true
+konbini, false, true, null, false, card/eps/konbini, true, true, oneTime, true
+konbini, false, false, null, false, card/konbini, false, false, not available, false
+konbini, false, false, null, false, card/eps/konbini, false, false, not available, false
+konbini, true, true, off_session, true, card/konbini, true, true, merchantRequiredSave, true
+konbini, true, true, off_session, true, card/eps/konbini, true, true, merchantRequiredSave, true
+konbini, true, false, off_session, true, card/konbini, false, false, not available, false
+konbini, true, false, off_session, true, card/eps/konbini, false, false, not available, false
+konbini, true, true, on_session, true, card/konbini, true, true, merchantRequiredSave, true
+konbini, true, true, on_session, true, card/eps/konbini, true, true, merchantRequiredSave, true
+konbini, true, false, on_session, true, card/konbini, false, false, not available, false
+konbini, true, false, on_session, true, card/eps/konbini, false, false, not available, false
+konbini, true, true, null, true, card/konbini, true, true, userSelectedSave, true
+konbini, true, true, null, true, card/eps/konbini, true, true, userSelectedSave, true
+konbini, true, false, null, true, card/konbini, false, false, not available, false
+konbini, true, false, null, true, card/eps/konbini, false, false, not available, false
+konbini, false, true, off_session, true, card/konbini, true, true, merchantRequiredSave, true
+konbini, false, true, off_session, true, card/eps/konbini, true, true, merchantRequiredSave, true
+konbini, false, false, off_session, true, card/konbini, false, false, not available, false
+konbini, false, false, off_session, true, card/eps/konbini, false, false, not available, false
+konbini, false, true, on_session, true, card/konbini, true, true, merchantRequiredSave, true
+konbini, false, true, on_session, true, card/eps/konbini, true, true, merchantRequiredSave, true
+konbini, false, false, on_session, true, card/konbini, false, false, not available, false
+konbini, false, false, on_session, true, card/eps/konbini, false, false, not available, false
+konbini, false, true, null, true, card/konbini, true, true, oneTime, true
+konbini, false, true, null, true, card/eps/konbini, true, true, oneTime, true
+konbini, false, false, null, true, card/konbini, false, false, not available, false
+konbini, false, false, null, true, card/eps/konbini, false, false, not available, false

--- a/paymentsheet/src/test/resources/konbini-support.csv
+++ b/paymentsheet/src/test/resources/konbini-support.csv
@@ -1,46 +1,46 @@
 lpm, hasCustomer, allowsDelayedPayment, intentSetupFutureUsage, intentHasShipping, intentLpms, supportCustomerSavedCard, formExists, formType, supportsAdding
-konbini, true, true, off_session, false, card/konbini, true, true, merchantRequiredSave, true
-konbini, true, true, off_session, false, card/eps/konbini, true, true, merchantRequiredSave, true
+konbini, true, true, off_session, false, card/konbini, false, false, not available, false
+konbini, true, true, off_session, false, card/eps/konbini, false, false, not available, false
 konbini, true, false, off_session, false, card/konbini, false, false, not available, false
 konbini, true, false, off_session, false, card/eps/konbini, false, false, not available, false
-konbini, true, true, on_session, false, card/konbini, true, true, merchantRequiredSave, true
-konbini, true, true, on_session, false, card/eps/konbini, true, true, merchantRequiredSave, true
+konbini, true, true, on_session, false, card/konbini, false, false, not available, false
+konbini, true, true, on_session, false, card/eps/konbini, false, false, not available, false
 konbini, true, false, on_session, false, card/konbini, false, false, not available, false
 konbini, true, false, on_session, false, card/eps/konbini, false, false, not available, false
-konbini, true, true, null, false, card/konbini, true, true, userSelectedSave, true
-konbini, true, true, null, false, card/eps/konbini, true, true, userSelectedSave, true
+konbini, true, true, null, false, card/konbini, true, true, oneTime, true
+konbini, true, true, null, false, card/eps/konbini, true, true, oneTime, true
 konbini, true, false, null, false, card/konbini, false, false, not available, false
 konbini, true, false, null, false, card/eps/konbini, false, false, not available, false
-konbini, false, true, off_session, false, card/konbini, true, true, merchantRequiredSave, true
-konbini, false, true, off_session, false, card/eps/konbini, true, true, merchantRequiredSave, true
+konbini, false, true, off_session, false, card/konbini, false, false, not available, false
+konbini, false, true, off_session, false, card/eps/konbini, false, false, not available, false
 konbini, false, false, off_session, false, card/konbini, false, false, not available, false
 konbini, false, false, off_session, false, card/eps/konbini, false, false, not available, false
-konbini, false, true, on_session, false, card/konbini, true, true, merchantRequiredSave, true
-konbini, false, true, on_session, false, card/eps/konbini, true, true, merchantRequiredSave, true
+konbini, false, true, on_session, false, card/konbini, false, false, not available, false
+konbini, false, true, on_session, false, card/eps/konbini, false, false, not available, false
 konbini, false, false, on_session, false, card/konbini, false, false, not available, false
 konbini, false, false, on_session, false, card/eps/konbini, false, false, not available, false
 konbini, false, true, null, false, card/konbini, true, true, oneTime, true
 konbini, false, true, null, false, card/eps/konbini, true, true, oneTime, true
 konbini, false, false, null, false, card/konbini, false, false, not available, false
 konbini, false, false, null, false, card/eps/konbini, false, false, not available, false
-konbini, true, true, off_session, true, card/konbini, true, true, merchantRequiredSave, true
-konbini, true, true, off_session, true, card/eps/konbini, true, true, merchantRequiredSave, true
+konbini, true, true, off_session, true, card/konbini, false, false, not available, false
+konbini, true, true, off_session, true, card/eps/konbini, false, false, not available, false
 konbini, true, false, off_session, true, card/konbini, false, false, not available, false
 konbini, true, false, off_session, true, card/eps/konbini, false, false, not available, false
-konbini, true, true, on_session, true, card/konbini, true, true, merchantRequiredSave, true
-konbini, true, true, on_session, true, card/eps/konbini, true, true, merchantRequiredSave, true
+konbini, true, true, on_session, true, card/konbini, false, false, not available, false
+konbini, true, true, on_session, true, card/eps/konbini, false, false, not available, false
 konbini, true, false, on_session, true, card/konbini, false, false, not available, false
 konbini, true, false, on_session, true, card/eps/konbini, false, false, not available, false
-konbini, true, true, null, true, card/konbini, true, true, userSelectedSave, true
-konbini, true, true, null, true, card/eps/konbini, true, true, userSelectedSave, true
+konbini, true, true, null, true, card/konbini, true, true, oneTime, true
+konbini, true, true, null, true, card/eps/konbini, true, true, oneTime, true
 konbini, true, false, null, true, card/konbini, false, false, not available, false
 konbini, true, false, null, true, card/eps/konbini, false, false, not available, false
-konbini, false, true, off_session, true, card/konbini, true, true, merchantRequiredSave, true
-konbini, false, true, off_session, true, card/eps/konbini, true, true, merchantRequiredSave, true
+konbini, false, true, off_session, true, card/konbini, false, false, not available, false
+konbini, false, true, off_session, true, card/eps/konbini, false, false, not available, false
 konbini, false, false, off_session, true, card/konbini, false, false, not available, false
 konbini, false, false, off_session, true, card/eps/konbini, false, false, not available, false
-konbini, false, true, on_session, true, card/konbini, true, true, merchantRequiredSave, true
-konbini, false, true, on_session, true, card/eps/konbini, true, true, merchantRequiredSave, true
+konbini, false, true, on_session, true, card/konbini, false, false, not available, false
+konbini, false, true, on_session, true, card/eps/konbini, false, false, not available, false
 konbini, false, false, on_session, true, card/konbini, false, false, not available, false
 konbini, false, false, on_session, true, card/eps/konbini, false, false, not available, false
 konbini, false, true, null, true, card/konbini, true, true, oneTime, true

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/IdentifierSpec.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/IdentifierSpec.kt
@@ -78,6 +78,11 @@ data class IdentifierSpec(
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         val BlikCode = IdentifierSpec("blik[code]", apiParameterDestination = ApiParameterDestination.Options)
 
+        val KonbiniConfirmationNumber = IdentifierSpec(
+            v1 = "konbini[confirmation_number]",
+            apiParameterDestination = ApiParameterDestination.Options
+        )
+
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
         fun get(value: String) = when (value) {
             CardBrand.v1 -> CardBrand

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/IdentifierSpec.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/IdentifierSpec.kt
@@ -78,6 +78,7 @@ data class IdentifierSpec(
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         val BlikCode = IdentifierSpec("blik[code]", apiParameterDestination = ApiParameterDestination.Options)
 
+        @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         val KonbiniConfirmationNumber = IdentifierSpec(
             v1 = "konbini[confirmation_number]",
             apiParameterDestination = ApiParameterDestination.Options


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Note both Checkout and web PE don't use their normal 'phone number' field to collect it - it's just a normal text field (11 digits max, numbers only) and doesn't interact with merchant configuration related to the collection of a phone number (e.g. Checkout shows a separate phone field if you tell it to collect a phone number).


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
LPM Sprint

[Screen_recording_20230914_093653.webm](https://github.com/stripe/stripe-android/assets/116920913/56a1ce85-d645-46da-b6fb-28a15d49ed99)

