### PR TITLE
Show two decimal places for Serbian Dinar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [ADDED][7302](https://github.com/stripe/stripe-android/pull/7302) PaymentSheet now supports Alma for PaymentIntents in private beta.
 * [ADDED][7191](https://github.com/stripe/stripe-android/pull/7191) `PaymentSheet.GooglePayConfiguration` now takes an optional `amount` and `label`. The `amount` will be displayed in Google Pay for SetupIntents, while `label` will be displayed for both PaymentIntents and SetupIntents.
 * [ADDED][7308](https://github.com/stripe/stripe-android/pull/7308) PaymentSheet now supports Konbini for PaymentIntents.
+* [FIXED][7316](https://github.com/stripe/stripe-android/pull/7316) Fixed an issue where amounts in Serbian Dinar were displayed incorrectly.
 
 ### Payments
 * [ADDED][7191](https://github.com/stripe/stripe-android/pull/7191) `GooglePayLauncher` now takes an optional `label` when presenting Google Pay for PaymentIntents, and an optional `amount` and `label` when presenting for SetupIntents.

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/format/CurrencyFormatter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/format/CurrencyFormatter.kt
@@ -11,8 +11,9 @@ import kotlin.math.pow
 object CurrencyFormatter {
 
     private const val MAJOR_UNIT_BASE = 10.0
+
     private val SERVER_DECIMAL_DIGITS = mapOf(
-        setOf("UGX", "AFN", "ALL", "AMD", "COP", "IDR", "ISK", "PKR", "LBP", "MMK", "LAK") to 2,
+        setOf("UGX", "AFN", "ALL", "AMD", "COP", "IDR", "ISK", "PKR", "LBP", "MMK", "LAK", "RSD") to 2,
     )
 
     fun format(
@@ -31,8 +32,7 @@ object CurrencyFormatter {
         targetLocale: Locale = Locale.getDefault()
     ): String {
         val amountCurrencyDecimalDigits = getDefaultDecimalDigits(amountCurrency)
-        val majorUnitAmount =
-            amount / MAJOR_UNIT_BASE.pow(amountCurrencyDecimalDigits.toDouble())
+        val majorUnitAmount = amount / MAJOR_UNIT_BASE.pow(amountCurrencyDecimalDigits.toDouble())
 
         /**
          * The currencyFormat for a country and region specifies many things including:

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/format/CurrencyFormatterTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/format/CurrencyFormatterTest.kt
@@ -35,7 +35,8 @@ class CurrencyFormatterTest {
         assertThat(
             CurrencyFormatter.format(
                 123412L,
-                Currency.getInstance("USD")
+                Currency.getInstance("USD"),
+                Locale.US,
             )
         ).isEqualTo("$1,234.12")
     }
@@ -234,6 +235,13 @@ class CurrencyFormatterTest {
         val currency = Currency.getInstance("LAK")
         val formattedAmount = CurrencyFormatter.format(5099L, currency)
         assertThat(formattedAmount).isEqualTo("LAK50.99")
+    }
+
+    @Test
+    fun `Treats RSD as a two-decimal currency`() {
+        val currency = Currency.getInstance("RSD")
+        val formattedAmount = CurrencyFormatter.format(5099L, currency)
+        assertThat(formattedAmount).isEqualTo("RSD50.99")
     }
 
     companion object {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where amounts in Serbian Dinar were displayed incorrectly in PaymentSheet. For instance, we would show `RSD10,000` instead of `RSD100.00`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

Fixed an issue where amounts in Serbian Dinar were displayed incorrectly.
