### PR TITLE
Only show playground status once.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -510,7 +510,7 @@ internal class PlaygroundTestDriver(
             // Observe the result of the PaymentSheet completion
             activity.lifecycleScope.launch {
                 activity.viewModel.status.collect {
-                    resultValue = it
+                    resultValue = it?.message
                 }
             }
             launchPlayground.countDown()

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -121,9 +121,10 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
             val status by viewModel.status.collectAsState()
             val context = LocalContext.current
             LaunchedEffect(status) {
-                if (!status.isNullOrEmpty()) {
-                    Toast.makeText(context, status, Toast.LENGTH_LONG).show()
+                if (!status?.message.isNullOrEmpty() && status?.hasBeenDisplayed == false) {
+                    Toast.makeText(context, status?.message, Toast.LENGTH_LONG).show()
                 }
+                viewModel.status.value = status?.copy(hasBeenDisplayed = true)
             }
         }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
@@ -44,7 +44,7 @@ internal class PaymentSheetPlaygroundViewModel(
     }
 
     val playgroundSettingsFlow = MutableStateFlow<PlaygroundSettings?>(null)
-    val status = MutableStateFlow<String?>(null)
+    val status = MutableStateFlow<StatusMessage?>(null)
     val state = MutableStateFlow<PlaygroundState?>(null)
     val flowControllerState = MutableStateFlow<FlowControllerState?>(null)
 
@@ -80,8 +80,9 @@ internal class PaymentSheetPlaygroundViewModel(
                 .awaitModel(CheckoutResponse.serializer())
             when (apiResponse) {
                 is Result.Failure -> {
-                    status.value =
+                    status.value = StatusMessage(
                         "Preparing checkout failed:\n${apiResponse.getException().message}"
+                    )
                 }
 
                 is Result.Success -> {
@@ -106,7 +107,7 @@ internal class PaymentSheetPlaygroundViewModel(
         if (success) {
             flowControllerState.value = FlowControllerState()
         } else {
-            status.value = error?.message ?: "Failed to configure flow controller."
+            status.value = StatusMessage(error?.message ?: "Failed to configure flow controller.")
         }
     }
 
@@ -149,7 +150,7 @@ internal class PaymentSheetPlaygroundViewModel(
             }
         }
 
-        status.value = statusMessage
+        status.value = StatusMessage(statusMessage)
     }
 
     private fun createIntent(clientSecret: String): CreateIntentResult {
@@ -227,7 +228,7 @@ internal class PaymentSheetPlaygroundViewModel(
         val createIntentResult = when (result) {
             is Result.Failure -> {
                 val message = "Creating intent failed:\n${result.getException().message}"
-                status.value = message
+                status.value = StatusMessage(message)
 
                 val error = if (result.error.cause is IOException) {
                     ConfirmIntentNetworkException()
@@ -253,7 +254,7 @@ internal class PaymentSheetPlaygroundViewModel(
     fun onAddressLauncherResult(addressLauncherResult: AddressLauncherResult) {
         when (addressLauncherResult) {
             AddressLauncherResult.Canceled -> {
-                status.value = "Canceled"
+                status.value = StatusMessage("Canceled")
             }
 
             is AddressLauncherResult.Succeeded -> {
@@ -281,3 +282,8 @@ class ConfirmIntentNetworkException : Exception()
 
 private const val RETURN_URL = "stripesdk://payment_return_url/" +
     "com.stripe.android.paymentsheet.example"
+
+data class StatusMessage(
+    val message: String?,
+    val hasBeenDisplayed: Boolean = false
+)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We showed the last status again after an activity configuration change (this was undesired behavior). This change makes it so we only show the status a single time, even after an activity configuration change.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Bug

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
