### PR TITLE
Filter CustomerSheet saved payment methods the same as we filter payment sheet payment methods.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -11,7 +11,6 @@ import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethod.Type.Link
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.payments.core.injection.APP_NAME
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.InitializationMode.DeferredIntent
@@ -216,23 +215,11 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             PaymentMethod.Type.fromCode(it.code)
         }
 
-        val walletTypesToRemove = setOf(Wallet.Type.ApplePay, Wallet.Type.GooglePay, Wallet.Type.SamsungPay)
-
         val paymentMethods = customerRepository.getPaymentMethods(
             customerConfig = customerConfig,
-            types = paymentMethodTypes.filter { paymentMethodType ->
-                paymentMethodType in setOf(
-                    PaymentMethod.Type.Card,
-                    PaymentMethod.Type.USBankAccount,
-                    PaymentMethod.Type.SepaDebit,
-                )
-            },
+            types = paymentMethodTypes,
             silentlyFail = true,
-        ).getOrDefault(emptyList()).filter { paymentMethod ->
-            val isCardWithWallet = paymentMethod.type == PaymentMethod.Type.Card &&
-                walletTypesToRemove.contains(paymentMethod.card?.wallet?.walletType)
-            !isCardWithWallet
-        }
+        ).getOrDefault(emptyList())
 
         return paymentMethods.filter { paymentMethod ->
             paymentMethod.hasExpectedDetails()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
@@ -7,6 +7,7 @@ import com.stripe.android.core.Logger
 import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -62,6 +63,80 @@ internal class CustomerRepositoryTest {
                 productUsageTokens = any(),
                 requestOptions = any()
             )
+        }
+
+    // PayPal isn't supported as a saved payment method due to issues with on-session.
+    // See: https://docs.google.com/document/d/1_bCPJXxhV4Kdgy7LX7HPwpZfElN3a2DcYUooiWC9SgM
+    @Test
+    fun `getPaymentMethods() should filter unsupported payment method types`() =
+        runTest {
+            givenGetPaymentMethodsReturns(
+                Result.success(emptyList())
+            )
+
+            repository.getPaymentMethods(
+                PaymentSheet.CustomerConfiguration(
+                    "customer_id",
+                    "ephemeral_key"
+                ),
+                listOf(PaymentMethod.Type.Card, PaymentMethod.Type.PayPal),
+                true,
+            )
+
+            verify(stripeRepository).getPaymentMethods(
+                listPaymentMethodsParams = eq(
+                    ListPaymentMethodsParams(
+                        customerId = "customer_id",
+                        paymentMethodType = PaymentMethod.Type.Card
+                    )
+                ),
+                productUsageTokens = any(),
+                requestOptions = any()
+            )
+        }
+
+    @Test
+    fun `getPaymentMethods() should filter cards attached to wallets`() =
+        runTest {
+            givenGetPaymentMethodsReturns(
+                Result.success(emptyList())
+            )
+
+            val mockedReturnPaymentMethods = listOf(
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
+                    card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "filtered").card?.copy(
+                        wallet = Wallet.GooglePayWallet("3000")
+                    )
+                )
+            )
+
+            stripeRepository.stub {
+                onBlocking {
+                    getPaymentMethods(
+                        listPaymentMethodsParams = eq(
+                            ListPaymentMethodsParams(
+                                customerId = "customer_id",
+                                paymentMethodType = PaymentMethod.Type.Card
+                            )
+                        ),
+                        productUsageTokens = any(),
+                        requestOptions = any()
+                    )
+                }.thenReturn(Result.success(mockedReturnPaymentMethods))
+            }
+
+            val result = repository.getPaymentMethods(
+                PaymentSheet.CustomerConfiguration(
+                    "customer_id",
+                    "ephemeral_key"
+                ),
+                listOf(PaymentMethod.Type.Card),
+                true,
+            ).getOrThrow()
+
+            assertThat(result).hasSize(1)
+            assertThat(result[0].id).isEqualTo("pm_123456789")
         }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We want to filter customersheet and paymentsheet for cards attached to wallets.
