### PR TITLE
[Android] Navigating back from institution picker requires two taps


### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+### Financial Connections
+* [FIXED][7331](https://github.com/stripe/stripe-android/pull/7331) When cancelling out of a auth session, going back to the consent screen requires two back taps.
+
 Dependencies updated:
 * [7297](https://github.com/stripe/stripe-android/pull/7297) Bumped Compose Foundation, Compose Material, Compose Runtime, and Compose UI from 1.4.3 to 1.5.1.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## XX.XX.XX - 2023-XX-XX
 
 ### Financial Connections
-* [FIXED][7331](https://github.com/stripe/stripe-android/pull/7331) When cancelling out of a auth session, going back to the consent screen requires two back taps.
+* [FIXED][7331](https://github.com/stripe/stripe-android/pull/7331) When cancelling out of a auth session, going back to the consent screen required two back taps.
 
 Dependencies updated:
 * [7297](https://github.com/stripe/stripe-android/pull/7297) Bumped Compose Foundation, Compose Material, Compose Runtime, and Compose UI from 1.4.3 to 1.5.1.

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/NavigationManager.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/NavigationManager.kt
@@ -12,21 +12,16 @@ internal interface NavigationManager {
         route: String,
         popUpToCurrent: Boolean = false,
         inclusive: Boolean = false,
-        isSingleTop: Boolean = false,
+        isSingleTop: Boolean = true,
     )
 }
 
 internal sealed class NavigationIntent {
-    data class NavigateBack(
-        val route: String? = null,
-        val inclusive: Boolean = false,
-    ) : NavigationIntent()
-
     data class NavigateTo(
         val route: String,
-        val popUpToCurrent: Boolean = false,
-        val inclusive: Boolean = false,
-        val isSingleTop: Boolean = true,
+        val popUpToCurrent: Boolean,
+        val inclusive: Boolean,
+        val isSingleTop: Boolean,
     ) : NavigationIntent()
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -219,14 +219,6 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
                     return@onEach
                 }
                 when (intent) {
-                    is NavigationIntent.NavigateBack -> {
-                        if (intent.route != null) {
-                            navHostController.popBackStack(intent.route, intent.inclusive)
-                        } else {
-                            navHostController.popBackStack()
-                        }
-                    }
-
                     is NavigationIntent.NavigateTo -> {
                         val from: String? = navHostController.currentDestination?.route
                         val destination: String = intent.route


### PR DESCRIPTION
# Summary
- **Problem**: PartnerAuth navigates to InstitutionPicker without `isSingleTop`. That creates a second instance of the picker (that already exists on the back stack)
- **Solution**: Make it singleTop. This PR makes singleTop the default on the flow, as we never want two instances of the same screen. 

# Motivation
:notebook_with_decorative_cover: &nbsp;**[Android] Navigating back from institution picker requires two taps**
:globe_with_meridians: &nbsp;[BANKCON-7646](https://jira.corp.stripe.com/browse/BANKCON-7646)

> It *seems* like the bug is because of a missing `isSingleTop = true` in `cancelAuthSessionAndContinue`
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing

you can test running Maestro tests: ` maestro test -e APP_ID=com.stripe.android.financialconnections.example maestro/financial-connections/ `

- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
