### PR TITLE
Fix bottom padding in CustomerSheet

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -2,7 +2,6 @@ package com.stripe.android.customersheet.ui
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -23,6 +22,7 @@ import com.stripe.android.paymentsheet.ui.PaymentElement
 import com.stripe.android.paymentsheet.ui.PaymentOptions
 import com.stripe.android.paymentsheet.ui.PaymentSheetScaffold
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBar
+import com.stripe.android.paymentsheet.utils.PaymentSheetContentPadding
 import com.stripe.android.ui.core.FormUI
 import com.stripe.android.ui.core.elements.H4Text
 import com.stripe.android.utils.FeatureFlags.customerSheetACHv2
@@ -37,8 +37,6 @@ internal fun CustomerSheetScreen(
     viewActionHandler: (CustomerSheetViewAction) -> Unit = {},
     paymentMethodNameProvider: (PaymentMethodCode?) -> String,
 ) {
-    val bottomPadding = dimensionResource(R.dimen.stripe_paymentsheet_button_container_spacing_bottom)
-
     PaymentSheetScaffold(
         topBar = {
             PaymentSheetTopBar(
@@ -54,7 +52,7 @@ internal fun CustomerSheetScreen(
             )
         },
         content = {
-            Box(modifier = Modifier.animateContentSize()) {
+            Column(modifier = Modifier.animateContentSize()) {
                 when (viewState) {
                     is CustomerSheetViewState.Loading -> {
                         BottomSheetLoadingIndicator()
@@ -65,6 +63,7 @@ internal fun CustomerSheetScreen(
                             viewActionHandler = viewActionHandler,
                             paymentMethodNameProvider = paymentMethodNameProvider,
                         )
+                        PaymentSheetContentPadding()
                     }
                     is CustomerSheetViewState.AddPaymentMethod -> {
                         if (customerSheetACHv2.isEnabled) {
@@ -79,11 +78,12 @@ internal fun CustomerSheetScreen(
                                 viewActionHandler = viewActionHandler,
                             )
                         }
+                        PaymentSheetContentPadding()
                     }
                 }
             }
         },
-        modifier = modifier.padding(bottom = bottomPadding)
+        modifier = modifier,
     )
 }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the bottom padding in CustomerSheet was applied _outside_ the scrollable column, resulting in an odd visual glitch.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before | After |
| ------------- | ------------- |
| ![Screenshot_1698268011](https://github.com/stripe/stripe-android/assets/110940675/b759e097-daae-4fd3-b4a8-a07831ef7848) | ![Screenshot_1698267966](https://github.com/stripe/stripe-android/assets/110940675/cfef455b-b565-40f6-9d1f-a9862c5538d1) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
