### PR TITLE
Remove injector from 3ds2.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry.kt
@@ -10,15 +10,12 @@ import androidx.lifecycle.ViewModel
 import com.stripe.android.PaymentRelayContract
 import com.stripe.android.PaymentRelayStarter
 import com.stripe.android.auth.PaymentBrowserAuthContract
-import com.stripe.android.core.injection.Injectable
-import com.stripe.android.core.injection.Injector
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.model.Source
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.PaymentFlowResult
-import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2TransactionViewModelFactory
 import com.stripe.android.payments.core.injection.AuthenticationComponent
 import com.stripe.android.payments.core.injection.DaggerAuthenticationComponent
 import com.stripe.android.payments.core.injection.IntentAuthenticatorMap
@@ -38,7 +35,7 @@ internal class DefaultPaymentAuthenticatorRegistry @Inject internal constructor(
     private val noOpIntentAuthenticator: NoOpIntentAuthenticator,
     private val sourceAuthenticator: SourceAuthenticator,
     @IntentAuthenticatorMap private val paymentAuthenticators: Map<AuthenticatorKey, Authenticator>
-) : PaymentAuthenticatorRegistry, Injector {
+) : PaymentAuthenticatorRegistry {
 
     private val additionalAuthenticators = mutableMapOf<AuthenticatorKey, Authenticator>()
 
@@ -130,15 +127,6 @@ internal class DefaultPaymentAuthenticatorRegistry @Inject internal constructor(
         paymentBrowserAuthLauncher = null
     }
 
-    override fun inject(injectable: Injectable<*>) {
-        when (injectable) {
-            is Stripe3ds2TransactionViewModelFactory -> authenticationComponent.inject(injectable)
-            else -> {
-                throw IllegalArgumentException("invalid Injectable $injectable requested in $this")
-            }
-        }
-    }
-
     companion object {
         fun createInstance(
             context: Context,
@@ -167,7 +155,6 @@ internal class DefaultPaymentAuthenticatorRegistry @Inject internal constructor(
                 .build()
             val registry = component.registry
             registry.authenticationComponent = component
-            WeakMapInjectorRegistry.register(registry, injectorKey)
             return registry
         }
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
@@ -9,7 +9,6 @@ import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.UIContext
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.core.authentication.DefaultPaymentAuthenticatorRegistry
-import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2TransactionViewModelFactory
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Named
@@ -35,8 +34,6 @@ import kotlin.coroutines.CoroutineContext
 )
 internal interface AuthenticationComponent {
     val registry: DefaultPaymentAuthenticatorRegistry
-
-    fun inject(stripe3ds2TransactionViewModelFactory: Stripe3ds2TransactionViewModelFactory)
 
     @Component.Builder
     interface Builder {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelFactoryComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelFactoryComponent.kt
@@ -5,16 +5,11 @@ import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2TransactionViewModelFactory
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Named
 import javax.inject.Singleton
 
-/**
- * Component to inject [Stripe3ds2TransactionViewModelFactory] when the app process is killed and
- * there is no [Injector] available.
- */
 @Singleton
 @Component(
     modules = [
@@ -25,7 +20,7 @@ import javax.inject.Singleton
     ]
 )
 internal interface Stripe3ds2TransactionViewModelFactoryComponent {
-    fun inject(stripe3ds2TransactionViewModelFactory: Stripe3ds2TransactionViewModelFactory)
+    val subcomponentBuilder: Stripe3ds2TransactionViewModelSubcomponent.Builder
 
     @Component.Builder
     interface Builder {

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelTest.kt
@@ -10,17 +10,13 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ApplicationProvider
-import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentAuthConfig
-import com.stripe.android.core.injection.Injectable
-import com.stripe.android.core.injection.Injector
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
-import com.stripe.android.payments.core.injection.Stripe3ds2TransactionViewModelSubcomponent
 import com.stripe.android.stripe3ds2.init.ui.StripeUiCustomization
 import com.stripe.android.stripe3ds2.service.StripeThreeDs2ServiceImpl
 import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
@@ -31,13 +27,9 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.spy
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertNotNull
 
@@ -91,62 +83,15 @@ class Stripe3ds2TransactionViewModelTest {
         }
 
     @Test
-    fun `Stripe3ds2TransactionViewModel gets initialized by Injector when Injector is available`() {
+    fun `Stripe3ds2TransactionViewModel gets initialized`() {
         scenario.onFragment { fragment ->
-            val viewModel: Stripe3ds2TransactionViewModel = mock()
-            val mockBuilder = mock<Stripe3ds2TransactionViewModelSubcomponent.Builder>()
-            val mockSubcomponent = mock<Stripe3ds2TransactionViewModelSubcomponent>()
-
-            whenever(mockBuilder.build()).thenReturn(mockSubcomponent)
-            whenever(mockBuilder.application(any())).thenReturn(mockBuilder)
-            whenever(mockBuilder.savedStateHandle(any())).thenReturn(mockBuilder)
-            whenever(mockBuilder.args(any())).thenReturn(mockBuilder)
-            whenever(mockSubcomponent.viewModel).thenReturn(viewModel)
-
-            val injector = object : Injector {
-                override fun inject(injectable: Injectable<*>) {
-                    val factory = injectable as Stripe3ds2TransactionViewModelFactory
-                    factory.subComponentBuilder = mockBuilder
-                }
-            }
-            WeakMapInjectorRegistry.register(injector, INJECTOR_KEY)
-
             val factory = Stripe3ds2TransactionViewModelFactory { ARGS }
-            val factorySpy = spy(factory)
-
-            val createdViewModel = factorySpy.create(
-                modelClass = Stripe3ds2TransactionViewModel::class.java,
-                extras = fragment.fakeCreationExtras(),
-            )
-
-            verify(factorySpy, times(0)).fallbackInitialize(any())
-            assertThat(createdViewModel).isEqualTo(viewModel)
-
-            WeakMapInjectorRegistry.clear()
-        }
-    }
-
-    @Test
-    fun `Stripe3ds2TransactionViewModel gets initialized with fallback when no Injector is available`() {
-        scenario.onFragment { fragment ->
-            val application = ApplicationProvider.getApplicationContext<Application>()
-            val factory = Stripe3ds2TransactionViewModelFactory { ARGS }
-            val factorySpy = spy(factory)
 
             assertNotNull(
-                factorySpy.create(
+                factory.create(
                     modelClass = Stripe3ds2TransactionViewModel::class.java,
                     extras = fragment.fakeCreationExtras(),
                 )
-            )
-
-            verify(factorySpy).fallbackInitialize(
-                argWhere {
-                    it.application == application &&
-                        it.enableLogging == ENABLE_LOGGING &&
-                        it.productUsage == PRODUCT_USAGE &&
-                        it.publishableKey == ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
-                }
             )
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Removing because it created 2 code paths without benefit, causing confusion, and uncertainty in process death situations. There weren't any problems with it, but no reason to have it either, removing to reduce complexity.


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
reduce complexity
