### PR TITLE
Add check for FC SDK in CustomerSheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## XX.XX.XX - 2023-XX-XX
+* [FIXED][7530](https://github.com/stripe/stripe-android/pull/7530) Fixed an issue which caused PaymentSheet to transitively include the Financial Connections SDK even if not requested.
 
 ## 20.34.2 - 2023-10-30
 
@@ -8,7 +9,6 @@
 * [FIXED][7499](https://github.com/stripe/stripe-android/pull/7499) Fixed an issue with incorrect error messages when encountering a failure after 3D Secure authentication.
 * [FIXED][7464](https://github.com/stripe/stripe-android/pull/7464) Fixed an issue where canceling the US Bank Account selection flow prevents the user from launching it again.
 * [FIXED][7529](https://github.com/stripe/stripe-android/pull/7529) PaymentSheet no longer displays saved cards that originated from Apple Pay or Google Pay.
-* [FIXED][7530](https://github.com/stripe/stripe-android/pull/7530) Fixed an issue which caused PaymentSheet to transitively include the Financial Connections SDK even if not requested.
 
 ## 20.34.1 - 2023-10-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * [FIXED][7499](https://github.com/stripe/stripe-android/pull/7499) Fixed an issue with incorrect error messages when encountering a failure after 3D Secure authentication.
 * [FIXED][7464](https://github.com/stripe/stripe-android/pull/7464) Fixed an issue where canceling the US Bank Account selection flow prevents the user from launching it again.
 * [FIXED][7529](https://github.com/stripe/stripe-android/pull/7529) PaymentSheet no longer displays saved cards that originated from Apple Pay or Google Pay.
-* [FIXED][7530](https://github.com/stripe/stripe-android/pull/7530) Fixed an issue where the Link module included the Financial Connections SDK which caused PaymentSheet to transitively include the Financial Connections SDK. Also fixed an issue where PaymentSheet would show the US Bank Account form when the Financial Connections SDK is not included, which could lead to a crash.
+* [FIXED][7530](https://github.com/stripe/stripe-android/pull/7530) Fixed an issue which caused PaymentSheet to transitively include the Financial Connections SDK even if not requested.
 
 ## 20.34.1 - 2023-10-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [FIXED][7499](https://github.com/stripe/stripe-android/pull/7499) Fixed an issue with incorrect error messages when encountering a failure after 3D Secure authentication.
 * [FIXED][7464](https://github.com/stripe/stripe-android/pull/7464) Fixed an issue where canceling the US Bank Account selection flow prevents the user from launching it again.
 * [FIXED][7529](https://github.com/stripe/stripe-android/pull/7529) PaymentSheet no longer displays saved cards that originated from Apple Pay or Google Pay.
+* [FIXED][7530](https://github.com/stripe/stripe-android/pull/7530) Fixed an issue where the Link module included the Financial Connections SDK which caused PaymentSheet to transitively include the Financial Connections SDK. Also fixed an issue where PaymentSheet would show the US Bank Account form when the Financial Connections SDK is not included, which could lead to a crash.
 
 ## 20.34.1 - 2023-10-24
 

--- a/link/build.gradle
+++ b/link/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     implementation project(':payments-core')
     implementation project(':stripe-core')
     implementation project(':payments-ui-core')
-    implementation project(':financial-connections')
     implementation project(':stripe-ui-core')
 
     implementation libs.androidx.appCompat

--- a/paymentsheet/res/drawable/stripe_ic_paymentsheet_bank.xml
+++ b/paymentsheet/res/drawable/stripe_ic_paymentsheet_bank.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M0.134,5.5C0.323,5.826 0.667,6.006 1.019,6H14.981C15.333,6.006 15.677,5.826 15.866,5.5C16.142,5.022 15.978,4.41 15.5,4.134C15.181,3.95 12.681,2.572 8,0C3.319,2.572 0.819,3.95 0.5,4.134C0.022,4.41 -0.142,5.022 0.134,5.5ZM11,7.5V14H9.5V7.5H6.5V14H5V7.5H2V14H1C0.448,14 0,14.448 0,15V16H16V15C16,14.448 15.552,14 15,14H14V7.5H11Z"
+      android:fillColor="#545969"
+      android:fillType="evenOdd"/>
+</vector>

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -26,6 +26,7 @@ import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAvailable
 import com.stripe.android.payments.paymentlauncher.PaymentLauncher
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.PaymentResult
@@ -80,6 +81,7 @@ internal class CustomerSheetViewModel @Inject constructor(
     private val paymentLauncherFactory: StripePaymentLauncherAssistedFactory,
     private val intentConfirmationInterceptor: IntentConfirmationInterceptor,
     private val customerSheetLoader: CustomerSheetLoader,
+    private val isFinancialConnectionsAvailable: IsFinancialConnectionsAvailable,
 ) : ViewModel() {
 
     private val backStack = MutableStateFlow(initialBackStack)
@@ -100,9 +102,9 @@ internal class CustomerSheetViewModel @Inject constructor(
     )
     private val usBankAccount = LpmRepository.hardCodedUsBankAccount
 
-    private val supportedPaymentMethods = listOf(
+    private val supportedPaymentMethods = listOfNotNull(
         card,
-        usBankAccount
+        usBankAccount.takeIf { isFinancialConnectionsAvailable() }
     )
 
     init {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -22,6 +22,8 @@ import com.stripe.android.customersheet.DefaultCustomerSheetLoader
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.analytics.DefaultCustomerSheetEventReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.payments.financialconnections.DefaultIsFinancialConnectionsAvailable
+import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAvailable
 import com.stripe.android.paymentsheet.DefaultIntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
@@ -83,6 +85,11 @@ internal interface CustomerSheetViewModelModule {
         @Provides
         fun provideCoroutineContext(): CoroutineContext {
             return Dispatchers.IO
+        }
+
+        @Provides
+        fun providesIsFinancialConnectionsAvailable(): IsFinancialConnectionsAvailable {
+            return DefaultIsFinancialConnectionsAvailable()
         }
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodKtx.kt
@@ -1,8 +1,11 @@
 package com.stripe.android.paymentsheet.model
 
 import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.payments.financialconnections.DefaultIsFinancialConnectionsAvailable
+import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAvailable
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.forms.Delayed
 import com.stripe.android.paymentsheet.forms.PIRequirement
@@ -199,7 +202,8 @@ internal fun getSupportedSavedCustomerPMs(
 internal fun getPMsToAdd(
     stripeIntent: StripeIntent?,
     config: PaymentSheet.Configuration?,
-    lpmRepository: LpmRepository
+    lpmRepository: LpmRepository,
+    isFinancialConnectionsAvailable: IsFinancialConnectionsAvailable = DefaultIsFinancialConnectionsAvailable()
 ) = stripeIntent?.paymentMethodTypes?.mapNotNull {
     lpmRepository.fromCode(it)
 }?.filter { supportedPaymentMethod ->
@@ -210,4 +214,7 @@ internal fun getPMsToAdd(
 }?.filterNot { supportedPaymentMethod ->
     stripeIntent.isLiveMode &&
         stripeIntent.unactivatedPaymentMethods.contains(supportedPaymentMethod.code)
+}?.filterNot { supportedPaymentMethod ->
+    !isFinancialConnectionsAvailable() &&
+        supportedPaymentMethod.code == PaymentMethod.Type.USBankAccount.code
 } ?: emptyList()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtension.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtension.kt
@@ -4,6 +4,7 @@ import android.content.res.Resources
 import androidx.annotation.DrawableRes
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.payments.financialconnections.DefaultIsFinancialConnectionsAvailable
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.TransformToBankIcon
 import com.stripe.android.financialconnections.R as FinancialConnectionsR
@@ -45,8 +46,9 @@ internal fun PaymentMethod.getLabel(resources: Resources): String? = when (type)
     else -> null
 }
 
-internal fun PaymentMethod.getLabelIcon(): Int? = when (type) {
-    PaymentMethod.Type.USBankAccount -> FinancialConnectionsR.drawable.stripe_ic_bank
+internal fun PaymentMethod.getLabelIcon(): Int? = when {
+    type == PaymentMethod.Type.USBankAccount &&
+        DefaultIsFinancialConnectionsAvailable()() -> FinancialConnectionsR.drawable.stripe_ic_bank
     else -> null
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtension.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtension.kt
@@ -4,10 +4,8 @@ import android.content.res.Resources
 import androidx.annotation.DrawableRes
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.payments.financialconnections.DefaultIsFinancialConnectionsAvailable
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.TransformToBankIcon
-import com.stripe.android.financialconnections.R as FinancialConnectionsR
 import com.stripe.android.ui.core.R as StripeUiCoreR
 
 @DrawableRes
@@ -46,9 +44,8 @@ internal fun PaymentMethod.getLabel(resources: Resources): String? = when (type)
     else -> null
 }
 
-internal fun PaymentMethod.getLabelIcon(): Int? = when {
-    type == PaymentMethod.Type.USBankAccount &&
-        DefaultIsFinancialConnectionsAvailable()() -> FinancialConnectionsR.drawable.stripe_ic_bank
+internal fun PaymentMethod.getLabelIcon(): Int? = when (type) {
+    PaymentMethod.Type.USBankAccount -> R.drawable.stripe_ic_paymentsheet_bank
     else -> null
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -1732,6 +1732,46 @@ class CustomerSheetViewModelTest {
         }
     }
 
+    @Test
+    fun `When FC SDK is not available, support payment methods should not include us bank account`() = runTest {
+        val viewModel = createViewModel(
+            isFinancialConnectionsAvailable = { false },
+            initialBackStack = listOf(
+                selectPaymentMethodViewState,
+            ),
+        )
+
+        viewModel.viewState.test {
+            assertThat(awaitItem()).isInstanceOf(SelectPaymentMethod::class.java)
+
+            viewModel.handleViewAction(CustomerSheetViewAction.OnAddCardPressed)
+
+            val viewState = awaitViewState<AddPaymentMethod>()
+            assertThat(viewState.supportedPaymentMethods.map { it.code })
+                .doesNotContain(PaymentMethod.Type.USBankAccount.code)
+        }
+    }
+
+    @Test
+    fun `When FC SDK is available, support payment methods should be included us bank account`() = runTest {
+        val viewModel = createViewModel(
+            isFinancialConnectionsAvailable = { true },
+            initialBackStack = listOf(
+                selectPaymentMethodViewState,
+            ),
+        )
+
+        viewModel.viewState.test {
+            assertThat(awaitItem()).isInstanceOf(SelectPaymentMethod::class.java)
+
+            viewModel.handleViewAction(CustomerSheetViewAction.OnAddCardPressed)
+
+            val viewState = awaitViewState<AddPaymentMethod>()
+            assertThat(viewState.supportedPaymentMethods.map { it.code })
+                .contains(PaymentMethod.Type.USBankAccount.code)
+        }
+    }
+
     @Suppress("UNCHECKED_CAST")
     private suspend inline fun <R> ReceiveTurbine<*>.awaitViewState(): R {
         return awaitItem() as R

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodTest.kt
@@ -215,16 +215,16 @@ class SupportedPaymentMethodTest {
                 )
             )
         }
-        val mockIntent = mock<PaymentIntent>()
-        whenever(mockIntent.paymentMethodTypes).thenReturn(listOf("card", "us_bank_account"))
-        whenever(mockIntent.isLiveMode).thenReturn(false)
-        whenever(mockIntent.unactivatedPaymentMethods).thenReturn(listOf("card"))
 
-        val expected = listOf<SupportedPaymentMethod>().plus(card)
+        val paymentIntent = PaymentIntentFactory.create(
+            paymentMethodTypes = listOf("card", "us_bank_account")
+        )
+
+        val expected = listOf(card)
 
         assertThat(
             getPMsToAdd(
-                stripeIntent = mockIntent,
+                stripeIntent = paymentIntent,
                 config = PaymentSheet.Configuration("Test", allowsDelayedPaymentMethods = true),
                 lpmRepository = lpmRepository,
                 isFinancialConnectionsAvailable = { false },
@@ -247,16 +247,16 @@ class SupportedPaymentMethodTest {
                 )
             )
         }
-        val mockIntent = mock<PaymentIntent>()
-        whenever(mockIntent.paymentMethodTypes).thenReturn(listOf("card", "us_bank_account"))
-        whenever(mockIntent.isLiveMode).thenReturn(false)
-        whenever(mockIntent.unactivatedPaymentMethods).thenReturn(listOf("card"))
 
-        val expected = listOf<SupportedPaymentMethod>().plus(card).plus(LpmRepository.hardCodedUsBankAccount)
+        val paymentIntent = PaymentIntentFactory.create(
+            paymentMethodTypes = listOf("card", "us_bank_account")
+        )
+
+        val expected = listOf(card, LpmRepository.hardCodedUsBankAccount)
 
         assertThat(
             getPMsToAdd(
-                stripeIntent = mockIntent,
+                stripeIntent = paymentIntent,
                 config = PaymentSheet.Configuration("Test", allowsDelayedPaymentMethods = true),
                 lpmRepository = lpmRepository,
                 isFinancialConnectionsAvailable = { true },


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

- Add check for FC SDK in CustomerSheet
- Remove FC from Link
- Fix an issue where us bank account was being shown in PS/FC when the FC SDK is not included

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

If the integrator does not have FC SDK in their gradle dependencies, then we shouldn't show the option to create a us bank account in CustomerSheet.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

* [FIXED][7530](https://github.com/stripe/stripe-android/pull/7530) Fixed an issue where the Link module included the Financial Connections SDK which caused PaymentSheet to transitively include the Financial Connections SDK. Also fixed an issue where PaymentSheet would show the US Bank Account form when the Financial Connections SDK is not included, which could lead to a crash.

