### PR TITLE
Update to compile SDK 34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+Dependencies updated:
+* [7603](https://github.com/stripe/stripe-android/pull/7603) Bumped compile SDK from 33 to 34.
+
 ## 20.36.1 - 2024-01-08
 
 ### Identity

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ allprojects {
 }
 
 ext {
-    compileSdkVersion = 33
+    compileSdkVersion = 34
 
     group_name = GROUP
     version_name = VERSION_NAME

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/screenshottests/FinancialConnectionsShotShowkaseScreenshotTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/screenshottests/FinancialConnectionsShotShowkaseScreenshotTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalInspectionMode
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
+import app.cash.paparazzi.detectEnvironment
 import com.airbnb.android.showkase.models.Showkase
 import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
 import com.google.testing.junit.testparameterinjector.TestParameter
@@ -34,7 +35,11 @@ class PaparazziSampleScreenshotTest {
     }
 
     @get:Rule
-    val paparazzi = Paparazzi()
+    val paparazzi = Paparazzi(
+        environment = detectEnvironment().run {
+            copy(compileSdkVersion = 33, platformDir = platformDir.replace("34", "33"))
+        },
+    )
 
     @Test
     fun preview_tests(

--- a/payments-core/detekt-baseline.xml
+++ b/payments-core/detekt-baseline.xml
@@ -56,6 +56,7 @@
     <ID>LongMethod:Stripe3ds2TransactionActivity.kt$Stripe3ds2TransactionActivity$public override fun onCreate(savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:StripeApiRepositoryTest.kt$StripeApiRepositoryTest$@Test fun getPaymentMethods_whenPopulated_returnsExpectedList()</ID>
     <ID>LongMethod:WebIntentAuthenticator.kt$WebIntentAuthenticator$override suspend fun performAuthentication( host: AuthActivityStarterHost, authenticatable: StripeIntent, requestOptions: ApiRequest.Options )</ID>
+    <ID>MagicNumber:AnimationConstants.kt$34</ID>
     <ID>MagicNumber:BecsDebitBsbEditText.kt$BecsDebitBsbEditText$3</ID>
     <ID>MagicNumber:BecsDebitBsbEditText.kt$BecsDebitBsbEditText.&lt;no name provided>$4</ID>
     <ID>MagicNumber:BecsDebitWidget.kt$BecsDebitWidget$4</ID>

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
@@ -12,7 +12,7 @@ import com.google.android.gms.wallet.AutoResolveHelper
 import com.google.android.gms.wallet.PaymentData
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.utils.AnimationConstants
+import com.stripe.android.utils.fadeOut
 import com.stripe.android.view.AuthActivityStarterHost
 import kotlinx.coroutines.launch
 import org.json.JSONObject
@@ -42,8 +42,6 @@ internal class GooglePayLauncherActivity : AppCompatActivity() {
     @SuppressLint("SourceLockedOrientationActivity")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        setFadeAnimations()
 
         args = runCatching {
             requireNotNull(GooglePayLauncherContract.Args.fromIntent(intent)) {
@@ -81,7 +79,7 @@ internal class GooglePayLauncherActivity : AppCompatActivity() {
 
     override fun finish() {
         super.finish()
-        setFadeAnimations()
+        fadeOut()
     }
 
     private fun payWithGoogle(task: Task<PaymentData>) {
@@ -169,10 +167,6 @@ internal class GooglePayLauncherActivity : AppCompatActivity() {
                 )
         )
         finish()
-    }
-
-    private fun setFadeAnimations() {
-        overridePendingTransition(AnimationConstants.FADE_IN, AnimationConstants.FADE_OUT)
     }
 
     private companion object {

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherActivity.kt
@@ -11,7 +11,7 @@ import com.google.android.gms.tasks.Task
 import com.google.android.gms.wallet.AutoResolveHelper
 import com.google.android.gms.wallet.PaymentData
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.utils.AnimationConstants
+import com.stripe.android.utils.fadeOut
 import kotlinx.coroutines.launch
 
 /**
@@ -169,7 +169,7 @@ internal class GooglePayPaymentMethodLauncherActivity : AppCompatActivity() {
     }
 
     private fun setFadeAnimations() {
-        overridePendingTransition(AnimationConstants.FADE_IN, AnimationConstants.FADE_OUT)
+        fadeOut()
     }
 
     private fun googlePayStatusCodeToErrorCode(googlePayStatusCode: Int):

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
@@ -10,7 +10,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
-import com.stripe.android.utils.AnimationConstants
+import com.stripe.android.utils.fadeOut
 import com.stripe.android.view.AuthActivityStarterHost
 import kotlinx.coroutines.launch
 
@@ -35,8 +35,6 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
     @SuppressLint("SourceLockedOrientationActivity")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        setFadeAnimations()
 
         val args = runCatching {
             requireNotNull(starterArgs) {
@@ -82,11 +80,7 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
 
     override fun finish() {
         super.finish()
-        setFadeAnimations()
-    }
-
-    private fun setFadeAnimations() {
-        overridePendingTransition(AnimationConstants.FADE_IN, AnimationConstants.FADE_OUT)
+        fadeOut()
     }
 
     /**

--- a/payments-core/src/main/java/com/stripe/android/utils/AnimationConstants.kt
+++ b/payments-core/src/main/java/com/stripe/android/utils/AnimationConstants.kt
@@ -1,8 +1,15 @@
+@file:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+
 package com.stripe.android.utils
 
+import android.app.Activity
+import android.app.Activity.OVERRIDE_TRANSITION_CLOSE
+import android.os.Build
 import androidx.annotation.AnimRes
 import androidx.annotation.RestrictTo
 import com.stripe.android.R
+import com.stripe.android.utils.AnimationConstants.FADE_IN
+import com.stripe.android.utils.AnimationConstants.FADE_OUT
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object AnimationConstants {
@@ -11,4 +18,14 @@ object AnimationConstants {
 
     @AnimRes
     val FADE_OUT = R.anim.stripe_paymentsheet_transition_fade_out
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun Activity.fadeOut() {
+    if (Build.VERSION.SDK_INT >= 34) {
+        overrideActivityTransition(OVERRIDE_TRANSITION_CLOSE, FADE_IN, FADE_OUT)
+    } else {
+        @Suppress("DEPRECATION")
+        overridePendingTransition(FADE_IN, FADE_OUT)
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetActivity.kt
@@ -18,7 +18,7 @@ import com.stripe.android.common.ui.BottomSheet
 import com.stripe.android.common.ui.rememberBottomSheetState
 import com.stripe.android.customersheet.ui.CustomerSheetScreen
 import com.stripe.android.uicore.StripeTheme
-import com.stripe.android.utils.AnimationConstants
+import com.stripe.android.utils.fadeOut
 
 internal class CustomerSheetActivity : AppCompatActivity() {
 
@@ -97,6 +97,6 @@ internal class CustomerSheetActivity : AppCompatActivity() {
 
     override fun finish() {
         super.finish()
-        overridePendingTransition(AnimationConstants.FADE_IN, AnimationConstants.FADE_OUT)
+        fadeOut()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
@@ -7,7 +7,6 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Surface
@@ -24,7 +23,7 @@ import com.stripe.android.common.ui.BottomSheet
 import com.stripe.android.common.ui.rememberBottomSheetState
 import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.uicore.StripeTheme
-import com.stripe.android.utils.AnimationConstants
+import com.stripe.android.utils.fadeOut
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterialApi::class)
@@ -43,7 +42,6 @@ internal class AddressElementActivity : ComponentActivity() {
         requireNotNull(AddressElementActivityContract.Args.fromIntent(intent))
     }
 
-    @OptIn(ExperimentalAnimationApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -118,6 +116,6 @@ internal class AddressElementActivity : ComponentActivity() {
 
     override fun finish() {
         super.finish()
-        overridePendingTransition(AnimationConstants.FADE_IN, AnimationConstants.FADE_OUT)
+        fadeOut()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationActivity.kt
@@ -20,7 +20,7 @@ import com.stripe.android.paymentsheet.ui.PaymentSheetScaffold
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBar
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBarState
 import com.stripe.android.uicore.StripeTheme
-import com.stripe.android.utils.AnimationConstants
+import com.stripe.android.utils.fadeOut
 import kotlinx.coroutines.flow.collectLatest
 import com.stripe.android.R as StripeR
 import com.stripe.android.ui.core.R as StripeUiCoreR
@@ -104,7 +104,7 @@ internal class BacsMandateConfirmationActivity : AppCompatActivity() {
 
     override fun finish() {
         super.finish()
-        overridePendingTransition(AnimationConstants.FADE_IN, AnimationConstants.FADE_OUT)
+        fadeOut()
     }
 
     private fun renderEdgeToEdge() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivity.kt
@@ -18,7 +18,7 @@ import com.stripe.android.common.ui.BottomSheet
 import com.stripe.android.common.ui.rememberBottomSheetState
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.uicore.StripeTheme
-import com.stripe.android.utils.AnimationConstants
+import com.stripe.android.utils.fadeOut
 import kotlin.time.Duration.Companion.seconds
 
 internal class PollingActivity : AppCompatActivity() {
@@ -91,6 +91,10 @@ internal class PollingActivity : AppCompatActivity() {
             Intent().putExtras(result.toBundle())
         )
         finish()
-        overridePendingTransition(0, AnimationConstants.FADE_OUT)
+    }
+
+    override fun finish() {
+        super.finish()
+        fadeOut()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -8,7 +8,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
 import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
-import com.stripe.android.utils.AnimationConstants
+import com.stripe.android.utils.fadeOut
 
 internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
     abstract val viewModel: BaseSheetViewModel
@@ -42,7 +42,7 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
 
     override fun finish() {
         super.finish()
-        overridePendingTransition(AnimationConstants.FADE_IN, AnimationConstants.FADE_OUT)
+        fadeOut()
     }
 
     private fun renderEdgeToEdge() {

--- a/paymentsheet/src/test/java/com/stripe/android/utils/screenshots/PaparazziRule.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/screenshots/PaparazziRule.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalInspectionMode
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
+import app.cash.paparazzi.detectEnvironment
 import com.android.ide.common.rendering.api.SessionParams
 import com.stripe.android.uicore.StripeTheme
 import org.junit.rules.TestRule
@@ -92,6 +93,9 @@ class PaparazziRule(
             // Needed to shrink the screenshot to the height of the composable
             renderingMode = SessionParams.RenderingMode.SHRINK,
             showSystemUi = false,
+            environment = detectEnvironment().run {
+                copy(compileSdkVersion = 33, platformDir = platformDir.replace("34", "33"))
+            },
         )
     }
 }

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/utils/PaparazziRule.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/utils/PaparazziRule.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
+import app.cash.paparazzi.detectEnvironment
 import com.android.ide.common.rendering.api.SessionParams
 import com.stripe.android.uicore.StripeTheme
 import org.junit.rules.TestRule
@@ -92,6 +93,9 @@ class PaparazziRule(
             // Needed to shrink the screenshot to the height of the composable
             renderingMode = SessionParams.RenderingMode.SHRINK,
             showSystemUi = false,
+            environment = detectEnvironment().run {
+                copy(compileSdkVersion = 33, platformDir = platformDir.replace("34", "33"))
+            },
         )
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates our SDKs to compile SDK 34. This enables us to use new versions of libraries such as [Activity 1.8.0+](https://github.com/stripe/stripe-android/pull/7311).

One inconvenience is that we have to manually downgrade Paparazzi to use compile SDK 33 due to missing support for 34.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
