### PR TITLE
Fix issue where confirming intent is possible with empty required field

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/CompleteFormFieldValueFilter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/CompleteFormFieldValueFilter.kt
@@ -46,16 +46,22 @@ internal class CompleteFormFieldValueFilter(
     ): FormFieldValues? {
         // This will run twice in a row when the save for future use state changes: once for the
         // saveController changing and once for the the hidden fields changing
-        var processedFieldsMap = idFieldSnapshotMap.filter {
-            !hiddenIdentifiers.contains(it.key)
+        val processedFieldsMap = idFieldSnapshotMap.filter {
+            it.key !in hiddenIdentifiers
         }.toMutableMap()
 
         // Apply defaults for fields with no value.
-        // Default values are added even if the field is hidden.
-        for (entry in defaultValues) {
-            val formValue = processedFieldsMap[entry.key]
-            if (formValue?.value.isNullOrBlank() && !entry.value.isNullOrBlank()) {
-                processedFieldsMap[entry.key] = FormFieldEntry(entry.value, true)
+        // Default values are added only if the field is hidden.
+        for (defaultValue in defaultValues) {
+            val key = defaultValue.key
+            val formValue = processedFieldsMap[key]
+
+            val hasNoValueInForm = formValue?.value.isNullOrBlank()
+            val hasDefaultValue = defaultValue.value.isNotBlank()
+            val isNotDisplayed = key in hiddenIdentifiers
+
+            if (hasNoValueInForm && hasDefaultValue && isNotDisplayed) {
+                processedFieldsMap[defaultValue.key] = FormFieldEntry(defaultValue.value, true)
             }
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/CompleteFormFieldValueFilter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/CompleteFormFieldValueFilter.kt
@@ -70,8 +70,7 @@ internal class CompleteFormFieldValueFilter(
             showingMandate,
             userRequestedReuse
         ).takeIf {
-            processedFieldsMap.values.map { it.isComplete }
-                .none { complete -> !complete }
+            processedFieldsMap.values.all { it.isComplete }
         }
     }
 }


### PR DESCRIPTION
PaymentSheet would use the provided default value, but this is confusing for the end user.

# Summary
<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
