### PR TITLE
Add form error handler

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -2,6 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
+    <ID>CyclomaticComplexMethod:CustomerSheetViewModel.kt$CustomerSheetViewModel$fun handleViewAction(viewAction: CustomerSheetViewAction)</ID>
     <ID>CyclomaticComplexMethod:PlaceholderHelper.kt$PlaceholderHelper$@VisibleForTesting internal fun specForPlaceholderField( field: PlaceholderField, placeholderOverrideList: List&lt;IdentifierSpec>, requiresMandate: Boolean, configuration: PaymentSheet.BillingDetailsCollectionConfiguration, )</ID>
     <ID>EmptyFunctionBlock:PrimaryButtonAnimator.kt$PrimaryButtonAnimator.&lt;no name provided>${ }</ID>
     <ID>ForbiddenComment:PaymentOptionFactory.kt$PaymentOptionFactory$// TODO: Should use labelResource paymentMethodCreateParams or extension function</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewAction.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewAction.kt
@@ -31,4 +31,7 @@ internal sealed class CustomerSheetViewAction {
     class OnUSBankAccountRetrieved(
         val usBankAccount: PaymentSelection.New.USBankAccount,
     ) : CustomerSheetViewAction()
+    class OnFormError(
+        val error: String?,
+    ) : CustomerSheetViewAction()
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -143,6 +143,9 @@ internal class CustomerSheetViewModel @Inject constructor(
             is CustomerSheetViewAction.OnUSBankAccountRetrieved -> {
                 onUSBankAccountRetrieved(viewAction.usBankAccount)
             }
+            is CustomerSheetViewAction.OnFormError -> {
+                onFormError(viewAction.error)
+            }
         }
     }
 
@@ -524,7 +527,9 @@ internal class CustomerSheetViewModel @Inject constructor(
                         handleViewAction(CustomerSheetViewAction.OnUpdateCustomButtonUIState(it))
                     },
                     onUpdatePrimaryButtonState = { /* no-op, CustomerSheetScreen does not use PrimaryButton.State */ },
-                    onError = { }
+                    onError = { error ->
+                        handleViewAction(CustomerSheetViewAction.OnFormError(error))
+                    }
                 ),
                 selectedPaymentMethod = selectedPaymentMethod,
                 enabled = true,
@@ -573,6 +578,14 @@ internal class CustomerSheetViewModel @Inject constructor(
 
     private fun onUSBankAccountRetrieved(usBankAccount: PaymentSelection.New.USBankAccount) {
         createAndAttach(usBankAccount.paymentMethodCreateParams)
+    }
+
+    private fun onFormError(error: String?) {
+        updateViewState<CustomerSheetViewState.AddPaymentMethod> {
+            it.copy(
+                errorMessage = error
+            )
+        }
     }
 
     private suspend fun createPaymentMethod(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -1701,6 +1701,31 @@ class CustomerSheetViewModelTest {
         }
     }
 
+    @Test
+    fun `When a form error is emitted, screen state is updated`() = runTest {
+        val viewModel = createViewModel(
+            initialBackStack = listOf(
+                addPaymentMethodViewState,
+            ),
+        )
+
+        viewModel.viewState.test {
+            var viewState = awaitViewState<AddPaymentMethod>()
+            assertThat(viewState.errorMessage)
+                .isNull()
+
+            viewModel.handleViewAction(
+                CustomerSheetViewAction.OnFormError(
+                    error = "This is an error."
+                )
+            )
+
+            viewState = awaitViewState()
+            assertThat(viewState.errorMessage)
+                .isEqualTo("This is an error.")
+        }
+    }
+
     @Suppress("UNCHECKED_CAST")
     private suspend inline fun <R> ReceiveTurbine<*>.awaitViewState(): R {
         return awaitItem() as R


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Add form error handler for CustomerSheet. This is used by the US Bank Account form to push errors to the screen when necessary.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
