### PR TITLE
[Android] Additional close confirmations + remove featured institutions limit

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/FeaturedInstitutions.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/FeaturedInstitutions.kt
@@ -16,11 +16,6 @@ internal class FeaturedInstitutions @Inject constructor(
     ): InstitutionResponse {
         return repository.featuredInstitutions(
             clientSecret = clientSecret,
-            limit = SEARCH_INSTITUTIONS_LIMIT
         )
-    }
-
-    private companion object {
-        private const val SEARCH_INSTITUTIONS_LIMIT = 10
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/SharedPartnerAuth.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/SharedPartnerAuth.kt
@@ -109,7 +109,7 @@ internal fun SharedPartnerAuth(
         onClickableTextClick = onClickableTextClick,
         onSelectAnotherBank = onSelectAnotherBank,
         onEnterDetailsManually = onEnterDetailsManually,
-        onCloseClick = { viewModel.onCloseNoConfirmationClick(state.pane) },
+        onCloseClick = { viewModel.onCloseWithConfirmationClick(state.pane) },
         onContinueClick = onContinueClick,
         onCloseFromErrorClick = viewModel::onCloseFromErrorClick
     )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
@@ -105,7 +105,7 @@ internal fun InstitutionPickerScreen() {
         onQueryChanged = viewModel::onQueryChanged,
         onInstitutionSelected = viewModel::onInstitutionSelected,
         onCancelSearchClick = viewModel::onCancelSearchClick,
-        onCloseClick = { parentViewModel.onCloseNoConfirmationClick(Pane.INSTITUTION_PICKER) },
+        onCloseClick = { parentViewModel.onCloseWithConfirmationClick(Pane.INSTITUTION_PICKER) },
         onSearchFocused = viewModel::onSearchFocused,
         onManualEntryClick = viewModel::onManualEntryClick,
         onScrollChanged = viewModel::onScrollChanged

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryScreen.kt
@@ -74,7 +74,7 @@ internal fun ManualEntryScreen() {
         onAccountEntered = viewModel::onAccountEntered,
         onAccountConfirmEntered = viewModel::onAccountConfirmEntered,
         onSubmit = viewModel::onSubmit,
-    ) { parentViewModel.onCloseNoConfirmationClick(Pane.MANUAL_ENTRY) }
+    ) { parentViewModel.onCloseWithConfirmationClick(Pane.MANUAL_ENTRY) }
 }
 
 @Composable

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessScreen.kt
@@ -59,7 +59,7 @@ internal fun ManualEntrySuccessScreen(
         microdepositVerificationMethod = Destination.ManualEntrySuccess.microdeposits(backStackEntry),
         last4 = Destination.ManualEntrySuccess.last4(backStackEntry),
         loading = completeAuthSessionAsync.value is Loading,
-        onCloseClick = { parentViewModel.onCloseWithConfirmationClick(Pane.MANUAL_ENTRY_SUCCESS) },
+        onCloseClick = { parentViewModel.onCloseNoConfirmationClick(Pane.MANUAL_ENTRY_SUCCESS) },
         onDoneClick = viewModel::onSubmit
     )
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupScreen.kt
@@ -59,7 +59,7 @@ internal fun NetworkingLinkLoginWarmupScreen() {
     val state = viewModel.collectAsState()
     NetworkingLinkLoginWarmupContent(
         state = state.value,
-        onCloseClick = { parentViewModel.onCloseNoConfirmationClick(PANE) },
+        onCloseClick = { parentViewModel.onCloseWithConfirmationClick(PANE) },
         onCloseFromErrorClick = parentViewModel::onCloseFromErrorClick,
         onClickableTextClick = viewModel::onClickableTextClick,
         onContinueClick = viewModel::onContinueClick,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/reset/ResetScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/reset/ResetScreen.kt
@@ -26,7 +26,7 @@ internal fun ResetScreen() {
     BackHandler(enabled = true) {}
     ResetContent(
         payload = payload.value,
-        onCloseClick = { parentViewModel.onCloseNoConfirmationClick(Pane.RESET) },
+        onCloseClick = { parentViewModel.onCloseWithConfirmationClick(Pane.RESET) },
         onCloseFromErrorClick = parentViewModel::onCloseFromErrorClick
     )
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsInstitutionsRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsInstitutionsRepository.kt
@@ -9,7 +9,6 @@ internal interface FinancialConnectionsInstitutionsRepository {
 
     suspend fun featuredInstitutions(
         clientSecret: String,
-        limit: Int
     ): InstitutionResponse
 
     suspend fun searchInstitutions(
@@ -39,14 +38,12 @@ private class FinancialConnectionsInstitutionsRepositoryImpl(
 
     override suspend fun featuredInstitutions(
         clientSecret: String,
-        limit: Int
     ): InstitutionResponse {
         val request = apiRequestFactory.createGet(
             url = featuredInstitutionsUrl,
             options = apiOptions,
             params = mapOf(
                 PARAMS_CLIENT_SECRET to clientSecret,
-                "limit" to limit
             )
         )
         return requestExecutor.execute(


### PR DESCRIPTION
# Summary
- Adds close confirmation dialog on all panes except for `Consent` and `Success/ManualEntrySuccess`.
- Removes limit on featured institutions.

# Motivation
:notebook_with_decorative_cover: &nbsp;**[Android] Add additional close confirmations in auth flow**
:globe_with_meridians: &nbsp;[BANKCON-7938](https://jira.corp.stripe.com/browse/BANKCON-7938)
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

| More institutions on the picker | Close confirmation on the picker | Close on prepane
|:------------:|:-----------:|:-----------:|
| <img src="https://github.com/stripe/stripe-android/assets/99293320/cacf0576-2a1e-48ce-aae8-0e4860b27b91" width="200"> | <img src="https://github.com/stripe/stripe-android/assets/99293320/a5405f11-093e-4ea4-b5b7-f860d8c717e8" width="200"> | <img width="200" alt="image" src="https://github.com/stripe/stripe-android/assets/99293320/aca03bf1-fe56-409d-b683-eeeb3e882d71"> |



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->