### PR TITLE
Show preferred card brands in existing card flow for payment options

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -3443,6 +3443,7 @@ public final class com/stripe/android/model/PaymentMethod$Card : com/stripe/andr
 	public final fun component1 ()Lcom/stripe/android/model/CardBrand;
 	public final fun component10 ()Lcom/stripe/android/model/wallets/Wallet;
 	public final fun component11 ()Lcom/stripe/android/model/PaymentMethod$Card$Networks;
+	public final fun component12 ()Lcom/stripe/android/model/PaymentMethod$Card$DisplayBrand;
 	public final fun component2 ()Lcom/stripe/android/model/PaymentMethod$Card$Checks;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/Integer;
@@ -3451,8 +3452,8 @@ public final class com/stripe/android/model/PaymentMethod$Card : com/stripe/andr
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;
-	public final fun copy (Lcom/stripe/android/model/CardBrand;Lcom/stripe/android/model/PaymentMethod$Card$Checks;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;Lcom/stripe/android/model/wallets/Wallet;Lcom/stripe/android/model/PaymentMethod$Card$Networks;)Lcom/stripe/android/model/PaymentMethod$Card;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$Card;Lcom/stripe/android/model/CardBrand;Lcom/stripe/android/model/PaymentMethod$Card$Checks;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;Lcom/stripe/android/model/wallets/Wallet;Lcom/stripe/android/model/PaymentMethod$Card$Networks;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$Card;
+	public final fun copy (Lcom/stripe/android/model/CardBrand;Lcom/stripe/android/model/PaymentMethod$Card$Checks;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;Lcom/stripe/android/model/wallets/Wallet;Lcom/stripe/android/model/PaymentMethod$Card$Networks;Lcom/stripe/android/model/PaymentMethod$Card$DisplayBrand;)Lcom/stripe/android/model/PaymentMethod$Card;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$Card;Lcom/stripe/android/model/CardBrand;Lcom/stripe/android/model/PaymentMethod$Card$Checks;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;Lcom/stripe/android/model/wallets/Wallet;Lcom/stripe/android/model/PaymentMethod$Card$Networks;Lcom/stripe/android/model/PaymentMethod$Card$DisplayBrand;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$Card;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getType ()Lcom/stripe/android/model/PaymentMethod$Type;
@@ -3492,6 +3493,14 @@ public final class com/stripe/android/model/PaymentMethod$Card$Creator : android
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Card;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethod$Card;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethod$Card$DisplayBrand$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$Card$DisplayBrand;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethod$Card$DisplayBrand;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -739,7 +739,11 @@ constructor(
         @JvmField val wallet: Wallet? = null,
 
         @JvmField
-        val networks: Networks? = null
+        val networks: Networks? = null,
+
+        @JvmField
+        @field:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        val displayBrand: DisplayBrand? = null
     ) : TypeData() {
         override val type: Type get() = Type.Card
 
@@ -789,6 +793,12 @@ constructor(
              * [payment_method.card.three_d_secure_usage.supported](https://stripe.com/docs/api/errors#errors-payment_method-card-three_d_secure_usage-supported)
              */
             @JvmField val isSupported: Boolean
+        ) : StripeModel
+
+        @Parcelize
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        data class DisplayBrand(
+            val type: CardBrand
         ) : StripeModel
 
         @Parcelize

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodJsonParser.kt
@@ -138,6 +138,9 @@ class PaymentMethodJsonParser : ModelJsonParser<PaymentMethod> {
                 },
                 networks = json.optJSONObject(FIELD_NETWORKS)?.let {
                     NetworksJsonParser().parse(it)
+                },
+                displayBrand = json.optJSONObject(FIELD_DISPLAY_BRAND)?.let {
+                    DisplayBrandParser().parse(it)
                 }
             )
         }
@@ -171,6 +174,18 @@ class PaymentMethodJsonParser : ModelJsonParser<PaymentMethod> {
 
             private companion object {
                 private const val FIELD_IS_SUPPORTED = "supported"
+            }
+        }
+
+        internal class DisplayBrandParser : ModelJsonParser<PaymentMethod.Card.DisplayBrand> {
+            override fun parse(json: JSONObject): PaymentMethod.Card.DisplayBrand {
+                return PaymentMethod.Card.DisplayBrand(
+                    type = CardBrand.fromCode(json.getString(FIELD_TYPE))
+                )
+            }
+
+            private companion object {
+                private const val FIELD_TYPE = "type"
             }
         }
 
@@ -208,6 +223,7 @@ class PaymentMethodJsonParser : ModelJsonParser<PaymentMethod> {
             private const val FIELD_LAST4 = "last4"
             private const val FIELD_THREE_D_SECURE_USAGE = "three_d_secure_usage"
             private const val FIELD_WALLET = "wallet"
+            private const val FIELD_DISPLAY_BRAND = "display_brand"
             private const val FIELD_NETWORKS = "networks"
         }
     }

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodJsonParser.kt
@@ -140,7 +140,7 @@ class PaymentMethodJsonParser : ModelJsonParser<PaymentMethod> {
                     NetworksJsonParser().parse(it)
                 },
                 displayBrand = json.optJSONObject(FIELD_DISPLAY_BRAND)?.let {
-                    DisplayBrandParser().parse(it)
+                    DisplayBrandParser.parse(it)
                 }
             )
         }
@@ -177,15 +177,13 @@ class PaymentMethodJsonParser : ModelJsonParser<PaymentMethod> {
             }
         }
 
-        internal class DisplayBrandParser : ModelJsonParser<PaymentMethod.Card.DisplayBrand> {
+        internal object DisplayBrandParser : ModelJsonParser<PaymentMethod.Card.DisplayBrand> {
+            private const val FIELD_TYPE = "type"
+
             override fun parse(json: JSONObject): PaymentMethod.Card.DisplayBrand {
                 return PaymentMethod.Card.DisplayBrand(
                     type = CardBrand.fromCode(json.getString(FIELD_TYPE))
                 )
-            }
-
-            private companion object {
-                private const val FIELD_TYPE = "type"
             }
         }
 

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
@@ -253,6 +253,54 @@ internal object PaymentMethodFixtures {
         """.trimIndent()
     )
 
+    internal val CARD_WITH_DISPLAY_BRAND_JSON = JSONObject(
+        """
+        {
+            "id": "pm_1GDwTNAI5zDH",
+            "object": "payment_method",
+            "billing_details": {
+                "address": {
+                    "city": null,
+                    "country": null,
+                    "line1": null,
+                    "line2": null,
+                    "postal_code": null,
+                    "state": null
+                },
+                "email": null,
+                "name": null,
+                "phone": null
+            },
+            "card": {
+                "brand": "visa",
+                "checks": {
+                    "address_line1_check": null,
+                    "address_postal_code_check": null,
+                    "cvc_check": null
+                },
+                "country": "US",
+                "exp_month": 12,
+                "exp_year": 2024,
+                "funding": "credit",
+                "generated_from": null,
+                "last4": "9999",
+                "display_brand": {
+                    "type": "cartes_bancaires"
+                },
+                "three_d_secure_usage": {
+                    "supported": true
+                },
+                "wallet": null
+            },
+            "created": 15821393,
+            "customer": null,
+            "livemode": false,
+            "metadata": {},
+            "type": "card"
+        }
+        """.trimIndent()
+    )
+
     val IDEAL_JSON = JSONObject(
         """
             {

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentMethodJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentMethodJsonParserTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.model.parsers
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.Address
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import kotlin.test.Test
@@ -20,6 +21,20 @@ class PaymentMethodJsonParserTest {
                     available = setOf("network1", "network2"),
                     selectionMandatory = true,
                     preferred = "network1"
+                )
+            )
+    }
+
+    @Test
+    fun parse_withCardWithDisplayBrand_shouldCreateExpectedObject() {
+        val actualDisplayBrand =
+            PaymentMethodJsonParser().parse(PaymentMethodFixtures.CARD_WITH_DISPLAY_BRAND_JSON)
+                .card?.displayBrand
+
+        assertThat(actualDisplayBrand)
+            .isEqualTo(
+                PaymentMethod.Card.DisplayBrand(
+                    type = CardBrand.CartesBancaires
                 )
             )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
@@ -75,7 +75,7 @@ internal class PaymentOptionFactory @Inject constructor(
             }
             is PaymentSelection.Saved -> {
                 PaymentOption(
-                    drawableResourceId = selection.paymentMethod.getSavedPaymentMethodIcon() ?: 0,
+                    drawableResourceId = selection.paymentMethod.getSavedPaymentMethodIcon(),
                     lightThemeIconUrl = null,
                     darkThemeIconUrl = null,
                     label = selection.paymentMethod.getLabel(resources).orEmpty(),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtension.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtension.kt
@@ -11,12 +11,13 @@ import com.stripe.android.ui.core.R as StripeUiCoreR
 import com.stripe.payments.model.R as PaymentsModelR
 
 @DrawableRes
-internal fun PaymentMethod.getSavedPaymentMethodIcon(): Int? = when (type) {
-    PaymentMethod.Type.Card -> card?.brand?.getCardBrandIcon()
-        ?: R.drawable.stripe_ic_paymentsheet_card_unknown
-    PaymentMethod.Type.SepaDebit -> StripeUiCoreR.drawable.stripe_ic_paymentsheet_pm_sepa_debit
-    PaymentMethod.Type.USBankAccount -> usBankAccount?.bankName?.let { TransformToBankIcon(it) }
-    else -> null
+internal fun PaymentMethod.getSavedPaymentMethodIcon(): Int {
+    return when (type) {
+        PaymentMethod.Type.Card -> (card?.displayBrand?.type ?: card?.brand)?.getCardBrandIcon()
+        PaymentMethod.Type.SepaDebit -> StripeUiCoreR.drawable.stripe_ic_paymentsheet_pm_sepa_debit
+        PaymentMethod.Type.USBankAccount -> usBankAccount?.bankName?.let { TransformToBankIcon(it) }
+        else -> null
+    } ?: R.drawable.stripe_ic_paymentsheet_card_unknown
 }
 
 @DrawableRes

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsUI.kt
@@ -284,7 +284,7 @@ private fun SavedPaymentMethod(
         isEditing = isEditing,
         isSelected = isSelected,
         isEnabled = isEnabled,
-        iconRes = paymentMethod.paymentMethod.getSavedPaymentMethodIcon() ?: 0,
+        iconRes = paymentMethod.paymentMethod.getSavedPaymentMethodIcon(),
         labelIcon = labelIcon,
         labelText = labelText,
         removePmDialogTitle = removeTitle,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodIconTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodIconTest.kt
@@ -1,0 +1,55 @@
+package com.stripe.android.paymentsheet.ui
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
+import com.stripe.android.model.PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD
+import com.stripe.android.model.PaymentMethodFixtures.US_BANK_ACCOUNT
+import com.stripe.android.paymentsheet.R
+import org.junit.Test
+import com.stripe.android.R as StripeR
+import com.stripe.android.ui.core.R as StripeUiCoreR
+import com.stripe.payments.model.R as PaymentsModelR
+
+class SavedPaymentMethodIconTest {
+    @Test
+    fun `on card payment method, should return proper card brand icon`() {
+        assertThat(
+            CARD_PAYMENT_METHOD.getSavedPaymentMethodIcon()
+        ).isEqualTo(R.drawable.stripe_ic_paymentsheet_card_visa)
+
+        assertThat(
+            CARD_PAYMENT_METHOD.copy(
+                card = CARD_PAYMENT_METHOD.card?.copy(brand = CardBrand.MasterCard)
+            ).getSavedPaymentMethodIcon()
+        ).isEqualTo(R.drawable.stripe_ic_paymentsheet_card_mastercard)
+    }
+
+    @Test
+    fun `on SEPA payment method, should return proper SEPA icon`() {
+        assertThat(
+            SEPA_DEBIT_PAYMENT_METHOD.getSavedPaymentMethodIcon()
+        ).isEqualTo(StripeUiCoreR.drawable.stripe_ic_paymentsheet_pm_sepa_debit)
+    }
+
+    @Test
+    fun `on US bank account payment method, should return proper US bank account icon`() {
+        assertThat(
+            US_BANK_ACCOUNT.getSavedPaymentMethodIcon()
+        ).isEqualTo(StripeR.drawable.stripe_ic_bank_stripe)
+    }
+
+    @Test
+    fun `on display brand available for card payment method, should return proper brand icon`() {
+        assertThat(
+            CARD_PAYMENT_METHOD.copy(
+                card = CARD_PAYMENT_METHOD.card?.copy(
+                    displayBrand = PaymentMethod.Card.DisplayBrand(
+                        type = CardBrand.CartesBancaires
+                    )
+                )
+            ).getSavedPaymentMethodIcon()
+        ).isEqualTo(PaymentsModelR.drawable.stripe_ic_cartes_bancaires)
+    }
+}


### PR DESCRIPTION
# Summary
Show preferred card brands in existing card flow for payment options

# Motivation
Allows us to properly show the brand associated with the co-branded card.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified