### PR TITLE
Add missing bottom sheet animation

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -4,6 +4,8 @@ package com.stripe.android.paymentsheet.ui
 
 import androidx.annotation.RestrictTo
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
@@ -100,10 +102,12 @@ internal fun PaymentSheetScreenContent(
             )
         }
 
-        currentScreen.Content(
-            viewModel = viewModel,
-            modifier = Modifier.padding(bottom = 8.dp),
-        )
+        Box(modifier = Modifier.animateContentSize()) {
+            currentScreen.Content(
+                viewModel = viewModel,
+                modifier = Modifier.padding(bottom = 8.dp),
+            )
+        }
 
         if (mandateText?.showAbovePrimaryButton == true) {
             Mandate(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds a missing animation to the bottom sheet, making sure we animate the content size when navigating back to the SPM screen.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screen recordings

<details><summary>Before</summary>
<p>

[without_animation.webm](https://github.com/stripe/stripe-android/assets/110940675/5deb31a6-be19-4d21-a08f-6ab075b7d01a)

</p>
</details>

<details><summary>After</summary>
<p>

[with_animation.webm](https://github.com/stripe/stripe-android/assets/110940675/d5e9af20-bc1b-454d-a40b-632f77a910af)

</p>
</details>

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
