### PR TITLE
Send user-preferred card network to backend

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4078,7 +4078,6 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Card$Build
 	public final fun setCvc (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Builder;
 	public final fun setExpiryMonth (Ljava/lang/Integer;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Builder;
 	public final fun setExpiryYear (Ljava/lang/Integer;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Builder;
-	public final fun setNetworks (Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Networks;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Builder;
 	public final fun setNumber (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Builder;
 }
 

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4060,8 +4060,8 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Card : and
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Companion;
-	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Card;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Networks;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Card;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Networks;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
 	public static final fun create (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
@@ -4078,6 +4078,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Card$Build
 	public final fun setCvc (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Builder;
 	public final fun setExpiryMonth (Ljava/lang/Integer;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Builder;
 	public final fun setExpiryYear (Ljava/lang/Integer;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Builder;
+	public final fun setNetworks (Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Networks;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Builder;
 	public final fun setNumber (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Builder;
 }
 
@@ -4090,6 +4091,14 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Card$Creat
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethodCreateParams$Card$Networks$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Networks;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Networks;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -296,7 +296,7 @@ data class PaymentMethodCreateParams internal constructor(
         internal val networks: Networks? = null,
     ) : StripeParamsModel, Parcelable {
 
-        // TODO(tillh-stripe) Add docs and remove restriction
+        // TODO(tillh-stripe) Add docs and make public
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @Parcelize
         class Networks(
@@ -312,8 +312,7 @@ data class PaymentMethodCreateParams internal constructor(
             }
 
             override fun equals(other: Any?): Boolean {
-                return other is Networks &&
-                    other.preferred == preferred
+                return other is Networks && other.preferred == preferred
             }
 
             override fun hashCode(): Int {
@@ -353,7 +352,7 @@ data class PaymentMethodCreateParams internal constructor(
             private var expiryMonth: Int? = null
             private var expiryYear: Int? = null
             private var cvc: String? = null
-            private var networks: Networks = Networks()
+            private var networks: Networks? = null
 
             fun setNumber(number: String?): Builder = apply {
                 this.number = number
@@ -371,7 +370,8 @@ data class PaymentMethodCreateParams internal constructor(
                 this.cvc = cvc
             }
 
-            fun setNetworks(networks: Networks): Builder = apply {
+            // TODO(tillh-stripe) Make public
+            internal fun setNetworks(networks: Networks?): Builder = apply {
                 this.networks = networks
             }
 

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -2,12 +2,12 @@ package com.stripe.android.model
 
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
-import com.stripe.android.CardUtils
 import com.stripe.android.Stripe
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
 import org.json.JSONException
 import org.json.JSONObject
+import java.util.Objects
 
 /**
  * Model for PaymentMethod creation parameters.
@@ -292,13 +292,40 @@ data class PaymentMethodCreateParams internal constructor(
         internal val expiryYear: Int? = null,
         internal val cvc: String? = null,
         private val token: String? = null,
-        internal val attribution: Set<String>? = null
+        internal val attribution: Set<String>? = null,
+        internal val networks: Networks? = null,
     ) : StripeParamsModel, Parcelable {
-        internal val brand: CardBrand get() = CardUtils.getPossibleCardBrand(number)
-        internal val last4: String? get() = number?.takeLast(4)
 
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet
-        fun getLast4() = last4
+        @Parcelize
+        class Networks(
+            val preferred: String? = null,
+        ) : StripeParamsModel, Parcelable {
+
+            override fun toParamMap(): Map<String, Any> {
+                return if (preferred != null) {
+                    mapOf(PARAM_PREFERRED to preferred)
+                } else {
+                    emptyMap()
+                }
+            }
+
+            override fun equals(other: Any?): Boolean {
+                return other is Networks &&
+                    other.preferred == preferred
+            }
+
+            override fun hashCode(): Int {
+                return Objects.hash(preferred)
+            }
+
+            override fun toString(): String {
+                return "PaymentMethodCreateParams.Card.Networks(preferred=$preferred)"
+            }
+
+            private companion object {
+                const val PARAM_PREFERRED = "preferred"
+            }
+        }
 
         override fun toParamMap(): Map<String, Any> {
             return listOf(
@@ -306,7 +333,8 @@ data class PaymentMethodCreateParams internal constructor(
                 PARAM_EXP_MONTH to expiryMonth,
                 PARAM_EXP_YEAR to expiryYear,
                 PARAM_CVC to cvc,
-                PARAM_TOKEN to token
+                PARAM_TOKEN to token,
+                PARAM_NETWORKS to networks?.toParamMap(),
             ).mapNotNull {
                 it.second?.let { value ->
                     it.first to value
@@ -323,6 +351,7 @@ data class PaymentMethodCreateParams internal constructor(
             private var expiryMonth: Int? = null
             private var expiryYear: Int? = null
             private var cvc: String? = null
+            private var networks: Networks = Networks()
 
             fun setNumber(number: String?): Builder = apply {
                 this.number = number
@@ -340,12 +369,17 @@ data class PaymentMethodCreateParams internal constructor(
                 this.cvc = cvc
             }
 
+            fun setNetworks(networks: Networks): Builder = apply {
+                this.networks = networks
+            }
+
             fun build(): Card {
                 return Card(
                     number = number,
                     expiryMonth = expiryMonth,
                     expiryYear = expiryYear,
-                    cvc = cvc
+                    cvc = cvc,
+                    networks = networks,
                 )
             }
         }
@@ -356,6 +390,7 @@ data class PaymentMethodCreateParams internal constructor(
             private const val PARAM_EXP_YEAR: String = "exp_year"
             private const val PARAM_CVC: String = "cvc"
             private const val PARAM_TOKEN: String = "token"
+            private const val PARAM_NETWORKS: String = "networks"
 
             /**
              * Create a [Card] from a Card token.

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -296,6 +296,8 @@ data class PaymentMethodCreateParams internal constructor(
         internal val networks: Networks? = null,
     ) : StripeParamsModel, Parcelable {
 
+        // TODO(tillh-stripe) Add docs and remove restriction
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @Parcelize
         class Networks(
             val preferred: String? = null,

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -186,13 +186,22 @@ class CardInputWidget @JvmOverloads constructor(
     override val paymentMethodCard: PaymentMethodCreateParams.Card?
         @OptIn(DelicateCardDetailsApi::class)
         get() {
-            return cardParams?.let {
+            return cardParams?.let { params ->
+                val networks = if (cardBrandView.isCbcEligible) {
+                    PaymentMethodCreateParams.Card.Networks(
+                        preferred = cardBrandView.brand.takeIf { it != CardBrand.Unknown }?.code,
+                    )
+                } else {
+                    null
+                }
+
                 PaymentMethodCreateParams.Card(
-                    number = it.number,
-                    cvc = it.cvc,
-                    expiryMonth = it.expMonth,
-                    expiryYear = it.expYear,
-                    attribution = it.attribution
+                    number = params.number,
+                    cvc = params.cvc,
+                    expiryMonth = params.expMonth,
+                    expiryYear = params.expYear,
+                    attribution = params.attribution,
+                    networks = networks,
                 )
             }
         }

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -190,15 +190,13 @@ class CardInputWidget @JvmOverloads constructor(
         @OptIn(DelicateCardDetailsApi::class)
         get() {
             return cardParams?.let { params ->
-                val networks = cardBrandView.createNetworksParam()
-
                 PaymentMethodCreateParams.Card(
                     number = params.number,
                     cvc = params.cvc,
                     expiryMonth = params.expMonth,
                     expiryYear = params.expYear,
                     attribution = params.attribution,
-                    networks = networks,
+                    networks = cardBrandView.createNetworksParam(),
                 )
             }
         }
@@ -765,8 +763,6 @@ class CardInputWidget @JvmOverloads constructor(
                 cardInputListener?.onFocusChange(CardInputListener.FocusField.CardNumber)
             }
         }
-
-        cardNumberEditText.viewModelStoreOwner = viewModelStoreOwner
 
         expiryDateEditText.internalFocusChangeListeners.add { _, hasFocus ->
             if (hasFocus) {

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -815,7 +815,9 @@ class CardInputWidget @JvmOverloads constructor(
         }
 
         cardNumberEditText.implicitCardBrandChangeCallback = { brand ->
-            // TODO Explanation
+            // With co-branded cards, a card number can belong to multiple brands. Since we still
+            // need do validate based on the card's pan length and expected CVC length, we add this
+            // callback to perform the validations, but don't update the current brand.
             hiddenCardText = createHiddenCardText(cardNumberEditText.panLength)
             updateCvc(brand)
         }

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -32,6 +32,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.core.view.updateLayoutParams
 import androidx.core.widget.doAfterTextChanged
+import androidx.lifecycle.ViewModelStoreOwner
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.cards.CardNumber
@@ -179,6 +180,8 @@ class CardInputWidget @JvmOverloads constructor(
                 .filterNotNull()
         }
 
+    internal var viewModelStoreOwner: ViewModelStoreOwner? = null
+
     /**
      * A [PaymentMethodCreateParams.Card] representing the card details if all fields are valid;
      * otherwise `null`. If a field is invalid focus will shift to the invalid field.
@@ -187,13 +190,7 @@ class CardInputWidget @JvmOverloads constructor(
         @OptIn(DelicateCardDetailsApi::class)
         get() {
             return cardParams?.let { params ->
-                val networks = if (cardBrandView.isCbcEligible) {
-                    PaymentMethodCreateParams.Card.Networks(
-                        preferred = cardBrandView.brand.takeIf { it != CardBrand.Unknown }?.code,
-                    )
-                } else {
-                    null
-                }
+                val networks = cardBrandView.createNetworksParam()
 
                 PaymentMethodCreateParams.Card(
                     number = params.number,
@@ -408,8 +405,12 @@ class CardInputWidget @JvmOverloads constructor(
         allFields = requiredFields.plus(postalCodeEditText)
 
         initView(attrs)
+    }
 
-        doWithCardWidgetViewModel { viewModel ->
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+
+        doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
             viewModel.isCbcEligible.launchAndCollect { isCbcEligible ->
                 cardBrandView.isCbcEligible = isCbcEligible
             }
@@ -765,6 +766,8 @@ class CardInputWidget @JvmOverloads constructor(
             }
         }
 
+        cardNumberEditText.viewModelStoreOwner = viewModelStoreOwner
+
         expiryDateEditText.internalFocusChangeListeners.add { _, hasFocus ->
             if (hasFocus) {
                 scrollEnd()
@@ -812,7 +815,13 @@ class CardInputWidget @JvmOverloads constructor(
         cardNumberEditText.brandChangeCallback = { brand ->
             cardBrandView.brand = brand
             hiddenCardText = createHiddenCardText(cardNumberEditText.panLength)
-            updateCvc()
+            updateCvc(brand)
+        }
+
+        cardNumberEditText.implicitCardBrandChangeCallback = { brand ->
+            // TODO Explanation
+            hiddenCardText = createHiddenCardText(cardNumberEditText.panLength)
+            updateCvc(brand)
         }
 
         cardNumberEditText.possibleCardBrandsCallback = this::handlePossibleCardBrandsChanged
@@ -848,10 +857,10 @@ class CardInputWidget @JvmOverloads constructor(
      */
     fun setCvcLabel(cvcLabel: String?) {
         customCvcLabel = cvcLabel
-        updateCvc()
+        updateCvc(cardBrandView.brand)
     }
 
-    private fun updateCvc(brand: CardBrand = cardBrandView.brand) {
+    private fun updateCvc(brand: CardBrand) {
         cvcEditText.updateBrand(
             brand,
             customCvcLabel

--- a/payments-core/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -47,7 +47,7 @@ class CardNumberEditText internal constructor(
     staticCardAccountRanges: StaticCardAccountRanges = DefaultStaticCardAccountRanges(),
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
-    viewModelStoreOwner: ViewModelStoreOwner? = null,
+    internal var viewModelStoreOwner: ViewModelStoreOwner? = null,
 ) : StripeEditText(context, attrs, defStyleAttr) {
 
     @JvmOverloads
@@ -102,6 +102,14 @@ class CardNumberEditText internal constructor(
             // Immediately display the brand if known, in case this method is invoked when
             // partial data already exists.
             callback(cardBrand)
+        }
+
+    private var implicitCardBrandForCbcFlow: CardBrand = CardBrand.Unknown
+
+    internal var implicitCardBrandChangeCallback: (CardBrand) -> Unit = {}
+        set(callback) {
+            field = callback
+            callback(implicitCardBrandForCbcFlow)
         }
 
     internal var possibleCardBrands: List<CardBrand> = emptyList()
@@ -160,10 +168,12 @@ class CardNumberEditText internal constructor(
             override fun onAccountRangesResult(accountRanges: List<AccountRange>) {
                 updateLengthFilter()
 
+                val brands = accountRanges.map { it.brand }.distinct()
+                cardBrand = brands.singleOrNull() ?: CardBrand.Unknown
+
                 if (isCbcEligible) {
-                    possibleCardBrands = accountRanges.map { it.brand }.distinct()
-                } else {
-                    cardBrand = accountRanges.singleOrNull()?.brand ?: CardBrand.Unknown
+                    implicitCardBrandForCbcFlow = brands.firstOrNull() ?: CardBrand.Unknown
+                    possibleCardBrands = brands
                 }
             }
         }
@@ -193,24 +203,30 @@ class CardNumberEditText internal constructor(
         updateLengthFilter()
 
         this.layoutDirection = LAYOUT_DIRECTION_LTR
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+
+        loadingJob = CoroutineScope(workContext).launch {
+            cardAccountRangeRepository.loading.collect {
+                withContext(Dispatchers.Main) {
+                    isLoadingCallback(it)
+                }
+            }
+        }
 
         doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
             viewModel.isCbcEligible.launchAndCollect { isCbcEligible ->
                 this@CardNumberEditText.isCbcEligible = isCbcEligible
 
-                if (isCbcEligible) {
-                    possibleCardBrands = accountRangeService.accountRanges.map { it.brand }.distinct()
-                }
-            }
-        }
-    }
+                val brands = accountRangeService.accountRanges.map { it.brand }.distinct()
 
-    override fun onAttachedToWindow() {
-        super.onAttachedToWindow()
-        loadingJob = CoroutineScope(workContext).launch {
-            cardAccountRangeRepository.loading.collect {
-                withContext(Dispatchers.Main) {
-                    isLoadingCallback(it)
+                if (isCbcEligible) {
+                    implicitCardBrandForCbcFlow = brands.firstOrNull() ?: CardBrand.Unknown
+                    possibleCardBrands = brands
+                } else {
+                    cardBrand = brands.singleOrNull() ?: CardBrand.Unknown
                 }
             }
         }

--- a/payments-core/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -159,10 +159,11 @@ class CardNumberEditText internal constructor(
         accountRangeResultListener = object : CardAccountRangeService.AccountRangeResultListener {
             override fun onAccountRangesResult(accountRanges: List<AccountRange>) {
                 updateLengthFilter()
-                cardBrand = accountRanges.singleOrNull()?.brand ?: CardBrand.Unknown
 
                 if (isCbcEligible) {
                     possibleCardBrands = accountRanges.map { it.brand }.distinct()
+                } else {
+                    cardBrand = accountRanges.singleOrNull()?.brand ?: CardBrand.Unknown
                 }
             }
         }

--- a/payments-core/src/main/java/com/stripe/android/view/CardWidgetViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardWidgetViewModel.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.view
 
 import android.view.View
-import androidx.core.view.doOnAttach
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModel
@@ -77,33 +76,35 @@ internal class CardWidgetViewModel(
 }
 
 internal fun View.doWithCardWidgetViewModel(
-    viewModelStoreOwner: ViewModelStoreOwner? = null,
+    viewModelStoreOwner: ViewModelStoreOwner?,
     action: LifecycleOwner.(CardWidgetViewModel) -> Unit,
 ) {
-    doOnAttach {
-        val lifecycleOwner = findViewTreeLifecycleOwner()
-        val storeOwner = viewModelStoreOwner ?: findViewTreeViewModelStoreOwner()
-
-        if (lifecycleOwner == null || storeOwner == null) {
-            if (DEBUG) {
-                if (lifecycleOwner == null) {
-                    error("Couldn't find a LifecycleOwner for view")
-                } else {
-                    error("Couldn't find a ViewModelStoreOwner for view")
-                }
-            }
-            return@doOnAttach
-        }
-
-        val factory = CardWidgetViewModel.Factory()
-
-        val viewModel = ViewModelProvider(
-            owner = storeOwner,
-            factory = factory,
-        )[CardWidgetViewModel::class.java]
-
-        lifecycleOwner.action(viewModel)
+    if (!isAttachedToWindow && DEBUG) {
+        error("Bla")
     }
+
+    val lifecycleOwner = findViewTreeLifecycleOwner()
+    val storeOwner = viewModelStoreOwner ?: findViewTreeViewModelStoreOwner()
+
+    if (lifecycleOwner == null || storeOwner == null) {
+        if (DEBUG) {
+            if (lifecycleOwner == null) {
+                error("Couldn't find a LifecycleOwner for view")
+            } else {
+                error("Couldn't find a ViewModelStoreOwner for view")
+            }
+        }
+        return
+    }
+
+    val factory = CardWidgetViewModel.Factory()
+
+    val viewModel = ViewModelProvider(
+        owner = storeOwner,
+        factory = factory,
+    )[CardWidgetViewModel::class.java]
+
+    lifecycleOwner.action(viewModel)
 }
 
 context(LifecycleOwner)

--- a/payments-core/src/test/java/com/stripe/android/utils/CardInputWidgetTestHelper.kt
+++ b/payments-core/src/test/java/com/stripe/android/utils/CardInputWidgetTestHelper.kt
@@ -1,0 +1,48 @@
+package com.stripe.android.utils
+
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.model.MobileCardElementConfig
+import com.stripe.android.testing.AbsFakeStripeRepository
+import com.stripe.android.view.CardWidgetViewModel
+
+internal object CardInputWidgetTestHelper {
+
+    fun createViewModelStoreOwner(
+        isCbcEligible: Boolean,
+    ): ViewModelStoreOwner {
+        val cardWidgetViewModel = CardWidgetViewModel(
+            paymentConfigProvider = {
+                PaymentConfiguration(
+                    publishableKey = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
+                    stripeAccountId = null,
+                )
+            },
+            stripeRepository = object : AbsFakeStripeRepository() {
+                override suspend fun retrieveCardElementConfig(
+                    requestOptions: ApiRequest.Options,
+                ): Result<MobileCardElementConfig> {
+                    return Result.success(
+                        MobileCardElementConfig(
+                            cardBrandChoice = MobileCardElementConfig.CardBrandChoice(
+                                eligible = isCbcEligible,
+                            ),
+                        )
+                    )
+                }
+            },
+        )
+
+        val viewModelStore = ViewModelStore().apply {
+            val className = CardWidgetViewModel::class.java.canonicalName
+            put("androidx.lifecycle.ViewModelProvider.DefaultKey:$className", cardWidgetViewModel)
+        }
+
+        return object : ViewModelStoreOwner {
+            override val viewModelStore: ViewModelStore = viewModelStore
+        }
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/view/ActivityScenarioFactory.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/ActivityScenarioFactory.kt
@@ -47,7 +47,8 @@ internal class ActivityScenarioFactory(
      * Return a view created with an `Activity` context.
      */
     fun <ViewType : View> createView(
-        viewFactory: (Activity) -> ViewType
+        beforeAttach: (ViewType) -> Unit = {},
+        viewFactory: (Activity) -> ViewType,
     ): ViewType {
         var view: ViewType? = null
 
@@ -60,6 +61,7 @@ internal class ActivityScenarioFactory(
                         root.removeAllViews()
 
                         view = viewFactory(activity).also {
+                            beforeAttach(it)
                             root.addView(it)
                         }
                     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds `PaymentMethodCreateParams.Card.Networks` and sends its value to the backend for CBC-eligible usage of `CardInputWidget`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

CBC in Card Element.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
