### PR TITLE
Remove LiveData from PaymentMethodsViewModel.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/CustomerSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/CustomerSession.kt
@@ -28,7 +28,6 @@ import kotlin.coroutines.CoroutineContext
  * See [Creating ephemeral keys](https://stripe.com/docs/mobile/android/standard#creating-ephemeral-keys)
  */
 class CustomerSession @VisibleForTesting internal constructor(
-    context: Context,
     stripeRepository: StripeRepository,
     publishableKey: String,
     stripeAccountId: String?,
@@ -473,7 +472,6 @@ class CustomerSession @VisibleForTesting internal constructor(
             val config = PaymentConfiguration.getInstance(context)
 
             instance = CustomerSession(
-                context,
                 StripeApiRepository(context, { config.publishableKey }, appInfo),
                 config.publishableKey,
                 config.stripeAccountId,

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
@@ -121,26 +121,7 @@ class PaymentMethodsActivity : AppCompatActivity() {
             }
         }
 
-        lifecycleScope.launch {
-            viewModel.paymentMethodsData.collect { result ->
-                result?.fold(
-                    onSuccess = { adapter.setPaymentMethods(it) },
-                    onFailure = {
-                        alertDisplayer.show(
-                            when (it) {
-                                is StripeException -> {
-                                    TranslatorManager.getErrorMessageTranslator()
-                                        .translate(it.statusCode, it.message, it.stripeError)
-                                }
-                                else -> {
-                                    it.message.orEmpty()
-                                }
-                            }
-                        )
-                    }
-                )
-            }
-        }
+        observePaymentMethodData()
 
         setupRecyclerView()
 
@@ -291,6 +272,29 @@ class PaymentMethodsActivity : AppCompatActivity() {
             footerView
         } else {
             null
+        }
+    }
+
+    private fun observePaymentMethodData() {
+        lifecycleScope.launch {
+            viewModel.paymentMethodsData.collect { result ->
+                result?.fold(
+                    onSuccess = { adapter.setPaymentMethods(it) },
+                    onFailure = {
+                        alertDisplayer.show(
+                            when (it) {
+                                is StripeException -> {
+                                    TranslatorManager.getErrorMessageTranslator()
+                                        .translate(it.statusCode, it.message, it.stripeError)
+                                }
+                                else -> {
+                                    it.message.orEmpty()
+                                }
+                            }
+                        )
+                    }
+                )
+            }
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsViewModel.kt
@@ -24,6 +24,7 @@ internal class PaymentMethodsViewModel(
 ) : AndroidViewModel(application) {
     private val resources = application.resources
     private val cardDisplayTextFactory = CardDisplayTextFactory(application)
+
     @Volatile
     private var paymentMethodsJob: Job? = null
 

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsViewModel.kt
@@ -3,17 +3,18 @@ package com.stripe.android.view
 import android.app.Application
 import androidx.annotation.StringRes
 import androidx.lifecycle.AndroidViewModel
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
 import com.stripe.android.CustomerSession
 import com.stripe.android.PaymentSession
 import com.stripe.android.R
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.model.PaymentMethod
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 
 internal class PaymentMethodsViewModel(
     application: Application,
@@ -23,20 +24,28 @@ internal class PaymentMethodsViewModel(
 ) : AndroidViewModel(application) {
     private val resources = application.resources
     private val cardDisplayTextFactory = CardDisplayTextFactory(application)
+    @Volatile
+    private var paymentMethodsJob: Job? = null
 
     internal val productUsage: Set<String> = listOfNotNull(
         PaymentSession.PRODUCT_TOKEN.takeIf { startedFromPaymentSession },
         PaymentMethodsActivity.PRODUCT_TOKEN
     ).toSet()
 
+    internal val paymentMethodsData: MutableStateFlow<Result<List<PaymentMethod>>?> = MutableStateFlow(null)
     internal val snackbarData: MutableStateFlow<String?> = MutableStateFlow(null)
     internal val progressData: MutableStateFlow<Boolean> = MutableStateFlow(false)
+
+    init {
+        getPaymentMethods()
+    }
 
     internal fun onPaymentMethodAdded(paymentMethod: PaymentMethod) {
         createSnackbarText(paymentMethod, R.string.stripe_added)?.let {
             snackbarData.value = it
             snackbarData.value = null
         }
+        getPaymentMethods()
     }
 
     internal fun onPaymentMethodRemoved(paymentMethod: PaymentMethod) {
@@ -58,46 +67,46 @@ internal class PaymentMethodsViewModel(
         }
     }
 
-    @JvmSynthetic
-    internal fun getPaymentMethods(): LiveData<Result<List<PaymentMethod>>> {
-        val resultData = MutableLiveData<Result<List<PaymentMethod>>>()
-        progressData.value = true
+    private fun getPaymentMethods() {
+        paymentMethodsJob?.cancel()
 
-        customerSession.fold(
-            onSuccess = {
-                it.getPaymentMethods(
-                    paymentMethodType = PaymentMethod.Type.Card,
-                    productUsage = productUsage,
-                    listener = object : CustomerSession.PaymentMethodsRetrievalListener {
-                        override fun onPaymentMethodsRetrieved(paymentMethods: List<PaymentMethod>) {
-                            resultData.value = Result.success(paymentMethods)
-                            progressData.value = false
-                        }
+        paymentMethodsJob = viewModelScope.launch {
+            progressData.value = true
 
-                        override fun onError(
-                            errorCode: Int,
-                            errorMessage: String,
-                            stripeError: StripeError?
-                        ) {
-                            resultData.value = Result.failure(
-                                APIException(
-                                    stripeError = stripeError,
-                                    statusCode = errorCode,
-                                    message = errorMessage
+            customerSession.fold(
+                onSuccess = {
+                    it.getPaymentMethods(
+                        paymentMethodType = PaymentMethod.Type.Card,
+                        productUsage = productUsage,
+                        listener = object : CustomerSession.PaymentMethodsRetrievalListener {
+                            override fun onPaymentMethodsRetrieved(paymentMethods: List<PaymentMethod>) {
+                                paymentMethodsData.value = Result.success(paymentMethods)
+                                progressData.value = false
+                            }
+
+                            override fun onError(
+                                errorCode: Int,
+                                errorMessage: String,
+                                stripeError: StripeError?
+                            ) {
+                                paymentMethodsData.value = Result.failure(
+                                    APIException(
+                                        stripeError = stripeError,
+                                        statusCode = errorCode,
+                                        message = errorMessage
+                                    )
                                 )
-                            )
-                            progressData.value = false
+                                progressData.value = false
+                            }
                         }
-                    }
-                )
-            },
-            onFailure = {
-                resultData.value = Result.failure(it)
-                progressData.value = false
-            }
-        )
-
-        return resultData
+                    )
+                },
+                onFailure = {
+                    paymentMethodsData.value = Result.failure(it)
+                    progressData.value = false
+                }
+            )
+        }
     }
 
     internal class Factory(

--- a/payments-core/src/test/java/com/stripe/android/CustomerSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/CustomerSessionTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android
 
-import androidx.test.core.app.ApplicationProvider
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.networking.ApiRequest
@@ -794,7 +793,6 @@ internal class CustomerSessionTest {
             createEphemeralKeyManagerFactory(timeSupplier)
     ): CustomerSession {
         return CustomerSession(
-            ApplicationProvider.getApplicationContext(),
             stripeRepository,
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
             "acct_abc123",

--- a/payments-core/src/test/java/com/stripe/android/PaymentSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentSessionTest.kt
@@ -335,7 +335,6 @@ class PaymentSessionTest {
         stripeRepository: StripeRepository = FakeStripeRepository()
     ): CustomerSession {
         return CustomerSession(
-            context,
             stripeRepository,
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
             "acct_abc123",


### PR DESCRIPTION
# Summary
We did a conversion to remove all these from the paymentsheet module, but it's not happened yet for payments core. I noticed this recently when working on another task.

This change also moves some logic that should have been in the view model to the view model.

# Motivation
Unify all of our observables around Flow

# Testing
Manually verified, and confirmed existing tests pass.