### PR TITLE
Add ability to save cards when using PaymentElement

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewAction.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewAction.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.customersheet
 
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.paymentsheet.forms.FormViewModel
+import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 
@@ -11,11 +11,13 @@ internal sealed class CustomerSheetViewAction {
     object OnEditPressed : CustomerSheetViewAction()
     object OnAddCardPressed : CustomerSheetViewAction()
     object OnPrimaryButtonPressed : CustomerSheetViewAction()
-    class OnFormDataUpdated(val formData: FormViewModel.ViewData) : CustomerSheetViewAction()
     class OnItemSelected(val selection: PaymentSelection?) : CustomerSheetViewAction()
     class OnModifyItem(val paymentMethod: PaymentMethod) : CustomerSheetViewAction()
     class OnItemRemoved(val paymentMethod: PaymentMethod) : CustomerSheetViewAction()
     class OnAddPaymentMethodItemChanged(
         val paymentMethod: LpmRepository.SupportedPaymentMethod,
+    ) : CustomerSheetViewAction()
+    class OnFormFieldValuesChanged(
+        val formFieldValues: FormFieldValues?,
     ) : CustomerSheetViewAction()
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -34,6 +34,7 @@ import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
+import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -127,9 +128,11 @@ internal class CustomerSheetViewModel @Inject constructor(
             is CustomerSheetViewAction.OnModifyItem -> onModifyItem(viewAction.paymentMethod)
             is CustomerSheetViewAction.OnItemSelected -> onItemSelected(viewAction.selection)
             is CustomerSheetViewAction.OnPrimaryButtonPressed -> onPrimaryButtonPressed()
-            is CustomerSheetViewAction.OnFormDataUpdated -> onFormDataUpdated(viewAction.formData)
             is CustomerSheetViewAction.OnAddPaymentMethodItemChanged ->
                 onAddPaymentMethodItemChanged(viewAction.paymentMethod)
+            is CustomerSheetViewAction.OnFormFieldValuesChanged -> {
+                onFormFieldValuesChanged(viewAction.formFieldValues)
+            }
         }
     }
 
@@ -309,6 +312,16 @@ internal class CustomerSheetViewModel @Inject constructor(
                         id = R.string.stripe_paymentsheet_save
                     )
                 }
+            )
+        }
+    }
+
+    private fun onFormFieldValuesChanged(formFieldValues: FormFieldValues?) {
+        updateViewState<CustomerSheetViewState.AddPaymentMethod> {
+            it.copy(
+                formViewData = it.formViewData.copy(
+                    completeFormValues = formFieldValues
+                )
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -232,7 +232,9 @@ internal fun AddPaymentMethodWithPaymentElement(
             onLinkSignupStateChanged = { _, _ -> },
             formArguments = viewState.formArguments,
             usBankAccountFormArguments = viewState.usBankAccountFormArguments,
-            onFormFieldValuesChanged = { }
+            onFormFieldValuesChanged = {
+                viewActionHandler(CustomerSheetViewAction.OnFormFieldValuesChanged(it))
+            }
         )
 
         AnimatedVisibility(visible = viewState.errorMessage != null) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
@@ -252,7 +252,7 @@ internal class FormViewModel @Inject internal constructor(
         )
     }
 
-    internal class ViewData(
+    internal data class ViewData(
         val elements: List<FormElement> = listOf(),
         val completeFormValues: FormFieldValues? = null,
         val hiddenIdentifiers: Set<IdentifierSpec> = setOf(),

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -810,15 +810,13 @@ class CustomerSheetViewModelTest {
             assertThat(awaitViewState<AddPaymentMethod>().primaryButtonEnabled).isFalse()
 
             viewModel.handleViewAction(
-                CustomerSheetViewAction.OnFormDataUpdated(
-                    formData = FormViewModel.ViewData(
-                        completeFormValues = FormFieldValues(
-                            fieldValuePairs = mapOf(
-                                IdentifierSpec.Generic("test") to FormFieldEntry("test", true)
-                            ),
-                            showsMandate = false,
-                            userRequestedReuse = PaymentSelection.CustomerRequestedSave.NoRequest,
-                        )
+                CustomerSheetViewAction.OnFormFieldValuesChanged(
+                    formFieldValues = FormFieldValues(
+                        fieldValuePairs = mapOf(
+                            IdentifierSpec.Generic("test") to FormFieldEntry("test", true)
+                        ),
+                        showsMandate = false,
+                        userRequestedReuse = PaymentSelection.CustomerRequestedSave.NoRequest,
                     )
                 )
             )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Add ability to save cards when using PaymentElement (new flow which is required for ACHv2). When the card form is complete, then the primary button becomes enabled and the customer can save their card.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

CustomerSheet ACHv2

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified