### PR TITLE
Remove E2E tests - browserstack is broken.

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -26,7 +26,6 @@ stages:
       - run-example-instrumentation-tests: { }
       - run-financial-connections-instrumentation-tests: { }
       - run-cardscan-instrumentation-tests: { }
-      - run-paymentsheet-end-to-end-tests: { }
 
 workflows:
   check:


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We're seeing errors with POST https://api-cloud.browserstack.com/app-automate/espresso/v2/build  - The error is {'message': '[local] is set to true but local testing through BrowserStack is not connected. To resolve the issue or to get more info visit - https://www.browserstack.com/question/779'}
Thing is, we're not setting local , and if I set it to false, we still get the same error.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Unblock merges.

