### PR TITLE
[Network] Expand HTTP retry mechanism in stripe-android SDK to include transport errors


### DIFF
--- a/stripe-core/src/main/java/com/stripe/android/core/networking/ConnectionFactory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/ConnectionFactory.kt
@@ -92,7 +92,7 @@ interface ConnectionFactory {
     }
 
     private companion object {
-        private val CONNECT_TIMEOUT = TimeUnit.SECONDS.toMillis(30).toInt()
+        private val CONNECT_TIMEOUT = 1 // TODO revert.
         private val READ_TIMEOUT = TimeUnit.SECONDS.toMillis(80).toInt()
     }
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/RetryInterceptor.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/RetryInterceptor.kt
@@ -1,0 +1,24 @@
+package com.stripe.android.core.networking
+
+import androidx.annotation.RestrictTo
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class RetryInterceptor {
+
+    /**
+     * @param request the [StripeRequest] that was made
+     * @param result the [Result] of the request.
+     *  - If the request was successful, this will be the [StripeResponse] that was returned
+     *  - If the request failed, this will be the [Exception] that was thrown
+     * @return `true` if the request can be retried, `false` otherwise
+     */
+    fun <BodyType> shouldRetry(
+        request: StripeRequest,
+        result: Result<StripeResponse<BodyType>>
+    ): Boolean = result.fold(
+        onSuccess = { request.retryResponseCodes.contains(it.code) },
+        onFailure = { it is SocketTimeoutException || it is ConnectException }
+    )
+}


### PR DESCRIPTION
# Summary

**Problem**: The only retry logic we contemplate in our network layer just considerates http result codes that are retriable. If a request fails, there's no implemented default retry policy across SDK.

**Solution**:

- Adds a `requestInterceptor` configurable component that allows to specify a retry policy for both succeeded and failed network calls
- By default, **includes `SocketTimeout` and `Connect` network errors as retriable**. 

# Motivation
:notebook_with_decorative_cover: &nbsp;**[🧵] Expand HTTP retry mechanism in stripe-android SDK to include transport errors and consider connection pooling**
:globe_with_meridians: &nbsp;[BANKCON-8324](https://jira.corp.stripe.com/browse/BANKCON-8324)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->