### PR TITLE
Fix escaping character issue in Lokalise script

### DIFF
--- a/scripts/lokalise/lokalise_client.rb
+++ b/scripts/lokalise/lokalise_client.rb
@@ -42,7 +42,7 @@ class LokaliseClient
                     "translations": [
                         {
                             "language_iso": "en",
-                            "translation": key_object[:value],
+                            "translation": key_object[:lokalise_value],
                             "is_reviewed": true,
                             "is_unverified": false,
                             "is_archived": false,

--- a/scripts/lokalise/string_resources.rb
+++ b/scripts/lokalise/string_resources.rb
@@ -80,10 +80,7 @@ class StringResources
     end
 
     def escape_for_lokalise(value)
-        value
-            # Wrap any placeholders in square brackets
-            .gsub("%s", "[%s]")
-            # Wrap any numbered placeholders such as ""%1$s" in square brackets
-            .gsub(/[%]*[0-9]*[$][s]/) { |value| "[#{value}]" }
+        # Remove escape characters, as Lokalise doesn't understand them
+        return value.gsub("\\", "")
     end
 end


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue in our Lokalise script where we sent the escaped string instead of the unescaped one. Lokalise seemingly doesn’t handle that.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Noticed the double-escaped characters in the first commit of https://github.com/stripe/stripe-android/pull/7413.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
