### PR TITLE
Add animation for CBC dropdown icon

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -9,7 +9,7 @@ import android.text.Layout
 import android.text.TextPaint
 import android.text.TextWatcher
 import android.util.AttributeSet
-import android.util.TypedValue
+import android.util.TypedValue.COMPLEX_UNIT_DIP
 import android.util.TypedValue.applyDimension
 import android.view.LayoutInflater
 import android.view.MotionEvent
@@ -353,8 +353,8 @@ class CardInputWidget @JvmOverloads constructor(
 
     private val cardBrandChoiceDropdownWidth: Float by lazy {
         val displayMetrics = context.resources.displayMetrics
-        val spacing = applyDimension(TypedValue.COMPLEX_UNIT_DIP, 4f, displayMetrics)
-        val icon = applyDimension(TypedValue.COMPLEX_UNIT_DIP, 16f, displayMetrics)
+        val spacing = applyDimension(COMPLEX_UNIT_DIP, CBC_DROPDOWN_SPACING_DP, displayMetrics)
+        val icon = applyDimension(COMPLEX_UNIT_DIP, CBC_DROPDOWN_ICON_WIDTH_DP, displayMetrics)
         spacing + icon
     }
 
@@ -876,6 +876,7 @@ class CardInputWidget @JvmOverloads constructor(
         }
 
         val newAnimator = ValueAnimator.ofFloat(cardBrandView.width.toFloat(), desiredWidth)
+        newAnimator.duration = CBC_DROPDOWN_ICON_ANIMATION_DURATION
 
         newAnimator.addUpdateListener { currentAnimator ->
             val animatedWidth = currentAnimator.animatedValue as Float
@@ -1311,6 +1312,10 @@ class CardInputWidget @JvmOverloads constructor(
         private const val STATE_CARD_VIEWED = "state_card_viewed"
         private const val STATE_SUPER_STATE = "state_super_state"
         private const val STATE_POSTAL_CODE_ENABLED = "state_postal_code_enabled"
+
+        private const val CBC_DROPDOWN_ICON_WIDTH_DP = 16f
+        private const val CBC_DROPDOWN_SPACING_DP = 4f
+        private const val CBC_DROPDOWN_ICON_ANIMATION_DURATION = 200L
 
         // This value is used to ensure that onSaveInstanceState is called
         // in the event that the user doesn't give this control an ID.

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -1092,6 +1092,12 @@ class CardInputWidget @JvmOverloads constructor(
         }
     }
 
+    override fun onDetachedFromWindow() {
+        dropdownAnimator?.cancel()
+        dropdownAnimator = null
+        super.onDetachedFromWindow()
+    }
+
     private var hiddenCardText: String = createHiddenCardText(cardNumberEditText.panLength)
 
     private val cvcPlaceHolder: String


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds an animation for showing and hiding the CBC dropdown icon via `ValueAnimator`. See the screen recordings for details.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

CBC.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screen recordings

<details><summary>Before</summary>
<p>

[before_animation.webm](https://github.com/stripe/stripe-android/assets/110940675/05963558-af8f-46ac-9e16-088c0af9857d)

</p>
</details> 

<details><summary>After</summary>
<p>

[after_animation.webm](https://github.com/stripe/stripe-android/assets/110940675/0c82c914-1e3d-4716-ba1b-cd77c1687e1d)

</p>
</details> 

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
