### PR TITLE
Change the behavior of edit

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -360,7 +360,6 @@ internal class CustomerSheetViewModel @Inject constructor(
                         updateViewState<CustomerSheetViewState.SelectPaymentMethod> { viewState ->
                             viewState.copy(
                                 savedPaymentMethods = savedPaymentMethods,
-                                isEditing = false,
                                 paymentSelection = viewState.paymentSelection.takeUnless { selection ->
                                     val removedPaymentSelection = selection is PaymentSelection.Saved &&
                                         selection.paymentMethod == paymentMethod

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -415,6 +415,12 @@ class CustomerSheetViewModelTest {
             viewState = awaitViewState()
             assertThat(viewState.isEditing)
                 .isTrue()
+
+            viewModel.handleViewAction(CustomerSheetViewAction.OnItemRemoved(CARD_PAYMENT_METHOD))
+
+            viewState = awaitViewState()
+            assertThat(viewState.isEditing)
+                .isTrue()
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Change the behavior of edit in CustomerSheet so that a user can delete multiple payment methods while in edit mode.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Previous to this change, the edit mode would be disabled after removing one item, this made multi-delete operations difficult.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
