### PR TITLE
Use placeholder text color in dropwdown menu for CBC.

### DIFF
--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -100,6 +100,13 @@ public final class com/stripe/android/uicore/elements/ComposableSingletons$Secti
 	public final fun getLambda-1$stripe_ui_core_release ()Lkotlin/jvm/functions/Function2;
 }
 
+public final class com/stripe/android/uicore/elements/ComposableSingletons$TextFieldUIKt {
+	public static final field INSTANCE Lcom/stripe/android/uicore/elements/ComposableSingletons$TextFieldUIKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$stripe_ui_core_release ()Lkotlin/jvm/functions/Function2;
+}
+
 public final class com/stripe/android/uicore/elements/DropdownConfig$DefaultImpls {
 	public static fun getDisableDropdownWithSingleElement (Lcom/stripe/android/uicore/elements/DropdownConfig;)Z
 	public static fun getTinyMode (Lcom/stripe/android/uicore/elements/DropdownConfig;)Z

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
@@ -15,10 +15,12 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
+import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -276,13 +278,19 @@ fun TextField(
                                     )
 
                                     if (show) {
-                                        TrailingIcon(
-                                            trailingIcon = TextFieldIcon.Trailing(
-                                                R.drawable.stripe_ic_chevron_down,
-                                                isTintable = false
-                                            ),
-                                            loading = false
-                                        )
+                                        CompositionLocalProvider(
+                                            LocalContentColor
+                                                provides
+                                                    MaterialTheme.stripeColors.placeholderText
+                                        ) {
+                                            TrailingIcon(
+                                                trailingIcon = TextFieldIcon.Trailing(
+                                                    R.drawable.stripe_ic_chevron_down,
+                                                    isTintable = true
+                                                ),
+                                                loading = false
+                                            )
+                                        }
                                     }
                                 }
 


### PR DESCRIPTION
# Summary
Use placeholder text color in dropwdown menu for CBC.

# Motivation
Makes chevron more visible in dark mode.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/stripe/stripe-android/assets/141707240/f60a3b18-272d-4e26-a33c-0dcc9bdb6cf3) | ![image](https://github.com/stripe/stripe-android/assets/141707240/979c1e90-8df8-4688-9358-812d96601e87) |
