### PR TITLE
[Identity] Remove the boolean params in DocumentUploadDestination

### DIFF
--- a/identity/detekt-baseline.xml
+++ b/identity/detekt-baseline.xml
@@ -7,7 +7,7 @@
     <ID>CyclomaticComplexMethod:IdentityTopLevelDestination.kt$internal fun String.routeToScreenName(): String</ID>
     <ID>CyclomaticComplexMethod:IdentityViewModel.kt$IdentityViewModel$fun updateNewScanType(scanType: IdentityScanState.ScanType)</ID>
     <ID>CyclomaticComplexMethod:OTPScreen.kt$@Composable internal fun OTPScreen( navController: NavController, identityViewModel: IdentityViewModel, otpViewModelFactory: ViewModelProvider.Factory = OTPViewModel.Factory( identityRepository = identityViewModel.identityRepository, verificationArgs = identityViewModel.verificationArgs ) )</ID>
-    <ID>CyclomaticComplexMethod:UploadScreen.kt$@Composable internal fun UploadScreen( navController: NavController, identityViewModel: IdentityViewModel, collectedDataParamType: CollectedDataParam.Type, route: String, @StringRes titleRes: Int, @StringRes contextRes: Int, frontInfo: DocumentUploadSideInfo, backInfo: DocumentUploadSideInfo?, shouldShowTakePhoto: Boolean, shouldShowChoosePhoto: Boolean )</ID>
+    <ID>CyclomaticComplexMethod:UploadScreen.kt$@Composable internal fun UploadScreen( navController: NavController, identityViewModel: IdentityViewModel, collectedDataParamType: CollectedDataParam.Type, route: String, @StringRes titleRes: Int, @StringRes contextRes: Int, frontInfo: DocumentUploadSideInfo, backInfo: DocumentUploadSideInfo? )</ID>
     <ID>LargeClass:IdentityViewModel.kt$IdentityViewModel : AndroidViewModel</ID>
     <ID>LargeClass:IdentityViewModelTest.kt$IdentityViewModelTest</ID>
     <ID>LongMethod:AddressSection.kt$@Composable internal fun AddressSection( enabled: Boolean, identityViewModel: IdentityViewModel, addressCountries: List&lt;Country>, addressNotListedText: String, navController: NavController, onAddressCollected: (Resource&lt;RequiredInternationalAddress>) -> Unit )</ID>
@@ -35,7 +35,7 @@
     <ID>LongMethod:OTPScreen.kt$@Composable private fun OTPViewStateEffect( viewState: OTPViewState?, navController: NavController, identityViewModel: IdentityViewModel, viewModel: OTPViewModel, focusRequester: FocusRequester )</ID>
     <ID>LongMethod:SelfieScreen.kt$@Composable internal fun SelfieScanScreen( navController: NavController, identityViewModel: IdentityViewModel, identityScanViewModel: IdentityScanViewModel, )</ID>
     <ID>LongMethod:SelfieScreen.kt$@Composable private fun ResultView( displayState: IdentityScanState, allowImageCollectionHtml: String, isSubmittingSelfie: Boolean, allowImageCollection: Boolean, navController: NavController, onAllowImageCollectionChanged: (Boolean) -> Unit )</ID>
-    <ID>LongMethod:UploadScreen.kt$@Composable internal fun UploadScreen( navController: NavController, identityViewModel: IdentityViewModel, collectedDataParamType: CollectedDataParam.Type, route: String, @StringRes titleRes: Int, @StringRes contextRes: Int, frontInfo: DocumentUploadSideInfo, backInfo: DocumentUploadSideInfo?, shouldShowTakePhoto: Boolean, shouldShowChoosePhoto: Boolean )</ID>
+    <ID>LongMethod:UploadScreen.kt$@Composable internal fun UploadScreen( navController: NavController, identityViewModel: IdentityViewModel, collectedDataParamType: CollectedDataParam.Type, route: String, @StringRes titleRes: Int, @StringRes contextRes: Int, frontInfo: DocumentUploadSideInfo, backInfo: DocumentUploadSideInfo? )</ID>
     <ID>MagicNumber:DefaultIdentityIO.kt$DefaultIdentityIO$100</ID>
     <ID>MagicNumber:DefaultIdentityIO.kt$DefaultIdentityIO$5</ID>
     <ID>MagicNumber:DobParam.kt$DobParam.Companion$4</ID>
@@ -77,7 +77,6 @@
     <ID>TooManyFunctions:IdentityAnalyticsRequestFactory.kt$IdentityAnalyticsRequestFactory</ID>
     <ID>TooManyFunctions:IdentityRepository.kt$IdentityRepository</ID>
     <ID>TooManyFunctions:IdentityViewModel.kt$IdentityViewModel : AndroidViewModel</ID>
-    <ID>TooManyFunctions:UploadDestinations.kt$DocumentUploadDestination$Companion</ID>
     <ID>TopLevelPropertyNaming:ConfirmationScreen.kt$internal const val confirmationConfirmButtonTag = "ConfirmButton"</ID>
     <ID>TopLevelPropertyNaming:ConfirmationScreen.kt$internal const val confirmationTitleTag = "ConfirmationTitle"</ID>
     <ID>TopLevelPropertyNaming:DocSelectionScreen.kt$internal const val docSelectionTitleTag = "Title"</ID>

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityNavGraph.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityNavGraph.kt
@@ -268,10 +268,7 @@ internal fun IdentityNavGraph(
                                 IdentityAnalyticsRequestFactory.SCREEN_NAME_ERROR
                             )
                             navController.navigateTo(
-                                collectedDataParamType.toUploadDestination(
-                                    shouldShowTakePhoto = false,
-                                    shouldShowChoosePhoto = true
-                                )
+                                collectedDataParamType.toUploadDestination()
                             )
                         }
                     } else {
@@ -312,10 +309,7 @@ internal fun IdentityNavGraph(
                                 IdentityAnalyticsRequestFactory.SCREEN_NAME_ERROR
                             )
                             navController.navigateTo(
-                                scanType.toUploadDestination(
-                                    shouldShowTakePhoto = true,
-                                    shouldShowChoosePhoto = !requireLiveCapture
-                                )
+                                scanType.toUploadDestination()
                             )
                         }
                     },
@@ -444,9 +438,7 @@ private fun DocumentUploadScreenContent(
             )
         } else {
             null
-        },
-        shouldShowTakePhoto = DocumentUploadDestination.shouldShowTakePhoto(backStackEntry),
-        shouldShowChoosePhoto = DocumentUploadDestination.shouldShowChoosePhoto(backStackEntry)
+        }
     )
 }
 

--- a/identity/src/main/java/com/stripe/android/identity/navigation/UploadDestinations.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/UploadDestinations.kt
@@ -9,8 +9,6 @@ import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.states.IdentityScanState
 
 internal abstract class DocumentUploadDestination(
-    shouldShowTakePhoto: Boolean,
-    shouldShowChoosePhoto: Boolean,
     shouldPopUpToDocSelection: Boolean,
     frontScanType: IdentityScanState.ScanType,
     backScanType: IdentityScanState.ScanType,
@@ -33,8 +31,6 @@ internal abstract class DocumentUploadDestination(
 ) {
     override val routeWithArgs by lazy {
         destinationRoute.withParams(
-            ARG_SHOULD_SHOW_TAKE_PHOTO to shouldShowTakePhoto,
-            ARG_SHOULD_SHOW_CHOOSE_PHOTO to shouldShowChoosePhoto,
             ARG_FRONT_SCAN_TYPE to frontScanType,
             ARG_BACK_SCAN_TYPE to backScanType,
             ARG_TITLE_RES to titleRes,
@@ -52,12 +48,6 @@ internal abstract class DocumentUploadDestination(
         val ROUTE = object : DestinationRoute() {
             override val routeBase = PASSPORT_UPLOAD
         }
-
-        fun shouldShowTakePhoto(backStackEntry: NavBackStackEntry) =
-            backStackEntry.getBooleanArgument(ARG_SHOULD_SHOW_TAKE_PHOTO)
-
-        fun shouldShowChoosePhoto(backStackEntry: NavBackStackEntry) =
-            backStackEntry.getBooleanArgument(ARG_SHOULD_SHOW_CHOOSE_PHOTO)
 
         fun frontScanType(backStackEntry: NavBackStackEntry) =
             backStackEntry.arguments?.getSerializable(ARG_FRONT_SCAN_TYPE) as IdentityScanState.ScanType
@@ -92,12 +82,6 @@ internal class DocumentUploadDestinationRoute(
     override val routeBase: String
 ) : IdentityTopLevelDestination.DestinationRoute() {
     override val arguments = mutableListOf(
-        navArgument(ARG_SHOULD_SHOW_TAKE_PHOTO) {
-            type = NavType.BoolType
-        },
-        navArgument(ARG_SHOULD_SHOW_CHOOSE_PHOTO) {
-            type = NavType.BoolType
-        },
         navArgument(ARG_FRONT_SCAN_TYPE) {
             type = NavType.EnumType(IdentityScanState.ScanType::class.java)
         },
@@ -129,12 +113,8 @@ internal class DocumentUploadDestinationRoute(
 }
 
 internal class PassportUploadDestination(
-    shouldShowTakePhoto: Boolean,
-    shouldShowChoosePhoto: Boolean,
     shouldPopUpToDocSelection: Boolean = false,
 ) : DocumentUploadDestination(
-    shouldShowTakePhoto = shouldShowTakePhoto,
-    shouldShowChoosePhoto = shouldShowChoosePhoto,
     shouldPopUpToDocSelection = shouldPopUpToDocSelection,
     frontScanType = IdentityScanState.ScanType.PASSPORT,
     backScanType = IdentityScanState.ScanType.PASSPORT,
@@ -153,12 +133,8 @@ internal class PassportUploadDestination(
 }
 
 internal class IDUploadDestination(
-    shouldShowTakePhoto: Boolean,
-    shouldShowChoosePhoto: Boolean,
     shouldPopUpToDocSelection: Boolean = false
 ) : DocumentUploadDestination(
-    shouldShowTakePhoto = shouldShowTakePhoto,
-    shouldShowChoosePhoto = shouldShowChoosePhoto,
     shouldPopUpToDocSelection = shouldPopUpToDocSelection,
     frontScanType = IdentityScanState.ScanType.ID_FRONT,
     backScanType = IdentityScanState.ScanType.ID_BACK,
@@ -179,12 +155,8 @@ internal class IDUploadDestination(
 }
 
 internal class DriverLicenseUploadDestination(
-    shouldShowTakePhoto: Boolean,
-    shouldShowChoosePhoto: Boolean,
     shouldPopUpToDocSelection: Boolean = false
 ) : DocumentUploadDestination(
-    shouldShowTakePhoto = shouldShowTakePhoto,
-    shouldShowChoosePhoto = shouldShowChoosePhoto,
     shouldPopUpToDocSelection = shouldPopUpToDocSelection,
     frontScanType = IdentityScanState.ScanType.DL_FRONT,
     backScanType = IdentityScanState.ScanType.DL_BACK,
@@ -203,16 +175,6 @@ internal class DriverLicenseUploadDestination(
         val ROUTE = DocumentUploadDestinationRoute(routeBase = DRIVE_LICENSE_UPLOAD)
     }
 }
-
-/**
- * Argument to indicate if choose photo option should be shown when picking an image.
- */
-internal const val ARG_SHOULD_SHOW_CHOOSE_PHOTO = "shouldShowChoosePhoto"
-
-/**
- * Argument to indicate if take photo option should be shown when picking an image.
- */
-internal const val ARG_SHOULD_SHOW_TAKE_PHOTO = "shouldShowTakePhoto"
 
 internal const val ARG_TITLE_RES = "titleRes"
 internal const val ARG_CONTEXT_RES = "contextRes"

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/CollectedDataParam.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/CollectedDataParam.kt
@@ -231,22 +231,10 @@ internal data class CollectedDataParam(
             return requirements
         }
 
-        fun Type.toUploadDestination(
-            shouldShowTakePhoto: Boolean,
-            shouldShowChoosePhoto: Boolean
-        ) = when (this) {
-            Type.IDCARD -> IDUploadDestination(
-                shouldShowTakePhoto,
-                shouldShowChoosePhoto
-            )
-            Type.DRIVINGLICENSE -> DriverLicenseUploadDestination(
-                shouldShowTakePhoto,
-                shouldShowChoosePhoto
-            )
-            Type.PASSPORT -> PassportUploadDestination(
-                shouldShowTakePhoto,
-                shouldShowChoosePhoto
-            )
+        fun Type.toUploadDestination() = when (this) {
+            Type.IDCARD -> IDUploadDestination()
+            Type.DRIVINGLICENSE -> DriverLicenseUploadDestination()
+            Type.PASSPORT -> PassportUploadDestination()
             else -> throw java.lang.IllegalStateException("Invalid CollectedDataParam.Type")
         }
 

--- a/identity/src/main/java/com/stripe/android/identity/states/IdentityScanState.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/IdentityScanState.kt
@@ -142,21 +142,18 @@ internal sealed class IdentityScanState(
 
         fun ScanType?.isNullOrFront() = this == null || this.isFront()
 
-        fun ScanType.toUploadDestination(
-            shouldShowTakePhoto: Boolean,
-            shouldShowChoosePhoto: Boolean
-        ) =
+        fun ScanType.toUploadDestination() =
             when (this) {
                 ScanType.ID_FRONT ->
-                    IDUploadDestination(shouldShowTakePhoto, shouldShowChoosePhoto, true)
+                    IDUploadDestination(true)
                 ScanType.ID_BACK ->
-                    IDUploadDestination(shouldShowTakePhoto, shouldShowChoosePhoto, true)
+                    IDUploadDestination(true)
                 ScanType.DL_FRONT ->
-                    DriverLicenseUploadDestination(shouldShowTakePhoto, shouldShowChoosePhoto, true)
+                    DriverLicenseUploadDestination(true)
                 ScanType.DL_BACK ->
-                    DriverLicenseUploadDestination(shouldShowTakePhoto, shouldShowChoosePhoto, true)
+                    DriverLicenseUploadDestination(true)
                 ScanType.PASSPORT ->
-                    PassportUploadDestination(shouldShowTakePhoto, shouldShowChoosePhoto, true)
+                    PassportUploadDestination(true)
                 ScanType.SELFIE -> {
                     throw IllegalArgumentException("SELFIE doesn't support upload")
                 }

--- a/identity/src/main/java/com/stripe/android/identity/ui/UploadScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/UploadScreen.kt
@@ -88,9 +88,7 @@ internal fun UploadScreen(
     @StringRes titleRes: Int,
     @StringRes contextRes: Int,
     frontInfo: DocumentUploadSideInfo,
-    backInfo: DocumentUploadSideInfo?,
-    shouldShowTakePhoto: Boolean,
-    shouldShowChoosePhoto: Boolean
+    backInfo: DocumentUploadSideInfo?
 ) {
     val localContext = LocalContext.current
     val verificationState by identityViewModel.verificationPage.observeAsState(Resource.loading())
@@ -108,6 +106,9 @@ internal fun UploadScreen(
         val backUploadState by identityViewModel.documentBackUploadedState.collectAsState()
         val collectedData by identityViewModel.collectedData.collectAsState()
         val missings by identityViewModel.missingRequirements.collectAsState()
+        val cameraPermissionGranted by identityViewModel.cameraPermissionGranted.collectAsState()
+        val shouldShowChoosePhoto = !it.documentCapture.requireLiveCapture
+
         LaunchedEffect(Unit) {
             launch {
                 identityViewModel.collectDataForDocumentUploadScreen(
@@ -187,7 +188,7 @@ internal fun UploadScreen(
             if (shouldShowFrontDialog) {
                 UploadImageDialog(
                     uploadInfo = frontInfo,
-                    shouldShowTakePhoto = shouldShowTakePhoto,
+                    shouldShowTakePhoto = cameraPermissionGranted,
                     shouldShowChoosePhoto = shouldShowChoosePhoto,
                     onPhotoSelected = { uploadMethod ->
                         when (uploadMethod) {
@@ -254,7 +255,7 @@ internal fun UploadScreen(
                 if (shouldShowBackDialog) {
                     UploadImageDialog(
                         uploadInfo = backInfo,
-                        shouldShowTakePhoto = shouldShowTakePhoto,
+                        shouldShowTakePhoto = cameraPermissionGranted,
                         shouldShowChoosePhoto = shouldShowChoosePhoto,
                         onPhotoSelected = { uploadMethod ->
                             when (uploadMethod) {

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
@@ -190,8 +190,7 @@ internal class IdentityViewModel constructor(
     val collectedData: StateFlow<CollectedDataParam> = _collectedData
 
     private val _cameraPermissionGranted = MutableStateFlow(
-        savedStateHandle[CAMERA_PERMISSION_GRANTED] ?: run {
-            false
+        savedStateHandle[CAMERA_PERMISSION_GRANTED] ?: false
         }
     )
     val cameraPermissionGranted: StateFlow<Boolean> = _cameraPermissionGranted

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
@@ -189,6 +189,13 @@ internal class IdentityViewModel constructor(
     )
     val collectedData: StateFlow<CollectedDataParam> = _collectedData
 
+    private val _cameraPermissionGranted = MutableStateFlow(
+        savedStateHandle[CAMERA_PERMISSION_GRANTED] ?: run {
+            false
+        }
+    )
+    val cameraPermissionGranted: StateFlow<Boolean> = _cameraPermissionGranted
+
     /**
      * StateFlow to track request status of postVerificationPageData
      */
@@ -1369,6 +1376,7 @@ internal class IdentityViewModel constructor(
                                 type.toAnalyticsScanType()
                             )
                         )
+                        _cameraPermissionGranted.update { true }
                         idDetectorModelFile.observe(viewLifecycleOwner) { modelResource ->
                             when (modelResource.status) {
                                 // model ready, camera permission is granted -> navigate to scan
@@ -1393,10 +1401,7 @@ internal class IdentityViewModel constructor(
                                             )
                                         } else {
                                             navController.navigateTo(
-                                                type.toUploadDestination(
-                                                    shouldShowTakePhoto = true,
-                                                    shouldShowChoosePhoto = true
-                                                )
+                                                type.toUploadDestination()
                                             )
                                         }
                                     }
@@ -1413,6 +1418,7 @@ internal class IdentityViewModel constructor(
                                 type.toAnalyticsScanType()
                             )
                         )
+                        _cameraPermissionGranted.update { false }
                         requireVerificationPage(
                             viewLifecycleOwner,
                             navController
@@ -1717,28 +1723,16 @@ internal class IdentityViewModel constructor(
             else -> throw IllegalStateException("Invalid CollectedDataParam.Type")
         }
 
-    private fun CollectedDataParam.Type.toUploadDestination(
-        shouldShowTakePhoto: Boolean,
-        shouldShowChoosePhoto: Boolean
-    ) =
+    private fun CollectedDataParam.Type.toUploadDestination() =
         when (this) {
             CollectedDataParam.Type.IDCARD ->
-                IDUploadDestination(
-                    shouldShowTakePhoto,
-                    shouldShowChoosePhoto
-                )
+                IDUploadDestination()
 
             CollectedDataParam.Type.PASSPORT ->
-                PassportUploadDestination(
-                    shouldShowTakePhoto,
-                    shouldShowChoosePhoto
-                )
+                PassportUploadDestination()
 
             CollectedDataParam.Type.DRIVINGLICENSE ->
-                DriverLicenseUploadDestination(
-                    shouldShowTakePhoto,
-                    shouldShowChoosePhoto
-                )
+                DriverLicenseUploadDestination()
 
             else -> throw IllegalStateException("Invalid CollectedDataParam.Type")
         }
@@ -1760,6 +1754,7 @@ internal class IdentityViewModel constructor(
                 _documentBackUploadedState -> DOCUMENT_BACK_UPLOAD_STATE
                 _collectedData -> COLLECTED_DATA
                 _missingRequirements -> MISSING_REQUIREMENTS
+                _cameraPermissionGranted -> CAMERA_PERMISSION_GRANTED
                 verificationPageData -> VERIFICATION_PAGE_DATA
                 verificationPageSubmit -> VERIFICATION_PAGE_SUBMIT
                 else -> {
@@ -1811,6 +1806,7 @@ internal class IdentityViewModel constructor(
         private const val ANALYTICS_STATE = "analytics_upload_state"
         private const val COLLECTED_DATA = "collected_data"
         private const val MISSING_REQUIREMENTS = "missing_requirements"
+        private const val CAMERA_PERMISSION_GRANTED = "cameraPermissionGranted"
         private const val VERIFICATION_PAGE = "verification_page"
         private const val VERIFICATION_PAGE_DATA = "verification_page_data"
         private const val VERIFICATION_PAGE_SUBMIT = "verification_page_submit"

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
@@ -163,9 +163,7 @@ internal class IdentityViewModel constructor(
      * StateFlow to track the upload status of high/low resolution images of selfies.
      */
     private val _selfieUploadedState = MutableStateFlow(
-        savedStateHandle[SELFIE_UPLOAD_STATE] ?: run {
-            SelfieUploadState()
-        }
+        savedStateHandle[SELFIE_UPLOAD_STATE] ?: SelfieUploadState()
     )
     val selfieUploadState: StateFlow<SelfieUploadState> = _selfieUploadedState
 
@@ -173,9 +171,7 @@ internal class IdentityViewModel constructor(
      * StateFlow to track analytics status.
      */
     private val _analyticsState = MutableStateFlow(
-        savedStateHandle[ANALYTICS_STATE] ?: run {
-            AnalyticsState()
-        }
+        savedStateHandle[ANALYTICS_STATE] ?: AnalyticsState()
     )
     val analyticsState: StateFlow<AnalyticsState> = _analyticsState
 
@@ -183,15 +179,12 @@ internal class IdentityViewModel constructor(
      * StateFlow to track the data collected so far.
      */
     private val _collectedData = MutableStateFlow(
-        savedStateHandle[COLLECTED_DATA] ?: run {
-            CollectedDataParam()
-        }
+        savedStateHandle[COLLECTED_DATA] ?: CollectedDataParam()
     )
     val collectedData: StateFlow<CollectedDataParam> = _collectedData
 
     private val _cameraPermissionGranted = MutableStateFlow(
         savedStateHandle[CAMERA_PERMISSION_GRANTED] ?: false
-        }
     )
     val cameraPermissionGranted: StateFlow<Boolean> = _cameraPermissionGranted
 
@@ -200,9 +193,7 @@ internal class IdentityViewModel constructor(
      */
     @VisibleForTesting
     internal val verificationPageData = MutableStateFlow<Resource<Int>>(
-        savedStateHandle[VERIFICATION_PAGE_DATA] ?: run {
-            Resource.idle()
-        }
+        savedStateHandle[VERIFICATION_PAGE_DATA] ?: Resource.idle()
     )
 
     /**
@@ -210,18 +201,14 @@ internal class IdentityViewModel constructor(
      */
     @VisibleForTesting
     internal val verificationPageSubmit = MutableStateFlow<Resource<Int>>(
-        savedStateHandle[VERIFICATION_PAGE_SUBMIT] ?: run {
-            Resource.idle()
-        }
+        savedStateHandle[VERIFICATION_PAGE_SUBMIT] ?: Resource.idle()
     )
 
     /**
      * StateFlow to track missing requirements.
      */
     private val _missingRequirements = MutableStateFlow<Set<Requirement>>(
-        savedStateHandle[MISSING_REQUIREMENTS] ?: run {
-            setOf()
-        }
+        savedStateHandle[MISSING_REQUIREMENTS] ?: setOf()
     )
     val missingRequirements: StateFlow<Set<Requirement>> = _missingRequirements
 

--- a/identity/src/test/java/com/stripe/android/identity/ui/UploadScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/UploadScreenTest.kt
@@ -17,6 +17,8 @@ import com.stripe.android.identity.networking.Resource
 import com.stripe.android.identity.networking.SingleSideDocumentUploadState
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.Requirement
+import com.stripe.android.identity.networking.models.VerificationPage
+import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
 import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.utils.IdentityImageHandler
 import com.stripe.android.identity.viewmodel.IdentityViewModel
@@ -51,14 +53,29 @@ class UploadScreenTest {
     private val missingRequirements =
         MutableStateFlow(setOf(Requirement.IDDOCUMENTFRONT, Requirement.IDDOCUMENTBACK))
 
+    private val cameraPermissionGranted = MutableStateFlow(true)
+
+    private val documentCaptureRequireLiveCaptureMock =
+        mock<VerificationPageStaticContentDocumentCapturePage> {
+            on { requireLiveCapture } doReturn true
+        }
+    private val verificationPageRequireLiveCapture = mock<VerificationPage> {
+        on { documentCapture } doReturn documentCaptureRequireLiveCaptureMock
+    }
     private val mockImageHandler = mock<IdentityImageHandler>()
+
     private val mockIdentityViewModel = mock<IdentityViewModel> {
         on { documentFrontUploadedState } doReturn documentFrontUploadState
         on { documentBackUploadedState } doReturn documentBackUploadState
         on { collectedData } doReturn collectedData
         on { missingRequirements } doReturn missingRequirements
-        on { verificationPage } doReturn MutableLiveData(Resource.success(mock()))
+        on { verificationPage } doReturn MutableLiveData(
+            Resource.success(
+                verificationPageRequireLiveCapture
+            )
+        )
         on { imageHandler } doReturn mockImageHandler
+        on { cameraPermissionGranted } doReturn cameraPermissionGranted
     }
 
     @Test
@@ -195,9 +212,7 @@ class UploadScreenTest {
                     )
                 } else {
                     null
-                },
-                shouldShowTakePhoto = true,
-                shouldShowChoosePhoto = true,
+                }
             )
         }
         with(composeTestRule, testBlock)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Simplify the logic of these two booleans(the legacy logic was inherited pre jetpack compose rewrite), instead of passing them around, refer to source of truth when they are set.
`shouldShowTakePhoto` is set true when Verificaiton.requireLiveCapture is true, which is already available in `IdentityViewModel`
`shouldShowChoosePhoto` is set true/false when camera permission is granted/denied. Add a stateflow in `IdentityViewModel` when `CameraPermissionEnsureable` callback returns.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Simplify navigation logic

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
