### PR TITLE
Add ability to start us bank account flow

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewAction.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewAction.kt
@@ -3,6 +3,7 @@ package com.stripe.android.customersheet
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 
 internal sealed class CustomerSheetViewAction {
@@ -17,7 +18,10 @@ internal sealed class CustomerSheetViewAction {
     class OnAddPaymentMethodItemChanged(
         val paymentMethod: LpmRepository.SupportedPaymentMethod,
     ) : CustomerSheetViewAction()
-    class OnFormFieldValuesChanged(
+    class OnFormFieldValuesCompleted(
         val formFieldValues: FormFieldValues?,
+    ) : CustomerSheetViewAction()
+    class OnUpdateCustomButtonUIState(
+        val callback: (PrimaryButton.UIState?) -> PrimaryButton.UIState?,
     ) : CustomerSheetViewAction()
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
@@ -10,6 +10,7 @@ import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBarState
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBarStateFactory
+import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 
 internal sealed class CustomerSheetViewState(
@@ -75,6 +76,8 @@ internal sealed class CustomerSheetViewState(
         val errorMessage: String? = null,
         val isFirstPaymentMethod: Boolean,
         val primaryButtonLabel: ResolvableString,
+        val primaryButtonEnabled: Boolean,
+        val customPrimaryButtonUiState: PrimaryButton.UIState?,
     ) : CustomerSheetViewState(
         savedPaymentMethods = emptyList(),
         isLiveMode = isLiveMode,
@@ -85,8 +88,5 @@ internal sealed class CustomerSheetViewState(
         } else {
             PaymentSheetScreen.AddAnotherPaymentMethod
         },
-    ) {
-        val primaryButtonEnabled: Boolean
-            get() = formViewData.completeFormValues != null && !isProcessing
-    }
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -233,7 +233,8 @@ internal fun AddPaymentMethodWithPaymentElement(
             formArguments = viewState.formArguments,
             usBankAccountFormArguments = viewState.usBankAccountFormArguments,
             onFormFieldValuesChanged = {
-                viewActionHandler(CustomerSheetViewAction.OnFormFieldValuesChanged(it))
+                // This only gets emitted if form field values are complete
+                viewActionHandler(CustomerSheetViewAction.OnFormFieldValuesCompleted(it))
             }
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
@@ -288,6 +288,8 @@ internal class CustomerSheetActivityTest {
             isProcessing = isProcessing,
             isFirstPaymentMethod = false,
             primaryButtonLabel = resolvableString("Save"),
+            primaryButtonEnabled = false,
+            customPrimaryButtonUiState = null,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -98,6 +98,8 @@ internal class CustomerSheetScreenshotTest {
         errorMessage = null,
         isFirstPaymentMethod = false,
         primaryButtonLabel = resolvableString("Save"),
+        primaryButtonEnabled = false,
+        customPrimaryButtonUiState = null,
     )
 
     @Test
@@ -232,6 +234,7 @@ internal class CustomerSheetScreenshotTest {
                             userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestNoReuse
                         )
                     ),
+                    primaryButtonEnabled = true,
                 ),
                 paymentMethodNameProvider = { it!! },
                 formViewModelSubComponentBuilderProvider = null,
@@ -270,7 +273,8 @@ internal class CustomerSheetScreenshotTest {
                             userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestNoReuse
                         )
                     ),
-                    isFirstPaymentMethod = true
+                    isFirstPaymentMethod = true,
+                    primaryButtonEnabled = true,
                 ),
                 paymentMethodNameProvider = { it!! },
                 formViewModelSubComponentBuilderProvider = null,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -23,6 +23,7 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -810,7 +811,7 @@ class CustomerSheetViewModelTest {
             assertThat(awaitViewState<AddPaymentMethod>().primaryButtonEnabled).isFalse()
 
             viewModel.handleViewAction(
-                CustomerSheetViewAction.OnFormFieldValuesChanged(
+                CustomerSheetViewAction.OnFormFieldValuesCompleted(
                     formFieldValues = FormFieldValues(
                         fieldValuePairs = mapOf(
                             IdentifierSpec.Generic("test") to FormFieldEntry("test", true)
@@ -1571,6 +1572,38 @@ class CustomerSheetViewModelTest {
             viewState = awaitViewState()
             assertThat(viewState.primaryButtonLabel)
                 .isEqualTo(resolvableString(UiCoreR.string.stripe_continue_button_label))
+        }
+    }
+
+    @Test
+    fun `The custom primary button can be updated`() = runTest {
+        val viewModel = createViewModel(
+            initialBackStack = listOf(
+                addPaymentMethodViewState,
+            ),
+        )
+
+        viewModel.viewState.test {
+            var viewState = awaitViewState<AddPaymentMethod>()
+            assertThat(viewState.customPrimaryButtonUiState)
+                .isNull()
+
+            viewModel.handleViewAction(
+                CustomerSheetViewAction.OnUpdateCustomButtonUIState(
+                    callback = {
+                        PrimaryButton.UIState(
+                            label = "Continue",
+                            enabled = true,
+                            lockVisible = false,
+                            onClick = {}
+                        )
+                    }
+                )
+            )
+
+            viewState = awaitViewState()
+            assertThat(viewState.customPrimaryButtonUiState)
+                .isNotNull()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -115,6 +115,8 @@ internal object CustomerSheetTestHelper {
         errorMessage = null,
         isFirstPaymentMethod = false,
         primaryButtonLabel = resolvableString(R.string.stripe_paymentsheet_save),
+        primaryButtonEnabled = false,
+        customPrimaryButtonUiState = null,
     )
 
     internal fun mockedFormViewModel(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

* Refactor AddPaymentMethod with `primaryButtonEnabled`, rather than a computed value
* Hook up `updateCustomButtonUIState` so that when pressing the primary button, the us bank account flow launches

Future PRs will handle the us bank account

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

CustomerSheet ACHv2

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots

https://github.com/stripe/stripe-android/assets/99316447/9c18fcc3-3f3a-4d0d-ac02-4a232281f5b5