### PR TITLE
[FC] Live events - Rely on client events for non-error events.

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -85,7 +85,7 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
         withState { state ->
             viewModelScope.launch {
                 kotlin.runCatching {
-                    synchronizeFinancialConnectionsSession(emitEvents = true)
+                    synchronizeFinancialConnectionsSession()
                 }.onFailure {
                     finishWithResult(state, Failed(it))
                 }.onSuccess {
@@ -116,6 +116,7 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
                 )
             }
         } else {
+            FinancialConnections.emitEvent(name = Name.OPEN)
             if (nativeAuthFlowEnabled) {
                 setState {
                     copy(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsResponseEventEmitter.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsResponseEventEmitter.kt
@@ -45,8 +45,8 @@ internal class FinancialConnectionsResponseEventEmitter @Inject constructor(
             .optJSONObject("error")
             ?.optJSONObject("extra_fields")
 
-        // success responses: events to emit come in the root json object
-        else -> responseJson()
+        // success responses: events are emitted by clients.
+        else -> null
     }
         ?.optString(EVENTS_TO_EMIT)
         ?.takeIf { it.isNotEmpty() }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/RetrieveAuthorizationSession.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/RetrieveAuthorizationSession.kt
@@ -18,10 +18,6 @@ internal class RetrieveAuthorizationSession @Inject constructor(
         return repository.retrieveAuthorizationSession(
             clientSecret = configuration.financialConnectionsSessionClientSecret,
             sessionId = authorizationSessionId,
-            // Retrieve session is currently just called after returning from institution
-            // auth, and we expect a "institution_authorized" event.
-            // If we ever call this method in other places, this value should be passed in.
-            emitEvents = true
         ).also { coordinator().emit(Message.ClearPartnerWebAuth) }
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SynchronizeFinancialConnectionsSession.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SynchronizeFinancialConnectionsSession.kt
@@ -18,21 +18,10 @@ internal class SynchronizeFinancialConnectionsSession @Inject constructor(
     private val financialConnectionsRepository: FinancialConnectionsManifestRepository
 ) {
 
-    /**
-     * @param emitEvents whether the backend should return live events to emit in the response.
-     * events should just be emitted on the first sync call.
-     */
-    suspend operator fun invoke(
-        emitEvents: Boolean
-    ): SynchronizeSessionResponse {
+    suspend operator fun invoke(): SynchronizeSessionResponse {
         return financialConnectionsRepository.synchronizeFinancialConnectionsSession(
             clientSecret = configuration.financialConnectionsSessionClientSecret,
             applicationId = applicationId,
-            // Sync session is called in a few places:
-            // - when the flow starts -> we expect an "open" event.
-            // - networking account picker (to retrieve the latest TextUpdate) -> no events expected
-            // - after process kills, to restore the session. -> no events expected
-            emitEvents = emitEvents
         )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
@@ -8,6 +8,7 @@ import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.ViewModelContext
 import com.stripe.android.core.Logger
+import com.stripe.android.financialconnections.FinancialConnections
 import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.AccountSelected
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.ClickLearnMoreDataAccess
@@ -15,6 +16,7 @@ import com.stripe.android.financialconnections.analytics.FinancialConnectionsAna
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.PaneLoaded
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.PollAccountsSucceeded
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
+import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.Name
 import com.stripe.android.financialconnections.analytics.logError
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.PollAuthorizationSessionAccounts
@@ -214,6 +216,7 @@ internal class AccountPickerViewModel @Inject constructor(
         viewModelScope.launch {
             eventTracker.track(ClickLinkAccounts(PANE))
         }
+        FinancialConnections.emitEvent(name = Name.ACCOUNTS_SELECTED)
         withState { state ->
             state.payload()?.let {
                 submitAccounts(state.selectedIds, updateLocalCache = true)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentViewModel.kt
@@ -5,10 +5,12 @@ import com.airbnb.mvrx.MavericksViewModel
 import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.ViewModelContext
 import com.stripe.android.core.Logger
+import com.stripe.android.financialconnections.FinancialConnections
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.Click
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.ConsentAgree
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.PaneLoaded
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
+import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.Name
 import com.stripe.android.financialconnections.analytics.logError
 import com.stripe.android.financialconnections.domain.AcceptConsent
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
@@ -74,6 +76,7 @@ internal class ConsentViewModel @Inject constructor(
     fun onContinueClick() {
         suspend {
             eventTracker.track(ConsentAgree)
+            FinancialConnections.emitEvent(Name.CONSENT_ACQUIRED)
             val updatedManifest: FinancialConnectionsSessionManifest = acceptConsent()
             navigationManager.tryNavigateTo(updatedManifest.nextPane.destination(referrer = Pane.CONSENT))
         }.execute { copy(acceptConsent = it) }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModel.kt
@@ -9,6 +9,7 @@ import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.ViewModelContext
 import com.stripe.android.core.Logger
+import com.stripe.android.financialconnections.FinancialConnections
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.FeaturedInstitutionsLoaded
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.InstitutionSelected
@@ -16,6 +17,8 @@ import com.stripe.android.financialconnections.analytics.FinancialConnectionsAna
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.SearchScroll
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.SearchSucceeded
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
+import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.Metadata
+import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.Name
 import com.stripe.android.financialconnections.analytics.logError
 import com.stripe.android.financialconnections.domain.FeaturedInstitutions
 import com.stripe.android.financialconnections.domain.GetManifest
@@ -145,6 +148,7 @@ internal class InstitutionPickerViewModel @Inject constructor(
                         resultCount = result.data.count()
                     )
                 )
+                FinancialConnections.emitEvent(Name.SEARCH_INITIATED)
                 result
             } else {
                 InstitutionResponse(
@@ -166,6 +170,10 @@ internal class InstitutionPickerViewModel @Inject constructor(
                     fromFeatured = fromFeatured,
                     institutionId = institution.id
                 )
+            )
+            FinancialConnections.emitEvent(
+                name = Name.INSTITUTION_SELECTED,
+                metadata = Metadata(institutionName = institution.name)
             )
             // updates local manifest with active institution and cleans auth session if present.
             updateLocalManifest {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
@@ -7,10 +7,12 @@ import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.ViewModelContext
 import com.stripe.android.core.Logger
+import com.stripe.android.financialconnections.FinancialConnections
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.Click
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.ClickLearnMoreDataAccess
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.PaneLoaded
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
+import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.Name
 import com.stripe.android.financialconnections.analytics.logError
 import com.stripe.android.financialconnections.domain.FetchNetworkedAccounts
 import com.stripe.android.financialconnections.domain.GetCachedConsumerSession
@@ -157,6 +159,7 @@ internal class LinkAccountPickerViewModel @Inject constructor(
             else -> Unit
         }
         nextPane?.let {
+            FinancialConnections.emitEvent(name = Name.ACCOUNTS_SELECTED)
             navigationManager.tryNavigateTo(it.destination(referrer = PANE))
         }
         Unit

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessViewModel.kt
@@ -7,10 +7,13 @@ import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.ViewModelContext
 import com.stripe.android.core.Logger
+import com.stripe.android.financialconnections.FinancialConnections
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.ClickDone
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.Complete
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.PaneLoaded
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
+import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.Metadata
+import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.Name
 import com.stripe.android.financialconnections.domain.CompleteFinancialConnectionsSession
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Finish
@@ -71,6 +74,10 @@ internal class ManualEntrySuccessViewModel @Inject constructor(
                 val result = Completed(
                     financialConnectionsSession = it,
                     token = it.parsedToken
+                )
+                FinancialConnections.emitEvent(
+                    name = Name.SUCCESS,
+                    metadata = Metadata(manualEntry = true)
                 )
                 nativeAuthFlowCoordinator().emit(Finish(result))
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
@@ -67,7 +67,7 @@ internal class NetworkingLinkSignupViewModel @Inject constructor(
         observeAsyncs()
         suspend {
             val manifest = getManifest()
-            val content = requireNotNull(sync(emitEvents = false).text?.networkingLinkSignupPane)
+            val content = requireNotNull(sync().text?.networkingLinkSignupPane)
             eventTracker.track(PaneLoaded(PANE))
             NetworkingLinkSignupState.Payload(
                 content = content,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessViewModel.kt
@@ -96,7 +96,7 @@ internal class SuccessViewModel @Inject constructor(
             },
             onSuccess = {
                 if (it.skipSuccessPane.not()) {
-                    eventTracker.track(PaneLoaded(Pane.SUCCESS))
+                    eventTracker.track(PaneLoaded(PANE))
                 } else {
                     completeSession()
                 }
@@ -205,7 +205,7 @@ internal class SuccessViewModel @Inject constructor(
     }
 
     fun onDoneClick() {
-        viewModelScope.launch { eventTracker.track(ClickDone(Pane.SUCCESS)) }
+        viewModelScope.launch { eventTracker.track(ClickDone(PANE)) }
         completeSession()
     }
 
@@ -222,13 +222,13 @@ internal class SuccessViewModel @Inject constructor(
 
     fun onLearnMoreAboutDataAccessClick() {
         viewModelScope.launch {
-            eventTracker.track(ClickLearnMoreDataAccess(Pane.SUCCESS))
+            eventTracker.track(ClickLearnMoreDataAccess(PANE))
         }
     }
 
     fun onDisconnectLinkClick() {
         viewModelScope.launch {
-            eventTracker.track(ClickDisconnectLink(Pane.SUCCESS))
+            eventTracker.track(ClickDisconnectLink(PANE))
         }
     }
 
@@ -246,6 +246,8 @@ internal class SuccessViewModel @Inject constructor(
                 .build()
                 .viewModel
         }
+
+        private val PANE = Pane.SUCCESS
     }
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessViewModel.kt
@@ -8,6 +8,7 @@ import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.ViewModelContext
 import com.stripe.android.core.Logger
+import com.stripe.android.financialconnections.FinancialConnections
 import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.ClickDisconnectLink
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.ClickDone
@@ -15,6 +16,8 @@ import com.stripe.android.financialconnections.analytics.FinancialConnectionsAna
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.Complete
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.PaneLoaded
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
+import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.Metadata
+import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.Name
 import com.stripe.android.financialconnections.domain.CompleteFinancialConnectionsSession
 import com.stripe.android.financialconnections.domain.GetCachedAccounts
 import com.stripe.android.financialconnections.domain.GetManifest
@@ -208,7 +211,12 @@ internal class SuccessViewModel @Inject constructor(
 
     private fun completeSession() {
         suspend {
-            completeFinancialConnectionsSession()
+            completeFinancialConnectionsSession().also {
+                FinancialConnections.emitEvent(
+                    name = Name.SUCCESS,
+                    metadata = Metadata(manualEntry = false)
+                )
+            }
         }.execute { copy(completeSession = it) }
     }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -262,7 +262,6 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
                     )
                     when {
                         session.isCustomManualEntryError() -> {
-                            FinancialConnections.emitEvent(name = Name.MANUAL_ENTRY_INITIATED)
                             finishWithResult(Failed(CustomManualEntryRequiredError()))
                         }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -12,6 +12,7 @@ import com.airbnb.mvrx.PersistState
 import com.airbnb.mvrx.ViewModelContext
 import com.airbnb.mvrx.compose.mavericksActivityViewModel
 import com.stripe.android.core.Logger
+import com.stripe.android.financialconnections.FinancialConnections
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.AppBackgrounded
@@ -20,6 +21,7 @@ import com.stripe.android.financialconnections.analytics.FinancialConnectionsAna
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.Complete
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.PaneLaunched
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
+import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.Name
 import com.stripe.android.financialconnections.di.APPLICATION_ID
 import com.stripe.android.financialconnections.di.DaggerFinancialConnectionsSheetNativeComponent
 import com.stripe.android.financialconnections.di.FinancialConnectionsSheetNativeComponent
@@ -36,6 +38,7 @@ import com.stripe.android.financialconnections.launcher.FinancialConnectionsShee
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityResult.Completed
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityResult.Failed
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetNativeActivityArgs
+import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane.NETWORKING_LINK_SIGNUP_PANE
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane.UNEXPECTED_ERROR
@@ -259,26 +262,27 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
                     )
                     when {
                         session.isCustomManualEntryError() -> {
-                            val result = Failed(CustomManualEntryRequiredError())
-                            setState { copy(viewEffect = Finish(result)) }
+                            FinancialConnections.emitEvent(name = Name.MANUAL_ENTRY_INITIATED)
+                            finishWithResult(Failed(CustomManualEntryRequiredError()))
                         }
 
-                        session.accounts.data.isNotEmpty() ||
-                            session.paymentAccount != null ||
-                            session.bankAccountToken != null -> {
-                            val result = Completed(
-                                financialConnectionsSession = session,
-                                token = session.parsedToken
+                        session.hasAValidAccount() -> {
+                            FinancialConnections.emitEvent(name = Name.SUCCESS)
+                            finishWithResult(
+                                Completed(
+                                    financialConnectionsSession = session,
+                                    token = session.parsedToken
+                                )
                             )
-                            setState { copy(viewEffect = Finish(result)) }
                         }
 
-                        closeAuthFlowError != null -> setState {
-                            copy(viewEffect = Finish(Failed(closeAuthFlowError)))
+                        closeAuthFlowError != null -> {
+                            finishWithResult(Failed(closeAuthFlowError))
                         }
 
-                        else -> setState {
-                            copy(viewEffect = Finish(Canceled))
+                        else -> {
+                            FinancialConnections.emitEvent(name = Name.CANCEL)
+                            finishWithResult(Canceled)
                         }
                     }
                 }
@@ -292,16 +296,21 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
                             connectedAccounts = null
                         )
                     )
-                    setState {
-                        copy(
-                            viewEffect = Finish(
-                                Failed(closeAuthFlowError ?: completeSessionError)
-                            )
-                        )
-                    }
+                    finishWithResult(Failed(closeAuthFlowError ?: completeSessionError))
                 }
         }
     }
+
+    private fun finishWithResult(
+        result: FinancialConnectionsSheetActivityResult
+    ) {
+        setState { copy(viewEffect = Finish(result)) }
+    }
+
+    private fun FinancialConnectionsSession.hasAValidAccount() =
+        accounts.data.isNotEmpty() ||
+            paymentAccount != null ||
+            bankAccountToken != null
 
     fun onPaneLaunched(pane: Pane, referrer: Pane?) {
         viewModelScope.launch {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepository.kt
@@ -53,8 +53,7 @@ internal interface FinancialConnectionsManifestRepository {
     )
     suspend fun synchronizeFinancialConnectionsSession(
         clientSecret: String,
-        applicationId: String,
-        emitEvents: Boolean
+        applicationId: String
     ): SynchronizeSessionResponse
 
     /**
@@ -119,8 +118,7 @@ internal interface FinancialConnectionsManifestRepository {
 
     suspend fun retrieveAuthorizationSession(
         clientSecret: String,
-        sessionId: String,
-        emitEvents: Boolean
+        sessionId: String
     ): FinancialConnectionsAuthorizationSession
 
     /**
@@ -228,7 +226,6 @@ private class FinancialConnectionsManifestRepositoryImpl(
                 synchronizeRequest(
                     applicationId = applicationId,
                     clientSecret = clientSecret,
-                    emitEvents = false
                 ),
                 SynchronizeSessionResponse.serializer()
             ).also { updateCachedSynchronizeSessionResponse("get/fetch", it) }
@@ -237,14 +234,12 @@ private class FinancialConnectionsManifestRepositoryImpl(
 
     override suspend fun synchronizeFinancialConnectionsSession(
         clientSecret: String,
-        applicationId: String,
-        emitEvents: Boolean
+        applicationId: String
     ): SynchronizeSessionResponse = mutex.withLock {
         val financialConnectionsRequest =
             synchronizeRequest(
                 applicationId = applicationId,
                 clientSecret = clientSecret,
-                emitEvents = emitEvents
             )
         return requestExecutor.execute(
             financialConnectionsRequest,
@@ -255,13 +250,12 @@ private class FinancialConnectionsManifestRepositoryImpl(
     private fun synchronizeRequest(
         applicationId: String,
         clientSecret: String,
-        emitEvents: Boolean
     ): ApiRequest = apiRequestFactory.createPost(
         url = synchronizeSessionUrl,
         options = apiOptions,
         params = mapOf(
             "expand" to listOf("manifest.active_auth_session"),
-            "emit_events" to emitEvents,
+            "emit_events" to true,
             "locale" to locale.toLanguageTag(),
             "mobile" to mapOf(
                 PARAMS_FULLSCREEN to true,
@@ -359,8 +353,7 @@ private class FinancialConnectionsManifestRepositoryImpl(
 
     override suspend fun retrieveAuthorizationSession(
         clientSecret: String,
-        sessionId: String,
-        emitEvents: Boolean
+        sessionId: String
     ): FinancialConnectionsAuthorizationSession = requestExecutor.execute(
         request = apiRequestFactory.createPost(
             url = retrieveAuthSessionUrl,
@@ -368,7 +361,7 @@ private class FinancialConnectionsManifestRepositoryImpl(
             params = mapOf(
                 NetworkConstants.PARAMS_ID to sessionId,
                 NetworkConstants.PARAMS_CLIENT_SECRET to clientSecret,
-                "emit_events" to emitEvents
+                "emit_events" to true
             )
         ),
         FinancialConnectionsAuthorizationSession.serializer()

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
@@ -83,7 +83,7 @@ class FinancialConnectionsSheetViewModelTest {
             whenever(synchronizeFinancialConnectionsSession(emitEvents = true)).thenReturn(syncResponse)
             createViewModel(defaultInitialState)
 
-            verify(synchronizeFinancialConnectionsSession).invoke(emitEvents = true)
+            verify(synchronizeFinancialConnectionsSession).invoke()
         }
 
     @Test

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
@@ -80,7 +80,7 @@ class FinancialConnectionsSheetViewModelTest {
     @Test
     fun `init - if manifest not present in initial state, fetchManifest triggered`() =
         runTest {
-            whenever(synchronizeFinancialConnectionsSession(emitEvents = true)).thenReturn(syncResponse)
+            whenever(synchronizeFinancialConnectionsSession()).thenReturn(syncResponse)
             createViewModel(defaultInitialState)
 
             verify(synchronizeFinancialConnectionsSession).invoke()
@@ -99,7 +99,7 @@ class FinancialConnectionsSheetViewModelTest {
     fun `init - When no browser available, AuthFlow closes and logs error`() = runTest {
         // Given
         whenever(browserManager.canOpenHttpsUrl()).thenReturn(false)
-        whenever(synchronizeFinancialConnectionsSession(emitEvents = true)).thenReturn(syncResponse)
+        whenever(synchronizeFinancialConnectionsSession()).thenReturn(syncResponse)
 
         // When
         val viewModel = createViewModel(defaultInitialState)
@@ -129,7 +129,7 @@ class FinancialConnectionsSheetViewModelTest {
         runTest {
             // Given
             whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)
-            whenever(synchronizeFinancialConnectionsSession(emitEvents = true)).thenReturn(syncResponse)
+            whenever(synchronizeFinancialConnectionsSession()).thenReturn(syncResponse)
             val viewModel = createViewModel(defaultInitialState)
 
             // When
@@ -147,7 +147,7 @@ class FinancialConnectionsSheetViewModelTest {
             // Given
             val linkedAccountId = "1234"
             whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)
-            whenever(synchronizeFinancialConnectionsSession(emitEvents = true)).thenReturn(syncResponse)
+            whenever(synchronizeFinancialConnectionsSession()).thenReturn(syncResponse)
             val viewModel = createViewModel(
                 defaultInitialState.copy(initialArgs = ForLink(configuration))
             )
@@ -174,7 +174,7 @@ class FinancialConnectionsSheetViewModelTest {
     fun `handleOnNewIntent - on Link flows with invalid account, error is thrown`() {
         runTest {
             // Given
-            whenever(synchronizeFinancialConnectionsSession(emitEvents = true)).thenReturn(syncResponse)
+            whenever(synchronizeFinancialConnectionsSession()).thenReturn(syncResponse)
             whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)
             val viewModel = createViewModel(
                 defaultInitialState.copy(initialArgs = ForLink(configuration))
@@ -204,7 +204,7 @@ class FinancialConnectionsSheetViewModelTest {
             whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)
             whenever(fetchFinancialConnectionsSession(any()))
                 .thenReturn(financialConnectionsSessionWithNoMoreAccounts)
-            whenever(synchronizeFinancialConnectionsSession(emitEvents = true)).thenReturn(syncResponse)
+            whenever(synchronizeFinancialConnectionsSession()).thenReturn(syncResponse)
             val viewModel = createViewModel(defaultInitialState)
             val cancelIntent = cancelIntent()
 
@@ -225,7 +225,7 @@ class FinancialConnectionsSheetViewModelTest {
             whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)
             whenever(fetchFinancialConnectionsSession(any()))
                 .thenReturn(financialConnectionsSessionWithNoMoreAccounts)
-            whenever(synchronizeFinancialConnectionsSession(emitEvents = true)).thenReturn(syncResponse)
+            whenever(synchronizeFinancialConnectionsSession()).thenReturn(syncResponse)
             val viewModel = createViewModel(defaultInitialState)
 
             // When
@@ -251,7 +251,7 @@ class FinancialConnectionsSheetViewModelTest {
                 )
             )
             whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)
-            whenever(synchronizeFinancialConnectionsSession(emitEvents = true)).thenReturn(syncResponse)
+            whenever(synchronizeFinancialConnectionsSession()).thenReturn(syncResponse)
             whenever(fetchFinancialConnectionsSession(any())).thenReturn(expectedSession)
             val viewModel = createViewModel(defaultInitialState)
 
@@ -272,7 +272,7 @@ class FinancialConnectionsSheetViewModelTest {
     fun `handleOnNewIntent - when intent with unknown received, then finish with Result#Failed`() =
         runTest {
             // Given
-            whenever(synchronizeFinancialConnectionsSession(emitEvents = true)).thenReturn(syncResponse)
+            whenever(synchronizeFinancialConnectionsSession()).thenReturn(syncResponse)
             val viewModel = createViewModel(defaultInitialState)
             val errorIntent = Intent()
 
@@ -294,7 +294,7 @@ class FinancialConnectionsSheetViewModelTest {
             // Given
             val expectedSession = financialConnectionsSession()
             whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)
-            whenever(synchronizeFinancialConnectionsSession(emitEvents = true)).thenReturn(syncResponse)
+            whenever(synchronizeFinancialConnectionsSession()).thenReturn(syncResponse)
             whenever(fetchFinancialConnectionsSession(any())).thenReturn(expectedSession)
 
             val viewModel = createViewModel(defaultInitialState)
@@ -321,7 +321,7 @@ class FinancialConnectionsSheetViewModelTest {
                 "skip_aggregation=true&referral_source=APP&client_redirect_url=123"
             val nativeRedirectUrl = "stripe-auth://native-redirect/com.example.app/$aggregatorUrl"
             val expectedSession = financialConnectionsSession()
-            whenever(synchronizeFinancialConnectionsSession(emitEvents = true)).thenReturn(syncResponse)
+            whenever(synchronizeFinancialConnectionsSession()).thenReturn(syncResponse)
             whenever(fetchFinancialConnectionsSession(any())).thenReturn(expectedSession)
 
             val viewModel = createViewModel(defaultInitialState)
@@ -347,7 +347,7 @@ class FinancialConnectionsSheetViewModelTest {
                 "stripe-auth://link-accounts/com.example.app/authentication_return#$returnUrlQueryParams"
             val expectedSession = financialConnectionsSession()
             whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)
-            whenever(synchronizeFinancialConnectionsSession(emitEvents = true)).thenReturn(syncResponse)
+            whenever(synchronizeFinancialConnectionsSession()).thenReturn(syncResponse)
             whenever(fetchFinancialConnectionsSession(any())).thenReturn(expectedSession)
 
             val viewModel = createViewModel(defaultInitialState)
@@ -372,7 +372,7 @@ class FinancialConnectionsSheetViewModelTest {
             // Given
             val apiException = APIException()
             whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)
-            whenever(synchronizeFinancialConnectionsSession(emitEvents = true)).thenReturn(syncResponse)
+            whenever(synchronizeFinancialConnectionsSession()).thenReturn(syncResponse)
             whenever(fetchFinancialConnectionsSession.invoke(any())).thenAnswer { throw apiException }
             val viewModel = createViewModel(defaultInitialState)
 
@@ -393,7 +393,7 @@ class FinancialConnectionsSheetViewModelTest {
         runTest {
             // Given
             whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)
-            whenever(synchronizeFinancialConnectionsSession(emitEvents = true)).thenReturn(syncResponse)
+            whenever(synchronizeFinancialConnectionsSession()).thenReturn(syncResponse)
             whenever(fetchFinancialConnectionsSession(any())).thenAnswer { throw APIException() }
             val viewModel = createViewModel(defaultInitialState)
             // When
@@ -414,7 +414,7 @@ class FinancialConnectionsSheetViewModelTest {
         runTest {
             // Given
             whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)
-            whenever(synchronizeFinancialConnectionsSession(emitEvents = true))
+            whenever(synchronizeFinancialConnectionsSession())
                 .thenReturn(
                     syncResponse.copy(
                         manifest = sessionManifest().copy(
@@ -470,7 +470,7 @@ class FinancialConnectionsSheetViewModelTest {
         runTest {
             // Given
             whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)
-            whenever(synchronizeFinancialConnectionsSession(emitEvents = true)).thenReturn(syncResponse)
+            whenever(synchronizeFinancialConnectionsSession()).thenReturn(syncResponse)
 
             // When
             val viewModel = createViewModel(defaultInitialState)

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsResponseEventEmitterTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsResponseEventEmitterTest.kt
@@ -61,27 +61,4 @@ class FinancialConnectionsResponseEventEmitterTest {
             )
         )
     }
-
-    @Test
-    fun `emmitIfPresent - consent acquired`() {
-        val response = StripeResponse(
-            code = 200,
-            body = """
-            {
-                "events_to_emit": "[{\"type\":\"consent_acquired\"}]"
-            }
-            """.trimIndent()
-
-        )
-
-        emitter.emitIfPresent(response)
-
-        assertContains(
-            liveEvents,
-            FinancialConnectionsEvent(
-                name = Name.CONSENT_ACQUIRED,
-                metadata = Metadata()
-            )
-        )
-    }
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
@@ -65,7 +65,7 @@ class NetworkingLinkSignupViewModelTest {
             businessName = "Business",
             accountholderCustomerEmailAddress = "test@test.com"
         )
-        whenever(sync(emitEvents = false)).thenReturn(
+        whenever(sync()).thenReturn(
             syncResponse().copy(
                 text = TextUpdate(
                     consent = null,

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsManifestRepository.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsManifestRepository.kt
@@ -63,8 +63,7 @@ internal class FakeFinancialConnectionsManifestRepository : FinancialConnections
 
     override suspend fun retrieveAuthorizationSession(
         clientSecret: String,
-        sessionId: String,
-        emitEvents: Boolean
+        sessionId: String
     ): FinancialConnectionsAuthorizationSession {
         TODO("Not yet implemented")
     }
@@ -98,8 +97,7 @@ internal class FakeFinancialConnectionsManifestRepository : FinancialConnections
 
     override suspend fun synchronizeFinancialConnectionsSession(
         clientSecret: String,
-        applicationId: String,
-        emitEvents: Boolean
+        applicationId: String
     ): SynchronizeSessionResponse = getSynchronizeSessionResponseProvider()
 
     override fun updateLocalManifest(


### PR DESCRIPTION
# Summary

- Remove backend-driven event response.
- Manually trigger client events
- Still emit events in error responses 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-4c30ea92-7fff-9c52-629b-0210ba37fd25"><div dir="ltr" style="margin-left:0pt;" align="center">

Name | Description | Metadata
-- | -- | --
open | The modal successfully opens |  
manual_entry_initiated | Manual entry flow initiated |  
consent_acquired | “Agree and continue” selected on consent pane |  
search_initiated | The search bar is selected, the user types some search terms and gets an API response. This returns for ANY successful search API response. |  
institution_selected | Institution selected, either from featured institutions or search results | {institutionName: string}This will match the institution name on the Authorization object
institution_authorized | Successful authorization completed |  
accounts_selected | Accounts selected and “confirm” selected |  
success | The flow is completed and selected accounts are correctly attached to the payment instrument. | {manualEntry?: boolean}
error | An error is encountered; see error codes for more | {errorCode: ErrorCode}
cancel | The modal is closed by the user, either by clicking the “X” or clicking outside the modal |  