### PR TITLE
Don't warn on missing financialconnections classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+### PaymentSheet
+* [FIXED][7570](https://github.com/stripe/stripe-android/pull/7570) Fixed an issue where compiling PaymentSheet with R8 would cause a warning for missing classes from financial connections if the module wasn't included.
+
 ## 20.34.3 - 2023-10-31
+
+### PaymentSheet
 * [FIXED][7530](https://github.com/stripe/stripe-android/pull/7530) Fixed an issue which caused PaymentSheet to transitively include the Financial Connections SDK even if not requested.
 * [FIXED][7545](https://github.com/stripe/stripe-android/pull/7545) Fixed an issue where the US Bank Account collection flow would not launch when using FlowController with Payment Intents.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## XX.XX.XX - 2023-XX-XX
 
 ### PaymentSheet
-* [FIXED][7570](https://github.com/stripe/stripe-android/pull/7570) Fixed an issue where compiling PaymentSheet with R8 would cause a warning for missing classes from financial connections if the module wasn't included.
+* [FIXED][7570](https://github.com/stripe/stripe-android/pull/7570) Fixed an issue where compiling PaymentSheet with R8 would cause an irrelevant warning for missing classes from Financial Connections if the module wasn't included.
 
 ## 20.34.3 - 2023-10-31
 

--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -15,6 +15,7 @@ def getGooglePlacesApiKey() {
 dependencies {
     implementation project(':payments')
     implementation project(':stripecardscan')
+    implementation project(':financial-connections')
 
     implementation libs.androidx.activity
     implementation libs.androidx.appCompat

--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -15,7 +15,6 @@ def getGooglePlacesApiKey() {
 dependencies {
     implementation project(':payments')
     implementation project(':stripecardscan')
-    implementation project(':financial-connections')
 
     implementation libs.androidx.activity
     implementation libs.androidx.appCompat

--- a/paymentsheet-example/proguard-rules.pro
+++ b/paymentsheet-example/proguard-rules.pro
@@ -30,3 +30,5 @@
 # kept. Suspend functions are wrapped in continuations where the type argument
 # is used.
 -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+-dontwarn com.stripe.android.financialconnections.**


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fix an issue where financial connections classes would throw a warning when compiling with R8.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fixes #7569 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
