### PR TITLE
Add dropdown to select card brand

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -1062,7 +1062,7 @@ public abstract interface class com/stripe/android/cards/CardAccountRangeReposit
 }
 
 public abstract interface class com/stripe/android/cards/CardAccountRangeService$AccountRangeResultListener {
-	public abstract fun onAccountRangeResult (Lcom/stripe/android/model/AccountRange;)V
+	public abstract fun onAccountRangesResult (Ljava/util/List;)V
 }
 
 public final class com/stripe/android/exception/CardException : com/stripe/android/core/exception/StripeException {

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -20,12 +20,16 @@ dependencies {
     implementation libs.androidx.savedState
     implementation libs.androidx.viewModel
     implementation libs.compose.activity
+    implementation libs.compose.foundation
+    implementation libs.compose.material
+    implementation libs.compose.materialIcons
+    implementation libs.compose.ui
     implementation libs.dagger
+    implementation libs.kotlin.coroutines
+    implementation libs.kotlin.coroutinesAndroid
     implementation libs.material
     implementation libs.playServicesWallet
     implementation libs.instantApps
-    implementation libs.kotlin.coroutines
-    implementation libs.kotlin.coroutinesAndroid
     // For instructions on replacing the BouncyCastle dependency used by the 3DS2 SDK, see
     // https://github.com/stripe/stripe-android/issues/3173#issuecomment-785176608
     implementation libs.stripe3ds2

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     api project(":payments-model")
     compileOnly project(':financial-connections')
 
+    implementation libs.accompanist.themeAdapter
     implementation libs.androidx.activity
     implementation libs.androidx.annotation
     implementation libs.androidx.appCompat

--- a/payments-core/res/layout/stripe_card_brand_view.xml
+++ b/payments-core/res/layout/stripe_card_brand_view.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <ImageView
+    <androidx.compose.ui.platform.ComposeView
         android:id="@+id/icon"
-        android:layout_width="@dimen/stripe_card_brand_view_width"
-        android:layout_height="@dimen/stripe_card_brand_view_height"
-        android:contentDescription="@null"
-        app:srcCompat="@drawable/stripe_ic_unknown" />
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
 
     <com.stripe.android.view.CardWidgetProgressView
         android:id="@+id/progress"

--- a/payments-core/res/layout/stripe_card_input_widget.xml
+++ b/payments-core/res/layout/stripe_card_input_widget.xml
@@ -5,7 +5,7 @@
 
     <com.stripe.android.view.CardBrandView
         android:id="@+id/card_brand_view"
-        android:layout_width="@dimen/stripe_card_brand_view_width"
+        android:layout_width="wrap_content"
         android:layout_height="@dimen/stripe_card_brand_view_height"
         android:layout_marginTop="@dimen/stripe_card_icon_padding"
         android:layout_marginBottom="@dimen/stripe_card_icon_padding"

--- a/payments-core/res/values/strings.xml
+++ b/payments-core/res/values/strings.xml
@@ -102,6 +102,10 @@
   <string name="stripe_becs_widget_name_required">Your name is required.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="stripe_cancel">Cancel</string>
+  <!-- Title for a dropdown option when selecting a card brand -->
+  <string name="stripe_card_brand_choice_no_selection">No selection</string>
+  <!-- Title for a dropdown where the customer can select a card brand -->
+  <string name="stripe_card_brand_choice_selection_header">Select card brand (optional)</string>
   <!-- Error when the card was declined by the credit card networks -->
   <string name="stripe_card_declined">Your card was declined</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->

--- a/payments-core/src/main/java/com/stripe/android/cards/CbcTestCardDelegate.kt
+++ b/payments-core/src/main/java/com/stripe/android/cards/CbcTestCardDelegate.kt
@@ -1,0 +1,53 @@
+package com.stripe.android.cards
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.model.AccountRange
+import com.stripe.android.model.BinRange
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+object CbcTestCardDelegate {
+
+    private val testAccountRanges = mapOf(
+        "40000025" to listOf(
+            AccountRange(
+                BinRange(
+                    low = "4000000000000000",
+                    high = "4999999999999999"
+                ),
+                panLength = 16,
+                brandInfo = AccountRange.BrandInfo.CartesBancaires,
+            ),
+            AccountRange(
+                BinRange(
+                    low = "4000000000000000",
+                    high = "4999999999999999"
+                ),
+                panLength = 16,
+                brandInfo = AccountRange.BrandInfo.Visa,
+            ),
+        ),
+        "55555525" to listOf(
+            AccountRange(
+                binRange = BinRange(
+                    low = "5100000000000000",
+                    high = "5599999999999999"
+                ),
+                panLength = 16,
+                brandInfo = AccountRange.BrandInfo.CartesBancaires,
+            ),
+            AccountRange(
+                binRange = BinRange(
+                    low = "5100000000000000",
+                    high = "5599999999999999"
+                ),
+                panLength = 16,
+                brandInfo = AccountRange.BrandInfo.Mastercard,
+            ),
+        ),
+    )
+
+    fun onCardNumberChanged(cardNumber: CardNumber.Unvalidated): List<AccountRange> {
+        val matches = testAccountRanges.filterKeys { cardNumber.normalized.startsWith(it) }
+        return matches.entries.singleOrNull()?.value.orEmpty()
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/view/CardBrandChoiceDropdown.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardBrandChoiceDropdown.kt
@@ -1,0 +1,122 @@
+package com.stripe.android.view
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSizeIn
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.stripe.android.R
+import com.stripe.android.model.CardBrand
+import com.stripe.payments.model.R as PaymentsModelR
+
+@Composable
+internal fun CardBrandChoiceDropdown(
+    expanded: Boolean,
+    currentBrand: CardBrand?,
+    possibleBrands: List<CardBrand>,
+    onBrandSelected: (CardBrand?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismiss,
+    ) {
+        Text(
+            text = stringResource(R.string.stripe_card_brand_choice_selection_header),
+            modifier = Modifier.padding(vertical = 5.dp, horizontal = 13.dp),
+        )
+
+        CardBrandChoiceItem(
+            icon = PaymentsModelR.drawable.stripe_ic_unknown,
+            displayValue = stringResource(R.string.stripe_card_brand_choice_no_selection),
+            isSelected = currentBrand == CardBrand.Unknown,
+            currentTextColor = MaterialTheme.colors.onSurface,
+            onClick = {
+                onBrandSelected(null)
+            }
+        )
+
+        possibleBrands.forEach { brand ->
+            CardBrandChoiceItem(
+                icon = brand.icon,
+                displayValue = brand.displayName,
+                isSelected = brand == currentBrand,
+                currentTextColor = MaterialTheme.colors.onSurface,
+                onClick = {
+                    onBrandSelected(brand)
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun CardBrandChoiceItem(
+    icon: Int,
+    displayValue: String,
+    isSelected: Boolean,
+    currentTextColor: Color,
+    onClick: () -> Unit = {}
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Start,
+        modifier = Modifier
+            .fillMaxWidth()
+            .requiredSizeIn(minHeight = 48.dp)
+            .clickable { onClick() }
+    ) {
+        Image(
+            painter = painterResource(id = icon),
+            contentDescription = null,
+            modifier = Modifier.padding(start = 13.dp),
+        )
+
+        Text(
+            text = displayValue,
+            modifier = Modifier.padding(start = 16.dp),
+            color = if (isSelected) {
+                MaterialTheme.colors.primary
+            } else {
+                currentTextColor
+            },
+            fontWeight = if (isSelected) {
+                FontWeight.Bold
+            } else {
+                FontWeight.Normal
+            },
+            maxLines = 1,
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Icon(
+            imageVector = Icons.Filled.Check,
+            contentDescription = null,
+            modifier = Modifier
+                .height(20.dp)
+                .padding(start = 8.dp, end = 16.dp)
+                .alpha(if (isSelected) 1f else 0f),
+            tint = MaterialTheme.colors.primary,
+        )
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -5,10 +5,30 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
 import androidx.annotation.ColorInt
-import androidx.core.graphics.drawable.DrawableCompat
-import androidx.core.view.doOnNextLayout
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
 import com.stripe.android.databinding.StripeCardBrandViewBinding
 import com.stripe.android.model.CardBrand
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlin.properties.Delegates
 
 internal class CardBrandView @JvmOverloads constructor(
@@ -26,12 +46,20 @@ internal class CardBrandView @JvmOverloads constructor(
     @ColorInt
     internal var tintColorInt: Int = 0
 
+    private val isLoadingFlow = MutableStateFlow(false)
+    private val brandFlow = MutableStateFlow(CardBrand.Unknown)
+    private val possibleBrandsFlow = MutableStateFlow(emptyList<CardBrand>())
+    private val shouldShowCvcFlow = MutableStateFlow(false)
+    private val shouldShowErrorIconFlow = MutableStateFlow(false)
+
+    var isCbcEligible: Boolean = false
+
     var isLoading: Boolean by Delegates.observable(
         false
     ) { _, wasLoading, isLoading ->
-        if (wasLoading != isLoading) {
-            updateIcon()
+        isLoadingFlow.value = isLoading
 
+        if (wasLoading != isLoading) {
             if (isLoading) {
                 progressView.show()
             } else {
@@ -40,72 +68,128 @@ internal class CardBrandView @JvmOverloads constructor(
         }
     }
 
-    var brand: CardBrand by Delegates.observable(
-        CardBrand.Unknown
-    ) { _, prevValue, newValue ->
-        if (prevValue != newValue) {
-            updateIcon()
+    var brand: CardBrand
+        get() = brandFlow.value
+        set(value) {
+            brandFlow.value = value
         }
-    }
 
-    var shouldShowCvc: Boolean by Delegates.observable(
-        false
-    ) { _, prevValue, newValue ->
-        if (prevValue != newValue) {
-            updateIcon()
+    var possibleBrands: List<CardBrand>
+        get() = possibleBrandsFlow.value
+        set(value) {
+            possibleBrandsFlow.value = value
         }
-    }
 
-    var shouldShowErrorIcon: Boolean by Delegates.observable(
-        false
-    ) { _, prevValue, newValue ->
-        if (prevValue != newValue) {
-            updateIcon()
+    var shouldShowCvc: Boolean
+        get() = shouldShowCvcFlow.value
+        set(value) {
+            shouldShowCvcFlow.value = value
         }
-    }
+
+    var shouldShowErrorIcon: Boolean
+        get() = shouldShowErrorIconFlow.value
+        set(value) {
+            shouldShowErrorIconFlow.value = value
+        }
 
     init {
         isClickable = false
         isFocusable = false
 
-        doOnNextLayout {
-            updateIcon()
-        }
-    }
+        iconView.setContent {
+            val isLoading by isLoadingFlow.collectAsState()
+            val currentBrand by brandFlow.collectAsState()
+            val possibleBrands by possibleBrandsFlow.collectAsState()
+            val shouldShowCvc by shouldShowCvcFlow.collectAsState()
+            val shouldShowErrorIcon by shouldShowErrorIconFlow.collectAsState()
 
-    private fun updateIcon() {
-        when {
-            isLoading -> {
-                renderBrandIcon()
-            }
-            shouldShowErrorIcon -> {
-                iconView.setImageResource(brand.errorIcon)
-            }
-            shouldShowCvc -> {
-                iconView.setImageResource(brand.cvcIcon)
-                applyTint()
-            }
-            else -> {
-                renderBrandIcon()
-            }
-        }
-    }
-
-    private fun renderBrandIcon() {
-        iconView.setImageResource(brand.icon)
-
-        if (brand == CardBrand.Unknown) {
-            applyTint()
-        }
-    }
-
-    private fun applyTint() {
-        iconView.setImageDrawable(
-            DrawableCompat.unwrap(
-                DrawableCompat.wrap(iconView.drawable).also { compatIcon ->
-                    DrawableCompat.setTint(compatIcon.mutate(), tintColorInt)
-                }
+            CardBrand(
+                isLoading = isLoading,
+                currentBrand = currentBrand,
+                possibleBrands = possibleBrands,
+                shouldShowCvc = shouldShowCvc,
+                shouldShowErrorIcon = shouldShowErrorIcon,
+                tintColorInt = tintColorInt,
+                isCbcEligible = isCbcEligible,
+                onBrandSelected = this::handleBrandSelected,
             )
-        )
+        }
+    }
+
+    private fun handleBrandSelected(brand: CardBrand?) {
+        brandFlow.value = brand ?: CardBrand.Unknown
+    }
+}
+
+@Composable
+private fun CardBrand(
+    isLoading: Boolean,
+    currentBrand: CardBrand,
+    possibleBrands: List<CardBrand>,
+    shouldShowCvc: Boolean,
+    shouldShowErrorIcon: Boolean,
+    tintColorInt: Int,
+    isCbcEligible: Boolean,
+    modifier: Modifier = Modifier,
+    onBrandSelected: (CardBrand?) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    val icon = remember(isLoading, currentBrand, shouldShowCvc, shouldShowErrorIcon) {
+        when {
+            isLoading -> currentBrand.icon
+            shouldShowErrorIcon -> currentBrand.errorIcon
+            shouldShowCvc -> currentBrand.cvcIcon
+            else -> currentBrand.icon
+        }
+    }
+
+    val tint = remember(isLoading, currentBrand, shouldShowCvc, shouldShowErrorIcon) {
+        when {
+            isLoading -> Color(tintColorInt).takeIf { currentBrand == CardBrand.Unknown }
+            shouldShowErrorIcon -> null
+            shouldShowCvc -> Color(tintColorInt)
+            else -> Color(tintColorInt).takeIf { currentBrand == CardBrand.Unknown }
+        }
+    }
+
+    val showDropdown = remember(possibleBrands) { isCbcEligible && possibleBrands.size > 1 }
+
+    Box(modifier) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.clickable(enabled = showDropdown) {
+                expanded = true
+            },
+        ) {
+            Image(
+                painter = painterResource(icon),
+                colorFilter = tint?.let { ColorFilter.tint(it) },
+                contentDescription = null,
+                modifier = Modifier.requiredSize(width = 32.dp, height = 21.dp),
+            )
+
+            if (showDropdown) {
+                Image(
+                    imageVector = Icons.Default.ArrowDropDown,
+                    contentDescription = null,
+                    alpha = ContentAlpha.disabled,
+                    modifier = Modifier.padding(end = 4.dp),
+                )
+            }
+        }
+
+        if (showDropdown) {
+            CardBrandChoiceDropdown(
+                expanded = expanded,
+                currentBrand = currentBrand,
+                possibleBrands = possibleBrands,
+                onBrandSelected = {
+                    onBrandSelected(it)
+                    expanded = false
+                },
+                onDismiss = { expanded = false },
+            )
+        }
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import com.google.accompanist.themeadapter.material.MdcTheme
 import com.stripe.android.databinding.StripeCardBrandViewBinding
 import com.stripe.android.model.CardBrand
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -97,22 +98,24 @@ internal class CardBrandView @JvmOverloads constructor(
         isFocusable = false
 
         iconView.setContent {
-            val isLoading by isLoadingFlow.collectAsState()
-            val currentBrand by brandFlow.collectAsState()
-            val possibleBrands by possibleBrandsFlow.collectAsState()
-            val shouldShowCvc by shouldShowCvcFlow.collectAsState()
-            val shouldShowErrorIcon by shouldShowErrorIconFlow.collectAsState()
+            MdcTheme {
+                val isLoading by isLoadingFlow.collectAsState()
+                val currentBrand by brandFlow.collectAsState()
+                val possibleBrands by possibleBrandsFlow.collectAsState()
+                val shouldShowCvc by shouldShowCvcFlow.collectAsState()
+                val shouldShowErrorIcon by shouldShowErrorIconFlow.collectAsState()
 
-            CardBrand(
-                isLoading = isLoading,
-                currentBrand = currentBrand,
-                possibleBrands = possibleBrands,
-                shouldShowCvc = shouldShowCvc,
-                shouldShowErrorIcon = shouldShowErrorIcon,
-                tintColorInt = tintColorInt,
-                isCbcEligible = isCbcEligible,
-                onBrandSelected = this::handleBrandSelected,
-            )
+                CardBrand(
+                    isLoading = isLoading,
+                    currentBrand = currentBrand,
+                    possibleBrands = possibleBrands,
+                    shouldShowCvc = shouldShowCvc,
+                    shouldShowErrorIcon = shouldShowErrorIcon,
+                    tintColorInt = tintColorInt,
+                    isCbcEligible = isCbcEligible,
+                    onBrandSelected = this::handleBrandSelected,
+                )
+            }
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -8,7 +8,6 @@ import android.text.Layout
 import android.text.TextPaint
 import android.text.TextWatcher
 import android.util.AttributeSet
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
@@ -29,7 +28,6 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.core.view.updateLayoutParams
 import androidx.core.widget.doAfterTextChanged
-import com.stripe.android.BuildConfig
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.cards.CardNumber
@@ -75,7 +73,7 @@ class CardInputWidget @JvmOverloads constructor(
     private val cardNumberTextInputLayout = viewBinding.cardNumberTextInputLayout
     private val expiryDateTextInputLayout = viewBinding.expiryDateTextInputLayout
     private val cvcNumberTextInputLayout = viewBinding.cvcTextInputLayout
-    internal val postalCodeTextInputLayout = viewBinding.postalCodeTextInputLayout
+    private val postalCodeTextInputLayout = viewBinding.postalCodeTextInputLayout
 
     @JvmSynthetic
     internal val cardNumberEditText = viewBinding.cardNumberEditText
@@ -386,9 +384,7 @@ class CardInputWidget @JvmOverloads constructor(
 
         doWithCardWidgetViewModel { viewModel ->
             viewModel.isCbcEligible.launchAndCollect { isCbcEligible ->
-                if (BuildConfig.DEBUG) {
-                    Log.d("CardInputWidget", "Is CBC eligible: $isCbcEligible")
-                }
+                cardBrandView.isCbcEligible = isCbcEligible
             }
         }
     }
@@ -786,6 +782,8 @@ class CardInputWidget @JvmOverloads constructor(
             updateCvc()
         }
 
+        cardNumberEditText.possibleCardBrandsCallback = this::handlePossibleCardBrandsChanged
+
         expiryDateEditText.completionCallback = {
             cvcEditText.requestFocus()
             cardInputListener?.onExpirationComplete()
@@ -820,11 +818,36 @@ class CardInputWidget @JvmOverloads constructor(
         updateCvc()
     }
 
-    private fun updateCvc() {
+    private fun updateCvc(brand: CardBrand = cardBrandView.brand) {
         cvcEditText.updateBrand(
-            cardBrandView.brand,
+            brand,
             customCvcLabel
         )
+    }
+
+    private fun handlePossibleCardBrandsChanged(brands: List<CardBrand>) {
+        val didShowDropdown = cardBrandView.possibleBrands.size > 1
+        val shouldShowDropdown = brands.size > 1
+
+        val currentBrand = cardBrandView.brand
+        cardBrandView.possibleBrands = brands
+
+        if (currentBrand !in brands) {
+            // The brand is no longer available, so we reset to an unknown brand
+            cardBrandView.brand = CardBrand.Unknown
+        }
+
+        hiddenCardText = createHiddenCardText(cardNumberEditText.panLength)
+
+        // We need to use known card brand to set the correct expected CVC length. Since both
+        // brands of a co-branded card have the same CVC length, we can just choose the first one.
+        val brandForCvcLength = brands.firstOrNull() ?: CardBrand.Unknown
+        updateCvc(brand = brandForCvcLength)
+
+        if (shouldShowDropdown != didShowDropdown) {
+            isViewInitialized = false
+            requestLayout()
+        }
     }
 
     /**

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -839,7 +839,7 @@ class CardInputWidget @JvmOverloads constructor(
 
         hiddenCardText = createHiddenCardText(cardNumberEditText.panLength)
 
-        // We need to use known card brand to set the correct expected CVC length. Since both
+        // We need to use a known card brand to set the correct expected CVC length. Since both
         // brands of a co-branded card have the same CVC length, we can just choose the first one.
         val brandForCvcLength = brands.firstOrNull() ?: CardBrand.Unknown
         updateCvc(brand = brandForCvcLength)

--- a/payments-core/src/main/java/com/stripe/android/view/CardWidgetViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardWidgetViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import androidx.lifecycle.lifecycleScope
@@ -38,6 +39,7 @@ internal class CardWidgetViewModel(
 
     private suspend fun determineCbcEligibility(): Boolean {
         // TODO(tillh-stripe) Query /wallets-config here
+        // TODO(tillh-stripe) Make sure we don't use an outdated PaymentConfiguration
         delay(1.seconds)
         return DEBUG
     }
@@ -54,13 +56,14 @@ internal class CardWidgetViewModel(
 }
 
 internal fun View.doWithCardWidgetViewModel(
+    viewModelStoreOwner: ViewModelStoreOwner? = null,
     action: LifecycleOwner.(CardWidgetViewModel) -> Unit,
 ) {
     doOnAttach {
         val lifecycleOwner = findViewTreeLifecycleOwner()
-        val viewModelStoreOwner = findViewTreeViewModelStoreOwner()
+        val storeOwner = viewModelStoreOwner ?: findViewTreeViewModelStoreOwner()
 
-        if (lifecycleOwner == null || viewModelStoreOwner == null) {
+        if (lifecycleOwner == null || storeOwner == null) {
             if (DEBUG) {
                 if (lifecycleOwner == null) {
                     error("Couldn't find a LifecycleOwner for view")
@@ -76,7 +79,7 @@ internal fun View.doWithCardWidgetViewModel(
         )
 
         val viewModel = ViewModelProvider(
-            owner = viewModelStoreOwner,
+            owner = storeOwner,
             factory = factory,
         )[CardWidgetViewModel::class.java]
 

--- a/payments-core/src/main/java/com/stripe/android/view/CardWidgetViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardWidgetViewModel.kt
@@ -37,6 +37,7 @@ internal class CardWidgetViewModel(
     }
 
     private suspend fun determineCbcEligibility(): Boolean {
+        // TODO(tillh-stripe) Query /wallets-config here
         delay(1.seconds)
         return DEBUG
     }

--- a/payments-core/src/test/java/com/stripe/android/cards/CardAccountRangeServiceTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/cards/CardAccountRangeServiceTest.kt
@@ -11,9 +11,11 @@ import com.stripe.android.cards.DefaultStaticCardAccountRanges.Companion.UNIONPA
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.model.AccountRange
+import com.stripe.android.model.BinRange
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.utils.TestUtils
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -81,6 +83,111 @@ class CardAccountRangeServiceTest {
         ).getAccountRanges(cardNumber)
     }
 
+    @Test
+    fun `test card metadata service pan length`() = runTest {
+        verifyRemotePanLength("6500079999999999999", 16)
+    }
+
+    @Test
+    fun `If CBC is disabled, return the matched brand as soon as there is input`() = runTest {
+        val expectedAccountRange = AccountRange(
+            binRange = BinRange(
+                low = "4000000000000000",
+                high = "4999999999999999",
+            ),
+            panLength = 16,
+            brandInfo = AccountRange.BrandInfo.Visa,
+        )
+
+        val accountRanges = testBehavior(
+            cardNumber = "4",
+            isCbcEligible = false,
+        )
+
+        assertThat(accountRanges).containsExactly(expectedAccountRange)
+    }
+
+    @Test
+    fun `If CBC is enabled, don't return a matched brand until 8 characters are entered`() = runTest {
+        val accountRanges = testBehavior(
+            cardNumber = "4",
+            isCbcEligible = true,
+        )
+
+        assertThat(accountRanges).isEmpty()
+    }
+
+    @Test
+    fun `If CBC is enabled, return a matched brand once 8 characters are entered`() = runTest {
+        val expectedAccountRange = AccountRange(
+            binRange = BinRange(
+                low = "4000000000000000",
+                high = "4999999999999999",
+            ),
+            panLength = 16,
+            brandInfo = AccountRange.BrandInfo.Visa,
+        )
+
+        val accountRanges = testBehavior(
+            cardNumber = "4000 0000",
+            isCbcEligible = true,
+        )
+
+        assertThat(accountRanges).containsExactly(expectedAccountRange)
+    }
+
+    @Test
+    fun `If CBC is enabled, return all matched brands once 8 characters are entered`() = runTest {
+        val expectedAccountRanges = listOf(
+            AccountRange(
+                binRange = BinRange(
+                    low = "4000000000000000",
+                    high = "4999999999999999",
+                ),
+                panLength = 16,
+                brandInfo = AccountRange.BrandInfo.CartesBancaires,
+            ),
+            AccountRange(
+                binRange = BinRange(
+                    low = "4000000000000000",
+                    high = "4999999999999999",
+                ),
+                panLength = 16,
+                brandInfo = AccountRange.BrandInfo.Visa,
+            ),
+        )
+
+        val accountRanges = testBehavior(
+            cardNumber = "4000 0025",
+            isCbcEligible = true,
+        )
+
+        assertThat(accountRanges).containsExactlyElementsIn(expectedAccountRanges).inOrder()
+    }
+
+    private suspend fun testBehavior(
+        cardNumber: String,
+        isCbcEligible: Boolean,
+    ): List<AccountRange> {
+        val completable = CompletableDeferred<List<AccountRange>>()
+
+        val service = CardAccountRangeService(
+            cardAccountRangeRepository = createDefaultCardAccountRangeRepository(),
+            workContext = testDispatcher,
+            staticCardAccountRanges = DefaultStaticCardAccountRanges(),
+            accountRangeResultListener = object : CardAccountRangeService.AccountRangeResultListener {
+                override fun onAccountRangesResult(accountRanges: List<AccountRange>) {
+                    completable.complete(accountRanges)
+                }
+            },
+            isCbcEligible = { isCbcEligible },
+        )
+
+        service.onCardNumberChanged(CardNumber.Unvalidated(cardNumber))
+
+        return completable.await()
+    }
+
     private fun createMockRemoteDefaultCardAccountRangeRepository(
         mockRemoteCardAccountRangeSource: CardAccountRangeSource
     ): CardAccountRangeRepository {
@@ -91,11 +198,6 @@ class CardAccountRangeServiceTest {
             staticSource = StaticCardAccountRangeSource(),
             store = store
         )
-    }
-
-    @Test
-    fun `test card metadata service pan length`() = runTest {
-        verifyRemotePanLength("6500079999999999999", 16)
     }
 
     private fun verifyRemotePanLength(cardNumberString: String, expectedPanLength: Int) {

--- a/payments-core/src/test/java/com/stripe/android/cards/CardAccountRangeServiceTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/cards/CardAccountRangeServiceTest.kt
@@ -63,9 +63,10 @@ class CardAccountRangeServiceTest {
             testDispatcher,
             DefaultStaticCardAccountRanges(),
             object : CardAccountRangeService.AccountRangeResultListener {
-                override fun onAccountRangeResult(newAccountRange: AccountRange?) {
+                override fun onAccountRangesResult(accountRanges: List<AccountRange>) {
                 }
-            }
+            },
+            isCbcEligible = { false },
         )
 
         val cardNumber = CardNumber.Unvalidated(cardNumberString)
@@ -77,7 +78,7 @@ class CardAccountRangeServiceTest {
             } else {
                 never()
             }
-        ).getAccountRange(cardNumber)
+        ).getAccountRanges(cardNumber)
     }
 
     private fun createMockRemoteDefaultCardAccountRangeRepository(
@@ -105,11 +106,13 @@ class CardAccountRangeServiceTest {
             testDispatcher,
             DefaultStaticCardAccountRanges(),
             object : CardAccountRangeService.AccountRangeResultListener {
-                override fun onAccountRangeResult(newAccountRange: AccountRange?) {
+                override fun onAccountRangesResult(accountRanges: List<AccountRange>) {
+                    val newAccountRange = accountRanges.firstOrNull()
                     panLength = newAccountRange?.panLength
                     latch.countDown()
                 }
-            }
+            },
+            isCbcEligible = { false },
         )
 
         val cardNumber = CardNumber.Unvalidated(cardNumberString)

--- a/payments-core/src/test/java/com/stripe/android/cards/CardAccountRangeServiceTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/cards/CardAccountRangeServiceTest.kt
@@ -84,11 +84,6 @@ class CardAccountRangeServiceTest {
     }
 
     @Test
-    fun `test card metadata service pan length`() = runTest {
-        verifyRemotePanLength("6500079999999999999", 16)
-    }
-
-    @Test
     fun `If CBC is disabled, return the matched brand as soon as there is input`() = runTest {
         val expectedAccountRange = AccountRange(
             binRange = BinRange(
@@ -198,6 +193,11 @@ class CardAccountRangeServiceTest {
             staticSource = StaticCardAccountRangeSource(),
             store = store
         )
+    }
+
+    @Test
+    fun `test card metadata service pan length`() = runTest {
+        verifyRemotePanLength("6500079999999999999", 16)
     }
 
     private fun verifyRemotePanLength(cardNumberString: String, expectedPanLength: Int) {

--- a/payments-core/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
@@ -134,8 +134,8 @@ internal class CardNumberEditTextTest {
     @Test
     fun calculateCursorPosition_whenAmEx_increasesIndexWhenGoingPastTheSpaces() =
         runTest {
-            cardNumberEditText.accountRangeService.updateAccountRangeResult(
-                AccountRangeFixtures.AMERICANEXPRESS
+            cardNumberEditText.accountRangeService.updateAccountRangesResult(
+                listOf(AccountRangeFixtures.AMERICANEXPRESS)
             )
 
             assertThat(
@@ -149,8 +149,8 @@ internal class CardNumberEditTextTest {
     @Test
     fun calculateCursorPosition_whenDinersClub16_decreasesIndexWhenDeletingPastTheSpaces() =
         runTest {
-            cardNumberEditText.accountRangeService.updateAccountRangeResult(
-                AccountRangeFixtures.DINERSCLUB16
+            cardNumberEditText.accountRangeService.updateAccountRangesResult(
+                listOf(AccountRangeFixtures.DINERSCLUB16)
             )
 
             assertThat(
@@ -167,8 +167,8 @@ internal class CardNumberEditTextTest {
     @Test
     fun calculateCursorPosition_whenDeletingNotOnGaps_doesNotDecreaseIndex() =
         runTest {
-            cardNumberEditText.accountRangeService.updateAccountRangeResult(
-                AccountRangeFixtures.DINERSCLUB14
+            cardNumberEditText.accountRangeService.updateAccountRangesResult(
+                listOf(AccountRangeFixtures.DINERSCLUB14)
             )
 
             assertThat(
@@ -179,8 +179,8 @@ internal class CardNumberEditTextTest {
     @Test
     fun calculateCursorPosition_whenAmEx_decreasesIndexWhenDeletingPastTheSpaces() =
         runTest {
-            cardNumberEditText.accountRangeService.updateAccountRangeResult(
-                AccountRangeFixtures.AMERICANEXPRESS
+            cardNumberEditText.accountRangeService.updateAccountRangesResult(
+                listOf(AccountRangeFixtures.AMERICANEXPRESS)
             )
 
             assertThat(
@@ -194,8 +194,8 @@ internal class CardNumberEditTextTest {
     @Test
     fun calculateCursorPosition_whenSelectionInTheMiddle_increasesIndexOverASpace() =
         runTest {
-            cardNumberEditText.accountRangeService.updateAccountRangeResult(
-                AccountRangeFixtures.VISA
+            cardNumberEditText.accountRangeService.updateAccountRangesResult(
+                listOf(AccountRangeFixtures.VISA)
             )
 
             assertThat(

--- a/payments-core/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
@@ -3,6 +3,8 @@ package com.stripe.android.view
 import android.text.TextWatcher
 import android.view.ViewGroup
 import androidx.appcompat.view.ContextThemeWrapper
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
@@ -33,10 +35,12 @@ import com.stripe.android.cards.StaticCardAccountRanges
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.model.AccountRange
+import com.stripe.android.model.BinRange
 import com.stripe.android.model.CardBrand
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.testharness.ViewTestUtils
 import com.stripe.android.utils.TestUtils.idleLooper
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -50,7 +54,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.LooperMode
 import java.util.concurrent.TimeUnit
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -61,7 +64,6 @@ import kotlin.test.assertNull
  * Test class for [CardNumberEditText].
  */
 @RunWith(RobolectricTestRunner::class)
-@LooperMode(LooperMode.Mode.PAUSED)
 internal class CardNumberEditTextTest {
     private val testDispatcher = UnconfinedTestDispatcher()
     private val context = ContextThemeWrapper(
@@ -926,6 +928,114 @@ internal class CardNumberEditTextTest {
         verify(textChangeListener, times(1)).afterTextChanged(any())
     }
 
+    @Test
+    fun `Sets card brand and possible brands correctly when multiple brands without CBC eligibility`() {
+        val accountRanges = listOf(
+            AccountRange(
+                binRange = BinRange(
+                    low = "4000000000000000",
+                    high = "4999999999999999",
+                ),
+                panLength = 16,
+                brandInfo = AccountRange.BrandInfo.CartesBancaires,
+            ),
+            AccountRange(
+                binRange = BinRange(
+                    low = "4000000000000000",
+                    high = "4999999999999999",
+                ),
+                panLength = 16,
+                brandInfo = AccountRange.BrandInfo.Visa,
+            ),
+        )
+
+        testAccountRangeService(
+            accountRanges = accountRanges,
+            isCbcEligible = false,
+            dispatcher = testDispatcher,
+        ) { cardNumberEditText ->
+            assertThat(cardNumberEditText.cardBrand).isEqualTo(CardBrand.Unknown)
+            assertThat(cardNumberEditText.possibleCardBrands).isEmpty()
+        }
+    }
+
+    @Test
+    fun `Sets card brand and possible brands correctly when single brand without CBC eligibility`() {
+        val accountRanges = listOf(
+            AccountRange(
+                binRange = BinRange(
+                    low = "4000000000000000",
+                    high = "4999999999999999",
+                ),
+                panLength = 16,
+                brandInfo = AccountRange.BrandInfo.Visa,
+            ),
+        )
+
+        testAccountRangeService(
+            accountRanges = accountRanges,
+            isCbcEligible = false,
+            dispatcher = testDispatcher,
+        ) { cardNumberEditText ->
+            assertThat(cardNumberEditText.cardBrand).isEqualTo(CardBrand.Visa)
+            assertThat(cardNumberEditText.possibleCardBrands).isEmpty()
+        }
+    }
+
+    @Test
+    fun `Sets card brand and possible brands correctly when multiple brands with CBC eligibility`() = runTest {
+        val accountRanges = listOf(
+            AccountRange(
+                binRange = BinRange(
+                    low = "4000000000000000",
+                    high = "4999999999999999",
+                ),
+                panLength = 16,
+                brandInfo = AccountRange.BrandInfo.CartesBancaires,
+            ),
+            AccountRange(
+                binRange = BinRange(
+                    low = "4000000000000000",
+                    high = "4999999999999999",
+                ),
+                panLength = 16,
+                brandInfo = AccountRange.BrandInfo.Visa,
+            ),
+        )
+
+        testAccountRangeService(
+            accountRanges = accountRanges,
+            isCbcEligible = true,
+            dispatcher = testDispatcher,
+        ) { cardNumberEditText ->
+            assertThat(cardNumberEditText.cardBrand).isEqualTo(CardBrand.Unknown)
+            assertThat(cardNumberEditText.possibleCardBrands).containsExactly(CardBrand.CartesBancaires, CardBrand.Visa)
+        }
+    }
+
+    @Test
+    fun `Sets card brand and possible brands correctly when single brand with CBC eligibility`() = runTest {
+        val accountRanges = listOf(
+            AccountRange(
+                binRange = BinRange(
+                    low = "4000000000000000",
+                    high = "4999999999999999",
+                ),
+                panLength = 16,
+                brandInfo = AccountRange.BrandInfo.Visa,
+            ),
+        )
+
+        testAccountRangeService(
+            accountRanges = accountRanges,
+            isCbcEligible = true,
+            dispatcher = testDispatcher,
+        ) { cardNumberEditText ->
+            assertThat(cardNumberEditText.cardBrand).isEqualTo(CardBrand.Visa)
+            assertThat(cardNumberEditText.possibleCardBrands).containsExactly(CardBrand.Visa)
+        }
+    }
+
     private fun verifyCardBrandBin(
         cardBrand: CardBrand,
         bin: String
@@ -940,6 +1050,55 @@ internal class CardNumberEditTextTest {
     private fun updateCardNumberAndIdle(cardNumber: String) {
         cardNumberEditText.setText(cardNumber)
         idleLooper()
+    }
+
+    private fun testAccountRangeService(
+        accountRanges: List<AccountRange>,
+        isCbcEligible: Boolean,
+        dispatcher: CoroutineDispatcher,
+        block: (CardNumberEditText) -> Unit,
+    ) {
+        PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
+
+        val cardWidgetViewModel = CardWidgetViewModel(
+            cbcEnabled = { isCbcEligible },
+            dispatcher = dispatcher,
+        )
+
+        val store = ViewModelStore().apply {
+            val className = CardWidgetViewModel::class.java.canonicalName
+            put("androidx.lifecycle.ViewModelProvider.DefaultKey:$className", cardWidgetViewModel)
+        }
+
+        val storeOwner = object : ViewModelStoreOwner {
+            override val viewModelStore: ViewModelStore = store
+        }
+
+        val activityScenario = activityScenarioFactory.createAddPaymentMethodActivity()
+
+        activityScenario.use { scenario ->
+            scenario.onActivity { activity ->
+                val cardNumberEditText = CardNumberEditText(
+                    context = activity,
+                    workContext = testDispatcher,
+                    cardAccountRangeRepository = DelayedCardAccountRangeRepository(),
+                    analyticsRequestExecutor = analyticsRequestExecutor,
+                    paymentAnalyticsRequestFactory = analyticsRequestFactory,
+                    viewModelStoreOwner = storeOwner,
+                )
+
+                activity.findViewById<ViewGroup>(R.id.add_payment_method_card).also {
+                    it.removeAllViews()
+                    it.addView(cardNumberEditText)
+                }
+
+                testDispatcher.scheduler.advanceTimeBy(2_001)
+
+                cardNumberEditText.accountRangeService.updateAccountRangesResult(accountRanges)
+
+                block(cardNumberEditText)
+            }
+        }
     }
 
     private class DelayedCardAccountRangeRepository : CardAccountRangeRepository {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -132,13 +132,15 @@ internal class CardNumberEditableController constructor(
         workContext,
         staticCardAccountRanges,
         object : CardAccountRangeService.AccountRangeResultListener {
-            override fun onAccountRangeResult(newAccountRange: AccountRange?) {
+            override fun onAccountRangesResult(accountRanges: List<AccountRange>) {
+                val newAccountRange = accountRanges.firstOrNull()
                 newAccountRange?.panLength?.let { panLength ->
                     (visualTransformation as CardNumberVisualTransformation).binBasedMaxPan =
                         panLength
                 }
             }
-        }
+        },
+        isCbcEligible = { isEligibleForCardBrandChoice },
     )
 
     override val loading: Flow<Boolean> = accountRangeService.isLoading


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds a dropdown to `CardInputWidget` that allows end users to select their preferred card network when processing the transaction.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

CBC.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screen recording

[cbc card element.webm](https://github.com/stripe/stripe-android/assets/110940675/43410c95-a766-4138-87fc-93a91acbf460)

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
