### PR TITLE
Fix flaky `PaymentSheet` test for Card Brand Choice.

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
@@ -31,6 +31,8 @@ internal class PaymentSheetPage(
     }
 
     fun fillOutCardDetailsWithCardBrandChoice(fillOutZipCode: Boolean = true) {
+        composeTestRule.waitForIdle()
+
         waitForText("Card number")
 
         replaceText("Card number", "4000002500001001")


### PR DESCRIPTION
# Summary
Fix flaky `PaymentSheet` test for Card Brand Choice by waiting for the `ComposeTestRule` to be idle.

# Motivation
Fixes flaky `PaymentSheet` test.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified
