### PR TITLE
Only send US Bank account payment method to elements session when the feature flag is enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### PaymentSheet
 * [FIXED][7570](https://github.com/stripe/stripe-android/pull/7570) Fixed an issue where compiling PaymentSheet with R8 would cause an irrelevant warning for missing classes from Financial Connections if the module wasn't included.
+* [FIXED][7571](https://github.com/stripe/stripe-android/pull/7571) Fixed an issue where CustomerSheet would throw an error related to invalid payment_method_types.
 
 ## 20.34.3 - 2023-10-31
 

--- a/payments-ui-core/detekt-baseline.xml
+++ b/payments-ui-core/detekt-baseline.xml
@@ -5,11 +5,11 @@
     <ID>ConstructorParameterNaming:CardNumberElement.kt$CardNumberElement$val _identifier: IdentifierSpec</ID>
     <ID>ConstructorParameterNaming:CvcElement.kt$CvcElement$val _identifier: IdentifierSpec</ID>
     <ID>CyclomaticComplexMethod:FormItemSpec.kt$FormItemSpecSerializer$override fun selectDeserializer(element: JsonElement): DeserializationStrategy&lt;out FormItemSpec></ID>
-    <ID>CyclomaticComplexMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration, )</ID>
+    <ID>CyclomaticComplexMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration, isDeferred: Boolean = false, )</ID>
     <ID>CyclomaticComplexMethod:TransformGoogleToStripeAddress.kt$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun Place.transformGoogleToStripeAddress( context: Context ): com.stripe.android.model.Address</ID>
     <ID>CyclomaticComplexMethod:TransformSpecToElements.kt$TransformSpecToElements$fun transform(list: List&lt;FormItemSpec>): List&lt;FormElement></ID>
     <ID>ForbiddenComment:Menu.kt$// TODO: Make sure this gets the rounded corner values</ID>
-    <ID>LongMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration, )</ID>
+    <ID>LongMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration, isDeferred: Boolean = false, )</ID>
     <ID>LongMethod:Menu.kt$@Suppress("ModifierParameter") @Composable internal fun DropdownMenuContent( expandedStates: MutableTransitionState&lt;Boolean>, transformOriginState: MutableState&lt;TransformOrigin>, initialFirstVisibleItemIndex: Int, modifier: Modifier = Modifier, content: LazyListScope.() -> Unit )</ID>
     <ID>LongMethod:TransformGoogleToStripeAddress.kt$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun Place.transformGoogleToStripeAddress( context: Context ): com.stripe.android.model.Address</ID>
     <ID>LongMethod:TransformGoogleToStripeAddressTest.kt$TransformGoogleToStripeAddressTest$@Test fun `test JP address`()</ID>
@@ -54,6 +54,7 @@
     <ID>MaxLineLength:CardNumberConfigTest.kt$CardNumberConfigTest$val state = cardNumberConfig.determineState(CardBrand.Visa, "4242424242424242", CardBrand.Visa.getMaxLengthForCardNumber("4242424242424242"))</ID>
     <ID>MaxLineLength:CardNumberConfigTest.kt$CardNumberConfigTest$val state = cardNumberConfig.determineState(CardBrand.Visa, "4242424242424243", CardBrand.Visa.getMaxLengthForCardNumber("4242424242424243"))</ID>
     <ID>MaxLineLength:LpmRepository.kt$LpmRepository.SupportedPaymentMethod$/** This describes the image in the LPM selector. These can be found internally [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0) */</ID>
+    <ID>MaxLineLength:LpmRepositoryTest.kt$LpmRepositoryTest$fun</ID>
     <ID>MaxLineLength:NextActionSpec.kt$PostConfirmHandlingPiStatusSpecsSerializer$override</ID>
     <ID>MaximumLineLength:com.stripe.android.ui.core.elements.NextActionSpec.kt:63</ID>
     <ID>ReturnCount:AuBankAccountNumberConfig.kt$AuBankAccountNumberConfig$override fun determineState(input: String): TextFieldState</ID>

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/resources/LpmRepositoryTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/resources/LpmRepositoryTest.kt
@@ -250,7 +250,7 @@ class LpmRepositoryTest {
     }
 
     @Test
-    fun `Verify that us_bank_account is not supported when is payment intent and financial connections sdk available`() {
+    fun `Verify that us_bank_account is supported when is payment intent and financial connections sdk available`() {
         lpmRepository.update(
             stripeIntent = PaymentIntentFactory.create(
                 paymentMethodTypes = listOf("us_bank_account")

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/networking/Models.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/networking/Models.kt
@@ -185,6 +185,10 @@ data class PlaygroundCustomerSheetRequest(
     val customerId: String,
     @SerialName("mode")
     val mode: String,
+    @SerialName("merchant_country_code")
+    val merchantCountryCode: String,
+    @SerialName("currency")
+    val currency: String,
 )
 
 @Serializable

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/playground/CustomerSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/playground/CustomerSheetPlaygroundViewModel.kt
@@ -155,7 +155,9 @@ class CustomerSheetPlaygroundViewModel(
     ): Result<PlaygroundCustomerSheetResponse, FuelError> {
         val request = PlaygroundCustomerSheetRequest(
             customerId = customerId,
-            mode = "payment"
+            mode = "payment",
+            merchantCountryCode = "US",
+            currency = "usd",
         )
 
         val requestBody = Json.encodeToString(

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -23,7 +23,6 @@
     <ID>LargeClass:USBankAccountFormViewModelTest.kt$USBankAccountFormViewModelTest</ID>
     <ID>LongMethod:AddPaymentMethod.kt$@Composable internal fun AddPaymentMethod( sheetViewModel: BaseSheetViewModel, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:AutocompleteScreen.kt$@Composable internal fun AutocompleteScreenUI(viewModel: AutocompleteViewModel)</ID>
-    <ID>LongMethod:CustomerSheetLoader.kt$DefaultCustomerSheetLoader$private suspend fun loadPaymentMethods( configuration: CustomerSheet.Configuration?, elementsSession: ElementsSession?, )</ID>
     <ID>LongMethod:CustomerSheetScreen.kt$@Composable internal fun AddPaymentMethodWithPaymentElement( viewState: CustomerSheetViewState.AddPaymentMethod, viewActionHandler: (CustomerSheetViewAction) -> Unit, formViewModelSubComponentBuilderProvider: Provider&lt;FormViewModelSubcomponent.Builder>?, )</ID>
     <ID>LongMethod:CustomerSheetViewModel.kt$CustomerSheetViewModel$private fun transitionToAddPaymentMethod(isFirstPaymentMethod: Boolean)</ID>
     <ID>LongMethod:FormViewModelTest.kt$FormViewModelTest$@Test fun `Verify params are set when element address fields are complete`()</ID>

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -23,6 +23,7 @@
     <ID>LargeClass:USBankAccountFormViewModelTest.kt$USBankAccountFormViewModelTest</ID>
     <ID>LongMethod:AddPaymentMethod.kt$@Composable internal fun AddPaymentMethod( sheetViewModel: BaseSheetViewModel, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:AutocompleteScreen.kt$@Composable internal fun AutocompleteScreenUI(viewModel: AutocompleteViewModel)</ID>
+    <ID>LongMethod:CustomerSheetLoader.kt$DefaultCustomerSheetLoader$private suspend fun loadPaymentMethods( configuration: CustomerSheet.Configuration?, elementsSession: ElementsSession?, )</ID>
     <ID>LongMethod:CustomerSheetScreen.kt$@Composable internal fun AddPaymentMethodWithPaymentElement( viewState: CustomerSheetViewState.AddPaymentMethod, viewActionHandler: (CustomerSheetViewAction) -> Unit, formViewModelSubComponentBuilderProvider: Provider&lt;FormViewModelSubcomponent.Builder>?, )</ID>
     <ID>LongMethod:CustomerSheetViewModel.kt$CustomerSheetViewModel$private fun transitionToAddPaymentMethod(isFirstPaymentMethod: Boolean)</ID>
     <ID>LongMethod:FormViewModelTest.kt$FormViewModelTest$@Test fun `Verify params are set when element address fields are complete`()</ID>
@@ -58,6 +59,7 @@
     <ID>MaxLineLength:CustomerRepositoryTest.kt$CustomerRepositoryTest$fun</ID>
     <ID>MaxLineLength:CustomerSheetViewModelTest.kt$CustomerSheetViewModelTest$fun</ID>
     <ID>MaxLineLength:CustomerSheetViewModelTest.kt$CustomerSheetViewModelTest$publishableKey = "pk_test_51HvTI7Lu5o3livep6t5AgBSkMvWoTtA0nyA7pVYDqpfLkRtWun7qZTYCOHCReprfLM464yaBeF72UFfB7cY9WG4a00ZnDtiC2C"</ID>
+    <ID>MaxLineLength:DefaultCustomerSheetLoaderTest.kt$DefaultCustomerSheetLoaderTest$fun</ID>
     <ID>MaxLineLength:DefaultFlowControllerTest.kt$DefaultFlowControllerTest$fun</ID>
     <ID>MaxLineLength:DefaultPaymentSheetLoaderTest.kt$DefaultPaymentSheetLoaderTest$fun</ID>
     <ID>MaxLineLength:FlowControllerConfigurationHandlerTest.kt$FlowControllerConfigurationHandlerTest$.</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -12,6 +12,7 @@ import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.paymentsheet.state.toInternal
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.forms.resources.LpmRepository
+import com.stripe.android.utils.FeatureFlags.customerSheetACHv2
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
@@ -53,9 +54,9 @@ internal class DefaultCustomerSheetLoader @Inject constructor(
             PaymentSheet.InitializationMode.DeferredIntent(
                 PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Setup(),
-                    paymentMethodTypes = listOf(
+                    paymentMethodTypes = listOfNotNull(
                         PaymentMethod.Type.Card.code,
-                        PaymentMethod.Type.USBankAccount.code,
+                        PaymentMethod.Type.USBankAccount.code.takeIf { customerSheetACHv2.isEnabled }
                     )
                 )
             )

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -4,7 +4,6 @@ import com.stripe.android.core.injection.IS_LIVE_MODE
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.model.ElementsSession
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.requireValidOrThrow
@@ -12,7 +11,6 @@ import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.paymentsheet.state.toInternal
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.forms.resources.LpmRepository
-import com.stripe.android.utils.FeatureFlags.customerSheetACHv2
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
@@ -54,10 +52,6 @@ internal class DefaultCustomerSheetLoader @Inject constructor(
             PaymentSheet.InitializationMode.DeferredIntent(
                 PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Setup(),
-                    paymentMethodTypes = listOfNotNull(
-                        PaymentMethod.Type.Card.code,
-                        PaymentMethod.Type.USBankAccount.code.takeIf { customerSheetACHv2.isEnabled }
-                    )
                 )
             )
         ).mapCatching { elementsSession ->

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetState.kt
@@ -3,6 +3,7 @@ package com.stripe.android.customersheet
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.ui.core.forms.resources.LpmRepository
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 internal sealed interface CustomerSheetState {
@@ -12,6 +13,7 @@ internal sealed interface CustomerSheetState {
         val config: CustomerSheet.Configuration?,
         val stripeIntent: StripeIntent?,
         val customerPaymentMethods: List<PaymentMethod>,
+        val supportedPaymentMethods: List<LpmRepository.SupportedPaymentMethod>,
         val isGooglePayReady: Boolean,
         val paymentSelection: PaymentSelection?,
     ) : CustomerSheetState

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -97,8 +97,7 @@ internal class CustomerSheetViewModel @Inject constructor(
     private var supportedPaymentMethods = mutableListOf<LpmRepository.SupportedPaymentMethod>()
 
     private val card = LpmRepository.hardcodedCardSpec(
-        billingDetailsCollectionConfiguration =
-        configuration.billingDetailsCollectionConfiguration.toInternal()
+        billingDetailsCollectionConfiguration = configuration.billingDetailsCollectionConfiguration.toInternal()
     )
 
     init {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -27,7 +27,6 @@ import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResultInternal
-import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAvailable
 import com.stripe.android.payments.paymentlauncher.PaymentLauncher
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.PaymentResult
@@ -82,7 +81,6 @@ internal class CustomerSheetViewModel @Inject constructor(
     private val paymentLauncherFactory: StripePaymentLauncherAssistedFactory,
     private val intentConfirmationInterceptor: IntentConfirmationInterceptor,
     private val customerSheetLoader: CustomerSheetLoader,
-    private val isFinancialConnectionsAvailable: IsFinancialConnectionsAvailable,
 ) : ViewModel() {
 
     private val backStack = MutableStateFlow(initialBackStack)
@@ -96,23 +94,14 @@ internal class CustomerSheetViewModel @Inject constructor(
 
     private var unconfirmedPaymentMethod: PaymentMethod? = null
     private var stripeIntent: StripeIntent? = null
+    private var supportedPaymentMethods = mutableListOf<LpmRepository.SupportedPaymentMethod>()
 
     private val card = LpmRepository.hardcodedCardSpec(
         billingDetailsCollectionConfiguration =
         configuration.billingDetailsCollectionConfiguration.toInternal()
     )
-    private val usBankAccount = LpmRepository.hardCodedUsBankAccount
-
-    private val supportedPaymentMethods = listOfNotNull(
-        card,
-        usBankAccount.takeIf { isFinancialConnectionsAvailable() }
-    )
 
     init {
-        lpmRepository.initializeWithPaymentMethods(
-            supportedPaymentMethods.associateBy { it.code }
-        )
-
         configuration.appearance.parseAppearance()
 
         if (viewState.value is CustomerSheetViewState.Loading) {
@@ -260,6 +249,9 @@ internal class CustomerSheetViewModel @Inject constructor(
 
         result.fold(
             onSuccess = { state ->
+                supportedPaymentMethods.clear()
+                supportedPaymentMethods.addAll(state.supportedPaymentMethods)
+
                 savedPaymentSelection = state.paymentSelection
                 isGooglePayReadyAndEnabled = state.isGooglePayReady
                 stripeIntent = state.stripeIntent

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -14,7 +14,6 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.payments.core.injection.APP_NAME
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always
 import com.stripe.android.paymentsheet.PaymentSheet.InitializationMode.DeferredIntent
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
@@ -249,6 +248,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
                 stripeIntent = elementsSession.stripeIntent,
                 serverLpmSpecs = elementsSession.paymentMethodSpecs,
                 billingDetailsCollectionConfiguration = billingDetailsCollectionConfig,
+                isDeferred = initializationMode is DeferredIntent,
             )
 
             if (!didParseServerResponse) {
@@ -393,13 +393,12 @@ private fun PaymentMethod.toPaymentSelection(): PaymentSelection.Saved {
     return PaymentSelection.Saved(this)
 }
 
-internal fun PaymentSheet.BillingDetailsCollectionConfiguration.toInternal():
-    BillingDetailsCollectionConfiguration {
+internal fun PaymentSheet.BillingDetailsCollectionConfiguration?.toInternal(): BillingDetailsCollectionConfiguration {
     return BillingDetailsCollectionConfiguration(
-        collectName = name == Always,
-        collectEmail = email == Always,
-        collectPhone = phone == Always,
-        address = when (address) {
+        collectName = this?.name == PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+        collectEmail = this?.email == PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+        collectPhone = this?.phone == PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+        address = when (this?.address) {
             PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic -> {
                 BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
             }
@@ -409,6 +408,7 @@ internal fun PaymentSheet.BillingDetailsCollectionConfiguration.toInternal():
             PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full -> {
                 BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
             }
+            else -> BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
         },
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -1734,46 +1734,6 @@ class CustomerSheetViewModelTest {
     }
 
     @Test
-    fun `When FC SDK is not available, support payment methods should not include us bank account`() = runTest {
-        val viewModel = createViewModel(
-            isFinancialConnectionsAvailable = { false },
-            initialBackStack = listOf(
-                selectPaymentMethodViewState,
-            ),
-        )
-
-        viewModel.viewState.test {
-            assertThat(awaitItem()).isInstanceOf(SelectPaymentMethod::class.java)
-
-            viewModel.handleViewAction(CustomerSheetViewAction.OnAddCardPressed)
-
-            val viewState = awaitViewState<AddPaymentMethod>()
-            assertThat(viewState.supportedPaymentMethods.map { it.code })
-                .doesNotContain(PaymentMethod.Type.USBankAccount.code)
-        }
-    }
-
-    @Test
-    fun `When FC SDK is available, support payment methods should be included us bank account`() = runTest {
-        val viewModel = createViewModel(
-            isFinancialConnectionsAvailable = { true },
-            initialBackStack = listOf(
-                selectPaymentMethodViewState,
-            ),
-        )
-
-        viewModel.viewState.test {
-            assertThat(awaitItem()).isInstanceOf(SelectPaymentMethod::class.java)
-
-            viewModel.handleViewAction(CustomerSheetViewAction.OnAddCardPressed)
-
-            val viewState = awaitViewState<AddPaymentMethod>()
-            assertThat(viewState.supportedPaymentMethods.map { it.code })
-                .contains(PaymentMethod.Type.USBankAccount.code)
-        }
-    }
-
-    @Test
     fun `When adding a US Bank account and user taps on scrim, a confirmation dialog should be visible`() = runTest {
         val viewModel = createViewModel(
             isFinancialConnectionsAvailable = { true },

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -461,7 +461,7 @@ class DefaultCustomerSheetLoaderTest {
     }
 
     @Test
-    fun `When the FC available, flag enabled, us bank in intent, then us bank account is not available`() = runTest {
+    fun `When the FC available, flag enabled, us bank in intent, then us bank account is available`() = runTest {
         featureFlagTestRule.setEnabled(true)
 
         val loader = createCustomerSheetLoader(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -58,7 +58,7 @@ class DefaultCustomerSheetLoaderTest {
     private val unreadyGooglePayRepository = mock<GooglePayRepository>()
 
     @get:Rule
-    val featureFlagTestRule = FeatureFlagTestRule(FeatureFlags.customerSheetACHv2, isEnabled = true)
+    val featureFlagTestRule = FeatureFlagTestRule(FeatureFlags.customerSheetACHv2, isEnabled = false)
 
     @Before
     fun setup() {
@@ -79,6 +79,7 @@ class DefaultCustomerSheetLoaderTest {
 
     @Test
     fun `load with configuration should return expected result`() = runTest {
+        featureFlagTestRule.setEnabled(true)
         val elementsSessionRepository = FakeElementsSessionRepository(
             stripeIntent = STRIPE_INTENT,
             error = null,
@@ -129,7 +130,6 @@ class DefaultCustomerSheetLoaderTest {
 
     @Test
     fun `load with configuration should load elements sessions with only supported payment method types`() = runTest {
-        featureFlagTestRule.setEnabled(false)
         val elementsSessionRepository = FakeElementsSessionRepository(
             stripeIntent = STRIPE_INTENT,
             error = null,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -170,6 +170,10 @@ internal object CustomerSheetTestHelper {
         ),
         isGooglePayAvailable: Boolean = true,
         customerPaymentMethods: List<PaymentMethod> = listOf(CARD_PAYMENT_METHOD),
+        supportedPaymentMethods: List<LpmRepository.SupportedPaymentMethod> = listOf(
+            LpmRepository.HardcodedCard,
+            LpmRepository.hardCodedUsBankAccount,
+        ),
         savedPaymentSelection: PaymentSelection? = null,
         stripeRepository: StripeRepository = FakeStripeRepository(),
         paymentConfiguration: PaymentConfiguration = PaymentConfiguration(
@@ -190,6 +194,7 @@ internal object CustomerSheetTestHelper {
         ),
         customerSheetLoader: CustomerSheetLoader = FakeCustomerSheetLoader(
             customerPaymentMethods = customerPaymentMethods,
+            supportedPaymentMethods = supportedPaymentMethods,
             paymentSelection = savedPaymentSelection,
             isGooglePayAvailable = isGooglePayAvailable,
         ),
@@ -223,7 +228,6 @@ internal object CustomerSheetTestHelper {
             statusBarColor = { null },
             eventReporter = eventReporter,
             customerSheetLoader = customerSheetLoader,
-            isFinancialConnectionsAvailable = isFinancialConnectionsAvailable
         ).apply {
             registerFromActivity(DummyActivityResultCaller(), TestLifecycleOwner())
         }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
@@ -8,6 +8,7 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.ui.core.forms.resources.LpmRepository
 import kotlinx.coroutines.delay
 import kotlin.time.Duration
 
@@ -16,6 +17,10 @@ internal class FakeCustomerSheetLoader(
     private val stripeIntent: StripeIntent = PaymentIntentFixtures.PI_SUCCEEDED,
     private val shouldFail: Boolean = false,
     private val customerPaymentMethods: List<PaymentMethod> = emptyList(),
+    private val supportedPaymentMethods: List<LpmRepository.SupportedPaymentMethod> = listOf(
+        LpmRepository.HardcodedCard,
+        LpmRepository.hardCodedUsBankAccount,
+    ),
     private val paymentSelection: PaymentSelection? = null,
     private val isGooglePayAvailable: Boolean = false,
     private val delay: Duration = Duration.ZERO,
@@ -30,6 +35,7 @@ internal class FakeCustomerSheetLoader(
                 CustomerSheetState.Full(
                     config = configuration,
                     stripeIntent = stripeIntent,
+                    supportedPaymentMethods = supportedPaymentMethods,
                     customerPaymentMethods = customerPaymentMethods,
                     isGooglePayReady = isGooglePayAvailable,
                     paymentSelection = paymentSelection,

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
@@ -11,9 +11,12 @@ internal class FakeElementsSessionRepository(
     private val linkSettings: ElementsSession.LinkSettings?,
 ) : ElementsSessionRepository {
 
+    var lastGetParam: PaymentSheet.InitializationMode? = null
+
     override suspend fun get(
         initializationMode: PaymentSheet.InitializationMode,
     ): Result<ElementsSession> {
+        lastGetParam = initializationMode
         return if (error != null) {
             Result.failure(error)
         } else {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Don't send `us_bank_account` to elements/sessions when we shouldn't.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
ir-conductor-inform

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
