### PR TITLE
Fix description setting in Lokalise script

### DIFF
--- a/scripts/lokalise/string_resources.rb
+++ b/scripts/lokalise/string_resources.rb
@@ -62,6 +62,8 @@ class StringResources
                 if description.start_with?('<!--') && description.end_with?('-->')
                     # Remove the leading <!-- and trailing --> from description
                     description = description.delete_prefix('<!--').delete_suffix('-->').strip
+                else
+                    description = nil
                 end
 
                 key_object = {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue in the Lokalise script where it would use the previous line as the translation’s description even if it wasn’t an XML comment.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
