### PR TITLE
Update mandate text when in setup mode

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -28,6 +28,7 @@ internal sealed class PaymentSelection : Parcelable {
         context: Context,
         merchantName: String,
         isSaveForFutureUseSelected: Boolean,
+        isSetupFlow: Boolean,
     ): String?
 
     @Parcelize
@@ -40,6 +41,7 @@ internal sealed class PaymentSelection : Parcelable {
             context: Context,
             merchantName: String,
             isSaveForFutureUseSelected: Boolean,
+            isSetupFlow: Boolean,
         ): String? {
             return null
         }
@@ -55,6 +57,7 @@ internal sealed class PaymentSelection : Parcelable {
             context: Context,
             merchantName: String,
             isSaveForFutureUseSelected: Boolean,
+            isSetupFlow: Boolean,
         ): String? {
             return null
         }
@@ -83,10 +86,16 @@ internal sealed class PaymentSelection : Parcelable {
             context: Context,
             merchantName: String,
             isSaveForFutureUseSelected: Boolean,
+            isSetupFlow: Boolean,
         ): String? {
             return when (paymentMethod.type) {
                 USBankAccount -> {
-                    ACHText.getContinueMandateText(context, merchantName, isSaveForFutureUseSelected)
+                    ACHText.getContinueMandateText(
+                        context = context,
+                        merchantName = merchantName,
+                        isSaveForFutureUseSelected = isSaveForFutureUseSelected,
+                        isSetupFlow = isSetupFlow,
+                    )
                 }
                 PaymentMethod.Type.SepaDebit -> {
                     context.getString(StripeUiCoreR.string.stripe_sepa_mandate, merchantName)
@@ -117,6 +126,7 @@ internal sealed class PaymentSelection : Parcelable {
             context: Context,
             merchantName: String,
             isSaveForFutureUseSelected: Boolean,
+            isSetupFlow: Boolean,
         ): String? {
             return null
         }
@@ -147,6 +157,7 @@ internal sealed class PaymentSelection : Parcelable {
                 context: Context,
                 merchantName: String,
                 isSaveForFutureUseSelected: Boolean,
+                isSetupFlow: Boolean,
             ): String? {
                 return screenState.mandateText
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/ACHText.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/ACHText.kt
@@ -12,8 +12,9 @@ internal object ACHText {
         context: Context,
         merchantName: String,
         isSaveForFutureUseSelected: Boolean,
+        isSetupFlow: Boolean,
     ): String {
-        val text = if (isSaveForFutureUseSelected) {
+        val text = if (isSaveForFutureUseSelected || isSetupFlow) {
             context.getString(R.string.stripe_paymentsheet_ach_save_mandate, merchantName)
         } else {
             context.getString(R.string.stripe_paymentsheet_ach_continue_mandate)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountEmitters.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountEmitters.kt
@@ -52,6 +52,7 @@ internal fun USBankAccountEmitters(
                 context = context,
                 merchantName = merchantName,
                 isSaveForFutureUseSelected = saved,
+                isSetupFlow = !usBankAccountFormArgs.isPaymentFlow,
             )
             usBankAccountFormArgs.updateMandateText(
                 context = context,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -521,6 +521,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
             context = application,
             merchantName = formattedMerchantName(),
             isSaveForFutureUseSelected = saveForFutureUse.value,
+            isSetupFlow = !args.isPaymentFlow,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -12,6 +12,7 @@ import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.LinkHandler
@@ -394,6 +395,7 @@ internal abstract class BaseSheetViewModel(
             context = getApplication(),
             merchantName = merchantName,
             isSaveForFutureUseSelected = isRequestingReuse,
+            isSetupFlow = stripeIntent.value is SetupIntent,
         )
 
         val showAbove = (selection as? PaymentSelection.Saved?)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
@@ -23,6 +23,7 @@ class PaymentSelectionTest {
                 context = context,
                 merchantName = "Merchant",
                 isSaveForFutureUseSelected = isSaveForFutureUseSelected,
+                isSetupFlow = false,
             )
             assertThat(result).isNull()
         }
@@ -35,6 +36,7 @@ class PaymentSelectionTest {
                 context = context,
                 merchantName = "Merchant",
                 isSaveForFutureUseSelected = isSaveForFutureUseSelected,
+                isSetupFlow = false,
             )
             assertThat(result).isNull()
         }
@@ -69,6 +71,7 @@ class PaymentSelectionTest {
                 context = context,
                 merchantName = "Merchant",
                 isSaveForFutureUseSelected = isSaveForFutureUseSelected,
+                isSetupFlow = false,
             )
 
             assertThat(result).isNull()
@@ -80,10 +83,23 @@ class PaymentSelectionTest {
             paymentMethod = PaymentMethodFactory.usBankAccount(),
         )
 
-        val result = newPaymentSelection.mandateText(
+        var result = newPaymentSelection.mandateText(
             context = context,
             merchantName = "Merchant",
             isSaveForFutureUseSelected = true,
+            isSetupFlow = false,
+        )
+
+        assertThat(result).isEqualTo(
+            "By saving your bank account for Merchant you agree to authorize payments pursuant " +
+                "to <a href=\"https://stripe.com/ach-payments/authorization\">these terms</a>."
+        )
+
+        result = newPaymentSelection.mandateText(
+            context = context,
+            merchantName = "Merchant",
+            isSaveForFutureUseSelected = false,
+            isSetupFlow = true,
         )
 
         assertThat(result).isEqualTo(
@@ -102,6 +118,7 @@ class PaymentSelectionTest {
             context = context,
             merchantName = "Merchant",
             isSaveForFutureUseSelected = false,
+            isSetupFlow = false,
         )
 
         assertThat(result).isEqualTo(
@@ -120,6 +137,7 @@ class PaymentSelectionTest {
             context = context,
             merchantName = "Merchant",
             isSaveForFutureUseSelected = false,
+            isSetupFlow = false,
         )
 
         assertThat(result).isEqualTo(
@@ -143,6 +161,7 @@ class PaymentSelectionTest {
             context = context,
             merchantName = "Merchant",
             isSaveForFutureUseSelected = false,
+            isSetupFlow = false,
         )
 
         assertThat(result).isEqualTo(
@@ -162,6 +181,7 @@ class PaymentSelectionTest {
                 context = context,
                 merchantName = "Merchant",
                 isSaveForFutureUseSelected = isSaveForFutureUseSelected,
+                isSetupFlow = false,
             )
             assertThat(result).isNull()
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Update mandate text when in setup mode

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

The mandate text should show mandate specific to saving, instead of continuing.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| <img src="https://github.com/stripe/stripe-android/assets/99316447/bc9a8750-ba4d-4b18-9cf6-f1eca9a10942" height=400/>  | <img src="https://github.com/stripe/stripe-android/assets/99316447/246ed8b5-fb1c-44f7-af93-d5506ef66840" height=400/> |

Ignore the message of the form ("save" vs "pay"), it is from a different PR. The main difference is the mandate.

