### PR TITLE
Refactor `CardMultilineWidgetTest`

### DIFF
--- a/payments-core/detekt-baseline.xml
+++ b/payments-core/detekt-baseline.xml
@@ -105,6 +105,8 @@
     <ID>MaxLineLength:BecsDebitMandateAcceptanceFactoryTest.kt$BecsDebitMandateAcceptanceFactoryTest$.</ID>
     <ID>MaxLineLength:BecsDebitMandateAcceptanceTextViewTest.kt$BecsDebitMandateAcceptanceTextViewTest$.</ID>
     <ID>MaxLineLength:CardFormView.kt$CardFormView$*</ID>
+    <ID>MaxLineLength:CardMultilineWidgetTest.kt$CardMultilineWidgetTest$fun</ID>
+    <ID>MaxLineLength:CardMultilineWidgetTest.kt$CardMultilineWidgetTest$val cardMultilineWidget = activity.findViewById&lt;CardMultilineWidget>(CardMultilineWidgetTestActivity.VIEW_ID)</ID>
     <ID>MaxLineLength:CardNumberEditText.kt$CardNumberEditText.CardNumberTextWatcher$// TODO (michelleb-stripe) Should set error message to incomplete, then in focus change if it isn't complete it will update it.</ID>
     <ID>MaxLineLength:CardNumberEditTextTest.kt$CardNumberEditTextTest$fun</ID>
     <ID>MaxLineLength:ConfirmPaymentIntentParams.kt$ConfirmPaymentIntentParams$*</ID>

--- a/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -18,6 +18,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.withStyledAttributes
 import androidx.core.view.updateLayoutParams
 import androidx.core.widget.doAfterTextChanged
+import androidx.lifecycle.ViewModelStoreOwner
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.cards.CardNumber
@@ -152,6 +153,8 @@ class CardMultilineWidget @JvmOverloads constructor(
 
     private fun isPostalRequired() =
         (postalCodeRequired || usZipCodeRequired) && shouldShowPostalCode
+
+    internal var viewModelStoreOwner: ViewModelStoreOwner? = null
 
     /**
      * A [PaymentMethodCreateParams.Card] representing the card details if all fields are valid;


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request refactors `CardMultilineWidgetTest` in the style of `CardInputWidgetTest`, allowing us to more easily configure the widget and not share instances across tests.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
