### PR TITLE
Remove dependency on BaseSheetViewModel

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -100,7 +100,7 @@ internal fun AddPaymentMethod(
                 ?.intentConfiguration
                 ?.onBehalfOf
             PaymentElement(
-                sheetViewModel = sheetViewModel,
+                formViewModelSubComponentBuilderProvider = sheetViewModel.formViewModelSubComponentBuilderProvider,
                 enabled = !processing,
                 supportedPaymentMethods = sheetViewModel.supportedPaymentMethods,
                 selectedItem = selectedItem,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -20,17 +19,18 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentMethodsUI
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.forms.FormFieldValues
+import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountForm
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
-import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.uicore.image.StripeImageLoader
 import kotlinx.coroutines.flow.Flow
+import javax.inject.Provider
 
 @Composable
 internal fun PaymentElement(
-    sheetViewModel: BaseSheetViewModel,
+    formViewModelSubComponentBuilderProvider: Provider<FormViewModelSubcomponent.Builder>,
     enabled: Boolean,
     supportedPaymentMethods: List<LpmRepository.SupportedPaymentMethod>,
     selectedItem: LpmRepository.SupportedPaymentMethod,
@@ -52,8 +52,6 @@ internal fun PaymentElement(
         id = R.dimen.stripe_paymentsheet_outer_spacing_horizontal
     )
 
-    val primaryButtonState = sheetViewModel.primaryButtonState.collectAsState()
-
     Column(modifier = Modifier.fillMaxWidth()) {
         if (supportedPaymentMethods.size > 1) {
             PaymentMethodsUI(
@@ -71,7 +69,7 @@ internal fun PaymentElement(
                 USBankAccountForm(
                     formArgs = formArguments,
                     usBankAccountFormArgs = usBankAccountFormArguments,
-                    isProcessing = primaryButtonState.value?.isProcessing == true,
+                    isProcessing = !enabled,
                     modifier = Modifier.padding(horizontal = horizontalPadding),
                 )
             } else {
@@ -80,7 +78,7 @@ internal fun PaymentElement(
                     enabled = enabled,
                     onFormFieldValuesChanged = onFormFieldValuesChanged,
                     showCheckboxFlow = showCheckboxFlow,
-                    formViewModelSubComponentBuilderProvider = sheetViewModel.formViewModelSubComponentBuilderProvider,
+                    formViewModelSubComponentBuilderProvider = formViewModelSubComponentBuilderProvider,
                     modifier = Modifier.padding(horizontal = horizontalPadding)
                 )
             }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Remove dependency on BaseSheetViewModel in preparation for CustomerSheet ACHv2.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

The PaymentElement will be reused in CustomerSheet.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
