### PR TITLE
Use the correct check to attach default billing details

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
@@ -30,7 +30,7 @@ data class TestParameters(
     val merchantCountryCode: String,
     val supportedPaymentMethods: List<PaymentMethodCode> = listOf(),
     val customPrimaryButtonLabel: String? = null,
-    val attachDefaults: Boolean = false,
+    val attachDefaults: Boolean = true,
     val collectName: PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
     val collectEmail: PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
     val collectPhone: PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -78,6 +78,7 @@ class Selectors(
         IntentType.PayWithSetup -> EspressoLabelIdButton(R.string.payment_with_setup)
         IntentType.Setup -> EspressoLabelIdButton(R.string.setup)
     }
+
     val billing = when (testParameters.billing) {
         Billing.Off -> EspressoIdButton(R.id.default_billing_off_button)
         Billing.On -> EspressoIdButton(R.id.default_billing_on_button)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
@@ -753,7 +753,7 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
             email = "email@email.com",
             name = "Jenny Rosen",
             phone = "+18008675309"
-        ).takeIf { viewBinding.defaultBillingOnButton.isChecked }
+        ).takeIf { viewBinding.attachDefaultsOnButton.isChecked }
 
         val appearance = intent.extras?.getParcelable(APPEARANCE_EXTRA) ?: AppearanceStore.state
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Use the correct check to attach default billing details. Previously, the default billing details was being set even if attach defaults was set to off. Found during bug bash.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified