### PR TITLE
Don't force Material Theme with CardBrandView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+### Payments
+* [FIXED][7485](https://github.com/stripe/stripe-android/pull/7485) Fixed a crash when using `CardInputWidget` in an AppCompat theme.
+
 ## 20.34.0 - 2023-10-23
 
 ### Payments

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -91,10 +91,14 @@ ext.configs = [
 
 ext.libs = [
         accompanist                         : [
-                flowLayout         : "com.google.accompanist:accompanist-flowlayout:${versions.accompanist}",
-                systemUiController : "com.google.accompanist:accompanist-systemuicontroller:${versions.accompanist}",
-                themeAdapter       : "com.google.accompanist:accompanist-themeadapter-material:${versions.accompanist}",
-                webView            : "com.google.accompanist:accompanist-webview:${versions.accompanist}",
+                appCompatThemeAdapter: "com.google.accompanist:accompanist-themeadapter-appcompat:${versions.accompanist}",
+                flowLayout           : "com.google.accompanist:accompanist-flowlayout:${versions.accompanist}",
+                navigationAnimation  : "com.google.accompanist:accompanist-navigation-animation:${versions.accompanist}",
+                navigationMaterial   : "com.google.accompanist:accompanist-navigation-material:${versions.accompanist}",
+                systemUiController   : "com.google.accompanist:accompanist-systemuicontroller:${versions.accompanist}",
+                materialThemeAdapter : "com.google.accompanist:accompanist-themeadapter-material:${versions.accompanist}",
+                material3ThemeAdapter : "com.google.accompanist:accompanist-themeadapter-material3:${versions.accompanist}",
+                webView              : "com.google.accompanist:accompanist-webview:${versions.accompanist}",
         ],
         alipay                              : "com.alipay.sdk:alipaysdk-android:${versions.alipay}",
         androidx                            : [

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation project(':payments')
     implementation project(':financial-connections')
 
-    implementation libs.accompanist.themeAdapter
+    implementation libs.accompanist.materialThemeAdapter
     implementation libs.alipay
     implementation libs.androidx.appCompat
     implementation libs.androidx.constraintLayout

--- a/identity-example/build.gradle
+++ b/identity-example/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation project(':identity')
     implementation project(':stripe-ui-core')
 
-    implementation libs.accompanist.themeAdapter
+    implementation libs.accompanist.materialThemeAdapter
     implementation libs.androidx.appCompat
     implementation libs.androidx.browser
     implementation libs.androidx.constraintLayout

--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation project(":stripe-ui-core")
     implementation project(":ml-core:default")
 
-    implementation libs.accompanist.themeAdapter
+    implementation libs.accompanist.materialThemeAdapter
     implementation libs.androidx.activity
     implementation libs.androidx.appCompat
     implementation libs.androidx.browser

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -10,7 +10,9 @@ dependencies {
     implementation project(":stripe-ui-core")
     compileOnly project(':financial-connections')
 
-    implementation libs.accompanist.themeAdapter
+    implementation libs.accompanist.appCompatThemeAdapter
+    implementation libs.accompanist.materialThemeAdapter
+    implementation libs.accompanist.material3ThemeAdapter
     implementation libs.androidx.activity
     implementation libs.androidx.annotation
     implementation libs.androidx.appCompat

--- a/payments-core/src/main/java/com/stripe/android/utils/Theming.kt
+++ b/payments-core/src/main/java/com/stripe/android/utils/Theming.kt
@@ -1,0 +1,38 @@
+package com.stripe.android.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.res.use
+import com.google.accompanist.themeadapter.appcompat.AppCompatTheme
+import com.google.accompanist.themeadapter.material.MdcTheme
+import com.google.accompanist.themeadapter.material3.Mdc3Theme
+import com.google.accompanist.themeadapter.material.R as MaterialR
+import com.google.accompanist.themeadapter.material3.R as Material3R
+
+@Composable
+internal fun AppCompatOrMdcTheme(
+    content: @Composable () -> Unit,
+) {
+    val context = LocalContext.current
+
+    val isMaterialTheme = remember {
+        context.obtainStyledAttributes(MaterialR.styleable.ThemeAdapterMaterialTheme).use { ta ->
+            ta.hasValue(MaterialR.styleable.ThemeAdapterMaterialTheme_isMaterialTheme)
+        }
+    }
+
+    val isMaterial3Theme = remember {
+        context.obtainStyledAttributes(Material3R.styleable.ThemeAdapterMaterial3Theme).use { ta ->
+            ta.hasValue(Material3R.styleable.ThemeAdapterMaterial3Theme_isMaterial3Theme)
+        }
+    }
+
+    if (isMaterialTheme) {
+        MdcTheme(content = content)
+    } else if (isMaterial3Theme) {
+        Mdc3Theme(content = content)
+    } else {
+        AppCompatTheme(content = content)
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.themeadapter.material.MdcTheme
 import com.stripe.android.R
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.databinding.StripeCardBrandViewBinding
@@ -33,6 +32,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardBrand.Unknown
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.uicore.elements.SingleChoiceDropdown
+import com.stripe.android.utils.AppCompatOrMdcTheme
 import com.stripe.android.utils.FeatureFlags
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlin.properties.Delegates
@@ -120,7 +120,7 @@ internal class CardBrandView @JvmOverloads constructor(
         isFocusable = false
 
         iconView.setContent {
-            MdcTheme {
+            AppCompatOrMdcTheme {
                 val isCbcEligible by isCbcEligibleFlow.collectAsState()
                 val isLoading by isLoadingFlow.collectAsState()
                 val currentBrand by brandFlow.collectAsState()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where `CardBrandView` inadvertently required the use of a MaterialComponents theme.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Resolves https://github.com/stripe/stripe-android/issues/7484

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
