### PR TITLE
[Identity] Fix dark mode test screen text color

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/ui/DebugScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/DebugScreen.kt
@@ -43,7 +43,6 @@ import com.stripe.android.identity.ui.CompleteOption.FAILURE_ASYNC
 import com.stripe.android.identity.ui.CompleteOption.SUCCESS
 import com.stripe.android.identity.ui.CompleteOption.SUCCESS_ASYNC
 import com.stripe.android.identity.viewmodel.IdentityViewModel
-import com.stripe.android.uicore.text.Html
 import kotlinx.coroutines.launch
 
 /**
@@ -170,8 +169,8 @@ internal fun CompleteWithTestDataSection(
         text = stringResource(id = R.string.stripe_complete_with_test_data),
         style = MaterialTheme.typography.h4
     )
-    Html(
-        html = stringResource(id = R.string.stripe_complete_with_test_data_details),
+    Text(
+        text = stringResource(id = R.string.stripe_complete_with_test_data_details),
         modifier = Modifier.padding(vertical = 8.dp)
     )
     CompleteOptionRow(
@@ -234,8 +233,8 @@ private fun FinishMobileFlowWithResultSection(
         text = stringResource(id = R.string.stripe_finish_mobile_flow),
         style = MaterialTheme.typography.h4
     )
-    Html(
-        html = stringResource(id = R.string.stripe_finish_mobile_flow_details),
+    Text(
+        text = stringResource(id = R.string.stripe_finish_mobile_flow_details),
         modifier = Modifier.padding(vertical = 8.dp)
     )
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use `Text` instead of `Html` to get the correct dark mode color

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
UX improvement

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![before](https://github.com/stripe/stripe-android/assets/79880926/eb108b0c-d9f6-4087-ba59-568f0f4abf64)  | ![after](https://github.com/stripe/stripe-android/assets/79880926/7bea99d7-fb87-4aa4-9fe8-ac27832fb811) |







# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
