### PR TITLE
Add example activity for CBC in Card Element

### DIFF
--- a/example/AndroidManifest.xml
+++ b/example/AndroidManifest.xml
@@ -53,6 +53,7 @@
         <activity android:name=".activity.GooglePayPaymentMethodLauncherIntegrationActivity" />
         <activity android:name=".activity.GooglePayPaymentMethodLauncherComposeActivity" />
         <activity android:name=".activity.PaymentAuthActivity" />
+        <activity android:name=".activity.CardBrandChoiceExampleActivity" />
         <activity android:name=".activity.FragmentExamplesActivity" />
         <activity android:name=".activity.ConfirmSepaDebitActivity" />
         <activity android:name=".activity.FpxPaymentActivity" />

--- a/example/res/layout/card_brand_choice_example_activity.xml
+++ b/example/res/layout/card_brand_choice_example_activity.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <com.stripe.android.view.CardInputWidget
+        android:id="@+id/card_input_widget"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <Button
+        android:id="@+id/confirm_with_new_card_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        android:text="@string/confirm_with_new_card_button" />
+
+    <View
+        style="@style/Divider"
+        android:layout_marginTop="12dp"
+        android:layout_marginBottom="12dp" />
+
+    <TextView
+        android:id="@+id/status"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:typeface="monospace"
+        android:layout_marginTop="40dp" />
+
+</LinearLayout>

--- a/example/res/values/strings.xml
+++ b/example/res/values/strings.xml
@@ -70,6 +70,7 @@
 
     <!-- Payment Confirmation and Authentication example -->
     <string name="payment_auth_example">Payment Intent &amp; Setup Intent Confirmation</string>
+    <string name="card_brand_choice">Card Brand Choice Example</string>
     <string name="auth_payment_intent">Authenticate PaymentIntent</string>
     <string name="auth_setup_intent">Authenticate SetupIntent</string>
     <string name="confirm_with_3ds2_button">Confirm with 3DS2</string>

--- a/example/src/androidTestDebug/java/com/stripe/example/activity/AddNetbankingPaymentMethodTest.kt
+++ b/example/src/androidTestDebug/java/com/stripe/example/activity/AddNetbankingPaymentMethodTest.kt
@@ -66,7 +66,7 @@ class AddNetbankingPaymentMethodTest {
     private fun launchBankSelector() {
         // launch Netbanking selection activity
         onView(withId(R.id.examples)).perform(
-            RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(12, click())
+            RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(13, click())
         )
 
         // click select payment method button

--- a/example/src/androidTestDebug/java/com/stripe/example/activity/CreateCardTokenActivityTest.kt
+++ b/example/src/androidTestDebug/java/com/stripe/example/activity/CreateCardTokenActivityTest.kt
@@ -49,7 +49,7 @@ class CreateCardTokenActivityTest {
 
         // launch create a card token activity
         onView(withId(R.id.examples)).perform(
-            RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click())
+            RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(2, click())
         )
 
         // fill out card details

--- a/example/src/main/java/com/stripe/example/activity/CardBrandChoiceExampleActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CardBrandChoiceExampleActivity.kt
@@ -1,0 +1,62 @@
+package com.stripe.example.activity
+
+import android.os.Bundle
+import com.stripe.android.Stripe
+import com.stripe.android.model.Address
+import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.example.Settings
+import com.stripe.example.databinding.CardBrandChoiceExampleActivityBinding
+
+/**
+ * An example of creating a PaymentIntent, then confirming it with [Stripe.confirmPayment]
+ */
+class CardBrandChoiceExampleActivity : StripeIntentActivity() {
+
+    private val viewBinding: CardBrandChoiceExampleActivityBinding by lazy {
+        CardBrandChoiceExampleActivityBinding.inflate(layoutInflater)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(viewBinding.root)
+
+        viewModel.inProgress.observe(this, this::enableUi)
+        viewModel.status.observe(this, viewBinding.status::setText)
+
+        val stripeAccountId = Settings(this).stripeAccountId
+
+        viewBinding.confirmWithNewCardButton.setOnClickListener {
+            viewBinding.root.clearFocus()
+
+            viewBinding.cardInputWidget.paymentMethodCreateParams?.let { params ->
+                createAndConfirmPaymentIntent(
+                    country = "fr",
+                    paymentMethodCreateParams = params,
+                    shippingDetails = SHIPPING,
+                    stripeAccountId = stripeAccountId,
+                )
+            }
+        }
+    }
+
+    private fun enableUi(inProgress: Boolean) {
+        viewBinding.confirmWithNewCardButton.isEnabled = !inProgress
+    }
+
+    private companion object {
+
+        private val SHIPPING = ConfirmPaymentIntentParams.Shipping(
+            address = Address.Builder()
+                .setCity("San Francisco")
+                .setCountry("US")
+                .setLine1("123 Market St")
+                .setLine2("#345")
+                .setPostalCode("94107")
+                .setState("CA")
+                .build(),
+            name = "Jenny Rosen",
+            carrier = "Fedex",
+            trackingNumber = "12345"
+        )
+    }
+}

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
@@ -41,6 +41,10 @@ class LauncherActivity : AppCompatActivity() {
                 PaymentAuthActivity::class.java
             ),
             Item(
+                activity.getString(R.string.card_brand_choice),
+                CardBrandChoiceExampleActivity::class.java
+            ),
+            Item(
                 activity.getString(R.string.create_card_token),
                 CreateCardTokenActivity::class.java
             ),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds an example activity for Card Element with CBC enabled. It uses our French test merchant. In future pull requests, I’ll add additional configuration options above the card widget.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
