### PR TITLE
Add support for unverified us bank accounts

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
@@ -1,9 +1,11 @@
 package com.stripe.android.customersheet
 
 import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResultInternal
+import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAvailable
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
@@ -31,10 +33,15 @@ internal sealed class CustomerSheetViewState(
             isEditing = isEditing,
         )
 
-    val shouldDisplayDismissConfirmationModal: Boolean
-        get() = this is AddPaymentMethod &&
+    fun shouldDisplayDismissConfirmationModal(
+        isFinancialConnectionsAvailable: IsFinancialConnectionsAvailable,
+    ): Boolean {
+        return this is AddPaymentMethod &&
             paymentMethodCode == PaymentMethod.Type.USBankAccount.code &&
-            bankAccountResult is CollectBankAccountResultInternal.Completed
+            isFinancialConnectionsAvailable() &&
+            bankAccountResult is CollectBankAccountResultInternal.Completed &&
+            bankAccountResult.response.financialConnectionsSession.paymentAccount is FinancialConnectionsAccount
+    }
 
     data class Loading(
         override val isLiveMode: Boolean,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/util/PaymentMethodKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/util/PaymentMethodKtx.kt
@@ -1,0 +1,7 @@
+package com.stripe.android.customersheet.util
+
+import com.stripe.android.model.PaymentMethod
+
+internal fun PaymentMethod.isUnverifiedUSBankAccount(): Boolean {
+    return type == PaymentMethod.Type.USBankAccount && usBankAccount?.linkedAccount == null
+}

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -16,10 +16,15 @@ import com.stripe.android.customersheet.utils.CustomerSheetTestHelper.addPayment
 import com.stripe.android.customersheet.utils.CustomerSheetTestHelper.createViewModel
 import com.stripe.android.customersheet.utils.CustomerSheetTestHelper.selectPaymentMethodViewState
 import com.stripe.android.customersheet.utils.FakeCustomerSheetLoader
+import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
+import com.stripe.android.financialconnections.model.FinancialConnectionsSession
+import com.stripe.android.financialconnections.model.PaymentAccount
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
 import com.stripe.android.model.PaymentMethodFixtures.US_BANK_ACCOUNT
+import com.stripe.android.model.PaymentMethodFixtures.US_BANK_ACCOUNT_VERIFIED
 import com.stripe.android.model.SetupIntentFixtures
+import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResponseInternal
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResultInternal
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.forms.FormFieldValues
@@ -39,6 +44,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertFailsWith
 import com.stripe.android.ui.core.R as UiCoreR
@@ -1675,7 +1681,7 @@ class CustomerSheetViewModelTest {
                 addPaymentMethodViewState,
             ),
             stripeRepository = FakeStripeRepository(
-                createPaymentMethodResult = Result.success(US_BANK_ACCOUNT),
+                createPaymentMethodResult = Result.success(US_BANK_ACCOUNT_VERIFIED),
                 retrieveSetupIntent = Result.success(SetupIntentFixtures.SI_SUCCEEDED),
             ),
             customerAdapter = FakeCustomerAdapter(
@@ -1701,7 +1707,7 @@ class CustomerSheetViewModelTest {
 
             assertThat(viewState.paymentSelection)
                 .isEqualTo(
-                    PaymentSelection.Saved(US_BANK_ACCOUNT)
+                    PaymentSelection.Saved(US_BANK_ACCOUNT_VERIFIED)
                 )
 
             cancelAndIgnoreRemainingEvents()
@@ -1751,13 +1757,13 @@ class CustomerSheetViewModelTest {
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnCollectBankAccountResult(
-                    bankAccountResult = CollectBankAccountResultInternal.Completed(
-                        response = mock(),
+                    bankAccountResult = mockUSBankAccountResult(
+                        isVerified = true
                     ),
                 )
             )
 
-            viewState = awaitViewState<AddPaymentMethod>()
+            viewState = awaitViewState()
             assertThat(viewState.displayDismissConfirmationModal)
                 .isFalse()
 
@@ -1821,8 +1827,8 @@ class CustomerSheetViewModelTest {
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnCollectBankAccountResult(
-                    bankAccountResult = CollectBankAccountResultInternal.Completed(
-                        response = mock(),
+                    bankAccountResult = mockUSBankAccountResult(
+                        isVerified = true
                     ),
                 )
             )
@@ -1869,13 +1875,13 @@ class CustomerSheetViewModelTest {
 
         viewModel.handleViewAction(
             CustomerSheetViewAction.OnCollectBankAccountResult(
-                bankAccountResult = CollectBankAccountResultInternal.Completed(
-                    response = mock(),
+                bankAccountResult = mockUSBankAccountResult(
+                    isVerified = true
                 ),
             )
         )
 
-        viewState = viewStateTurbine.awaitViewState<AddPaymentMethod>()
+        viewState = viewStateTurbine.awaitViewState()
         assertThat(viewState.displayDismissConfirmationModal)
             .isFalse()
 
@@ -1907,8 +1913,8 @@ class CustomerSheetViewModelTest {
             initialBackStack = listOf(
                 addPaymentMethodViewState.copy(
                     paymentMethodCode = PaymentMethod.Type.USBankAccount.code,
-                    bankAccountResult = CollectBankAccountResultInternal.Completed(
-                        response = mock(),
+                    bankAccountResult = mockUSBankAccountResult(
+                        isVerified = true
                     ),
                 ),
             ),
@@ -1916,8 +1922,59 @@ class CustomerSheetViewModelTest {
 
         viewModel.viewState.test {
             val viewState = awaitViewState<AddPaymentMethod>()
-            assertThat(viewState.shouldDisplayDismissConfirmationModal)
-                .isTrue()
+            assertThat(
+                viewState.shouldDisplayDismissConfirmationModal(
+                    isFinancialConnectionsAvailable = { true }
+                )
+            ).isTrue()
+        }
+    }
+
+    @Test
+    fun `When in add flow and unverified us bank account is retrieved, then shouldDisplayConfirmationDialog should be false`() = runTest {
+        val viewModel = createViewModel(
+            isFinancialConnectionsAvailable = { true },
+            initialBackStack = listOf(
+                addPaymentMethodViewState.copy(
+                    paymentMethodCode = PaymentMethod.Type.USBankAccount.code,
+                    bankAccountResult = mockUSBankAccountResult(
+                        isVerified = false
+                    ),
+                ),
+            ),
+        )
+
+        viewModel.viewState.test {
+            val viewState = awaitViewState<AddPaymentMethod>()
+            assertThat(
+                viewState.shouldDisplayDismissConfirmationModal(
+                    isFinancialConnectionsAvailable = { true }
+                )
+            ).isFalse()
+        }
+    }
+
+    @Test
+    fun `When financial connections is not available, then shouldDisplayConfirmationDialog should be false`() = runTest {
+        val viewModel = createViewModel(
+            isFinancialConnectionsAvailable = { true },
+            initialBackStack = listOf(
+                addPaymentMethodViewState.copy(
+                    paymentMethodCode = PaymentMethod.Type.USBankAccount.code,
+                    bankAccountResult = mockUSBankAccountResult(
+                        isVerified = false
+                    ),
+                ),
+            ),
+        )
+
+        viewModel.viewState.test {
+            val viewState = awaitViewState<AddPaymentMethod>()
+            assertThat(
+                viewState.shouldDisplayDismissConfirmationModal(
+                    isFinancialConnectionsAvailable = { false }
+                )
+            ).isFalse()
         }
     }
 
@@ -2198,6 +2255,85 @@ class CustomerSheetViewModelTest {
             val newViewState = awaitViewState<AddPaymentMethod>()
             assertThat(newViewState.formViewData.completeFormValues).isNull()
         }
+    }
+
+    @Test
+    fun `When attaching a non-verified bank account, the sheet closes and returns the account`() = runTest {
+        val usBankAccount = PaymentSelection.New.USBankAccount(
+            labelResource = "Test",
+            iconResource = 0,
+            paymentMethodCreateParams = mock(),
+            customerRequestedSave = mock(),
+            input = PaymentSelection.New.USBankAccount.Input(
+                name = "",
+                email = null,
+                phone = null,
+                address = null,
+                saveForFutureUse = false,
+            ),
+            screenState = USBankAccountFormScreenState.SavedAccount(
+                financialConnectionsSessionId = "session_1234",
+                intentId = "intent_1234",
+                bankName = "Stripe Bank",
+                last4 = "6789",
+                primaryButtonText = "Continue",
+                mandateText = null,
+            ),
+        )
+        val viewModel = createViewModel(
+            initialBackStack = listOf(
+                addPaymentMethodViewState,
+            ),
+            stripeRepository = FakeStripeRepository(
+                createPaymentMethodResult = Result.success(US_BANK_ACCOUNT),
+                retrieveSetupIntent = Result.success(SetupIntentFixtures.SI_SUCCEEDED),
+            ),
+            customerAdapter = FakeCustomerAdapter(
+                onSetupIntentClientSecretForCustomerAttach = {
+                    CustomerAdapter.Result.success("seti_123")
+                },
+                canCreateSetupIntents = true,
+            ),
+        )
+
+        viewModel.result.test {
+            assertThat(awaitItem())
+                .isNull()
+            viewModel.handleViewAction(
+                CustomerSheetViewAction.OnConfirmUSBankAccount(usBankAccount)
+            )
+
+            viewModel.handleViewAction(
+                CustomerSheetViewAction.OnPrimaryButtonPressed
+            )
+
+            assertThat(awaitItem())
+                .isEqualTo(
+                    InternalCustomerSheetResult.Selected(
+                        PaymentSelection.Saved(US_BANK_ACCOUNT)
+                    )
+                )
+        }
+    }
+
+    private fun mockUSBankAccountResult(
+        isVerified: Boolean
+    ): CollectBankAccountResultInternal.Completed {
+        val paymentAccount = mock<PaymentAccount>()
+        val financialConnectionsAccount = mock<FinancialConnectionsAccount>()
+        val financialConnectionsSession = mock<FinancialConnectionsSession>()
+        val bankAccountResponse = mock<CollectBankAccountResponseInternal>()
+        whenever(bankAccountResponse.financialConnectionsSession).thenReturn(financialConnectionsSession)
+        whenever(financialConnectionsSession.paymentAccount).thenReturn(
+            if (isVerified) {
+                financialConnectionsAccount
+            } else {
+                paymentAccount
+            }
+        )
+        return CollectBankAccountResultInternal.Completed(
+            response = bankAccountResponse,
+        )
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -229,6 +229,7 @@ internal object CustomerSheetTestHelper {
             statusBarColor = { null },
             eventReporter = eventReporter,
             customerSheetLoader = customerSheetLoader,
+            isFinancialConnectionsAvailable = isFinancialConnectionsAvailable,
         ).apply {
             registerFromActivity(DummyActivityResultCaller(), TestLifecycleOwner())
         }

--- a/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
@@ -301,6 +301,44 @@ internal object PaymentMethodFixtures {
 
     val AU_BECS_DEBIT = PaymentMethodJsonParser().parse(AU_BECS_DEBIT_JSON)
 
+    val US_BANK_ACCOUNT_VERIFIED_JSON = JSONObject(
+        """
+        {
+            "id": "pm_1Kr4seLu5o3P18ZperrPnk39",
+            "object": "payment_method",
+            "us_bank_account": {
+                "account_holder_type": "individual",
+                "account_type": "checking",
+                "bank_name": "STRIPE TEST BANK",
+                "fingerprint": "FFDMA0xfhBjWSZLu",
+                "last4": "6789",
+                "routing_number": "110000000",
+                "linked_account": "la_account_123"
+            },
+            "billing_details": {
+                "address": {
+                    "city": null,
+                    "country": null,
+                    "line1": null,
+                    "line2": null,
+                    "postal_code": null,
+                    "state": null
+                },
+                "email": "jenny.rosen@example.com",
+                "name": "Jenny Rosen",
+                "phone": null
+            },
+            "created": 1583356750,
+            "customer": null,
+            "livemode": false,
+            "metadata": null,
+            "type": "us_bank_account"
+        }
+        """.trimIndent()
+    )
+
+    val US_BANK_ACCOUNT_VERIFIED = PaymentMethodJsonParser().parse(US_BANK_ACCOUNT_VERIFIED_JSON)
+
     val US_BANK_ACCOUNT_JSON = JSONObject(
         """
         {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Add support for unverified us bank accounts. Whenever a user attempts to attach a us bank account through the microdesposits flow, CustomerSheet should return the payment method and close the sheet immediately.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
