### PR TITLE
Filter saved cards originating from a wallet when showing saved payment methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### PaymentSheet
 * [FIXED][7499](https://github.com/stripe/stripe-android/pull/7499) Fixed an issue with incorrect error messages when encountering a failure after 3D Secure authentication.
+* [FIXED][7529](https://github.com/stripe/stripe-android/pull/7529) PaymentSheet no longer displays saved cards that originated from Apple Pay or Google Pay.
 
 ## 20.34.1 - 2023-10-24
 

--- a/payments-core/src/main/java/com/stripe/android/model/wallets/Wallet.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/wallets/Wallet.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model.wallets
 
 import android.os.Parcelable
+import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.model.Address
 import kotlinx.parcelize.Parcelize
@@ -11,11 +12,14 @@ import kotlinx.parcelize.Parcelize
  * [card.wallet](https://stripe.com/docs/api/payment_methods/object#payment_method_object-card-wallet)
  */
 sealed class Wallet(
-    internal val walletType: Type
+    @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    val walletType: Type
 ) : StripeModel {
 
     @Parcelize
-    data class AmexExpressCheckoutWallet internal constructor(
+    data class AmexExpressCheckoutWallet
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    constructor(
         val dynamicLast4: String?
     ) : Wallet(Type.AmexExpressCheckout)
 
@@ -25,7 +29,9 @@ sealed class Wallet(
     ) : Wallet(Type.ApplePay)
 
     @Parcelize
-    data class GooglePayWallet internal constructor(
+    data class GooglePayWallet
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    constructor(
         val dynamicLast4: String?
     ) : Wallet(Type.GooglePay), Parcelable
 
@@ -51,7 +57,8 @@ sealed class Wallet(
         val dynamicLast4: String?
     ) : Wallet(Type.VisaCheckout)
 
-    internal enum class Type(val code: String) {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    enum class Type(val code: String) {
         AmexExpressCheckout("amex_express_checkout"),
         ApplePay("apple_pay"),
         GooglePay("google_pay"),


### PR DESCRIPTION
## Summary
Hide Apple/Google Pay saved cards in PaymentSheet.

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1089

https://github.com/stripe/stripe-ios/pull/3027

## Testing
See unit test.

## Changelog
* [Fixed] PaymentSheet no longer displays saved cards that originated from Apple Pay or Google Pay.
