### PR TITLE
Add address element to new playground.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/FlowControllerState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/FlowControllerState.kt
@@ -1,10 +1,12 @@
 package com.stripe.android.paymentsheet.example.playground
 
 import android.graphics.drawable.Drawable
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.model.PaymentOption
 
 internal data class FlowControllerState(
     val selectedPaymentOption: PaymentOption? = null,
+    val addressDetails: AddressDetails? = null,
 )
 
 internal fun FlowControllerState?.paymentMethodLabel(): String {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
@@ -16,6 +16,7 @@ import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.DelicatePaymentSheetApi
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResult
+import com.stripe.android.paymentsheet.addresselement.AddressLauncherResult
 import com.stripe.android.paymentsheet.example.Settings
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState.Companion.asPlaygroundState
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
@@ -24,6 +25,7 @@ import com.stripe.android.paymentsheet.example.playground.model.ConfirmIntentReq
 import com.stripe.android.paymentsheet.example.playground.model.ConfirmIntentResponse
 import com.stripe.android.paymentsheet.example.playground.settings.InitializationTypeSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettings
+import com.stripe.android.paymentsheet.example.playground.settings.ShippingAddressSettingsDefinition
 import com.stripe.android.paymentsheet.example.samples.networking.awaitModel
 import com.stripe.android.paymentsheet.model.PaymentOption
 import kotlinx.coroutines.Dispatchers
@@ -246,6 +248,20 @@ internal class PaymentSheetPlaygroundViewModel(
             }
         }
         return createIntentResult
+    }
+
+    fun onAddressLauncherResult(addressLauncherResult: AddressLauncherResult) {
+        when (addressLauncherResult) {
+            AddressLauncherResult.Canceled -> {
+                status.value = "Canceled"
+            }
+
+            is AddressLauncherResult.Succeeded -> {
+                val addressDetails = addressLauncherResult.address
+                playgroundSettingsFlow.value?.set(ShippingAddressSettingsDefinition, addressDetails)
+                flowControllerState.update { it?.copy(addressDetails = addressDetails) }
+            }
+        }
     }
 
     internal class Factory(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -198,6 +198,7 @@ internal class PlaygroundSettings private constructor(
         private val nonUiSettingDefinitions: List<PlaygroundSettingDefinition<*>> = listOf(
             SupportedPaymentMethodsSettingsDefinition,
             AppearanceSettingsDefinition,
+            ShippingAddressSettingsDefinition,
         )
 
         private val allSettingDefinitions: List<PlaygroundSettingDefinition<*>> =

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/ShippingAddressSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/ShippingAddressSettingsDefinition.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.example.playground.PlaygroundState
+
+internal object ShippingAddressSettingsDefinition : PlaygroundSettingDefinition<AddressDetails?>(
+    key = "shippingAddress",
+    displayName = "" // Not displayed.
+) {
+    override val defaultValue: AddressDetails? = null
+    override val options: List<Option<AddressDetails?>> = emptyList()
+
+    override fun convertToValue(value: String): AddressDetails? {
+        return null
+    }
+
+    override fun convertToString(value: AddressDetails?): String {
+        return ""
+    }
+
+    override fun configure(
+        value: AddressDetails?,
+        configurationBuilder: PaymentSheet.Configuration.Builder,
+        playgroundState: PlaygroundState,
+        configurationData: PaymentSheetConfigurationData
+    ) {
+        configurationBuilder.shippingDetails(value)
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This change updates the playground to include the ability to attach shipping address details to payment sheet and flow controller.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Playground rewrite
