### PR TITLE
Restore CBC state in Card Element on config change

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -7244,6 +7244,22 @@ public final class com/stripe/android/view/BillingAddressFields : java/lang/Enum
 	public static fun values ()[Lcom/stripe/android/view/BillingAddressFields;
 }
 
+public final class com/stripe/android/view/CardBrandView$SavedState$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/view/CardBrandView$SavedState;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/view/CardBrandView$SavedState;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/view/CardBrandView$State$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/view/CardBrandView$State;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/view/CardBrandView$State;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/view/CardFormView : android/widget/LinearLayout {
 	public static final field $stable I
 	public static final field CARD_FORM_VIEW Ljava/lang/String;
@@ -7354,7 +7370,17 @@ public final class com/stripe/android/view/CardNumberEditText : com/stripe/andro
 	public final fun getCardBrand ()Lcom/stripe/android/model/CardBrand;
 	public final fun getWorkContext ()Lkotlin/coroutines/CoroutineContext;
 	public final fun isCardNumberValid ()Z
+	public fun onRestoreInstanceState (Landroid/os/Parcelable;)V
+	public fun onSaveInstanceState ()Landroid/os/Parcelable;
 	public final fun setWorkContext (Lkotlin/coroutines/CoroutineContext;)V
+}
+
+public final class com/stripe/android/view/CardNumberEditText$SavedState$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/view/CardNumberEditText$SavedState;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/view/CardNumberEditText$SavedState;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public abstract interface class com/stripe/android/view/CardValidCallback {

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     testImplementation project(':network-testing')
     testImplementation project(':payments-core-testing')
     testImplementation testLibs.androidx.archCore
+    testImplementation testLibs.androidx.composeUi
     testImplementation testLibs.androidx.core
     testImplementation testLibs.androidx.fragment
     testImplementation testLibs.androidx.junit

--- a/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -45,7 +45,7 @@ import kotlinx.parcelize.Parcelize
 import kotlin.properties.Delegates
 import com.stripe.android.uicore.R as StripeUiCoreR
 
-internal val CardBrandDropdownTestTag = "CardBrandDropdownTestTag"
+internal const val CardBrandDropdownTestTag = "CardBrandDropdownTestTag"
 
 internal class CardBrandView @JvmOverloads constructor(
     context: Context,

--- a/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.stripe.android.R
@@ -43,6 +44,8 @@ import kotlinx.coroutines.flow.update
 import kotlinx.parcelize.Parcelize
 import kotlin.properties.Delegates
 import com.stripe.android.uicore.R as StripeUiCoreR
+
+internal val CardBrandDropdownTestTag = "CardBrandDropdownTestTag"
 
 internal class CardBrandView @JvmOverloads constructor(
     context: Context,
@@ -246,9 +249,9 @@ private fun CardBrand(
     Box(modifier) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.clickable(enabled = showDropdown) {
-                expanded = true
-            },
+            modifier = Modifier
+                .clickable(enabled = showDropdown) { expanded = true }
+                .testTag(CardBrandDropdownTestTag),
         ) {
             val dropdownIconAlpha by animateFloatAsState(
                 targetValue = if (showDropdown) ContentAlpha.medium else 0f,

--- a/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.view
 
 import android.content.Context
+import android.os.Parcelable
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
@@ -38,6 +39,8 @@ import com.stripe.android.uicore.elements.SingleChoiceDropdown
 import com.stripe.android.utils.AppCompatOrMdcTheme
 import com.stripe.android.utils.FeatureFlags
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.parcelize.Parcelize
 import kotlin.properties.Delegates
 import com.stripe.android.uicore.R as StripeUiCoreR
 
@@ -53,26 +56,37 @@ internal class CardBrandView @JvmOverloads constructor(
     private val iconView = viewBinding.icon
     private val progressView = viewBinding.progress
 
-    private val isCbcEligibleFlow = MutableStateFlow(false)
-    private val isLoadingFlow = MutableStateFlow(false)
-    private val brandFlow = MutableStateFlow(Unknown)
-    private val userSelectedBrandFlow = MutableStateFlow<CardBrand?>(null)
-    private val possibleBrandsFlow = MutableStateFlow(emptyList<CardBrand>())
-    private val merchantPreferredNetworksFlow = MutableStateFlow(emptyList<CardBrand>())
-    private val shouldShowCvcFlow = MutableStateFlow(false)
-    private val shouldShowErrorIconFlow = MutableStateFlow(false)
-    private val tintColorFlow = MutableStateFlow(0)
+    @Parcelize
+    internal data class State(
+        val isCbcEligible: Boolean = false,
+        val isLoading: Boolean = false,
+        val brand: CardBrand = Unknown,
+        val userSelectedBrand: CardBrand? = null,
+        val possibleBrands: List<CardBrand> = emptyList(),
+        val merchantPreferredNetworks: List<CardBrand> = emptyList(),
+        val shouldShowCvc: Boolean = false,
+        val shouldShowErrorIcon: Boolean = false,
+        val tintColor: Int = 0,
+    ) : Parcelable
+
+    private val stateFlow = MutableStateFlow(State())
+
+    private var state: State
+        get() = stateFlow.value
+        set(value) {
+            stateFlow.value = value
+        }
 
     var isCbcEligible: Boolean
-        get() = isCbcEligibleFlow.value
+        get() = state.isCbcEligible
         set(value) {
-            isCbcEligibleFlow.value = value
+            stateFlow.update { it.copy(isCbcEligible = value) }
         }
 
     var isLoading: Boolean by Delegates.observable(
         false
     ) { _, wasLoading, isLoading ->
-        isLoadingFlow.value = isLoading
+        stateFlow.update { it.copy(isLoading = isLoading) }
 
         if (wasLoading != isLoading) {
             if (isLoading) {
@@ -84,39 +98,39 @@ internal class CardBrandView @JvmOverloads constructor(
     }
 
     var brand: CardBrand
-        get() = brandFlow.value
+        get() = state.brand
         set(value) {
-            brandFlow.value = value
+            stateFlow.update { it.copy(brand = value) }
         }
 
     var possibleBrands: List<CardBrand>
-        get() = possibleBrandsFlow.value
+        get() = state.possibleBrands
         set(value) {
-            possibleBrandsFlow.value = value
+            stateFlow.update { it.copy(possibleBrands = value) }
         }
 
     var merchantPreferredNetworks: List<CardBrand>
-        get() = merchantPreferredNetworksFlow.value
+        get() = state.merchantPreferredNetworks
         set(value) {
-            merchantPreferredNetworksFlow.value = value
+            stateFlow.update { it.copy(merchantPreferredNetworks = value) }
         }
 
     var shouldShowCvc: Boolean
-        get() = shouldShowCvcFlow.value
+        get() = state.shouldShowCvc
         set(value) {
-            shouldShowCvcFlow.value = value
+            stateFlow.update { it.copy(shouldShowCvc = value) }
         }
 
     var shouldShowErrorIcon: Boolean
-        get() = shouldShowErrorIconFlow.value
+        get() = state.shouldShowErrorIcon
         set(value) {
-            shouldShowErrorIconFlow.value = value
+            stateFlow.update { it.copy(shouldShowErrorIcon = value) }
         }
 
     internal var tintColorInt: Int
-        get() = tintColorFlow.value
+        get() = state.tintColor
         set(value) {
-            tintColorFlow.value = value
+            stateFlow.update { it.copy(tintColor = value) }
         }
 
     init {
@@ -125,33 +139,25 @@ internal class CardBrandView @JvmOverloads constructor(
 
         iconView.setContent {
             AppCompatOrMdcTheme {
-                val isCbcEligible by isCbcEligibleFlow.collectAsState()
-                val isLoading by isLoadingFlow.collectAsState()
-                val currentBrand by brandFlow.collectAsState()
-                val userSelectedBrand by userSelectedBrandFlow.collectAsState()
-                val possibleBrands by possibleBrandsFlow.collectAsState()
-                val merchantPreferredBrands by merchantPreferredNetworksFlow.collectAsState()
-                val shouldShowCvc by shouldShowCvcFlow.collectAsState()
-                val shouldShowErrorIcon by shouldShowErrorIconFlow.collectAsState()
-                val tintColorInt by tintColorFlow.collectAsState()
+                val state by stateFlow.collectAsState()
 
-                LaunchedEffect(userSelectedBrand, currentBrand, possibleBrands, merchantPreferredBrands) {
+                LaunchedEffect(state) {
                     determineCardBrandToDisplay(
-                        userSelectedBrand = userSelectedBrand,
-                        autoDeterminedBrand = currentBrand,
-                        possibleBrands = possibleBrands,
-                        merchantPreferredBrands = merchantPreferredBrands,
+                        userSelectedBrand = state.userSelectedBrand,
+                        autoDeterminedBrand = state.brand,
+                        possibleBrands = state.possibleBrands,
+                        merchantPreferredBrands = state.merchantPreferredNetworks,
                     )
                 }
 
                 CardBrand(
-                    isLoading = isLoading,
-                    currentBrand = currentBrand,
-                    possibleBrands = possibleBrands,
-                    shouldShowCvc = shouldShowCvc,
-                    shouldShowErrorIcon = shouldShowErrorIcon,
-                    tintColorInt = tintColorInt,
-                    isCbcEligible = isCbcEligible,
+                    isLoading = state.isLoading,
+                    currentBrand = state.brand,
+                    possibleBrands = state.possibleBrands,
+                    shouldShowCvc = state.shouldShowCvc,
+                    shouldShowErrorIcon = state.shouldShowErrorIcon,
+                    tintColorInt = state.tintColor,
+                    isCbcEligible = state.isCbcEligible,
                     onBrandSelected = this::handleBrandSelected,
                 )
             }
@@ -167,7 +173,7 @@ internal class CardBrandView @JvmOverloads constructor(
     }
 
     private fun handleBrandSelected(brand: CardBrand?) {
-        userSelectedBrandFlow.value = brand ?: Unknown
+        stateFlow.update { it.copy(userSelectedBrand = brand) }
     }
 
     private fun determineCardBrandToDisplay(
@@ -182,6 +188,23 @@ internal class CardBrandView @JvmOverloads constructor(
             autoDeterminedBrand
         }
     }
+
+    override fun onSaveInstanceState(): Parcelable {
+        val superState = super.onSaveInstanceState()
+        return SavedState(superState, state)
+    }
+
+    override fun onRestoreInstanceState(state: Parcelable?) {
+        val savedState = state as? SavedState
+        this.state = savedState?.state ?: State()
+        super.onRestoreInstanceState(savedState?.superState ?: state)
+    }
+
+    @Parcelize
+    internal data class SavedState(
+        val superSavedState: Parcelable?,
+        val state: State,
+    ) : BaseSavedState(superSavedState), Parcelable
 }
 
 @Composable

--- a/payments-core/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -2,6 +2,7 @@ package com.stripe.android.view
 
 import android.content.Context
 import android.os.Build
+import android.os.Parcelable
 import android.text.Editable
 import android.text.InputFilter
 import android.util.AttributeSet
@@ -27,6 +28,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.parcelize.Parcelize
 import kotlin.coroutines.CoroutineContext
 import androidx.appcompat.R as AppCompatR
 
@@ -301,6 +303,23 @@ class CardNumberEditText internal constructor(
             paymentAnalyticsRequestFactory.createRequest(PaymentAnalyticsEvent.CardMetadataLoadedTooSlow)
         )
     }
+
+    override fun onSaveInstanceState(): Parcelable {
+        val superState = super.onSaveInstanceState()
+        return SavedState(superState, isCbcEligible)
+    }
+
+    override fun onRestoreInstanceState(state: Parcelable?) {
+        val savedState = state as? SavedState
+        this.isCbcEligible = savedState?.isCbcEligible ?: false
+        super.onRestoreInstanceState(savedState?.superState ?: state)
+    }
+
+    @Parcelize
+    internal data class SavedState(
+        val superSavedState: Parcelable?,
+        val isCbcEligible: Boolean,
+    ) : BaseSavedState(superSavedState), Parcelable
 
     private inner class CardNumberTextWatcher : StripeTextWatcher() {
         private var latestChangeStart: Int = 0

--- a/payments-core/src/test/java/com/stripe/android/view/ActivityScenarioFactory.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/ActivityScenarioFactory.kt
@@ -70,4 +70,27 @@ internal class ActivityScenarioFactory(
 
         return requireNotNull(view)
     }
+
+    fun <ViewType : View> createViewAndScenario(
+        beforeAttach: (ViewType) -> Unit = {},
+        viewFactory: (Activity) -> ViewType,
+    ): Pair<ViewType, ActivityScenario<AddPaymentMethodActivity>> {
+        var view: ViewType? = null
+        val activityScenario = createAddPaymentMethodActivity()
+
+        activityScenario.onActivity { activity ->
+            activity.setTheme(R.style.StripePaymentSheetDefaultTheme)
+
+            activity.findViewById<ViewGroup>(R.id.add_payment_method_card).let { root ->
+                root.removeAllViews()
+
+                view = viewFactory(activity).also {
+                    beforeAttach(it)
+                    root.addView(it)
+                }
+            }
+        }
+
+        return requireNotNull(view) to activityScenario
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds restoration to the CardInputWidget’s brand state. This is to ensure that configuration changes don’t reset any previous user input.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screen recording

[untitled.webm](https://github.com/stripe/stripe-android/assets/110940675/30005b7b-74d1-4d52-9ae2-c0a833fd2264)

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
