### PR TITLE
Adds timestamps to maestro records + some improvements

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/SharedPartnerAuth.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/SharedPartnerAuth.kt
@@ -28,12 +28,16 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -257,6 +261,7 @@ private fun LoadedContent(
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 @Suppress("LongMethod")
 private fun InstitutionalPrePaneContent(
@@ -366,6 +371,8 @@ private fun InstitutionalPrePaneContent(
         FinancialConnectionsButton(
             onClick = onContinueClick,
             modifier = Modifier
+                .semantics { testTagsAsResourceId = true }
+                .testTag("prepane_cta")
                 .fillMaxWidth()
         ) {
             Row(

--- a/maestro/common/subflow-skip-chrome-welcome.yaml
+++ b/maestro/common/subflow-skip-chrome-welcome.yaml
@@ -1,25 +1,12 @@
 appId: ${APP_ID}
 ---
 ####### Bypass Chrome on-boarding screen #######
-# If no default browser selected, select Chrome
-- tapOn:
-    text: ".*Chrome.*"
-    optional: true
-- tapOn:
-    text: ".*ALWAYS.*"
-    optional: true
-# ACCEPT TERMS (tries id and text)
+# ACCEPT TERMS
 - tapOn:
     id: "com.android.chrome:id/terms_accept"
     optional: true
-- tapOn:
-    text: ".*(?i)Accept.*"
-    optional: true
-# REJECT TURN ON SYNC (tries id and text)
+# REJECT TURN ON SYNC
 - tapOn:
     id: "com.android.chrome:id/negative_button"
-    optional: true
-- tapOn:
-    text: ".*(?i)No thanks.*"
     optional: true
 ###############################################

--- a/maestro/financial-connections/Livemode-Data-Finbank.yaml
+++ b/maestro/financial-connections/Livemode-Data-Finbank.yaml
@@ -4,6 +4,7 @@ tags:
   - livemode-data
 ---
 - startRecording: ${'/tmp/test_results/livemode-data-finbank-' + new Date().getTime()}
+- clearState
 - openLink: stripeconnectionsexample://playground?flow=Data&financial_connections_override_native=native&merchant=live_testing
 - tapOn:
     id: "connect_accounts"

--- a/maestro/financial-connections/Livemode-Data-Finbank.yaml
+++ b/maestro/financial-connections/Livemode-Data-Finbank.yaml
@@ -3,7 +3,7 @@ tags:
   - all
   - livemode-data
 ---
-- startRecording: /tmp/test_results/livemode-data-finbank
+- startRecording: ${'/tmp/test_results/livemode-data-finbank-' + new Date().getTime()}
 - openLink: stripeconnectionsexample://playground?flow=Data&financial_connections_override_native=native&merchant=live_testing
 - tapOn:
     id: "connect_accounts"

--- a/maestro/financial-connections/Livemode-Data-MXBank.yaml
+++ b/maestro/financial-connections/Livemode-Data-MXBank.yaml
@@ -20,7 +20,8 @@ tags:
 - inputText: "mx"
 - tapOn:
     id: "search_result_1"
-- tapOn: "Continue"
+- tapOn:
+    id: "prepane_cta"
 ####### Bypass Chrome on-boarding screen #######
 - runFlow:
     file: ../common/subflow-skip-chrome-welcome.yaml

--- a/maestro/financial-connections/Livemode-Data-MXBank.yaml
+++ b/maestro/financial-connections/Livemode-Data-MXBank.yaml
@@ -4,6 +4,7 @@ tags:
   - livemode-data
 ---
 - startRecording: ${'/tmp/test_results/livemode-data-mxbank-' + new Date().getTime()}
+- clearState
 - openLink: stripeconnectionsexample://playground?flow=Data&financial_connections_override_native=native&merchant=live_testing
 - tapOn:
     id: "connect_accounts"

--- a/maestro/financial-connections/Livemode-Data-MXBank.yaml
+++ b/maestro/financial-connections/Livemode-Data-MXBank.yaml
@@ -3,7 +3,7 @@ tags:
   - all
   - livemode-data
 ---
-- startRecording: /tmp/test_results/livemode-data-mxbank
+- startRecording: ${'/tmp/test_results/livemode-data-mxbank-' + new Date().getTime()}
 - openLink: stripeconnectionsexample://playground?flow=Data&financial_connections_override_native=native&merchant=live_testing
 - tapOn:
     id: "connect_accounts"

--- a/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
+++ b/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
@@ -5,6 +5,7 @@ tags:
   - testmode-data
 ---
 - startRecording: ${'/tmp/test_results/testmode-data-testoauthinstitution-' + new Date().getTime()}
+- clearState
 - openLink: stripeconnectionsexample://playground?flow=Data&financial_connections_override_native=native&merchant=testmode
 - tapOn:
     id: "connect_accounts"

--- a/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
+++ b/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
@@ -4,7 +4,7 @@ tags:
   - edge
   - testmode-data
 ---
-- startRecording: /tmp/test_results/testmode-data-testoauthinstitution
+- startRecording: ${'/tmp/test_results/testmode-data-testoauthinstitution-' + new Date().getTime()}
 - openLink: stripeconnectionsexample://playground?flow=Data&financial_connections_override_native=native&merchant=testmode
 - tapOn:
     id: "connect_accounts"

--- a/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
+++ b/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
@@ -22,7 +22,8 @@ tags:
 - tapOn: "Select another bank"
 # SELECT OAUTH INSTITUTION
 - tapOn: "Test OAuth Institution"
-- tapOn: "Continue"
+- tapOn:
+    id: "prepane_cta"
 ####### Bypass Chrome on-boarding screen #######
 - runFlow:
     file: ../common/subflow-skip-chrome-welcome.yaml

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking.yaml
@@ -4,7 +4,7 @@ tags:
   - edge
   - testmode-payments
 ---
-- startRecording: /tmp/test_results/testmode-paymentintent-testinstitution-networking
+- startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-networking-' + new Date().getTime()}
 - openLink: stripeconnectionsexample://playground?flow=PaymentIntent&financial_connections_override_native=native&merchant=networking_testmode
 - tapOn:
     id: "Customer email setting"

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking.yaml
@@ -5,6 +5,7 @@ tags:
   - testmode-payments
 ---
 - startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-networking-' + new Date().getTime()}
+- clearState
 - openLink: stripeconnectionsexample://playground?flow=PaymentIntent&financial_connections_override_native=native&merchant=networking_testmode
 - tapOn:
     id: "Customer email setting"

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
@@ -5,6 +5,7 @@ tags:
   - testmode-payments
 ---
 - startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-' + new Date().getTime()}
+- clearState
 - openLink: stripeconnectionsexample://playground?flow=PaymentIntent&financial_connections_override_native=native&merchant=testmode
 - tapOn:
     id: "connect_accounts"

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
@@ -4,7 +4,7 @@ tags:
   - edge
   - testmode-payments
 ---
-- startRecording: /tmp/test_results/testmode-paymentintent-testinstitution
+- startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-' + new Date().getTime()}
 - openLink: stripeconnectionsexample://playground?flow=PaymentIntent&financial_connections_override_native=native&merchant=testmode
 - tapOn:
     id: "connect_accounts"

--- a/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
+++ b/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
@@ -4,7 +4,7 @@ tags:
   - edge
   - testmode-data
 ---
-- startRecording: /tmp/test_results/testmode-token_manualentry
+- startRecording: ${'/tmp/test_results/testmode-token_manualentry-' + new Date().getTime()}
 - openLink: stripeconnectionsexample://playground?flow=Token&financial_connections_override_native=native&merchant=testmode
 - tapOn:
     id: "connect_accounts"

--- a/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
+++ b/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
@@ -5,6 +5,7 @@ tags:
   - testmode-data
 ---
 - startRecording: ${'/tmp/test_results/testmode-token_manualentry-' + new Date().getTime()}
+- clearState
 - openLink: stripeconnectionsexample://playground?flow=Token&financial_connections_override_native=native&merchant=testmode
 - tapOn:
     id: "connect_accounts"


### PR DESCRIPTION
# Summary
- If a test fails and gets retried, videos are overriden due to name overlap. 
- This adds timestamps so that we keep failing videos as artifacts.
- Also makes the prepane clickable by id (text changes from backend)
- And clears state between executions

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified