### PR TITLE
Use separate token for updating Lokalise translations

### DIFF
--- a/.github/workflows/fetch_translations.yml
+++ b/.github/workflows/fetch_translations.yml
@@ -22,6 +22,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         id: create-pull-request
         with:
+          token: ${{ secrets.LOKALISE_CREATE_PR_TOKEN }}
           commit-message: Fetch latest Lokalize translations
           title: Update translations
           body: This pull request contains the latest translations from Lokalize.


### PR DESCRIPTION
# Summary
Uses separate token secret for updating Lokalise translations

# Motivation
Doing this allows for the workflow-triggered translation PRs to also run the end-to-end test workflows and any other workflows we may attach to translation PRs in the future.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified