### PR TITLE
Show the default selected payment method in flow controller.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/FlowControllerState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/FlowControllerState.kt
@@ -7,6 +7,7 @@ import com.stripe.android.paymentsheet.model.PaymentOption
 internal data class FlowControllerState(
     val selectedPaymentOption: PaymentOption? = null,
     val addressDetails: AddressDetails? = null,
+    val shouldFetchPaymentOption: Boolean = true
 )
 
 internal fun FlowControllerState?.paymentMethodLabel(): String {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -51,6 +51,7 @@ import com.stripe.android.paymentsheet.example.samples.ui.shared.CHECKOUT_TEST_T
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentMethodSelector
 import com.stripe.android.paymentsheet.rememberPaymentSheet
 import com.stripe.android.paymentsheet.rememberPaymentSheetFlowController
+import kotlinx.coroutines.flow.update
 
 internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
     companion object {
@@ -239,6 +240,17 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
 
         val flowControllerState by viewModel.flowControllerState.collectAsState()
         val localFlowControllerState = flowControllerState
+
+        LaunchedEffect(localFlowControllerState) {
+            if (localFlowControllerState?.shouldFetchPaymentOption == true) {
+                viewModel.flowControllerState.update { previousState ->
+                    previousState?.copy(
+                        selectedPaymentOption = flowController.getPaymentOption(),
+                        shouldFetchPaymentOption = false,
+                    )
+                }
+            }
+        }
 
         LaunchedEffect(localFlowControllerState?.addressDetails) {
             flowController.shippingDetails = localFlowControllerState?.addressDetails


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This was a bug when I rewrote the playground. We were never showing the default selected PM until after the sheet was shown. Now we show the default selected PM once the flow controller is configured.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix a bug in the new playground.
