### PR TITLE
Fix error mapping when returning from 3DS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## XX.XX.XX - 2023-XX-XX
+
+### PaymentSheet
+* [FIXED][7499](https://github.com/stripe/stripe-android/pull/7499) Fixed an issue with incorrect error messages when encountering a failure after 3D Secure authentication.
+
 ## 20.34.1 - 2023-10-24
 
 ### Payments

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeErrorMapping.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeErrorMapping.kt
@@ -3,11 +3,32 @@ package com.stripe.android.networking
 import android.content.Context
 import com.stripe.android.R
 import com.stripe.android.core.StripeError
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
 import java.util.Locale
 import com.stripe.android.uicore.R as UiCoreR
 
-@Suppress("ComplexMethod")
 internal fun StripeError.withLocalizedMessage(context: Context): StripeError {
+    val newMessage = if (shouldFallBackToLocalizedError) {
+        context.mapErrorCodeToLocalizedMessage(code)
+    } else {
+        message ?: context.mapErrorCodeToLocalizedMessage(code)
+    }
+
+    return copy(message = newMessage)
+}
+
+internal fun PaymentIntent.Error.withLocalizedMessage(context: Context): PaymentIntent.Error {
+    val newMessage = if (shouldFallBackToLocalizedError) {
+        context.mapErrorCodeToLocalizedMessage(code)
+    } else {
+        message ?: context.mapErrorCodeToLocalizedMessage(code)
+    }
+
+    return copy(message = newMessage)
+}
+
+internal fun SetupIntent.Error.withLocalizedMessage(context: Context): SetupIntent.Error {
     val newMessage = if (shouldFallBackToLocalizedError) {
         context.mapErrorCodeToLocalizedMessage(code)
     } else {

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowFailureMessageFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowFailureMessageFactory.kt
@@ -7,7 +7,7 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.networking.mapErrorCodeToLocalizedMessage
+import com.stripe.android.networking.withLocalizedMessage
 
 internal class PaymentFlowFailureMessageFactory(
     private val context: Context
@@ -52,8 +52,7 @@ internal class PaymentFlowFailureMessageFactory(
             context.resources.getString(R.string.stripe_failure_reason_authentication)
         }
         paymentIntent.lastPaymentError?.type == PaymentIntent.Error.Type.CardError -> {
-            val error = paymentIntent.lastPaymentError
-            context.mapErrorCodeToLocalizedMessage(error.code) ?: error.message
+            paymentIntent.lastPaymentError.withLocalizedMessage(context).message
         }
         else -> {
             null
@@ -67,8 +66,7 @@ internal class PaymentFlowFailureMessageFactory(
             context.resources.getString(R.string.stripe_failure_reason_authentication)
         }
         setupIntent.lastSetupError?.type == SetupIntent.Error.Type.CardError -> {
-            val error = setupIntent.lastSetupError
-            context.mapErrorCodeToLocalizedMessage(error.code) ?: error.message
+            setupIntent.lastSetupError.withLocalizedMessage(context).message
         }
         else -> {
             null

--- a/payments-core/src/test/java/com/stripe/android/payments/PaymentFlowFailureMessageFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/PaymentFlowFailureMessageFactoryTest.kt
@@ -125,6 +125,10 @@ class PaymentFlowFailureMessageFactoryTest {
 private fun withLocale(locale: Locale, block: () -> Unit) {
     val original = Locale.getDefault()
     Locale.setDefault(locale)
-    block()
-    Locale.setDefault(original)
+
+    try {
+        block()
+    } finally {
+        Locale.setDefault(original)
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request resolves an issue where we displayed the client-side error message when returning from 3DS instead of a valid server-side message.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Resolves https://github.com/stripe/stripe-android/issues/7478

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
