### PR TITLE
Fix issue where FC + PI would not launch ach collection flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## XX.XX.XX - 2023-XX-XX
 * [FIXED][7530](https://github.com/stripe/stripe-android/pull/7530) Fixed an issue which caused PaymentSheet to transitively include the Financial Connections SDK even if not requested.
+* [FIXED][7545](https://github.com/stripe/stripe-android/pull/7545) Fixed an issue where the US Bank Account collection flow would not launch when using FlowController with Payment Intents.
 
 ## 20.34.2 - 2023-10-30
 

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
@@ -37,4 +37,17 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
             }
         )
     }
+
+    @Test
+    fun testUSBankAccountInCustomFlow() {
+        testDriver.confirmCustomUSBankAccount(
+            testParameters = testParameters.copy(
+                authorizationAction = AuthorizeAction.Cancel,
+            ),
+            afterAuthorization = {
+                rules.compose.onNode(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
+                    .assertIsEnabled()
+            }
+        )
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.platform.LocalContext
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.InlineSignupViewState
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -120,7 +121,7 @@ internal fun AddPaymentMethod(
                 usBankAccountFormArguments = USBankAccountFormArguments(
                     onBehalfOf = onBehalfOf,
                     isCompleteFlow = sheetViewModel is PaymentSheetViewModel,
-                    isPaymentFlow = initializationMode is PaymentSheet.InitializationMode.PaymentIntent,
+                    isPaymentFlow = stripeIntent.value is PaymentIntent,
                     stripeIntentId = stripeIntent.value?.id,
                     clientSecret = stripeIntent.value?.clientSecret,
                     shippingDetails = sheetViewModel.config?.shippingDetails,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Fix issue where FC + PI would not launch ach collection flow

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

* [FIXED][]() Fixed an issue where the US Bank Account collection flow would not launch when using FlowController with Payment Intents.
