### PR TITLE
Remove createPaymentMethod_withNetBanking_shouldCreateObject.

### DIFF
--- a/payments-core/src/test/java/com/stripe/android/ApiKeyFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/ApiKeyFixtures.kt
@@ -22,7 +22,6 @@ internal object ApiKeyFixtures {
     const val PAYPAL_PUBLISHABLE_KEY = "pk_test_vOo1umqsYxSrP5UXfOeL3ecm"
     const val AFTERPAY_PUBLISHABLE_KEY = "pk_test_vOo1umqsYxSrP5UXfOeL3ecm"
     const val UPI_PUBLISHABLE_KEY = "pk_test_51H7wmsBte6TMTRd4gph9Wm7gnQOKJwdVTCj30AhtB8MhWtlYj6v9xDn1vdCtKYGAE7cybr6fQdbQQtgvzBihE9cl00tOnrTpL9"
-    const val NETBANKING_PUBLISHABLE_KEY = "pk_test_51H7wmsBte6TMTRd4gph9Wm7gnQOKJwdVTCj30AhtB8MhWtlYj6v9xDn1vdCtKYGAE7cybr6fQdbQQtgvzBihE9cl00tOnrTpL9"
     const val BLIK_PUBLISHABLE_KEY = "pk_test_ErsyMEOTudSjQR8hh0VrQr5X008sBXGOu6"
     const val WECHAT_PAY_PUBLISHABLE_KEY = "pk_test_h0JFD5q63mLThM5JVSbrREmR"
     const val AFFIRM_PUBLISHABLE_KEY = "pk_test_51HvTI7Lu5o3P18Zp6t5AgBSkMvWoTtA0nyA7pVYDqpfLkRtWun7qZTYCOHCReprfLM464yaBeF72UFfB7cY9WG4a00ZnDtiC2C"

--- a/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
@@ -94,16 +94,6 @@ internal class PaymentMethodEndToEndTest {
     }
 
     @Test
-    fun createPaymentMethod_withNetBanking_shouldCreateObject() {
-        val params = PaymentMethodCreateParamsFixtures.NETBANKING
-        val paymentMethod =
-            Stripe(context, ApiKeyFixtures.NETBANKING_PUBLISHABLE_KEY)
-                .createPaymentMethodSynchronous(params)
-        assertThat(paymentMethod.type)
-            .isEqualTo(PaymentMethod.Type.Netbanking)
-    }
-
-    @Test
     fun createPaymentMethod_withUSBankAccount_shouldCreateObject() {
         val params = PaymentMethodCreateParamsFixtures.US_BANK_ACCOUNT
         val paymentMethod =

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsFixtures.kt
@@ -96,13 +96,6 @@ internal object PaymentMethodCreateParamsFixtures {
         billingDetails = BILLING_DETAILS
     )
 
-    internal val NETBANKING = PaymentMethodCreateParams.create(
-        netbanking = PaymentMethodCreateParams.Netbanking(
-            bank = "hdfc"
-        ),
-        billingDetails = BILLING_DETAILS
-    )
-
     internal val US_BANK_ACCOUNT = PaymentMethodCreateParams.create(
         usBankAccount = PaymentMethodCreateParams.USBankAccount(
             accountNumber = "000123456789",


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove a failing test case.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This was failing because the owning team is removing this PM (ungating our test merchant). This PM was never GA'd.
