### PR TITLE
[Identity] Support softblock and continue anyway

### DIFF
--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -102,6 +102,10 @@ public final class com/stripe/android/identity/analytics/AnalyticsState$Creator 
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/identity/navigation/NavControllerExtKt {
+	public static final field NAV_CONTROLLER_TAG Ljava/lang/String;
+}
+
 public final class com/stripe/android/identity/networking/Resource$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/identity/networking/Resource;

--- a/identity/detekt-baseline.xml
+++ b/identity/detekt-baseline.xml
@@ -84,6 +84,6 @@
     <ID>UnnecessaryAbstractClass:IdentityCommonModule.kt$IdentityCommonModule$IdentityCommonModule</ID>
     <ID>UnusedPrivateMember:IDDetectorTransitionerTest.kt$IDDetectorTransitionerTest$i</ID>
     <ID>VariableNaming:IdentityViewModel.kt$IdentityViewModel$/** * Response for initial VerificationPage, used for building UI. */ @VisibleForTesting internal val _verificationPage: MutableLiveData&lt;Resource&lt;VerificationPage>> = // No need to write to savedStateHandle for livedata savedStateHandle.getLiveData( key = VERIFICATION_PAGE, initialValue = Resource.idle() )</ID>
-    <ID>VariableNaming:IdentityViewModel.kt$IdentityViewModel$/** * StateFlow to track the data collected so far. */ @VisibleForTesting internal val _collectedData = MutableStateFlow( savedStateHandle[COLLECTED_DATA] ?: run { CollectedDataParam() } )</ID>
+    <ID>VariableNaming:IdentityViewModel.kt$IdentityViewModel$/** * StateFlow to track the data collected so far. */ @VisibleForTesting internal val _collectedData = MutableStateFlow( savedStateHandle[COLLECTED_DATA] ?: CollectedDataParam() )</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/identity/detekt-baseline.xml
+++ b/identity/detekt-baseline.xml
@@ -84,5 +84,6 @@
     <ID>UnnecessaryAbstractClass:IdentityCommonModule.kt$IdentityCommonModule$IdentityCommonModule</ID>
     <ID>UnusedPrivateMember:IDDetectorTransitionerTest.kt$IDDetectorTransitionerTest$i</ID>
     <ID>VariableNaming:IdentityViewModel.kt$IdentityViewModel$/** * Response for initial VerificationPage, used for building UI. */ @VisibleForTesting internal val _verificationPage: MutableLiveData&lt;Resource&lt;VerificationPage>> = // No need to write to savedStateHandle for livedata savedStateHandle.getLiveData( key = VERIFICATION_PAGE, initialValue = Resource.idle() )</ID>
+    <ID>VariableNaming:IdentityViewModel.kt$IdentityViewModel$/** * StateFlow to track the data collected so far. */ @VisibleForTesting internal val _collectedData = MutableStateFlow( savedStateHandle[COLLECTED_DATA] ?: run { CollectedDataParam() } )</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ErrorDestination.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ErrorDestination.kt
@@ -5,10 +5,13 @@ import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
 import com.stripe.android.identity.R
+import com.stripe.android.identity.networking.models.Requirement
 
 internal class ErrorDestination(
     errorTitle: String,
     errorContent: String,
+    continueButtonText: String = UNSET_BUTTON_TEXT,
+    continueButtonRequirement: Requirement? = null,
     backButtonText: String,
     backButtonDestination: String = UNEXPECTED_ROUTE,
     shouldFail: Boolean = false
@@ -18,6 +21,8 @@ internal class ErrorDestination(
     override val routeWithArgs = destinationRoute.withParams(
         ARG_ERROR_TITLE to errorTitle,
         ARG_ERROR_CONTENT to errorContent,
+        ARG_CONTINUE_BUTTON_TEXT to continueButtonText,
+        ARG_CONTINUE_BUTTON_REQUIREMENT to (continueButtonRequirement ?: UNSET_BUTTON_REQUIREMENT),
         ARG_GO_BACK_BUTTON_DESTINATION to backButtonDestination.toRouteBase(),
         ARG_GO_BACK_BUTTON_TEXT to backButtonText,
         ARG_SHOULD_FAIL to shouldFail
@@ -27,6 +32,10 @@ internal class ErrorDestination(
         const val ERROR = "Error"
         const val ARG_ERROR_TITLE = "errorTitle"
         const val ARG_ERROR_CONTENT = "errorContent"
+
+        // if set, shows continue button, clickign it would clear the requirement
+        const val ARG_CONTINUE_BUTTON_TEXT = "continueButtonText"
+        const val ARG_CONTINUE_BUTTON_REQUIREMENT = "continueButtonRequirement"
 
         // if set, shows go_back button, clicking it would navigate to the destination.
         const val ARG_GO_BACK_BUTTON_TEXT = "goBackButtonText"
@@ -40,6 +49,9 @@ internal class ErrorDestination(
         // If this happens, set the back button destination to [DEFAULT_BACK_BUTTON_DESTINATION]
         const val UNEXPECTED_ROUTE = "UnexpectedRoute"
 
+        const val UNSET_BUTTON_TEXT = "unset"
+        const val UNSET_BUTTON_REQUIREMENT = "unset"
+
         const val TAG = "ErrorDestination"
 
         fun errorTitle(backStackEntry: NavBackStackEntry) =
@@ -47,6 +59,24 @@ internal class ErrorDestination(
 
         fun errorContent(backStackEntry: NavBackStackEntry) =
             backStackEntry.getStringArgument(ARG_ERROR_CONTENT)
+
+        fun continueButtonContext(backStackEntry: NavBackStackEntry): Pair<String, Requirement>? {
+            val continueButtonText = backStackEntry.getStringArgument(ARG_CONTINUE_BUTTON_TEXT)
+            val continueButtonRequirement: Requirement? =
+                backStackEntry.getStringArgument(ARG_CONTINUE_BUTTON_REQUIREMENT)
+                    .let { requirementString ->
+                        if (requirementString == UNSET_BUTTON_REQUIREMENT) {
+                            null
+                        } else {
+                            Requirement.valueOf(requirementString)
+                        }
+                    }
+            return if (continueButtonText != UNSET_BUTTON_TEXT && continueButtonRequirement != null) {
+                (continueButtonText to continueButtonRequirement)
+            } else {
+                null
+            }
+        }
 
         fun backButtonText(backStackEntry: NavBackStackEntry) =
             backStackEntry.getStringArgument(ARG_GO_BACK_BUTTON_TEXT)
@@ -74,6 +104,12 @@ internal class ErrorDestination(
                 },
                 navArgument(ARG_SHOULD_FAIL) {
                     type = NavType.BoolType
+                },
+                navArgument(ARG_CONTINUE_BUTTON_TEXT) {
+                    type = NavType.StringType
+                },
+                navArgument(ARG_CONTINUE_BUTTON_REQUIREMENT) {
+                    type = NavType.StringType
                 }
             )
         }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityNavGraph.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityNavGraph.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -50,6 +51,7 @@ import com.stripe.android.identity.ui.SelfieWarmupScreen
 import com.stripe.android.identity.ui.UploadScreen
 import com.stripe.android.identity.viewmodel.IdentityScanViewModel
 import com.stripe.android.identity.viewmodel.IdentityViewModel
+import kotlinx.coroutines.launch
 
 @Composable
 internal fun IdentityNavGraph(
@@ -65,6 +67,7 @@ internal fun IdentityNavGraph(
     onNavControllerCreated: (NavController) -> Unit
 ) {
     val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
     LaunchedEffect(Unit) {
         onNavControllerCreated(navController)
     }
@@ -335,6 +338,17 @@ internal fun IdentityNavGraph(
                     identityViewModel = identityViewModel,
                     title = ErrorDestination.errorTitle(it),
                     message1 = ErrorDestination.errorContent(it),
+                    topButton = ErrorDestination.continueButtonContext(it)
+                        ?.let { (topButtonText, topButtonRequirement) ->
+                            ErrorScreenButton(buttonText = topButtonText) {
+                                coroutineScope.launch {
+                                    identityViewModel.postVerificationPageDataForForceConfirm(
+                                        requirementToForceConfirm = topButtonRequirement,
+                                        navController = navController
+                                    )
+                                }
+                            }
+                        },
                     bottomButton = ErrorScreenButton(
                         buttonText = ErrorDestination.backButtonText(it)
                     ) {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityTopLevelDestination.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityTopLevelDestination.kt
@@ -54,7 +54,7 @@ internal data class PopUpToParam(
 internal fun String.toRouteBase() = substringBefore('?')
 
 internal fun IdentityTopLevelDestination.DestinationRoute.withParams(
-    vararg params: Pair<String, Any>
+    vararg params: Pair<String, Any?>
 ): String {
     var ret = this.route
     params.forEach { (key, value) ->

--- a/identity/src/main/java/com/stripe/android/identity/navigation/SelfieWarmupDestination.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/SelfieWarmupDestination.kt
@@ -1,7 +1,12 @@
 package com.stripe.android.identity.navigation
 
-internal object SelfieWarmupDestination : IdentityTopLevelDestination() {
-    private const val SELFIE_WARMUP = "SelfieWarmup"
+internal object SelfieWarmupDestination : IdentityTopLevelDestination(
+    popUpToParam = PopUpToParam(
+        route = DocSelectionDestination.ROUTE.route,
+        inclusive = false
+    )
+) {
+    const val SELFIE_WARMUP = "SelfieWarmup"
     val ROUTE = object : DestinationRoute() {
         override val routeBase = SELFIE_WARMUP
     }

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/CollectedDataParam.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/CollectedDataParam.kt
@@ -5,8 +5,11 @@ import android.os.Parcelable
 import com.stripe.android.core.networking.toMap
 import com.stripe.android.identity.R
 import com.stripe.android.identity.ml.IDDetectorAnalyzer
+import com.stripe.android.identity.navigation.DriverLicenseScanDestination
 import com.stripe.android.identity.navigation.DriverLicenseUploadDestination
+import com.stripe.android.identity.navigation.IDScanDestination
 import com.stripe.android.identity.navigation.IDUploadDestination
+import com.stripe.android.identity.navigation.PassportScanDestination
 import com.stripe.android.identity.navigation.PassportUploadDestination
 import com.stripe.android.identity.networking.UploadedResult
 import com.stripe.android.identity.ui.DRIVING_LICENSE_KEY
@@ -231,11 +234,34 @@ internal data class CollectedDataParam(
             return requirements
         }
 
-        fun Type.toUploadDestination() = when (this) {
-            Type.IDCARD -> IDUploadDestination()
-            Type.DRIVINGLICENSE -> DriverLicenseUploadDestination()
-            Type.PASSPORT -> PassportUploadDestination()
+        fun Type.toUploadDestination(
+            shouldPopUpToDocSelection: Boolean = false
+        ) = when (this) {
+            Type.IDCARD -> IDUploadDestination(shouldPopUpToDocSelection = shouldPopUpToDocSelection)
+            Type.DRIVINGLICENSE -> DriverLicenseUploadDestination(shouldPopUpToDocSelection = shouldPopUpToDocSelection)
+            Type.PASSPORT -> PassportUploadDestination(shouldPopUpToDocSelection = shouldPopUpToDocSelection)
             else -> throw java.lang.IllegalStateException("Invalid CollectedDataParam.Type")
+        }
+        fun Type.toScanDestination(
+            shouldStartFromBack: Boolean = false,
+            shouldPopUpToDocSelection: Boolean = false
+        ) = when (this) {
+            Type.IDCARD -> IDScanDestination(
+                shouldStartFromBack,
+                shouldPopUpToDocSelection
+            )
+
+            Type.PASSPORT -> PassportScanDestination(
+                shouldStartFromBack,
+                shouldPopUpToDocSelection
+            )
+
+            Type.DRIVINGLICENSE -> DriverLicenseScanDestination(
+                shouldStartFromBack,
+                shouldPopUpToDocSelection
+            )
+
+            else -> throw IllegalStateException("Invalid CollectedDataParam.Type")
         }
 
         fun Type.getDisplayName(context: Context) =

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/DocumentUploadParam.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/DocumentUploadParam.kt
@@ -21,7 +21,9 @@ internal data class DocumentUploadParam(
     @SerialName("passport_score")
     val passportScore: Float? = null,
     @SerialName("upload_method")
-    val uploadMethod: UploadMethod
+    val uploadMethod: UploadMethod,
+    @SerialName("force_confirm")
+    val forceConfirm: Boolean? = null
 ) : Parcelable {
     @Serializable
     internal enum class UploadMethod {

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/Requirement.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/Requirement.kt
@@ -71,6 +71,11 @@ internal enum class Requirement {
             IDNUMBER
         )
 
+        private val REQUIREMENTS_SUPPORTS_FORCE_CONFIRM = setOf(
+            IDDOCUMENTFRONT,
+            IDDOCUMENTBACK
+        )
+
         /**
          * Checks whether the Requirement matches the route the error occurred from.
          */
@@ -79,25 +84,31 @@ internal enum class Requirement {
                 BIOMETRICCONSENT -> {
                     fromRoute == ConsentDestination.ROUTE.route
                 }
+
                 IDDOCUMENTBACK -> {
                     SCAN_UPLOAD_ROUTE_SET.any {
                         it.route == fromRoute
                     }
                 }
+
                 IDDOCUMENTFRONT -> {
                     SCAN_UPLOAD_ROUTE_SET.any {
                         it.route == fromRoute
                     }
                 }
+
                 IDDOCUMENTTYPE -> {
                     fromRoute == DocSelectionDestination.ROUTE.route
                 }
+
                 FACE -> {
                     fromRoute == SelfieDestination.ROUTE.route
                 }
+
                 DOB, NAME, IDNUMBER, ADDRESS, PHONE_NUMBER -> {
                     fromRoute == IndividualDestination.ROUTE.route
                 }
+
                 PHONE_OTP -> {
                     fromRoute == OTPDestination.ROUTE.route
                 }
@@ -115,6 +126,7 @@ internal enum class Requirement {
                 contains(BIOMETRICCONSENT) -> {
                     ConsentDestination
                 }
+
                 intersect(listOf(IDDOCUMENTTYPE, IDDOCUMENTFRONT, IDDOCUMENTBACK)).isNotEmpty() -> {
                     DocSelectionDestination
                 }
@@ -131,12 +143,17 @@ internal enum class Requirement {
                 intersect(listOf(IDNUMBER, ADDRESS)).isNotEmpty() -> {
                     IndividualDestination
                 }
+
                 isEmpty() -> {
                     ConfirmationDestination
                 }
+
                 else -> {
                     context.finalErrorDestination()
                 }
             }
+
+        fun Requirement.supportsForceConfirm() =
+            REQUIREMENTS_SUPPORTS_FORCE_CONFIRM.contains(this)
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageDataRequirementError.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageDataRequirementError.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.identity.networking.models
 
+import com.stripe.android.identity.networking.models.Requirement.Companion.supportsForceConfirm
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -15,4 +16,14 @@ internal data class VerificationPageDataRequirementError(
     val requirement: Requirement,
     @SerialName("title")
     val title: String? = null
-)
+) {
+    companion object {
+
+        /**
+         * Checks if the error supports continue button.
+         * [continueButtonText] should but non empty and [requirement] should support force confirm
+         */
+        fun VerificationPageDataRequirementError.supportsContinueButton() =
+            !continueButtonText.isNullOrEmpty() && requirement.supportsForceConfirm()
+    }
+}

--- a/identity/src/main/java/com/stripe/android/identity/ui/ErrorScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/ErrorScreen.kt
@@ -10,10 +10,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Button
-import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -102,29 +104,33 @@ internal fun ErrorScreen(
                 )
             }
         }
+        var topButtonState by remember { mutableStateOf(LoadingButtonState.Idle) }
+        var bottomButtonState by remember { mutableStateOf(LoadingButtonState.Idle) }
 
         topButton?.let { (buttonText, onClick) ->
-            OutlinedButton(
-                onClick = onClick,
+            LoadingTextButton(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .testTag(
-                        ErrorTopButtonTag
-                    )
+                    .testTag((ErrorTopButtonTag)),
+                text = buttonText.uppercase(),
+                state = topButtonState
             ) {
-                Text(text = buttonText.uppercase())
+                topButtonState = LoadingButtonState.Loading
+                bottomButtonState = LoadingButtonState.Disabled
+                onClick()
             }
         }
         bottomButton?.let { (buttonText, onClick) ->
-            Button(
-                onClick = onClick,
+            LoadingButton(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .testTag(
-                        ErrorBottomButtonTag
-                    )
+                    .testTag(ErrorBottomButtonTag),
+                text = buttonText.uppercase(),
+                state = bottomButtonState
             ) {
-                Text(text = buttonText.uppercase())
+                topButtonState = LoadingButtonState.Disabled
+                bottomButtonState = LoadingButtonState.Loading
+                onClick()
             }
         }
     }

--- a/identity/src/test/java/com/stripe/android/identity/ui/ErrorScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/ErrorScreenTest.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onChildAt
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.stripe.android.identity.TestApplication
@@ -12,6 +13,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -61,7 +63,7 @@ class ErrorScreenTest {
             onNodeWithTag(ErrorTitleTag).assertTextEquals(ERROR_TITLE)
             onNodeWithTag(ErrorMessage1Tag).assertDoesNotExist()
             onNodeWithTag(ErrorMessage2Tag).assertDoesNotExist()
-            onNodeWithTag(ErrorTopButtonTag).assertTextEquals(ERROR_TOP_BUTTON_TEXT.uppercase())
+            onNodeWithTag(ErrorTopButtonTag).onChildAt(0).assertTextEquals(ERROR_TOP_BUTTON_TEXT.uppercase())
             onNodeWithTag(ErrorBottomButtonTag).assertDoesNotExist()
 
             onNodeWithTag(ErrorTopButtonTag).performClick()
@@ -81,7 +83,7 @@ class ErrorScreenTest {
             onNodeWithTag(ErrorMessage1Tag).assertDoesNotExist()
             onNodeWithTag(ErrorMessage2Tag).assertDoesNotExist()
             onNodeWithTag(ErrorTopButtonTag).assertDoesNotExist()
-            onNodeWithTag(ErrorBottomButtonTag).assertTextEquals(ERROR_BOTTOM_BUTTON_TEXT.uppercase())
+            onNodeWithTag(ErrorBottomButtonTag).onChildAt(0).assertTextEquals(ERROR_BOTTOM_BUTTON_TEXT.uppercase())
 
             onNodeWithTag(ErrorBottomButtonTag).performClick()
             verify(mockBottomButtonClicked).invoke()
@@ -105,14 +107,15 @@ class ErrorScreenTest {
             onNodeWithTag(ErrorTitleTag).assertTextEquals(ERROR_TITLE)
             onNodeWithTag(ErrorMessage1Tag).assertTextEquals(ERROR_MESSAGE1)
             onNodeWithTag(ErrorMessage2Tag).assertTextEquals(ERROR_MESSAGE2)
-            onNodeWithTag(ErrorTopButtonTag).assertTextEquals(ERROR_TOP_BUTTON_TEXT.uppercase())
-            onNodeWithTag(ErrorBottomButtonTag).assertTextEquals(ERROR_BOTTOM_BUTTON_TEXT.uppercase())
+            onNodeWithTag(ErrorTopButtonTag).onChildAt(0).assertTextEquals(ERROR_TOP_BUTTON_TEXT.uppercase())
+            onNodeWithTag(ErrorBottomButtonTag).onChildAt(0).assertTextEquals(ERROR_BOTTOM_BUTTON_TEXT.uppercase())
 
             onNodeWithTag(ErrorTopButtonTag).performClick()
             verify(mockTopButtonClicked).invoke()
 
+            // Disabled
             onNodeWithTag(ErrorBottomButtonTag).performClick()
-            verify(mockBottomButtonClicked).invoke()
+            verifyNoInteractions(mockBottomButtonClicked)
         }
     }
 

--- a/identity/src/test/java/com/stripe/android/identity/viewmodel/IdentityViewModelTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/viewmodel/IdentityViewModelTest.kt
@@ -573,7 +573,6 @@ internal class IdentityViewModelTest {
                 any()
             )
 
-
             // no missing, submit
             verify(mockIdentityRepository).postVerificationPageSubmit(
                 eq(VERIFICATION_SESSION_ID),

--- a/identity/src/test/java/com/stripe/android/identity/viewmodel/IdentityViewModelTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/viewmodel/IdentityViewModelTest.kt
@@ -41,7 +41,6 @@ import com.stripe.android.identity.navigation.ConsentDestination
 import com.stripe.android.identity.navigation.DocSelectionDestination
 import com.stripe.android.identity.navigation.ErrorDestination
 import com.stripe.android.identity.navigation.IdentityTopLevelDestination
-import com.stripe.android.identity.navigation.SELFIE
 import com.stripe.android.identity.navigation.SelfieWarmupDestination
 import com.stripe.android.identity.navigation.SelfieWarmupDestination.SELFIE_WARMUP
 import com.stripe.android.identity.networking.IdentityModelFetcher
@@ -546,6 +545,14 @@ internal class IdentityViewModelTest {
     @Test
     fun `forceConfirm back - noMissing - submit`() =
         testForceConfirm(CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA) { _, failedCollectedDataParam ->
+
+            whenever(
+                mockIdentityRepository.postVerificationPageSubmit(
+                    any(),
+                    any()
+                )
+            ).thenReturn(CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA)
+
             // fulfilling back, should post with force confirm bcak
             viewModel.postVerificationPageDataForForceConfirm(
                 requirementToForceConfirm = Requirement.IDDOCUMENTBACK,
@@ -565,6 +572,7 @@ internal class IdentityViewModelTest {
                 ),
                 any()
             )
+
 
             // no missing, submit
             verify(mockIdentityRepository).postVerificationPageSubmit(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Support softblock/continue anyway when user fails to upload correct image more than once*.

Note the behavior is driven by server, please see details in [this](https://docs.google.com/document/d/1s6WwYpvnP_V6QRqjEbDnnVlzv8g5eUlROrSGh3XrK4U/edit#heading=h.nkvu6fer6ghi) internal doc. 

Client side change - When `VerificationPageDataRequirementError.continueButtonText` is populated by server, invoke the VerificationData endpoint with new parameter `force_confirm`


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Don't hardblock users when uploading incorrect images

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![continueAnywayBefore](https://github.com/stripe/stripe-android/assets/79880926/44905cc5-e247-42d8-828b-961f00a27a04)  | ![continueAnywayAfter](https://github.com/stripe/stripe-android/assets/79880926/32f092c3-e056-4f55-a57b-52cb3a2b2cf1) |







# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
