### PR TITLE
Upgrade to Activity 1.8.2 and use `enableEdgeToEdge`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 Dependencies updated:
 * [7603](https://github.com/stripe/stripe-android/pull/7603) Bumped compile SDK from 33 to 34.
+* [7311](https://github.com/stripe/stripe-android/pull/7311) Bumped AndroidX Activity dependencies from `1.7.2` to `1.8.2`.
 
 ## 20.36.1 - 2024-01-08
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,7 @@ ext.versions = [
         androidTestJunit            : '1.1.5',
         androidTestOrchestrator     : '1.4.2',
         androidTestRunner           : '1.5.2',
-        androidxActivity            : '1.7.2',
+        androidxActivity            : '1.8.2',
         androidxAnnotation          : '1.6.0',
         androidxAppcompat           : '1.6.1',
         androidxArchCore            : '2.2.0',

--- a/payments-core/res/values/themes.xml
+++ b/payments-core/res/values/themes.xml
@@ -36,9 +36,7 @@
 
     <style name="StripePaymentSheetDefaultTheme" parent="StripePaymentSheetBaseTheme" />
 
-    <style name="StripeGooglePayDefaultTheme" parent="StripePaymentSheetBaseTheme">
-        <item name="android:statusBarColor">@android:color/transparent</item>
-    </style>
+    <style name="StripeGooglePayDefaultTheme" parent="StripePaymentSheetBaseTheme" />
 
     <style name="StripePayLauncherDefaultTheme" parent="@style/Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="android:windowIsTranslucent">true</item>
@@ -50,7 +48,5 @@
         <item name="android:windowAnimationStyle">@null</item>
         <item name="colorSurface">@color/stripe_paymentsheet_background</item>
         <item name="actionMenuTextColor">@color/stripe_paymentsheet_toolbar_items_color</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
-        <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 </resources>

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
@@ -2,6 +2,7 @@ package com.stripe.android.googlepaylauncher
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.bundleOf
@@ -39,6 +40,7 @@ internal class GooglePayLauncherActivity : AppCompatActivity() {
     private lateinit var args: GooglePayLauncherContract.Args
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         args = runCatching {

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherActivity.kt
@@ -2,6 +2,7 @@ package com.stripe.android.googlepaylauncher
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.bundleOf
@@ -36,9 +37,8 @@ internal class GooglePayPaymentMethodLauncherActivity : AppCompatActivity() {
     private lateinit var args: GooglePayPaymentMethodLauncherContractV2.Args
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
-
-        setFadeAnimations()
 
         val nullableArgs = GooglePayPaymentMethodLauncherContractV2.Args.fromIntent(intent)
         if (nullableArgs == null) {
@@ -80,11 +80,6 @@ internal class GooglePayPaymentMethodLauncherActivity : AppCompatActivity() {
                 )
             }
         }
-    }
-
-    override fun finish() {
-        super.finish()
-        setFadeAnimations()
     }
 
     private fun launchGooglePay(task: Task<PaymentData>) {
@@ -168,7 +163,8 @@ internal class GooglePayPaymentMethodLauncherActivity : AppCompatActivity() {
         finish()
     }
 
-    private fun setFadeAnimations() {
+    override fun finish() {
+        super.finish()
         fadeOut()
     }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
@@ -2,8 +2,11 @@ package com.stripe.android.payments.paymentlauncher
 
 import android.app.Activity
 import android.content.Intent
+import android.graphics.Color
 import android.os.Bundle
+import androidx.activity.SystemBarStyle
 import androidx.activity.addCallback
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
@@ -32,6 +35,10 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
     internal val viewModel: PaymentLauncherViewModel by viewModels { viewModelFactory }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
+        )
+
         super.onCreate(savedInstanceState)
 
         val args = runCatching {

--- a/paymentsheet/res/values/themes.xml
+++ b/paymentsheet/res/values/themes.xml
@@ -26,10 +26,7 @@
         <item name="actionMenuTextColor">@color/stripe_paymentsheet_toolbar_items_color</item>
     </style>
 
-    <style name="StripePaymentSheetDefaultTheme" parent="StripePaymentSheetBaseTheme">
-        <item name="android:statusBarColor">@android:color/transparent</item>
-        <item name="android:navigationBarColor">@android:color/transparent</item>
-    </style>
+    <style name="StripePaymentSheetDefaultTheme" parent="StripePaymentSheetBaseTheme" />
 
     <style name="StripePaymentSheetAddPaymentMethodTheme">
         <item name="colorOnSurface">@color/stripe_paymentsheet_form</item>

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
@@ -12,7 +13,6 @@ import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.core.view.WindowCompat
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.common.ui.BottomSheet
 import com.stripe.android.common.ui.rememberBottomSheetState
@@ -40,9 +40,8 @@ internal class CustomerSheetActivity : AppCompatActivity() {
 
     @OptIn(ExperimentalMaterialApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
-
-        WindowCompat.setDecorFitsSystemWindows(window, false)
 
         viewModel.registerFromActivity(
             activityResultCaller = this,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,7 +13,6 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Surface
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.core.view.WindowCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -43,9 +43,9 @@ internal class AddressElementActivity : ComponentActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
-        WindowCompat.setDecorFitsSystemWindows(window, false)
         starterArgs.config?.appearance?.parseAppearance()
 
         setContent {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationActivity.kt
@@ -1,15 +1,14 @@
 package com.stripe.android.paymentsheet.paymentdatacollection.bacs
 
 import android.app.Activity
-import android.os.Build
 import android.os.Bundle
 import androidx.activity.addCallback
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.LaunchedEffect
-import androidx.core.view.WindowCompat
 import com.stripe.android.common.ui.BottomSheet
 import com.stripe.android.common.ui.rememberBottomSheetState
 import com.stripe.android.paymentsheet.R
@@ -36,9 +35,8 @@ internal class BacsMandateConfirmationActivity : AppCompatActivity() {
 
     @OptIn(ExperimentalMaterialApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
-
-        renderEdgeToEdge()
 
         onBackPressedDispatcher.addCallback {
             viewModel.handleViewAction(BacsMandateConfirmationViewAction.OnBackPressed)
@@ -96,13 +94,5 @@ internal class BacsMandateConfirmationActivity : AppCompatActivity() {
     override fun finish() {
         super.finish()
         fadeOut()
-    }
-
-    private fun renderEdgeToEdge() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-            return
-        }
-
-        WindowCompat.setDecorFitsSystemWindows(window, false)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -1,10 +1,9 @@
 package com.stripe.android.paymentsheet.ui
 
-import android.os.Build
 import android.os.Bundle
 import androidx.activity.addCallback
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.WindowCompat
 import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.utils.fadeOut
@@ -20,13 +19,12 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
     abstract fun setActivityResult(result: ResultType)
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         if (earlyExitDueToIllegalState) {
             return
         }
-
-        renderEdgeToEdge()
 
         onBackPressedDispatcher.addCallback {
             viewModel.handleBackPressed()
@@ -36,13 +34,5 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
     override fun finish() {
         super.finish()
         fadeOut()
-    }
-
-    private fun renderEdgeToEdge() {
-        if (Build.VERSION.SDK_INT < 30) {
-            return
-        }
-
-        WindowCompat.setDecorFitsSystemWindows(window, false)
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates the AndroidX Activity dependencies to 1.8.2. This version adds the `enableEdgeToEdge()` that we can use instead of our manual edge-to-edge approach.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
