### PR TITLE
Fix bug in `PaymentSheet` where newly save payment method is not set as default payment method.

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -6888,6 +6888,62 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherKt
 	public static final fun rememberPaymentLauncher (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;Landroidx/compose/runtime/Composer;II)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
 }
 
+public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Canceled : com/stripe/android/payments/paymentlauncher/PaymentLauncherResult {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field INSTANCE Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Canceled;
+	public fun describeContents ()I
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Canceled$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Canceled;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Canceled;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Completed : com/stripe/android/payments/paymentlauncher/PaymentLauncherResult {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Lcom/stripe/android/model/StripeIntent;)V
+	public final fun component1 ()Lcom/stripe/android/model/StripeIntent;
+	public final fun copy (Lcom/stripe/android/model/StripeIntent;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Completed;
+	public static synthetic fun copy$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Completed;Lcom/stripe/android/model/StripeIntent;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Completed;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIntent ()Lcom/stripe/android/model/StripeIntent;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Completed$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Completed;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Completed;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Failed : com/stripe/android/payments/paymentlauncher/PaymentLauncherResult {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/Throwable;)V
+	public fun describeContents ()I
+	public final fun getThrowable ()Ljava/lang/Throwable;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Failed$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Failed;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Failed;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public abstract class com/stripe/android/payments/paymentlauncher/PaymentResult : android/os/Parcelable {
 	public static final field $stable I
 	public final synthetic fun toBundle ()Landroid/os/Bundle;

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -6888,14 +6888,6 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherKt
 	public static final fun rememberPaymentLauncher (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;Landroidx/compose/runtime/Composer;II)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
 }
 
-public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Canceled : com/stripe/android/payments/paymentlauncher/PaymentLauncherResult {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public static final field INSTANCE Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Canceled;
-	public fun describeContents ()I
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
 public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Canceled$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Canceled;
@@ -6904,36 +6896,12 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherRe
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Completed : com/stripe/android/payments/paymentlauncher/PaymentLauncherResult {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Lcom/stripe/android/model/StripeIntent;)V
-	public final fun component1 ()Lcom/stripe/android/model/StripeIntent;
-	public final fun copy (Lcom/stripe/android/model/StripeIntent;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Completed;
-	public static synthetic fun copy$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Completed;Lcom/stripe/android/model/StripeIntent;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Completed;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getIntent ()Lcom/stripe/android/model/StripeIntent;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
 public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Completed$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Completed;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Completed;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
-}
-
-public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Failed : com/stripe/android/payments/paymentlauncher/PaymentLauncherResult {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Ljava/lang/Throwable;)V
-	public fun describeContents ()I
-	public final fun getThrowable ()Ljava/lang/Throwable;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Failed$Creator : android/os/Parcelable$Creator {

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -6833,6 +6833,30 @@ public final class com/stripe/android/payments/core/injection/NamedConstantsKt {
 	public static final field PRODUCT_USAGE Ljava/lang/String;
 }
 
+public final class com/stripe/android/payments/paymentlauncher/InternalPaymentResult$Canceled$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/payments/paymentlauncher/InternalPaymentResult$Canceled;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/payments/paymentlauncher/InternalPaymentResult$Canceled;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/payments/paymentlauncher/InternalPaymentResult$Completed$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/payments/paymentlauncher/InternalPaymentResult$Completed;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/payments/paymentlauncher/InternalPaymentResult$Completed;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/payments/paymentlauncher/InternalPaymentResult$Failed$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/payments/paymentlauncher/InternalPaymentResult$Failed;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/payments/paymentlauncher/InternalPaymentResult$Failed;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public abstract interface class com/stripe/android/payments/paymentlauncher/PaymentLauncher {
 	public static final field Companion Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$Companion;
 	public abstract fun confirm (Lcom/stripe/android/model/ConfirmPaymentIntentParams;)V
@@ -6886,30 +6910,6 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherCo
 
 public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherKt {
 	public static final fun rememberPaymentLauncher (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;Landroidx/compose/runtime/Composer;II)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
-}
-
-public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Canceled$Creator : android/os/Parcelable$Creator {
-	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Canceled;
-	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Canceled;
-	public synthetic fun newArray (I)[Ljava/lang/Object;
-}
-
-public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Completed$Creator : android/os/Parcelable$Creator {
-	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Completed;
-	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Completed;
-	public synthetic fun newArray (I)[Ljava/lang/Object;
-}
-
-public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Failed$Creator : android/os/Parcelable$Creator {
-	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Failed;
-	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherResult$Failed;
-	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public abstract class com/stripe/android/payments/paymentlauncher/PaymentResult : android/os/Parcelable {

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/InternalPaymentResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/InternalPaymentResult.kt
@@ -8,18 +8,18 @@ import com.stripe.android.model.StripeIntent
 import kotlinx.parcelize.Parcelize
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-sealed class PaymentLauncherResult : Parcelable {
+sealed class InternalPaymentResult : Parcelable {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
-    data class Completed(val intent: StripeIntent) : PaymentLauncherResult()
+    data class Completed(val intent: StripeIntent) : InternalPaymentResult()
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
-    class Failed(val throwable: Throwable) : PaymentLauncherResult()
+    class Failed(val throwable: Throwable) : InternalPaymentResult()
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
-    object Canceled : PaymentLauncherResult()
+    object Canceled : InternalPaymentResult()
 
     @JvmSynthetic
     internal fun toBundle() = bundleOf(EXTRA to this)
@@ -28,7 +28,7 @@ sealed class PaymentLauncherResult : Parcelable {
         private const val EXTRA = "extra_args"
 
         @JvmSynthetic
-        fun fromIntent(intent: Intent?): PaymentLauncherResult {
+        fun fromIntent(intent: Intent?): InternalPaymentResult {
             return intent?.getParcelableExtra(EXTRA)
                 ?: Failed(IllegalStateException("Failed to get PaymentSheetResult from Intent"))
         }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
@@ -3,6 +3,7 @@ package com.stripe.android.payments.paymentlauncher
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResultLauncher
+import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.fragment.app.Fragment
@@ -43,6 +44,11 @@ interface PaymentLauncher {
         fun onPaymentResult(paymentResult: PaymentResult)
     }
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun interface PaymentLauncherResultCallback {
+        fun onPaymentResult(launcherResult: PaymentLauncherResult)
+    }
+
     companion object {
         /**
          * Create a [PaymentLauncher] instance with [ComponentActivity].
@@ -57,7 +63,10 @@ interface PaymentLauncher {
             publishableKey: String,
             stripeAccountId: String? = null,
             callback: PaymentResultCallback
-        ) = PaymentLauncherFactory(activity, callback).create(publishableKey, stripeAccountId)
+        ) = PaymentLauncherFactory(
+            activity,
+            callback.toLauncherResultCallback()
+        ).create(publishableKey, stripeAccountId)
 
         /**
          * Create a [PaymentLauncher] instance with [Fragment].
@@ -72,7 +81,10 @@ interface PaymentLauncher {
             publishableKey: String,
             stripeAccountId: String? = null,
             callback: PaymentResultCallback
-        ) = PaymentLauncherFactory(fragment, callback).create(publishableKey, stripeAccountId)
+        ) = PaymentLauncherFactory(
+            fragment,
+            callback.toLauncherResultCallback()
+        ).create(publishableKey, stripeAccountId)
 
         /**
          * Create a [PaymentLauncher] used for Jetpack Compose.
@@ -141,9 +153,13 @@ fun rememberPaymentLauncher(
 ): PaymentLauncher {
     val activity = rememberActivityOrNull()
 
+    val launcherCallback = remember(callback) {
+        callback.toLauncherResultCallback()
+    }
+
     val activityResultLauncher = rememberLauncherForActivityResult(
         PaymentLauncherContract(),
-        callback::onPaymentResult
+        launcherCallback::onPaymentResult
     )
 
     return remember(publishableKey, stripeAccountId) {

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
@@ -45,8 +45,8 @@ interface PaymentLauncher {
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    fun interface PaymentLauncherResultCallback {
-        fun onPaymentResult(launcherResult: PaymentLauncherResult)
+    fun interface InternalPaymentResultCallback {
+        fun onPaymentResult(launcherResult: InternalPaymentResult)
     }
 
     companion object {
@@ -65,7 +65,7 @@ interface PaymentLauncher {
             callback: PaymentResultCallback
         ) = PaymentLauncherFactory(
             activity,
-            callback.toLauncherResultCallback()
+            callback.toInternalResultCallback()
         ).create(publishableKey, stripeAccountId)
 
         /**
@@ -83,7 +83,7 @@ interface PaymentLauncher {
             callback: PaymentResultCallback
         ) = PaymentLauncherFactory(
             fragment,
-            callback.toLauncherResultCallback()
+            callback.toInternalResultCallback()
         ).create(publishableKey, stripeAccountId)
 
         /**
@@ -154,7 +154,7 @@ fun rememberPaymentLauncher(
     val activity = rememberActivityOrNull()
 
     val launcherCallback = remember(callback) {
-        callback.toLauncherResultCallback()
+        callback.toInternalResultCallback()
     }
 
     val activityResultLauncher = rememberLauncherForActivityResult(

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
@@ -43,7 +43,7 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
                 EMPTY_ARG_ERROR
             }
         }.getOrElse {
-            finishWithResult(PaymentLauncherResult.Failed(it))
+            finishWithResult(InternalPaymentResult.Failed(it))
             return
         }
 
@@ -52,7 +52,7 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
         }
 
         lifecycleScope.launch {
-            viewModel.paymentLauncherResult.collect {
+            viewModel.internalPaymentResult.collect {
                 it?.let(::finishWithResult)
             }
         }
@@ -93,7 +93,7 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
      * After confirmation and next action is handled, finish the activity with
      * corresponding [PaymentResult]
      */
-    private fun finishWithResult(result: PaymentLauncherResult) {
+    private fun finishWithResult(result: InternalPaymentResult) {
         setResult(
             Activity.RESULT_OK,
             Intent()

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
@@ -43,7 +43,7 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
                 EMPTY_ARG_ERROR
             }
         }.getOrElse {
-            finishWithResult(PaymentResult.Failed(it))
+            finishWithResult(PaymentLauncherResult.Failed(it))
             return
         }
 
@@ -93,7 +93,7 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
      * After confirmation and next action is handled, finish the activity with
      * corresponding [PaymentResult]
      */
-    private fun finishWithResult(result: PaymentResult) {
+    private fun finishWithResult(result: PaymentLauncherResult) {
         setResult(
             Activity.RESULT_OK,
             Intent()

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherContract.kt
@@ -15,7 +15,7 @@ import kotlinx.parcelize.Parcelize
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class PaymentLauncherContract :
-    ActivityResultContract<PaymentLauncherContract.Args, PaymentResult>() {
+    ActivityResultContract<PaymentLauncherContract.Args, PaymentLauncherResult>() {
     override fun createIntent(context: Context, input: Args): Intent {
         return Intent(
             context,
@@ -23,8 +23,8 @@ class PaymentLauncherContract :
         ).putExtras(input.toBundle())
     }
 
-    override fun parseResult(resultCode: Int, intent: Intent?): PaymentResult {
-        return PaymentResult.fromIntent(intent)
+    override fun parseResult(resultCode: Int, intent: Intent?): PaymentLauncherResult {
+        return PaymentLauncherResult.fromIntent(intent)
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherContract.kt
@@ -15,7 +15,7 @@ import kotlinx.parcelize.Parcelize
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class PaymentLauncherContract :
-    ActivityResultContract<PaymentLauncherContract.Args, PaymentLauncherResult>() {
+    ActivityResultContract<PaymentLauncherContract.Args, InternalPaymentResult>() {
     override fun createIntent(context: Context, input: Args): Intent {
         return Intent(
             context,
@@ -23,8 +23,8 @@ class PaymentLauncherContract :
         ).putExtras(input.toBundle())
     }
 
-    override fun parseResult(resultCode: Int, intent: Intent?): PaymentLauncherResult {
-        return PaymentLauncherResult.fromIntent(intent)
+    override fun parseResult(resultCode: Int, intent: Intent?): InternalPaymentResult {
+        return InternalPaymentResult.fromIntent(intent)
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherFactory.kt
@@ -19,7 +19,7 @@ class PaymentLauncherFactory(
 
     constructor(
         activity: ComponentActivity,
-        callback: PaymentLauncher.PaymentResultCallback
+        callback: PaymentLauncher.PaymentLauncherResultCallback
     ) : this(
         hostActivityLauncher = activity.registerForActivityResult(
             PaymentLauncherContract(),
@@ -30,7 +30,7 @@ class PaymentLauncherFactory(
 
     constructor(
         fragment: Fragment,
-        callback: PaymentLauncher.PaymentResultCallback
+        callback: PaymentLauncher.PaymentLauncherResultCallback
     ) : this(
         hostActivityLauncher = fragment.registerForActivityResult(
             PaymentLauncherContract(),

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherFactory.kt
@@ -19,7 +19,7 @@ class PaymentLauncherFactory(
 
     constructor(
         activity: ComponentActivity,
-        callback: PaymentLauncher.PaymentLauncherResultCallback
+        callback: PaymentLauncher.InternalPaymentResultCallback
     ) : this(
         hostActivityLauncher = activity.registerForActivityResult(
             PaymentLauncherContract(),
@@ -30,7 +30,7 @@ class PaymentLauncherFactory(
 
     constructor(
         fragment: Fragment,
-        callback: PaymentLauncher.PaymentLauncherResultCallback
+        callback: PaymentLauncher.InternalPaymentResultCallback
     ) : this(
         hostActivityLauncher = fragment.registerForActivityResult(
             PaymentLauncherContract(),

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherResult.kt
@@ -1,0 +1,33 @@
+package com.stripe.android.payments.paymentlauncher
+
+import android.content.Intent
+import android.os.Parcelable
+import androidx.annotation.RestrictTo
+import androidx.core.os.bundleOf
+import com.stripe.android.model.StripeIntent
+import kotlinx.parcelize.Parcelize
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+sealed class PaymentLauncherResult : Parcelable {
+    @Parcelize
+    data class Completed(val intent: StripeIntent) : PaymentLauncherResult()
+
+    @Parcelize
+    class Failed(val throwable: Throwable) : PaymentLauncherResult()
+
+    @Parcelize
+    object Canceled : PaymentLauncherResult()
+
+    @JvmSynthetic
+    fun toBundle() = bundleOf(EXTRA to this)
+
+    internal companion object {
+        private const val EXTRA = "extra_args"
+
+        @JvmSynthetic
+        fun fromIntent(intent: Intent?): PaymentLauncherResult {
+            return intent?.getParcelableExtra(EXTRA)
+                ?: Failed(IllegalStateException("Failed to get PaymentSheetResult from Intent"))
+        }
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherResult.kt
@@ -9,17 +9,20 @@ import kotlinx.parcelize.Parcelize
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 sealed class PaymentLauncherResult : Parcelable {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     data class Completed(val intent: StripeIntent) : PaymentLauncherResult()
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     class Failed(val throwable: Throwable) : PaymentLauncherResult()
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     object Canceled : PaymentLauncherResult()
 
     @JvmSynthetic
-    fun toBundle() = bundleOf(EXTRA to this)
+    internal fun toBundle() = bundleOf(EXTRA to this)
 
     internal companion object {
         private const val EXTRA = "extra_args"

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherUtils.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherUtils.kt
@@ -1,0 +1,29 @@
+@file:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+
+package com.stripe.android.payments.paymentlauncher
+
+import androidx.annotation.RestrictTo
+
+internal fun PaymentLauncher.PaymentResultCallback.toLauncherResultCallback():
+    PaymentLauncher.PaymentLauncherResultCallback {
+    return PaymentLauncher.PaymentLauncherResultCallback { result ->
+        when (result) {
+            is PaymentLauncherResult.Completed -> onPaymentResult(PaymentResult.Completed)
+            is PaymentLauncherResult.Failed -> onPaymentResult(PaymentResult.Failed(result.throwable))
+            is PaymentLauncherResult.Canceled -> onPaymentResult(PaymentResult.Canceled)
+        }
+    }
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun toPaymentLauncherResultCallback(
+    callback: (result: PaymentResult) -> Unit
+): (result: PaymentLauncherResult) -> Unit {
+    return { result ->
+        when (result) {
+            is PaymentLauncherResult.Completed -> callback.invoke(PaymentResult.Completed)
+            is PaymentLauncherResult.Failed -> callback.invoke(PaymentResult.Failed(result.throwable))
+            is PaymentLauncherResult.Canceled -> callback.invoke(PaymentResult.Canceled)
+        }
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherUtils.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherUtils.kt
@@ -4,26 +4,26 @@ package com.stripe.android.payments.paymentlauncher
 
 import androidx.annotation.RestrictTo
 
-internal fun PaymentLauncher.PaymentResultCallback.toLauncherResultCallback():
-    PaymentLauncher.PaymentLauncherResultCallback {
-    return PaymentLauncher.PaymentLauncherResultCallback { result ->
+internal fun PaymentLauncher.PaymentResultCallback.toInternalResultCallback():
+    PaymentLauncher.InternalPaymentResultCallback {
+    return PaymentLauncher.InternalPaymentResultCallback { result ->
         when (result) {
-            is PaymentLauncherResult.Completed -> onPaymentResult(PaymentResult.Completed)
-            is PaymentLauncherResult.Failed -> onPaymentResult(PaymentResult.Failed(result.throwable))
-            is PaymentLauncherResult.Canceled -> onPaymentResult(PaymentResult.Canceled)
+            is InternalPaymentResult.Completed -> onPaymentResult(PaymentResult.Completed)
+            is InternalPaymentResult.Failed -> onPaymentResult(PaymentResult.Failed(result.throwable))
+            is InternalPaymentResult.Canceled -> onPaymentResult(PaymentResult.Canceled)
         }
     }
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun toPaymentLauncherResultCallback(
+fun toInternalPaymentResultCallback(
     callback: (result: PaymentResult) -> Unit
-): (result: PaymentLauncherResult) -> Unit {
+): (result: InternalPaymentResult) -> Unit {
     return { result ->
         when (result) {
-            is PaymentLauncherResult.Completed -> callback.invoke(PaymentResult.Completed)
-            is PaymentLauncherResult.Failed -> callback.invoke(PaymentResult.Failed(result.throwable))
-            is PaymentLauncherResult.Canceled -> callback.invoke(PaymentResult.Canceled)
+            is InternalPaymentResult.Completed -> callback.invoke(PaymentResult.Completed)
+            is InternalPaymentResult.Failed -> callback.invoke(PaymentResult.Failed(result.throwable))
+            is InternalPaymentResult.Canceled -> callback.invoke(PaymentResult.Canceled)
         }
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -70,7 +70,7 @@ internal class PaymentLauncherViewModel @Inject constructor(
     private val hasStarted: Boolean
         get() = savedStateHandle.get(KEY_HAS_STARTED) ?: false
 
-    internal val paymentLauncherResult = MutableStateFlow<PaymentResult?>(null)
+    internal val paymentLauncherResult = MutableStateFlow<PaymentLauncherResult?>(null)
 
     /**
      * Registers the calling activity to listen to payment flow results. Should be called in the
@@ -125,7 +125,7 @@ internal class PaymentLauncherViewModel @Inject constructor(
                     }
                     if (!intent.requiresAction()) {
                         withContext(uiContext) {
-                            paymentLauncherResult.value = PaymentResult.Completed
+                            paymentLauncherResult.value = PaymentLauncherResult.Completed(intent)
                         }
                     } else {
                         authenticatorRegistry.getAuthenticator(intent).authenticate(
@@ -137,7 +137,7 @@ internal class PaymentLauncherViewModel @Inject constructor(
                 },
                 onFailure = {
                     withContext(uiContext) {
-                        paymentLauncherResult.value = PaymentResult.Failed(it)
+                        paymentLauncherResult.value = PaymentLauncherResult.Failed(it)
                     }
                 }
             )
@@ -193,7 +193,7 @@ internal class PaymentLauncherViewModel @Inject constructor(
                 },
                 onFailure = {
                     withContext(uiContext) {
-                        paymentLauncherResult.value = PaymentResult.Failed(it)
+                        paymentLauncherResult.value = PaymentLauncherResult.Failed(it)
                     }
                 }
             )
@@ -217,7 +217,7 @@ internal class PaymentLauncherViewModel @Inject constructor(
                 },
                 onFailure = {
                     withContext(uiContext) {
-                        paymentLauncherResult.value = PaymentResult.Failed(it)
+                        paymentLauncherResult.value = PaymentLauncherResult.Failed(it)
                     }
                 }
             )
@@ -231,19 +231,19 @@ internal class PaymentLauncherViewModel @Inject constructor(
         paymentLauncherResult.value =
             when (stripeIntentResult.outcome) {
                 StripeIntentResult.Outcome.SUCCEEDED ->
-                    PaymentResult.Completed
+                    PaymentLauncherResult.Completed(stripeIntentResult.intent)
                 StripeIntentResult.Outcome.FAILED ->
-                    PaymentResult.Failed(
+                    PaymentLauncherResult.Failed(
                         LocalStripeException(displayMessage = stripeIntentResult.failureMessage)
                     )
                 StripeIntentResult.Outcome.CANCELED ->
-                    PaymentResult.Canceled
+                    PaymentLauncherResult.Canceled
                 StripeIntentResult.Outcome.TIMEDOUT ->
-                    PaymentResult.Failed(
+                    PaymentLauncherResult.Failed(
                         LocalStripeException(displayMessage = TIMEOUT_ERROR + stripeIntentResult.failureMessage)
                     )
                 else ->
-                    PaymentResult.Failed(
+                    PaymentLauncherResult.Failed(
                         LocalStripeException(displayMessage = UNKNOWN_ERROR + stripeIntentResult.failureMessage)
                     )
             }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -70,7 +70,7 @@ internal class PaymentLauncherViewModel @Inject constructor(
     private val hasStarted: Boolean
         get() = savedStateHandle.get(KEY_HAS_STARTED) ?: false
 
-    internal val paymentLauncherResult = MutableStateFlow<PaymentLauncherResult?>(null)
+    internal val internalPaymentResult = MutableStateFlow<InternalPaymentResult?>(null)
 
     /**
      * Registers the calling activity to listen to payment flow results. Should be called in the
@@ -125,7 +125,7 @@ internal class PaymentLauncherViewModel @Inject constructor(
                     }
                     if (!intent.requiresAction()) {
                         withContext(uiContext) {
-                            paymentLauncherResult.value = PaymentLauncherResult.Completed(intent)
+                            internalPaymentResult.value = InternalPaymentResult.Completed(intent)
                         }
                     } else {
                         authenticatorRegistry.getAuthenticator(intent).authenticate(
@@ -137,7 +137,7 @@ internal class PaymentLauncherViewModel @Inject constructor(
                 },
                 onFailure = {
                     withContext(uiContext) {
-                        paymentLauncherResult.value = PaymentLauncherResult.Failed(it)
+                        internalPaymentResult.value = InternalPaymentResult.Failed(it)
                     }
                 }
             )
@@ -193,7 +193,7 @@ internal class PaymentLauncherViewModel @Inject constructor(
                 },
                 onFailure = {
                     withContext(uiContext) {
-                        paymentLauncherResult.value = PaymentLauncherResult.Failed(it)
+                        internalPaymentResult.value = InternalPaymentResult.Failed(it)
                     }
                 }
             )
@@ -217,7 +217,7 @@ internal class PaymentLauncherViewModel @Inject constructor(
                 },
                 onFailure = {
                     withContext(uiContext) {
-                        paymentLauncherResult.value = PaymentLauncherResult.Failed(it)
+                        internalPaymentResult.value = InternalPaymentResult.Failed(it)
                     }
                 }
             )
@@ -228,22 +228,22 @@ internal class PaymentLauncherViewModel @Inject constructor(
      * Parse [StripeIntentResult] into [PaymentResult].
      */
     private fun postResult(stripeIntentResult: StripeIntentResult<StripeIntent>) {
-        paymentLauncherResult.value =
+        internalPaymentResult.value =
             when (stripeIntentResult.outcome) {
                 StripeIntentResult.Outcome.SUCCEEDED ->
-                    PaymentLauncherResult.Completed(stripeIntentResult.intent)
+                    InternalPaymentResult.Completed(stripeIntentResult.intent)
                 StripeIntentResult.Outcome.FAILED ->
-                    PaymentLauncherResult.Failed(
+                    InternalPaymentResult.Failed(
                         LocalStripeException(displayMessage = stripeIntentResult.failureMessage)
                     )
                 StripeIntentResult.Outcome.CANCELED ->
-                    PaymentLauncherResult.Canceled
+                    InternalPaymentResult.Canceled
                 StripeIntentResult.Outcome.TIMEDOUT ->
-                    PaymentLauncherResult.Failed(
+                    InternalPaymentResult.Failed(
                         LocalStripeException(displayMessage = TIMEOUT_ERROR + stripeIntentResult.failureMessage)
                     )
                 else ->
-                    PaymentLauncherResult.Failed(
+                    InternalPaymentResult.Failed(
                         LocalStripeException(displayMessage = UNKNOWN_ERROR + stripeIntentResult.failureMessage)
                     )
             }

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
@@ -23,7 +23,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class PaymentLauncherConfirmationActivityTest {
     private val viewModel = mock<PaymentLauncherViewModel>().also {
-        whenever(it.paymentLauncherResult).thenReturn(mock())
+        whenever(it.internalPaymentResult).thenReturn(mock())
     }
     private val testFactory = TestUtils.viewModelFactoryFor(viewModel)
 
@@ -161,9 +161,9 @@ class PaymentLauncherConfirmationActivityTest {
             assertThat(activityScenario.state)
                 .isEqualTo(Lifecycle.State.DESTROYED)
             val result =
-                PaymentLauncherResult.fromIntent(
+                InternalPaymentResult.fromIntent(
                     activityScenario.getResult().resultData
-                ) as PaymentLauncherResult.Failed
+                ) as InternalPaymentResult.Failed
             assertThat(result.throwable.message)
                 .isEqualTo(
                     PaymentLauncherConfirmationActivity.EMPTY_ARG_ERROR

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
@@ -161,7 +161,9 @@ class PaymentLauncherConfirmationActivityTest {
             assertThat(activityScenario.state)
                 .isEqualTo(Lifecycle.State.DESTROYED)
             val result =
-                PaymentResult.fromIntent(activityScenario.getResult().resultData) as PaymentResult.Failed
+                PaymentLauncherResult.fromIntent(
+                    activityScenario.getResult().resultData
+                ) as PaymentLauncherResult.Failed
             assertThat(result.throwable.message)
                 .isEqualTo(
                     PaymentLauncherConfirmationActivity.EMPTY_ARG_ERROR

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherUtilsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherUtilsTest.kt
@@ -13,9 +13,9 @@ class PaymentLauncherUtilsTest {
     fun `Converted 'PaymentResultCallback' should return completed result`() {
         val mockedResultCallback = mock<PaymentLauncher.PaymentResultCallback>()
 
-        val launcherResultCallback = mockedResultCallback.toLauncherResultCallback()
+        val launcherResultCallback = mockedResultCallback.toInternalResultCallback()
 
-        launcherResultCallback.onPaymentResult(PaymentLauncherResult.Completed(paymentIntent))
+        launcherResultCallback.onPaymentResult(InternalPaymentResult.Completed(paymentIntent))
         verify(mockedResultCallback).onPaymentResult(PaymentResult.Completed)
     }
 
@@ -23,9 +23,9 @@ class PaymentLauncherUtilsTest {
     fun `Converted 'PaymentResultCallback' should return failed result`() {
         val mockedResultCallback = mock<PaymentLauncher.PaymentResultCallback>()
 
-        val launcherResultCallback = mockedResultCallback.toLauncherResultCallback()
+        val launcherResultCallback = mockedResultCallback.toInternalResultCallback()
 
-        launcherResultCallback.onPaymentResult(PaymentLauncherResult.Failed(Exception()))
+        launcherResultCallback.onPaymentResult(InternalPaymentResult.Failed(Exception()))
         verify(mockedResultCallback).onPaymentResult(any<PaymentResult.Failed>())
     }
 
@@ -33,9 +33,9 @@ class PaymentLauncherUtilsTest {
     fun `Converted 'PaymentResultCallback' should return canceled result`() {
         val mockedResultCallback = mock<PaymentLauncher.PaymentResultCallback>()
 
-        val launcherResultCallback = mockedResultCallback.toLauncherResultCallback()
+        val launcherResultCallback = mockedResultCallback.toInternalResultCallback()
 
-        launcherResultCallback.onPaymentResult(PaymentLauncherResult.Canceled)
+        launcherResultCallback.onPaymentResult(InternalPaymentResult.Canceled)
         verify(mockedResultCallback).onPaymentResult(PaymentResult.Canceled)
     }
 
@@ -43,9 +43,9 @@ class PaymentLauncherUtilsTest {
     fun `Converted 'PaymentResult' lambda should return completed result`() {
         val mockedResultCallback = mock<(result: PaymentResult) -> Unit>()
 
-        val launcherResultCallback = toPaymentLauncherResultCallback(mockedResultCallback)
+        val launcherResultCallback = toInternalPaymentResultCallback(mockedResultCallback)
 
-        launcherResultCallback(PaymentLauncherResult.Completed(paymentIntent))
+        launcherResultCallback(InternalPaymentResult.Completed(paymentIntent))
         verify(mockedResultCallback).invoke(PaymentResult.Completed)
     }
 
@@ -53,11 +53,11 @@ class PaymentLauncherUtilsTest {
     fun `Converted 'PaymentResult' lambda should return failed result`() {
         val mockedResultCallback = mock<(result: PaymentResult) -> Unit>()
 
-        val launcherResultCallback = toPaymentLauncherResultCallback(mockedResultCallback)
+        val launcherResultCallback = toInternalPaymentResultCallback(mockedResultCallback)
 
         val exception = Exception()
 
-        launcherResultCallback(PaymentLauncherResult.Failed(exception))
+        launcherResultCallback(InternalPaymentResult.Failed(exception))
         verify(mockedResultCallback).invoke(any<PaymentResult.Failed>())
     }
 
@@ -65,9 +65,9 @@ class PaymentLauncherUtilsTest {
     fun `Converted 'PaymentResult' lambda should return canceled result`() {
         val mockedResultCallback = mock<(result: PaymentResult) -> Unit>()
 
-        val launcherResultCallback = toPaymentLauncherResultCallback(mockedResultCallback)
+        val launcherResultCallback = toInternalPaymentResultCallback(mockedResultCallback)
 
-        launcherResultCallback(PaymentLauncherResult.Canceled)
+        launcherResultCallback(InternalPaymentResult.Canceled)
         verify(mockedResultCallback).invoke(PaymentResult.Canceled)
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherUtilsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherUtilsTest.kt
@@ -1,0 +1,73 @@
+package com.stripe.android.payments.paymentlauncher
+
+import com.stripe.android.model.PaymentIntent
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class PaymentLauncherUtilsTest {
+    private val paymentIntent = mock<PaymentIntent>()
+
+    @Test
+    fun `Converted 'PaymentResultCallback' should return completed result`() {
+        val mockedResultCallback = mock<PaymentLauncher.PaymentResultCallback>()
+
+        val launcherResultCallback = mockedResultCallback.toLauncherResultCallback()
+
+        launcherResultCallback.onPaymentResult(PaymentLauncherResult.Completed(paymentIntent))
+        verify(mockedResultCallback).onPaymentResult(PaymentResult.Completed)
+    }
+
+    @Test
+    fun `Converted 'PaymentResultCallback' should return failed result`() {
+        val mockedResultCallback = mock<PaymentLauncher.PaymentResultCallback>()
+
+        val launcherResultCallback = mockedResultCallback.toLauncherResultCallback()
+
+        launcherResultCallback.onPaymentResult(PaymentLauncherResult.Failed(Exception()))
+        verify(mockedResultCallback).onPaymentResult(any<PaymentResult.Failed>())
+    }
+
+    @Test
+    fun `Converted 'PaymentResultCallback' should return canceled result`() {
+        val mockedResultCallback = mock<PaymentLauncher.PaymentResultCallback>()
+
+        val launcherResultCallback = mockedResultCallback.toLauncherResultCallback()
+
+        launcherResultCallback.onPaymentResult(PaymentLauncherResult.Canceled)
+        verify(mockedResultCallback).onPaymentResult(PaymentResult.Canceled)
+    }
+
+    @Test
+    fun `Converted 'PaymentResult' lambda should return completed result`() {
+        val mockedResultCallback = mock<(result: PaymentResult) -> Unit>()
+
+        val launcherResultCallback = toPaymentLauncherResultCallback(mockedResultCallback)
+
+        launcherResultCallback(PaymentLauncherResult.Completed(paymentIntent))
+        verify(mockedResultCallback).invoke(PaymentResult.Completed)
+    }
+
+    @Test
+    fun `Converted 'PaymentResult' lambda should return failed result`() {
+        val mockedResultCallback = mock<(result: PaymentResult) -> Unit>()
+
+        val launcherResultCallback = toPaymentLauncherResultCallback(mockedResultCallback)
+
+        val exception = Exception()
+
+        launcherResultCallback(PaymentLauncherResult.Failed(exception))
+        verify(mockedResultCallback).invoke(any<PaymentResult.Failed>())
+    }
+
+    @Test
+    fun `Converted 'PaymentResult' lambda should return canceled result`() {
+        val mockedResultCallback = mock<(result: PaymentResult) -> Unit>()
+
+        val launcherResultCallback = toPaymentLauncherResultCallback(mockedResultCallback)
+
+        launcherResultCallback(PaymentLauncherResult.Canceled)
+        verify(mockedResultCallback).invoke(PaymentResult.Canceled)
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
@@ -251,7 +251,7 @@ class PaymentLauncherViewModelTest {
             )
 
             assertThat(viewModel.paymentLauncherResult.value)
-                .isEqualTo(PaymentResult.Completed)
+                .isEqualTo(PaymentLauncherResult.Completed(paymentIntent))
         }
 
     @Test
@@ -341,7 +341,7 @@ class PaymentLauncherViewModelTest {
             viewModel.confirmStripeIntent(confirmPaymentIntentParams, authHost)
 
             assertThat(viewModel.paymentLauncherResult.value)
-                .isInstanceOf(PaymentResult.Failed::class.java)
+                .isInstanceOf(PaymentLauncherResult.Failed::class.java)
         }
 
     @Test
@@ -354,7 +354,7 @@ class PaymentLauncherViewModelTest {
             viewModel.confirmStripeIntent(confirmSetupIntentParams, authHost)
 
             assertThat(viewModel.paymentLauncherResult.value)
-                .isInstanceOf(PaymentResult.Failed::class.java)
+                .isInstanceOf(PaymentLauncherResult.Failed::class.java)
         }
 
     @Test
@@ -385,7 +385,7 @@ class PaymentLauncherViewModelTest {
             viewModel.handleNextActionForStripeIntent(CLIENT_SECRET, authHost)
 
             assertThat(viewModel.paymentLauncherResult.value)
-                .isInstanceOf(PaymentResult.Failed::class.java)
+                .isInstanceOf(PaymentLauncherResult.Failed::class.java)
         }
 
     @Test
@@ -425,7 +425,7 @@ class PaymentLauncherViewModelTest {
             viewModel.onPaymentFlowResult(paymentFlowResult)
 
             assertThat(viewModel.paymentLauncherResult.value)
-                .isEqualTo(PaymentResult.Completed)
+                .isEqualTo(PaymentLauncherResult.Completed(paymentIntent))
         }
 
     @Test
@@ -439,7 +439,7 @@ class PaymentLauncherViewModelTest {
             viewModel.onPaymentFlowResult(paymentFlowResult)
 
             assertThat(viewModel.paymentLauncherResult.value)
-                .isInstanceOf(PaymentResult.Failed::class.java)
+                .isInstanceOf(PaymentLauncherResult.Failed::class.java)
         }
 
     @Test
@@ -453,7 +453,7 @@ class PaymentLauncherViewModelTest {
             viewModel.onPaymentFlowResult(paymentFlowResult)
 
             assertThat(viewModel.paymentLauncherResult.value)
-                .isEqualTo(PaymentResult.Canceled)
+                .isEqualTo(PaymentLauncherResult.Canceled)
         }
 
     @Test
@@ -467,7 +467,7 @@ class PaymentLauncherViewModelTest {
             viewModel.onPaymentFlowResult(paymentFlowResult)
 
             assertThat(viewModel.paymentLauncherResult.value)
-                .isInstanceOf(PaymentResult.Failed::class.java)
+                .isInstanceOf(PaymentLauncherResult.Failed::class.java)
         }
 
     @Test
@@ -481,7 +481,7 @@ class PaymentLauncherViewModelTest {
             viewModel.onPaymentFlowResult(paymentFlowResult)
 
             assertThat(viewModel.paymentLauncherResult.value)
-                .isInstanceOf(PaymentResult.Failed::class.java)
+                .isInstanceOf(PaymentLauncherResult.Failed::class.java)
         }
 
     @Test

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
@@ -250,8 +250,8 @@ class PaymentLauncherViewModelTest {
                 eq(apiRequestOptions)
             )
 
-            assertThat(viewModel.paymentLauncherResult.value)
-                .isEqualTo(PaymentLauncherResult.Completed(paymentIntent))
+            assertThat(viewModel.internalPaymentResult.value)
+                .isEqualTo(InternalPaymentResult.Completed(paymentIntent))
         }
 
     @Test
@@ -340,8 +340,8 @@ class PaymentLauncherViewModelTest {
             val viewModel = createViewModel()
             viewModel.confirmStripeIntent(confirmPaymentIntentParams, authHost)
 
-            assertThat(viewModel.paymentLauncherResult.value)
-                .isInstanceOf(PaymentLauncherResult.Failed::class.java)
+            assertThat(viewModel.internalPaymentResult.value)
+                .isInstanceOf(InternalPaymentResult.Failed::class.java)
         }
 
     @Test
@@ -353,8 +353,8 @@ class PaymentLauncherViewModelTest {
             val viewModel = createViewModel()
             viewModel.confirmStripeIntent(confirmSetupIntentParams, authHost)
 
-            assertThat(viewModel.paymentLauncherResult.value)
-                .isInstanceOf(PaymentLauncherResult.Failed::class.java)
+            assertThat(viewModel.internalPaymentResult.value)
+                .isInstanceOf(InternalPaymentResult.Failed::class.java)
         }
 
     @Test
@@ -384,8 +384,8 @@ class PaymentLauncherViewModelTest {
             val viewModel = createViewModel()
             viewModel.handleNextActionForStripeIntent(CLIENT_SECRET, authHost)
 
-            assertThat(viewModel.paymentLauncherResult.value)
-                .isInstanceOf(PaymentLauncherResult.Failed::class.java)
+            assertThat(viewModel.internalPaymentResult.value)
+                .isInstanceOf(InternalPaymentResult.Failed::class.java)
         }
 
     @Test
@@ -424,8 +424,8 @@ class PaymentLauncherViewModelTest {
 
             viewModel.onPaymentFlowResult(paymentFlowResult)
 
-            assertThat(viewModel.paymentLauncherResult.value)
-                .isEqualTo(PaymentLauncherResult.Completed(paymentIntent))
+            assertThat(viewModel.internalPaymentResult.value)
+                .isEqualTo(InternalPaymentResult.Completed(paymentIntent))
         }
 
     @Test
@@ -438,8 +438,8 @@ class PaymentLauncherViewModelTest {
 
             viewModel.onPaymentFlowResult(paymentFlowResult)
 
-            assertThat(viewModel.paymentLauncherResult.value)
-                .isInstanceOf(PaymentLauncherResult.Failed::class.java)
+            assertThat(viewModel.internalPaymentResult.value)
+                .isInstanceOf(InternalPaymentResult.Failed::class.java)
         }
 
     @Test
@@ -452,8 +452,8 @@ class PaymentLauncherViewModelTest {
 
             viewModel.onPaymentFlowResult(paymentFlowResult)
 
-            assertThat(viewModel.paymentLauncherResult.value)
-                .isEqualTo(PaymentLauncherResult.Canceled)
+            assertThat(viewModel.internalPaymentResult.value)
+                .isEqualTo(InternalPaymentResult.Canceled)
         }
 
     @Test
@@ -466,8 +466,8 @@ class PaymentLauncherViewModelTest {
 
             viewModel.onPaymentFlowResult(paymentFlowResult)
 
-            assertThat(viewModel.paymentLauncherResult.value)
-                .isInstanceOf(PaymentLauncherResult.Failed::class.java)
+            assertThat(viewModel.internalPaymentResult.value)
+                .isInstanceOf(InternalPaymentResult.Failed::class.java)
         }
 
     @Test
@@ -480,8 +480,8 @@ class PaymentLauncherViewModelTest {
 
             viewModel.onPaymentFlowResult(paymentFlowResult)
 
-            assertThat(viewModel.paymentLauncherResult.value)
-                .isInstanceOf(PaymentLauncherResult.Failed::class.java)
+            assertThat(viewModel.internalPaymentResult.value)
+                .isInstanceOf(InternalPaymentResult.Failed::class.java)
         }
 
     @Test

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
@@ -94,7 +94,7 @@ internal class TestCard : BasePlaygroundTest() {
             customerId = state?.customerConfig?.id,
             testParameters = testParameters,
             beforeBuyAction = { selectors ->
-                selectors.composeTestRule.waitUntilAtLeastOneExists(
+                selectors.composeTestRule.waitUntilExactlyOneExists(
                     hasTestTag(SAVED_PAYMENT_OPTION_TEST_TAG)
                         .and(isSelected())
                         .and(hasText(cardNumber.takeLast(4), substring = true))
@@ -140,7 +140,7 @@ internal class TestCard : BasePlaygroundTest() {
             customerId = state?.customerConfig?.id,
             testParameters = testParameters,
             beforeBuyAction = { selectors ->
-                selectors.composeTestRule.waitUntilAtLeastOneExists(
+                selectors.composeTestRule.waitUntilExactlyOneExists(
                     hasTestTag(SAVED_PAYMENT_OPTION_TEST_TAG)
                         .and(isSelected())
                         .and(hasText(secondCardNumber.takeLast(4), substring = true))

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1729,6 +1729,9 @@ public final class com/stripe/android/paymentsheet/ui/ComposableSingletons$SepaM
 	public final fun getLambda-2$paymentsheet_release ()Lkotlin/jvm/functions/Function3;
 }
 
+public final class com/stripe/android/paymentsheet/ui/PaymentOptionsUIKt {
+}
+
 public final class com/stripe/android/paymentsheet/ui/SepaMandateContract$Args$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/ui/SepaMandateContract$Args;

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -33,7 +33,7 @@ import com.stripe.android.payments.paymentlauncher.PaymentLauncher
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
-import com.stripe.android.payments.paymentlauncher.toPaymentLauncherResultCallback
+import com.stripe.android.payments.paymentlauncher.toInternalPaymentResultCallback
 import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
@@ -184,7 +184,7 @@ internal class CustomerSheetViewModel @Inject constructor(
     ) {
         val launcher = activityResultCaller.registerForActivityResult(
             PaymentLauncherContract(),
-            toPaymentLauncherResultCallback(::onPaymentLauncherResult)
+            toInternalPaymentResultCallback(::onPaymentLauncherResult)
         )
 
         paymentLauncher = paymentLauncherFactory.create(

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -33,6 +33,7 @@ import com.stripe.android.payments.paymentlauncher.PaymentLauncher
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
+import com.stripe.android.payments.paymentlauncher.toPaymentLauncherResultCallback
 import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
@@ -183,7 +184,7 @@ internal class CustomerSheetViewModel @Inject constructor(
     ) {
         val launcher = activityResultCaller.registerForActivityResult(
             PaymentLauncherContract(),
-            ::onPaymentLauncherResult
+            toPaymentLauncherResultCallback(::onPaymentLauncherResult)
         )
 
         paymentLauncher = paymentLauncherFactory.create(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -29,8 +29,8 @@ import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
+import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncher
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -30,7 +30,7 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
-import com.stripe.android.payments.paymentlauncher.PaymentLauncherResult
+import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncher
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
@@ -471,7 +471,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             statusBarColor = args.statusBarColor,
             hostActivityLauncher = activityResultCaller.registerForActivityResult(
                 PaymentLauncherContract(),
-                ::onPaymentLauncherResult
+                ::onInternalPaymentResult
             ),
             includePaymentSheetAuthenticators = true,
         )
@@ -532,22 +532,22 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         }
     }
 
-    private fun onPaymentLauncherResult(launcherResult: PaymentLauncherResult) {
+    private fun onInternalPaymentResult(launcherResult: InternalPaymentResult) {
         viewModelScope.launch {
             runCatching {
                 requireNotNull(stripeIntent.value)
             }.fold(
                 onSuccess = { originalIntent ->
                     when (launcherResult) {
-                        is PaymentLauncherResult.Completed -> processPayment(
+                        is InternalPaymentResult.Completed -> processPayment(
                             stripeIntent = launcherResult.intent,
                             paymentResult = PaymentResult.Completed
                         )
-                        is PaymentLauncherResult.Failed -> processPayment(
+                        is InternalPaymentResult.Failed -> processPayment(
                             stripeIntent = originalIntent,
                             paymentResult = PaymentResult.Failed(launcherResult.throwable)
                         )
-                        is PaymentLauncherResult.Canceled -> processPayment(
+                        is InternalPaymentResult.Canceled -> processPayment(
                             stripeIntent = originalIntent,
                             paymentResult = PaymentResult.Canceled
                         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -32,6 +32,7 @@ import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncher
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
+import com.stripe.android.payments.paymentlauncher.toPaymentLauncherResultCallback
 import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.PaymentOptionCallback
 import com.stripe.android.paymentsheet.PaymentOptionContract
@@ -118,7 +119,7 @@ internal class DefaultFlowController @Inject internal constructor(
     init {
         val paymentLauncherActivityResultLauncher = activityResultRegistryOwner.register(
             PaymentLauncherContract(),
-            ::onPaymentResult
+            toPaymentLauncherResultCallback(::onPaymentResult)
         )
 
         paymentOptionActivityLauncher = activityResultRegistryOwner.register(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -32,7 +32,7 @@ import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncher
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
-import com.stripe.android.payments.paymentlauncher.toPaymentLauncherResultCallback
+import com.stripe.android.payments.paymentlauncher.toInternalPaymentResultCallback
 import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.PaymentOptionCallback
 import com.stripe.android.paymentsheet.PaymentOptionContract
@@ -119,7 +119,7 @@ internal class DefaultFlowController @Inject internal constructor(
     init {
         val paymentLauncherActivityResultLauncher = activityResultRegistryOwner.register(
             PaymentLauncherContract(),
-            toPaymentLauncherResultCallback(::onPaymentResult)
+            toInternalPaymentResultCallback(::onPaymentResult)
         )
 
         paymentOptionActivityLauncher = activityResultRegistryOwner.register(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsUI.kt
@@ -1,6 +1,9 @@
 package com.stripe.android.paymentsheet.ui
 
+import androidx.annotation.RestrictTo
+import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,8 +20,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.semantics.testTagsAsResourceId
+import androidx.compose.ui.semantics.text
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -287,25 +294,37 @@ private fun SavedPaymentMethod(
         paymentMethod.displayName,
     )
 
-    PaymentOptionUi(
-        viewWidth = width,
-        editState = when {
-            isEditing && isModifiable -> PaymentOptionEditState.Modifiable
-            isEditing -> PaymentOptionEditState.Removable
-            else -> PaymentOptionEditState.None
-        },
-        isSelected = isSelected,
-        isEnabled = isEnabled,
-        iconRes = paymentMethod.paymentMethod.getSavedPaymentMethodIcon(),
-        labelIcon = labelIcon,
-        labelText = labelText,
-        removePmDialogTitle = removeTitle,
-        description = paymentMethod.getDescription(context.resources),
-        onModifyListener = { onModifyItem(paymentMethod.paymentMethod) },
-        onModifyAccessibilityDescription = paymentMethod.getModifyDescription(context.resources),
-        onRemoveListener = { onItemRemoved(paymentMethod.paymentMethod) },
-        onRemoveAccessibilityDescription = paymentMethod.getRemoveDescription(context.resources),
-        onItemSelectedListener = { onItemSelected(paymentMethod.toPaymentSelection()) },
-        modifier = modifier,
-    )
+    Box(
+        modifier = Modifier.semantics {
+            testTag = SAVED_PAYMENT_OPTION_TEST_TAG
+            selected = isSelected
+            text = AnnotatedString(labelText)
+        }
+    ) {
+        PaymentOptionUi(
+            viewWidth = width,
+            editState = when {
+                isEditing && isModifiable -> PaymentOptionEditState.Modifiable
+                isEditing -> PaymentOptionEditState.Removable
+                else -> PaymentOptionEditState.None
+            },
+            isSelected = isSelected,
+            isEnabled = isEnabled,
+            iconRes = paymentMethod.paymentMethod.getSavedPaymentMethodIcon(),
+            labelIcon = labelIcon,
+            labelText = labelText,
+            removePmDialogTitle = removeTitle,
+            description = paymentMethod.getDescription(context.resources),
+            onModifyListener = { onModifyItem(paymentMethod.paymentMethod) },
+            onModifyAccessibilityDescription = paymentMethod.getModifyDescription(context.resources),
+            onRemoveListener = { onItemRemoved(paymentMethod.paymentMethod) },
+            onRemoveAccessibilityDescription = paymentMethod.getRemoveDescription(context.resources),
+            onItemSelectedListener = { onItemSelected(paymentMethod.toPaymentSelection()) },
+            modifier = modifier,
+        )
+    }
 }
+
+@VisibleForTesting
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val SAVED_PAYMENT_OPTION_TEST_TAG = "PaymentSheetSavedPaymentOption"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/SelectionUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/SelectionUtils.kt
@@ -1,0 +1,21 @@
+@file:RestrictTo(RestrictTo.Scope.LIBRARY)
+
+package com.stripe.android.paymentsheet.utils
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.model.PaymentSelection
+
+internal fun PaymentSelection.New.canSave(
+    initializationMode: PaymentSheet.InitializationMode
+): Boolean {
+    val requestedToSave = customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse
+
+    return when (initializationMode) {
+        is PaymentSheet.InitializationMode.PaymentIntent -> requestedToSave
+        is PaymentSheet.InitializationMode.SetupIntent -> true
+        is PaymentSheet.InitializationMode.DeferredIntent -> {
+            initializationMode.intentConfiguration.mode.setupFutureUse != null || requestedToSave
+        }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
@@ -696,6 +696,8 @@ internal object PaymentIntentFixtures {
         """.trimIndent()
     )
 
+    val PI_WITH_PAYMENT_METHOD = PARSER.parse(EXPANDED_PAYMENT_METHOD_JSON)
+
     val PI_WITH_SHIPPING_JSON = org.json.JSONObject(
         """
         {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -35,8 +35,8 @@ import com.stripe.android.model.PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
+import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncher
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.paymentsheet
 
 import android.app.Application
+import androidx.activity.result.ActivityResultCallback
+import androidx.activity.result.ActivityResultCaller
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
@@ -26,12 +28,15 @@ import com.stripe.android.model.MandateDataParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
+import com.stripe.android.payments.paymentlauncher.PaymentLauncherResult
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncher
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
@@ -71,6 +76,7 @@ import org.junit.runner.RunWith
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
@@ -1620,6 +1626,152 @@ internal class PaymentSheetViewModelTest {
         )
     }
 
+    @Test
+    fun `On complete payment launcher result in PI mode & should reuse, should save payment selection`() = runTest {
+        selectionSavedTest(
+            initializationMode = InitializationMode.PaymentIntent(
+                clientSecret = "pi_12345"
+            ),
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
+        )
+    }
+
+    @Test
+    fun `On complete payment launcher result in PI mode & should not reuse, should not save payment selection`() = runTest {
+        selectionSavedTest(
+            initializationMode = InitializationMode.PaymentIntent(
+                clientSecret = "pi_12345"
+            ),
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse,
+            shouldSave = false
+        )
+    }
+
+    @Test
+    fun `On complete payment launcher result in SI mode, should save payment selection`() = runTest {
+        selectionSavedTest(
+            initializationMode = InitializationMode.SetupIntent(
+                clientSecret = "si_123456"
+            )
+        )
+    }
+
+    @Test
+    fun `On complete payment launcher result with PI config but no SFU, should not save payment selection`() = runTest {
+        selectionSavedTest(
+            initializationMode = InitializationMode.DeferredIntent(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                        amount = 10L,
+                        currency = "USD"
+                    )
+                )
+            ),
+            shouldSave = false
+        )
+    }
+
+    @Test
+    fun `On complete payment launcher result with DI (PI+SFU), should save payment selection`() = runTest {
+        selectionSavedTest(
+            initializationMode = InitializationMode.DeferredIntent(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                        amount = 10L,
+                        currency = "USD",
+                        setupFutureUse = PaymentSheet.IntentConfiguration.SetupFutureUse.OffSession
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `On complete payment launcher result with DI (SI), should save payment selection`() = runTest {
+        selectionSavedTest(
+            initializationMode = InitializationMode.DeferredIntent(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Setup(
+                        currency = "USD"
+                    )
+                )
+            )
+        )
+    }
+
+    private suspend fun selectionSavedTest(
+        initializationMode: InitializationMode = ARGS_CUSTOMER_WITH_GOOGLEPAY.initializationMode,
+        customerRequestedSave: PaymentSelection.CustomerRequestedSave =
+            PaymentSelection.CustomerRequestedSave.NoRequest,
+        shouldSave: Boolean = true
+    ) {
+        val intent = PAYMENT_INTENT_WITH_PAYMENT_METHOD!!
+        val mockActivityResultCaller = mock<ActivityResultCaller> {
+            on {
+                registerForActivityResult<
+                    PaymentLauncherContract.Args,
+                    PaymentLauncherResult
+                    >(any(), any())
+            } doReturn mock()
+        }
+
+        val viewModel = createViewModel(
+            args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
+                initializationMode = initializationMode
+            ),
+            stripeIntent = PAYMENT_INTENT
+        ).apply {
+            registerFromActivity(mockActivityResultCaller, TestLifecycleOwner())
+        }
+
+        val selection = PaymentSelection.New.Card(
+            brand = CardBrand.Visa,
+            customerRequestedSave = customerRequestedSave,
+            paymentMethodCreateParams = PaymentMethodCreateParams.create(
+                card = PaymentMethodCreateParams.Card()
+            )
+        )
+
+        viewModel.updateSelection(selection)
+
+        val onPaymentResult = argumentCaptor<ActivityResultCallback<PaymentLauncherResult>>()
+
+        verify(mockActivityResultCaller).registerForActivityResult(
+            any<PaymentLauncherContract>(),
+            onPaymentResult.capture()
+        )
+
+        onPaymentResult.firstValue.onActivityResult(
+            PaymentLauncherResult.Completed(intent)
+        )
+
+        val savedSelection = PaymentSelection.Saved(
+            paymentMethod = intent.paymentMethod!!
+        )
+
+        if (shouldSave) {
+            assertThat(prefsRepository.paymentSelectionArgs).containsExactly(savedSelection)
+
+            assertThat(
+                prefsRepository.getSavedSelection(
+                    isGooglePayAvailable = true,
+                    isLinkAvailable = true
+                )
+            ).isEqualTo(
+                SavedSelection.PaymentMethod(savedSelection.paymentMethod.id.orEmpty())
+            )
+        } else {
+            assertThat(prefsRepository.paymentSelectionArgs).isEmpty()
+
+            assertThat(
+                prefsRepository.getSavedSelection(
+                    isGooglePayAvailable = true,
+                    isLinkAvailable = true
+                )
+            ).isEqualTo(SavedSelection.None)
+        }
+    }
+
     private fun createViewModel(
         args: PaymentSheetContractV2.Args = ARGS_CUSTOMER_WITH_GOOGLEPAY,
         stripeIntent: StripeIntent = PAYMENT_INTENT,
@@ -1690,6 +1842,7 @@ internal class PaymentSheetViewModelTest {
         private val PAYMENT_METHODS = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
 
         val PAYMENT_INTENT = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
+        val PAYMENT_INTENT_WITH_PAYMENT_METHOD = PaymentIntentFixtures.PI_WITH_PAYMENT_METHOD
         val SETUP_INTENT = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -36,7 +36,7 @@ import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
-import com.stripe.android.payments.paymentlauncher.PaymentLauncherResult
+import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncher
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
@@ -1710,7 +1710,7 @@ internal class PaymentSheetViewModelTest {
             on {
                 registerForActivityResult<
                     PaymentLauncherContract.Args,
-                    PaymentLauncherResult
+                    InternalPaymentResult
                     >(any(), any())
             } doReturn mock()
         }
@@ -1734,7 +1734,7 @@ internal class PaymentSheetViewModelTest {
 
         viewModel.updateSelection(selection)
 
-        val onPaymentResult = argumentCaptor<ActivityResultCallback<PaymentLauncherResult>>()
+        val onPaymentResult = argumentCaptor<ActivityResultCallback<InternalPaymentResult>>()
 
         verify(mockActivityResultCaller).registerForActivityResult(
             any<PaymentLauncherContract>(),
@@ -1742,7 +1742,7 @@ internal class PaymentSheetViewModelTest {
         )
 
         onPaymentResult.firstValue.onActivityResult(
-            PaymentLauncherResult.Completed(intent)
+            InternalPaymentResult.Completed(intent)
         )
 
         val savedSelection = PaymentSelection.Saved(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/SelectionUtilsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/SelectionUtilsTest.kt
@@ -1,0 +1,115 @@
+package com.stripe.android.paymentsheet.utils
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import org.junit.Test
+
+class SelectionUtilsTest {
+    @Test
+    fun `should not be able to save if mode is payment intent`() {
+        assertThat(
+            NEW_SELECTION.canSave(
+                PaymentSheet.InitializationMode.PaymentIntent(clientSecret = "pi_12345")
+            )
+        ).isFalse()
+    }
+
+    @Test
+    fun `should be able to save if mode is payment intent but customer requested it`() {
+        assertThat(
+            NEW_SELECTION_WITH_CUSTOMER_REQUEST.canSave(
+                PaymentSheet.InitializationMode.PaymentIntent(clientSecret = "pi_12345")
+            )
+        ).isTrue()
+    }
+
+    @Test
+    fun `should be able to save if initialization mode is setup intent`() {
+        assertThat(
+            NEW_SELECTION.canSave(
+                PaymentSheet.InitializationMode.SetupIntent(clientSecret = "si_12345")
+            )
+        ).isTrue()
+    }
+
+    @Test
+    fun `should be able to save if initialization mode is PI deferred with future setup`() {
+        assertThat(
+            NEW_SELECTION.canSave(
+                PaymentSheet.InitializationMode.DeferredIntent(
+                    intentConfiguration = PaymentSheet.IntentConfiguration(
+                        mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                            amount = 10L,
+                            currency = "USD",
+                            setupFutureUse = PaymentSheet.IntentConfiguration.SetupFutureUse.OffSession
+                        )
+                    )
+                )
+            )
+        ).isTrue()
+    }
+
+    @Test
+    fun `should not be able to save if initialization mode is PI deferred without future setup`() {
+        assertThat(
+            NEW_SELECTION.canSave(
+                PaymentSheet.InitializationMode.DeferredIntent(
+                    intentConfiguration = PaymentSheet.IntentConfiguration(
+                        mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                            amount = 10L,
+                            currency = "USD",
+                            setupFutureUse = null
+                        )
+                    )
+                )
+            )
+        ).isFalse()
+    }
+
+    @Test
+    fun `should be able to save if customer requested in PI deferred without future setup mode`() {
+        assertThat(
+            NEW_SELECTION_WITH_CUSTOMER_REQUEST.canSave(
+                PaymentSheet.InitializationMode.DeferredIntent(
+                    intentConfiguration = PaymentSheet.IntentConfiguration(
+                        mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                            amount = 10L,
+                            currency = "USD",
+                            setupFutureUse = null
+                        )
+                    ),
+                )
+            )
+        ).isTrue()
+    }
+
+    @Test
+    fun `should be able to save if customer requested in SI deferred mode`() {
+        assertThat(
+            NEW_SELECTION_WITH_CUSTOMER_REQUEST.canSave(
+                PaymentSheet.InitializationMode.DeferredIntent(
+                    intentConfiguration = PaymentSheet.IntentConfiguration(
+                        mode = PaymentSheet.IntentConfiguration.Mode.Setup()
+                    ),
+                )
+            )
+        ).isTrue()
+    }
+
+    private companion object {
+        private val NEW_SELECTION = PaymentSelection.New.Card(
+            brand = CardBrand.Visa,
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
+            paymentMethodCreateParams = PaymentMethodCreateParams.Companion.create(
+                card = PaymentMethodCreateParams.Card()
+            )
+        )
+
+        private val NEW_SELECTION_WITH_CUSTOMER_REQUEST = NEW_SELECTION.copy(
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
+        )
+    }
+}


### PR DESCRIPTION
# Summary
Fix bug in `PaymentSheet` where newly save payment method is not set as default payment method.

# Motivation
[RUN_MOBILESDK-2667](https://jira.corp.stripe.com/projects/RUN_MOBILESDK/issues/RUN_MOBILESDK-2667?filter=allopenissues)

Makes sure that newly added payment methods are selected by default.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
