### PR TITLE
Add ability to switch payment methods in add flow

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewAction.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewAction.kt
@@ -3,6 +3,7 @@ package com.stripe.android.customersheet
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.ui.core.forms.resources.LpmRepository
 
 internal sealed class CustomerSheetViewAction {
     object OnDismissed : CustomerSheetViewAction()
@@ -14,4 +15,7 @@ internal sealed class CustomerSheetViewAction {
     class OnItemSelected(val selection: PaymentSelection?) : CustomerSheetViewAction()
     class OnModifyItem(val paymentMethod: PaymentMethod) : CustomerSheetViewAction()
     class OnItemRemoved(val paymentMethod: PaymentMethod) : CustomerSheetViewAction()
+    class OnAddPaymentMethodItemChanged(
+        val paymentMethod: LpmRepository.SupportedPaymentMethod,
+    ) : CustomerSheetViewAction()
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -60,7 +60,7 @@ import com.stripe.android.ui.core.R as UiCoreR
 @OptIn(ExperimentalCustomerSheetApi::class)
 @CustomerSheetViewModelScope
 internal class CustomerSheetViewModel @Inject constructor(
-    private val application: Application,
+    private val application: Application, // TODO (jameswoo) remove application
     initialBackStack: @JvmSuppressWildcards List<CustomerSheetViewState>,
     private var savedPaymentSelection: PaymentSelection?,
     private val paymentConfigurationProvider: Provider<PaymentConfiguration>,
@@ -303,11 +303,11 @@ internal class CustomerSheetViewModel @Inject constructor(
                 primaryButtonLabel = if (paymentMethod.code == PaymentMethod.Type.USBankAccount.code) {
                     resolvableString(
                         id = UiCoreR.string.stripe_continue_button_label
-                    ).resolve(application)
+                    )
                 } else {
                     resolvableString(
                         id = R.string.stripe_paymentsheet_save
-                    ).resolve(application)
+                    )
                 }
             )
         }
@@ -494,7 +494,7 @@ internal class CustomerSheetViewModel @Inject constructor(
                 isFirstPaymentMethod = isFirstPaymentMethod,
                 primaryButtonLabel = resolvableString(
                     id = R.string.stripe_paymentsheet_save
-                ).resolve(application)
+                )
             ),
             reset = isFirstPaymentMethod
         )

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.customersheet
 
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.forms.FormViewModel
@@ -73,7 +74,7 @@ internal sealed class CustomerSheetViewState(
         override val isProcessing: Boolean,
         val errorMessage: String? = null,
         val isFirstPaymentMethod: Boolean,
-        val primaryButtonLabel: String,
+        val primaryButtonLabel: ResolvableString,
     ) : CustomerSheetViewState(
         savedPaymentMethods = emptyList(),
         isLiveMode = isLiveMode,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
@@ -72,7 +72,8 @@ internal sealed class CustomerSheetViewState(
         override val isLiveMode: Boolean,
         override val isProcessing: Boolean,
         val errorMessage: String? = null,
-        val isFirstPaymentMethod: Boolean
+        val isFirstPaymentMethod: Boolean,
+        val primaryButtonLabel: String?,
     ) : CustomerSheetViewState(
         savedPaymentMethods = emptyList(),
         isLiveMode = isLiveMode,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
@@ -73,7 +73,7 @@ internal sealed class CustomerSheetViewState(
         override val isProcessing: Boolean,
         val errorMessage: String? = null,
         val isFirstPaymentMethod: Boolean,
-        val primaryButtonLabel: String?,
+        val primaryButtonLabel: String,
     ) : CustomerSheetViewState(
         savedPaymentMethods = emptyList(),
         isLiveMode = isLiveMode,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -206,6 +207,7 @@ internal fun AddPaymentMethodWithPaymentElement(
     formViewModelSubComponentBuilderProvider: Provider<FormViewModelSubcomponent.Builder>?,
 ) {
     requireNotNull(formViewModelSubComponentBuilderProvider)
+    val context = LocalContext.current
     val horizontalPadding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
 
     // TODO (jameswoo) make sure that the spacing is consistent with paymentsheet
@@ -244,7 +246,7 @@ internal fun AddPaymentMethodWithPaymentElement(
         }
 
         PrimaryButton(
-            label = viewState.primaryButtonLabel,
+            label = viewState.primaryButtonLabel.resolve(context),
             isEnabled = viewState.primaryButtonEnabled,
             isLoading = viewState.isProcessing,
             onButtonClick = {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -225,7 +225,9 @@ internal fun AddPaymentMethodWithPaymentElement(
             showLinkInlineSignup = false,
             linkConfigurationCoordinator = null,
             showCheckboxFlow = flowOf(false),
-            onItemSelectedListener = { },
+            onItemSelectedListener = {
+                viewActionHandler(CustomerSheetViewAction.OnAddPaymentMethodItemChanged(it))
+            },
             onLinkSignupStateChanged = { _, _ -> },
             formArguments = viewState.formArguments,
             usBankAccountFormArguments = viewState.usBankAccountFormArguments,
@@ -242,7 +244,9 @@ internal fun AddPaymentMethodWithPaymentElement(
         }
 
         PrimaryButton(
-            label = stringResource(id = R.string.stripe_paymentsheet_save),
+            label = viewState.primaryButtonLabel ?: stringResource(
+                id = R.string.stripe_paymentsheet_save
+            ),
             isEnabled = viewState.primaryButtonEnabled,
             isLoading = viewState.isProcessing,
             onButtonClick = {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -26,6 +25,7 @@ import com.stripe.android.paymentsheet.ui.PaymentSheetScaffold
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBar
 import com.stripe.android.ui.core.FormUI
 import com.stripe.android.ui.core.elements.H4Text
+import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.utils.FeatureFlags.customerSheetACHv2
 import kotlinx.coroutines.flow.flowOf
 import javax.inject.Provider
@@ -207,7 +207,6 @@ internal fun AddPaymentMethodWithPaymentElement(
     formViewModelSubComponentBuilderProvider: Provider<FormViewModelSubcomponent.Builder>?,
 ) {
     requireNotNull(formViewModelSubComponentBuilderProvider)
-    val context = LocalContext.current
     val horizontalPadding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
 
     // TODO (jameswoo) make sure that the spacing is consistent with paymentsheet
@@ -246,7 +245,7 @@ internal fun AddPaymentMethodWithPaymentElement(
         }
 
         PrimaryButton(
-            label = viewState.primaryButtonLabel.resolve(context),
+            label = viewState.primaryButtonLabel.resolve(),
             isEnabled = viewState.primaryButtonEnabled,
             isLoading = viewState.isProcessing,
             onButtonClick = {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -244,9 +244,7 @@ internal fun AddPaymentMethodWithPaymentElement(
         }
 
         PrimaryButton(
-            label = viewState.primaryButtonLabel ?: stringResource(
-                id = R.string.stripe_paymentsheet_save
-            ),
+            label = viewState.primaryButtonLabel,
             isEnabled = viewState.primaryButtonEnabled,
             isLoading = viewState.isProcessing,
             onButtonClick = {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.paymentsheet.forms
 
+import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -62,6 +64,24 @@ internal object FormArgumentsFactory {
             cbcEligibility = cbcEligibility,
             requiresMandate = paymentMethod.requiresMandate,
             requiredFields = paymentMethod.placeholderOverrideList,
+        )
+    }
+
+    @OptIn(ExperimentalCustomerSheetApi::class)
+    fun create(
+        paymentMethod: LpmRepository.SupportedPaymentMethod,
+        configuration: CustomerSheet.Configuration,
+        merchantName: String,
+    ): FormArguments {
+        return FormArguments(
+            paymentMethodCode = paymentMethod.code,
+            showCheckbox = false,
+            showCheckboxControlledFields = false,
+            merchantName = merchantName,
+            billingDetails = configuration.defaultBillingDetails,
+            billingDetailsCollectionConfiguration = configuration.billingDetailsCollectionConfiguration,
+            // TODO(tillh-stripe) Determine this based on /wallets-config response
+            cbcEligibility = CardBrandChoiceEligibility.Ineligible,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
@@ -8,6 +8,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.customersheet.utils.CustomerSheetTestHelper.createViewModel
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
@@ -286,7 +287,7 @@ internal class CustomerSheetActivityTest {
             isLiveMode = isLiveMode,
             isProcessing = isProcessing,
             isFirstPaymentMethod = false,
-            primaryButtonLabel = "Save",
+            primaryButtonLabel = resolvableString("Save"),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
@@ -286,7 +286,7 @@ internal class CustomerSheetActivityTest {
             isLiveMode = isLiveMode,
             isProcessing = isProcessing,
             isFirstPaymentMethod = false,
-            primaryButtonLabel = null,
+            primaryButtonLabel = "Save",
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
@@ -285,7 +285,8 @@ internal class CustomerSheetActivityTest {
             enabled = enabled,
             isLiveMode = isLiveMode,
             isProcessing = isProcessing,
-            isFirstPaymentMethod = false
+            isFirstPaymentMethod = false,
+            primaryButtonLabel = null,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -96,7 +96,7 @@ internal class CustomerSheetScreenshotTest {
         isProcessing = false,
         errorMessage = null,
         isFirstPaymentMethod = false,
-        primaryButtonLabel = null,
+        primaryButtonLabel = "Save",
     )
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -96,6 +96,7 @@ internal class CustomerSheetScreenshotTest {
         isProcessing = false,
         errorMessage = null,
         isFirstPaymentMethod = false,
+        primaryButtonLabel = null,
     )
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.customersheet.ui.CustomerSheetScreen
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
@@ -96,7 +97,7 @@ internal class CustomerSheetScreenshotTest {
         isProcessing = false,
         errorMessage = null,
         isFirstPaymentMethod = false,
-        primaryButtonLabel = "Save",
+        primaryButtonLabel = resolvableString("Save"),
     )
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -1520,7 +1520,7 @@ class CustomerSheetViewModelTest {
     }
 
     @Test
-    fun `Payment method form can change`() = runTest {
+    fun `Payment method form changes on user selection`() = runTest {
         featureFlagTestRule.setEnabled(true)
 
         val viewModel = createViewModel(
@@ -1558,7 +1558,8 @@ class CustomerSheetViewModelTest {
 
         viewModel.viewState.test {
             var viewState = awaitViewState<AddPaymentMethod>()
-            assertThat(viewState.primaryButtonLabel).isNull()
+            assertThat(viewState.primaryButtonLabel)
+                .isEqualTo("Save")
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnAddPaymentMethodItemChanged(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -7,6 +7,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.customersheet.CustomerSheetViewState.AddPaymentMethod
 import com.stripe.android.customersheet.CustomerSheetViewState.SelectPaymentMethod
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
@@ -18,6 +19,7 @@ import com.stripe.android.customersheet.utils.FakeCustomerSheetLoader
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
 import com.stripe.android.model.SetupIntentFixtures
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -35,6 +37,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertFailsWith
+import com.stripe.android.ui.core.R as UiCoreR
 
 @RunWith(RobolectricTestRunner::class)
 @OptIn(ExperimentalCustomerSheetApi::class)
@@ -1559,7 +1562,7 @@ class CustomerSheetViewModelTest {
         viewModel.viewState.test {
             var viewState = awaitViewState<AddPaymentMethod>()
             assertThat(viewState.primaryButtonLabel)
-                .isEqualTo("Save")
+                .isEqualTo(resolvableString(R.string.stripe_paymentsheet_save))
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
@@ -1569,7 +1572,7 @@ class CustomerSheetViewModelTest {
 
             viewState = awaitViewState()
             assertThat(viewState.primaryButtonLabel)
-                .isEqualTo("Continue")
+                .isEqualTo(resolvableString(UiCoreR.string.stripe_continue_button_label))
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -112,7 +112,7 @@ internal object CustomerSheetTestHelper {
         isProcessing = false,
         errorMessage = null,
         isFirstPaymentMethod = false,
-        primaryButtonLabel = null,
+        primaryButtonLabel = "Save",
     )
 
     internal fun mockedFormViewModel(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetLoader
@@ -22,6 +23,7 @@ import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncher
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
 import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
@@ -112,7 +114,7 @@ internal object CustomerSheetTestHelper {
         isProcessing = false,
         errorMessage = null,
         isFirstPaymentMethod = false,
-        primaryButtonLabel = "Save",
+        primaryButtonLabel = resolvableString(R.string.stripe_paymentsheet_save),
     )
 
     internal fun mockedFormViewModel(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -112,6 +112,7 @@ internal object CustomerSheetTestHelper {
         isProcessing = false,
         errorMessage = null,
         isFirstPaymentMethod = false,
+        primaryButtonLabel = null,
     )
 
     internal fun mockedFormViewModel(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Add ability to switch payment methods in add flow, us bank account flow is not working yet. Coming soon in future PRs.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

CustomerSheet ACHv2 support

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

<img src="https://github.com/stripe/stripe-android/assets/99316447/30226a39-e1c4-4bbb-8ef4-91af78dae102" height=400/>

