### PR TITLE
Refactor payment element

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
@@ -26,6 +27,7 @@ import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFo
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.uicore.image.StripeImageLoader
 import kotlinx.coroutines.flow.Flow
+import java.util.UUID
 import javax.inject.Provider
 
 @Composable
@@ -43,6 +45,10 @@ internal fun PaymentElement(
     usBankAccountFormArguments: USBankAccountFormArguments,
     onFormFieldValuesChanged: (FormFieldValues?) -> Unit,
 ) {
+    // The PaymentMethodForm has a reference to a FormViewModel, which is scoped to a key. This is to ensure that
+    // the FormViewModel is recreated when the PaymentElement is recomposed.
+    val uuid = rememberSaveable { UUID.randomUUID().toString() }
+
     val context = LocalContext.current
     val imageLoader = remember {
         StripeImageLoader(context.applicationContext)
@@ -73,6 +79,7 @@ internal fun PaymentElement(
                 )
             } else {
                 PaymentMethodForm(
+                    uuid = uuid,
                     args = formArguments,
                     enabled = enabled,
                     onFormFieldValuesChanged = onFormFieldValuesChanged,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
@@ -19,6 +19,7 @@ import javax.inject.Provider
 
 @Composable
 internal fun PaymentMethodForm(
+    uuid: String,
     args: FormArguments,
     enabled: Boolean,
     onFormFieldValuesChanged: (FormFieldValues?) -> Unit,
@@ -27,7 +28,7 @@ internal fun PaymentMethodForm(
     modifier: Modifier = Modifier,
 ) {
     val formViewModel: FormViewModel = viewModel(
-        key = args.paymentMethodCode,
+        key = args.paymentMethodCode + "_" + uuid,
         factory = FormViewModel.Factory(
             config = args,
             showCheckboxFlow = showCheckboxFlow,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Refactor PaymentMethodForm to use unique keys in cases where the activity does not get destroyed (e.g. in CustomerSheet's case)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

The FormViewModel cannot be reset, so the complete form values were being persisted when they should be cleared. Found during testing CustomerSheet. When you attach a card to a customer, then try to add another card, the form values are still present. It should be cleared instead.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

