### PR TITLE
Tweak CBC dropdown animation and visibility

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
@@ -8,6 +8,7 @@ import com.stripe.android.Stripe
 import com.stripe.android.model.Address
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.utils.FeatureFlags
 import com.stripe.example.Settings
 import com.stripe.example.databinding.PaymentAuthActivityBinding
 
@@ -26,6 +27,8 @@ class PaymentAuthActivity : StripeIntentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(viewBinding.root)
+
+        FeatureFlags.cardBrandChoice.setEnabled(false)
 
         viewModel.inProgress.observe(this, { enableUi(!it) })
         viewModel.status.observe(this, Observer(viewBinding.status::setText))
@@ -88,6 +91,11 @@ class PaymentAuthActivity : StripeIntentActivity() {
         viewBinding.confirmWith3ds1Button.isEnabled = enable
         viewBinding.confirmWithNewCardButton.isEnabled = enable
         viewBinding.setupButton.isEnabled = enable
+    }
+
+    override fun onDestroy() {
+        FeatureFlags.cardBrandChoice.reset()
+        super.onDestroy()
     }
 
     private companion object {

--- a/payments-core/detekt-baseline.xml
+++ b/payments-core/detekt-baseline.xml
@@ -36,6 +36,7 @@
     <ID>LargeClass:StripeApiRepository.kt$StripeApiRepository : StripeRepository</ID>
     <ID>LargeClass:StripeApiRepositoryTest.kt$StripeApiRepositoryTest</ID>
     <ID>LargeClass:StripeKtxTest.kt$StripeKtxTest</ID>
+    <ID>LongMethod:CardBrandView.kt$@Composable private fun CardBrand( isLoading: Boolean, currentBrand: CardBrand, possibleBrands: List&lt;CardBrand>, shouldShowCvc: Boolean, shouldShowErrorIcon: Boolean, tintColorInt: Int, isCbcEligible: Boolean, modifier: Modifier = Modifier, onBrandSelected: (CardBrand?) -> Unit, )</ID>
     <ID>LongMethod:CardFormView.kt$CardFormView$private fun setupCardWidget()</ID>
     <ID>LongMethod:CardFormViewTest.kt$CardFormViewTest$@Test fun testCardValidCallback()</ID>
     <ID>LongMethod:CardInputWidget.kt$CardInputWidget$private fun initView(attrs: AttributeSet?)</ID>

--- a/payments-core/res/drawable/stripe_ic_arrow_down.xml
+++ b/payments-core/res/drawable/stripe_ic_arrow_down.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="12dp"
+    android:tint="#000000"
+    android:viewportHeight="12"
+    android:viewportWidth="12"
+    android:width="12dp"
+    android:adjustViewBounds="true">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M1,4l5,5 5,-5z" />
+</vector>

--- a/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -4,15 +4,13 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.material.ContentAlpha
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -24,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.themeadapter.material.MdcTheme
@@ -203,7 +202,9 @@ private fun CardBrand(
         }
     }
 
-    val showDropdown = remember(possibleBrands) { isCbcEligible && possibleBrands.size > 1 }
+    val showDropdown = remember(possibleBrands, shouldShowCvc) {
+        isCbcEligible && possibleBrands.size > 1 && !shouldShowCvc
+    }
 
     Box(modifier) {
         Row(
@@ -212,6 +213,11 @@ private fun CardBrand(
                 expanded = true
             },
         ) {
+            val dropdownIconAlpha by animateFloatAsState(
+                targetValue = if (showDropdown) ContentAlpha.medium else 0f,
+                label = "CbcDropdownIconAlpha",
+            )
+
             Image(
                 painter = painterResource(icon),
                 colorFilter = tint?.let { ColorFilter.tint(it) },
@@ -219,14 +225,13 @@ private fun CardBrand(
                 modifier = Modifier.requiredSize(width = 32.dp, height = 21.dp),
             )
 
-            if (showDropdown) {
-                Image(
-                    imageVector = Icons.Default.ArrowDropDown,
-                    contentDescription = null,
-                    alpha = ContentAlpha.disabled,
-                    modifier = Modifier.padding(end = 4.dp),
-                )
-            }
+            Image(
+                painter = painterResource(R.drawable.stripe_ic_arrow_down),
+                contentDescription = null,
+                modifier = Modifier
+                    .requiredSize(8.dp)
+                    .graphicsLayer { alpha = dropdownIconAlpha },
+            )
         }
 
         if (showDropdown) {

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.view
 
-import android.animation.ValueAnimator
 import android.content.Context
 import android.os.Bundle
 import android.os.Parcelable
@@ -9,8 +8,6 @@ import android.text.Layout
 import android.text.TextPaint
 import android.text.TextWatcher
 import android.util.AttributeSet
-import android.util.TypedValue.COMPLEX_UNIT_DIP
-import android.util.TypedValue.applyDimension
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
@@ -45,7 +42,6 @@ import com.stripe.android.model.DelicateCardDetailsApi
 import com.stripe.android.model.ExpirationDate
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
-import kotlin.math.roundToInt
 import kotlin.properties.Delegates
 
 /**
@@ -348,19 +344,6 @@ class CardInputWidget @JvmOverloads constructor(
         }
 
         updatePostalRequired()
-    }
-
-    private var dropdownAnimator: ValueAnimator? = null
-
-    private val cardBrandIconWidth: Float by lazy {
-        resources.getDimension(R.dimen.stripe_card_brand_view_width)
-    }
-
-    private val cardBrandChoiceDropdownWidth: Float by lazy {
-        val displayMetrics = context.resources.displayMetrics
-        val spacing = applyDimension(COMPLEX_UNIT_DIP, CBC_DROPDOWN_SPACING_DP, displayMetrics)
-        val icon = applyDimension(COMPLEX_UNIT_DIP, CBC_DROPDOWN_ICON_WIDTH_DP, displayMetrics)
-        spacing + icon
     }
 
     private fun updatePostalRequired() {
@@ -866,9 +849,6 @@ class CardInputWidget @JvmOverloads constructor(
     }
 
     private fun handlePossibleCardBrandsChanged(brands: List<CardBrand>) {
-        val didShowDropdown = cardBrandView.possibleBrands.size > 1
-        val shouldShowDropdown = brands.size > 1
-
         val currentBrand = cardBrandView.brand
         cardBrandView.possibleBrands = brands
 
@@ -883,35 +863,6 @@ class CardInputWidget @JvmOverloads constructor(
         // brands of a co-branded card have the same CVC length, we can just choose the first one.
         val brandForCvcLength = brands.firstOrNull() ?: CardBrand.Unknown
         updateCvc(brand = brandForCvcLength)
-
-        if (shouldShowDropdown != didShowDropdown) {
-            animateCardBrandChoiceDropdown(isVisible = shouldShowDropdown)
-        }
-    }
-
-    private fun animateCardBrandChoiceDropdown(isVisible: Boolean) {
-        dropdownAnimator?.cancel()
-
-        val desiredWidth = if (isVisible) {
-            cardBrandIconWidth + cardBrandChoiceDropdownWidth
-        } else {
-            cardBrandIconWidth
-        }
-
-        val newAnimator = ValueAnimator.ofFloat(cardBrandView.width.toFloat(), desiredWidth)
-        newAnimator.duration = CBC_DROPDOWN_ICON_ANIMATION_DURATION
-
-        newAnimator.addUpdateListener { currentAnimator ->
-            val animatedWidth = currentAnimator.animatedValue as Float
-            cardBrandView.updateLayoutParams<LayoutParams> {
-                width = animatedWidth.roundToInt()
-            }
-            isViewInitialized = false
-            requestLayout()
-        }
-
-        dropdownAnimator = newAnimator
-        newAnimator.start()
     }
 
     /**
@@ -1113,12 +1064,6 @@ class CardInputWidget @JvmOverloads constructor(
                 newMarginStart = placement.getPostalCodeStartMargin(isShowingFullCard)
             )
         }
-    }
-
-    override fun onDetachedFromWindow() {
-        dropdownAnimator?.cancel()
-        dropdownAnimator = null
-        super.onDetachedFromWindow()
     }
 
     private var hiddenCardText: String = createHiddenCardText(cardNumberEditText.panLength)
@@ -1341,10 +1286,6 @@ class CardInputWidget @JvmOverloads constructor(
         private const val STATE_CARD_VIEWED = "state_card_viewed"
         private const val STATE_SUPER_STATE = "state_super_state"
         private const val STATE_POSTAL_CODE_ENABLED = "state_postal_code_enabled"
-
-        private const val CBC_DROPDOWN_ICON_WIDTH_DP = 16f
-        private const val CBC_DROPDOWN_SPACING_DP = 4f
-        private const val CBC_DROPDOWN_ICON_ANIMATION_DURATION = 200L
 
         // This value is used to ensure that onSaveInstanceState is called
         // in the event that the user doesn't give this control an ID.


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates the Card Element as discussed with Design. We reserve some space for the icon and fade it in/out depending on CBC eligibility and the entered card number.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

CBC in Card Element.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screen recording

https://github.com/stripe/stripe-android/assets/110940675/3d43e3d3-8379-449e-a650-eb5e3746fb7c

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
