### PR TITLE
Make merchant-preferred networks configurable in sample apps

### DIFF
--- a/example/res/layout/card_brand_choice_example_activity.xml
+++ b/example/res/layout/card_brand_choice_example_activity.xml
@@ -6,6 +6,12 @@
     android:orientation="vertical"
     android:padding="16dp">
 
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/preferred_network_switch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Set Cartes Bancaires as preferred network" />
+
     <com.stripe.android.view.CardInputWidget
         android:id="@+id/card_input_widget"
         android:layout_width="match_parent"

--- a/example/src/main/java/com/stripe/example/activity/CardBrandChoiceExampleActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CardBrandChoiceExampleActivity.kt
@@ -24,9 +24,15 @@ class CardBrandChoiceExampleActivity : StripeIntentActivity() {
         viewModel.inProgress.observe(this, this::enableUi)
         viewModel.status.observe(this, viewBinding.status::setText)
 
-        viewBinding.cardInputWidget.setPreferredNetworks(
-            preferredNetworks = listOf(CardBrand.CartesBancaires),
-        )
+        viewBinding.preferredNetworkSwitch.setOnCheckedChangeListener { _, isChecked ->
+            viewBinding.cardInputWidget.setPreferredNetworks(
+                preferredNetworks = if (isChecked) {
+                    listOf(CardBrand.CartesBancaires)
+                } else {
+                    emptyList()
+                },
+            )
+        }
 
         val stripeAccountId = Settings(this).stripeAccountId
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -200,6 +200,7 @@ internal class PlaygroundSettings private constructor(
             DelayedPaymentMethodsSettingsDefinition,
             AutomaticPaymentMethodsSettingsDefinition,
             PrimaryButtonLabelSettingsDefinition,
+            PreferredNetworkSettingsDefinition,
             IntegrationTypeSettingsDefinition,
         )
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PreferredNetworkSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PreferredNetworkSettingsDefinition.kt
@@ -1,0 +1,23 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.model.CardBrand
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.playground.PlaygroundState
+
+internal object PreferredNetworkSettingsDefinition : BooleanSettingsDefinition(
+    key = "cartesBancairesAsMerchantPreferredNetwork",
+    displayName = "Cartes Bancaires as preferred network",
+    defaultValue = false,
+) {
+
+    override fun configure(
+        value: Boolean,
+        configurationBuilder: PaymentSheet.Configuration.Builder,
+        playgroundState: PlaygroundState,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData
+    ) {
+        if (value) {
+            configurationBuilder.preferredNetworks(listOf(CardBrand.CartesBancaires))
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -6,6 +6,7 @@ import android.os.Parcelable
 import androidx.activity.ComponentActivity
 import androidx.annotation.ColorInt
 import androidx.annotation.FontRes
+import androidx.annotation.RestrictTo
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.fragment.app.Fragment
@@ -529,7 +530,8 @@ class PaymentSheet internal constructor(
             /*
              * TODO(samer-stripe): Make this function public prior to release
              */
-            internal fun preferredNetworks(
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun preferredNetworks(
                 preferredNetworks: List<CardBrand>
             ) = apply {
                 this.preferredNetworks = preferredNetworks


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds settings to make the merchant-preferred network configurable in the CBC example activity and the PaymentSheet playground.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
