### PR TITLE
Upgrade to version 19.2.1 of Google Pay dependency

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -56,7 +56,7 @@ ext.versions = [
         places                      : '3.0.0',
         playServices                : '1.6.4',
         playServicesTfLite          : '16.0.1',
-        playServicesWallet          : '19.2.0',
+        playServicesWallet          : '19.2.1',
         retrofit                    : '2.9.0',
         robolectric                 : '4.10.3',
         shot                        : '5.14.1',


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates to version 19.2.1 of the Google Pay dependency.

> Released version 19.2.1 of the Play Services Wallet library, which updates the PayButton API to fall back to a static button asset for users with Google Play Services version less than 23.21.0.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
