### PR TITLE
Add support for Swish in PaymentSheet and bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### PaymentSheet
 * [ADDED][7337](https://github.com/stripe/stripe-android/pull/7337) PaymentSheet now supports Swish for PaymentIntents in private beta.
 
+### Payments
+* [ADDED][7337](https://github.com/stripe/stripe-android/pull/7337) Added support for Swish for PaymentIntents in private beta.
+
 ### Financial Connections
 * [FIXED][7331](https://github.com/stripe/stripe-android/pull/7331) When cancelling out of a auth session, going back to the consent screen required two back taps.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+### PaymentSheet
+* [ADDED][7337](https://github.com/stripe/stripe-android/pull/7337) PaymentSheet now supports Swish for PaymentIntents in private beta.
+
 ### Financial Connections
 * [FIXED][7331](https://github.com/stripe/stripe-android/pull/7331) When cancelling out of a auth session, going back to the consent screen required two back taps.
 

--- a/example/AndroidManifest.xml
+++ b/example/AndroidManifest.xml
@@ -79,6 +79,7 @@
         <activity android:name=".activity.CashAppPayActivity"/>
         <activity android:name=".activity.BlikPaymentMethodActivity"/>
         <activity android:name=".activity.RevolutPayActivity"/>
+        <activity android:name=".activity.SwishExampleActivity"/>
     </application>
 
 </manifest>

--- a/example/res/values/strings.xml
+++ b/example/res/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="manual_us_bank_account_example">"Manual US Bank Account Example"</string>
     <string name="cash_app_pay_example">Cash App Pay</string>
     <string name="revolut_pay_example">Revolut Pay</string>
+    <string name="swish_example">Swish</string>
     <string name="card_brands">Card Brands</string>
     <string name="card_brands_hint">Card number</string>
     <string name="possible_card_brands">Possible Card Brands</string>

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
@@ -177,6 +177,10 @@ class LauncherActivity : AppCompatActivity() {
                 activity.getString(R.string.revolut_pay_example),
                 RevolutPayActivity::class.java
             ),
+            Item(
+                activity.getString(R.string.swish_example),
+                SwishExampleActivity::class.java
+            ),
             // This is for internal use so as not to confuse the user.
             Item(
                 "StripeImage Example",

--- a/example/src/main/java/com/stripe/example/activity/SwishExampleActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/SwishExampleActivity.kt
@@ -1,0 +1,91 @@
+package com.stripe.example.activity
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Button
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Divider
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.google.accompanist.themeadapter.material.MdcTheme
+import com.stripe.android.model.PaymentMethodCreateParams
+
+class SwishExampleActivity : StripeIntentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            val isProcessing by viewModel.inProgress.observeAsState(initial = false)
+            val status by viewModel.status.observeAsState(initial = "")
+
+            SwishScreen(
+                isProcessing = isProcessing,
+                status = status,
+                onButtonPressed = { payWithSwish() },
+            )
+        }
+    }
+
+    private fun payWithSwish() {
+        val params = PaymentMethodCreateParams.createSwish()
+
+        createAndConfirmPaymentIntent(
+            country = "FR",
+            currency = "SEK",
+            paymentMethodCreateParams = params,
+            supportedPaymentMethods = "swish",
+        )
+    }
+}
+
+@Composable
+private fun SwishScreen(
+    isProcessing: Boolean,
+    status: String,
+    onButtonPressed: () -> Unit,
+) {
+    MdcTheme {
+        Column(modifier = Modifier.fillMaxSize()) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Button(
+                    onClick = onButtonPressed,
+                    enabled = !isProcessing,
+                    modifier = Modifier.padding(16.dp),
+                ) {
+                    Text("Pay with Swish")
+                }
+
+                if (isProcessing) {
+                    CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                }
+            }
+
+            if (status.isNotBlank()) {
+                Divider(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                )
+
+                Text(
+                    text = status,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                )
+            }
+        }
+    }
+}

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -3799,6 +3799,7 @@ public final class com/stripe/android/model/PaymentMethod$Type : java/lang/Enum,
 	public static final field RevolutPay Lcom/stripe/android/model/PaymentMethod$Type;
 	public static final field SepaDebit Lcom/stripe/android/model/PaymentMethod$Type;
 	public static final field Sofort Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field Swish Lcom/stripe/android/model/PaymentMethod$Type;
 	public static final field USBankAccount Lcom/stripe/android/model/PaymentMethod$Type;
 	public static final field Upi Lcom/stripe/android/model/PaymentMethod$Type;
 	public static final field WeChatPay Lcom/stripe/android/model/PaymentMethod$Type;
@@ -6210,6 +6211,29 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$SdkData$
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/model/StripeIntent$NextActionData$SwishRedirect : com/stripe/android/model/StripeIntent$NextActionData {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/StripeIntent$NextActionData$SwishRedirect;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/StripeIntent$NextActionData$SwishRedirect;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/StripeIntent$NextActionData$SwishRedirect;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMobileAuthUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/StripeIntent$NextActionData$SwishRedirect$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/StripeIntent$NextActionData$SwishRedirect;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/StripeIntent$NextActionData$SwishRedirect;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/model/StripeIntent$NextActionData$UpiAwaitNotification : com/stripe/android/model/StripeIntent$NextActionData {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
@@ -6271,6 +6295,7 @@ public final class com/stripe/android/model/StripeIntent$NextActionType : java/l
 	public static final field DisplayKonbiniDetails Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field DisplayOxxoDetails Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field RedirectToUrl Lcom/stripe/android/model/StripeIntent$NextActionType;
+	public static final field SwishRedirect Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field UpiAwaitNotification Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field UseStripeSdk Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field VerifyWithMicrodeposits Lcom/stripe/android/model/StripeIntent$NextActionType;

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -3969,12 +3969,13 @@ public final class com/stripe/android/model/PaymentMethodCreateParams : android/
 	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethodCreateParams$Swish;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethodCreateParams$USBankAccount;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component15 ()Lcom/stripe/android/model/PaymentMethod$BillingDetails;
+	public final fun component16 ()Lcom/stripe/android/model/PaymentMethod$BillingDetails;
 	public final fun component3 ()Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
-	public final fun copy (Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethodCreateParams$Card;Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;Lcom/stripe/android/model/PaymentMethodCreateParams$USBankAccount;Lcom/stripe/android/model/PaymentMethodCreateParams$Link;Lcom/stripe/android/model/PaymentMethodCreateParams$CashAppPay;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Ljava/util/Set;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethodCreateParams$Card;Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;Lcom/stripe/android/model/PaymentMethodCreateParams$USBankAccount;Lcom/stripe/android/model/PaymentMethodCreateParams$Link;Lcom/stripe/android/model/PaymentMethodCreateParams$CashAppPay;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Ljava/util/Set;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun copy (Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethodCreateParams$Card;Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;Lcom/stripe/android/model/PaymentMethodCreateParams$USBankAccount;Lcom/stripe/android/model/PaymentMethodCreateParams$Link;Lcom/stripe/android/model/PaymentMethodCreateParams$CashAppPay;Lcom/stripe/android/model/PaymentMethodCreateParams$Swish;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Ljava/util/Set;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethodCreateParams$Card;Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;Lcom/stripe/android/model/PaymentMethodCreateParams$USBankAccount;Lcom/stripe/android/model/PaymentMethodCreateParams$Link;Lcom/stripe/android/model/PaymentMethodCreateParams$CashAppPay;Lcom/stripe/android/model/PaymentMethodCreateParams$Swish;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Ljava/util/Set;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
@@ -4039,6 +4040,9 @@ public final class com/stripe/android/model/PaymentMethodCreateParams : android/
 	public static final fun createRevolutPay ()Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun createRevolutPay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun createRevolutPay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createSwish ()Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createSwish (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createSwish (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun createUSBankAccount ()Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun createUSBankAccount (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun createUSBankAccount (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
@@ -4255,6 +4259,10 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Companion 
 	public final fun createRevolutPay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun createRevolutPay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static synthetic fun createRevolutPay$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createSwish ()Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createSwish (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createSwish (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun createSwish$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun createUSBankAccount ()Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun createUSBankAccount (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun createUSBankAccount (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
@@ -4412,6 +4420,23 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Sofort$Cre
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethodCreateParams$Swish : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun describeContents ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/PaymentMethodCreateParams$Swish$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$Swish;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodCreateParams$Swish;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/payments-core/detekt-baseline.xml
+++ b/payments-core/detekt-baseline.xml
@@ -7,6 +7,7 @@
     <ID>ComplexCondition:ExpiryDateEditText.kt$ExpiryDateEditText.&lt;no name provided>$expirationDate.month.length == 2 &amp;&amp; latestInsertionSize > 0 &amp;&amp; !inErrorState || rawNumericInput.length > 2</ID>
     <ID>ConstructorParameterNaming:Source.kt$Source$private val _klarna: Klarna? = null</ID>
     <ID>ConstructorParameterNaming:Source.kt$Source$private val _weChat: WeChat? = null</ID>
+    <ID>CyclomaticComplexMethod:NextActionDataParser.kt$NextActionDataParser$override fun parse( json: JSONObject ): StripeIntent.NextActionData?</ID>
     <ID>CyclomaticComplexMethod:PaymentMethodJsonParser.kt$PaymentMethodJsonParser$override fun parse(json: JSONObject): PaymentMethod</ID>
     <ID>CyclomaticComplexMethod:Source.kt$Source.Companion$@SourceType @JvmStatic fun asSourceType(sourceType: String?): String</ID>
     <ID>CyclomaticComplexMethod:SourceJsonParser.kt$SourceJsonParser.Companion$@Source.SourceType private fun asSourceType(sourceType: String?): String</ID>

--- a/payments-core/src/main/java/com/stripe/android/StripeIntentResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripeIntentResult.kt
@@ -91,6 +91,7 @@ abstract class StripeIntentResult<out T : StripeIntent> internal constructor(
             StripeIntent.NextActionType.AlipayRedirect,
             StripeIntent.NextActionType.WeChatPayRedirect,
             StripeIntent.NextActionType.CashAppRedirect,
+            StripeIntent.NextActionType.SwishRedirect,
             null -> {
                 false
             }

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -189,6 +189,9 @@ constructor(
             is StripeIntent.NextActionData.BlikAuthorize -> {
                 StripeIntent.NextActionType.BlikAuthorize
             }
+            is StripeIntent.NextActionData.SwishRedirect -> {
+                StripeIntent.NextActionType.SwishRedirect
+            }
             is StripeIntent.NextActionData.AlipayRedirect,
             is StripeIntent.NextActionData.WeChatPayRedirect,
             null -> {

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -397,6 +397,13 @@ constructor(
             isVoucher = true,
             requiresMandate = false,
             hasDelayedSettlement = true,
+        ),
+        Swish(
+            code = "swish",
+            isReusable = false,
+            isVoucher = false,
+            requiresMandate = false,
+            hasDelayedSettlement = false,
         );
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -34,6 +34,7 @@ data class PaymentMethodCreateParams internal constructor(
     private val usBankAccount: USBankAccount? = null,
     private val link: Link? = null,
     private val cashAppPay: CashAppPay? = null,
+    private val swish: Swish? = null,
     val billingDetails: PaymentMethod.BillingDetails? = null,
     private val metadata: Map<String, String>? = null,
     private val productUsage: Set<String> = emptySet(),
@@ -65,6 +66,7 @@ data class PaymentMethodCreateParams internal constructor(
         usBankAccount: USBankAccount? = null,
         link: Link? = null,
         cashAppPay: CashAppPay? = null,
+        swish: Swish? = null,
         billingDetails: PaymentMethod.BillingDetails? = null,
         metadata: Map<String, String>? = null,
         productUsage: Set<String> = emptySet(),
@@ -84,6 +86,7 @@ data class PaymentMethodCreateParams internal constructor(
         usBankAccount,
         link,
         cashAppPay,
+        swish,
         billingDetails,
         metadata,
         productUsage,
@@ -220,6 +223,17 @@ data class PaymentMethodCreateParams internal constructor(
     ) : this(
         type = PaymentMethod.Type.CashAppPay,
         cashAppPay = cashAppPay,
+        billingDetails = billingDetails,
+        metadata = metadata,
+    )
+
+    private constructor(
+        swish: Swish,
+        billingDetails: PaymentMethod.BillingDetails?,
+        metadata: Map<String, String>?,
+    ) : this(
+        type = PaymentMethod.Type.Swish,
+        swish = swish,
         billingDetails = billingDetails,
         metadata = metadata,
     )
@@ -490,6 +504,14 @@ data class PaymentMethodCreateParams internal constructor(
      */
     @Parcelize
     class CashAppPay : StripeParamsModel, Parcelable {
+        override fun toParamMap(): Map<String, Any> = emptyMap()
+    }
+
+    /**
+     * Encapsulates parameters used to create [PaymentMethodCreateParams] when using Swish.
+     */
+    @Parcelize
+    class Swish : StripeParamsModel, Parcelable {
         override fun toParamMap(): Map<String, Any> = emptyMap()
     }
 
@@ -956,6 +978,19 @@ data class PaymentMethodCreateParams internal constructor(
             metadata: Map<String, String>? = null
         ): PaymentMethodCreateParams {
             return PaymentMethodCreateParams(CashAppPay(), billingDetails, metadata)
+        }
+
+        /**
+         * Helper method to create [PaymentMethodCreateParams] with [Swish] as the payment
+         * method type.
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun createSwish(
+            billingDetails: PaymentMethod.BillingDetails? = null,
+            metadata: Map<String, String>? = null
+        ): PaymentMethodCreateParams {
+            return PaymentMethodCreateParams(Swish(), billingDetails, metadata)
         }
 
         @JvmStatic

--- a/payments-core/src/main/java/com/stripe/android/model/SetupIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/SetupIntent.kt
@@ -141,6 +141,7 @@ data class SetupIntent internal constructor(
             is StripeIntent.NextActionData.BlikAuthorize,
             is StripeIntent.NextActionData.WeChatPayRedirect,
             is StripeIntent.NextActionData.UpiAwaitNotification,
+            is StripeIntent.NextActionData.SwishRedirect,
             null -> {
                 null
             }

--- a/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -97,7 +97,8 @@ sealed interface StripeIntent : StripeModel {
         UpiAwaitNotification("upi_await_notification"),
         CashAppRedirect("cashapp_handle_redirect_or_display_qr_code"),
         DisplayBoletoDetails("boleto_display_details"),
-        DisplayKonbiniDetails("konbini_display_details");
+        DisplayKonbiniDetails("konbini_display_details"),
+        SwishRedirect("swish_handle_redirect_or_display_qr_code");
 
         @Keep
         override fun toString(): String {
@@ -331,6 +332,14 @@ sealed interface StripeIntent : StripeModel {
          */
         @Parcelize
         data class CashAppRedirect(
+            val mobileAuthUrl: String,
+        ) : NextActionData()
+
+        /**
+         * Contains the authentication URL for redirecting your customer to Swish.
+         */
+        @Parcelize
+        data class SwishRedirect(
             val mobileAuthUrl: String,
         ) : NextActionData()
     }

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/NextActionDataParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/NextActionDataParser.kt
@@ -28,6 +28,7 @@ internal class NextActionDataParser : ModelJsonParser<StripeIntent.NextActionDat
             StripeIntent.NextActionType.VerifyWithMicrodeposits -> VerifyWithMicrodepositsParser()
             StripeIntent.NextActionType.UpiAwaitNotification -> UpiAwaitNotificationParser()
             StripeIntent.NextActionType.CashAppRedirect -> CashAppRedirectParser()
+            StripeIntent.NextActionType.SwishRedirect -> SwishRedirectParser()
             null -> return null
         }
         return parser.parse(json.optJSONObject(nextActionType.code) ?: JSONObject())
@@ -260,6 +261,16 @@ internal class NextActionDataParser : ModelJsonParser<StripeIntent.NextActionDat
 
         override fun parse(json: JSONObject): StripeIntent.NextActionData.CashAppRedirect {
             return StripeIntent.NextActionData.CashAppRedirect(
+                mobileAuthUrl = json.optString("mobile_auth_url"),
+            )
+        }
+    }
+
+    internal class SwishRedirectParser :
+        ModelJsonParser<StripeIntent.NextActionData.SwishRedirect> {
+
+        override fun parse(json: JSONObject): StripeIntent.NextActionData.SwishRedirect {
+            return StripeIntent.NextActionData.SwishRedirect(
                 mobileAuthUrl = json.optString("mobile_auth_url"),
             )
         }

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -155,8 +155,13 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
         val shouldRefreshForCashApp = stripeIntent.requiresAction() &&
             stripeIntent.paymentMethod?.type == PaymentMethod.Type.CashAppPay
 
+        // For Swish, the intent status can still be `requires_action` by the time the user
+        // gets back to the merchant app. We poll until it's succeeded.
+        val shouldRefreshForSwish = stripeIntent.requiresAction() &&
+            stripeIntent.paymentMethod?.type == PaymentMethod.Type.Swish
+
         return succeededMaybeRefresh || cancelledMaybeRefresh ||
-            actionNotProcessedMaybeRefresh || shouldRefreshForCashApp
+            actionNotProcessedMaybeRefresh || shouldRefreshForCashApp || shouldRefreshForSwish
     }
 
     private fun determineFlowOutcome(intent: StripeIntent, originalFlowOutcome: Int): Int {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
@@ -103,8 +103,14 @@ internal class WebIntentAuthenticator @Inject constructor(
                 returnUrl = defaultReturnUrl.value
                 shouldCancelIntentOnUserNavigation = false
             }
-            else ->
+            is StripeIntent.NextActionData.SwishRedirect -> {
+                authUrl = nextActionData.mobileAuthUrl
+                returnUrl = defaultReturnUrl.value
+                shouldCancelIntentOnUserNavigation = false
+            }
+            else -> {
                 throw IllegalArgumentException("WebAuthenticator can't process nextActionData: $nextActionData")
+            }
         }
 
         beginWebAuth(

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationModule.kt
@@ -82,6 +82,14 @@ internal abstract class AuthenticationModule {
         webIntentAuthenticator: WebIntentAuthenticator
     ): PaymentAuthenticator<StripeIntent>
 
+    @IntentAuthenticatorMap
+    @Binds
+    @IntoMap
+    @IntentAuthenticatorKey(NextActionData.SwishRedirect::class)
+    abstract fun bindsSwishRedirectAuthenticator(
+        webIntentAuthenticator: WebIntentAuthenticator
+    ): PaymentAuthenticator<StripeIntent>
+
     companion object {
         @Provides
         @Singleton

--- a/payments-core/src/test/java/com/stripe/android/ApiKeyFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/ApiKeyFixtures.kt
@@ -30,4 +30,6 @@ internal object ApiKeyFixtures {
     const val CASH_APP_PAY_PUBLISHABLE_KEY = "pk_test_ErsyMEOTudSjQR8hh0VrQr5X008sBXGOu6"
     const val REVOLUT_PAY_PUBLISHABLE_KEY =
         "pk_test_51KmkHbGoesj9fw9QAZJlz1qY4dns8nFmLKc7rXiWKAIj8QU7NPFPwSY1h8mqRaFRKQ9njs9pVJoo2jhN6ZKSDA4h00mjcbGF7b"
+    const val SWISH_PUBLISHABLE_KEY =
+        "pk_test_51JtgfQKG6vc7r7YCU0qQNOkDaaHrEgeHgGKrJMNfuWwaKgXMLzPUA1f8ZlCNPonIROLOnzpUnJK1C1xFH3M3Mz8X00Q6O4GfUt"
 }

--- a/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
@@ -456,4 +456,13 @@ internal class PaymentMethodEndToEndTest {
         val paymentMethod = stripe.createPaymentMethodSynchronous(params)
         assertThat(paymentMethod.type).isEqualTo(PaymentMethod.Type.RevolutPay)
     }
+
+    @Test
+    fun createPaymentMethod_withSwish_shouldCreateObject() {
+        val params = PaymentMethodCreateParamsFixtures.SWISH
+        val stripe = Stripe(context, ApiKeyFixtures.SWISH_PUBLISHABLE_KEY)
+
+        val paymentMethod = stripe.createPaymentMethodSynchronous(params)
+        assertThat(paymentMethod.type).isEqualTo(PaymentMethod.Type.Swish)
+    }
 }

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsFixtures.kt
@@ -121,6 +121,10 @@ internal object PaymentMethodCreateParamsFixtures {
         billingDetails = BILLING_DETAILS,
     )
 
+    internal val SWISH = PaymentMethodCreateParams.createSwish(
+        billingDetails = BILLING_DETAILS,
+    )
+
     @JvmStatic
     fun createWith(metadata: Map<String, String>): PaymentMethodCreateParams {
         return PaymentMethodCreateParams.create(

--- a/payments-ui-core/res/drawable/stripe_ic_paymentsheet_pm_swish.xml
+++ b/payments-ui-core/res/drawable/stripe_ic_paymentsheet_pm_swish.xml
@@ -1,0 +1,76 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="32"
+    android:viewportHeight="32">
+  <path
+      android:pathData="M0,0h32v32H0z"
+      android:fillColor="#F6F8FA"/>
+  <path
+      android:pathData="M10.827,26.832c4.82,2.305 10.77,1.164 14.366,-3.12 4.26,-5.075 3.6,-12.644 -1.478,-16.903l-3.376,4.021a9.372,9.372 0,0 1,1.155 13.206c-2.653,3.163 -7.024,4.218 -10.667,2.794"
+      android:fillType="evenOdd">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="19.869"
+          android:startY="21.674"
+          android:endX="14.753"
+          android:endY="11.407"
+          android:type="linear">
+        <item android:offset="0" android:color="#FFEF2131"/>
+        <item android:offset="1" android:color="#FFFECF2C"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="M10.827,26.832c4.82,2.305 10.77,1.164 14.366,-3.12 0.441,-0.523 0.827,-1.075 1.163,-1.647a10.493,10.493 0,0 0,-3.617 -9.72,10.497 10.497,0 0,0 -2.398,-1.515 9.374,9.374 0,0 1,1.154 13.206c-2.653,3.163 -7.024,4.218 -10.667,2.794"
+      android:fillType="evenOdd">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="23.985"
+          android:startY="13.155"
+          android:endX="15.145"
+          android:endY="28.628"
+          android:type="linear">
+        <item android:offset="0" android:color="#FFFBC52C"/>
+        <item android:offset="0.26" android:color="#FFF87130"/>
+        <item android:offset="0.56" android:color="#FFEF52E2"/>
+        <item android:offset="1" android:color="#FF661EEC"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="M21.175,5.168c-4.821,-2.305 -10.771,-1.164 -14.367,3.12 -4.26,5.076 -3.6,12.644 1.479,16.903l3.375,-4.021a9.372,9.372 0,0 1,-1.155 -13.206c2.654,-3.163 7.025,-4.22 10.668,-2.796Z"
+      android:fillType="evenOdd">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="12.184"
+          android:startY="10.18"
+          android:endX="17.062"
+          android:endY="20.064"
+          android:type="linear">
+        <item android:offset="0" android:color="#FF78F6D8"/>
+        <item android:offset="0.27" android:color="#FF77D1F6"/>
+        <item android:offset="0.55" android:color="#FF70A4F3"/>
+        <item android:offset="1" android:color="#FF661EEC"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="M21.175,5.168c-4.821,-2.305 -10.771,-1.164 -14.367,3.12 -0.44,0.523 -0.827,1.075 -1.163,1.647a10.493,10.493 0,0 0,3.618 9.72c0.746,0.626 1.553,1.13 2.398,1.515a9.374,9.374 0,0 1,-1.155 -13.206c2.655,-3.163 7.026,-4.22 10.669,-2.796Z"
+      android:fillType="evenOdd">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="8.021"
+          android:startY="18.849"
+          android:endX="16.861"
+          android:endY="3.376"
+          android:type="linear">
+        <item android:offset="0" android:color="#FF536EED"/>
+        <item android:offset="0.25" android:color="#FF54C3EC"/>
+        <item android:offset="0.56" android:color="#FF64D769"/>
+        <item android:offset="1" android:color="#FFFECF2C"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+</vector>

--- a/payments-ui-core/res/values/donottranslate.xml
+++ b/payments-ui-core/res/values/donottranslate.xml
@@ -17,7 +17,7 @@
     <string name="stripe_paymentsheet_payment_method_grabpay">GrabPay</string>
     <string name="stripe_paymentsheet_payment_method_fpx">FPX Bank</string>
     <string name="stripe_paymentsheet_payment_method_boleto">Boleto</string>
-
+    <string name="stripe_paymentsheet_payment_method_swish">Swish</string>
     <string name="stripe_paymentsheet_payment_method_affirm">Affirm</string>
     <string name="stripe_paymentsheet_payment_method_revolut_pay">Revolut Pay</string>
     <string name="stripe_paymentsheet_payment_method_amazon_pay">Amazon Pay</string>

--- a/payments-ui-core/src/main/assets/lpms.json
+++ b/payments-ui-core/src/main/assets/lpms.json
@@ -1086,5 +1086,14 @@
         "type": "konbini_confirmation_number"
       }
     ]
+  },
+  {
+    "type": "swish",
+    "async": false,
+    "fields": [],
+    "selector_icon": {
+      "light_theme_png": null,
+      "light_theme_svg": null
+    }
   }
 ]

--- a/payments-ui-core/src/main/assets/lpms.json
+++ b/payments-ui-core/src/main/assets/lpms.json
@@ -1090,10 +1090,6 @@
   {
     "type": "swish",
     "async": false,
-    "fields": [],
-    "selector_icon": {
-      "light_theme_png": null,
-      "light_theme_svg": null
-    }
+    "fields": []
   }
 ]

--- a/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
@@ -295,3 +295,9 @@ internal val KonbiniRequirement = PaymentMethodRequirements(
     siRequirements = null,
     confirmPMFromCustomer = null,
 )
+
+internal val SwishRequirement = PaymentMethodRequirements(
+    piRequirements = emptySet(),
+    siRequirements = null,
+    confirmPMFromCustomer = false,
+)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
@@ -40,6 +40,7 @@ import com.stripe.android.paymentsheet.forms.PaypalRequirement
 import com.stripe.android.paymentsheet.forms.RevolutPayRequirement
 import com.stripe.android.paymentsheet.forms.SepaDebitRequirement
 import com.stripe.android.paymentsheet.forms.SofortRequirement
+import com.stripe.android.paymentsheet.forms.SwishRequirement
 import com.stripe.android.paymentsheet.forms.USBankAccountRequirement
 import com.stripe.android.paymentsheet.forms.UpiRequirement
 import com.stripe.android.paymentsheet.forms.ZipRequirement
@@ -598,6 +599,17 @@ class LpmRepository constructor(
             darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
             tintIconOnSelection = false,
             requirement = KonbiniRequirement,
+            formSpec = LayoutSpec(sharedDataSpec.fields),
+        )
+        PaymentMethod.Type.Swish.code -> SupportedPaymentMethod(
+            code = "swish",
+            requiresMandate = false,
+            displayNameResource = R.string.stripe_paymentsheet_payment_method_swish,
+            iconResource = R.drawable.stripe_ic_paymentsheet_pm_swish,
+            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+            tintIconOnSelection = false,
+            requirement = SwishRequirement,
             formSpec = LayoutSpec(sharedDataSpec.fields),
         )
         else -> null

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSwish.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSwish.kt
@@ -1,0 +1,35 @@
+package com.stripe.android.lpm
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.stripe.android.BaseLpmTest
+import com.stripe.android.test.core.Currency
+import com.stripe.android.test.core.DelayedPMs
+import com.stripe.android.test.core.GooglePayState
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class TestSwish : BaseLpmTest() {
+
+    private val swishUser = newUser.copy(
+        paymentMethod = lpmRepository.fromCode("swish")!!,
+        currency = Currency.SEK,
+        merchantCountryCode = "FR",
+        delayed = DelayedPMs.On,
+        googlePayState = GooglePayState.Off,
+    )
+
+    @Test
+    fun testSwish() {
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = swishUser,
+        )
+    }
+
+    @Test
+    fun testSwishInCustomFlow() {
+        testDriver.confirmCustom(
+            testParameters = swishUser,
+        )
+    }
+}

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
@@ -147,6 +147,7 @@ enum class Currency {
     BRL,
     MXN,
     JPY,
+    SEK,
 }
 
 /**

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
@@ -936,7 +936,8 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
             "MYR",
             "MXN",
             "BRL",
-            "JPY"
+            "JPY",
+            "SEK",
         )
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -52,6 +52,7 @@ data class CheckoutCurrency(val value: String) {
         val AUD = CheckoutCurrency("aud")
         val GBP = CheckoutCurrency("gbp")
         val PLN = CheckoutCurrency("pln")
+        val SEK = CheckoutCurrency("sek")
     }
 }
 

--- a/paymentsheet/src/test/resources/swish-support.csv
+++ b/paymentsheet/src/test/resources/swish-support.csv
@@ -1,0 +1,49 @@
+lpm, hasCustomer, allowsDelayedPayment, intentSetupFutureUsage, intentHasShipping, intentLpms, supportCustomerSavedCard, formExists, formType, supportsAdding
+swish, true, true, off_session, false, card/swish, false, false, not available, false
+swish, true, true, off_session, false, card/eps/swish, false, false, not available, false
+swish, true, false, off_session, false, card/swish, false, false, not available, false
+swish, true, false, off_session, false, card/eps/swish, false, false, not available, false
+swish, true, true, on_session, false, card/swish, false, false, not available, false
+swish, true, true, on_session, false, card/eps/swish, false, false, not available, false
+swish, true, false, on_session, false, card/swish, false, false, not available, false
+swish, true, false, on_session, false, card/eps/swish, false, false, not available, false
+swish, true, true, null, false, card/swish, false, true, oneTime, true
+swish, true, true, null, false, card/eps/swish, false, true, oneTime, true
+swish, true, false, null, false, card/swish, false, true, oneTime, true
+swish, true, false, null, false, card/eps/swish, false, true, oneTime, true
+swish, false, true, off_session, false, card/swish, false, false, not available, false
+swish, false, true, off_session, false, card/eps/swish, false, false, not available, false
+swish, false, false, off_session, false, card/swish, false, false, not available, false
+swish, false, false, off_session, false, card/eps/swish, false, false, not available, false
+swish, false, true, on_session, false, card/swish, false, false, not available, false
+swish, false, true, on_session, false, card/eps/swish, false, false, not available, false
+swish, false, false, on_session, false, card/swish, false, false, not available, false
+swish, false, false, on_session, false, card/eps/swish, false, false, not available, false
+swish, false, true, null, false, card/swish, false, true, oneTime, true
+swish, false, true, null, false, card/eps/swish, false, true, oneTime, true
+swish, false, false, null, false, card/swish, false, true, oneTime, true
+swish, false, false, null, false, card/eps/swish, false, true, oneTime, true
+swish, true, true, off_session, true, card/swish, false, false, not available, false
+swish, true, true, off_session, true, card/eps/swish, false, false, not available, false
+swish, true, false, off_session, true, card/swish, false, false, not available, false
+swish, true, false, off_session, true, card/eps/swish, false, false, not available, false
+swish, true, true, on_session, true, card/swish, false, false, not available, false
+swish, true, true, on_session, true, card/eps/swish, false, false, not available, false
+swish, true, false, on_session, true, card/swish, false, false, not available, false
+swish, true, false, on_session, true, card/eps/swish, false, false, not available, false
+swish, true, true, null, true, card/swish, false, true, oneTime, true
+swish, true, true, null, true, card/eps/swish, false, true, oneTime, true
+swish, true, false, null, true, card/swish, false, true, oneTime, true
+swish, true, false, null, true, card/eps/swish, false, true, oneTime, true
+swish, false, true, off_session, true, card/swish, false, false, not available, false
+swish, false, true, off_session, true, card/eps/swish, false, false, not available, false
+swish, false, false, off_session, true, card/swish, false, false, not available, false
+swish, false, false, off_session, true, card/eps/swish, false, false, not available, false
+swish, false, true, on_session, true, card/swish, false, false, not available, false
+swish, false, true, on_session, true, card/eps/swish, false, false, not available, false
+swish, false, false, on_session, true, card/swish, false, false, not available, false
+swish, false, false, on_session, true, card/eps/swish, false, false, not available, false
+swish, false, true, null, true, card/swish, false, true, oneTime, true
+swish, false, true, null, true, card/eps/swish, false, true, oneTime, true
+swish, false, false, null, true, card/swish, false, true, oneTime, true
+swish, false, false, null, true, card/eps/swish, false, true, oneTime, true


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds support for Swish for PaymentIntents in PaymentSheet and via bindings in private beta.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

🇸🇪

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

### PaymentSheet
PaymentSheet now supports Swish for PaymentIntents in private beta.

### Payments
Added support for Swish for PaymentIntents in private beta.
