### PR TITLE
Fix issue where the payment method form is not being preserved

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -337,6 +337,11 @@ internal class CustomerSheetViewModel @Inject constructor(
     }
 
     private fun onAddPaymentMethodItemChanged(paymentMethod: LpmRepository.SupportedPaymentMethod) {
+        (viewState.value as? CustomerSheetViewState.AddPaymentMethod)?.let {
+            if (it.paymentMethodCode == paymentMethod.code) {
+                return
+            }
+        }
         updateViewState<CustomerSheetViewState.AddPaymentMethod> {
             it.copy(
                 paymentMethodCode = paymentMethod.code,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -360,7 +360,6 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         _collectBankAccountResult.tryEmit(null)
         collectBankAccountLauncher?.unregister()
         collectBankAccountLauncher = null
-        reset()
     }
 
     fun formattedMerchantName(): String {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -1961,6 +1961,33 @@ class CustomerSheetViewModelTest {
         }
     }
 
+    @Test
+    fun `Selecting the already selected payment method in add flow does nothing`() = runTest {
+        val viewModel = createViewModel(
+            isFinancialConnectionsAvailable = { true },
+            initialBackStack = listOf(
+                addPaymentMethodViewState.copy(
+                    paymentMethodCode = PaymentMethod.Type.USBankAccount.code,
+                    selectedPaymentMethod = LpmRepository.hardCodedUsBankAccount,
+                ),
+            ),
+        )
+
+        viewModel.viewState.test {
+            val viewState = awaitViewState<AddPaymentMethod>()
+            assertThat(viewState.selectedPaymentMethod)
+                .isEqualTo(LpmRepository.hardCodedUsBankAccount)
+
+            viewModel.handleViewAction(
+                CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
+                    LpmRepository.hardCodedUsBankAccount
+                )
+            )
+
+            expectNoEvents()
+        }
+    }
+
     @Suppress("UNCHECKED_CAST")
     private suspend inline fun <R> ReceiveTurbine<*>.awaitViewState(): R {
         return awaitItem() as R

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -815,7 +815,7 @@ class USBankAccountFormViewModelTest {
     }
 
     @Test
-    fun `When form destroyed, collect bank account result is null and reset to billing collection screen`() = runTest {
+    fun `When form destroyed, collect bank account result is null and screen is not reset`() = runTest {
         val viewModel = createViewModel(
             defaultArgs.copy(
                 clientSecret = null,
@@ -824,6 +824,10 @@ class USBankAccountFormViewModelTest {
         )
 
         viewModel.result.test {
+            viewModel.handleCollectBankAccountResult(
+                result = mockVerifiedBankAccount()
+            )
+
             viewModel.onDestroy()
 
             assertThat(awaitItem()).isNull()
@@ -832,7 +836,7 @@ class USBankAccountFormViewModelTest {
                 viewModel.currentScreenState.stateIn(viewModel.viewModelScope).value
 
             assertThat(currentScreenState)
-                .isInstanceOf(USBankAccountFormScreenState.BillingDetailsCollection::class.java)
+                .isInstanceOf(USBankAccountFormScreenState.MandateCollection::class.java)
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Fix issue where the payment method form is not being preserved. For example, when you fill out the US Bank account form and get a result back, switch payment method to card, then back to us bank account, the form is reset.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

