### PR TITLE
Fix flaky `FlowController` tests.

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.onParent
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextReplacement
+import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.uicore.elements.DROPDOWN_MENU_CLICKABLE_TEST_TAG
@@ -17,6 +18,7 @@ internal class PaymentSheetPage(
     private val composeTestRule: ComposeTestRule,
 ) {
     fun fillOutCardDetails(fillOutZipCode: Boolean = true) {
+        Espresso.onIdle()
         composeTestRule.waitForIdle()
 
         waitForText("Card number")
@@ -31,6 +33,7 @@ internal class PaymentSheetPage(
     }
 
     fun fillOutCardDetailsWithCardBrandChoice(fillOutZipCode: Boolean = true) {
+        Espresso.onIdle()
         composeTestRule.waitForIdle()
 
         waitForText("Card number")
@@ -75,6 +78,7 @@ internal class PaymentSheetPage(
     }
 
     fun addPaymentMethod() {
+        Espresso.onIdle()
         composeTestRule.waitForIdle()
 
         waitForText("+ Add")

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestRunner.kt
@@ -110,12 +110,6 @@ internal class SynchronizedTestFlowController(
     private var isIdleNow: Boolean = false
     private var onIdleTransitionCallback: IdlingResource.ResourceCallback? = null
 
-    override var shippingDetails: AddressDetails?
-        get() = flowController.shippingDetails
-        set(value) {
-            flowController.shippingDetails = value
-        }
-
     init {
         IdlingRegistry.getInstance().register(this)
     }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestRunner.kt
@@ -12,7 +12,6 @@ import com.stripe.android.paymentsheet.MainActivity
 import com.stripe.android.paymentsheet.PaymentOptionCallback
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
-import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 


### PR DESCRIPTION
# Summary
In `PaymentSheetTest`, tests are completely fine because the entire process from configuring to launching the payment sheet is synchronous (no coroutines are launched). In `FlowController` however, there are a couple configuration processes that launch coroutines and switch between coroutine contexts, causing the instrumentation tests to be fall out of sync and result in inconsistent failures depending on if the payment sheet was launched before the `composeTestRule.waitForIdle` call was made.

This PR fixes that by introducing a `SynchronizedTestFlowController` which uses `Espresso` internally to register an `Espresso` resource which waits until the payment options are presented before un-idling. The compose test helpers functions also wait for `Espresso` to be idle before continuing execution.

# Motivation
Allows us to re-enable `FlowController` instrumentation tests which are valuable for testing.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
