### PR TITLE
Remove LiveData from PaymentMethodsViewModel.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
@@ -16,6 +16,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.text.util.LinkifyCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.isVisible
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.snackbar.Snackbar
 import com.stripe.android.CustomerSession
 import com.stripe.android.R
@@ -24,6 +25,7 @@ import com.stripe.android.databinding.StripePaymentMethodsActivityBinding
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.utils.argsAreInvalid
 import com.stripe.android.view.i18n.TranslatorManager
+import kotlinx.coroutines.launch
 
 /**
  * An activity that allows a customer to select from their attached payment methods,
@@ -105,13 +107,18 @@ class PaymentMethodsActivity : AppCompatActivity() {
             finishWithResult(adapter.selectedPaymentMethod, Activity.RESULT_CANCELED)
         }
 
-        viewModel.snackbarData.observe(this) { snackbarText ->
-            snackbarText?.let {
-                Snackbar.make(viewBinding.coordinator, it, Snackbar.LENGTH_SHORT).show()
+        lifecycleScope.launch {
+            viewModel.snackbarData.collect { snackbarText ->
+                snackbarText?.let {
+                    Snackbar.make(viewBinding.coordinator, it, Snackbar.LENGTH_SHORT).show()
+                }
             }
         }
-        viewModel.progressData.observe(this) {
-            viewBinding.progressBar.isVisible = it
+
+        lifecycleScope.launch {
+            viewModel.progressData.collect {
+                viewBinding.progressBar.isVisible = it
+            }
         }
 
         setupRecyclerView()

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsViewModel.kt
@@ -13,6 +13,7 @@ import com.stripe.android.R
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.model.PaymentMethod
+import kotlinx.coroutines.flow.MutableStateFlow
 
 internal class PaymentMethodsViewModel(
     application: Application,
@@ -28,8 +29,8 @@ internal class PaymentMethodsViewModel(
         PaymentMethodsActivity.PRODUCT_TOKEN
     ).toSet()
 
-    internal val snackbarData: MutableLiveData<String?> = MutableLiveData()
-    internal val progressData: MutableLiveData<Boolean> = MutableLiveData()
+    internal val snackbarData: MutableStateFlow<String?> = MutableStateFlow(null)
+    internal val progressData: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     internal fun onPaymentMethodAdded(paymentMethod: PaymentMethod) {
         createSnackbarText(paymentMethod, R.string.stripe_added)?.let {

--- a/payments-core/src/test/java/com/stripe/android/view/PaymentMethodsViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/PaymentMethodsViewModelTest.kt
@@ -1,12 +1,14 @@
 package com.stripe.android.view
 
 import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.CustomerSession
 import com.stripe.android.PaymentSession
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
+import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.argumentCaptor
@@ -79,27 +81,29 @@ class PaymentMethodsViewModelTest {
     }
 
     @Test
-    fun onPaymentMethodAdded_shouldUpdateSnackbarData() {
-        val values: MutableList<String?> = mutableListOf()
-        viewModel.snackbarData.observeForever { values.add(it) }
-
-        viewModel.onPaymentMethodAdded(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
-        assertThat(values[0])
-            .isEqualTo("Added Visa ending in 4242")
-        assertThat(values[1])
-            .isNull()
+    fun onPaymentMethodAdded_shouldUpdateSnackbarData() = runTest {
+        viewModel.snackbarData.test {
+            assertThat(awaitItem())
+                .isNull()
+            viewModel.onPaymentMethodAdded(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+            assertThat(awaitItem())
+                .isEqualTo("Added Visa ending in 4242")
+            assertThat(awaitItem())
+                .isNull()
+        }
     }
 
     @Test
-    fun onPaymentMethodRemoved_shouldUpdateSnackbarData() {
-        val values: MutableList<String?> = mutableListOf()
-        viewModel.snackbarData.observeForever { values.add(it) }
-
-        viewModel.onPaymentMethodRemoved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
-        assertThat(values[0])
-            .isEqualTo("Removed Visa ending in 4242")
-        assertThat(values[1])
-            .isNull()
+    fun onPaymentMethodRemoved_shouldUpdateSnackbarData() = runTest {
+        viewModel.snackbarData.test {
+            assertThat(awaitItem())
+                .isNull()
+            viewModel.onPaymentMethodRemoved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+            assertThat(awaitItem())
+                .isEqualTo("Removed Visa ending in 4242")
+            assertThat(awaitItem())
+                .isNull()
+        }
     }
 
     @Test


### PR DESCRIPTION
# Summary
We did a conversion to remove all these from the paymentsheet module, but it's not happened yet for payments core. I noticed this recently when working on another task.

# Motivation
Unify all of our observables around Flow

# Testing
Manually verified, and confirmed existing tests pass.