### PR TITLE
Use CustomerSheetLoader in CustomerSheetViewModel

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -20,7 +20,7 @@ import javax.inject.Named
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 internal interface CustomerSheetLoader {
-    suspend fun load(configuration: CustomerSheet.Configuration?): Result<CustomerSheetState>
+    suspend fun load(configuration: CustomerSheet.Configuration?): Result<CustomerSheetState.Full>
 }
 
 @OptIn(ExperimentalCustomerSheetApi::class)
@@ -31,7 +31,7 @@ internal class DefaultCustomerSheetLoader @Inject constructor(
     private val lpmRepository: LpmRepository,
     private val customerAdapter: CustomerAdapter,
 ) : CustomerSheetLoader {
-    override suspend fun load(configuration: CustomerSheet.Configuration?): Result<CustomerSheetState> {
+    override suspend fun load(configuration: CustomerSheet.Configuration?): Result<CustomerSheetState.Full> {
         val card = LpmRepository.hardcodedCardSpec(
             billingDetailsCollectionConfiguration =
             configuration?.billingDetailsCollectionConfiguration?.toInternal()

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -16,8 +16,6 @@ import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.injection.CustomerSheetViewModelScope
-import com.stripe.android.googlepaylauncher.GooglePayEnvironment
-import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
@@ -38,19 +36,19 @@ import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.parseAppearance
-import com.stripe.android.paymentsheet.state.toInternal
 import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
 import com.stripe.android.paymentsheet.utils.mapAsStateFlow
 import com.stripe.android.ui.core.forms.resources.LpmRepository
-import kotlinx.coroutines.async
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Provider
+import kotlin.coroutines.CoroutineContext
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 @CustomerSheetViewModelScope
@@ -67,12 +65,12 @@ internal class CustomerSheetViewModel @Inject constructor(
     private val lpmRepository: LpmRepository,
     private val statusBarColor: () -> Int?,
     private val eventReporter: CustomerSheetEventReporter,
+    private val workContext: CoroutineContext = Dispatchers.IO,
     @Named(IS_LIVE_MODE) private val isLiveModeProvider: () -> Boolean,
     private val formViewModelSubcomponentBuilderProvider: Provider<FormViewModelSubcomponent.Builder>,
     private val paymentLauncherFactory: StripePaymentLauncherAssistedFactory,
     private val intentConfirmationInterceptor: IntentConfirmationInterceptor,
-    private val googlePayRepositoryFactory: @JvmSuppressWildcards (GooglePayEnvironment) -> GooglePayRepository,
-    @Suppress("unused") private val customerSheetLoader: CustomerSheetLoader,
+    private val customerSheetLoader: CustomerSheetLoader,
 ) : ViewModel() {
 
     private val backStack = MutableStateFlow(initialBackStack)
@@ -85,20 +83,15 @@ internal class CustomerSheetViewModel @Inject constructor(
     private var paymentLauncher: PaymentLauncher? = null
 
     private var unconfirmedPaymentMethod: PaymentMethod? = null
+    private var stripeIntent: StripeIntent? = null
 
     init {
-        lpmRepository.initializeWithPaymentMethods(
-            mapOf(
-                PaymentMethod.Type.Card.code to LpmRepository.hardcodedCardSpec(
-                    configuration.billingDetailsCollectionConfiguration.toInternal()
-                )
-            )
-        )
-
         configuration.appearance.parseAppearance()
 
         if (viewState.value is CustomerSheetViewState.Loading) {
-            loadPaymentMethods()
+            viewModelScope.launch {
+                loadCustomerSheetState()
+            }
         }
     }
 
@@ -188,60 +181,30 @@ internal class CustomerSheetViewModel @Inject constructor(
         }
     }
 
-    private fun loadPaymentMethods() {
-        viewModelScope.launch {
-            val paymentMethodsResult = async {
-                customerAdapter.retrievePaymentMethods()
-            }
-            val selectedPaymentOption = async {
-                customerAdapter.retrieveSelectedPaymentOption()
-            }
+    private suspend fun loadCustomerSheetState() {
+        val result = withContext(workContext) {
+            customerSheetLoader.load(
+                configuration = configuration,
+            )
+        }
 
-            paymentMethodsResult.await().flatMap { paymentMethods ->
-                selectedPaymentOption.await().map { paymentOption ->
-                    Pair(paymentMethods, paymentOption)
-                }
-            }.map {
-                val paymentMethods = it.first
-                val paymentOption = it.second
-                val selection = paymentOption?.toPaymentSelection { id ->
-                    paymentMethods.find { it.id == id }
-                }
-                Pair(paymentMethods, selection)
-            }.onFailure { cause, _ ->
+        result.fold(
+            onSuccess = { state ->
+                savedPaymentSelection = state.paymentSelection
+                isGooglePayReadyAndEnabled = state.isGooglePayReady
+                stripeIntent = state.stripeIntent
+
+                transitionToInitialScreen(
+                    paymentMethods = state.customerPaymentMethods,
+                    paymentSelection = state.paymentSelection
+                )
+            },
+            onFailure = { cause ->
                 _result.update {
                     InternalCustomerSheetResult.Error(exception = cause)
                 }
-            }.onSuccess { result ->
-                var paymentMethods = result.first
-                val paymentSelection = result.second
-
-                paymentSelection?.apply {
-                    val selectedPaymentMethod = (this as? PaymentSelection.Saved)?.paymentMethod
-                    // The order of the payment methods should be selected PM and then any additional PMs
-                    // The carousel always starts with Add and Google Pay (if enabled)
-                    paymentMethods = paymentMethods.sortedWith { left, right ->
-                        // We only care to move the selected payment method, all others stay in the
-                        // order they were before
-                        when {
-                            left.id == selectedPaymentMethod?.id -> -1
-                            right.id == selectedPaymentMethod?.id -> 1
-                            else -> 0
-                        }
-                    }
-                }
-
-                savedPaymentSelection = paymentSelection
-                isGooglePayReadyAndEnabled = configuration.googlePayEnabled && googlePayRepositoryFactory(
-                    if (isLiveModeProvider()) GooglePayEnvironment.Production else GooglePayEnvironment.Test
-                ).isReady().first()
-
-                transitionToInitialScreen(
-                    paymentMethods = paymentMethods,
-                    paymentSelection = paymentSelection
-                )
             }
-        }
+        )
     }
 
     private fun transitionToInitialScreen(paymentMethods: List<PaymentMethod>, paymentSelection: PaymentSelection?) {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
@@ -8,7 +8,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.customersheet.CustomerSheetTestHelper.createViewModel
+import com.stripe.android.customersheet.utils.CustomerSheetTestHelper.createViewModel
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodFixtures

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -7,18 +7,18 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
-import com.stripe.android.customersheet.CustomerSheetTestHelper.createViewModel
 import com.stripe.android.customersheet.CustomerSheetViewState.AddPaymentMethod
 import com.stripe.android.customersheet.CustomerSheetViewState.SelectPaymentMethod
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.injection.CustomerSheetViewModelModule
+import com.stripe.android.customersheet.utils.CustomerSheetTestHelper.createViewModel
+import com.stripe.android.customersheet.utils.FakeCustomerSheetLoader
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor
@@ -90,10 +90,10 @@ class CustomerSheetViewModelTest {
     @Test
     fun `init emits CustomerSheetViewState#AddPaymentMethod when no payment methods available`() = runTest {
         val viewModel = createViewModel(
-            isGooglePayAvailable = false,
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(listOf())
-            )
+            customerSheetLoader = FakeCustomerSheetLoader(
+                isGooglePayAvailable = false,
+                customerPaymentMethods = listOf()
+            ),
         )
         viewModel.viewState.test {
             assertThat(awaitItem()).isInstanceOf(
@@ -125,31 +125,6 @@ class CustomerSheetViewModelTest {
     }
 
     @Test
-    fun `LPM repository is initialized with the necessary payment methods`() {
-        val lpmRepository = LpmRepository(
-            arguments = LpmRepository.LpmRepositoryArguments(
-                resources = CustomerSheetTestHelper.application.resources,
-                isFinancialConnectionsAvailable = { true },
-            ),
-            lpmInitialFormData = LpmRepository.LpmInitialFormData()
-        )
-
-        var card = lpmRepository.fromCode("card")
-        assertThat(card).isNull()
-
-        // createViewModel by default initializes a FormViewModel, which requires a valid LpmRepository
-        // initialized with supported payment methods. We are passing in a mocked provider that doesn't
-        // initialize a FormViewModel
-        createViewModel(
-            lpmRepository = lpmRepository,
-            formViewModelSubcomponentBuilderProvider = mock()
-        )
-
-        card = lpmRepository.fromCode("card")
-        assertThat(card).isNotNull()
-    }
-
-    @Test
     fun `CustomerSheetViewAction#OnBackPressed emits canceled result`() = runTest {
         val viewModel = createViewModel(
             initialBackStack = listOf(
@@ -166,19 +141,11 @@ class CustomerSheetViewModelTest {
     @Test
     fun `When payment methods loaded, CustomerSheetViewState is populated`() = runTest {
         val viewModel = createViewModel(
-            isGooglePayAvailable = false,
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        CARD_PAYMENT_METHOD
-                    )
-                ),
-                selectedPaymentOption = CustomerAdapter.Result.success(
-                    CustomerAdapter.PaymentOption.fromId(
-                        CARD_PAYMENT_METHOD.id!!
-                    )
-                )
-            )
+            customerSheetLoader = FakeCustomerSheetLoader(
+                isGooglePayAvailable = false,
+                customerPaymentMethods = listOf(CARD_PAYMENT_METHOD),
+                paymentSelection = PaymentSelection.Saved(CARD_PAYMENT_METHOD),
+            ),
         )
         viewModel.viewState.test {
             assertThat(awaitItem())
@@ -199,41 +166,36 @@ class CustomerSheetViewModelTest {
     @Test
     fun `When payment methods cannot be loaded, sheet closes`() = runTest {
         val viewModel = createViewModel(
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.failure(
-                    cause = APIException(message = "Failed to retrieve payment methods."),
-                    displayMessage = "We couldn't get your payment methods. Please try again."
-                )
-            )
+            customerSheetLoader = FakeCustomerSheetLoader(
+                shouldFail = true,
+            ),
         )
         viewModel.result.test {
             assertThat((awaitItem() as InternalCustomerSheetResult.Error).exception.message)
-                .isEqualTo("Failed to retrieve payment methods.")
+                .isEqualTo("failed to load")
         }
     }
 
     @Test
-    fun `When the selected payment method cannot be loaded, paymentSelection is null and an error message is displayed`() = runTest {
+    fun `When the selected payment method cannot be loaded, sheet closes`() = runTest {
         val viewModel = createViewModel(
-            customerAdapter = FakeCustomerAdapter(
-                selectedPaymentOption = CustomerAdapter.Result.failure(
-                    cause = Exception("Failed to retrieve selected payment option."),
-                    displayMessage = null,
-                )
-            )
+            customerSheetLoader = FakeCustomerSheetLoader(
+                shouldFail = true,
+            ),
         )
         viewModel.result.test {
             assertThat((awaitItem() as InternalCustomerSheetResult.Error).exception.message)
-                .isEqualTo("Failed to retrieve selected payment option.")
+                .isEqualTo("failed to load")
         }
     }
 
     @Test
     fun `When the Google Pay is selected payment method, paymentSelection is GooglePay`() = runTest {
         val viewModel = createViewModel(
-            customerAdapter = FakeCustomerAdapter(
-                selectedPaymentOption = CustomerAdapter.Result.success(CustomerAdapter.PaymentOption.GooglePay)
-            )
+            customerSheetLoader = FakeCustomerSheetLoader(
+                isGooglePayAvailable = true,
+                paymentSelection = PaymentSelection.GooglePay,
+            ),
         )
         viewModel.viewState.test {
             val viewState = awaitViewState<SelectPaymentMethod>()
@@ -245,36 +207,14 @@ class CustomerSheetViewModelTest {
     }
 
     @Test
-    fun `When the Link is selected payment method, paymentSelection is Link`() = runTest {
-        val viewModel = createViewModel(
-            customerAdapter = FakeCustomerAdapter(
-                selectedPaymentOption = CustomerAdapter.Result.success(CustomerAdapter.PaymentOption.Link)
-            )
-        )
-        viewModel.viewState.test {
-            val viewState = awaitViewState<SelectPaymentMethod>()
-            assertThat(viewState.paymentSelection)
-                .isEqualTo(PaymentSelection.Link)
-            assertThat(viewState.errorMessage)
-                .isEqualTo(null)
-        }
-    }
-
-    @Test
     fun `When the payment method is selected payment method, paymentSelection is payment method`() = runTest {
         val viewModel = createViewModel(
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        CARD_PAYMENT_METHOD
-                    )
+            customerSheetLoader = FakeCustomerSheetLoader(
+                customerPaymentMethods = listOf(CARD_PAYMENT_METHOD),
+                paymentSelection = PaymentSelection.Saved(
+                    CARD_PAYMENT_METHOD
                 ),
-                selectedPaymentOption = CustomerAdapter.Result.success(
-                    CustomerAdapter.PaymentOption.fromId(
-                        CARD_PAYMENT_METHOD.id!!
-                    )
-                )
-            )
+            ),
         )
         viewModel.viewState.test {
             val viewState = awaitViewState<SelectPaymentMethod>()
@@ -296,16 +236,12 @@ class CustomerSheetViewModelTest {
     @Test
     fun `When selection, primary button label should not be null`() = runTest {
         val viewModel = createViewModel(
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        CARD_PAYMENT_METHOD
-                    )
+            customerSheetLoader = FakeCustomerSheetLoader(
+                customerPaymentMethods = listOf(
+                    CARD_PAYMENT_METHOD
                 ),
-                selectedPaymentOption = CustomerAdapter.Result.success(
-                    CustomerAdapter.PaymentOption.fromId(
-                        CARD_PAYMENT_METHOD.id!!
-                    )
+                paymentSelection = PaymentSelection.Saved(
+                    paymentMethod = CARD_PAYMENT_METHOD
                 )
             )
         )
@@ -320,16 +256,7 @@ class CustomerSheetViewModelTest {
 
     @Test
     fun `When no selection, the primary button is not visible`() = runTest {
-        val viewModel = createViewModel(
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        CARD_PAYMENT_METHOD
-                    )
-                ),
-                selectedPaymentOption = CustomerAdapter.Result.success(null)
-            )
-        )
+        val viewModel = createViewModel()
         viewModel.viewState.test {
             assertThat(awaitViewState<SelectPaymentMethod>().primaryButtonVisible)
                 .isFalse()
@@ -338,16 +265,7 @@ class CustomerSheetViewModelTest {
 
     @Test
     fun `When Stripe payment method is selected, the primary button is visible`() = runTest {
-        val viewModel = createViewModel(
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        CARD_PAYMENT_METHOD
-                    )
-                ),
-                selectedPaymentOption = CustomerAdapter.Result.success(null)
-            )
-        )
+        val viewModel = createViewModel()
         viewModel.viewState.test {
             var viewState = awaitViewState<SelectPaymentMethod>()
             assertThat(viewState.primaryButtonVisible)
@@ -373,16 +291,7 @@ class CustomerSheetViewModelTest {
 
     @Test
     fun `When Google Pay is selected, the primary button is visible`() = runTest {
-        val viewModel = createViewModel(
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        CARD_PAYMENT_METHOD
-                    )
-                ),
-                selectedPaymentOption = CustomerAdapter.Result.success(null)
-            )
-        )
+        val viewModel = createViewModel()
         viewModel.viewState.test {
             var viewState = awaitViewState<SelectPaymentMethod>()
             assertThat(viewState.primaryButtonLabel)
@@ -409,17 +318,15 @@ class CustomerSheetViewModelTest {
     @Test
     fun `When CustomerViewAction#OnItemSelected with editing view state, payment selection should not be updated`() = runTest {
         val viewModel = createViewModel(
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        CARD_PAYMENT_METHOD,
-                        CARD_PAYMENT_METHOD.copy(id = "pm_2")
-                    )
+            customerSheetLoader = FakeCustomerSheetLoader(
+                customerPaymentMethods = listOf(
+                    CARD_PAYMENT_METHOD,
+                    CARD_PAYMENT_METHOD.copy(id = "pm_2")
                 ),
-                selectedPaymentOption = CustomerAdapter.Result.success(
-                    CustomerAdapter.PaymentOption.fromId(CARD_PAYMENT_METHOD.id!!)
+                paymentSelection = PaymentSelection.Saved(
+                    CARD_PAYMENT_METHOD
                 )
-            )
+            ),
         )
         viewModel.viewState.test {
             val initialViewState = awaitViewState<SelectPaymentMethod>()
@@ -445,16 +352,7 @@ class CustomerSheetViewModelTest {
 
     @Test
     fun `When CustomerViewAction#OnItemSelected with Link, exception should be thrown`() = runTest {
-        val viewModel = createViewModel(
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        CARD_PAYMENT_METHOD
-                    )
-                ),
-                selectedPaymentOption = CustomerAdapter.Result.success(null)
-            )
-        )
+        val viewModel = createViewModel()
         viewModel.viewState.test {
             assertThat(awaitItem()).isInstanceOf(SelectPaymentMethod::class.java)
             val error = assertFailsWith<IllegalStateException> {
@@ -470,16 +368,7 @@ class CustomerSheetViewModelTest {
 
     @Test
     fun `When CustomerViewAction#OnItemSelected with null, primary button label should be null`() = runTest {
-        val viewModel = createViewModel(
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        CARD_PAYMENT_METHOD
-                    )
-                ),
-                selectedPaymentOption = CustomerAdapter.Result.success(null)
-            )
-        )
+        val viewModel = createViewModel()
         viewModel.viewState.test {
             assertThat(awaitItem()).isInstanceOf(SelectPaymentMethod::class.java)
             val error = assertFailsWith<IllegalStateException> {
@@ -540,19 +429,15 @@ class CustomerSheetViewModelTest {
     @Test
     fun `When removing a payment method, payment method list should be updated`() = runTest {
         val viewModel = createViewModel(
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        CARD_PAYMENT_METHOD,
-                        CARD_PAYMENT_METHOD.copy(id = "pm_2")
-                    )
+            customerSheetLoader = FakeCustomerSheetLoader(
+                customerPaymentMethods = listOf(
+                    CARD_PAYMENT_METHOD,
+                    CARD_PAYMENT_METHOD.copy(id = "pm_2")
                 ),
-                selectedPaymentOption = CustomerAdapter.Result.success(
-                    CustomerAdapter.PaymentOption.fromId(
-                        CARD_PAYMENT_METHOD.id!!
-                    )
+                paymentSelection = PaymentSelection.Saved(
+                    CARD_PAYMENT_METHOD
                 )
-            )
+            ),
         )
         viewModel.viewState.test {
             var viewState = awaitViewState<SelectPaymentMethod>()
@@ -574,19 +459,11 @@ class CustomerSheetViewModelTest {
     @Test
     fun `When removing last payment method & google pay disabled, should transition to add payment screen`() = runTest {
         val viewModel = createViewModel(
-            isGooglePayAvailable = false,
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        CARD_PAYMENT_METHOD
-                    )
-                ),
-                selectedPaymentOption = CustomerAdapter.Result.success(
-                    CustomerAdapter.PaymentOption.fromId(
-                        CARD_PAYMENT_METHOD.id!!
-                    )
-                )
-            )
+            customerSheetLoader = FakeCustomerSheetLoader(
+                isGooglePayAvailable = false,
+                customerPaymentMethods = listOf(CARD_PAYMENT_METHOD),
+                paymentSelection = PaymentSelection.Saved(CARD_PAYMENT_METHOD),
+            ),
         )
         viewModel.viewState.test {
             val viewState = awaitViewState<SelectPaymentMethod>()
@@ -609,11 +486,6 @@ class CustomerSheetViewModelTest {
     fun `When removing a payment method fails, error message is displayed`() = runTest {
         val viewModel = createViewModel(
             customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        CARD_PAYMENT_METHOD
-                    )
-                ),
                 onDetachPaymentMethod = {
                     CustomerAdapter.Result.failure(
                         cause = APIException(
@@ -647,18 +519,8 @@ class CustomerSheetViewModelTest {
     @Test
     fun `When primary button is pressed for saved payment method, selected payment method is emitted`() = runTest {
         val viewModel = createViewModel(
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        CARD_PAYMENT_METHOD
-                    )
-                ),
-                selectedPaymentOption = CustomerAdapter.Result.success(
-                    CustomerAdapter.PaymentOption.fromId(
-                        CARD_PAYMENT_METHOD.id!!
-                    )
-                )
-            )
+            customerPaymentMethods = listOf(CARD_PAYMENT_METHOD),
+            savedPaymentSelection = PaymentSelection.Saved(CARD_PAYMENT_METHOD),
         )
         val viewStateTurbine = viewModel.viewState.testIn(backgroundScope)
         val resultTurbine = viewModel.result.testIn(backgroundScope)
@@ -674,17 +536,9 @@ class CustomerSheetViewModelTest {
     @Test
     fun `When primary button is pressed for saved payment method that cannot be saved, error message is emitted`() = runTest {
         val viewModel = createViewModel(
+            customerPaymentMethods = listOf(CARD_PAYMENT_METHOD),
+            savedPaymentSelection = PaymentSelection.Saved(CARD_PAYMENT_METHOD),
             customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        CARD_PAYMENT_METHOD
-                    )
-                ),
-                selectedPaymentOption = CustomerAdapter.Result.success(
-                    CustomerAdapter.PaymentOption.fromId(
-                        CARD_PAYMENT_METHOD.id!!
-                    )
-                ),
                 onSetSelectedPaymentOption = {
                     CustomerAdapter.Result.failure(
                         cause = Exception("Unable to set payment option"),
@@ -1184,52 +1038,6 @@ class CustomerSheetViewModelTest {
     }
 
     @Test
-    fun `When there is a payment selection, the selected PM should be first in the list`() = runTest {
-        val viewModel = createViewModel(
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        CARD_PAYMENT_METHOD.copy(id = "pm_1"),
-                        CARD_PAYMENT_METHOD.copy(id = "pm_2"),
-                        CARD_PAYMENT_METHOD.copy(id = "pm_3"),
-                    )
-                ),
-                selectedPaymentOption = CustomerAdapter.Result.success(
-                    CustomerAdapter.PaymentOption.fromId("pm_3")
-                )
-            )
-        )
-
-        viewModel.viewState.test {
-            val viewState = awaitViewState<SelectPaymentMethod>()
-            assertThat(viewState.savedPaymentMethods.indexOfFirst { it.id == "pm_3" }).isEqualTo(0)
-        }
-    }
-
-    @Test
-    fun `When there is no payment selection, the order of the payment methods is preserved`() = runTest {
-        val viewModel = createViewModel(
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        CARD_PAYMENT_METHOD.copy(id = "pm_1"),
-                        CARD_PAYMENT_METHOD.copy(id = "pm_2"),
-                        CARD_PAYMENT_METHOD.copy(id = "pm_3"),
-                    )
-                ),
-                selectedPaymentOption = CustomerAdapter.Result.success(null)
-            )
-        )
-
-        viewModel.viewState.test {
-            val viewState = awaitViewState<SelectPaymentMethod>()
-            assertThat(viewState.savedPaymentMethods.indexOfFirst { it.id == "pm_1" }).isEqualTo(0)
-            assertThat(viewState.savedPaymentMethods.indexOfFirst { it.id == "pm_2" }).isEqualTo(1)
-            assertThat(viewState.savedPaymentMethods.indexOfFirst { it.id == "pm_3" }).isEqualTo(2)
-        }
-    }
-
-    @Test
     fun `Moving from screen to screen preserves state`() = runTest {
         val viewModel = createViewModel(
             initialBackStack = listOf(
@@ -1348,7 +1156,9 @@ class CustomerSheetViewModelTest {
             configuration = CustomerSheet.Configuration(
                 googlePayEnabled = true,
             ),
-            isGooglePayAvailable = true,
+            customerSheetLoader = FakeCustomerSheetLoader(
+                isGooglePayAvailable = true,
+            ),
         )
 
         viewModel.viewState.test {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.customersheet
+package com.stripe.android.customersheet.utils
 
 import android.app.Application
 import androidx.activity.result.ActivityResultLauncher
@@ -6,8 +6,15 @@ import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
+import com.stripe.android.customersheet.CustomerAdapter
+import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.customersheet.CustomerSheetLoader
+import com.stripe.android.customersheet.CustomerSheetViewModel
+import com.stripe.android.customersheet.CustomerSheetViewState
+import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.customersheet.FakeCustomerAdapter
+import com.stripe.android.customersheet.FakeStripeRepository
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
-import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
 import com.stripe.android.networking.StripeRepository
@@ -25,11 +32,12 @@ import com.stripe.android.uicore.address.AddressRepository
 import com.stripe.android.utils.DummyActivityResultCaller
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.flowOf
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import javax.inject.Provider
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 object CustomerSheetTestHelper {
@@ -85,32 +93,44 @@ object CustomerSheetTestHelper {
     }
 
     internal fun createViewModel(
-        lpmRepository: LpmRepository = this.lpmRepository,
+        lpmRepository: LpmRepository = CustomerSheetTestHelper.lpmRepository,
         isLiveMode: Boolean = false,
-        initialBackStack: List<CustomerSheetViewState> = listOf(CustomerSheetViewState.Loading(isLiveMode)),
-        savedPaymentSelection: PaymentSelection? = null,
-        customerAdapter: CustomerAdapter = FakeCustomerAdapter(
-            paymentMethods = CustomerAdapter.Result.success(listOf(CARD_PAYMENT_METHOD))
+        workContext: CoroutineContext = EmptyCoroutineContext,
+        initialBackStack: List<CustomerSheetViewState> = listOf(
+            CustomerSheetViewState.Loading(
+                isLiveMode
+            )
         ),
+        isGooglePayAvailable: Boolean = true,
+        customerPaymentMethods: List<PaymentMethod> = listOf(CARD_PAYMENT_METHOD),
+        savedPaymentSelection: PaymentSelection? = null,
         stripeRepository: StripeRepository = FakeStripeRepository(),
         paymentConfiguration: PaymentConfiguration = PaymentConfiguration(
             publishableKey = "pk_test_123",
             stripeAccountId = null,
         ),
         configuration: CustomerSheet.Configuration = CustomerSheet.Configuration(
-            googlePayEnabled = true
+            googlePayEnabled = isGooglePayAvailable
         ),
-        isGooglePayAvailable: Boolean = true,
         formViewModelSubcomponentBuilderProvider: Provider<FormViewModelSubcomponent.Builder> =
             mockedFormViewModel(configuration),
         eventReporter: CustomerSheetEventReporter = mock(),
         intentConfirmationInterceptor: IntentConfirmationInterceptor = FakeIntentConfirmationInterceptor().apply {
             enqueueCompleteStep(true)
-        }
+        },
+        customerAdapter: CustomerAdapter = FakeCustomerAdapter(
+            paymentMethods = CustomerAdapter.Result.success(customerPaymentMethods)
+        ),
+        customerSheetLoader: CustomerSheetLoader = FakeCustomerSheetLoader(
+            customerPaymentMethods = customerPaymentMethods,
+            paymentSelection = savedPaymentSelection,
+            isGooglePayAvailable = isGooglePayAvailable,
+        ),
     ): CustomerSheetViewModel {
         return CustomerSheetViewModel(
             application = application,
             initialBackStack = initialBackStack,
+            workContext = workContext,
             savedPaymentSelection = savedPaymentSelection,
             paymentConfigurationProvider = { paymentConfiguration },
             formViewModelSubcomponentBuilderProvider = formViewModelSubcomponentBuilderProvider,
@@ -132,14 +152,9 @@ object CustomerSheetTestHelper {
                     return mock()
                 }
             },
-            googlePayRepositoryFactory = {
-                GooglePayRepository {
-                    flowOf(isGooglePayAvailable)
-                }
-            },
             statusBarColor = { null },
             eventReporter = eventReporter,
-            customerSheetLoader = mock()
+            customerSheetLoader = customerSheetLoader,
         ).apply {
             registerFromActivity(DummyActivityResultCaller(), TestLifecycleOwner())
         }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
@@ -1,0 +1,40 @@
+package com.stripe.android.customersheet.utils
+
+import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.customersheet.CustomerSheetLoader
+import com.stripe.android.customersheet.CustomerSheetState
+import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import kotlinx.coroutines.delay
+import kotlin.time.Duration
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+internal class FakeCustomerSheetLoader(
+    private val stripeIntent: StripeIntent = PaymentIntentFixtures.PI_SUCCEEDED,
+    private val shouldFail: Boolean = false,
+    private val customerPaymentMethods: List<PaymentMethod> = emptyList(),
+    private val paymentSelection: PaymentSelection? = null,
+    private val isGooglePayAvailable: Boolean = false,
+    private val delay: Duration = Duration.ZERO,
+) : CustomerSheetLoader {
+
+    override suspend fun load(configuration: CustomerSheet.Configuration?): Result<CustomerSheetState.Full> {
+        delay(delay)
+        return if (shouldFail) {
+            Result.failure(IllegalStateException("failed to load"))
+        } else {
+            Result.success(
+                CustomerSheetState.Full(
+                    config = configuration,
+                    stripeIntent = stripeIntent,
+                    customerPaymentMethods = customerPaymentMethods,
+                    isGooglePayReady = isGooglePayAvailable,
+                    paymentSelection = paymentSelection,
+                )
+            )
+        }
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Use CustomerSheetLoader in CustomerSheetViewModel. Nothing should have changed, just refactoring the payment method loading mechanisms in preparation for ACHv2 payment methods.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

CustomerSheet ACHv2

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

