### PR TITLE
Remove no-selection option in CBC dropdown

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -252,39 +252,28 @@ private fun CardBrandChoiceDropdown(
     onBrandSelected: (CardBrand?) -> Unit,
     onDismiss: () -> Unit
 ) {
-    val noSelection = CardBrandChoice(
-        label = resolvableString(id = R.string.stripe_card_brand_choice_no_selection),
-        icon = Unknown.icon
-    )
-
-    val allPossibleBrands = listOf(Unknown) + brands
-    val choices = allPossibleBrands.map { brand ->
-        brand.toChoice(noSelection)
-    }
+    val choices = brands.map { it.toChoice() }
 
     SingleChoiceDropdown(
         title = resolvableString(id = R.string.stripe_card_brand_choice_selection_header),
         expanded = expanded,
-        currentChoice = currentBrand.toChoice(noSelection),
+        currentChoice = currentBrand.takeIf { it != Unknown }?.toChoice(),
         choices = choices,
         onChoiceSelected = { choice ->
-            when (val choiceIndex = choices.indexOf(choice)) {
-                -1 -> Unit
-                0 -> onBrandSelected(null)
-                else -> onBrandSelected(allPossibleBrands[choiceIndex])
+            val choiceIndex = choices.indexOf(choice)
+            val brand = brands.getOrNull(choiceIndex)
+
+            if (brand != null) {
+                onBrandSelected(brand)
             }
         },
         onDismiss = onDismiss,
     )
 }
 
-private fun CardBrand.toChoice(noSelection: CardBrandChoice): CardBrandChoice {
-    return if (this == Unknown) {
-        noSelection
-    } else {
-        CardBrandChoice(
-            label = resolvableString(displayName),
-            icon = icon
-        )
-    }
+private fun CardBrand.toChoice(): CardBrandChoice {
+    return CardBrandChoice(
+        label = resolvableString(displayName),
+        icon = icon
+    )
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -168,7 +168,7 @@ internal class DefaultCardNumberController constructor(
                 )
             } else {
                 when (chosen) {
-                    CardBrand.Unknown -> noSelection
+                    CardBrand.Unknown -> null
                     else -> TextFieldIcon.Dropdown.Item(
                         id = chosen.code,
                         label = resolvableString(chosen.displayName),
@@ -187,8 +187,8 @@ internal class DefaultCardNumberController constructor(
 
             TextFieldIcon.Dropdown(
                 title = resolvableString(PaymentsCoreR.string.stripe_card_brand_choice_selection_header),
-                currentItem = selected,
-                items = listOf(noSelection) + items,
+                currentItem = selected ?: noSelection,
+                items = items,
                 hide = brands.size < 2
             )
         } else if (accountRangeService.accountRange != null) {

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
@@ -230,11 +230,6 @@ internal class CardNumberControllerTest {
                     ),
                     items = listOf(
                         TextFieldIcon.Dropdown.Item(
-                            id = CardBrand.Unknown.code,
-                            label = resolvableString(R.string.stripe_card_brand_choice_no_selection),
-                            icon = CardBrand.Unknown.icon
-                        ),
-                        TextFieldIcon.Dropdown.Item(
                             id = CardBrand.CartesBancaires.code,
                             label = resolvableString("Cartes Bancaires"),
                             icon = CardBrand.CartesBancaires.icon
@@ -283,11 +278,6 @@ internal class CardNumberControllerTest {
                         icon = CardBrand.CartesBancaires.icon
                     ),
                     items = listOf(
-                        TextFieldIcon.Dropdown.Item(
-                            id = CardBrand.Unknown.code,
-                            label = resolvableString(R.string.stripe_card_brand_choice_no_selection),
-                            icon = CardBrand.Unknown.icon
-                        ),
                         TextFieldIcon.Dropdown.Item(
                             id = CardBrand.CartesBancaires.code,
                             label = resolvableString("Cartes Bancaires"),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request removes the `No selection` option in the CBC dropdown in both PaymentSheet and Card Element.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
