### PR TITLE
Add CustomerSheetLoader interface

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.customersheet
+
+import com.stripe.android.core.injection.IS_LIVE_MODE
+import com.stripe.android.googlepaylauncher.GooglePayEnvironment
+import com.stripe.android.googlepaylauncher.GooglePayRepository
+import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
+import com.stripe.android.ui.core.forms.resources.LpmRepository
+import javax.inject.Inject
+import javax.inject.Named
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+internal interface CustomerSheetLoader {
+    suspend fun load(configuration: CustomerSheet.Configuration?): Result<CustomerSheetState>
+}
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+@Suppress("unused")
+internal class DefaultCustomerSheetLoader @Inject constructor(
+    @Named(IS_LIVE_MODE) private val isLiveModeProvider: () -> Boolean,
+    private val googlePayRepositoryFactory: @JvmSuppressWildcards (GooglePayEnvironment) -> GooglePayRepository,
+    private val elementsSessionRepository: ElementsSessionRepository,
+    private val lpmRepository: LpmRepository,
+    private val customerAdapter: CustomerAdapter,
+) : CustomerSheetLoader {
+    override suspend fun load(configuration: CustomerSheet.Configuration?): Result<CustomerSheetState> {
+        TODO("Not yet implemented")
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetState.kt
@@ -1,0 +1,18 @@
+package com.stripe.android.customersheet
+
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentsheet.model.PaymentSelection
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+internal sealed interface CustomerSheetState {
+    object Loading : CustomerSheetState
+
+    data class Full(
+        val config: CustomerSheet.Configuration?,
+        val stripeIntent: StripeIntent?,
+        val customerPaymentMethods: List<PaymentMethod>,
+        val isGooglePayReady: Boolean,
+        val paymentSelection: PaymentSelection?,
+    ) : CustomerSheetState
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -72,6 +72,7 @@ internal class CustomerSheetViewModel @Inject constructor(
     private val paymentLauncherFactory: StripePaymentLauncherAssistedFactory,
     private val intentConfirmationInterceptor: IntentConfirmationInterceptor,
     private val googlePayRepositoryFactory: @JvmSuppressWildcards (GooglePayEnvironment) -> GooglePayRepository,
+    @Suppress("unused") private val customerSheetLoader: CustomerSheetLoader,
 ) : ViewModel() {
 
     private val backStack = MutableStateFlow(initialBackStack)

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -16,7 +16,9 @@ import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.NetworkTypeDetector
 import com.stripe.android.core.utils.ContextUtils.packageInfo
+import com.stripe.android.customersheet.CustomerSheetLoader
 import com.stripe.android.customersheet.CustomerSheetViewState
+import com.stripe.android.customersheet.DefaultCustomerSheetLoader
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.analytics.DefaultCustomerSheetEventReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
@@ -25,6 +27,8 @@ import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.injection.IS_FLOW_CONTROLLER
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
+import com.stripe.android.paymentsheet.repositories.RealElementsSessionRepository
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import dagger.Binds
 import dagger.Module
@@ -51,6 +55,16 @@ internal interface CustomerSheetViewModelModule {
         impl: DefaultCustomerSheetEventReporter
     ): CustomerSheetEventReporter
 
+    @Binds
+    fun bindsCustomerSheetLoader(
+        impl: DefaultCustomerSheetLoader
+    ): CustomerSheetLoader
+
+    @Binds
+    fun bindsStripeIntentRepository(
+        impl: RealElementsSessionRepository,
+    ): ElementsSessionRepository
+
     @Suppress("TooManyFunctions")
     companion object {
         /**
@@ -64,6 +78,11 @@ internal interface CustomerSheetViewModelModule {
         @Provides
         fun paymentConfiguration(application: Application): PaymentConfiguration {
             return PaymentConfiguration.getInstance(application)
+        }
+
+        @Provides
+        fun provideCoroutineContext(): CoroutineContext {
+            return Dispatchers.IO
         }
 
         @Provides

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTestHelper.kt
@@ -139,6 +139,7 @@ object CustomerSheetTestHelper {
             },
             statusBarColor = { null },
             eventReporter = eventReporter,
+            customerSheetLoader = mock()
         ).apply {
             registerFromActivity(DummyActivityResultCaller(), TestLifecycleOwner())
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Add CustomerSheetLoader interface. Will add implementation in a subsequent PR.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

In preparation for ACHv2 support in CustomerSheet, we need access to the ElementsSession model. The loader will be used to retrieve the ElementsSession, similar to how PaymentSheet works.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

