### PR TITLE
Add Bacs support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### PaymentSheet
 * [ADDED][7713](https://github.com/stripe/stripe-android/pull/7713) PaymentSheet now supports [card brand choice](https://stripe.com/docs/card-brand-choice) for eligible merchants and transactions. To provide a list of preferred networks, use `PaymentSheet.Configuration.preferredNetworks`.
+* [ADDED][7447](https://github.com/stripe/stripe-android/pull/7447) PaymentSheet now supports [Bacs Direct Debit](https://stripe.com/docs/payments/payment-methods/bacs-debit) for PaymentIntents.
 
 ### CustomerSheet
 * [ADDED][7713](https://github.com/stripe/stripe-android/pull/7713) CustomerSheet now supports [card brand choice](https://stripe.com/docs/card-brand-choice) for eligible merchants and transactions. To provide a list of preferred networks, use `PaymentSheet.Configuration.preferredNetworks`.

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -128,10 +128,6 @@ public final class com/stripe/android/ui/core/elements/BacsDebitBankAccountSpec$
 	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/stripe/android/ui/core/elements/BacsDebitBankAccountSpec$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
 public final class com/stripe/android/ui/core/elements/BacsDebitConfirmSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/BacsDebitConfirmSpec$$serializer;

--- a/payments-ui-core/res/values/strings.xml
+++ b/payments-ui-core/res/values/strings.xml
@@ -67,6 +67,8 @@
   <string name="stripe_paymentsheet_buy_using_upi_id">Buy using a UPI ID</string>
   <!-- Payment Method type brand name. -->
   <string name="stripe_paymentsheet_payment_method_au_becs_debit">AU BECS Direct Debit</string>
+  <!-- Payment Method type brand name. -->
+  <string name="stripe_paymentsheet_payment_method_bacs_debit">Bacs Direct Debit</string>
   <!-- Title for credit card number entry field -->
   <string name="stripe_paymentsheet_payment_method_card">Card</string>
   <!-- Label for Konbini Payment Method -->

--- a/payments-ui-core/src/main/assets/lpms.json
+++ b/payments-ui-core/src/main/assets/lpms.json
@@ -756,6 +756,11 @@
     }
   },
   {
+    "type": "bacs_debit",
+    "async": true,
+    "fields": []
+  },
+  {
     "type": "revolut_pay",
     "async": false,
     "selector_icon": {

--- a/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
@@ -227,6 +227,15 @@ internal val AuBecsDebitRequirement = PaymentMethodRequirements(
     confirmPMFromCustomer = true
 )
 
+/**
+ * This defines the requirements for usage as a Payment Method.
+ */
+internal val BacsDebitRequirement = PaymentMethodRequirements(
+    piRequirements = setOf(Delayed),
+    siRequirements = null,
+    confirmPMFromCustomer = null
+)
+
 internal val ZipRequirement = PaymentMethodRequirements(
     piRequirements = emptySet(),
     siRequirements = null,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
@@ -24,6 +24,8 @@ import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.elements.SaveForFutureUseElementUI
 import com.stripe.android.ui.core.elements.StaticTextElement
 import com.stripe.android.ui.core.elements.StaticTextElementUI
+import com.stripe.android.uicore.elements.CheckboxFieldElement
+import com.stripe.android.uicore.elements.CheckboxFieldUI
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.OTPElement
@@ -75,6 +77,10 @@ fun FormUI(
                         element,
                         hiddenIdentifiers,
                         lastTextFieldIdentifier
+                    )
+                    is CheckboxFieldElement -> CheckboxFieldUI(
+                        controller = element.controller,
+                        enabled = enabled
                     )
                     is StaticTextElement -> StaticTextElementUI(element)
                     is SaveForFutureUseElement -> SaveForFutureUseElementUI(enabled, element)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitBankAccountSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitBankAccountSpec.kt
@@ -10,6 +10,9 @@ import kotlinx.serialization.Serializable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 @Serializable
 class BacsDebitBankAccountSpec : FormItemSpec() {
+    private val sortCodeIdentifier = IdentifierSpec.Generic(SORT_CODE_API_PATH)
+    private val accountNumberIdentifier = IdentifierSpec.Generic(ACCOUNT_NUMBER_API_PATH)
+
     override val apiPath: IdentifierSpec = IdentifierSpec()
 
     fun transform(
@@ -17,20 +20,25 @@ class BacsDebitBankAccountSpec : FormItemSpec() {
     ) = createSectionElement(
         listOf(
             SimpleTextElement(
-                IdentifierSpec.Generic("bacs_debit[sort_code]"),
+                sortCodeIdentifier,
                 SimpleTextFieldController(
                     BacsDebitSortCodeConfig(),
-                    initialValue = initialValues[this.apiPath]
+                    initialValue = initialValues[sortCodeIdentifier]
                 )
             ),
             SimpleTextElement(
-                IdentifierSpec.Generic("bacs_debit[account_number]"),
+                accountNumberIdentifier,
                 SimpleTextFieldController(
                     BacsDebitAccountNumberConfig(),
-                    initialValue = initialValues[this.apiPath]
+                    initialValue = initialValues[accountNumberIdentifier]
                 )
             )
         ),
         R.string.stripe_bacs_bank_account_title
     )
+
+    private companion object {
+        const val SORT_CODE_API_PATH = "bacs_debit[sort_code]"
+        const val ACCOUNT_NUMBER_API_PATH = "bacs_debit[account_number]"
+    }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitConfirmSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitConfirmSpec.kt
@@ -10,19 +10,20 @@ import kotlinx.serialization.Serializable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 @Serializable
 class BacsDebitConfirmSpec : FormItemSpec() {
-    override val apiPath: IdentifierSpec = IdentifierSpec(
-        v1 = "bacs_debit[confirmed]",
-        ignoreField = true
-    )
+    override val apiPath: IdentifierSpec = IdentifierSpec.BacsDebitConfirmed
 
-    fun transform(merchantName: String) = CheckboxFieldElement(
+    fun transform(
+        merchantName: String,
+        initialValues: Map<IdentifierSpec, String?>
+    ) = CheckboxFieldElement(
         apiPath,
         CheckboxFieldController(
             labelResource = CheckboxFieldController.LabelResource(
                 R.string.stripe_bacs_confirm_mandate_label,
                 merchantName
             ),
-            debugTag = "BACS_MANDATE_CHECKBOX"
+            debugTag = "BACS_MANDATE_CHECKBOX",
+            initialValue = initialValues[this.apiPath].toBoolean()
         )
     )
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
@@ -74,7 +74,7 @@ class TransformSpecToElements(
                 is MandateTextSpec -> it.transform(merchantName)
                 is AuBecsDebitMandateTextSpec -> it.transform(merchantName)
                 is BacsDebitBankAccountSpec -> it.transform(initialValues)
-                is BacsDebitConfirmSpec -> it.transform(merchantName)
+                is BacsDebitConfirmSpec -> it.transform(merchantName, initialValues)
                 is CardDetailsSectionSpec -> it.transform(
                     context = context,
                     cbcEligibility = cbcEligibility,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
@@ -20,6 +20,7 @@ import com.stripe.android.paymentsheet.forms.AlipayRequirement
 import com.stripe.android.paymentsheet.forms.AlmaRequirement
 import com.stripe.android.paymentsheet.forms.AmazonPayRequirement
 import com.stripe.android.paymentsheet.forms.AuBecsDebitRequirement
+import com.stripe.android.paymentsheet.forms.BacsDebitRequirement
 import com.stripe.android.paymentsheet.forms.BancontactRequirement
 import com.stripe.android.paymentsheet.forms.BlikRequirement
 import com.stripe.android.paymentsheet.forms.BoletoRequirement
@@ -47,6 +48,8 @@ import com.stripe.android.paymentsheet.forms.ZipRequirement
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.AfterpayClearpayHeaderElement.Companion.isClearpay
+import com.stripe.android.ui.core.elements.BacsDebitBankAccountSpec
+import com.stripe.android.ui.core.elements.BacsDebitConfirmSpec
 import com.stripe.android.ui.core.elements.CardBillingSpec
 import com.stripe.android.ui.core.elements.CardDetailsSectionSpec
 import com.stripe.android.ui.core.elements.CashAppPayMandateTextSpec
@@ -56,6 +59,7 @@ import com.stripe.android.ui.core.elements.FormItemSpec
 import com.stripe.android.ui.core.elements.LayoutSpec
 import com.stripe.android.ui.core.elements.LpmSerializer
 import com.stripe.android.ui.core.elements.MandateTextSpec
+import com.stripe.android.ui.core.elements.PlaceholderSpec
 import com.stripe.android.ui.core.elements.SaveForFutureUseSpec
 import com.stripe.android.ui.core.elements.SharedDataSpec
 import com.stripe.android.ui.core.elements.transform
@@ -468,6 +472,45 @@ class LpmRepository constructor(
             requirement = AuBecsDebitRequirement,
             formSpec = LayoutSpec(sharedDataSpec.fields)
         )
+        PaymentMethod.Type.BacsDebit.code -> {
+            val localFields = listOfNotNull(
+                PlaceholderSpec(
+                    apiPath = IdentifierSpec.Name,
+                    field = PlaceholderSpec.PlaceholderField.Name
+                ),
+                PlaceholderSpec(
+                    apiPath = IdentifierSpec.Email,
+                    field = PlaceholderSpec.PlaceholderField.Email
+                ),
+                PlaceholderSpec(
+                    apiPath = IdentifierSpec.Phone,
+                    field = PlaceholderSpec.PlaceholderField.Phone
+                ),
+                BacsDebitBankAccountSpec(),
+                PlaceholderSpec(
+                    apiPath = IdentifierSpec.BillingAddress,
+                    field = PlaceholderSpec.PlaceholderField.BillingAddress
+                ),
+                BacsDebitConfirmSpec()
+            )
+
+            SupportedPaymentMethod(
+                code = "bacs_debit",
+                requiresMandate = true,
+                displayNameResource = R.string.stripe_paymentsheet_payment_method_bacs_debit,
+                iconResource = R.drawable.stripe_ic_paymentsheet_pm_bank,
+                lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+                darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+                tintIconOnSelection = true,
+                requirement = BacsDebitRequirement,
+                formSpec = LayoutSpec(items = sharedDataSpec.fields + localFields),
+                placeholderOverrideList = listOf(
+                    IdentifierSpec.Name,
+                    IdentifierSpec.Email,
+                    IdentifierSpec.BillingAddress
+                )
+            )
+        }
         PaymentMethod.Type.USBankAccount.code -> {
             val pmo = stripeIntent.getPaymentMethodOptions()[PaymentMethod.Type.USBankAccount.code]
             val verificationMethod = (pmo as? Map<*, *>)?.get("verification_method") as? String

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestBacs.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestBacs.kt
@@ -1,0 +1,60 @@
+package com.stripe.android.lpm
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.paymentsheet.example.playground.settings.AutomaticPaymentMethodsSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Country
+import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
+import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymentMethodsSettingsDefinition
+import com.stripe.android.test.core.AuthorizeAction
+import com.stripe.android.test.core.TestParameters
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class TestBacs : BasePlaygroundTest() {
+    @Test
+    fun testBacsWhenConfirmed() {
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = createTestParameters(AuthorizeAction.Bacs.Confirm)
+        )
+    }
+
+    @Test
+    fun testBacsWhenCancelled() {
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = createTestParameters(AuthorizeAction.Bacs.ModifyDetails)
+        )
+    }
+
+    @Test
+    fun testBacsWhenConfirmedInCustomFlow() {
+        testDriver.confirmCustomAndBuy(
+            testParameters = createTestParameters(AuthorizeAction.Bacs.Confirm)
+        )
+    }
+
+    @Test
+    fun testBacsWhenCancelledInCustomFlow() {
+        testDriver.confirmCustomAndBuy(
+            testParameters = createTestParameters(AuthorizeAction.Bacs.ModifyDetails)
+        )
+    }
+
+    private fun createTestParameters(
+        bacsAuthAction: AuthorizeAction.Bacs
+    ): TestParameters {
+        return TestParameters.create(
+            paymentMethodCode = "bacs_debit",
+        ) { settings ->
+            settings[AutomaticPaymentMethodsSettingsDefinition] = true
+            settings[DelayedPaymentMethodsSettingsDefinition] = true
+            settings[CountrySettingsDefinition] = Country.GB
+            settings[CurrencySettingsDefinition] = Currency.GBP
+        }.copy(
+            authorizationAction = bacsAuthAction
+        )
+    }
+}

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/FieldPopulator.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/FieldPopulator.kt
@@ -14,6 +14,8 @@ import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillin
 import com.stripe.android.test.core.ui.Selectors
 import com.stripe.android.ui.core.elements.AddressSpec
 import com.stripe.android.ui.core.elements.AuBankAccountNumberSpec
+import com.stripe.android.ui.core.elements.BacsDebitBankAccountSpec
+import com.stripe.android.ui.core.elements.BacsDebitConfirmSpec
 import com.stripe.android.ui.core.elements.BoletoTaxIdSpec
 import com.stripe.android.ui.core.elements.BsbSpec
 import com.stripe.android.ui.core.elements.CardBillingSpec
@@ -99,6 +101,8 @@ internal class FieldPopulator(
         val cardCvc: String = "321",
         val auBecsBsbNumber: String = "000000",
         val auBecsAccountNumber: String = "000123456",
+        val bacsSortCode: String = "108800",
+        val bacsAccountNumber: String = "00012345",
         val boletoTaxId: String = "00000000000",
     )
 
@@ -156,6 +160,16 @@ internal class FieldPopulator(
                     selectors.getAuAccountNumber()
                         .assertContentDescriptionEquals(values.auBecsAccountNumber)
                 }
+                is BacsDebitBankAccountSpec -> {
+                    selectors.getBacsAccountNumber()
+                        .assertContentDescriptionEquals(values.bacsAccountNumber)
+                    selectors.getBacsSortCode()
+                        .assertContentDescriptionEquals(values.bacsSortCode)
+                }
+                is BacsDebitConfirmSpec -> {
+                    selectors.getBacsConfirmed()
+                        .assertIsOn()
+                }
                 is DropdownSpec -> {}
                 is IbanSpec -> {}
                 is KlarnaCountrySpec -> {}
@@ -211,6 +225,17 @@ internal class FieldPopulator(
                     selectors.getAuAccountNumber().apply {
                         performTextInput(values.auBecsAccountNumber)
                     }
+                }
+                is BacsDebitBankAccountSpec -> {
+                    selectors.getBacsAccountNumber()
+                        .performTextInput(values.bacsAccountNumber)
+                    selectors.getBacsSortCode()
+                        .performTextInput(values.bacsSortCode)
+                }
+                is BacsDebitConfirmSpec -> {
+                    selectors.getBacsConfirmed()
+                        .performScrollTo()
+                        .performClick()
                 }
                 is IbanSpec -> {}
                 is KlarnaCountrySpec -> {}

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -770,7 +770,15 @@ internal class PlaygroundTestDriver(
                             }.isSuccess
                         }
                     }
-
+                    is AuthorizeAction.Bacs.Confirm -> {}
+                    is AuthorizeAction.Bacs.ModifyDetails -> {
+                        buyButton.apply {
+                            scrollTo()
+                            waitProcessingComplete()
+                            isEnabled()
+                            isDisplayed()
+                        }
+                    }
                     null -> {}
                 }
             } else {

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
@@ -129,4 +129,16 @@ internal sealed interface AuthorizeAction {
         override fun text(checkoutMode: CheckoutMode): String = ""
         override val requiresBrowser: Boolean = true
     }
+
+    sealed interface Bacs : AuthorizeAction {
+        object Confirm : Bacs {
+            override fun text(checkoutMode: CheckoutMode): String = "Confirm"
+            override val requiresBrowser: Boolean = false
+        }
+
+        object ModifyDetails : Bacs {
+            override fun text(checkoutMode: CheckoutMode): String = "Modify details"
+            override val requiresBrowser: Boolean = false
+        }
+    }
 }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/BuyButton.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/BuyButton.kt
@@ -36,6 +36,11 @@ class BuyButton(
             .assertIsDisplayed()
     }
 
+    fun scrollTo() {
+        composeTestRule.onNode(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
+            .performScrollTo()
+    }
+
     fun waitProcessingComplete() {
         composeTestRule.waitUntil(timeoutMillis = processingCompleteTimeout.inWholeMilliseconds) {
             runCatching {

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -2,7 +2,10 @@ package com.stripe.android.test.core.ui
 
 import android.content.pm.PackageManager
 import androidx.annotation.StringRes
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isToggleable
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -27,6 +30,7 @@ import com.stripe.android.ui.core.elements.SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG
 import kotlin.time.Duration.Companion.seconds
 import com.stripe.android.R as StripeR
 import com.stripe.android.core.R as CoreR
+import com.stripe.android.paymentsheet.R as PaymentSheetR
 import com.stripe.android.ui.core.R as PaymentsUiCoreR
 import com.stripe.android.uicore.R as UiCoreR
 
@@ -122,6 +126,7 @@ internal class Selectors(
     private val checkoutMode =
         testParameters.playgroundSettingsSnapshot[CheckoutModeSettingsDefinition]
 
+    @OptIn(ExperimentalTestApi::class)
     val authorizeAction = when (testParameters.authorizationAction) {
         is AuthorizeAction.AuthorizePayment -> {
             object : UiAutomatorText(
@@ -161,6 +166,50 @@ internal class Selectors(
                 className = "android.widget.Button",
                 device = device
             ) {}
+        }
+
+        is AuthorizeAction.Bacs.Confirm -> {
+            object : UiAutomatorText(
+                label = testParameters.authorizationAction.text(checkoutMode),
+                className = "android.widget.Button",
+                device = device
+            ) {
+                override fun click() {
+                    composeTestRule.waitUntilExactlyOneExists(
+                        hasText(
+                            getResourceString(
+                                PaymentSheetR.string.stripe_paymentsheet_bacs_mandate_title
+                            )
+                        )
+                    )
+
+                    composeTestRule.onNodeWithText(
+                        getResourceString(PaymentSheetR.string.stripe_paymentsheet_confirm)
+                    ).performClick()
+                }
+            }
+        }
+
+        is AuthorizeAction.Bacs.ModifyDetails -> {
+            object : UiAutomatorText(
+                label = testParameters.authorizationAction.text(checkoutMode),
+                className = "android.widget.Button",
+                device = device
+            ) {
+                override fun click() {
+                    composeTestRule.waitUntilExactlyOneExists(
+                        hasText(getResourceString(PaymentSheetR.string.stripe_paymentsheet_bacs_mandate_title))
+                    )
+
+                    composeTestRule.onNodeWithText(
+                        getResourceString(
+                            PaymentSheetR
+                                .string
+                                .stripe_paymentsheet_bacs_modify_details_button_label
+                        )
+                    ).performClick()
+                }
+            }
         }
 
         else -> null
@@ -211,6 +260,18 @@ internal class Selectors(
 
     fun getAuAccountNumber() = composeTestRule.onNodeWithText(
         getResourceString(StripeR.string.stripe_becs_widget_account_number)
+    )
+
+    fun getBacsSortCode() = composeTestRule.onNodeWithText(
+        getResourceString(PaymentsUiCoreR.string.stripe_bacs_sort_code)
+    )
+
+    fun getBacsAccountNumber() = composeTestRule.onNodeWithText(
+        getResourceString(StripeR.string.stripe_becs_widget_account_number)
+    )
+
+    fun getBacsConfirmed() = composeTestRule.onNode(
+        isToggleable().and(hasTestTag("BACS_MANDATE_CHECKBOX"))
     )
 
     fun getBoletoTaxId() = composeTestRule.onNodeWithText(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
@@ -69,7 +69,7 @@ internal class FormViewModel @Inject internal constructor(
             lpmRepository.fromCode(formArguments.paymentMethodCode)
         ).formSpec.items
 
-        // Cards are a special case and already contain specs based on the configuration.
+        // Cards & Bacs debit are a special case and already contain specs based on the configuration.
         if (formArguments.paymentMethodCode != PaymentMethod.Type.Card.code) {
             specs = specsForConfiguration(
                 configuration = formArguments.billingDetailsCollectionConfiguration,

--- a/paymentsheet/src/test/resources/bacs_debit-support.csv
+++ b/paymentsheet/src/test/resources/bacs_debit-support.csv
@@ -1,0 +1,49 @@
+lpm, hasCustomer, allowsDelayedPayment, intentSetupFutureUsage, intentHasShipping, intentLpms, supportCustomerSavedCard, formExists, formType, supportsAdding
+bacs_debit, true, true, off_session, false, card/bacs_debit, false, false, not available, false
+bacs_debit, true, true, off_session, false, card/eps/bacs_debit, false, false, not available, false
+bacs_debit, true, false, off_session, false, card/bacs_debit, false, false, not available, false
+bacs_debit, true, false, off_session, false, card/eps/bacs_debit, false, false, not available, false
+bacs_debit, true, true, on_session, false, card/bacs_debit, false, false, not available, false
+bacs_debit, true, true, on_session, false, card/eps/bacs_debit, false, false, not available, false
+bacs_debit, true, false, on_session, false, card/bacs_debit, false, false, not available, false
+bacs_debit, true, false, on_session, false, card/eps/bacs_debit, false, false, not available, false
+bacs_debit, true, true, null, false, card/bacs_debit, false, true, oneTime, true
+bacs_debit, true, true, null, false, card/eps/bacs_debit, false, true, oneTime, true
+bacs_debit, true, false, null, false, card/bacs_debit, false, false, not available, false
+bacs_debit, true, false, null, false, card/eps/bacs_debit, false, false, not available, false
+bacs_debit, false, true, off_session, false, card/bacs_debit, false, false, not available, false
+bacs_debit, false, true, off_session, false, card/eps/bacs_debit, false, false, not available, false
+bacs_debit, false, false, off_session, false, card/bacs_debit, false, false, not available, false
+bacs_debit, false, false, off_session, false, card/eps/bacs_debit, false, false, not available, false
+bacs_debit, false, true, on_session, false, card/bacs_debit, false, false, not available, false
+bacs_debit, false, true, on_session, false, card/eps/bacs_debit, false, false, not available, false
+bacs_debit, false, false, on_session, false, card/bacs_debit, false, false, not available, false
+bacs_debit, false, false, on_session, false, card/eps/bacs_debit, false, false, not available, false
+bacs_debit, false, true, null, false, card/bacs_debit, false, true, oneTime, true
+bacs_debit, false, true, null, false, card/eps/bacs_debit, false, true, oneTime, true
+bacs_debit, false, false, null, false, card/bacs_debit, false, false, not available, false
+bacs_debit, false, false, null, false, card/eps/bacs_debit, false, false, not available, false
+bacs_debit, true, true, off_session, true, card/bacs_debit, false, false, not available, false
+bacs_debit, true, true, off_session, true, card/eps/bacs_debit, false, false, not available, false
+bacs_debit, true, false, off_session, true, card/bacs_debit, false, false, not available, false
+bacs_debit, true, false, off_session, true, card/eps/bacs_debit, false, false, not available, false
+bacs_debit, true, true, on_session, true, card/bacs_debit, false, false, not available, false
+bacs_debit, true, true, on_session, true, card/eps/bacs_debit, false, false, not available, false
+bacs_debit, true, false, on_session, true, card/bacs_debit, false, false, not available, false
+bacs_debit, true, false, on_session, true, card/eps/bacs_debit, false, false, not available, false
+bacs_debit, true, true, null, true, card/bacs_debit, false, true, oneTime, true
+bacs_debit, true, true, null, true, card/eps/bacs_debit, false, true, oneTime, true
+bacs_debit, true, false, null, true, card/bacs_debit, false, false, not available, false
+bacs_debit, true, false, null, true, card/eps/bacs_debit, false, false, not available, false
+bacs_debit, false, true, off_session, true, card/bacs_debit, false, false, not available, false
+bacs_debit, false, true, off_session, true, card/eps/bacs_debit, false, false, not available, false
+bacs_debit, false, false, off_session, true, card/bacs_debit, false, false, not available, false
+bacs_debit, false, false, off_session, true, card/eps/bacs_debit, false, false, not available, false
+bacs_debit, false, true, on_session, true, card/bacs_debit, false, false, not available, false
+bacs_debit, false, true, on_session, true, card/eps/bacs_debit, false, false, not available, false
+bacs_debit, false, false, on_session, true, card/bacs_debit, false, false, not available, false
+bacs_debit, false, false, on_session, true, card/eps/bacs_debit, false, false, not available, false
+bacs_debit, false, true, null, true, card/bacs_debit, false, true, oneTime, true
+bacs_debit, false, true, null, true, card/eps/bacs_debit, false, true, oneTime, true
+bacs_debit, false, false, null, true, card/bacs_debit, false, false, not available, false
+bacs_debit, false, false, null, true, card/eps/bacs_debit, false, false, not available, false

--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -136,6 +136,7 @@ public final class com/stripe/android/uicore/elements/IdentifierSpec$$serializer
 
 public final class com/stripe/android/uicore/elements/IdentifierSpec$Companion {
 	public final fun Generic (Ljava/lang/String;)Lcom/stripe/android/uicore/elements/IdentifierSpec;
+	public final fun getBillingAddress ()Lcom/stripe/android/uicore/elements/IdentifierSpec;
 	public final fun getBlik ()Lcom/stripe/android/uicore/elements/IdentifierSpec;
 	public final fun getBlikCode ()Lcom/stripe/android/uicore/elements/IdentifierSpec;
 	public final fun getCardBrand ()Lcom/stripe/android/uicore/elements/IdentifierSpec;

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/IdentifierSpec.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/IdentifierSpec.kt
@@ -55,6 +55,8 @@ data class IdentifierSpec(
 
         val CardExpYear = IdentifierSpec("card[exp_year]")
 
+        val BillingAddress = IdentifierSpec("billing_details[address]")
+
         val Email = IdentifierSpec("billing_details[email]")
 
         val Phone = IdentifierSpec("billing_details[phone]")


### PR DESCRIPTION
# Summary
Adds Bacs support for the Android SDK by connecting all the LUXE and confirmation form pieces together and enabling it in the `LpmRepository`.

# Motivation
Adds another payment method that can be used within the SDK.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Video
[BacsOnAndroid.webm](https://github.com/stripe/stripe-android/assets/141707240/8f8c02cc-012e-430b-abfd-6c814846df3b)