### PR TITLE
Add CBC to multi-line card and card form element

### DIFF
--- a/example/res/layout/card_brand_choice_example_activity.xml
+++ b/example/res/layout/card_brand_choice_example_activity.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
     android:padding="16dp">
+
+    <Spinner
+        android:id="@+id/spinner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
 
     <androidx.appcompat.widget.SwitchCompat
         android:id="@+id/preferred_network_switch"
@@ -16,6 +20,18 @@
         android:id="@+id/card_input_widget"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
+
+    <com.stripe.android.view.CardMultilineWidget
+        android:id="@+id/card_multiline_widget"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone" />
+
+    <com.stripe.android.view.CardFormView
+        android:id="@+id/card_form_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone" />
 
     <Button
         android:id="@+id/confirm_with_new_card_button"

--- a/example/src/main/java/com/stripe/example/activity/CardBrandChoiceExampleActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CardBrandChoiceExampleActivity.kt
@@ -1,6 +1,10 @@
 package com.stripe.example.activity
 
 import android.os.Bundle
+import android.view.View
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import androidx.core.view.isVisible
 import com.stripe.android.Stripe
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
@@ -24,14 +28,34 @@ class CardBrandChoiceExampleActivity : StripeIntentActivity() {
         viewModel.inProgress.observe(this, this::enableUi)
         viewModel.status.observe(this, viewBinding.status::setText)
 
+        viewBinding.spinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+                viewBinding.cardInputWidget.isVisible = position == 0
+                viewBinding.cardMultilineWidget.isVisible = position == 1
+                viewBinding.cardFormView.isVisible = position == 2
+            }
+
+            override fun onNothingSelected(parent: AdapterView<*>?) = Unit
+        }
+
+        viewBinding.spinner.adapter = ArrayAdapter(
+            this,
+            android.R.layout.simple_spinner_item,
+            arrayListOf("CardInputWidget", "CardMultilineWidget", "CardFormView")
+        ).also { adapter ->
+            adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        }
+
         viewBinding.preferredNetworkSwitch.setOnCheckedChangeListener { _, isChecked ->
-            viewBinding.cardInputWidget.setPreferredNetworks(
-                preferredNetworks = if (isChecked) {
-                    listOf(CardBrand.CartesBancaires)
-                } else {
-                    emptyList()
-                },
-            )
+            val networks = if (isChecked) {
+                listOf(CardBrand.CartesBancaires)
+            } else {
+                emptyList()
+            }
+
+            viewBinding.cardInputWidget.setPreferredNetworks(networks)
+            viewBinding.cardMultilineWidget.setPreferredNetworks(networks)
+            viewBinding.cardFormView.setPreferredNetworks(networks)
         }
 
         val stripeAccountId = Settings(this).stripeAccountId
@@ -39,7 +63,14 @@ class CardBrandChoiceExampleActivity : StripeIntentActivity() {
         viewBinding.confirmWithNewCardButton.setOnClickListener {
             viewBinding.root.clearFocus()
 
-            viewBinding.cardInputWidget.paymentMethodCreateParams?.let { params ->
+            val params = when (viewBinding.spinner.selectedItemPosition) {
+                0 -> viewBinding.cardInputWidget.paymentMethodCreateParams
+                1 -> viewBinding.cardMultilineWidget.paymentMethodCreateParams
+                2 -> viewBinding.cardFormView.paymentMethodCreateParams
+                else -> error("bla")
+            }
+
+            if (params != null) {
                 createAndConfirmPaymentIntent(
                     country = "fr",
                     paymentMethodCreateParams = params,

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -7258,6 +7258,7 @@ public final class com/stripe/android/view/CardFormView : android/widget/LinearL
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getBrand ()Lcom/stripe/android/model/CardBrand;
 	public final fun getCardParams ()Lcom/stripe/android/model/CardParams;
+	public final fun getPaymentMethodCreateParams ()Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun setCardValidCallback (Lcom/stripe/android/view/CardValidCallback;)V
 	public fun setEnabled (Z)V
 }

--- a/payments-core/detekt-baseline.xml
+++ b/payments-core/detekt-baseline.xml
@@ -7,7 +7,7 @@
     <ID>ComplexCondition:ExpiryDateEditText.kt$ExpiryDateEditText.&lt;no name provided>$expirationDate.month.length == 2 &amp;&amp; latestInsertionSize > 0 &amp;&amp; !inErrorState || rawNumericInput.length > 2</ID>
     <ID>ConstructorParameterNaming:Source.kt$Source$private val _klarna: Klarna? = null</ID>
     <ID>ConstructorParameterNaming:Source.kt$Source$private val _weChat: WeChat? = null</ID>
-    <ID>CyclomaticComplexMethod:CardBrandView.kt$@Composable private fun CardBrand( isLoading: Boolean, currentBrand: CardBrand, possibleBrands: List&lt;CardBrand>, shouldShowCvc: Boolean, shouldShowErrorIcon: Boolean, tintColorInt: Int, isCbcEligible: Boolean, modifier: Modifier = Modifier, onBrandSelected: (CardBrand?) -> Unit, )</ID>
+    <ID>CyclomaticComplexMethod:CardBrandView.kt$@Composable private fun CardBrand( isLoading: Boolean, currentBrand: CardBrand, possibleBrands: List&lt;CardBrand>, shouldShowCvc: Boolean, shouldShowErrorIcon: Boolean, tintColorInt: Int, isCbcEligible: Boolean, reserveSpaceForCbcDropdown: Boolean, modifier: Modifier = Modifier, onBrandSelected: (CardBrand?) -> Unit, )</ID>
     <ID>CyclomaticComplexMethod:NextActionDataParser.kt$NextActionDataParser$override fun parse( json: JSONObject ): StripeIntent.NextActionData?</ID>
     <ID>CyclomaticComplexMethod:PaymentMethodJsonParser.kt$PaymentMethodJsonParser$override fun parse(json: JSONObject): PaymentMethod</ID>
     <ID>CyclomaticComplexMethod:Source.kt$Source.Companion$@SourceType @JvmStatic fun asSourceType(sourceType: String?): String</ID>
@@ -37,7 +37,7 @@
     <ID>LargeClass:StripeApiRepository.kt$StripeApiRepository : StripeRepository</ID>
     <ID>LargeClass:StripeApiRepositoryTest.kt$StripeApiRepositoryTest</ID>
     <ID>LargeClass:StripeKtxTest.kt$StripeKtxTest</ID>
-    <ID>LongMethod:CardBrandView.kt$@Composable private fun CardBrand( isLoading: Boolean, currentBrand: CardBrand, possibleBrands: List&lt;CardBrand>, shouldShowCvc: Boolean, shouldShowErrorIcon: Boolean, tintColorInt: Int, isCbcEligible: Boolean, modifier: Modifier = Modifier, onBrandSelected: (CardBrand?) -> Unit, )</ID>
+    <ID>LongMethod:CardBrandView.kt$@Composable private fun CardBrand( isLoading: Boolean, currentBrand: CardBrand, possibleBrands: List&lt;CardBrand>, shouldShowCvc: Boolean, shouldShowErrorIcon: Boolean, tintColorInt: Int, isCbcEligible: Boolean, reserveSpaceForCbcDropdown: Boolean, modifier: Modifier = Modifier, onBrandSelected: (CardBrand?) -> Unit, )</ID>
     <ID>LongMethod:CardFormView.kt$CardFormView$private fun setupCardWidget()</ID>
     <ID>LongMethod:CardFormViewTest.kt$CardFormViewTest$@Test fun testCardValidCallback()</ID>
     <ID>LongMethod:CardInputWidget.kt$CardInputWidget$private fun initView(attrs: AttributeSet?)</ID>

--- a/payments-core/res/layout/stripe_card_multiline_widget.xml
+++ b/payments-core/res/layout/stripe_card_multiline_widget.xml
@@ -4,24 +4,40 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <com.stripe.android.view.CardNumberTextInputLayout
-        android:id="@+id/tl_card_number"
-        style="@style/Stripe.CardMultilineWidget.TextInputLayout"
+    <FrameLayout
+        android:id="@+id/card_number_input_container"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="@string/stripe_acc_label_card_number"
-        android:layout_marginTop="@dimen/stripe_add_card_element_vertical_margin">
+        android:layout_height="wrap_content">
 
-        <com.stripe.android.view.CardNumberEditText
-            android:id="@+id/et_card_number"
+        <com.stripe.android.view.CardNumberTextInputLayout
+            android:id="@+id/tl_card_number"
+            style="@style/Stripe.CardMultilineWidget.TextInputLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:drawablePadding="@dimen/stripe_card_icon_multiline_padding"
-            android:imeOptions="actionNext"
-            android:nextFocusDown="@+id/et_expiry"
-            android:nextFocusForward="@+id/et_expiry" />
+            android:hint="@string/stripe_acc_label_card_number"
+            android:layout_marginTop="@dimen/stripe_add_card_element_vertical_margin">
 
-    </com.stripe.android.view.CardNumberTextInputLayout>
+            <com.stripe.android.view.CardNumberEditText
+                android:id="@+id/et_card_number"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:drawablePadding="@dimen/stripe_card_icon_multiline_padding"
+                android:imeOptions="actionNext"
+                android:nextFocusDown="@+id/et_expiry"
+                android:nextFocusForward="@+id/et_expiry" />
+
+        </com.stripe.android.view.CardNumberTextInputLayout>
+
+        <com.stripe.android.view.CardBrandView
+            android:id="@+id/card_brand_view"
+            android:layout_width="wrap_content"
+            android:layout_height="@dimen/stripe_card_brand_view_height"
+            android:layout_marginTop="@dimen/stripe_card_icon_padding"
+            android:layout_marginBottom="@dimen/stripe_card_icon_padding"
+            android:layout_marginEnd="@dimen/stripe_card_icon_padding"
+            android:layout_gravity="center_vertical|end" />
+
+    </FrameLayout>
 
     <LinearLayout
         android:id="@+id/second_row_layout"

--- a/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -5,6 +5,7 @@ import android.os.Parcelable
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -62,6 +63,7 @@ internal class CardBrandView @JvmOverloads constructor(
     @Parcelize
     internal data class State(
         val isCbcEligible: Boolean = false,
+        val reserveSpaceForCbcDropdown: Boolean = true,
         val isLoading: Boolean = false,
         val brand: CardBrand = Unknown,
         val userSelectedBrand: CardBrand? = null,
@@ -136,6 +138,12 @@ internal class CardBrandView @JvmOverloads constructor(
             stateFlow.update { it.copy(tintColor = value) }
         }
 
+    internal var reserveSpaceForCbcDropdown: Boolean
+        get() = state.reserveSpaceForCbcDropdown
+        set(value) {
+            stateFlow.update { it.copy(reserveSpaceForCbcDropdown = value) }
+        }
+
     init {
         isClickable = false
         isFocusable = false
@@ -161,6 +169,7 @@ internal class CardBrandView @JvmOverloads constructor(
                     shouldShowErrorIcon = state.shouldShowErrorIcon,
                     tintColorInt = state.tintColor,
                     isCbcEligible = state.isCbcEligible,
+                    reserveSpaceForCbcDropdown = state.reserveSpaceForCbcDropdown,
                     onBrandSelected = this::handleBrandSelected,
                 )
             }
@@ -219,6 +228,7 @@ private fun CardBrand(
     shouldShowErrorIcon: Boolean,
     tintColorInt: Int,
     isCbcEligible: Boolean,
+    reserveSpaceForCbcDropdown: Boolean,
     modifier: Modifier = Modifier,
     onBrandSelected: (CardBrand?) -> Unit,
 ) {
@@ -267,13 +277,17 @@ private fun CardBrand(
 
             Spacer(modifier = Modifier.requiredWidth(1.dp))
 
-            Image(
-                painter = painterResource(StripeUiCoreR.drawable.stripe_ic_chevron_down),
-                contentDescription = null,
-                modifier = Modifier
-                    .requiredSize(8.dp)
-                    .graphicsLayer { alpha = dropdownIconAlpha },
-            )
+            AnimatedVisibility(visible = showDropdown || reserveSpaceForCbcDropdown) {
+                Spacer(modifier = Modifier.requiredWidth(1.dp))
+
+                Image(
+                    painter = painterResource(StripeUiCoreR.drawable.stripe_ic_chevron_down),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .requiredSize(8.dp)
+                        .graphicsLayer { alpha = dropdownIconAlpha },
+                )
+            }
         }
 
         if (showDropdown) {

--- a/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
@@ -10,7 +10,9 @@ import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.inputmethod.EditorInfo
+import android.widget.FrameLayout
 import android.widget.LinearLayout
+import androidx.annotation.RestrictTo
 import androidx.core.content.ContextCompat
 import androidx.core.content.withStyledAttributes
 import androidx.core.os.bundleOf
@@ -27,6 +29,8 @@ import com.stripe.android.databinding.StripeVerticalDividerBinding
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardParams
+import com.stripe.android.model.DelicateCardDetailsApi
+import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.view.CardFormView.Style
 import com.stripe.android.view.CardValidCallback.Fields
 import com.stripe.android.uicore.R as UiCoreR
@@ -141,7 +145,7 @@ class CardFormView @JvmOverloads constructor(
                 requireNotNull(cardMultilineWidget.expiryDateEditText.validatedDate)
 
             return CardParams(
-                brand = cardMultilineWidget.brand,
+                brand = brand,
                 loggingTokens = setOf(CARD_FORM_VIEW),
                 number = cardMultilineWidget.validatedCardNumber?.value.orEmpty(),
                 expMonth = expirationDate.month,
@@ -153,6 +157,32 @@ class CardFormView @JvmOverloads constructor(
                     .build()
             )
         }
+
+    /**
+     * A [PaymentMethodCreateParams.Card] representing the card details if all fields are valid;
+     * otherwise `null`
+     */
+    private val paymentMethodCard: PaymentMethodCreateParams.Card?
+        @OptIn(DelicateCardDetailsApi::class)
+        get() {
+            return cardParams?.let {
+                PaymentMethodCreateParams.Card(
+                    number = it.number,
+                    cvc = it.cvc,
+                    expiryMonth = it.expMonth,
+                    expiryYear = it.expYear,
+                    attribution = it.attribution,
+                    networks = cardMultilineWidget.cardBrandView.createNetworksParam(),
+                )
+            }
+        }
+
+    /**
+     * A [PaymentMethodCreateParams] representing the card details and postal code if all fields
+     * are valid; otherwise `null`
+     */
+    val paymentMethodCreateParams: PaymentMethodCreateParams?
+        get() = paymentMethodCard?.let { PaymentMethodCreateParams.create(it) }
 
     init {
         orientation = VERTICAL
@@ -307,19 +337,26 @@ class CardFormView @JvmOverloads constructor(
             resources.getDimensionPixelSize(R.dimen.stripe_card_form_view_text_margin_horizontal)
         val layoutMarginVertical =
             resources.getDimensionPixelSize(R.dimen.stripe_card_form_view_text_margin_vertical)
+
+        cardMultilineWidget.cardNumberTextInputLayout.updateLayoutParams<FrameLayout.LayoutParams> {
+            marginStart = layoutMarginHorizontal
+            marginEnd = layoutMarginHorizontal
+            topMargin = layoutMarginVertical
+            bottomMargin = layoutMarginVertical
+        }
+
         setOf(
-            cardMultilineWidget.cardNumberTextInputLayout,
             cardMultilineWidget.expiryTextInputLayout,
             cardMultilineWidget.cvcInputLayout
-        ).forEach { layout ->
-            layout.updateLayoutParams<LayoutParams> {
+        ).forEach { frameLayout ->
+            frameLayout.updateLayoutParams<LayoutParams> {
                 marginStart = layoutMarginHorizontal
                 marginEnd = layoutMarginHorizontal
                 topMargin = layoutMarginVertical
                 bottomMargin = layoutMarginVertical
             }
-            layout.isErrorEnabled = false
-            layout.error = null
+            frameLayout.isErrorEnabled = false
+            frameLayout.error = null
         }
 
         cardMultilineWidget.setCvcIcon(PaymentsModelR.drawable.stripe_ic_cvc)
@@ -371,6 +408,12 @@ class CardFormView @JvmOverloads constructor(
         } else {
             super.onRestoreInstanceState(state)
         }
+    }
+
+    // TODO(tillh-stripe) Add docs and make public
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun setPreferredNetworks(preferredNetworks: List<CardBrand>) {
+        cardMultilineWidget.cardBrandView.merchantPreferredNetworks = preferredNetworks
     }
 
     private fun applyStandardStyle() {

--- a/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -17,6 +17,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.content.ContextCompat
 import androidx.core.content.withStyledAttributes
 import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.ViewModelStoreOwner
 import com.stripe.android.PaymentConfiguration
@@ -30,7 +31,6 @@ import com.stripe.android.model.DelicateCardDetailsApi
 import com.stripe.android.model.ExpirationDate
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.android.view.CardMultilineWidget.CardBrandIconSupplier
 import kotlin.properties.Delegates
 
 /**
@@ -55,6 +55,8 @@ class CardMultilineWidget @JvmOverloads constructor(
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet
     val cardNumberEditText = viewBinding.etCardNumber
+
+    internal val cardBrandView: CardBrandView = viewBinding.cardBrandView
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet
     val expiryDateEditText = viewBinding.etExpiry
@@ -115,14 +117,12 @@ class CardMultilineWidget @JvmOverloads constructor(
     private var customCvcLabel: String? = null
     private var customCvcPlaceholderText: String? = null
 
-    private var cardBrand: CardBrand = CardBrand.Unknown
-
     /**
      * A [CardBrand] matching the current card number inputted by the user.
      */
     val brand: CardBrand
         @JvmSynthetic
-        get() = cardBrand
+        get() = cardBrandView.brand
 
     /**
      * If [shouldShowPostalCode] is true and [postalCodeRequired] is true, then postal code is a
@@ -169,7 +169,8 @@ class CardMultilineWidget @JvmOverloads constructor(
                     cvc = it.cvc,
                     expiryMonth = it.expMonth,
                     expiryYear = it.expYear,
-                    attribution = it.attribution
+                    attribution = it.attribution,
+                    networks = cardBrandView.createNetworksParam(),
                 )
             }
         }
@@ -285,12 +286,6 @@ class CardMultilineWidget @JvmOverloads constructor(
 
     private var showCvcIconInCvcField: Boolean = false
 
-    internal var cardBrandIconSupplier: CardBrandIconSupplier by Delegates.observable(
-        DEFAULT_CARD_BRAND_ICON_SUPPLIER
-    ) { _, _, _ ->
-        updateBrandUi()
-    }
-
     internal var cardNumberErrorListener: StripeEditText.ErrorMessageListener by Delegates.observable(
         ErrorListener(cardNumberTextInputLayout)
     ) { _, _, newValue ->
@@ -335,6 +330,12 @@ class CardMultilineWidget @JvmOverloads constructor(
         postalCodeErrorListener = listener
     }
 
+    // TODO(tillh-stripe) Add docs and make public
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun setPreferredNetworks(preferredNetworks: List<CardBrand>) {
+        cardBrandView.merchantPreferredNetworks = preferredNetworks
+    }
+
     init {
         orientation = VERTICAL
 
@@ -350,14 +351,38 @@ class CardMultilineWidget @JvmOverloads constructor(
         initFocusChangeListeners()
         initDeleteEmptyListeners()
 
+        cardBrandView.reserveSpaceForCbcDropdown = false
+        cardBrandView.tintColorInt = cardNumberEditText.hintTextColors.defaultColor
+
         cardNumberEditText.completionCallback = {
             expiryDateEditText.requestFocus()
             cardInputListener?.onCardComplete()
         }
 
         cardNumberEditText.brandChangeCallback = { brand ->
-            cardBrand = brand
+            cardBrandView.brand = brand
             updateBrandUi()
+        }
+
+        cardNumberEditText.implicitCardBrandChangeCallback = { brand ->
+            // With co-branded cards, a card number can belong to multiple brands. Since we still
+            // need do validate based on the card's pan length and expected CVC length, we add this
+            // callback to perform the validations, but don't update the current brand.
+            updateCvc(brand)
+        }
+
+        cardNumberEditText.possibleCardBrandsCallback = { brands ->
+            val currentBrand = cardBrandView.brand
+            cardBrandView.possibleBrands = brands
+
+            if (currentBrand !in brands) {
+                cardBrandView.brand = CardBrand.Unknown
+            }
+
+            // We need to use a known card brand to set the correct expected CVC length. Since both
+            // brands of a co-branded card have the same CVC length, we can just choose the first one.
+            val brandForCvcLength = brands.firstOrNull() ?: CardBrand.Unknown
+            updateCvc(brand = brandForCvcLength)
         }
 
         expiryDateEditText.completionCallback = {
@@ -366,7 +391,12 @@ class CardMultilineWidget @JvmOverloads constructor(
         }
 
         cvcEditText.setAfterTextChangedListener { text ->
-            if (cardBrand.isMaxCvc(text)) {
+            val brand = cardNumberEditText.implicitCardBrandForCbc.takeUnless {
+                it == CardBrand.Unknown
+            } ?: cardNumberEditText.cardBrand
+
+            // TODO
+            if (brand.isMaxCvc(text)) {
                 updateBrandUi()
                 if (shouldShowPostalCode) {
                     postalCodeEditText.requestFocus()
@@ -388,7 +418,6 @@ class CardMultilineWidget @JvmOverloads constructor(
 
         cardNumberEditText.updateLengthFilter()
 
-        cardBrand = CardBrand.Unknown
         updateBrandUi()
 
         allFields.forEach { field ->
@@ -403,12 +432,27 @@ class CardMultilineWidget @JvmOverloads constructor(
 
         postalCodeEditText.config = PostalCodeEditText.Config.Global
         isEnabled = true
+
+        val cardBrandViewPadding = resources.getDimensionPixelSize(
+            R.dimen.stripe_card_form_view_text_input_layout_padding_horizontal
+        )
+
+        cardBrandView.addOnLayoutChangeListener { view, _, _, _, _, _, _, _, _ ->
+            val inset = view.width + cardBrandViewPadding
+            cardNumberEditText.updatePadding(right = inset)
+        }
     }
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         // see https://github.com/stripe/stripe-android/pull/3154
         cvcEditText.hint = null
+
+        doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
+            viewModel.isCbcEligible.launchAndCollect { isCbcEligible ->
+                cardBrandView.isCbcEligible = isCbcEligible
+            }
+        }
     }
 
     /**
@@ -423,8 +467,7 @@ class CardMultilineWidget @JvmOverloads constructor(
         expiryDateEditText.shouldShowError = false
         cvcEditText.shouldShowError = false
         postalCodeEditText.shouldShowError = false
-
-        cardBrand = CardBrand.Unknown
+        cardBrandView.shouldShowErrorIcon = false
         updateBrandUi()
     }
 
@@ -661,21 +704,11 @@ class CardMultilineWidget @JvmOverloads constructor(
     }
 
     private fun flipToCvcIconIfNotFinished() {
-        if (cardBrand.isMaxCvc(cvcEditText.fieldText)) {
+        if (brand.isMaxCvc(cvcEditText.fieldText)) {
             return
         }
 
-        if (shouldShowErrorIcon) {
-            updateEndIcon(
-                iconResourceId = cardBrand.errorIcon,
-                editText = cardNumberEditText
-            )
-        } else {
-            updateEndIcon(
-                iconResourceId = cardBrand.cvcIcon,
-                editText = cardNumberEditText
-            )
-        }
+        cardBrandView.shouldShowErrorIcon = shouldShowErrorIcon
     }
 
     private fun initDeleteEmptyListeners() {
@@ -714,7 +747,7 @@ class CardMultilineWidget @JvmOverloads constructor(
                 }
                 cardInputListener?.onFocusChange(CardInputListener.FocusField.Cvc)
             } else {
-                updateBrandUi()
+                cardBrandView.shouldShowErrorIcon = shouldShowErrorIcon
             }
         }
 
@@ -734,22 +767,11 @@ class CardMultilineWidget @JvmOverloads constructor(
 
     private fun updateBrandUi() {
         updateCvc()
-        if (shouldShowErrorIcon) {
-            updateEndIcon(
-                iconResourceId = cardBrand.errorIcon,
-                editText = cardNumberEditText
-            )
-        } else {
-            val cardBrandIcon = cardBrandIconSupplier.get(cardBrand)
-            updateEndIcon(
-                iconResourceId = cardBrandIcon.iconResourceId,
-                editText = cardNumberEditText
-            )
-        }
+        cardBrandView.shouldShowErrorIcon = shouldShowErrorIcon
     }
 
-    private fun updateCvc() {
-        cvcEditText.updateBrand(cardBrand, customCvcLabel, customCvcPlaceholderText, cvcInputLayout)
+    private fun updateCvc(brand: CardBrand = this.brand) {
+        cvcEditText.updateBrand(brand, customCvcLabel, customCvcPlaceholderText, cvcInputLayout)
     }
 
     private fun updateEndIcon(editText: StripeEditText, @DrawableRes iconResourceId: Int) {
@@ -762,21 +784,8 @@ class CardMultilineWidget @JvmOverloads constructor(
             )
         }
     }
-    internal fun interface CardBrandIconSupplier {
-        fun get(cardBrand: CardBrand): CardBrandIcon
-    }
-
-    internal data class CardBrandIcon(
-        val iconResourceId: Int
-    )
 
     private companion object {
         private const val CARD_MULTILINE_TOKEN = "CardMultilineView"
-
-        private val DEFAULT_CARD_BRAND_ICON_SUPPLIER = CardBrandIconSupplier { cardBrand ->
-            CardBrandIcon(
-                cardBrand.icon
-            )
-        }
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -107,12 +107,20 @@ class CardNumberEditText internal constructor(
             callback(cardBrand)
         }
 
-    private var implicitCardBrandForCbcFlow: CardBrand = CardBrand.Unknown
+    internal var implicitCardBrandForCbc: CardBrand = CardBrand.Unknown
+        set(value) {
+            val prevBrands = field
+            field = value
+            if (value != prevBrands) {
+                implicitCardBrandChangeCallback(value)
+                updateLengthFilter()
+            }
+        }
 
     internal var implicitCardBrandChangeCallback: (CardBrand) -> Unit = {}
         set(callback) {
             field = callback
-            callback(implicitCardBrandForCbcFlow)
+            callback(implicitCardBrandForCbc)
         }
 
     internal var possibleCardBrands: List<CardBrand> = emptyList()
@@ -176,7 +184,7 @@ class CardNumberEditText internal constructor(
                 cardBrand = brands.singleOrNull() ?: CardBrand.Unknown
 
                 if (isCbcEligible) {
-                    implicitCardBrandForCbcFlow = brands.firstOrNull() ?: CardBrand.Unknown
+                    implicitCardBrandForCbc = brands.firstOrNull() ?: CardBrand.Unknown
                     possibleCardBrands = brands
                 }
             }
@@ -227,7 +235,7 @@ class CardNumberEditText internal constructor(
                 val brands = accountRangeService.accountRanges.map { it.brand }.distinct()
 
                 if (isCbcEligible) {
-                    implicitCardBrandForCbcFlow = brands.firstOrNull() ?: CardBrand.Unknown
+                    implicitCardBrandForCbc = brands.firstOrNull() ?: CardBrand.Unknown
                     possibleCardBrands = brands
                 } else {
                     cardBrand = brands.singleOrNull() ?: CardBrand.Unknown

--- a/payments-core/src/main/java/com/stripe/android/view/CardWidgetViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardWidgetViewModel.kt
@@ -76,7 +76,7 @@ internal class CardWidgetViewModel(
 }
 
 internal fun View.doWithCardWidgetViewModel(
-    viewModelStoreOwner: ViewModelStoreOwner?,
+    viewModelStoreOwner: ViewModelStoreOwner? = null,
     action: LifecycleOwner.(CardWidgetViewModel) -> Unit,
 ) {
     if (!isAttachedToWindow && DEBUG) {

--- a/payments-core/src/test/java/com/stripe/android/view/CardFormViewTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardFormViewTest.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.View
+import android.widget.FrameLayout
 import android.widget.LinearLayout
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
@@ -194,7 +195,7 @@ internal class CardFormViewTest {
             // 2 additional horizontal dividers added to card_multiline_widget.xml, now it has 4 child views
             assertThat(it.cardMultilineWidget.childCount).isEqualTo(4)
             // tl_card_number
-            assertThat(it.cardMultilineWidget.getChildAt(0)).isInstanceOf(
+            assertThat((it.cardMultilineWidget.getChildAt(0) as FrameLayout).getChildAt(0)).isInstanceOf(
                 CardNumberTextInputLayout::class.java
             )
             // horizontal divider
@@ -241,7 +242,7 @@ internal class CardFormViewTest {
             // no child views added to card_multiline_widget.xml, it still has 2 child views
             assertThat(it.cardMultilineWidget.childCount).isEqualTo(2)
             // tl_card_number
-            assertThat(it.cardMultilineWidget.getChildAt(0)).isInstanceOf(
+            assertThat((it.cardMultilineWidget.getChildAt(0) as FrameLayout).getChildAt(0)).isInstanceOf(
                 CardNumberTextInputLayout::class.java
             )
             // second_row_layout

--- a/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -1205,6 +1205,36 @@ internal class CardMultilineWidgetTest {
         assertThat(cardMultilineWidget.brand).isEqualTo(CardBrand.DinersClub)
     }
 
+    @Test
+    fun `Returns the correct create params when user selects no brand in CBC flow`() {
+        featureFlagTestRule.setEnabled(true)
+
+        runCardMultilineWidgetTest(isCbcEligible = true) {
+            cardMultilineWidget.setCardNumber("4000002500001001")
+            cardMultilineWidget.setExpiryDate(12, 2030)
+            cardMultilineWidget.setCvcCode("123")
+
+            val cardParams = cardMultilineWidget.paymentMethodCard
+            assertThat(cardParams?.networks?.preferred).isNull()
+        }
+    }
+
+    @Test
+    fun `Returns the correct create params when user selects a brand in CBC flow`() {
+        featureFlagTestRule.setEnabled(true)
+
+        runCardMultilineWidgetTest(isCbcEligible = true) {
+            cardMultilineWidget.setCardNumber("4000002500001001")
+            cardMultilineWidget.setExpiryDate(12, 2030)
+            cardMultilineWidget.setCvcCode("123")
+
+            cardMultilineWidget.cardBrandView.brand = CardBrand.CartesBancaires
+
+            val cardParams = cardMultilineWidget.paymentMethodCard
+            assertThat(cardParams?.networks?.preferred).isEqualTo(CardBrand.CartesBancaires.code)
+        }
+    }
+
     private fun runCardMultilineWidgetTest(
         isCbcEligible: Boolean = false,
         block: TestContext.() -> Unit,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodFormTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodFormTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.ui
 
+import android.os.Build
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -12,8 +13,10 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.Q])
 class PaymentMethodFormTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/SepaMandateActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/SepaMandateActivityTest.kt
@@ -19,7 +19,7 @@ import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.Q])
-internal class  SepaMandateActivityTest {
+internal class SepaMandateActivityTest {
     @get:Rule
     val composeRule = createEmptyComposeRule()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/SepaMandateActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/SepaMandateActivityTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.ui
 
 import android.content.Context
+import android.os.Build
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
@@ -14,9 +15,11 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-internal class SepaMandateActivityTest {
+@Config(sdk = [Build.VERSION_CODES.Q])
+internal class  SepaMandateActivityTest {
     @get:Rule
     val composeRule = createEmptyComposeRule()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/SepaMandateScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/SepaMandateScreenTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.ui
 
+import android.os.Build
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.performClick
@@ -8,10 +9,12 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.Q])
 internal class SepaMandateScreenTest {
     @get:Rule
     val composeRule = createComposeRule()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds card brand choice capability to `CardMultilineWidget` and `CardFormView`.

It also adds a `paymentMethodCreateParams` property to `CardFormView`. This was inexplicably missing from that view.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

CBC in Card Elements.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screen recording

<details><summary>Recording</summary>
<p>

[cbc-multiline-form.webm](https://github.com/stripe/stripe-android/assets/110940675/f9b70de4-952b-45cd-899a-b586615e8f6e)

</p>
</details> 

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
