### PR TITLE
Fix issue with emitting result after destroying form in USBankAccountForm

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountEmitters.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountEmitters.kt
@@ -21,7 +21,9 @@ internal fun USBankAccountEmitters(
 
     LaunchedEffect(Unit) {
         viewModel.result.collect { result ->
-            usBankAccountFormArgs.onHandleUSBankAccount(result)
+            result?.let {
+                usBankAccountFormArgs.onHandleUSBankAccount(result)
+            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -352,7 +352,6 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         collectBankAccountLauncher?.unregister()
         collectBankAccountLauncher = null
         reset()
-        onCleared()
     }
 
     fun formattedMerchantName(): String {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -188,8 +188,8 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         flowOf(null)
     }
 
-    private val _result = MutableSharedFlow<PaymentSelection.New.USBankAccount>(replay = 1)
-    val result: Flow<PaymentSelection.New.USBankAccount> = _result
+    private val _result = MutableSharedFlow<PaymentSelection.New.USBankAccount?>(replay = 1)
+    val result: Flow<PaymentSelection.New.USBankAccount?> = _result
 
     private val defaultSaveForFutureUse: Boolean =
         args.savedPaymentMethod?.input?.saveForFutureUse ?: false
@@ -348,8 +348,11 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
     }
 
     fun onDestroy() {
+        _result.tryEmit(null)
         collectBankAccountLauncher?.unregister()
         collectBankAccountLauncher = null
+        reset()
+        onCleared()
     }
 
     fun formattedMerchantName(): String {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -149,7 +149,7 @@ class USBankAccountFormViewModelTest {
             val currentScreenState = viewModel.currentScreenState.stateIn(viewModel.viewModelScope).value
             viewModel.handlePrimaryButtonClick(currentScreenState as USBankAccountFormScreenState.VerifyWithMicrodeposits)
 
-            assertThat(awaitItem().screenState).isEqualTo(currentScreenState)
+            assertThat(awaitItem()?.screenState).isEqualTo(currentScreenState)
         }
     }
 
@@ -163,7 +163,7 @@ class USBankAccountFormViewModelTest {
             val currentScreenState = viewModel.currentScreenState.stateIn(viewModel.viewModelScope).value
             viewModel.handlePrimaryButtonClick(currentScreenState as USBankAccountFormScreenState.MandateCollection)
 
-            assertThat(awaitItem().screenState).isEqualTo(currentScreenState)
+            assertThat(awaitItem()?.screenState).isEqualTo(currentScreenState)
         }
     }
 
@@ -178,7 +178,7 @@ class USBankAccountFormViewModelTest {
             val currentScreenState = viewModel.currentScreenState.stateIn(viewModel.viewModelScope).value
             viewModel.handlePrimaryButtonClick(currentScreenState as USBankAccountFormScreenState.VerifyWithMicrodeposits)
 
-            assertThat(awaitItem().screenState).isEqualTo(currentScreenState)
+            assertThat(awaitItem()?.screenState).isEqualTo(currentScreenState)
         }
     }
 
@@ -193,7 +193,7 @@ class USBankAccountFormViewModelTest {
             val currentScreenState = viewModel.currentScreenState.stateIn(viewModel.viewModelScope).value
             viewModel.handlePrimaryButtonClick(currentScreenState as USBankAccountFormScreenState.MandateCollection)
 
-            assertThat(awaitItem().screenState).isEqualTo(currentScreenState)
+            assertThat(awaitItem()?.screenState).isEqualTo(currentScreenState)
         }
     }
 
@@ -811,6 +811,28 @@ class USBankAccountFormViewModelTest {
             customerId = anyOrNull(),
             onBehalfOf = any(),
         )
+    }
+
+    @Test
+    fun `When form destroyed, collect bank account result is null and reset to billing collection screen`() = runTest {
+        val viewModel = createViewModel(
+            defaultArgs.copy(
+                clientSecret = null,
+                isPaymentFlow = false
+            )
+        )
+
+        viewModel.result.test {
+            viewModel.onDestroy()
+
+            assertThat(awaitItem()).isNull()
+
+            val currentScreenState =
+                viewModel.currentScreenState.stateIn(viewModel.viewModelScope).value
+
+            assertThat(currentScreenState)
+                .isInstanceOf(USBankAccountFormScreenState.BillingDetailsCollection::class.java)
+        }
     }
 
     private fun createViewModel(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Fix issue with emitting result after destroying form in USBankAccountForm and ensure that the form is reset after the form is disposed.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Fixing an issue with CustomerSheet. Since the us bank account form view model isn't destroyed, the result is still active and has a value which is then processed in CustomerSheetViewModel. PaymentSheet does not have this issue since the sheet always closes after successful payment, etc.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

