### PR TITLE
Remove LiveData from PaymentMethodsAdapter.

### DIFF
--- a/payments-core/detekt-baseline.xml
+++ b/payments-core/detekt-baseline.xml
@@ -49,6 +49,7 @@
     <ID>LongMethod:PaymentFlowResultProcessor.kt$PaymentFlowResultProcessor$suspend fun processResult( unvalidatedResult: PaymentFlowResult.Unvalidated ): Result&lt;S></ID>
     <ID>LongMethod:PaymentIntentJsonParser.kt$PaymentIntentJsonParser$override fun parse(json: JSONObject): PaymentIntent?</ID>
     <ID>LongMethod:PaymentMethodJsonParser.kt$PaymentMethodJsonParser$override fun parse(json: JSONObject): PaymentMethod</ID>
+    <ID>LongMethod:PaymentMethodsActivity.kt$PaymentMethodsActivity$override fun onCreate(savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:SourceParamsTest.kt$SourceParamsTest$@Test fun `createKlarna() should create expected params`()</ID>
     <ID>LongMethod:StaticCardAccountRangeSourceTest.kt$StaticCardAccountRangeSourceTest$@Test fun `getAccountRange() should return expected AccountRange`()</ID>
     <ID>LongMethod:Stripe3ds2ChallengeResultProcessor.kt$DefaultStripe3ds2ChallengeResultProcessor$override suspend fun process( challengeResult: ChallengeResult ): PaymentFlowResult.Unvalidated</ID>

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
@@ -127,9 +127,12 @@ class PaymentMethodsActivity : AppCompatActivity() {
             AddPaymentMethodContract(),
             ::onAddPaymentMethodResult
         )
-        adapter.addPaymentMethodArgs.observe(this) { args ->
-            if (args != null) {
-                addPaymentMethodLauncher.launch(args)
+
+        lifecycleScope.launch {
+            adapter.addPaymentMethodArgs.collect { args ->
+                if (args != null) {
+                    addPaymentMethodLauncher.launch(args)
+                }
             }
         }
 

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
@@ -7,14 +7,15 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.ViewCompat
 import androidx.core.widget.ImageViewCompat
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.recyclerview.widget.RecyclerView
 import com.stripe.android.R
 import com.stripe.android.databinding.StripeAddPaymentMethodRowBinding
 import com.stripe.android.databinding.StripeGooglePayRowBinding
 import com.stripe.android.databinding.StripeMaskedCardRowBinding
 import com.stripe.android.model.PaymentMethod
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * A [RecyclerView.Adapter] that holds a set of [MaskedCardView] items for a given set
@@ -41,8 +42,8 @@ internal class PaymentMethodsAdapter constructor(
     internal var listener: Listener? = null
     private val googlePayCount = 1.takeIf { shouldShowGooglePay } ?: 0
 
-    private val _addPaymentMethodArgs = MutableLiveData<AddPaymentMethodActivityStarter.Args>()
-    val addPaymentMethodArgs: LiveData<AddPaymentMethodActivityStarter.Args> = _addPaymentMethodArgs
+    private val _addPaymentMethodArgs = MutableStateFlow<AddPaymentMethodActivityStarter.Args?>(null)
+    val addPaymentMethodArgs: StateFlow<AddPaymentMethodActivityStarter.Args?> = _addPaymentMethodArgs.asStateFlow()
 
     internal val addCardArgs = AddPaymentMethodActivityStarter.Args.Builder()
         .setBillingAddressFields(intentArgs.billingAddressFields)

--- a/payments-core/src/test/java/com/stripe/android/view/PaymentMethodsAdapterTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/PaymentMethodsAdapterTest.kt
@@ -4,10 +4,12 @@ import android.widget.FrameLayout
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.R
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
+import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.mockito.Mockito.times
 import org.mockito.kotlin.mock
@@ -255,51 +257,47 @@ class PaymentMethodsAdapterTest {
     }
 
     @Test
-    fun `click on add card view should emit args`() {
+    fun `click on add card view should emit args`() = runTest {
         val adapter = PaymentMethodsAdapter(
             ARGS,
             shouldShowGooglePay = true
         )
 
-        val argsList = mutableListOf<AddPaymentMethodActivityStarter.Args?>()
-        adapter.addPaymentMethodArgs.observeForever { args ->
-            argsList.add(args)
+        adapter.addPaymentMethodArgs.test {
+            assertThat(awaitItem()).isNull() // Initial value.
+
+            val viewHolder = adapter.createViewHolder(
+                FrameLayout(context),
+                PaymentMethodsAdapter.ViewType.AddCard.ordinal
+            )
+            adapter.onBindViewHolder(viewHolder, 0)
+            viewHolder.itemView.performClick()
+
+            assertThat(awaitItem())
+                .isEqualTo(adapter.addCardArgs)
         }
-
-        val viewHolder = adapter.createViewHolder(
-            FrameLayout(context),
-            PaymentMethodsAdapter.ViewType.AddCard.ordinal
-        )
-        adapter.onBindViewHolder(viewHolder, 0)
-        viewHolder.itemView.performClick()
-
-        assertThat(argsList.filterNotNull())
-            .containsExactly(adapter.addCardArgs)
     }
 
     @Test
-    fun `click on add FPX view should emit args`() {
+    fun `click on add FPX view should emit args`() = runTest {
         val adapter = PaymentMethodsAdapter(
             ARGS,
             shouldShowGooglePay = true
         )
 
-        val argsList = mutableListOf<AddPaymentMethodActivityStarter.Args>()
-        adapter.addPaymentMethodArgs.observeForever { args ->
-            if (args != null) {
-                argsList.add(args)
-            }
+        adapter.addPaymentMethodArgs.test {
+            assertThat(awaitItem()).isNull() // Initial value.
+
+            val viewHolder = adapter.createViewHolder(
+                FrameLayout(context),
+                PaymentMethodsAdapter.ViewType.AddFpx.ordinal
+            )
+            adapter.onBindViewHolder(viewHolder, 0)
+            viewHolder.itemView.performClick()
+
+            assertThat(awaitItem())
+                .isEqualTo(adapter.addFpxArgs)
         }
-
-        val viewHolder = adapter.createViewHolder(
-            FrameLayout(context),
-            PaymentMethodsAdapter.ViewType.AddFpx.ordinal
-        )
-        adapter.onBindViewHolder(viewHolder, 0)
-        viewHolder.itemView.performClick()
-
-        assertThat(argsList)
-            .containsExactly(adapter.addFpxArgs)
     }
 
     private companion object {


### PR DESCRIPTION
# Summary
We did a conversion to remove all these from the paymentsheet module, but it's not happened yet for payments core. I noticed this recently when working on another task.

# Motivation
Unify all of our observables around Flow

# Testing
Manually verified, and confirmed existing tests pass.