### PR TITLE
[FC] Unify close logic and prevent repeated complete session calls

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.financialconnections.domain
 
-import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityResult
 import kotlinx.coroutines.flow.MutableSharedFlow
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -36,9 +35,5 @@ internal class NativeAuthFlowCoordinator @Inject constructor() {
                 USER_INITIATED_WITH_CUSTOM_MANUAL_ENTRY("user_initiated_with_custom_manual_entry")
             }
         }
-
-        data class Finish(
-            val result: FinancialConnectionsSheetActivityResult
-        ) : Message
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator.kt
@@ -29,8 +29,8 @@ internal class NativeAuthFlowCoordinator @Inject constructor() {
         /**
          * Triggers a termination of the AuthFlow, completing the session in the current state.
          */
-        data class Terminate(
-            val cause: EarlyTerminationCause
+        data class Complete(
+            val cause: EarlyTerminationCause? = null
         ) : Message {
             enum class EarlyTerminationCause(val value: String) {
                 USER_INITIATED_WITH_CUSTOM_MANUAL_ENTRY("user_initiated_with_custom_manual_entry")

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
@@ -12,8 +12,8 @@ import com.stripe.android.financialconnections.analytics.FinancialConnectionsEve
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.PaneLoaded
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
-import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Terminate
-import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Terminate.EarlyTerminationCause.USER_INITIATED_WITH_CUSTOM_MANUAL_ENTRY
+import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Complete
+import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Complete.EarlyTerminationCause.USER_INITIATED_WITH_CUSTOM_MANUAL_ENTRY
 import com.stripe.android.financialconnections.domain.PollAttachPaymentAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.model.LinkAccountSessionPaymentAccount
@@ -88,7 +88,7 @@ internal class ManualEntryViewModel @Inject constructor(
             onSuccess = { payload ->
                 if (payload.customManualEntry) {
                     nativeAuthFlowCoordinator().emit(
-                        Terminate(
+                        Complete(
                             USER_INITIATED_WITH_CUSTOM_MANUAL_ENTRY
                         )
                     )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessViewModel.kt
@@ -1,20 +1,16 @@
 package com.stripe.android.financialconnections.features.manualentrysuccess
 
 import com.airbnb.mvrx.Async
+import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.MavericksState
 import com.airbnb.mvrx.MavericksViewModel
 import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.ViewModelContext
-import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.ClickDone
-import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.Complete
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.PaneLoaded
-import com.stripe.android.financialconnections.domain.CompleteFinancialConnectionsSession
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
-import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Finish
-import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityResult.Completed
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
@@ -24,57 +20,22 @@ import javax.inject.Inject
 @Suppress("LongParameterList")
 internal class ManualEntrySuccessViewModel @Inject constructor(
     initialState: ManualEntrySuccessState,
-    private val completeFinancialConnectionsSession: CompleteFinancialConnectionsSession,
     private val eventTracker: FinancialConnectionsAnalyticsTracker,
     private val nativeAuthFlowCoordinator: NativeAuthFlowCoordinator,
-    private val logger: Logger
 ) : MavericksViewModel<ManualEntrySuccessState>(initialState) {
 
     init {
-        logErrors()
         viewModelScope.launch {
             eventTracker.track(PaneLoaded(Pane.MANUAL_ENTRY_SUCCESS))
         }
     }
 
-    private fun logErrors() {
-        onAsync(
-            ManualEntrySuccessState::completeSession,
-            onSuccess = {
-                eventTracker.track(
-                    Complete(
-                        connectedAccounts = it.accounts.data.count(),
-                        exceptionExtraMessage = null,
-                        exception = null
-                    )
-                )
-            },
-            onFail = {
-                eventTracker.track(
-                    Complete(
-                        connectedAccounts = null,
-                        exceptionExtraMessage = null,
-                        exception = it
-                    )
-                )
-                logger.error("Error completing session", it)
-            }
-        )
-    }
-
     fun onSubmit() {
         viewModelScope.launch {
+            setState { copy(completeSession = Loading()) }
             eventTracker.track(ClickDone(Pane.MANUAL_ENTRY_SUCCESS))
+            nativeAuthFlowCoordinator().emit(NativeAuthFlowCoordinator.Message.Complete())
         }
-        suspend {
-            completeFinancialConnectionsSession().also {
-                val result = Completed(
-                    financialConnectionsSession = it,
-                    token = it.parsedToken
-                )
-                nativeAuthFlowCoordinator().emit(Finish(result))
-            }
-        }.execute { copy(completeSession = it) }
     }
 
     companion object :

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.compose.collectAsState
 import com.airbnb.mvrx.compose.mavericksViewModel
 import com.stripe.android.financialconnections.R
@@ -63,7 +62,7 @@ internal fun SuccessScreen() {
             accounts = payload.accounts,
             institution = payload.institution,
             successMessage = payload.successMessage,
-            loading = state.value.completeSession is Loading,
+            loading = false,
             skipSuccessPane = payload.skipSuccessPane,
             onDoneClick = viewModel::onDoneClick,
             accountFailedToLinkMessage = payload.accountFailedToLinkMessage,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.compose.collectAsState
 import com.airbnb.mvrx.compose.mavericksViewModel
 import com.stripe.android.financialconnections.R
@@ -62,7 +63,7 @@ internal fun SuccessScreen() {
             accounts = payload.accounts,
             institution = payload.institution,
             successMessage = payload.successMessage,
-            loading = false,
+            loading = state.value.completeSession is Loading,
             skipSuccessPane = payload.skipSuccessPane,
             onDoneClick = viewModel::onDoneClick,
             accountFailedToLinkMessage = payload.accountFailedToLinkMessage,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessViewModel.kt
@@ -161,7 +161,7 @@ internal class SuccessViewModel @Inject constructor(
     }
 
     fun onDoneClick() = viewModelScope.launch {
-         eventTracker.track(ClickDone(PANE))
+        eventTracker.track(ClickDone(PANE))
         setState { copy(completeSession = Loading()) }
         completeSession()
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -80,10 +80,6 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
         viewModelScope.launch {
             nativeAuthFlowCoordinator().collect { message ->
                 when (message) {
-                    is Message.Finish -> {
-                        setState { copy(viewEffect = Finish(message.result)) }
-                    }
-
                     Message.ClearPartnerWebAuth -> {
                         setState { copy(webAuthFlow = WebAuthFlowState.Uninitialized) }
                     }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModelTest.kt
@@ -11,8 +11,8 @@ import com.stripe.android.financialconnections.ApiKeyFixtures.syncResponse
 import com.stripe.android.financialconnections.TestFinancialConnectionsAnalyticsTracker
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
-import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Terminate
-import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Terminate.EarlyTerminationCause.USER_INITIATED_WITH_CUSTOM_MANUAL_ENTRY
+import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Complete
+import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Complete.EarlyTerminationCause.USER_INITIATED_WITH_CUSTOM_MANUAL_ENTRY
 import com.stripe.android.financialconnections.domain.PollAttachPaymentAccount
 import com.stripe.android.financialconnections.features.manualentry.ManualEntryState.Payload
 import com.stripe.android.financialconnections.model.ManualEntryMode
@@ -59,7 +59,7 @@ class ManualEntryViewModelTest {
         nativeAuthFlowCoordinator().test {
             val viewModel = buildViewModel()
             assertEquals(
-                expected = Terminate(USER_INITIATED_WITH_CUSTOM_MANUAL_ENTRY),
+                expected = Complete(USER_INITIATED_WITH_CUSTOM_MANUAL_ENTRY),
                 actual = awaitItem(),
             )
             withState(viewModel) {

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModelTest.kt
@@ -12,8 +12,8 @@ import com.stripe.android.financialconnections.ApiKeyFixtures.financialConnectio
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.domain.CompleteFinancialConnectionsSession
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
-import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Terminate
-import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Terminate.EarlyTerminationCause
+import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Complete
+import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Complete.EarlyTerminationCause
 import com.stripe.android.financialconnections.exception.CustomManualEntryRequiredError
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityResult
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetNativeActivityArgs
@@ -65,7 +65,7 @@ internal class FinancialConnectionsSheetNativeViewModelTest {
 
             val viewModel = createViewModel()
 
-            messagesFlow.emit(Terminate(EarlyTerminationCause.USER_INITIATED_WITH_CUSTOM_MANUAL_ENTRY))
+            messagesFlow.emit(Complete(EarlyTerminationCause.USER_INITIATED_WITH_CUSTOM_MANUAL_ENTRY))
 
             withState(viewModel) {
                 require(it.viewEffect is FinancialConnectionsSheetNativeViewEffect.Finish)


### PR DESCRIPTION
# Summary
- **Problem**: close flow could be triggered many times (clicking the close button repeatedly, clicking the done CTA at the end + close button, etc)
- Also the complete logic was duplicated in 3 places:
  -  when clicking the X button
  - clicking done on the last pane
  - clicking done on the manual entry pane.

**This PR:**

- Relies on the existing **closeAuthFlow** function for any flow close request (same as iOS does)
- Ensures close can just be called once (using a flag in the viewmodel)

# Motivation
:notebook_with_decorative_cover: &nbsp;**[Android] Multiple close clicks trigger repeated complete session calls**
:globe_with_meridians: &nbsp;[BANKCON-7931](https://jira.corp.stripe.com/browse/BANKCON-7931)
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

<img width="497" alt="image" src="https://github.com/stripe/stripe-android/assets/99293320/af3d7ac9-839f-45c6-8d7e-e9885e28ced3">
