### PR TITLE
Hide CBC dropdown in error state

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -242,8 +242,8 @@ private fun CardBrand(
         }
     }
 
-    val showDropdown = remember(possibleBrands, shouldShowCvc) {
-        isCbcEligible && possibleBrands.size > 1 && !shouldShowCvc
+    val showDropdown = remember(possibleBrands, shouldShowCvc, shouldShowErrorIcon) {
+        isCbcEligible && possibleBrands.size > 1 && !shouldShowCvc && !shouldShowErrorIcon
     }
 
     Box(modifier) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request hides the CBC dropdown icon when we display the error state.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
