### PR TITLE
Add customer to server side confirmation examples.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/model/CartState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/model/CartState.kt
@@ -10,6 +10,8 @@ data class CartState(
     val subtotal: Long? = null,
     val salesTax: Long? = null,
     val total: Long? = null,
+    val customerId: String? = null,
+    val customerEphemeralKeySecret: String? = null,
 ) {
 
     val formattedSubtotal: String
@@ -35,6 +37,15 @@ data class CartState(
 
     fun countOf(id: CartProduct.Id): Int {
         return products.filter { it.id == id }.sumOf { it.quantity }
+    }
+
+    fun makeCustomerConfig() = if (customerId != null && customerEphemeralKeySecret != null) {
+        PaymentSheet.CustomerConfiguration(
+            id = customerId,
+            ephemeralKeySecret = customerEphemeralKeySecret
+        )
+    } else {
+        null
     }
 
     companion object {
@@ -70,6 +81,8 @@ internal fun CartState.updateWithResponse(
         subtotal = response.subtotal,
         salesTax = response.tax,
         total = response.total,
+        customerId = response.customer,
+        customerEphemeralKeySecret = response.ephemeralKey,
     )
 }
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/networking/Models.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/networking/Models.kt
@@ -111,6 +111,8 @@ data class ExampleCreateAndConfirmIntentRequest(
     val isSubscribing: Boolean,
     @SerialName("return_url")
     val returnUrl: String,
+    @SerialName("customer_id")
+    val customerId: String?,
 )
 
 fun CartState.toCreateIntentRequest(
@@ -126,6 +128,7 @@ fun CartState.toCreateIntentRequest(
         saladCount = countOf(CartProduct.Id.Salad),
         isSubscribing = isSubscription,
         returnUrl = returnUrl,
+        customerId = customerId,
     )
 }
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/server_side_confirm/complete_flow/ServerSideConfirmationCompleteFlowViewState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/server_side_confirm/complete_flow/ServerSideConfirmationCompleteFlowViewState.kt
@@ -18,7 +18,7 @@ data class ServerSideConfirmationCompleteFlowViewState(
     val paymentSheetConfig: PaymentSheet.Configuration
         get() = PaymentSheet.Configuration(
             merchantDisplayName = "Example, Inc.",
-            customer = null,
+            customer = cartState.makeCustomerConfig(),
             googlePay = PaymentSheet.GooglePayConfiguration(
                 environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
                 countryCode = "US",

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/server_side_confirm/custom_flow/ServerSideConfirmationCustomFlowViewState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/server_side_confirm/custom_flow/ServerSideConfirmationCustomFlowViewState.kt
@@ -20,7 +20,7 @@ data class ServerSideConfirmationCustomFlowViewState(
     val paymentSheetConfig: PaymentSheet.Configuration
         get() = PaymentSheet.Configuration(
             merchantDisplayName = "Example, Inc.",
-            customer = null,
+            customer = cartState.makeCustomerConfig(),
             googlePay = PaymentSheet.GooglePayConfiguration(
                 environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
                 countryCode = "US",


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This was a bug @wooj-stripe found. Similar to https://github.com/stripe/stripe-ios/pull/2961

Complete Flow:
- https://admin.corp.stripe.com/object/cus_OjAtHTykwYvSUz
- https://admin.corp.stripe.com/payment_intent/pi_3NviYULu5o3P18Zp1BYzeCa5

Custom Flow:
- https://admin.corp.stripe.com/object/cus_OjAvW7UAkiat5c
- https://admin.corp.stripe.com/payment_intent/pi_3NviZeLu5o3P18Zp0iS46xNh

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

