### PR TITLE
[FC] Adds missing permissions on Maestro tests

### DIFF
--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -161,7 +161,7 @@ internal class FinancialConnectionsPlaygroundViewModel(
 
     private fun showError(error: Throwable) {
         val errorText = when (error) {
-            is HttpException -> { error.response()?.errorBody()?.string() ?: error.message() }
+            is HttpException -> error.response()?.errorBody()?.string() ?: error.message()
             else -> error.message
         }
         _state.update {

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking.yaml
@@ -6,7 +6,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-networking-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?flow=PaymentIntent&financial_connections_override_native=native&merchant=networking_testmode&permissions=balances,transactions
+- openLink: stripeconnectionsexample://playground?flow=PaymentIntent&financial_connections_override_native=native&merchant=networking_testmode&permissions=balances,transactions,payment_method
 - tapOn:
     id: "Customer email setting"
 - inputRandomEmail

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking.yaml
@@ -6,7 +6,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-networking-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?flow=PaymentIntent&financial_connections_override_native=native&merchant=networking_testmode&permissions=balances,transactions,payment_method
+- openLink: stripeconnectionsexample://playground?flow=PaymentIntent&financial_connections_override_native=native&merchant=networking_testmode&permissions=transactions,payment_method
 - tapOn:
     id: "Customer email setting"
 - inputRandomEmail

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
@@ -6,7 +6,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?flow=PaymentIntent&financial_connections_override_native=native&merchant=testmode&permissions=balances,payment_method
+- openLink: stripeconnectionsexample://playground?flow=PaymentIntent&financial_connections_override_native=native&merchant=testmode&permissions=balances
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
@@ -6,7 +6,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?flow=PaymentIntent&financial_connections_override_native=native&merchant=testmode&permissions=balances
+- openLink: stripeconnectionsexample://playground?flow=PaymentIntent&financial_connections_override_native=native&merchant=testmode&permissions=payment_method
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
@@ -6,7 +6,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?flow=PaymentIntent&financial_connections_override_native=native&merchant=testmode
+- openLink: stripeconnectionsexample://playground?flow=PaymentIntent&financial_connections_override_native=native&merchant=testmode&permissions=balances,payment_method
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible

--- a/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
+++ b/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
@@ -6,7 +6,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/testmode-token_manualentry-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?flow=Token&financial_connections_override_native=native&merchant=testmode
+- openLink: stripeconnectionsexample://playground?flow=Token&financial_connections_override_native=native&merchant=testmode&permissions=balances,payment_method
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible


### PR DESCRIPTION
# Summary
- There are some required permissions to be set on specific connections flows
- This PR adds them on the deep links that launch flows in Maestro tests

See error below:

<img width="314" alt="image" src="https://github.com/stripe/stripe-android/assets/99293320/51875025-a17a-43b1-b3fb-ead7f478929f">


