### PR TITLE
Add QR code to playground.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -68,6 +68,7 @@ ext.versions = [
         truth                       : '1.1.3',
         turbine                     : '0.12.3',
         uiAutomator                 : '2.2.0',
+        zxing                       : '3.5.2',
 ]
 
 ext.buildLibs = [
@@ -173,6 +174,7 @@ ext.libs = [
         tensorflowLiteSupport               : "org.tensorflow:tensorflow-lite-support:${versions.tensorflowLiteSupport}",
         tensorflowLitePlayServices          : "com.google.android.gms:play-services-tflite-java:${versions.playServicesTfLite}",
         tensorflowLitePlayServicesSupport   : "com.google.android.gms:play-services-tflite-support:${versions.playServicesTfLite}",
+        zxing                               : "com.google.zxing:core:${versions.zxing}",
 ]
 
 ext.testLibs = [

--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -40,8 +40,10 @@ dependencies {
     implementation libs.kotlin.serialization
     implementation libs.loggingInterceptor
     implementation libs.material
+    implementation libs.okio
     implementation libs.places
     implementation libs.retrofitKotlinSerializationConverter
+    implementation libs.zxing
 
     // Needed for createComposeRule, but not createAndroidComposeRule:
     debugImplementation libs.compose.uiTestManifest

--- a/paymentsheet-example/src/main/AndroidManifest.xml
+++ b/paymentsheet-example/src/main/AndroidManifest.xml
@@ -45,7 +45,23 @@
         <activity android:name="com.stripe.android.paymentsheet.example.samples.ui.customersheet.playground.CustomerSheetPlaygroundActivity" />
         <activity android:name="com.stripe.android.paymentsheet.example.samples.ui.addresselement.AddressElementExampleActivity" />
         <activity android:name="com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity" />
-        <activity android:name="com.stripe.android.paymentsheet.example.playground.PaymentSheetPlaygroundActivity" />
+        <activity android:name="com.stripe.android.paymentsheet.example.playground.activity.QrCodeActivity" />
+        <activity
+            android:name="com.stripe.android.paymentsheet.example.playground.PaymentSheetPlaygroundActivity"
+            android:exported="true"
+            >
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="stripepaymentsheetexample"
+                    android:host="paymentsheetplayground"
+                    />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.sp
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.playground.activity.QrCodeActivity
@@ -114,6 +113,7 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
                     playgroundSettings = playgroundSettings,
                 )
             },
+            modifier = Modifier.testTag("RELOAD")
         ) {
             Text("Reload")
         }
@@ -154,7 +154,8 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
         Button(
             onClick = {
                 presentPaymentSheet(paymentSheet, playgroundState)
-            }
+            },
+            modifier = Modifier.testTag("CHECKOUT")
         ) {
             Text("Checkout")
         }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -17,8 +17,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.sp
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.playground.activity.QrCodeActivity
 import com.stripe.android.paymentsheet.example.playground.settings.CheckoutModeSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.InitializationTypeSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.IntegrationTypeSettingsDefinition
@@ -30,7 +32,12 @@ import com.stripe.android.paymentsheet.rememberPaymentSheet
 import com.stripe.android.paymentsheet.rememberPaymentSheetFlowController
 
 internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
-    private val viewModel: PaymentSheetPlaygroundViewModel by viewModels()
+    val viewModel: PaymentSheetPlaygroundViewModel by viewModels {
+        PaymentSheetPlaygroundViewModel.Factory(
+            applicationSupplier = { application },
+            uriSupplier = { intent.data },
+        )
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -58,6 +65,9 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
                     modifier = Modifier.verticalScroll(rememberScrollState())
                 ) {
                     SettingsUi(playgroundSettings = localPlaygroundSettings)
+
+                    QrCodeButton(playgroundSettings = localPlaygroundSettings)
+
                     ReloadButton(playgroundSettings = localPlaygroundSettings)
 
                     val playgroundState by viewModel.state.collectAsState()
@@ -76,6 +86,23 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
                     }
                 }
             }
+        }
+    }
+
+    @Composable
+    private fun QrCodeButton(playgroundSettings: PlaygroundSettings) {
+        val context = LocalContext.current
+        Button(
+            onClick = {
+                context.startActivity(
+                    QrCodeActivity.create(
+                        context = context,
+                        settingsJson = playgroundSettings.snapshot().asJsonString(),
+                    )
+                )
+            },
+        ) {
+            Text("QR code for current settings")
         }
     }
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -113,7 +113,6 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
                     playgroundSettings = playgroundSettings,
                 )
             },
-            modifier = Modifier.testTag("RELOAD")
         ) {
             Text("Reload")
         }
@@ -155,7 +154,6 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
             onClick = {
                 presentPaymentSheet(paymentSheet, playgroundState)
             },
-            modifier = Modifier.testTag("CHECKOUT")
         ) {
             Text("Checkout")
         }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundUrlHelper.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundUrlHelper.kt
@@ -1,0 +1,23 @@
+package com.stripe.android.paymentsheet.example.playground
+
+import android.net.Uri
+import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettings
+import okio.ByteString.Companion.decodeBase64
+import okio.ByteString.Companion.toByteString
+
+internal object PaymentSheetPlaygroundUrlHelper {
+    fun createUri(settingsJson: String): Uri {
+        val base64Settings = settingsJson.encodeToByteArray().toByteString().base64Url()
+            .trimEnd('=')
+        return Uri.parse(
+            "stripepaymentsheetexample://paymentsheetplayground?settings=" +
+                base64Settings
+        )
+    }
+
+    fun settingsFromUri(uri: Uri?): PlaygroundSettings? {
+        val base64Settings = uri?.getQueryParameter("settings") ?: return null
+        val settingsJson = base64Settings.decodeBase64()?.utf8() ?: return null
+        return PlaygroundSettings.createFromJsonString(settingsJson)
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundUrlHelper.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundUrlHelper.kt
@@ -16,8 +16,8 @@ internal object PaymentSheetPlaygroundUrlHelper {
     }
 
     fun settingsFromUri(uri: Uri?): PlaygroundSettings? {
-        val base64Settings = uri?.getQueryParameter("settings") ?: return null
-        val settingsJson = base64Settings.decodeBase64()?.utf8() ?: return null
+        val settingsJson = uri?.getQueryParameter("settings")
+            ?.decodeBase64()?.utf8() ?: return null
         return PlaygroundSettings.createFromJsonString(settingsJson)
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
@@ -1,7 +1,10 @@
 package com.stripe.android.paymentsheet.example.playground
 
 import android.app.Application
+import android.net.Uri
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.extensions.jsonBody
@@ -31,7 +34,8 @@ import kotlinx.serialization.json.Json
 import java.io.IOException
 
 internal class PaymentSheetPlaygroundViewModel(
-    application: Application
+    application: Application,
+    launchUri: Uri?,
 ) : AndroidViewModel(application) {
     private val settings by lazy {
         Settings(application)
@@ -45,7 +49,8 @@ internal class PaymentSheetPlaygroundViewModel(
     init {
         viewModelScope.launch(Dispatchers.IO) {
             playgroundSettingsFlow.value =
-                PlaygroundSettings.createFromSharedPreferences(application)
+                PaymentSheetPlaygroundUrlHelper.settingsFromUri(launchUri)
+                    ?: PlaygroundSettings.createFromSharedPreferences(application)
         }
     }
 
@@ -241,6 +246,16 @@ internal class PaymentSheetPlaygroundViewModel(
             }
         }
         return createIntentResult
+    }
+
+    internal class Factory(
+        private val applicationSupplier: () -> Application,
+        private val uriSupplier: () -> Uri?,
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            @Suppress("UNCHECKED_CAST")
+            return PaymentSheetPlaygroundViewModel(applicationSupplier(), uriSupplier()) as T
+        }
     }
 }
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/QrCodeActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/QrCodeActivity.kt
@@ -1,0 +1,80 @@
+package com.stripe.android.paymentsheet.example.playground.activity
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.net.Uri
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.qrcode.QRCodeWriter
+import com.stripe.android.paymentsheet.example.playground.PaymentSheetPlaygroundUrlHelper
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+internal class QrCodeActivity : AppCompatActivity() {
+    companion object {
+        fun create(context: Context, settingsJson: String): Intent {
+            return Intent(context, QrCodeActivity::class.java).apply {
+                putExtra("settingsJson", settingsJson)
+            }
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val settingsJson = intent.getStringExtra("settingsJson")
+        if (settingsJson == null) {
+            finish()
+            return
+        }
+
+        val uri = PaymentSheetPlaygroundUrlHelper.createUri(settingsJson)
+
+        setContent {
+            var bitmap: Bitmap? by remember { mutableStateOf(null) }
+
+            LaunchedEffect(uri) {
+                launch(Dispatchers.IO) {
+                    bitmap = getQrCodeBitmap(uri)
+                }
+            }
+
+            val localBitmap = bitmap
+            if (localBitmap != null) {
+                Image(
+                    bitmap = localBitmap.asImageBitmap(),
+                    contentDescription = "QR Code",
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier
+                        .fillMaxSize()
+                )
+            }
+        }
+    }
+
+    private fun getQrCodeBitmap(uri: Uri): Bitmap {
+        val size = 512 //pixels
+        val bits = QRCodeWriter().encode(uri.toString(), BarcodeFormat.QR_CODE, size, size)
+        return Bitmap.createBitmap(size, size, Bitmap.Config.RGB_565).also {
+            for (x in 0 until size) {
+                for (y in 0 until size) {
+                    it.setPixel(x, y, if (bits[x, y]) Color.BLACK else Color.WHITE)
+                }
+            }
+        }
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/QrCodeActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/QrCodeActivity.kt
@@ -59,15 +59,14 @@ internal class QrCodeActivity : AppCompatActivity() {
                     bitmap = localBitmap.asImageBitmap(),
                     contentDescription = "QR Code",
                     contentScale = ContentScale.Fit,
-                    modifier = Modifier
-                        .fillMaxSize()
+                    modifier = Modifier.fillMaxSize()
                 )
             }
         }
     }
 
     private fun getQrCodeBitmap(uri: Uri): Bitmap {
-        val size = 512 //pixels
+        val size = QR_CODE_SIZE
         val bits = QRCodeWriter().encode(uri.toString(), BarcodeFormat.QR_CODE, size, size)
         return Bitmap.createBitmap(size, size, Bitmap.Config.RGB_565).also {
             for (x in 0 until size) {
@@ -78,3 +77,5 @@ internal class QrCodeActivity : AppCompatActivity() {
         }
     }
 }
+
+private const val QR_CODE_SIZE = 512 // Pixels.


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This adds a button to the playground to generate a QR code from the current settings. This will be useful when sharing bug reports, or doing a bug bash, or trying the current configuration on another device.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Playground rewrite.

