### PR TITLE
Fix form not resetting after confirming bank account

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -254,6 +254,10 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         get() = savedStateHandle.get<Boolean>(HAS_LAUNCHED_KEY) == true
         set(value) = savedStateHandle.set(HAS_LAUNCHED_KEY, value)
 
+    private var shouldReset: Boolean
+        get() = savedStateHandle.get<Boolean>(SHOULD_RESET_KEY) == true
+        set(value) = savedStateHandle.set(SHOULD_RESET_KEY, value)
+
     fun register(activityResultRegistryOwner: ActivityResultRegistryOwner) {
         collectBankAccountLauncher = CollectBankAccountLauncher.create(
             activityResultRegistryOwner = activityResultRegistryOwner,
@@ -342,6 +346,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
 
     fun reset(@StringRes error: Int? = null) {
         hasLaunched = false
+        shouldReset = false
         saveForFutureUseElement.controller.onValueChange(true)
         _collectBankAccountResult.tryEmit(null)
         _currentScreenState.update {
@@ -356,6 +361,9 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
     }
 
     fun onDestroy() {
+        if (shouldReset) {
+            reset()
+        }
         _result.tryEmit(null)
         _collectBankAccountResult.tryEmit(null)
         collectBankAccountLauncher?.unregister()
@@ -452,6 +460,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         )
 
         _result.tryEmit(paymentSelection)
+        shouldReset = true
     }
 
     private fun createNewPaymentSelection(
@@ -555,6 +564,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
 
     private companion object {
         private const val HAS_LAUNCHED_KEY = "has_launched"
+        private const val SHOULD_RESET_KEY = "should_reset"
     }
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -913,6 +913,50 @@ class USBankAccountFormViewModelTest {
         }
     }
 
+    @Test
+    fun `Should be reset after confirming bank account and attempting to reset`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.currentScreenState.test {
+            assertThat(awaitItem())
+                .isInstanceOf(USBankAccountFormScreenState.BillingDetailsCollection::class.java)
+
+            val verifiedAccount = mockVerifiedBankAccount()
+            viewModel.handleCollectBankAccountResult(
+                result = verifiedAccount
+            )
+
+            assertThat(awaitItem())
+                .isInstanceOf(USBankAccountFormScreenState.MandateCollection::class.java)
+
+            viewModel.handlePrimaryButtonClick(viewModel.currentScreenState.value)
+            viewModel.reset()
+
+            assertThat(awaitItem())
+                .isInstanceOf(USBankAccountFormScreenState.BillingDetailsCollection::class.java)
+        }
+    }
+
+    @Test
+    fun `Should not be reset after attempting to reset on the billing details screen`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.currentScreenState.test {
+            assertThat(awaitItem())
+                .isInstanceOf(USBankAccountFormScreenState.BillingDetailsCollection::class.java)
+
+            viewModel.handlePrimaryButtonClick(viewModel.currentScreenState.value)
+
+            assertThat(awaitItem())
+                .isInstanceOf(USBankAccountFormScreenState.BillingDetailsCollection::class.java)
+
+            viewModel.reset()
+
+            assertThat(awaitItem())
+                .isInstanceOf(USBankAccountFormScreenState.BillingDetailsCollection::class.java)
+        }
+    }
+
     private fun createViewModel(
         args: USBankAccountFormViewModel.Args = defaultArgs
     ): USBankAccountFormViewModel {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Fix form not resetting after confirming bank account

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

When a user adds a bank account in CustomerSheet and tries to add another payment method, the bank account form is not being reset.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

