### PR TITLE
Fetch updated translations after updating Lokalise

### DIFF
--- a/scripts/localize.sh
+++ b/scripts/localize.sh
@@ -12,6 +12,18 @@
 # This script can be run with no arguments:
 #  ./localize.sh
 
+ENGLISH_ONLY=false
+
+for ARGUMENT in "$@"
+do
+    puts "$ARGUMENT"
+    if [ "$ARGUMENT" = "ENGLISH_ONLY" ]; then
+        echo "Only updating English translations due to ENGLISH_ONLY flag"
+        ENGLISH_ONLY=true
+        break
+    fi
+done
+
 API_TOKEN=$LOKALISE_API_TOKEN
 if [ -z "$API_TOKEN" ]; then
   echo "You need to add the API_TOKEN to: localization_vars.sh"
@@ -41,17 +53,20 @@ for MODULE in ${MODULES[@]}
 do
     echo ""
     echo "Downloading strings for $MODULE/strings.xml"
-    lokalise2 --token $API_TOKEN \
-          --project-id $PROJECT_ID \
-          file download \
-          --format xml \
-          --filter-langs $LANGUAGES \
-          --filter-filenames $MODULE/strings.xml \
-          --custom-translation-status-ids $FINAL_STATUS_ID \
-          --export-sort "a_z" \
-          --directory-prefix . \
-          --original-filenames=false \
-          --bundle-structure "android/$MODULE/values-%LANG_ISO%/strings.xml"
+
+    if [ "$ENGLISH_ONLY" = "false" ]; then
+        lokalise2 --token $API_TOKEN \
+                  --project-id $PROJECT_ID \
+                  file download \
+                  --format xml \
+                  --filter-langs $LANGUAGES \
+                  --filter-filenames $MODULE/strings.xml \
+                  --custom-translation-status-ids $FINAL_STATUS_ID \
+                  --export-sort "a_z" \
+                  --directory-prefix . \
+                  --original-filenames=false \
+                  --bundle-structure "android/$MODULE/values-%LANG_ISO%/strings.xml"
+    fi
 
     # Need to download english separately because their strings are not marked final (this is what we uploaded)
     # This must be done after the first one.
@@ -67,16 +82,22 @@ do
           --bundle-structure "android/$MODULE/values-%LANG_ISO%/strings.xml"
 
     #There is a command line switch that might be better than this, see: --language-mapping
-    mv android/$MODULE/values-es-r419 android/$MODULE/values-b+es+419
-    mv android/$MODULE/values-zh-rHant android/$MODULE/values-zh-rTW
-    mv android/$MODULE/values-zh-rHans android/$MODULE/values-zh
-    mv android/$MODULE/values-id android/$MODULE/values-in
+    if [ "$ENGLISH_ONLY" = "false" ]; then
+        mv android/$MODULE/values-es-r419 android/$MODULE/values-b+es+419
+        mv android/$MODULE/values-zh-rHant android/$MODULE/values-zh-rTW
+        mv android/$MODULE/values-zh-rHans android/$MODULE/values-zh
+        mv android/$MODULE/values-id android/$MODULE/values-in
+    fi
 
     # This is used by the untranslated_project_keys.sh script
-    cp android/$MODULE/values-en-rGB/strings.xml android/$MODULE-lokalize-strings.xml
+    if [ "$ENGLISH_ONLY" = "false" ]; then
+        cp android/$MODULE/values-en-rGB/strings.xml android/$MODULE-lokalize-strings.xml
+    fi
 
     # Remove the existing strings files
-    find ../$MODULE/res -type f -name strings.xml | xargs rm
+    if [ "$ENGLISH_ONLY" = "false" ]; then
+        find ../$MODULE/res -type f -name strings.xml | xargs rm
+    fi
 
     # Copy in the new strings files
     cp -R  android/$MODULE/* ../$MODULE/res/

--- a/scripts/localize.sh
+++ b/scripts/localize.sh
@@ -16,7 +16,6 @@ ENGLISH_ONLY=false
 
 for ARGUMENT in "$@"
 do
-    puts "$ARGUMENT"
     if [ "$ARGUMENT" = "ENGLISH_ONLY" ]; then
         echo "Only updating English translations due to ENGLISH_ONLY flag"
         ENGLISH_ONLY=true

--- a/scripts/localize.sh
+++ b/scripts/localize.sh
@@ -12,16 +12,10 @@
 # This script can be run with no arguments:
 #  ./localize.sh
 
-ENGLISH_ONLY=false
-
-for ARGUMENT in "$@"
-do
-    if [ "$ARGUMENT" = "ENGLISH_ONLY" ]; then
-        echo "Only updating English translations due to ENGLISH_ONLY flag"
-        ENGLISH_ONLY=true
-        break
-    fi
-done
+FETCH_ALL_LANGUAGES=true
+if [ $# -ne 0 ] && [ $1 = "ENGLISH_ONLY" ]; then
+    FETCH_ALL_LANGUAGES=false
+fi
 
 API_TOKEN=$LOKALISE_API_TOKEN
 if [ -z "$API_TOKEN" ]; then
@@ -48,12 +42,18 @@ FINAL_STATUS_ID=587
 
 rm -rf android/*
 
+if [ "$FETCH_ALL_LANGUAGES" = true ]; then
+    echo "Fetching translations for all languages…"
+else
+    echo "Fetching translations for English only…"
+fi
+
 for MODULE in ${MODULES[@]}
 do
     echo ""
     echo "Downloading strings for $MODULE/strings.xml"
 
-    if [ "$ENGLISH_ONLY" = "false" ]; then
+    if [ "$FETCH_ALL_LANGUAGES" = true ]; then
         lokalise2 --token $API_TOKEN \
                   --project-id $PROJECT_ID \
                   file download \
@@ -81,7 +81,7 @@ do
           --bundle-structure "android/$MODULE/values-%LANG_ISO%/strings.xml"
 
     #There is a command line switch that might be better than this, see: --language-mapping
-    if [ "$ENGLISH_ONLY" = "false" ]; then
+    if [ "$FETCH_ALL_LANGUAGES" = true ]; then
         mv android/$MODULE/values-es-r419 android/$MODULE/values-b+es+419
         mv android/$MODULE/values-zh-rHant android/$MODULE/values-zh-rTW
         mv android/$MODULE/values-zh-rHans android/$MODULE/values-zh
@@ -89,12 +89,12 @@ do
     fi
 
     # This is used by the untranslated_project_keys.sh script
-    if [ "$ENGLISH_ONLY" = "false" ]; then
+    if [ "$FETCH_ALL_LANGUAGES" = true ]; then
         cp android/$MODULE/values-en-rGB/strings.xml android/$MODULE-lokalize-strings.xml
     fi
 
     # Remove the existing strings files
-    if [ "$ENGLISH_ONLY" = "false" ]; then
+    if [ "$FETCH_ALL_LANGUAGES" = true ]; then
         find ../$MODULE/res -type f -name strings.xml | xargs rm
     fi
 

--- a/scripts/lokalise/update_lokalise_with_new_strings.rb
+++ b/scripts/lokalise/update_lokalise_with_new_strings.rb
@@ -26,16 +26,25 @@ def handle_result(client, actions)
         puts "Continue? (y/n)"
 
         answer = gets.chomp
-        if answer == "y"
-            outcomes = actions.each_with_index.map { |action, index| action.perform(client) }
-
-            outcomes.each_with_index do |outcome, index|
-                puts "#{index+1}. #{outcome}"
-            end
-        else
+        if answer != "y" && answer != "Y"
             abort("🤷 You aborted the automated script. Please create/update the keys manually… somehow…")
         end
+
+        outcomes = actions.each_with_index.map { |action, index| action.perform(client) }
+
+        outcomes.each_with_index do |outcome, index|
+            puts "#{index+1}. #{outcome}"
+        end
+
+        fetch_updated_translations
     end
+end
+
+def fetch_updated_translations
+    puts "Fetching updated translation from Lokalise…"
+    command = "./localize.sh ENGLISH_ONLY"
+    system(command) or raise "Failed to execute #{command}"
+    puts "✅ Fetched updated translations"
 end
 
 # ---------------- Start of script ----------------


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request makes a change to our translation flow: When someone is creating or updating a Lokalise key, we now immediately fetch English translations from Lokalise afterwards. This has the result that the new string resource is moved to the correct place in the `strings.xml` file and we avoid merge conflicts.

Tested with a test string and worked as expected.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
