### PR TITLE
Separate PlaygroundSettingDefinition responsibilities.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/TestCustomers.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/TestCustomers.kt
@@ -2,6 +2,7 @@ package com.stripe.android
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
 import com.stripe.android.test.core.Browser
 import com.stripe.android.test.core.TestParameters
 import org.junit.Test
@@ -19,8 +20,7 @@ internal class TestCustomers : BasePlaygroundTest() {
     fun testAuthorizeGuest() {
         testDriver.confirmNewOrGuestComplete(
             testParameters.copyPlaygroundSettings { settings ->
-                settings[CustomerSettingsDefinition] =
-                    CustomerSettingsDefinition.CustomerType.GUEST
+                settings[CustomerSettingsDefinition] = CustomerType.GUEST
             }
         )
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestAffirm.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestAffirm.kt
@@ -2,7 +2,9 @@ package com.stripe.android.lpm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.DefaultShippingAddressSettingsDefinition
 import com.stripe.android.test.core.TestParameters
@@ -14,8 +16,8 @@ internal class TestAffirm : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "affirm",
     ) { settings ->
-        settings[CountrySettingsDefinition] = CountrySettingsDefinition.Country.US
-        settings[CurrencySettingsDefinition] = CurrencySettingsDefinition.Currency.USD
+        settings[CountrySettingsDefinition] = Country.US
+        settings[CurrencySettingsDefinition] = Currency.USD
         settings[DefaultShippingAddressSettingsDefinition] = true
     }
 

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestAfterpay.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestAfterpay.kt
@@ -2,7 +2,9 @@ package com.stripe.android.lpm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.DefaultShippingAddressSettingsDefinition
 import com.stripe.android.test.core.TestParameters
@@ -14,8 +16,8 @@ internal class TestAfterpay : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "afterpay_clearpay"
     ) { settings ->
-        settings[CountrySettingsDefinition] = CountrySettingsDefinition.Country.US
-        settings[CurrencySettingsDefinition] = CurrencySettingsDefinition.Currency.USD
+        settings[CountrySettingsDefinition] = Country.US
+        settings[CurrencySettingsDefinition] = Currency.USD
         settings[DefaultShippingAddressSettingsDefinition] = true
     }
 

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestAlipay.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestAlipay.kt
@@ -3,7 +3,9 @@ package com.stripe.android.lpm
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
 import com.stripe.android.test.core.AuthorizeAction
@@ -17,8 +19,8 @@ internal class TestAlipay : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "alipay",
     ) { settings ->
-        settings[CountrySettingsDefinition] = CountrySettingsDefinition.Country.US
-        settings[CurrencySettingsDefinition] = CurrencySettingsDefinition.Currency.USD
+        settings[CountrySettingsDefinition] = Country.US
+        settings[CurrencySettingsDefinition] = Currency.USD
         settings[SupportedPaymentMethodsSettingsDefinition] = listOf(
             PaymentMethod.Type.Card.code,
             PaymentMethod.Type.Klarna.code,

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestAlma.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestAlma.kt
@@ -2,7 +2,9 @@ package com.stripe.android.lpm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.test.core.TestParameters
 import org.junit.Ignore
@@ -14,8 +16,8 @@ internal class TestAlma : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "alma",
     ) { settings ->
-        settings[CountrySettingsDefinition] = CountrySettingsDefinition.Country.FR
-        settings[CurrencySettingsDefinition] = CurrencySettingsDefinition.Currency.EUR
+        settings[CountrySettingsDefinition] = Country.FR
+        settings[CurrencySettingsDefinition] = Currency.EUR
     }
 
     @Ignore("Complex authorization handling required")

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestAmazonPay.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestAmazonPay.kt
@@ -2,7 +2,9 @@ package com.stripe.android.lpm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.test.core.TestParameters
 import org.junit.Ignore
@@ -14,8 +16,8 @@ internal class TestAmazonPay : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "amazon_pay",
     ) { settings ->
-        settings[CountrySettingsDefinition] = CountrySettingsDefinition.Country.US
-        settings[CurrencySettingsDefinition] = CurrencySettingsDefinition.Currency.USD
+        settings[CountrySettingsDefinition] = Country.US
+        settings[CurrencySettingsDefinition] = Currency.USD
     }
 
     @Ignore("Complex authorization handling required")

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestAuBecsDD.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestAuBecsDD.kt
@@ -3,8 +3,11 @@ package com.stripe.android.lpm
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
 import com.stripe.android.paymentsheet.example.playground.settings.AutomaticPaymentMethodsSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CheckoutMode
 import com.stripe.android.paymentsheet.example.playground.settings.CheckoutModeSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymentMethodsSettingsDefinition
 import com.stripe.android.test.core.TestParameters
@@ -17,8 +20,8 @@ internal class TestAuBecsDD : BasePlaygroundTest() {
         paymentMethodCode = "au_becs_debit",
     ) { settings ->
         settings[DelayedPaymentMethodsSettingsDefinition] = true
-        settings[CountrySettingsDefinition] = CountrySettingsDefinition.Country.AU
-        settings[CurrencySettingsDefinition] = CurrencySettingsDefinition.Currency.AUD
+        settings[CountrySettingsDefinition] = Country.AU
+        settings[CurrencySettingsDefinition] = Currency.AUD
     }.copy(
         authorizationAction = null,
     )
@@ -42,8 +45,7 @@ internal class TestAuBecsDD : BasePlaygroundTest() {
         testDriver.confirmNewOrGuestComplete(
             testParameters = testParameters.copyPlaygroundSettings { settings ->
                 settings[AutomaticPaymentMethodsSettingsDefinition] = true
-                settings[CheckoutModeSettingsDefinition] =
-                    CheckoutModeSettingsDefinition.CheckoutMode.PAYMENT_WITH_SETUP
+                settings[CheckoutModeSettingsDefinition] = CheckoutMode.PAYMENT_WITH_SETUP
             }
         )
     }
@@ -53,8 +55,7 @@ internal class TestAuBecsDD : BasePlaygroundTest() {
         testDriver.confirmNewOrGuestComplete(
             testParameters = testParameters.copyPlaygroundSettings { settings ->
                 settings[AutomaticPaymentMethodsSettingsDefinition] = true
-                settings[CheckoutModeSettingsDefinition] =
-                    CheckoutModeSettingsDefinition.CheckoutMode.SETUP
+                settings[CheckoutModeSettingsDefinition] = CheckoutMode.SETUP
             }
         )
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestBancontact.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestBancontact.kt
@@ -3,6 +3,7 @@ package com.stripe.android.lpm
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
 import com.stripe.android.paymentsheet.example.playground.settings.AutomaticPaymentMethodsSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CheckoutMode
 import com.stripe.android.paymentsheet.example.playground.settings.CheckoutModeSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymentMethodsSettingsDefinition
 import com.stripe.android.test.core.TestParameters
@@ -28,8 +29,7 @@ internal class TestBancontact : BasePlaygroundTest() {
             testParameters = testParameters.copyPlaygroundSettings { settings ->
                 settings[DelayedPaymentMethodsSettingsDefinition] = true
                 settings[AutomaticPaymentMethodsSettingsDefinition] = true
-                settings[CheckoutModeSettingsDefinition] =
-                    CheckoutModeSettingsDefinition.CheckoutMode.PAYMENT_WITH_SETUP
+                settings[CheckoutModeSettingsDefinition] = CheckoutMode.PAYMENT_WITH_SETUP
             },
         )
     }
@@ -40,8 +40,7 @@ internal class TestBancontact : BasePlaygroundTest() {
             testParameters = testParameters.copyPlaygroundSettings { settings ->
                 settings[DelayedPaymentMethodsSettingsDefinition] = true
                 settings[AutomaticPaymentMethodsSettingsDefinition] = true
-                settings[CheckoutModeSettingsDefinition] =
-                    CheckoutModeSettingsDefinition.CheckoutMode.SETUP
+                settings[CheckoutModeSettingsDefinition] = CheckoutMode.SETUP
             },
         )
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestBlik.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestBlik.kt
@@ -4,7 +4,9 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
 import com.stripe.android.test.core.AuthorizeAction
@@ -17,8 +19,8 @@ internal class TestBlik : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "blik",
     ) { settings ->
-        settings[CountrySettingsDefinition] = CountrySettingsDefinition.Country.FR
-        settings[CurrencySettingsDefinition] = CurrencySettingsDefinition.Currency.PLN
+        settings[CountrySettingsDefinition] = Country.FR
+        settings[CurrencySettingsDefinition] = Currency.PLN
         settings[SupportedPaymentMethodsSettingsDefinition] = listOf("card", "blik")
     }.copy(
         authorizationAction = AuthorizeAction.PollingSucceedsAfterDelay,

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestBoleto.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestBoleto.kt
@@ -2,10 +2,14 @@ package com.stripe.android.lpm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.paymentsheet.example.playground.settings.CheckoutMode
 import com.stripe.android.paymentsheet.example.playground.settings.CheckoutModeSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
 import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillingAddressSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymentMethodsSettingsDefinition
 import com.stripe.android.test.core.AuthorizeAction
@@ -19,9 +23,9 @@ internal class TestBoleto : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "boleto",
     ) { settings ->
-        settings[CustomerSettingsDefinition] = CustomerSettingsDefinition.CustomerType.GUEST
-        settings[CountrySettingsDefinition] = CountrySettingsDefinition.Country.BR
-        settings[CurrencySettingsDefinition] = CurrencySettingsDefinition.Currency.BRL
+        settings[CustomerSettingsDefinition] = CustomerType.GUEST
+        settings[CountrySettingsDefinition] = Country.BR
+        settings[CurrencySettingsDefinition] = Currency.BRL
         settings[DelayedPaymentMethodsSettingsDefinition] = true
         settings[DefaultBillingAddressSettingsDefinition] = false
     }.copy(
@@ -45,8 +49,7 @@ internal class TestBoleto : BasePlaygroundTest() {
     fun testBoletoSfu() {
         testDriver.confirmNewOrGuestComplete(
             testParameters = testParameters.copyPlaygroundSettings { settings ->
-                settings[CheckoutModeSettingsDefinition] =
-                    CheckoutModeSettingsDefinition.CheckoutMode.PAYMENT_WITH_SETUP
+                settings[CheckoutModeSettingsDefinition] = CheckoutMode.PAYMENT_WITH_SETUP
             },
             values = boletoValues,
         )
@@ -56,8 +59,7 @@ internal class TestBoleto : BasePlaygroundTest() {
     fun testBoletoSetup() {
         testDriver.confirmNewOrGuestComplete(
             testParameters = testParameters.copyPlaygroundSettings { settings ->
-                settings[CheckoutModeSettingsDefinition] =
-                    CheckoutModeSettingsDefinition.CheckoutMode.SETUP
+                settings[CheckoutModeSettingsDefinition] = CheckoutMode.SETUP
             },
             values = boletoValues,
         )

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCashApp.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCashApp.kt
@@ -2,8 +2,11 @@ package com.stripe.android.lpm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.paymentsheet.example.playground.settings.CheckoutMode
 import com.stripe.android.paymentsheet.example.playground.settings.CheckoutModeSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
 import com.stripe.android.test.core.AuthorizeAction
@@ -17,8 +20,8 @@ internal class TestCashApp : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "cashapp",
     ) { settings ->
-        settings[CountrySettingsDefinition] = CountrySettingsDefinition.Country.US
-        settings[CurrencySettingsDefinition] = CurrencySettingsDefinition.Currency.USD
+        settings[CountrySettingsDefinition] = Country.US
+        settings[CurrencySettingsDefinition] = Currency.USD
         settings[SupportedPaymentMethodsSettingsDefinition] = listOf("card", "cashapp")
     }
 
@@ -53,8 +56,7 @@ internal class TestCashApp : BasePlaygroundTest() {
     fun testCashAppPayWithSfu() {
         testDriver.confirmNewOrGuestComplete(
             testParameters = testParameters.copyPlaygroundSettings { settings ->
-                settings[CheckoutModeSettingsDefinition] =
-                    CheckoutModeSettingsDefinition.CheckoutMode.PAYMENT_WITH_SETUP
+                settings[CheckoutModeSettingsDefinition] = CheckoutMode.PAYMENT_WITH_SETUP
             }
         )
     }
@@ -63,8 +65,7 @@ internal class TestCashApp : BasePlaygroundTest() {
     fun testCashAppPayWithSetupIntent() {
         testDriver.confirmNewOrGuestComplete(
             testParameters = testParameters.copyPlaygroundSettings { settings ->
-                settings[CheckoutModeSettingsDefinition] =
-                    CheckoutModeSettingsDefinition.CheckoutMode.SETUP
+                settings[CheckoutModeSettingsDefinition] = CheckoutMode.SETUP
             }
         )
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestFpx.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestFpx.kt
@@ -3,7 +3,9 @@ package com.stripe.android.lpm
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
 import com.stripe.android.paymentsheet.example.playground.settings.AutomaticPaymentMethodsSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.test.core.TestParameters
 import org.junit.Test
@@ -14,8 +16,8 @@ internal class TestFpx : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "fpx",
     ) { settings ->
-        settings[CountrySettingsDefinition] = CountrySettingsDefinition.Country.MY
-        settings[CurrencySettingsDefinition] = CurrencySettingsDefinition.Currency.MYR
+        settings[CountrySettingsDefinition] = Country.MY
+        settings[CurrencySettingsDefinition] = Currency.MYR
         settings[AutomaticPaymentMethodsSettingsDefinition] = true
     }
 

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestGrabPay.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestGrabPay.kt
@@ -2,7 +2,9 @@ package com.stripe.android.lpm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.TestParameters
@@ -15,8 +17,8 @@ internal class TestGrabPay : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "grabpay",
     ) { settings ->
-        settings[CountrySettingsDefinition] = CountrySettingsDefinition.Country.SG
-        settings[CurrencySettingsDefinition] = CurrencySettingsDefinition.Currency.SGD
+        settings[CountrySettingsDefinition] = Country.SG
+        settings[CurrencySettingsDefinition] = Currency.SGD
     }
 
     @Test

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestIdeal.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestIdeal.kt
@@ -3,6 +3,7 @@ package com.stripe.android.lpm
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
 import com.stripe.android.paymentsheet.example.playground.settings.AutomaticPaymentMethodsSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CheckoutMode
 import com.stripe.android.paymentsheet.example.playground.settings.CheckoutModeSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymentMethodsSettingsDefinition
 import com.stripe.android.test.core.TestParameters
@@ -28,8 +29,7 @@ internal class TestIdeal : BasePlaygroundTest() {
             testParameters = testParameters.copyPlaygroundSettings { settings ->
                 settings[DelayedPaymentMethodsSettingsDefinition] = true
                 settings[AutomaticPaymentMethodsSettingsDefinition] = true
-                settings[CheckoutModeSettingsDefinition] =
-                    CheckoutModeSettingsDefinition.CheckoutMode.PAYMENT_WITH_SETUP
+                settings[CheckoutModeSettingsDefinition] = CheckoutMode.PAYMENT_WITH_SETUP
             }
         )
     }
@@ -40,8 +40,7 @@ internal class TestIdeal : BasePlaygroundTest() {
             testParameters = testParameters.copyPlaygroundSettings { settings ->
                 settings[DelayedPaymentMethodsSettingsDefinition] = true
                 settings[AutomaticPaymentMethodsSettingsDefinition] = true
-                settings[CheckoutModeSettingsDefinition] =
-                    CheckoutModeSettingsDefinition.CheckoutMode.SETUP
+                settings[CheckoutModeSettingsDefinition] = CheckoutMode.SETUP
             }
         )
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestKlarna.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestKlarna.kt
@@ -2,7 +2,9 @@ package com.stripe.android.lpm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.test.core.TestParameters
 import org.junit.Ignore
@@ -14,8 +16,8 @@ internal class TestKlarna : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "klarna",
     ) { settings ->
-        settings[CountrySettingsDefinition] = CountrySettingsDefinition.Country.US
-        settings[CurrencySettingsDefinition] = CurrencySettingsDefinition.Currency.USD
+        settings[CountrySettingsDefinition] = Country.US
+        settings[CurrencySettingsDefinition] = Currency.USD
     }
 
     @Ignore("Complex authorization handling required")

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestKonbini.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestKonbini.kt
@@ -2,9 +2,12 @@ package com.stripe.android.lpm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
 import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillingAddressSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymentMethodsSettingsDefinition
 import com.stripe.android.test.core.AuthorizeAction
@@ -17,9 +20,9 @@ internal class TestKonbini : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "konbini",
     ) { settings ->
-        settings[CountrySettingsDefinition] = CountrySettingsDefinition.Country.JP
-        settings[CurrencySettingsDefinition] = CurrencySettingsDefinition.Currency.JPY
-        settings[CustomerSettingsDefinition] = CustomerSettingsDefinition.CustomerType.GUEST
+        settings[CountrySettingsDefinition] = Country.JP
+        settings[CurrencySettingsDefinition] = Currency.JPY
+        settings[CustomerSettingsDefinition] = CustomerType.GUEST
         settings[DelayedPaymentMethodsSettingsDefinition] = true
         settings[DefaultBillingAddressSettingsDefinition] = false
     }.copy(

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestOxxo.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestOxxo.kt
@@ -2,9 +2,12 @@ package com.stripe.android.lpm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
 import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillingAddressSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymentMethodsSettingsDefinition
 import com.stripe.android.test.core.AuthorizeAction
@@ -17,9 +20,9 @@ internal class TestOxxo : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "oxxo",
     ) { settings ->
-        settings[CustomerSettingsDefinition] = CustomerSettingsDefinition.CustomerType.GUEST
-        settings[CountrySettingsDefinition] = CountrySettingsDefinition.Country.MX
-        settings[CurrencySettingsDefinition] = CurrencySettingsDefinition.Currency.MXN
+        settings[CustomerSettingsDefinition] = CustomerType.GUEST
+        settings[CountrySettingsDefinition] = Country.MX
+        settings[CurrencySettingsDefinition] = Currency.MXN
         settings[DelayedPaymentMethodsSettingsDefinition] = true
         settings[DefaultBillingAddressSettingsDefinition] = false
     }.copy(

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestPayPal.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestPayPal.kt
@@ -2,6 +2,7 @@ package com.stripe.android.lpm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.test.core.TestParameters
 import org.junit.Test
@@ -12,7 +13,7 @@ internal class TestPayPal : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "paypal",
     ) { settings ->
-        settings[CurrencySettingsDefinition] = CurrencySettingsDefinition.Currency.GBP
+        settings[CurrencySettingsDefinition] = Currency.GBP
     }
 
     @Test

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestRevolutPay.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestRevolutPay.kt
@@ -2,7 +2,9 @@ package com.stripe.android.lpm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.paymentsheet.example.playground.settings.CheckoutMode
 import com.stripe.android.paymentsheet.example.playground.settings.CheckoutModeSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
 import com.stripe.android.test.core.AuthorizeAction
@@ -16,7 +18,7 @@ internal class TestRevolutPay : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "revolut_pay",
     ) { settings ->
-        settings[CurrencySettingsDefinition] = CurrencySettingsDefinition.Currency.GBP
+        settings[CurrencySettingsDefinition] = Currency.GBP
         settings[SupportedPaymentMethodsSettingsDefinition] = listOf("card", "revolut_pay")
     }
 
@@ -55,8 +57,7 @@ internal class TestRevolutPay : BasePlaygroundTest() {
     fun testRevolutPayWithSfu() {
         testDriver.confirmNewOrGuestComplete(
             testParameters = testParameters.copyPlaygroundSettings { settings ->
-                settings[CheckoutModeSettingsDefinition] =
-                    CheckoutModeSettingsDefinition.CheckoutMode.PAYMENT_WITH_SETUP
+                settings[CheckoutModeSettingsDefinition] = CheckoutMode.PAYMENT_WITH_SETUP
             }
         )
     }
@@ -66,8 +67,7 @@ internal class TestRevolutPay : BasePlaygroundTest() {
     fun testRevolutPayWithSetupIntent() {
         testDriver.confirmNewOrGuestComplete(
             testParameters = testParameters.copyPlaygroundSettings { settings ->
-                settings[CheckoutModeSettingsDefinition] =
-                    CheckoutModeSettingsDefinition.CheckoutMode.SETUP
+                settings[CheckoutModeSettingsDefinition] = CheckoutMode.SETUP
             }
         )
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSepaDebit.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSepaDebit.kt
@@ -6,7 +6,9 @@ import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
 import com.stripe.android.paymentsheet.example.playground.settings.AutomaticPaymentMethodsSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CheckoutMode
 import com.stripe.android.paymentsheet.example.playground.settings.CheckoutModeSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymentMethodsSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.GooglePaySettingsDefinition
@@ -20,7 +22,7 @@ internal class TestSepaDebit : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "sepa_debit",
     ) { settings ->
-        settings[CountrySettingsDefinition] = CountrySettingsDefinition.Country.FR
+        settings[CountrySettingsDefinition] = Country.FR
         settings[DelayedPaymentMethodsSettingsDefinition] = true
         settings[GooglePaySettingsDefinition] = false
     }.copy(
@@ -45,8 +47,7 @@ internal class TestSepaDebit : BasePlaygroundTest() {
         testDriver.confirmNewOrGuestComplete(
             testParameters = testParameters.copyPlaygroundSettings { settings ->
                 settings[AutomaticPaymentMethodsSettingsDefinition] = true
-                settings[CheckoutModeSettingsDefinition] =
-                    CheckoutModeSettingsDefinition.CheckoutMode.PAYMENT_WITH_SETUP
+                settings[CheckoutModeSettingsDefinition] = CheckoutMode.PAYMENT_WITH_SETUP
             }
         ) {
             rules.compose.onNodeWithText("IBAN").apply {
@@ -62,8 +63,7 @@ internal class TestSepaDebit : BasePlaygroundTest() {
         testDriver.confirmNewOrGuestComplete(
             testParameters = testParameters.copyPlaygroundSettings { settings ->
                 settings[AutomaticPaymentMethodsSettingsDefinition] = true
-                settings[CheckoutModeSettingsDefinition] =
-                    CheckoutModeSettingsDefinition.CheckoutMode.SETUP
+                settings[CheckoutModeSettingsDefinition] = CheckoutMode.SETUP
             }
         ) {
             rules.compose.onNodeWithText("IBAN").apply {

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSofort.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSofort.kt
@@ -3,7 +3,9 @@ package com.stripe.android.lpm
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
 import com.stripe.android.paymentsheet.example.playground.settings.AutomaticPaymentMethodsSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CheckoutMode
 import com.stripe.android.paymentsheet.example.playground.settings.CheckoutModeSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymentMethodsSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.GooglePaySettingsDefinition
@@ -16,7 +18,7 @@ internal class TestSofort : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "sofort",
     ) { settings ->
-        settings[CountrySettingsDefinition] = CountrySettingsDefinition.Country.FR
+        settings[CountrySettingsDefinition] = Country.FR
         settings[DelayedPaymentMethodsSettingsDefinition] = true
         settings[GooglePaySettingsDefinition] = false
     }
@@ -33,8 +35,7 @@ internal class TestSofort : BasePlaygroundTest() {
         testDriver.confirmNewOrGuestComplete(
             testParameters = testParameters.copyPlaygroundSettings { settings ->
                 settings[AutomaticPaymentMethodsSettingsDefinition] = true
-                settings[CheckoutModeSettingsDefinition] =
-                    CheckoutModeSettingsDefinition.CheckoutMode.PAYMENT_WITH_SETUP
+                settings[CheckoutModeSettingsDefinition] = CheckoutMode.PAYMENT_WITH_SETUP
             }
         )
     }
@@ -44,8 +45,7 @@ internal class TestSofort : BasePlaygroundTest() {
         testDriver.confirmNewOrGuestComplete(
             testParameters = testParameters.copyPlaygroundSettings { settings ->
                 settings[AutomaticPaymentMethodsSettingsDefinition] = true
-                settings[CheckoutModeSettingsDefinition] =
-                    CheckoutModeSettingsDefinition.CheckoutMode.SETUP
+                settings[CheckoutModeSettingsDefinition] = CheckoutMode.SETUP
             }
         )
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSwish.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSwish.kt
@@ -2,7 +2,9 @@ package com.stripe.android.lpm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymentMethodsSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.GooglePaySettingsDefinition
@@ -16,8 +18,8 @@ internal class TestSwish : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "swish",
     ) { settings ->
-        settings[CountrySettingsDefinition] = CountrySettingsDefinition.Country.FR
-        settings[CurrencySettingsDefinition] = CurrencySettingsDefinition.Currency.SEK
+        settings[CountrySettingsDefinition] = Country.FR
+        settings[CurrencySettingsDefinition] = Currency.SEK
         settings[DelayedPaymentMethodsSettingsDefinition] = true
         settings[GooglePaySettingsDefinition] = false
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUpi.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUpi.kt
@@ -4,7 +4,9 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.test.core.TestParameters
 import org.junit.Test
@@ -15,8 +17,8 @@ internal class TestUpi : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "upi",
     ) { settings ->
-        settings[CountrySettingsDefinition] = CountrySettingsDefinition.Country.IN
-        settings[CurrencySettingsDefinition] = CurrencySettingsDefinition.Currency.INR
+        settings[CountrySettingsDefinition] = Country.IN
+        settings[CurrencySettingsDefinition] = Currency.INR
     }.copy(
         authorizationAction = null,
     )

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
@@ -8,6 +8,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.R
 import com.stripe.android.paymentsheet.example.playground.activity.AppearanceStore
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
 import com.stripe.android.paymentsheet.example.playground.settings.PrimaryButtonLabelSettingsDefinition
 import com.stripe.android.test.core.TestParameters
 import com.stripe.android.ui.core.forms.resources.LpmRepository
@@ -114,8 +115,7 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
     fun testPaymentSheetReturningCustomerLight() {
         testDriver.screenshotRegression(
             testParams.copyPlaygroundSettings { settings ->
-                settings[CustomerSettingsDefinition] =
-                    CustomerSettingsDefinition.CustomerType.RETURNING
+                settings[CustomerSettingsDefinition] = CustomerType.RETURNING
             }
         )
     }
@@ -125,8 +125,7 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
         AppearanceStore.state = appearance
         testDriver.screenshotRegression(
             testParams.copyPlaygroundSettings { settings ->
-                settings[CustomerSettingsDefinition] =
-                    CustomerSettingsDefinition.CustomerType.RETURNING
+                settings[CustomerSettingsDefinition] = CustomerType.RETURNING
             }
         )
     }
@@ -136,8 +135,7 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
         forceDarkMode()
         testDriver.screenshotRegression(
             testParams.copyPlaygroundSettings { settings ->
-                settings[CustomerSettingsDefinition] =
-                    CustomerSettingsDefinition.CustomerType.RETURNING
+                settings[CustomerSettingsDefinition] = CustomerType.RETURNING
             }
         )
     }
@@ -148,8 +146,7 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
         forceDarkMode()
         testDriver.screenshotRegression(
             testParams.copyPlaygroundSettings { settings ->
-                settings[CustomerSettingsDefinition] =
-                    CustomerSettingsDefinition.CustomerType.RETURNING
+                settings[CustomerSettingsDefinition] = CustomerType.RETURNING
             }
         )
     }
@@ -159,8 +156,7 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
         testDriver.screenshotRegression(
             testParameters = testParams
                 .copyPlaygroundSettings { settings ->
-                    settings[CustomerSettingsDefinition] =
-                        CustomerSettingsDefinition.CustomerType.RETURNING
+                    settings[CustomerSettingsDefinition] = CustomerType.RETURNING
                 },
             customOperations = {
                 testDriver.pressEdit()
@@ -173,8 +169,7 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
         AppearanceStore.state = appearance
         testDriver.screenshotRegression(
             testParameters = testParams.copyPlaygroundSettings { settings ->
-                settings[CustomerSettingsDefinition] =
-                    CustomerSettingsDefinition.CustomerType.RETURNING
+                settings[CustomerSettingsDefinition] = CustomerType.RETURNING
             },
             customOperations = {
                 testDriver.pressEdit()
@@ -188,8 +183,7 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
         testDriver.screenshotRegression(
             testParameters = testParams
                 .copyPlaygroundSettings { settings ->
-                    settings[CustomerSettingsDefinition] =
-                        CustomerSettingsDefinition.CustomerType.RETURNING
+                    settings[CustomerSettingsDefinition] = CustomerType.RETURNING
                 },
             customOperations = {
                 testDriver.pressEdit()
@@ -202,8 +196,7 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
         forceDarkMode()
         testDriver.screenshotRegression(
             testParameters = testParams.copyPlaygroundSettings { settings ->
-                settings[CustomerSettingsDefinition] =
-                    CustomerSettingsDefinition.CustomerType.RETURNING
+                settings[CustomerSettingsDefinition] = CustomerType.RETURNING
             },
             customOperations = {
                 testDriver.pressEdit()

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -27,7 +27,9 @@ import com.google.common.truth.Truth.assertThat
 import com.karumi.shot.ScreenshotTest
 import com.stripe.android.paymentsheet.PAYMENT_OPTION_CARD_TEST_TAG
 import com.stripe.android.paymentsheet.example.playground.PaymentSheetPlaygroundActivity
+import com.stripe.android.paymentsheet.example.playground.settings.CheckoutMode
 import com.stripe.android.paymentsheet.example.playground.settings.CheckoutModeSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.IntegrationType
 import com.stripe.android.paymentsheet.example.playground.settings.IntegrationTypeSettingsDefinition
 import com.stripe.android.test.core.ui.BrowserUI
 import com.stripe.android.test.core.ui.Selectors
@@ -163,8 +165,7 @@ internal class PlaygroundTestDriver(
     ) {
         setup(
             testParameters.copyPlaygroundSettings { settings ->
-                settings[IntegrationTypeSettingsDefinition] =
-                    IntegrationTypeSettingsDefinition.IntegrationType.FlowController
+                settings[IntegrationTypeSettingsDefinition] = IntegrationType.FlowController
             }
         )
         launchCustom()
@@ -408,7 +409,7 @@ internal class PlaygroundTestDriver(
                     assertThat(browserWindow(selectedBrowser)?.exists()).isTrue()
 
                     blockUntilAuthorizationPageLoaded(
-                        isSetup = checkoutMode == CheckoutModeSettingsDefinition.CheckoutMode.SETUP
+                        isSetup = checkoutMode == CheckoutMode.SETUP
                     )
                 }
 
@@ -429,7 +430,7 @@ internal class PlaygroundTestDriver(
 
                 when (val authAction = testParameters.authorizationAction) {
                     is AuthorizeAction.DisplayQrCode -> {
-                        if (checkoutMode != CheckoutModeSettingsDefinition.CheckoutMode.SETUP) {
+                        if (checkoutMode != CheckoutMode.SETUP) {
                             closeQrCodeButton.wait(5000)
                             onView(withText("CLOSE")).perform(click())
                         }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
@@ -2,10 +2,13 @@ package com.stripe.android.test.core
 
 import androidx.test.platform.app.InstrumentationRegistry
 import com.stripe.android.paymentsheet.example.playground.settings.AutomaticPaymentMethodsSettingsDefinition
-import com.stripe.android.paymentsheet.example.playground.settings.CheckoutModeSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CheckoutMode
+import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
 import com.stripe.android.paymentsheet.example.playground.settings.DefaultShippingAddressSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymentMethodsSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.LinkSettingsDefinition
@@ -57,10 +60,10 @@ internal data class TestParameters(
 
         fun playgroundSettings(block: (PlaygroundSettings) -> Unit = {}): PlaygroundSettings {
             val settings = PlaygroundSettings.createFromDefaults()
-            settings[CustomerSettingsDefinition] = CustomerSettingsDefinition.CustomerType.NEW
+            settings[CustomerSettingsDefinition] = CustomerType.NEW
             settings[LinkSettingsDefinition] = false
-            settings[CountrySettingsDefinition] = CountrySettingsDefinition.Country.GB
-            settings[CurrencySettingsDefinition] = CurrencySettingsDefinition.Currency.EUR
+            settings[CountrySettingsDefinition] = Country.GB
+            settings[CurrencySettingsDefinition] = Currency.EUR
             settings[DefaultShippingAddressSettingsDefinition] = false
             settings[DelayedPaymentMethodsSettingsDefinition] = false
             settings[AutomaticPaymentMethodsSettingsDefinition] = false
@@ -88,20 +91,19 @@ enum class Browser {
  */
 internal sealed interface AuthorizeAction {
 
-    fun text(checkoutMode: CheckoutModeSettingsDefinition.CheckoutMode): String
+    fun text(checkoutMode: CheckoutMode): String
 
     val requiresBrowser: Boolean
 
     object PollingSucceedsAfterDelay : AuthorizeAction {
-        override fun text(checkoutMode: CheckoutModeSettingsDefinition.CheckoutMode): String =
-            "POLLING SUCCEEDS AFTER DELAY"
+        override fun text(checkoutMode: CheckoutMode): String = "POLLING SUCCEEDS AFTER DELAY"
 
         override val requiresBrowser: Boolean = false
     }
 
     object AuthorizePayment : AuthorizeAction {
-        override fun text(checkoutMode: CheckoutModeSettingsDefinition.CheckoutMode): String {
-            return if (checkoutMode == CheckoutModeSettingsDefinition.CheckoutMode.SETUP) {
+        override fun text(checkoutMode: CheckoutMode): String {
+            return if (checkoutMode == CheckoutMode.SETUP) {
                 "AUTHORIZE TEST SETUP"
             } else {
                 "AUTHORIZE TEST PAYMENT"
@@ -112,21 +114,19 @@ internal sealed interface AuthorizeAction {
     }
 
     object DisplayQrCode : AuthorizeAction {
-        override fun text(checkoutMode: CheckoutModeSettingsDefinition.CheckoutMode): String =
-            "Display QR code"
+        override fun text(checkoutMode: CheckoutMode): String = "Display QR code"
 
         override val requiresBrowser: Boolean = false
     }
 
     data class Fail(val expectedError: String) : AuthorizeAction {
-        override fun text(checkoutMode: CheckoutModeSettingsDefinition.CheckoutMode): String =
-            "FAIL TEST PAYMENT"
+        override fun text(checkoutMode: CheckoutMode): String = "FAIL TEST PAYMENT"
 
         override val requiresBrowser: Boolean = true
     }
 
     object Cancel : AuthorizeAction {
-        override fun text(checkoutMode: CheckoutModeSettingsDefinition.CheckoutMode): String = ""
+        override fun text(checkoutMode: CheckoutMode): String = ""
         override val requiresBrowser: Boolean = true
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -34,9 +34,9 @@ import com.stripe.android.paymentsheet.addresselement.rememberAddressLauncher
 import com.stripe.android.paymentsheet.example.playground.activity.AppearanceBottomSheetDialogFragment
 import com.stripe.android.paymentsheet.example.playground.activity.AppearanceStore
 import com.stripe.android.paymentsheet.example.playground.activity.QrCodeActivity
-import com.stripe.android.paymentsheet.example.playground.settings.CheckoutModeSettingsDefinition
-import com.stripe.android.paymentsheet.example.playground.settings.InitializationTypeSettingsDefinition
-import com.stripe.android.paymentsheet.example.playground.settings.IntegrationTypeSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CheckoutMode
+import com.stripe.android.paymentsheet.example.playground.settings.InitializationType
+import com.stripe.android.paymentsheet.example.playground.settings.IntegrationType
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettings
 import com.stripe.android.paymentsheet.example.playground.settings.SettingsUi
 import com.stripe.android.paymentsheet.example.samples.ui.shared.BuyButton
@@ -174,14 +174,14 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
         )
 
         when (playgroundState.integrationType) {
-            IntegrationTypeSettingsDefinition.IntegrationType.PaymentSheet -> {
+            IntegrationType.PaymentSheet -> {
                 PaymentSheetUi(
                     paymentSheet = paymentSheet,
                     playgroundState = playgroundState,
                 )
             }
 
-            IntegrationTypeSettingsDefinition.IntegrationType.FlowController -> {
+            IntegrationType.FlowController -> {
                 FlowControllerUi(
                     flowController = flowController,
                     playgroundState = playgroundState,
@@ -254,8 +254,8 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
     }
 
     private fun presentPaymentSheet(paymentSheet: PaymentSheet, playgroundState: PlaygroundState) {
-        if (playgroundState.initializationType == InitializationTypeSettingsDefinition.InitializationType.Normal) {
-            if (playgroundState.checkoutMode == CheckoutModeSettingsDefinition.CheckoutMode.SETUP) {
+        if (playgroundState.initializationType == InitializationType.Normal) {
+            if (playgroundState.checkoutMode == CheckoutMode.SETUP) {
                 paymentSheet.presentWithSetupIntent(
                     setupIntentClientSecret = playgroundState.clientSecret,
                     configuration = playgroundState.paymentSheetConfiguration()
@@ -281,8 +281,8 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
         flowController: PaymentSheet.FlowController,
         playgroundState: PlaygroundState,
     ) {
-        if (playgroundState.initializationType == InitializationTypeSettingsDefinition.InitializationType.Normal) {
-            if (playgroundState.checkoutMode == CheckoutModeSettingsDefinition.CheckoutMode.SETUP) {
+        if (playgroundState.initializationType == InitializationType.Normal) {
+            if (playgroundState.checkoutMode == CheckoutMode.SETUP) {
                 flowController.configureWithSetupIntent(
                     setupIntentClientSecret = playgroundState.clientSecret,
                     configuration = playgroundState.paymentSheetConfiguration(),

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
@@ -23,7 +23,7 @@ import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutResponse
 import com.stripe.android.paymentsheet.example.playground.model.ConfirmIntentRequest
 import com.stripe.android.paymentsheet.example.playground.model.ConfirmIntentResponse
-import com.stripe.android.paymentsheet.example.playground.settings.InitializationTypeSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.InitializationType
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettings
 import com.stripe.android.paymentsheet.example.playground.settings.ShippingAddressSettingsDefinition
 import com.stripe.android.paymentsheet.example.samples.networking.awaitModel
@@ -180,16 +180,16 @@ internal class PaymentSheetPlaygroundViewModel(
         playgroundState: PlaygroundState,
     ): CreateIntentResult {
         return when (playgroundState.initializationType) {
-            InitializationTypeSettingsDefinition.InitializationType.Normal -> {
+            InitializationType.Normal -> {
                 error("createAndConfirmIntent should not be called when initialization type is Normal")
             }
 
-            InitializationTypeSettingsDefinition.InitializationType.DeferredClientSideConfirmation -> {
+            InitializationType.DeferredClientSideConfirmation -> {
                 createIntent(playgroundState.clientSecret)
             }
 
-            InitializationTypeSettingsDefinition.InitializationType.DeferredServerSideConfirmation,
-            InitializationTypeSettingsDefinition.InitializationType.DeferredManualConfirmation -> {
+            InitializationType.DeferredServerSideConfirmation,
+            InitializationType.DeferredManualConfirmation -> {
                 createAndConfirmIntentInternal(
                     paymentMethodId = paymentMethodId,
                     shouldSavePaymentMethod = shouldSavePaymentMethod,
@@ -197,7 +197,7 @@ internal class PaymentSheetPlaygroundViewModel(
                 )
             }
 
-            InitializationTypeSettingsDefinition.InitializationType.DeferredMultiprocessor -> {
+            InitializationType.DeferredMultiprocessor -> {
                 CreateIntentResult.Success(PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT)
             }
         }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/AppearanceSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/AppearanceSettingsDefinition.kt
@@ -4,27 +4,12 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 import com.stripe.android.paymentsheet.example.playground.activity.AppearanceStore
 
-internal object AppearanceSettingsDefinition : PlaygroundSettingDefinition<Unit>(
-    key = "appearance",
-    displayName = "", // Not displayed.
-) {
-    override val defaultValue: Unit = Unit
-    override val options: List<Option<Unit>> = emptyList()
-    override val saveToSharedPreferences: Boolean = false
-
-    override fun convertToValue(value: String) {
-        // No value, we're saving in memory only.
-    }
-
-    override fun convertToString(value: Unit): String {
-        return ""
-    }
-
+internal object AppearanceSettingsDefinition : PlaygroundSettingDefinition<Unit> {
     override fun configure(
         value: Unit,
         configurationBuilder: PaymentSheet.Configuration.Builder,
         playgroundState: PlaygroundState,
-        configurationData: PaymentSheetConfigurationData
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData
     ) {
         configurationBuilder.appearance(AppearanceStore.state)
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/AttachDefaultsSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/AttachDefaultsSettingsDefinition.kt
@@ -12,7 +12,7 @@ internal object AttachDefaultsSettingsDefinition : BooleanSettingsDefinition(
         value: Boolean,
         configurationBuilder: PaymentSheet.Configuration.Builder,
         playgroundState: PlaygroundState,
-        configurationData: PaymentSheetConfigurationData,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData,
     ) {
         configurationData.updateBillingDetails { copy(attachDefaultsToPaymentMethod = value) }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/BooleanSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/BooleanSettingsDefinition.kt
@@ -1,14 +1,18 @@
 package com.stripe.android.paymentsheet.example.playground.settings
 
 internal abstract class BooleanSettingsDefinition(
-    key: String,
-    displayName: String,
+    override val key: String,
+    override val displayName: String,
     override val defaultValue: Boolean,
-) : PlaygroundSettingDefinition<Boolean>(key, displayName) {
-    override val options: List<Option<Boolean>> = listOf(
-        Option("On", true),
-        Option("Off", false),
-    )
+) : PlaygroundSettingDefinition<Boolean>,
+    PlaygroundSettingDefinition.Saveable<Boolean>,
+    PlaygroundSettingDefinition.Displayable<Boolean> {
+    override val options: List<PlaygroundSettingDefinition.Displayable.Option<Boolean>> by lazy {
+        listOf(
+            option("On", true),
+            option("Off", false),
+        )
+    }
 
     override fun convertToString(value: Boolean): String {
         return value.toString()

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CheckoutModeSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CheckoutModeSettingsDefinition.kt
@@ -5,64 +5,61 @@ import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 
 internal object CheckoutModeSettingsDefinition :
-    PlaygroundSettingDefinition<CheckoutModeSettingsDefinition.CheckoutMode>(
+    PlaygroundSettingDefinition<CheckoutMode>,
+    PlaygroundSettingDefinition.Saveable<CheckoutMode> by EnumSaveable(
         key = "checkoutMode",
-        displayName = "Checkout Mode",
-    ) {
-    override val defaultValue: CheckoutMode = CheckoutMode.PAYMENT
-    override val options: List<Option<CheckoutMode>> = listOf(
-        Option("Pay", CheckoutMode.PAYMENT),
-        Option("P & S", CheckoutMode.PAYMENT_WITH_SETUP),
-        Option("Setup", CheckoutMode.SETUP),
-    )
+        values = CheckoutMode.values(),
+        defaultValue = CheckoutMode.PAYMENT
+    ),
+    PlaygroundSettingDefinition.Displayable<CheckoutMode> {
 
-    override fun convertToValue(value: String): CheckoutMode {
-        return CheckoutMode.values().firstOrNull { it.value == value } ?: defaultValue
-    }
-
-    override fun convertToString(value: CheckoutMode): String {
-        return value.value
-    }
+    override val displayName: String = "Checkout Mode"
+    override val options: List<PlaygroundSettingDefinition.Displayable.Option<CheckoutMode>> =
+        listOf(
+            option("Pay", CheckoutMode.PAYMENT),
+            option("P & S", CheckoutMode.PAYMENT_WITH_SETUP),
+            option("Setup", CheckoutMode.SETUP),
+        )
 
     override fun configure(value: CheckoutMode, checkoutRequestBuilder: CheckoutRequest.Builder) {
         checkoutRequestBuilder.mode(value.value)
     }
+}
 
-    enum class CheckoutMode(val value: String) {
-        SETUP("setup") {
-            override fun intentConfigurationMode(
-                playgroundState: PlaygroundState
-            ): PaymentSheet.IntentConfiguration.Mode {
-                return PaymentSheet.IntentConfiguration.Mode.Setup(
-                    currency = playgroundState.currencyCode.value,
-                    setupFutureUse = PaymentSheet.IntentConfiguration.SetupFutureUse.OffSession,
-                )
-            }
-        },
-        PAYMENT("payment") {
-            override fun intentConfigurationMode(
-                playgroundState: PlaygroundState
-            ): PaymentSheet.IntentConfiguration.Mode {
-                return PaymentSheet.IntentConfiguration.Mode.Payment(
-                    amount = playgroundState.amount,
-                    currency = playgroundState.currencyCode.value,
-                )
-            }
-        },
-        PAYMENT_WITH_SETUP("payment_with_setup") {
-            override fun intentConfigurationMode(
-                playgroundState: PlaygroundState
-            ): PaymentSheet.IntentConfiguration.Mode {
-                return PaymentSheet.IntentConfiguration.Mode.Payment(
-                    amount = playgroundState.amount,
-                    currency = playgroundState.currencyCode.value,
-                    setupFutureUse = PaymentSheet.IntentConfiguration.SetupFutureUse.OffSession,
-                )
-            }
-        };
-
-        abstract fun intentConfigurationMode(
+internal enum class CheckoutMode(override val value: String) : ValueEnum {
+    SETUP("setup") {
+        override fun intentConfigurationMode(
             playgroundState: PlaygroundState
-        ): PaymentSheet.IntentConfiguration.Mode
-    }
+        ): PaymentSheet.IntentConfiguration.Mode {
+            return PaymentSheet.IntentConfiguration.Mode.Setup(
+                currency = playgroundState.currencyCode.value,
+                setupFutureUse = PaymentSheet.IntentConfiguration.SetupFutureUse.OffSession,
+            )
+        }
+    },
+    PAYMENT("payment") {
+        override fun intentConfigurationMode(
+            playgroundState: PlaygroundState
+        ): PaymentSheet.IntentConfiguration.Mode {
+            return PaymentSheet.IntentConfiguration.Mode.Payment(
+                amount = playgroundState.amount,
+                currency = playgroundState.currencyCode.value,
+            )
+        }
+    },
+    PAYMENT_WITH_SETUP("payment_with_setup") {
+        override fun intentConfigurationMode(
+            playgroundState: PlaygroundState
+        ): PaymentSheet.IntentConfiguration.Mode {
+            return PaymentSheet.IntentConfiguration.Mode.Payment(
+                amount = playgroundState.amount,
+                currency = playgroundState.currencyCode.value,
+                setupFutureUse = PaymentSheet.IntentConfiguration.SetupFutureUse.OffSession,
+            )
+        }
+    };
+
+    abstract fun intentConfigurationMode(
+        playgroundState: PlaygroundState
+    ): PaymentSheet.IntentConfiguration.Mode
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CollectAddressSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CollectAddressSettingsDefinition.kt
@@ -4,22 +4,27 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode as CollectionMode
 
-internal object CollectAddressSettingsDefinition : PlaygroundSettingDefinition<CollectionMode>(
-    key = "collectAddress",
-    displayName = "Collect Address",
-) {
+internal object CollectAddressSettingsDefinition :
+    PlaygroundSettingDefinition<CollectionMode>,
+    PlaygroundSettingDefinition.Saveable<CollectionMode>,
+    PlaygroundSettingDefinition.Displayable<CollectionMode> {
+
     override val defaultValue: CollectionMode = CollectionMode.Automatic
-    override val options: List<Option<CollectionMode>> = listOf(
-        Option("Auto", CollectionMode.Automatic),
-        Option("Never", CollectionMode.Never),
-        Option("Full", CollectionMode.Full),
-    )
+    override val key: String = "collectAddress"
+    override val displayName: String = "Collect Address"
+    override val options: List<PlaygroundSettingDefinition.Displayable.Option<CollectionMode>> by lazy {
+        listOf(
+            option("Auto", CollectionMode.Automatic),
+            option("Never", CollectionMode.Never),
+            option("Full", CollectionMode.Full),
+        )
+    }
 
     override fun configure(
-        value: PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode,
+        value: CollectionMode,
         configurationBuilder: PaymentSheet.Configuration.Builder,
         playgroundState: PlaygroundState,
-        configurationData: PaymentSheetConfigurationData,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData,
     ) {
         configurationData.updateBillingDetails { copy(address = value) }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CollectEmailSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CollectEmailSettingsDefinition.kt
@@ -4,36 +4,16 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 
-internal object CollectEmailSettingsDefinition : PlaygroundSettingDefinition<CollectionMode>(
+internal object CollectEmailSettingsDefinition : CollectionModeSettingsDefinition(
     key = "collectEmail",
     displayName = "Collect Email",
 ) {
-    override val defaultValue: CollectionMode = CollectionMode.Automatic
-    override val options: List<Option<CollectionMode>> = listOf(
-        Option("Auto", CollectionMode.Automatic),
-        Option("Never", CollectionMode.Never),
-        Option("Always", CollectionMode.Always),
-    )
-
     override fun configure(
         value: CollectionMode,
         configurationBuilder: PaymentSheet.Configuration.Builder,
         playgroundState: PlaygroundState,
-        configurationData: PaymentSheetConfigurationData,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData,
     ) {
         configurationData.updateBillingDetails { copy(email = value) }
-    }
-
-    override fun convertToString(value: CollectionMode): String = when (value) {
-        CollectionMode.Automatic -> "auto"
-        CollectionMode.Never -> "never"
-        CollectionMode.Always -> "always"
-    }
-
-    override fun convertToValue(value: String): CollectionMode = when (value) {
-        "auto" -> CollectionMode.Automatic
-        "never" -> CollectionMode.Never
-        "always" -> CollectionMode.Always
-        else -> CollectionMode.Automatic
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CollectNameSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CollectNameSettingsDefinition.kt
@@ -4,36 +4,16 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 
-internal object CollectNameSettingsDefinition : PlaygroundSettingDefinition<CollectionMode>(
+internal object CollectNameSettingsDefinition : CollectionModeSettingsDefinition(
     key = "collectName",
     displayName = "Collect Name",
 ) {
-    override val defaultValue: CollectionMode = CollectionMode.Automatic
-    override val options: List<Option<CollectionMode>> = listOf(
-        Option("Auto", CollectionMode.Automatic),
-        Option("Never", CollectionMode.Never),
-        Option("Always", CollectionMode.Always),
-    )
-
     override fun configure(
         value: CollectionMode,
         configurationBuilder: PaymentSheet.Configuration.Builder,
         playgroundState: PlaygroundState,
-        configurationData: PaymentSheetConfigurationData,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData,
     ) {
         configurationData.updateBillingDetails { copy(name = value) }
-    }
-
-    override fun convertToString(value: CollectionMode): String = when (value) {
-        CollectionMode.Automatic -> "auto"
-        CollectionMode.Never -> "never"
-        CollectionMode.Always -> "always"
-    }
-
-    override fun convertToValue(value: String): CollectionMode = when (value) {
-        "auto" -> CollectionMode.Automatic
-        "never" -> CollectionMode.Never
-        "always" -> CollectionMode.Always
-        else -> CollectionMode.Automatic
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CollectPhoneSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CollectPhoneSettingsDefinition.kt
@@ -4,36 +4,16 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 
-internal object CollectPhoneSettingsDefinition : PlaygroundSettingDefinition<CollectionMode>(
+internal object CollectPhoneSettingsDefinition : CollectionModeSettingsDefinition(
     key = "collectPhone",
     displayName = "Collect Phone",
 ) {
-    override val defaultValue: CollectionMode = CollectionMode.Automatic
-    override val options: List<Option<CollectionMode>> = listOf(
-        Option("Auto", CollectionMode.Automatic),
-        Option("Never", CollectionMode.Never),
-        Option("Always", CollectionMode.Always),
-    )
-
     override fun configure(
         value: CollectionMode,
         configurationBuilder: PaymentSheet.Configuration.Builder,
         playgroundState: PlaygroundState,
-        configurationData: PaymentSheetConfigurationData,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData,
     ) {
         configurationData.updateBillingDetails { copy(phone = value) }
-    }
-
-    override fun convertToString(value: CollectionMode): String = when (value) {
-        CollectionMode.Automatic -> "auto"
-        CollectionMode.Never -> "never"
-        CollectionMode.Always -> "always"
-    }
-
-    override fun convertToValue(value: String): CollectionMode = when (value) {
-        "auto" -> CollectionMode.Automatic
-        "never" -> CollectionMode.Never
-        "always" -> CollectionMode.Always
-        else -> CollectionMode.Automatic
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CollectionModeSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CollectionModeSettingsDefinition.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
+
+internal open class CollectionModeSettingsDefinition(
+    override val key: String,
+    override val displayName: String
+) : PlaygroundSettingDefinition.Saveable<CollectionMode>,
+    PlaygroundSettingDefinition.Displayable<CollectionMode> {
+
+    override val defaultValue: CollectionMode = CollectionMode.Automatic
+    override val options: List<PlaygroundSettingDefinition.Displayable.Option<CollectionMode>> by lazy {
+        listOf(
+            option("Auto", CollectionMode.Automatic),
+            option("Never", CollectionMode.Never),
+            option("Always", CollectionMode.Always),
+        )
+    }
+
+    override fun convertToString(value: CollectionMode): String = when (value) {
+        CollectionMode.Automatic -> "auto"
+        CollectionMode.Never -> "never"
+        CollectionMode.Always -> "always"
+    }
+
+    override fun convertToValue(value: String): CollectionMode = when (value) {
+        "auto" -> CollectionMode.Automatic
+        "never" -> CollectionMode.Never
+        "always" -> CollectionMode.Always
+        else -> CollectionMode.Automatic
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CountrySettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CountrySettingsDefinition.kt
@@ -5,27 +5,22 @@ import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 import java.util.Locale
 
 internal object CountrySettingsDefinition :
-    PlaygroundSettingDefinition<CountrySettingsDefinition.Country>(
+    PlaygroundSettingDefinition<Country>,
+    PlaygroundSettingDefinition.Saveable<Country> by EnumSaveable(
         key = "country",
-        displayName = "Merchant",
-    ) {
+        values = Country.values(),
+        defaultValue = Country.US,
+    ),
+    PlaygroundSettingDefinition.Displayable<Country> {
     private val supportedCountries = Country.values().map { it.value }.toSet()
 
-    override val defaultValue: Country = Country.US
-    override val options: List<Option<Country>> =
+    override val displayName: String = "Merchant"
+    override val options: List<PlaygroundSettingDefinition.Displayable.Option<Country>> =
         CountryUtils.getOrderedCountries(Locale.getDefault()).filter { country ->
             country.code.value in supportedCountries
         }.map { country ->
-            Option(country.name, convertToValue(country.code.value))
+            option(country.name, convertToValue(country.code.value))
         }.toList()
-
-    override fun convertToValue(value: String): Country {
-        return Country.values().firstOrNull { it.value == value } ?: defaultValue
-    }
-
-    override fun convertToString(value: Country): String {
-        return value.value
-    }
 
     override fun configure(value: Country, checkoutRequestBuilder: CheckoutRequest.Builder) {
         checkoutRequestBuilder.merchantCountryCode(value.value)
@@ -35,31 +30,31 @@ internal object CountrySettingsDefinition :
         // When the country changes via the UI, update the currency to be the default currency for
         // that country.
         when (value) {
-            Country.GB -> CurrencySettingsDefinition.Currency.GBP
-            Country.FR -> CurrencySettingsDefinition.Currency.EUR
-            Country.AU -> CurrencySettingsDefinition.Currency.AUD
-            Country.US -> CurrencySettingsDefinition.Currency.USD
-            Country.IN -> CurrencySettingsDefinition.Currency.INR
-            Country.SG -> CurrencySettingsDefinition.Currency.SGD
-            Country.MY -> CurrencySettingsDefinition.Currency.MYR
-            Country.MX -> CurrencySettingsDefinition.Currency.MXN
-            Country.BR -> CurrencySettingsDefinition.Currency.BRL
-            Country.JP -> CurrencySettingsDefinition.Currency.JPY
+            Country.GB -> Currency.GBP
+            Country.FR -> Currency.EUR
+            Country.AU -> Currency.AUD
+            Country.US -> Currency.USD
+            Country.IN -> Currency.INR
+            Country.SG -> Currency.SGD
+            Country.MY -> Currency.MYR
+            Country.MX -> Currency.MXN
+            Country.BR -> Currency.BRL
+            Country.JP -> Currency.JPY
         }.let { currency ->
             playgroundSettings[CurrencySettingsDefinition] = currency
         }
     }
+}
 
-    enum class Country(val value: String) {
-        US("US"),
-        GB("GB"),
-        AU("AU"),
-        FR("FR"),
-        IN("IN"),
-        SG("SG"),
-        MY("MY"),
-        MX("MX"),
-        BR("BR"),
-        JP("JP"),
-    }
+enum class Country(override val value: String) : ValueEnum {
+    US("US"),
+    GB("GB"),
+    AU("AU"),
+    FR("FR"),
+    IN("IN"),
+    SG("SG"),
+    MY("MY"),
+    MX("MX"),
+    BR("BR"),
+    JP("JP"),
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CurrencySettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CurrencySettingsDefinition.kt
@@ -2,40 +2,37 @@ package com.stripe.android.paymentsheet.example.playground.settings
 
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 
-internal object CurrencySettingsDefinition : PlaygroundSettingDefinition<CurrencySettingsDefinition.Currency>(
-    key = "currency",
-    displayName = "Currency",
-) {
-    override val defaultValue: Currency = Currency.USD
+internal object CurrencySettingsDefinition :
+    PlaygroundSettingDefinition<Currency>,
+    PlaygroundSettingDefinition.Saveable<Currency> by EnumSaveable(
+        key = "currency",
+        values = Currency.values(),
+        defaultValue = Currency.USD,
+    ),
+    PlaygroundSettingDefinition.Displayable<Currency> {
+    override val displayName: String = "Currency"
 
-    override val options: List<Option<Currency>> = Currency.values().map {
-        Option(it.displayName, it)
-    }
-
-    override fun convertToValue(value: String): Currency {
-        return Currency.values().firstOrNull { it.value == value } ?: defaultValue
-    }
-
-    override fun convertToString(value: Currency): String {
-        return value.value
-    }
+    override val options: List<PlaygroundSettingDefinition.Displayable.Option<Currency>> =
+        Currency.values().map {
+            option(it.displayName, it)
+        }
 
     override fun configure(value: Currency, checkoutRequestBuilder: CheckoutRequest.Builder) {
         checkoutRequestBuilder.currency(value.value)
     }
+}
 
-    enum class Currency(val displayName: String, val value: String) {
-        AUD("AUD", "aud"),
-        EUR("EUR", "eur"),
-        GBP("GBP", "gbp"),
-        USD("USD", "usd"),
-        INR("INR", "inr"),
-        PLN("PLN", "pln"),
-        SGD("SGD", "sgd"),
-        MYR("MYR", "myr"),
-        MXN("MXN", "mxn"),
-        BRL("BRL", "brl"),
-        JPY("JPY", "jpy"),
-        SEK("SEK", "sek"),
-    }
+enum class Currency(val displayName: String, override val value: String) : ValueEnum {
+    AUD("AUD", "aud"),
+    EUR("EUR", "eur"),
+    GBP("GBP", "gbp"),
+    USD("USD", "usd"),
+    INR("INR", "inr"),
+    PLN("PLN", "pln"),
+    SGD("SGD", "sgd"),
+    MYR("MYR", "myr"),
+    MXN("MXN", "mxn"),
+    BRL("BRL", "brl"),
+    JPY("JPY", "jpy"),
+    SEK("SEK", "sek"),
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSettingsDefinition.kt
@@ -5,24 +5,20 @@ import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 
 internal object CustomerSettingsDefinition :
-    PlaygroundSettingDefinition<CustomerSettingsDefinition.CustomerType>(
+    PlaygroundSettingDefinition<CustomerType>,
+    PlaygroundSettingDefinition.Saveable<CustomerType> by EnumSaveable(
         key = "customer",
-        displayName = "Customer",
-    ) {
-    override val defaultValue: CustomerType = CustomerType.GUEST
-    override val options: List<Option<CustomerType>> = listOf(
-        Option("Guest", CustomerType.GUEST),
-        Option("New", CustomerType.NEW),
-        Option("Returning", CustomerType.RETURNING),
-    )
-
-    override fun convertToValue(value: String): CustomerType {
-        return CustomerType.values().firstOrNull { it.value == value } ?: defaultValue
-    }
-
-    override fun convertToString(value: CustomerType): String {
-        return value.value
-    }
+        values = CustomerType.values(),
+        defaultValue = CustomerType.GUEST,
+    ),
+    PlaygroundSettingDefinition.Displayable<CustomerType> {
+    override val displayName: String = "Customer"
+    override val options: List<PlaygroundSettingDefinition.Displayable.Option<CustomerType>> =
+        listOf(
+            option("Guest", CustomerType.GUEST),
+            option("New", CustomerType.NEW),
+            option("Returning", CustomerType.RETURNING),
+        )
 
     override fun configure(
         value: CustomerType,
@@ -35,15 +31,15 @@ internal object CustomerSettingsDefinition :
         value: CustomerType,
         configurationBuilder: PaymentSheet.Configuration.Builder,
         playgroundState: PlaygroundState,
-        configurationData: PaymentSheetConfigurationData,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData,
     ) {
         configurationBuilder.customer(playgroundState.customerConfig)
     }
+}
 
-    enum class CustomerType(val value: String) {
-        GUEST("guest"),
-        NEW("new"),
-        RETURNING("returning"),
-        SNAPSHOT("snapshot"),
-    }
+enum class CustomerType(override val value: String) : ValueEnum {
+    GUEST("guest"),
+    NEW("new"),
+    RETURNING("returning"),
+    SNAPSHOT("snapshot"),
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/DefaultBillingAddressSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/DefaultBillingAddressSettingsDefinition.kt
@@ -12,7 +12,7 @@ internal object DefaultBillingAddressSettingsDefinition : BooleanSettingsDefinit
         value: Boolean,
         configurationBuilder: PaymentSheet.Configuration.Builder,
         playgroundState: PlaygroundState,
-        configurationData: PaymentSheetConfigurationData,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData,
     ) {
         if (value) {
             configurationBuilder.defaultBillingDetails(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/DelayedPaymentMethodsSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/DelayedPaymentMethodsSettingsDefinition.kt
@@ -12,7 +12,7 @@ internal object DelayedPaymentMethodsSettingsDefinition : BooleanSettingsDefinit
         value: Boolean,
         configurationBuilder: PaymentSheet.Configuration.Builder,
         playgroundState: PlaygroundState,
-        configurationData: PaymentSheetConfigurationData
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData
     ) {
         configurationBuilder.allowsDelayedPaymentMethods(value)
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/EnumSaveable.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/EnumSaveable.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+internal class EnumSaveable<T : ValueEnum>(
+    override val key: String,
+    override val defaultValue: T,
+    private val values: Array<T>,
+) : PlaygroundSettingDefinition.Saveable<T> {
+    override fun convertToValue(value: String): T {
+        return values.firstOrNull { it.value == value } ?: defaultValue
+    }
+
+    override fun convertToString(value: T): String {
+        return value.value
+    }
+}
+
+internal interface ValueEnum {
+    val value: String
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/GooglePaySettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/GooglePaySettingsDefinition.kt
@@ -12,7 +12,7 @@ internal object GooglePaySettingsDefinition : BooleanSettingsDefinition(
         value: Boolean,
         configurationBuilder: PaymentSheet.Configuration.Builder,
         playgroundState: PlaygroundState,
-        configurationData: PaymentSheetConfigurationData,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData,
     ) {
         PaymentSheet.GooglePayConfiguration(
             environment = PaymentSheet.GooglePayConfiguration.Environment.Test,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/InitializationTypeSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/InitializationTypeSettingsDefinition.kt
@@ -3,26 +3,22 @@ package com.stripe.android.paymentsheet.example.playground.settings
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 
 internal object InitializationTypeSettingsDefinition :
-    PlaygroundSettingDefinition<InitializationTypeSettingsDefinition.InitializationType>(
+    PlaygroundSettingDefinition<InitializationType>,
+    PlaygroundSettingDefinition.Saveable<InitializationType> by EnumSaveable(
         key = "initialization",
-        displayName = "Initialization",
-    ) {
-    override val defaultValue: InitializationType = InitializationType.Normal
-    override val options: List<Option<InitializationType>> = listOf(
-        Option("Normal", InitializationType.Normal),
-        Option("Deferred CSC", InitializationType.DeferredClientSideConfirmation),
-        Option("Deferred SSC", InitializationType.DeferredServerSideConfirmation),
-        Option("Deferred SSC + MC", InitializationType.DeferredManualConfirmation),
-        Option("Deferred SSC + MP", InitializationType.DeferredMultiprocessor),
-    )
-
-    override fun convertToValue(value: String): InitializationType {
-        return InitializationType.values().firstOrNull { it.value == value } ?: defaultValue
-    }
-
-    override fun convertToString(value: InitializationType): String {
-        return value.value
-    }
+        values = InitializationType.values(),
+        defaultValue = InitializationType.Normal,
+    ),
+    PlaygroundSettingDefinition.Displayable<InitializationType> {
+    override val displayName: String = "Initialization"
+    override val options: List<PlaygroundSettingDefinition.Displayable.Option<InitializationType>> =
+        listOf(
+            option("Normal", InitializationType.Normal),
+            option("Deferred CSC", InitializationType.DeferredClientSideConfirmation),
+            option("Deferred SSC", InitializationType.DeferredServerSideConfirmation),
+            option("Deferred SSC + MC", InitializationType.DeferredManualConfirmation),
+            option("Deferred SSC + MP", InitializationType.DeferredMultiprocessor),
+        )
 
     override fun configure(
         value: InitializationType,
@@ -30,12 +26,12 @@ internal object InitializationTypeSettingsDefinition :
     ) {
         checkoutRequestBuilder.initialization(value.value)
     }
+}
 
-    enum class InitializationType(val value: String) {
-        Normal("Normal"),
-        DeferredClientSideConfirmation("Deferred CSC"),
-        DeferredServerSideConfirmation("Deferred SSC"),
-        DeferredManualConfirmation("Deferred SSC + MC"),
-        DeferredMultiprocessor("Deferred SSC + MP"),
-    }
+enum class InitializationType(override val value: String) : ValueEnum {
+    Normal("Normal"),
+    DeferredClientSideConfirmation("Deferred CSC"),
+    DeferredServerSideConfirmation("Deferred SSC"),
+    DeferredManualConfirmation("Deferred SSC + MC"),
+    DeferredMultiprocessor("Deferred SSC + MP"),
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/IntegrationTypeSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/IntegrationTypeSettingsDefinition.kt
@@ -1,25 +1,21 @@
 package com.stripe.android.paymentsheet.example.playground.settings
 
 internal object IntegrationTypeSettingsDefinition :
-    PlaygroundSettingDefinition<IntegrationTypeSettingsDefinition.IntegrationType>(
+    PlaygroundSettingDefinition<IntegrationType>,
+    PlaygroundSettingDefinition.Saveable<IntegrationType> by EnumSaveable(
         key = "integrationType",
-        displayName = "Integration Type",
-    ) {
-    override val defaultValue: IntegrationType = IntegrationType.PaymentSheet
-    override val options: List<Option<IntegrationType>> = listOf(
-        Option("Payment Sheet", IntegrationType.PaymentSheet),
-        Option("Flow Controller", IntegrationType.FlowController)
-    )
+        values = IntegrationType.values(),
+        defaultValue = IntegrationType.PaymentSheet,
+    ),
+    PlaygroundSettingDefinition.Displayable<IntegrationType> {
+    override val displayName: String = "Integration Type"
+    override val options: List<PlaygroundSettingDefinition.Displayable.Option<IntegrationType>> =
+        listOf(
+            option("Payment Sheet", IntegrationType.PaymentSheet),
+            option("Flow Controller", IntegrationType.FlowController)
+        )
+}
 
-    override fun convertToValue(value: String): IntegrationType {
-        return IntegrationType.values().firstOrNull { it.value == value } ?: defaultValue
-    }
-
-    override fun convertToString(value: IntegrationType): String {
-        return value.value
-    }
-
-    enum class IntegrationType(val value: String) {
-        PaymentSheet("paymentSheet"), FlowController("flowController")
-    }
+enum class IntegrationType(override val value: String) : ValueEnum {
+    PaymentSheet("paymentSheet"), FlowController("flowController")
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettingDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettingDefinition.kt
@@ -4,21 +4,8 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 
-internal abstract class PlaygroundSettingDefinition<T>(
-    val key: String,
-    val displayName: String,
-) {
-    abstract val defaultValue: T
-
-    abstract val options: List<Option<T>>
-
-    abstract fun convertToString(value: T): String
-
-    abstract fun convertToValue(value: String): T
-
-    open val saveToSharedPreferences: Boolean = true
-
-    open fun configure(
+internal interface PlaygroundSettingDefinition<T> {
+    fun configure(
         value: T,
         configurationBuilder: PaymentSheet.Configuration.Builder,
         playgroundState: PlaygroundState,
@@ -26,15 +13,22 @@ internal abstract class PlaygroundSettingDefinition<T>(
     ) {
     }
 
-    open fun configure(
+    fun configure(
         value: T,
         checkoutRequestBuilder: CheckoutRequest.Builder,
     ) {
     }
 
-    open fun valueUpdated(value: T, playgroundSettings: PlaygroundSettings) {}
+    fun valueUpdated(value: T, playgroundSettings: PlaygroundSettings) {}
 
-    data class Option<T>(val name: String, val value: T)
+    fun saveable(): Saveable<T>? {
+        @Suppress("UNCHECKED_CAST")
+        return this as? Saveable<T>?
+    }
+
+    fun displayable(): Displayable<T>? {
+        return this as? Displayable<T>?
+    }
 
     data class PaymentSheetConfigurationData(
         private val configurationBuilder: PaymentSheet.Configuration.Builder,
@@ -54,5 +48,25 @@ internal abstract class PlaygroundSettingDefinition<T>(
                 billingDetailsCollectionConfiguration
             )
         }
+    }
+
+    interface Saveable<T> {
+        val key: String
+        val defaultValue: T
+        fun convertToString(value: T): String
+        fun convertToValue(value: String): T
+        val saveToSharedPreferences: Boolean
+            get() = true
+    }
+
+    interface Displayable<T> : PlaygroundSettingDefinition<T> {
+        val displayName: String
+        val options: List<Option<T>>
+
+        fun option(name: String, value: T): Option<T> {
+            return Option(name, value)
+        }
+
+        data class Option<T>(val name: String, val value: T)
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -98,8 +98,8 @@ internal class PlaygroundSettings private constructor(
             configure(value as T, checkoutRequestBuilder)
         }
 
-        fun asJsonString(): String {
-            val settingsMap = settings.map {
+        private fun asJsonString(filter: (PlaygroundSettingDefinition<*>) -> Boolean): String {
+            val settingsMap = settings.filterKeys(filter).map {
                 val saveable = it.key.saveable()
                 if (saveable != null) {
                     saveable.key to JsonPrimitive(saveable.convertToString(it.value))
@@ -119,9 +119,13 @@ internal class PlaygroundSettings private constructor(
             sharedPreferences.edit {
                 putString(
                     sharedPreferencesKey,
-                    asJsonString()
+                    asJsonString(filter = { it.saveable()?.saveToSharedPreferences == true })
                 )
             }
+        }
+
+        fun asJsonString(): String {
+            return asJsonString { true }
         }
 
         private fun <T> PlaygroundSettingDefinition.Saveable<T>.convertToString(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PrimaryButtonLabelSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PrimaryButtonLabelSettingsDefinition.kt
@@ -3,12 +3,14 @@ package com.stripe.android.paymentsheet.example.playground.settings
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 
-internal object PrimaryButtonLabelSettingsDefinition : PlaygroundSettingDefinition<String>(
-    key = "customPrimaryButtonLabel",
-    displayName = "Custom primary button label",
-) {
+internal object PrimaryButtonLabelSettingsDefinition :
+    PlaygroundSettingDefinition<String>,
+    PlaygroundSettingDefinition.Saveable<String>,
+    PlaygroundSettingDefinition.Displayable<String> {
+    override val key: String = "customPrimaryButtonLabel"
+    override val displayName: String = "Custom primary button label"
     override val defaultValue: String = ""
-    override val options: List<Option<String>> = emptyList()
+    override val options: List<PlaygroundSettingDefinition.Displayable.Option<String>> = emptyList()
 
     override fun convertToString(value: String): String = value
     override fun convertToValue(value: String): String = value
@@ -17,7 +19,7 @@ internal object PrimaryButtonLabelSettingsDefinition : PlaygroundSettingDefiniti
         value: String,
         configurationBuilder: PaymentSheet.Configuration.Builder,
         playgroundState: PlaygroundState,
-        configurationData: PaymentSheetConfigurationData
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData
     ) {
         if (value.isNotEmpty()) {
             configurationBuilder.primaryButtonLabel(value)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
@@ -37,7 +37,7 @@ internal fun SettingsUi(playgroundSettings: PlaygroundSettings) {
 
 @Composable
 private fun <T> Setting(
-    settingDefinition: PlaygroundSettingDefinition<T>,
+    settingDefinition: PlaygroundSettingDefinition.Displayable<T>,
     playgroundSettings: PlaygroundSettings,
 ) {
     Setting(
@@ -52,7 +52,7 @@ private fun <T> Setting(
 @Composable
 private fun <T> Setting(
     name: String,
-    options: List<PlaygroundSettingDefinition.Option<T>>,
+    options: List<PlaygroundSettingDefinition.Displayable.Option<T>>,
     valueFlow: StateFlow<T>,
     onOptionChanged: (T) -> Unit,
 ) {
@@ -101,7 +101,7 @@ private fun TextSetting(
 @Composable
 private fun <T> RadioButtonSetting(
     name: String,
-    options: List<PlaygroundSettingDefinition.Option<T>>,
+    options: List<PlaygroundSettingDefinition.Displayable.Option<T>>,
     value: T,
     onOptionChanged: (T) -> Unit,
 ) {
@@ -145,7 +145,7 @@ private fun <T> RadioButtonSetting(
 @Composable
 private fun <T> DropdownSetting(
     name: String,
-    options: List<PlaygroundSettingDefinition.Option<T>>,
+    options: List<PlaygroundSettingDefinition.Displayable.Option<T>>,
     value: T,
     onOptionChanged: (T) -> Unit,
 ) {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/ShippingAddressSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/ShippingAddressSettingsDefinition.kt
@@ -4,26 +4,12 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 
-internal object ShippingAddressSettingsDefinition : PlaygroundSettingDefinition<AddressDetails?>(
-    key = "shippingAddress",
-    displayName = "" // Not displayed.
-) {
-    override val defaultValue: AddressDetails? = null
-    override val options: List<Option<AddressDetails?>> = emptyList()
-
-    override fun convertToValue(value: String): AddressDetails? {
-        return null
-    }
-
-    override fun convertToString(value: AddressDetails?): String {
-        return ""
-    }
-
+internal object ShippingAddressSettingsDefinition : PlaygroundSettingDefinition<AddressDetails?> {
     override fun configure(
         value: AddressDetails?,
         configurationBuilder: PaymentSheet.Configuration.Builder,
         playgroundState: PlaygroundState,
-        configurationData: PaymentSheetConfigurationData
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData
     ) {
         configurationBuilder.shippingDetails(value)
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SupportedPaymentMethodsSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SupportedPaymentMethodsSettingsDefinition.kt
@@ -3,27 +3,10 @@ package com.stripe.android.paymentsheet.example.playground.settings
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 
 internal object SupportedPaymentMethodsSettingsDefinition :
-    PlaygroundSettingDefinition<List<String>?>(
-        key = "supportedPaymentMethods",
-        displayName = "", // This is not a UI setting, only used for tests.
-    ) {
-    override val defaultValue: List<String>? = null
-
-    override val options: List<Option<List<String>?>> = emptyList()
-
-    override val saveToSharedPreferences: Boolean = false
-
+    PlaygroundSettingDefinition<List<String>?> {
     override fun configure(value: List<String>?, checkoutRequestBuilder: CheckoutRequest.Builder) {
         if (!value.isNullOrEmpty()) {
             checkoutRequestBuilder.supportedPaymentMethods(value)
         }
-    }
-
-    override fun convertToValue(value: String): List<String> {
-        return value.split(",").filter { it.isNotEmpty() }
-    }
-
-    override fun convertToString(value: List<String>?): String {
-        return value.orEmpty().joinToString(separator = ",")
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SupportedPaymentMethodsSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SupportedPaymentMethodsSettingsDefinition.kt
@@ -3,10 +3,23 @@ package com.stripe.android.paymentsheet.example.playground.settings
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 
 internal object SupportedPaymentMethodsSettingsDefinition :
-    PlaygroundSettingDefinition<List<String>?> {
+    PlaygroundSettingDefinition<List<String>?>,
+    PlaygroundSettingDefinition.Saveable<List<String>?> {
     override fun configure(value: List<String>?, checkoutRequestBuilder: CheckoutRequest.Builder) {
         if (!value.isNullOrEmpty()) {
             checkoutRequestBuilder.supportedPaymentMethods(value)
         }
+    }
+
+    override val key: String = "supportedPaymentMethods"
+    override val defaultValue: List<String> = emptyList()
+    override val saveToSharedPreferences: Boolean = false
+
+    override fun convertToValue(value: String): List<String> {
+        return value.split(",").filter { it.isNotEmpty() }
+    }
+
+    override fun convertToString(value: List<String>?): String {
+        return value.orEmpty().joinToString(separator = ",")
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Previous changes made it clear that not all `PlaygroundSettingDefinition`s would be `Displayable`. And not all of them would be `Saveable` either. I made some tradeoffs to make everything work together, and this makes a different set of more explicit tradeoffs. There's some good and some bad here, but overall I think it's worth it.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Playground rewrite.
