### PR TITLE
Fix dark mode in CBC dropdown

### DIFF
--- a/payments-core/detekt-baseline.xml
+++ b/payments-core/detekt-baseline.xml
@@ -7,6 +7,7 @@
     <ID>ComplexCondition:ExpiryDateEditText.kt$ExpiryDateEditText.&lt;no name provided>$expirationDate.month.length == 2 &amp;&amp; latestInsertionSize > 0 &amp;&amp; !inErrorState || rawNumericInput.length > 2</ID>
     <ID>ConstructorParameterNaming:Source.kt$Source$private val _klarna: Klarna? = null</ID>
     <ID>ConstructorParameterNaming:Source.kt$Source$private val _weChat: WeChat? = null</ID>
+    <ID>CyclomaticComplexMethod:CardBrandView.kt$@Composable private fun CardBrand( isLoading: Boolean, currentBrand: CardBrand, possibleBrands: List&lt;CardBrand>, shouldShowCvc: Boolean, shouldShowErrorIcon: Boolean, tintColorInt: Int, isCbcEligible: Boolean, modifier: Modifier = Modifier, onBrandSelected: (CardBrand?) -> Unit, )</ID>
     <ID>CyclomaticComplexMethod:NextActionDataParser.kt$NextActionDataParser$override fun parse( json: JSONObject ): StripeIntent.NextActionData?</ID>
     <ID>CyclomaticComplexMethod:PaymentMethodJsonParser.kt$PaymentMethodJsonParser$override fun parse(json: JSONObject): PaymentMethod</ID>
     <ID>CyclomaticComplexMethod:Source.kt$Source.Companion$@SourceType @JvmStatic fun asSourceType(sourceType: String?): String</ID>

--- a/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -9,7 +9,9 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -236,6 +238,8 @@ private fun CardBrand(
                 contentDescription = null,
                 modifier = Modifier.requiredSize(width = 32.dp, height = 21.dp),
             )
+
+            Spacer(modifier = Modifier.requiredWidth(1.dp))
 
             Image(
                 painter = painterResource(StripeUiCoreR.drawable.stripe_ic_chevron_down),

--- a/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.material.ContentAlpha
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -36,6 +37,7 @@ import com.stripe.android.utils.AppCompatOrMdcTheme
 import com.stripe.android.utils.FeatureFlags
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlin.properties.Delegates
+import com.stripe.android.uicore.R as StripeUiCoreR
 
 internal class CardBrandView @JvmOverloads constructor(
     context: Context,
@@ -236,7 +238,7 @@ private fun CardBrand(
             )
 
             Image(
-                painter = painterResource(R.drawable.stripe_ic_arrow_down),
+                painter = painterResource(StripeUiCoreR.drawable.stripe_ic_chevron_down),
                 contentDescription = null,
                 modifier = Modifier
                     .requiredSize(8.dp)
@@ -274,6 +276,8 @@ private fun CardBrandChoiceDropdown(
         expanded = expanded,
         currentChoice = currentBrand.takeIf { it != Unknown }?.toChoice(),
         choices = choices,
+        headerTextColor = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
+        optionTextColor = MaterialTheme.colors.onSurface,
         onChoiceSelected = { choice ->
             val choiceIndex = choices.indexOf(choice)
             val brand = brands.getOrNull(choiceIndex)

--- a/stripe-ui-core/res/drawable-night/stripe_ic_chevron_down.xml
+++ b/stripe-ui-core/res/drawable-night/stripe_ic_chevron_down.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="13dp"
+    android:height="12dp"
+    android:viewportWidth="13"
+    android:viewportHeight="12">
+  <path
+      android:pathData="M10.527,3.97C10.82,3.677 11.295,3.677 11.589,3.97C11.882,4.263 11.882,4.738 11.589,5.032L6.864,9.756C6.571,10.049 6.096,10.049 5.803,9.756L1.078,5.032C0.785,4.738 0.785,4.263 1.078,3.97C1.371,3.677 1.847,3.677 2.14,3.97L6.333,8.163L10.527,3.97Z"
+      android:fillColor="#FFF"
+      android:fillType="evenOdd"/>
+</vector>

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SingleChoiceDropdownUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SingleChoiceDropdownUI.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.strings.resolve
-import com.stripe.android.uicore.stripeColors
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -38,6 +37,8 @@ fun <TDropdownChoice : SingleChoiceDropdownItem> SingleChoiceDropdown(
     currentChoice: TDropdownChoice?,
     choices: List<TDropdownChoice>,
     onChoiceSelected: (TDropdownChoice) -> Unit,
+    headerTextColor: Color,
+    optionTextColor: Color,
     onDismiss: () -> Unit,
 ) {
     DropdownMenu(
@@ -46,7 +47,7 @@ fun <TDropdownChoice : SingleChoiceDropdownItem> SingleChoiceDropdown(
     ) {
         Text(
             text = title.resolve(),
-            color = MaterialTheme.stripeColors.subtitle,
+            color = headerTextColor,
             modifier = Modifier.padding(vertical = 5.dp, horizontal = 13.dp),
         )
 
@@ -55,7 +56,7 @@ fun <TDropdownChoice : SingleChoiceDropdownItem> SingleChoiceDropdown(
                 label = choice.label.resolve(),
                 icon = choice.icon,
                 isSelected = choice == currentChoice,
-                currentTextColor = MaterialTheme.stripeColors.onComponent,
+                currentTextColor = optionTextColor,
                 onClick = {
                     onChoiceSelected(choice)
                 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
@@ -291,6 +291,8 @@ fun TextField(
                                     title = it.title,
                                     currentChoice = it.currentItem,
                                     choices = it.items,
+                                    headerTextColor = MaterialTheme.stripeColors.subtitle,
+                                    optionTextColor = MaterialTheme.stripeColors.onComponent,
                                     onChoiceSelected = { item ->
                                         textFieldController.onDropdownItemClicked(item)
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue with dark mode in the Card Element’s CBC dropdown and switches from a down arrow to a down chevron.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Light mode | Dark mode |
| ------------- | ------------- |
| ![Screenshot_1698185266](https://github.com/stripe/stripe-android/assets/110940675/477c37a5-23d7-423b-acad-9f5b52440faa) | ![Screenshot_1698185275](https://github.com/stripe/stripe-android/assets/110940675/005f60b9-1939-4ff0-9a80-8b3b993bdb5c) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
