### PR TITLE
Move mandates to the end of the form.

### DIFF
--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -232,6 +232,22 @@ public final class com/stripe/android/ui/core/elements/CardDetailsSectionSpec$Co
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/CashAppPayMandateTextSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/CashAppPayMandateTextSpec$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/ui/core/elements/CashAppPayMandateTextSpec;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/ui/core/elements/CashAppPayMandateTextSpec;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/CashAppPayMandateTextSpec$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public abstract class com/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs {
 	public static final field $stable I
 	public static final field Companion Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$Companion;

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CashAppPayMandateTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CashAppPayMandateTextSpec.kt
@@ -11,7 +11,7 @@ import kotlinx.serialization.Transient
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Serializable
-internal data class CashAppPayMandateTextSpec(
+data class CashAppPayMandateTextSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("cashapp_mandate"),
     @StringRes

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PlaceholderHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PlaceholderHelper.kt
@@ -5,8 +5,10 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
 import com.stripe.android.ui.core.elements.AddressSpec
+import com.stripe.android.ui.core.elements.CashAppPayMandateTextSpec
 import com.stripe.android.ui.core.elements.EmailSpec
 import com.stripe.android.ui.core.elements.FormItemSpec
+import com.stripe.android.ui.core.elements.MandateTextSpec
 import com.stripe.android.ui.core.elements.NameSpec
 import com.stripe.android.ui.core.elements.PhoneSpec
 import com.stripe.android.ui.core.elements.PlaceholderSpec
@@ -81,7 +83,15 @@ internal object PlaceholderHelper {
             }
         )
 
-        return modifiedSpecs
+        return modifiedSpecs.sortedWith { o1, o2 ->
+            if (o1 is MandateTextSpec || o1 is CashAppPayMandateTextSpec) {
+                1
+            } else if (o2 is MandateTextSpec || o2 is CashAppPayMandateTextSpec) {
+                -1
+            } else {
+                0
+            }
+        }
     }
 
     @VisibleForTesting

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/PlaceholderHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/PlaceholderHelperTest.kt
@@ -6,7 +6,9 @@ import com.stripe.android.paymentsheet.forms.PlaceholderHelper.removeCorrespondi
 import com.stripe.android.paymentsheet.forms.PlaceholderHelper.specForPlaceholderField
 import com.stripe.android.paymentsheet.forms.PlaceholderHelper.specsForConfiguration
 import com.stripe.android.ui.core.elements.AddressSpec
+import com.stripe.android.ui.core.elements.CashAppPayMandateTextSpec
 import com.stripe.android.ui.core.elements.EmailSpec
+import com.stripe.android.ui.core.elements.MandateTextSpec
 import com.stripe.android.ui.core.elements.NameSpec
 import com.stripe.android.ui.core.elements.PhoneSpec
 import com.stripe.android.ui.core.elements.PlaceholderSpec
@@ -459,6 +461,76 @@ class PlaceholderHelperTest {
             )
         ).isInstanceOf(
             AddressSpec::class.java
+        )
+    }
+
+    @Test
+    fun `Test mandate is moved to the end of the list`() {
+        val billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+            name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+            attachDefaultsToPaymentMethod = false,
+        )
+
+        val exampleTextSpec = SimpleTextSpec(
+            apiPath = IdentifierSpec.Generic("dummy"),
+            label = StripeR.string.stripe_affirm_buy_now_pay_later,
+        )
+        val mandateTextSpec = MandateTextSpec(stringResId = 0)
+        val specs = specsForConfiguration(
+            configuration = billingDetailsCollectionConfiguration,
+            placeholderOverrideList = emptyList(),
+            requiresMandate = true,
+            specs = listOf(
+                exampleTextSpec,
+                mandateTextSpec,
+            ),
+        )
+
+        assertThat(specs).containsExactly(
+            exampleTextSpec,
+            NameSpec(),
+            EmailSpec(),
+            PhoneSpec(),
+            AddressSpec(),
+            mandateTextSpec
+        )
+    }
+
+    @Test
+    fun `Test cashapp mandate is moved to the end of the list`() {
+        val billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+            name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+            attachDefaultsToPaymentMethod = false,
+        )
+
+        val exampleTextSpec = SimpleTextSpec(
+            apiPath = IdentifierSpec.Generic("dummy"),
+            label = StripeR.string.stripe_affirm_buy_now_pay_later,
+        )
+        val mandateTextSpec = CashAppPayMandateTextSpec()
+        val specs = specsForConfiguration(
+            configuration = billingDetailsCollectionConfiguration,
+            placeholderOverrideList = emptyList(),
+            requiresMandate = true,
+            specs = listOf(
+                exampleTextSpec,
+                mandateTextSpec,
+            ),
+        )
+
+        assertThat(specs).containsExactly(
+            exampleTextSpec,
+            NameSpec(),
+            EmailSpec(),
+            PhoneSpec(),
+            AddressSpec(),
+            mandateTextSpec
         )
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Mandates that are added locally were being displayed above billing address collection fields. This change moves them to below the billing address collection fields.

<img width="200" alt="Screenshot 2023-10-20 at 9 25 29 AM" src="https://github.com/stripe/stripe-android/assets/116920913/8734ac0a-bfe2-4d63-b2cd-e59c425b2141">
<img width="200" alt="Screenshot 2023-10-20 at 9 24 54 AM" src="https://github.com/stripe/stripe-android/assets/116920913/7b387eae-2aba-4ef4-abeb-96f0e81b269f">
<img width="200" alt="Screenshot 2023-10-20 at 9 24 41 AM" src="https://github.com/stripe/stripe-android/assets/116920913/98e650a9-2ed4-46b6-8038-0df965499549">

