### PR TITLE
[Identity] Use outlined button instead of text button for secondary button

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/ui/ComposeLoadingButton.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/ComposeLoadingButton.kt
@@ -10,7 +10,6 @@ import androidx.compose.material.Button
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
-import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier

--- a/identity/src/main/java/com/stripe/android/identity/ui/ComposeLoadingButton.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/ComposeLoadingButton.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Button
 import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
@@ -58,7 +59,7 @@ internal fun LoadingTextButton(
     onClick: () -> Unit
 ) {
     Box(modifier = modifier) {
-        TextButton(
+        OutlinedButton(
             onClick = {
                 onClick()
             },


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use outlined button instead

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
better ux

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![before](https://github.com/stripe/stripe-android/assets/79880926/08fb29ef-3e5f-495c-8822-31535b68d54c)  | ![after](https://github.com/stripe/stripe-android/assets/79880926/161a0d59-db24-4d1f-a7ff-528246ae2956) |






# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
