### PR TITLE
Fix fetching us bank accounts

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
@@ -9,7 +9,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
-import com.stripe.android.utils.FeatureFlags.customerSheetACHv2
 import kotlinx.coroutines.withContext
 import java.io.IOException
 import javax.inject.Inject
@@ -50,13 +49,9 @@ internal class StripeCustomerAdapter @Inject constructor(
                     id = customerEphemeralKey.customerId,
                     ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 ),
-                types = listOfNotNull(
+                types = listOf(
                     PaymentMethod.Type.Card,
-                    if (customerSheetACHv2.isEnabled) {
-                        PaymentMethod.Type.USBankAccount
-                    } else {
-                        null
-                    },
+                    PaymentMethod.Type.USBankAccount,
                 ),
                 silentlyFail = false,
             ).getOrElse {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -151,25 +151,7 @@ class CustomerAdapterTest {
     }
 
     @Test
-    fun `When CustomerSheetACHV2Flag is disabled, retrievePaymentMethods does not request US Bank Account payment methods`() = runTest {
-        featureFlagTestRule.setEnabled(false)
-        val customerRepository = mock<CustomerRepository>()
-
-        val adapter = createAdapter(
-            customerRepository = customerRepository
-        )
-
-        adapter.retrievePaymentMethods()
-
-        verify(customerRepository).getPaymentMethods(
-            customerConfig = any(),
-            types = eq(listOf(PaymentMethod.Type.Card)),
-            silentlyFail = eq(false),
-        )
-    }
-
-    @Test
-    fun `When CustomerSheetACHV2Flag is enabled, retrievePaymentMethods requests US Bank Account payment methods`() = runTest {
+    fun `retrievePaymentMethods requests US Bank Account payment methods`() = runTest {
         val customerRepository = mock<CustomerRepository>()
 
         val adapter = createAdapter(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Fix fetching us bank accounts when the feature flag is disabled. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

StripeCustomerAdapter should always fetch us bank accounts regardless of feature flag.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

