### PR TITLE
Only match against full card numbers in `CbcTestCardDelegate`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/cards/CbcTestCardDelegate.kt
+++ b/payments-core/src/main/java/com/stripe/android/cards/CbcTestCardDelegate.kt
@@ -8,7 +8,7 @@ import com.stripe.android.model.BinRange
 object CbcTestCardDelegate {
 
     private val testAccountRanges = mapOf(
-        "40000025" to listOf(
+        "4000002500001001" to listOf(
             AccountRange(
                 BinRange(
                     low = "4000000000000000",
@@ -26,7 +26,7 @@ object CbcTestCardDelegate {
                 brandInfo = AccountRange.BrandInfo.Visa,
             ),
         ),
-        "55555525" to listOf(
+        "5555552500001001" to listOf(
             AccountRange(
                 binRange = BinRange(
                     low = "5100000000000000",

--- a/payments-core/src/test/java/com/stripe/android/cards/CardAccountRangeServiceTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/cards/CardAccountRangeServiceTest.kt
@@ -128,42 +128,8 @@ class CardAccountRangeServiceTest {
     }
 
     @Test
-    fun `If CBC is enabled, return a matched brand once 8 characters are entered`() = runTest {
-        val expectedAccountRange = AccountRange(
-            binRange = BinRange(
-                low = "4000000000000000",
-                high = "4999999999999999",
-            ),
-            panLength = 16,
-            brandInfo = AccountRange.BrandInfo.Visa,
-        )
-
-        val accountRanges = testBehavior(
-            cardNumber = "4000 0000",
-            isCbcEligible = true,
-            mockRemoteCardAccountRangeSource = object : CardAccountRangeSource {
-                override suspend fun getAccountRanges(cardNumber: CardNumber.Unvalidated): List<AccountRange>? {
-                    return listOf(expectedAccountRange)
-                }
-
-                override val loading: Flow<Boolean> = flowOf(false)
-            }
-        )
-
-        assertThat(accountRanges).containsExactly(expectedAccountRange)
-    }
-
-    @Test
-    fun `If CBC is enabled, return all matched brands once 8 characters are entered`() = runTest {
+    fun `If CBC is enabled, return the matched brands once 8 characters are entered`() = runTest {
         val expectedAccountRanges = listOf(
-            AccountRange(
-                binRange = BinRange(
-                    low = "4000000000000000",
-                    high = "4999999999999999",
-                ),
-                panLength = 16,
-                brandInfo = AccountRange.BrandInfo.CartesBancaires,
-            ),
             AccountRange(
                 binRange = BinRange(
                     low = "4000000000000000",
@@ -172,14 +138,29 @@ class CardAccountRangeServiceTest {
                 panLength = 16,
                 brandInfo = AccountRange.BrandInfo.Visa,
             ),
+            AccountRange(
+                binRange = BinRange(
+                    low = "4000000000000000",
+                    high = "4999999999999999",
+                ),
+                panLength = 16,
+                brandInfo = AccountRange.BrandInfo.CartesBancaires,
+            )
         )
 
         val accountRanges = testBehavior(
-            cardNumber = "4000 0025",
+            cardNumber = "4000 0000",
             isCbcEligible = true,
+            mockRemoteCardAccountRangeSource = object : CardAccountRangeSource {
+                override suspend fun getAccountRanges(cardNumber: CardNumber.Unvalidated): List<AccountRange>? {
+                    return expectedAccountRanges
+                }
+
+                override val loading: Flow<Boolean> = flowOf(false)
+            }
         )
 
-        assertThat(accountRanges).containsExactlyElementsIn(expectedAccountRanges).inOrder()
+        assertThat(accountRanges).containsExactlyElementsIn(expectedAccountRanges)
     }
 
     private suspend fun testBehavior(

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
@@ -217,7 +217,7 @@ internal class CardNumberControllerTest {
         cardNumberController.trailingIcon.asLiveData().observeForever {
             trailingIcons.add(it)
         }
-        cardNumberController.onValueChange("40000025")
+        cardNumberController.onValueChange("4000002500001001")
         idleLooper()
         assertThat(trailingIcons.last() as TextFieldIcon.Dropdown)
             .isEqualTo(
@@ -263,7 +263,7 @@ internal class CardNumberControllerTest {
         cardNumberController.trailingIcon.asLiveData().observeForever {
             trailingIcons.add(it)
         }
-        cardNumberController.onValueChange("40000025")
+        cardNumberController.onValueChange("4000002500001001")
         idleLooper()
         assertThat(trailingIcons.last() as TextFieldIcon.Dropdown)
             .isEqualTo(
@@ -309,7 +309,7 @@ internal class CardNumberControllerTest {
         cardNumberController.trailingIcon.asLiveData().observeForever {
             trailingIcons.add(it)
         }
-        cardNumberController.onValueChange("40000025")
+        cardNumberController.onValueChange("4000002500001001")
         cardNumberController.onDropdownItemClicked(
             TextFieldIcon.Dropdown.Item(
                 id = CardBrand.CartesBancaires.code,
@@ -362,7 +362,7 @@ internal class CardNumberControllerTest {
         cardNumberController.trailingIcon.asLiveData().observeForever {
             trailingIcons.add(it)
         }
-        cardNumberController.onValueChange("40000025")
+        cardNumberController.onValueChange("4000002500001001")
         cardNumberController.onDropdownItemClicked(
             TextFieldIcon.Dropdown.Item(
                 id = CardBrand.CartesBancaires.code,
@@ -370,8 +370,8 @@ internal class CardNumberControllerTest {
                 icon = PaymentModelR.drawable.stripe_ic_cartes_bancaires
             )
         )
-        cardNumberController.onValueChange("4000002")
-        cardNumberController.onValueChange("40000025")
+        cardNumberController.onValueChange("400000250000100")
+        cardNumberController.onValueChange("4000002500001001")
         idleLooper()
         assertThat(trailingIcons.last() as TextFieldIcon.Dropdown)
             .isEqualTo(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request changes the behavior in `CbcTestCardDelegate` to only match against full card numbers instead of prefixes. This is more consistent with the iOS and Web behavior.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
