### PR TITLE
Add SI & PI w/ SFU support for Revolut Pay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * [FIXED][7316](https://github.com/stripe/stripe-android/pull/7316) Fixed an issue where amounts in Serbian Dinar were displayed incorrectly.
 
 ### Payments
-* [ADDED][7315](https://github.com/stripe/stripe-android/pull/7314) Added support for Revolut Pay.
+* [ADDED][7315](https://github.com/stripe/stripe-android/pull/7315) Added support for Revolut Pay.
 * [ADDED][7191](https://github.com/stripe/stripe-android/pull/7191) `GooglePayLauncher` now takes an optional `label` when presenting Google Pay for PaymentIntents, and an optional `amount` and `label` when presenting for SetupIntents.
 * [ADDED][7191](https://github.com/stripe/stripe-android/pull/7191) `GooglePayPaymentMethodLauncher` now takes an optional `label` when presenting Google Pay.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## XX.XX.XX - 2023-XX-XX
 
 ### PaymentSheet
+* [ADDED][7314](https://github.com/stripe/stripe-android/pull/7314) PaymentSheet now supports Revolut Pay for SetupIntents, and PaymentIntents with setup for future usage.
 * [ADDED][7302](https://github.com/stripe/stripe-android/pull/7302) PaymentSheet now supports Alma for PaymentIntents in private beta.
 * [ADDED][7191](https://github.com/stripe/stripe-android/pull/7191) `PaymentSheet.GooglePayConfiguration` now takes an optional `amount` and `label`. The `amount` will be displayed in Google Pay for SetupIntents, while `label` will be displayed for both PaymentIntents and SetupIntents.
 * [ADDED][7308](https://github.com/stripe/stripe-android/pull/7308) PaymentSheet now supports Konbini for PaymentIntents.

--- a/payments-ui-core/res/values/strings.xml
+++ b/payments-ui-core/res/values/strings.xml
@@ -67,6 +67,8 @@
   <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
   <!-- PayPal mandate text -->
   <string name="stripe_paypal_mandate">By confirming your payment with PayPal, you allow %s to charge your PayPal account for future payments in accordance with their terms.</string>
+  <!-- Revolut mandate text -->
+  <string name="stripe_revolut_mandate">By confirming your payment with RevolutPay, you allow %s to charge your RevolutPay account for future payments in accordance with their terms.</string>
   <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
   <string name="stripe_save_for_future_payments_with_merchant_name">Save for future %s payments</string>
   <!-- Button title to open camera to scan credit/debit card -->

--- a/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
@@ -196,8 +196,8 @@ internal val AffirmRequirement = PaymentMethodRequirements(
 
 internal val RevolutPayRequirement = PaymentMethodRequirements(
     piRequirements = emptySet(),
-    siRequirements = null,
-    confirmPMFromCustomer = null
+    siRequirements = emptySet(),
+    confirmPMFromCustomer = true
 )
 
 internal val AmazonPayRequirement = PaymentMethodRequirements(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
@@ -381,17 +381,27 @@ class LpmRepository constructor(
             requirement = AffirmRequirement,
             formSpec = LayoutSpec(sharedDataSpec.fields)
         )
-        PaymentMethod.Type.RevolutPay.code -> SupportedPaymentMethod(
-            code = "revolut_pay",
-            requiresMandate = false,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_revolut_pay,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_revolut_pay,
-            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
-            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
-            tintIconOnSelection = false,
-            requirement = RevolutPayRequirement,
-            formSpec = LayoutSpec(sharedDataSpec.fields)
-        )
+        PaymentMethod.Type.RevolutPay.code -> {
+            val requiresMandate = stripeIntent.requiresMandate()
+
+            val localLayoutSpecs: List<FormItemSpec> = if (stripeIntent.requiresMandate()) {
+                listOf(MandateTextSpec(stringResId = R.string.stripe_revolut_mandate))
+            } else {
+                emptyList()
+            }
+
+            SupportedPaymentMethod(
+                code = "revolut_pay",
+                requiresMandate = requiresMandate,
+                displayNameResource = R.string.stripe_paymentsheet_payment_method_revolut_pay,
+                iconResource = R.drawable.stripe_ic_paymentsheet_pm_revolut_pay,
+                lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+                darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+                tintIconOnSelection = false,
+                requirement = RevolutPayRequirement,
+                formSpec = LayoutSpec(sharedDataSpec.fields + localLayoutSpecs)
+            )
+        }
         PaymentMethod.Type.AmazonPay.code -> SupportedPaymentMethod(
             code = "amazon_pay",
             requiresMandate = false,

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestRevolutPay.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestRevolutPay.kt
@@ -1,0 +1,73 @@
+package com.stripe.android.lpm
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.stripe.android.BaseLpmTest
+import com.stripe.android.test.core.AuthorizeAction
+import com.stripe.android.test.core.Currency
+import com.stripe.android.test.core.IntentType
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class TestRevolutPay : BaseLpmTest() {
+    private val revolutPay = newUser.copy(
+        paymentMethod = lpmRepository.fromCode("revolut_pay")!!,
+        currency = Currency.GBP,
+        merchantCountryCode = "GB",
+        authorizationAction = AuthorizeAction.AuthorizePayment,
+        supportedPaymentMethods = listOf("card", "revolut_pay"),
+    )
+
+    @Test
+    fun testRevolutPay_Success() {
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = revolutPay,
+        )
+    }
+
+    @Test
+    fun testRevolutPay_Fail() {
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = revolutPay.copy(
+                authorizationAction = AuthorizeAction.Fail(
+                    expectedError = "The customer declined this payment.",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun testRevolutPay_Cancel() {
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = revolutPay.copy(
+                authorizationAction = AuthorizeAction.Cancel,
+            ),
+        )
+    }
+
+    @Test
+    fun testRevolutPayWithSfu() {
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = revolutPay.copy(
+                intentType = IntentType.PayWithSetup,
+                authorizationAction = AuthorizeAction.AuthorizePayment,
+            ),
+        )
+    }
+
+    @Test
+    fun testRevolutPayWithSetupIntent() {
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = revolutPay.copy(
+                intentType = IntentType.Setup,
+            ),
+        )
+    }
+
+    @Test
+    fun testRevolutPayInCustomFlow() {
+        testDriver.confirmCustom(
+            testParameters = revolutPay,
+        )
+    }
+}

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestRevolutPay.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestRevolutPay.kt
@@ -5,6 +5,7 @@ import com.stripe.android.BaseLpmTest
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.Currency
 import com.stripe.android.test.core.IntentType
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -18,13 +19,15 @@ internal class TestRevolutPay : BaseLpmTest() {
         supportedPaymentMethods = listOf("card", "revolut_pay"),
     )
 
+    @Ignore("Requires complex auth handling")
     @Test
     fun testRevolutPay_Success() {
         testDriver.confirmNewOrGuestComplete(
-            testParameters = revolutPay,
+            testParameters = revolutPay
         )
     }
 
+    @Ignore("Requires complex auth handling")
     @Test
     fun testRevolutPay_Fail() {
         testDriver.confirmNewOrGuestComplete(
@@ -36,38 +39,41 @@ internal class TestRevolutPay : BaseLpmTest() {
         )
     }
 
+    @Ignore("Requires complex auth handling")
     @Test
     fun testRevolutPay_Cancel() {
         testDriver.confirmNewOrGuestComplete(
             testParameters = revolutPay.copy(
-                authorizationAction = AuthorizeAction.Cancel,
+                authorizationAction = AuthorizeAction.Cancel
             ),
         )
     }
 
+    @Ignore("Requires complex auth handling")
     @Test
     fun testRevolutPayWithSfu() {
         testDriver.confirmNewOrGuestComplete(
             testParameters = revolutPay.copy(
-                intentType = IntentType.PayWithSetup,
-                authorizationAction = AuthorizeAction.AuthorizePayment,
+                intentType = IntentType.PayWithSetup
             ),
         )
     }
 
+    @Ignore("Requires complex auth handling")
     @Test
     fun testRevolutPayWithSetupIntent() {
         testDriver.confirmNewOrGuestComplete(
             testParameters = revolutPay.copy(
-                intentType = IntentType.Setup,
+                intentType = IntentType.Setup
             ),
         )
     }
 
+    @Ignore("Requires complex auth handling")
     @Test
     fun testRevolutPayInCustomFlow() {
         testDriver.confirmCustom(
-            testParameters = revolutPay,
+            testParameters = revolutPay
         )
     }
 }

--- a/paymentsheet/src/test/resources/revolut_pay-support.csv
+++ b/paymentsheet/src/test/resources/revolut_pay-support.csv
@@ -1,49 +1,49 @@
 lpm, hasCustomer, allowsDelayedPayment, intentSetupFutureUsage, intentHasShipping, intentLpms, supportCustomerSavedCard, formExists, formType, supportsAdding
-revolut_pay, true, true, off_session, false, card/revolut_pay, false, false, not available, false
-revolut_pay, true, true, off_session, false, card/eps/revolut_pay, false, false, not available, false
-revolut_pay, true, false, off_session, false, card/revolut_pay, false, false, not available, false
-revolut_pay, true, false, off_session, false, card/eps/revolut_pay, false, false, not available, false
-revolut_pay, true, true, on_session, false, card/revolut_pay, false, false, not available, false
-revolut_pay, true, true, on_session, false, card/eps/revolut_pay, false, false, not available, false
-revolut_pay, true, false, on_session, false, card/revolut_pay, false, false, not available, false
-revolut_pay, true, false, on_session, false, card/eps/revolut_pay, false, false, not available, false
-revolut_pay, true, true, null, false, card/revolut_pay, false, true, oneTime, true
-revolut_pay, true, true, null, false, card/eps/revolut_pay, false, true, oneTime, true
-revolut_pay, true, false, null, false, card/revolut_pay, false, true, oneTime, true
-revolut_pay, true, false, null, false, card/eps/revolut_pay, false, true, oneTime, true
-revolut_pay, false, true, off_session, false, card/revolut_pay, false, false, not available, false
-revolut_pay, false, true, off_session, false, card/eps/revolut_pay, false, false, not available, false
-revolut_pay, false, false, off_session, false, card/revolut_pay, false, false, not available, false
-revolut_pay, false, false, off_session, false, card/eps/revolut_pay, false, false, not available, false
-revolut_pay, false, true, on_session, false, card/revolut_pay, false, false, not available, false
-revolut_pay, false, true, on_session, false, card/eps/revolut_pay, false, false, not available, false
-revolut_pay, false, false, on_session, false, card/revolut_pay, false, false, not available, false
-revolut_pay, false, false, on_session, false, card/eps/revolut_pay, false, false, not available, false
-revolut_pay, false, true, null, false, card/revolut_pay, false, true, oneTime, true
-revolut_pay, false, true, null, false, card/eps/revolut_pay, false, true, oneTime, true
-revolut_pay, false, false, null, false, card/revolut_pay, false, true, oneTime, true
-revolut_pay, false, false, null, false, card/eps/revolut_pay, false, true, oneTime, true
-revolut_pay, true, true, off_session, true, card/revolut_pay, false, false, not available, false
-revolut_pay, true, true, off_session, true, card/eps/revolut_pay, false, false, not available, false
-revolut_pay, true, false, off_session, true, card/revolut_pay, false, false, not available, false
-revolut_pay, true, false, off_session, true, card/eps/revolut_pay, false, false, not available, false
-revolut_pay, true, true, on_session, true, card/revolut_pay, false, false, not available, false
-revolut_pay, true, true, on_session, true, card/eps/revolut_pay, false, false, not available, false
-revolut_pay, true, false, on_session, true, card/revolut_pay, false, false, not available, false
-revolut_pay, true, false, on_session, true, card/eps/revolut_pay, false, false, not available, false
-revolut_pay, true, true, null, true, card/revolut_pay, false, true, oneTime, true
-revolut_pay, true, true, null, true, card/eps/revolut_pay, false, true, oneTime, true
-revolut_pay, true, false, null, true, card/revolut_pay, false, true, oneTime, true
-revolut_pay, true, false, null, true, card/eps/revolut_pay, false, true, oneTime, true
-revolut_pay, false, true, off_session, true, card/revolut_pay, false, false, not available, false
-revolut_pay, false, true, off_session, true, card/eps/revolut_pay, false, false, not available, false
-revolut_pay, false, false, off_session, true, card/revolut_pay, false, false, not available, false
-revolut_pay, false, false, off_session, true, card/eps/revolut_pay, false, false, not available, false
-revolut_pay, false, true, on_session, true, card/revolut_pay, false, false, not available, false
-revolut_pay, false, true, on_session, true, card/eps/revolut_pay, false, false, not available, false
-revolut_pay, false, false, on_session, true, card/revolut_pay, false, false, not available, false
-revolut_pay, false, false, on_session, true, card/eps/revolut_pay, false, false, not available, false
-revolut_pay, false, true, null, true, card/revolut_pay, false, true, oneTime, true
-revolut_pay, false, true, null, true, card/eps/revolut_pay, false, true, oneTime, true
-revolut_pay, false, false, null, true, card/revolut_pay, false, true, oneTime, true
-revolut_pay, false, false, null, true, card/eps/revolut_pay, false, true, oneTime, true
+revolut_pay, true, true, off_session, false, card/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, true, true, off_session, false, card/eps/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, true, false, off_session, false, card/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, true, false, off_session, false, card/eps/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, true, true, on_session, false, card/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, true, true, on_session, false, card/eps/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, true, false, on_session, false, card/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, true, false, on_session, false, card/eps/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, true, true, null, false, card/revolut_pay, true, true, userSelectedSave, true
+revolut_pay, true, true, null, false, card/eps/revolut_pay, true, true, userSelectedSave, true
+revolut_pay, true, false, null, false, card/revolut_pay, true, true, userSelectedSave, true
+revolut_pay, true, false, null, false, card/eps/revolut_pay, true, true, userSelectedSave, true
+revolut_pay, false, true, off_session, false, card/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, false, true, off_session, false, card/eps/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, false, false, off_session, false, card/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, false, false, off_session, false, card/eps/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, false, true, on_session, false, card/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, false, true, on_session, false, card/eps/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, false, false, on_session, false, card/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, false, false, on_session, false, card/eps/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, false, true, null, false, card/revolut_pay, true, true, oneTime, true
+revolut_pay, false, true, null, false, card/eps/revolut_pay, true, true, oneTime, true
+revolut_pay, false, false, null, false, card/revolut_pay, true, true, oneTime, true
+revolut_pay, false, false, null, false, card/eps/revolut_pay, true, true, oneTime, true
+revolut_pay, true, true, off_session, true, card/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, true, true, off_session, true, card/eps/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, true, false, off_session, true, card/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, true, false, off_session, true, card/eps/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, true, true, on_session, true, card/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, true, true, on_session, true, card/eps/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, true, false, on_session, true, card/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, true, false, on_session, true, card/eps/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, true, true, null, true, card/revolut_pay, true, true, userSelectedSave, true
+revolut_pay, true, true, null, true, card/eps/revolut_pay, true, true, userSelectedSave, true
+revolut_pay, true, false, null, true, card/revolut_pay, true, true, userSelectedSave, true
+revolut_pay, true, false, null, true, card/eps/revolut_pay, true, true, userSelectedSave, true
+revolut_pay, false, true, off_session, true, card/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, false, true, off_session, true, card/eps/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, false, false, off_session, true, card/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, false, false, off_session, true, card/eps/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, false, true, on_session, true, card/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, false, true, on_session, true, card/eps/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, false, false, on_session, true, card/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, false, false, on_session, true, card/eps/revolut_pay, true, true, merchantRequiredSave, true
+revolut_pay, false, true, null, true, card/revolut_pay, true, true, oneTime, true
+revolut_pay, false, true, null, true, card/eps/revolut_pay, true, true, oneTime, true
+revolut_pay, false, false, null, true, card/revolut_pay, true, true, oneTime, true
+revolut_pay, false, false, null, true, card/eps/revolut_pay, true, true, oneTime, true


### PR DESCRIPTION
# Summary
Add SI & PI w/ SFU support for Revolut Pay

# Motivation
More LPM support

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
[ADDED][7314](https://github.com/stripe/stripe-android/pull/7314) PaymentSheet now supports Revolut Pay for SetupIntents, and PaymentIntents with setup for future usage.
