### PR TITLE
Don't display sepa based LPMs because we don't show a mandate.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -214,17 +214,17 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
 
         val paymentMethods = customerRepository.getPaymentMethods(
             customerConfig = customerConfig,
-            types = paymentMethodTypes,
+            types = paymentMethodTypes.filter { paymentMethodType ->
+                paymentMethodType in setOf(
+                    PaymentMethod.Type.Card,
+                    PaymentMethod.Type.USBankAccount,
+                )
+            },
             silentlyFail = true,
         ).getOrDefault(emptyList())
 
         return paymentMethods.filter { paymentMethod ->
             paymentMethod.hasExpectedDetails()
-        }.filter { paymentMethod ->
-            paymentMethod.type in setOf(
-                PaymentMethod.Type.Card,
-                PaymentMethod.Type.USBankAccount,
-            )
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -221,18 +221,9 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         return paymentMethods.filter { paymentMethod ->
             paymentMethod.hasExpectedDetails()
         }.filter { paymentMethod ->
-            // PayPal isn't supported yet as a saved payment method (backend limitation).
-            paymentMethod.type != PaymentMethod.Type.PayPal
-        }.filter { paymentMethod ->
-            // CashAppPay isn't supported yet as a saved payment method (backend limitation).
-            paymentMethod.type != PaymentMethod.Type.CashAppPay
-        }.filter { paymentMethod ->
-            // Sepa based LPMs aren't supported since we don't show the mandate client side yet.
-            paymentMethod.type !in setOf(
-                PaymentMethod.Type.SepaDebit,
-                PaymentMethod.Type.Ideal,
-                PaymentMethod.Type.Bancontact,
-                PaymentMethod.Type.Sofort,
+            paymentMethod.type in setOf(
+                PaymentMethod.Type.Card,
+                PaymentMethod.Type.USBankAccount,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -226,6 +226,14 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         }.filter { paymentMethod ->
             // CashAppPay isn't supported yet as a saved payment method (backend limitation).
             paymentMethod.type != PaymentMethod.Type.CashAppPay
+        }.filter { paymentMethod ->
+            // Sepa based LPMs aren't supported since we don't show the mandate client side yet.
+            paymentMethod.type !in setOf(
+                PaymentMethod.Type.SepaDebit,
+                PaymentMethod.Type.Ideal,
+                PaymentMethod.Type.Bancontact,
+                PaymentMethod.Type.Sofort,
+            )
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -293,22 +293,32 @@ internal class DefaultPaymentSheetLoaderTest {
     // See: https://docs.google.com/document/d/1_bCPJXxhV4Kdgy7LX7HPwpZfElN3a2DcYUooiWC9SgM
     @Test
     fun `load() with customer should filter out PayPal`() = runTest {
+        var requestPaymentMethodTypes: List<PaymentMethod.Type>? = null
         val result = createPaymentSheetLoader(
-            customerRepo = FakeCustomerRepository(
-                listOf(
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                    PaymentMethodFixtures.PAYPAL_PAYMENT_METHOD,
-                )
+            customerRepo = object: FakeCustomerRepository() {
+                override suspend fun getPaymentMethods(
+                    customerConfig: PaymentSheet.CustomerConfiguration,
+                    types: List<PaymentMethod.Type>,
+                    silentlyFail: Boolean
+                ): Result<List<PaymentMethod>> {
+                    requestPaymentMethodTypes = types
+                    return Result.success(listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD))
+                }
+            },
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "paypal")
             )
         ).load(
             initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
                 clientSecret = PaymentSheetFixtures.CLIENT_SECRET,
             ),
-            paymentSheetConfiguration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
+            paymentSheetConfiguration = PaymentSheetFixtures.CONFIG_CUSTOMER,
         ).getOrThrow()
 
         assertThat(result.customerPaymentMethods)
             .containsExactly(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        assertThat(requestPaymentMethodTypes)
+            .containsExactly(PaymentMethod.Type.Card)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -295,7 +295,7 @@ internal class DefaultPaymentSheetLoaderTest {
     fun `load() with customer should filter out PayPal`() = runTest {
         var requestPaymentMethodTypes: List<PaymentMethod.Type>? = null
         val result = createPaymentSheetLoader(
-            customerRepo = object: FakeCustomerRepository() {
+            customerRepo = object : FakeCustomerRepository() {
                 override suspend fun getPaymentMethods(
                     customerConfig: PaymentSheet.CustomerConfiguration,
                     types: List<PaymentMethod.Type>,

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
@@ -5,7 +5,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 
-internal class FakeCustomerRepository(
+internal open class FakeCustomerRepository(
     private val paymentMethods: List<PaymentMethod> = emptyList(),
     private val customer: Customer? = null,
     private val onDetachPaymentMethod: () -> Result<PaymentMethod> = {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Changes allowed saved payment methods to be a list of allowed, rather than rejected.

These are the only 2 supported payment method types that are allowed as SPMs today. Will add sepa family after we add mandate support.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We displayed sepa family payment methods when we weren't ready to show them yet.
