### PR TITLE
Add query for CBC eligibility in Card Element

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -20,6 +20,7 @@ import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.ElementsSessionParams
 import com.stripe.android.model.FinancialConnectionsSession
 import com.stripe.android.model.ListPaymentMethodsParams
+import com.stripe.android.model.MobileCardElementConfig
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -34,7 +35,6 @@ import com.stripe.android.model.Stripe3ds2AuthResult
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.Token
 import com.stripe.android.model.TokenParams
-import com.stripe.android.model.MobileCardElementConfig
 import com.stripe.android.networking.StripeRepository
 import java.util.Locale
 
@@ -403,7 +403,9 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         TODO("Not yet implemented")
     }
 
-    override suspend fun retrieveCardElementConfig(requestOptions: ApiRequest.Options): Result<MobileCardElementConfig> {
+    override suspend fun retrieveCardElementConfig(
+        requestOptions: ApiRequest.Options,
+    ): Result<MobileCardElementConfig> {
         TODO("Not yet implemented")
     }
 

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -34,6 +34,7 @@ import com.stripe.android.model.Stripe3ds2AuthResult
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.Token
 import com.stripe.android.model.TokenParams
+import com.stripe.android.model.MobileCardElementConfig
 import com.stripe.android.networking.StripeRepository
 import java.util.Locale
 
@@ -399,6 +400,10 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         cardNumber: String,
         requestOptions: ApiRequest.Options
     ): Result<CardMetadata> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun retrieveCardElementConfig(requestOptions: ApiRequest.Options): Result<MobileCardElementConfig> {
         TODO("Not yet implemented")
     }
 

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -3052,6 +3052,22 @@ public final class com/stripe/android/model/MandateDataParams$Type$Online$Creato
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/model/MobileCardElementConfig$CardBrandChoice$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/MobileCardElementConfig$CardBrandChoice;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/MobileCardElementConfig$CardBrandChoice;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/MobileCardElementConfig$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/MobileCardElementConfig;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/MobileCardElementConfig;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/model/PaymentIntent : com/stripe/android/model/StripeIntent {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;

--- a/payments-core/src/main/java/com/stripe/android/model/MobileCardElementConfig.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/MobileCardElementConfig.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.model
+
+import android.os.Parcelable
+import androidx.annotation.RestrictTo
+import com.stripe.android.core.model.StripeModel
+import kotlinx.parcelize.Parcelize
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Parcelize
+data class MobileCardElementConfig(
+    val cardBrandChoice: CardBrandChoice,
+) : StripeModel {
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @Parcelize
+    data class CardBrandChoice(
+        val eligible: Boolean,
+    ) : Parcelable
+}

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/MobileCardElementConfigParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/MobileCardElementConfigParser.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.model.parsers
+
+import com.stripe.android.core.model.parsers.ModelJsonParser
+import com.stripe.android.model.MobileCardElementConfig
+import org.json.JSONObject
+
+internal class MobileCardElementConfigParser : ModelJsonParser<MobileCardElementConfig> {
+
+    override fun parse(json: JSONObject): MobileCardElementConfig {
+        return MobileCardElementConfig(
+            cardBrandChoice = MobileCardElementConfig.CardBrandChoice(
+                eligible = json.getJSONObject(FIELD_CARD_BRAND_CHOICE).getBoolean(FIELD_ELIGIBLE),
+            )
+        )
+    }
+
+    private companion object {
+        const val FIELD_CARD_BRAND_CHOICE = "card_brand_choice"
+        const val FIELD_ELIGIBLE = "eligible"
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -60,6 +60,7 @@ import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.ElementsSessionParams
 import com.stripe.android.model.FinancialConnectionsSession
 import com.stripe.android.model.ListPaymentMethodsParams
+import com.stripe.android.model.MobileCardElementConfig
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -83,6 +84,7 @@ import com.stripe.android.model.parsers.ElementsSessionJsonParser
 import com.stripe.android.model.parsers.FinancialConnectionsSessionJsonParser
 import com.stripe.android.model.parsers.FpxBankStatusesJsonParser
 import com.stripe.android.model.parsers.IssuingCardPinJsonParser
+import com.stripe.android.model.parsers.MobileCardElementConfigParser
 import com.stripe.android.model.parsers.PaymentIntentJsonParser
 import com.stripe.android.model.parsers.PaymentMethodJsonParser
 import com.stripe.android.model.parsers.PaymentMethodMessageJsonParser
@@ -1382,6 +1384,17 @@ class StripeApiRepository @JvmOverloads internal constructor(
         )
     }
 
+    override suspend fun retrieveCardElementConfig(requestOptions: ApiRequest.Options): Result<MobileCardElementConfig> {
+        return fetchStripeModelResult(
+            apiRequestFactory.createGet(
+                url = mobileCardElementConfigUrl,
+                options = requestOptions,
+                params = null,
+            ),
+            jsonParser = MobileCardElementConfigParser(),
+        )
+    }
+
     private suspend fun retrieveElementsSession(
         params: ElementsSessionParams,
         options: ApiRequest.Options,
@@ -1739,6 +1752,9 @@ class StripeApiRepository @JvmOverloads internal constructor(
             @JvmSynthetic
             get() = getApiUrl("connections/link_account_sessions_for_deferred_payment")
 
+        internal val mobileCardElementConfigUrl: String
+            get() = getMerchantUiUrl("mobile-card-element-config")
+
         /**
          * @return `https://api.stripe.com/v1/consumers/payment_details/:id`
          */
@@ -1949,6 +1965,10 @@ class StripeApiRepository @JvmOverloads internal constructor(
 
         private fun getEdgeUrl(path: String): String {
             return "${ApiRequest.API_HOST}/edge-internal/$path"
+        }
+
+        private fun getMerchantUiUrl(path: String): String {
+            return "https://merchant-ui-api.stripe.com/elements/$path"
         }
 
         private fun createExpandParam(expandFields: List<String>): Map<String, List<String>> {

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1384,7 +1384,9 @@ class StripeApiRepository @JvmOverloads internal constructor(
         )
     }
 
-    override suspend fun retrieveCardElementConfig(requestOptions: ApiRequest.Options): Result<MobileCardElementConfig> {
+    override suspend fun retrieveCardElementConfig(
+        requestOptions: ApiRequest.Options,
+    ): Result<MobileCardElementConfig> {
         return fetchStripeModelResult(
             apiRequestFactory.createGet(
                 url = mobileCardElementConfigUrl,

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -21,6 +21,7 @@ import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.ElementsSessionParams
 import com.stripe.android.model.FinancialConnectionsSession
 import com.stripe.android.model.ListPaymentMethodsParams
+import com.stripe.android.model.MobileCardElementConfig
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -35,7 +36,6 @@ import com.stripe.android.model.Stripe3ds2AuthResult
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.Token
 import com.stripe.android.model.TokenParams
-import com.stripe.android.model.MobileCardElementConfig
 import java.util.Locale
 
 /**

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -35,6 +35,7 @@ import com.stripe.android.model.Stripe3ds2AuthResult
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.Token
 import com.stripe.android.model.TokenParams
+import com.stripe.android.model.MobileCardElementConfig
 import java.util.Locale
 
 /**
@@ -366,6 +367,11 @@ interface StripeRepository {
         cardNumber: String,
         requestOptions: ApiRequest.Options
     ): Result<CardMetadata>
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun retrieveCardElementConfig(
+        requestOptions: ApiRequest.Options,
+    ): Result<MobileCardElementConfig>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun buildPaymentUserAgent(attribution: Set<String> = emptySet()): String

--- a/payments-core/src/main/java/com/stripe/android/view/CardWidgetViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardWidgetViewModel.kt
@@ -63,7 +63,7 @@ internal class CardWidgetViewModel(
             val context = extras.requireApplication()
 
             val stripeRepository = StripeApiRepository(
-                context = extras.requireApplication(),
+                context = context,
                 publishableKeyProvider = { PaymentConfiguration.getInstance(context).publishableKey },
             )
 

--- a/payments-core/src/test/java/com/stripe/android/utils/FakeCardElementConfigRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/utils/FakeCardElementConfigRepository.kt
@@ -11,13 +11,17 @@ class FakeCardElementConfigRepository : AbsFakeStripeRepository() {
     private val channel = Channel<Result<MobileCardElementConfig>>()
 
     fun enqueueEligible() {
-        val config = MobileCardElementConfig(cardBrandChoice = MobileCardElementConfig.CardBrandChoice(eligible = true))
+        val config = MobileCardElementConfig(
+            cardBrandChoice = MobileCardElementConfig.CardBrandChoice(eligible = true),
+        )
         val result = Result.success(config)
         channel.trySend(result)
     }
 
     fun enqueueNotEligible() {
-        val config = MobileCardElementConfig(cardBrandChoice = MobileCardElementConfig.CardBrandChoice(eligible = false))
+        val config = MobileCardElementConfig(
+            cardBrandChoice = MobileCardElementConfig.CardBrandChoice(eligible = false),
+        )
         val result = Result.success(config)
         channel.trySend(result)
     }

--- a/payments-core/src/test/java/com/stripe/android/utils/FakeCardElementConfigRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/utils/FakeCardElementConfigRepository.kt
@@ -1,0 +1,35 @@
+package com.stripe.android.utils
+
+import com.stripe.android.core.exception.APIConnectionException
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.model.MobileCardElementConfig
+import com.stripe.android.testing.AbsFakeStripeRepository
+import kotlinx.coroutines.channels.Channel
+
+class FakeCardElementConfigRepository : AbsFakeStripeRepository() {
+
+    private val channel = Channel<Result<MobileCardElementConfig>>()
+
+    fun enqueueEligible() {
+        val config = MobileCardElementConfig(cardBrandChoice = MobileCardElementConfig.CardBrandChoice(eligible = true))
+        val result = Result.success(config)
+        channel.trySend(result)
+    }
+
+    fun enqueueNotEligible() {
+        val config = MobileCardElementConfig(cardBrandChoice = MobileCardElementConfig.CardBrandChoice(eligible = false))
+        val result = Result.success(config)
+        channel.trySend(result)
+    }
+
+    fun enqueueFailure() {
+        val result = Result.failure<MobileCardElementConfig>(APIConnectionException())
+        channel.trySend(result)
+    }
+
+    override suspend fun retrieveCardElementConfig(
+        requestOptions: ApiRequest.Options,
+    ): Result<MobileCardElementConfig> {
+        return channel.receive()
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
@@ -39,6 +39,7 @@ import com.stripe.android.model.BinRange
 import com.stripe.android.model.CardBrand
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.testharness.ViewTestUtils
+import com.stripe.android.utils.FakeCardElementConfigRepository
 import com.stripe.android.utils.TestUtils.idleLooper
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -1058,10 +1059,13 @@ internal class CardNumberEditTextTest {
         dispatcher: CoroutineDispatcher,
         block: (CardNumberEditText) -> Unit,
     ) {
-        PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
+        PaymentConfiguration.init(context, ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
+
+        val repository = FakeCardElementConfigRepository()
 
         val cardWidgetViewModel = CardWidgetViewModel(
-            cbcEligible = { isCbcEligible },
+            paymentConfigProvider = { PaymentConfiguration.getInstance(context) },
+            stripeRepository = repository,
             dispatcher = dispatcher,
         )
 
@@ -1086,6 +1090,12 @@ internal class CardNumberEditTextTest {
                     paymentAnalyticsRequestFactory = analyticsRequestFactory,
                     viewModelStoreOwner = storeOwner,
                 )
+
+                if (isCbcEligible) {
+                    repository.enqueueEligible()
+                } else {
+                    repository.enqueueNotEligible()
+                }
 
                 activity.findViewById<ViewGroup>(R.id.add_payment_method_card).also {
                     it.removeAllViews()

--- a/payments-core/src/test/java/com/stripe/android/view/CardWidgetViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardWidgetViewModelTest.kt
@@ -27,59 +27,62 @@ class CardWidgetViewModelTest {
     private val testDispatcher = UnconfinedTestDispatcher()
 
     @Test
-    fun `Emits correct CBC eligibility when the feature is enabled and merchant is eligible`() = runTest(testDispatcher) {
-        featureFlagTestRule.setEnabled(true)
+    fun `Emits correct CBC eligibility when the feature is enabled and merchant is eligible`() =
+        runTest(testDispatcher) {
+            featureFlagTestRule.setEnabled(true)
 
-        val stripeRepository = FakeCardElementConfigRepository()
+            val stripeRepository = FakeCardElementConfigRepository()
 
-        val viewModel = CardWidgetViewModel(
-            paymentConfigProvider = { paymentConfig },
-            stripeRepository = stripeRepository,
-            dispatcher = testDispatcher,
-        )
+            val viewModel = CardWidgetViewModel(
+                paymentConfigProvider = { paymentConfig },
+                stripeRepository = stripeRepository,
+                dispatcher = testDispatcher,
+            )
 
-        viewModel.isCbcEligible.test {
-            assertThat(awaitItem()).isFalse()
-            stripeRepository.enqueueEligible()
-            assertThat(awaitItem()).isTrue()
+            viewModel.isCbcEligible.test {
+                assertThat(awaitItem()).isFalse()
+                stripeRepository.enqueueEligible()
+                assertThat(awaitItem()).isTrue()
+            }
         }
-    }
 
     @Test
-    fun `Emits correct CBC eligibility when the feature is disabled even if merchant is eligible`() = runTest(testDispatcher) {
-        val stripeRepository = FakeCardElementConfigRepository()
+    fun `Emits correct CBC eligibility when the feature is disabled even if merchant is eligible`() =
+        runTest(testDispatcher) {
+            val stripeRepository = FakeCardElementConfigRepository()
 
-        val viewModel = CardWidgetViewModel(
-            paymentConfigProvider = { paymentConfig },
-            stripeRepository = stripeRepository,
-            dispatcher = testDispatcher,
-        )
+            val viewModel = CardWidgetViewModel(
+                paymentConfigProvider = { paymentConfig },
+                stripeRepository = stripeRepository,
+                dispatcher = testDispatcher,
+            )
 
-        viewModel.isCbcEligible.test {
-            assertThat(awaitItem()).isFalse()
-            stripeRepository.enqueueEligible()
-            expectNoEvents()
+            viewModel.isCbcEligible.test {
+                assertThat(awaitItem()).isFalse()
+                stripeRepository.enqueueEligible()
+                expectNoEvents()
+            }
         }
-    }
 
     @Test
-    fun `Emits correct CBC eligibility when the feature is enabled and merchant is not eligible`() = runTest(testDispatcher) {
-        featureFlagTestRule.setEnabled(true)
+    fun `Emits correct CBC eligibility when the feature is enabled and merchant is not eligible`() =
+        runTest(testDispatcher) {
+            featureFlagTestRule.setEnabled(true)
 
-        val stripeRepository = FakeCardElementConfigRepository()
+            val stripeRepository = FakeCardElementConfigRepository()
 
-        val viewModel = CardWidgetViewModel(
-            paymentConfigProvider = { paymentConfig },
-            stripeRepository = stripeRepository,
-            dispatcher = testDispatcher,
-        )
+            val viewModel = CardWidgetViewModel(
+                paymentConfigProvider = { paymentConfig },
+                stripeRepository = stripeRepository,
+                dispatcher = testDispatcher,
+            )
 
-        viewModel.isCbcEligible.test {
-            assertThat(awaitItem()).isFalse()
-            stripeRepository.enqueueNotEligible()
-            expectNoEvents()
+            viewModel.isCbcEligible.test {
+                assertThat(awaitItem()).isFalse()
+                stripeRepository.enqueueNotEligible()
+                expectNoEvents()
+            }
         }
-    }
 
     @Test
     fun `Emits correct CBC eligibility when query fails`() = runTest(testDispatcher) {

--- a/payments-core/src/test/java/com/stripe/android/view/CardWidgetViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardWidgetViewModelTest.kt
@@ -2,12 +2,19 @@ package com.stripe.android.view
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.testing.FeatureFlagTestRule
+import com.stripe.android.utils.FakeCardElementConfigRepository
 import com.stripe.android.utils.FeatureFlags
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
+
+private val paymentConfig = PaymentConfiguration(
+    publishableKey = "pk_test_123",
+    stripeAccountId = null,
+)
 
 class CardWidgetViewModelTest {
 
@@ -20,29 +27,76 @@ class CardWidgetViewModelTest {
     private val testDispatcher = UnconfinedTestDispatcher()
 
     @Test
-    fun `Emits correct CBC eligibility when the feature is enabled`() = runTest(testDispatcher) {
+    fun `Emits correct CBC eligibility when the feature is enabled and merchant is eligible`() = runTest(testDispatcher) {
         featureFlagTestRule.setEnabled(true)
 
+        val stripeRepository = FakeCardElementConfigRepository()
+
         val viewModel = CardWidgetViewModel(
-            cbcEligible = { true },
+            paymentConfigProvider = { paymentConfig },
+            stripeRepository = stripeRepository,
             dispatcher = testDispatcher,
         )
 
         viewModel.isCbcEligible.test {
             assertThat(awaitItem()).isFalse()
+            stripeRepository.enqueueEligible()
             assertThat(awaitItem()).isTrue()
         }
     }
 
     @Test
-    fun `Emits correct CBC eligibility when the feature is disabled`() = runTest(testDispatcher) {
+    fun `Emits correct CBC eligibility when the feature is disabled even if merchant is eligible`() = runTest(testDispatcher) {
+        val stripeRepository = FakeCardElementConfigRepository()
+
         val viewModel = CardWidgetViewModel(
-            cbcEligible = { true },
+            paymentConfigProvider = { paymentConfig },
+            stripeRepository = stripeRepository,
             dispatcher = testDispatcher,
         )
 
         viewModel.isCbcEligible.test {
             assertThat(awaitItem()).isFalse()
+            stripeRepository.enqueueEligible()
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `Emits correct CBC eligibility when the feature is enabled and merchant is not eligible`() = runTest(testDispatcher) {
+        featureFlagTestRule.setEnabled(true)
+
+        val stripeRepository = FakeCardElementConfigRepository()
+
+        val viewModel = CardWidgetViewModel(
+            paymentConfigProvider = { paymentConfig },
+            stripeRepository = stripeRepository,
+            dispatcher = testDispatcher,
+        )
+
+        viewModel.isCbcEligible.test {
+            assertThat(awaitItem()).isFalse()
+            stripeRepository.enqueueNotEligible()
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `Emits correct CBC eligibility when query fails`() = runTest(testDispatcher) {
+        featureFlagTestRule.setEnabled(true)
+
+        val stripeRepository = FakeCardElementConfigRepository()
+
+        val viewModel = CardWidgetViewModel(
+            paymentConfigProvider = { paymentConfig },
+            stripeRepository = stripeRepository,
+            dispatcher = testDispatcher,
+        )
+
+        viewModel.isCbcEligible.test {
+            assertThat(awaitItem()).isFalse()
+            stripeRepository.enqueueFailure()
+            expectNoEvents()
         }
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds a query to the new `/elements/mobile-card-element-config` to the `CardWidgetViewModel`.

(cc @davidme-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

CBC in Card Elements.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
