### PR TITLE
Fix flow controller default payment method bug

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
@@ -12,6 +12,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.CollectEmailS
 import com.stripe.android.paymentsheet.example.playground.settings.CollectNameSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CollectPhoneSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillingAddressSettingsDefinition
+import com.stripe.android.paymentsheet.example.samples.ui.shared.PAYMENT_METHOD_SELECTOR_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
 import com.stripe.android.test.core.FieldPopulator
 import com.stripe.android.test.core.TestParameters
@@ -143,6 +144,89 @@ internal class TestCard : BasePlaygroundTest() {
                 selectors.composeTestRule.waitUntilExactlyOneExists(
                     hasTestTag(SAVED_PAYMENT_OPTION_TEST_TAG)
                         .and(isSelected())
+                        .and(hasText(secondCardNumber.takeLast(4), substring = true))
+                )
+            },
+        )
+    }
+
+    /*
+     * TODO(samer-stripe): Once we update `PaymentResult` to return a `StripeIntent`, update the test
+     *  to check against the payment method IDs rather than the last 4 digits.
+     */
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun testDefaultSavedPaymentMethodUsedAfterSingleSaveInCustomFlow() {
+        val cardNumber = "6011111111111117"
+
+        val testParameters = TestParameters.create(
+            paymentMethod = LpmRepository.HardcodedCard,
+        ).copy(
+            authorizationAction = null,
+            saveForFutureUseCheckboxVisible = true,
+            saveCheckboxValue = true,
+        )
+
+        val state = testDriver.confirmCustomAndBuy(
+            testParameters = testParameters,
+            values = FieldPopulator.Values(
+                cardNumber = cardNumber,
+            ),
+        )
+
+        testDriver.confirmCustomWithDefaultSavedPaymentMethod(
+            customerId = state?.customerConfig?.id,
+            testParameters = testParameters,
+            beforeBuyAction = { selectors ->
+                selectors.composeTestRule.waitUntilExactlyOneExists(
+                    hasTestTag(PAYMENT_METHOD_SELECTOR_TEST_TAG)
+                        .and(hasText(cardNumber.takeLast(4), substring = true))
+                )
+            },
+        )
+    }
+
+    /*
+     * TODO(samer-stripe): Once we update `PaymentResult` to return a `StripeIntent`, update the test
+     *  to check against the payment method IDs rather than the last 4 digits.
+     */
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun testDefaultSavedPaymentMethodUsedAfterMultipleSavesInCustomFlow() {
+        val cardNumber = "6011111111111117"
+        val secondCardNumber = "6011000990139424"
+
+        val testParameters = TestParameters.create(
+            paymentMethod = LpmRepository.HardcodedCard,
+        ).copy(
+            authorizationAction = null,
+            saveForFutureUseCheckboxVisible = true,
+            saveCheckboxValue = true,
+        )
+
+        val state = testDriver.confirmCustomAndBuy(
+            testParameters = testParameters,
+            values = FieldPopulator.Values(
+                cardNumber = cardNumber,
+            ),
+        )
+
+        val customerId = state?.customerConfig?.id
+
+        testDriver.confirmCustomAndBuy(
+            customerId = customerId,
+            testParameters = testParameters,
+            values = FieldPopulator.Values(
+                cardNumber = secondCardNumber,
+            ),
+        )
+
+        testDriver.confirmCustomWithDefaultSavedPaymentMethod(
+            customerId = customerId,
+            testParameters = testParameters,
+            beforeBuyAction = { selectors ->
+                selectors.composeTestRule.waitUntilExactlyOneExists(
+                    hasTestTag(PAYMENT_METHOD_SELECTOR_TEST_TAG)
                         .and(hasText(secondCardNumber.takeLast(4), substring = true))
                 )
             },

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/shared/Payment.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/shared/Payment.kt
@@ -18,6 +18,10 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.semantics.text
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentsheet.example.R
 import com.stripe.android.paymentsheet.example.samples.ui.MAIN_FONT_SIZE
@@ -48,7 +52,10 @@ fun PaymentMethodSelector(
             modifier = Modifier.clickable(
                 enabled = isEnabled,
                 onClick = onClick
-            ).testTag(PAYMENT_METHOD_SELECTOR_TEST_TAG),
+            ).semantics {
+                testTag = PAYMENT_METHOD_SELECTOR_TEST_TAG
+                text = AnnotatedString(paymentMethodLabel)
+            },
         ) {
             if (paymentMethodIcon != null) {
                 Icon(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -282,7 +282,6 @@ internal class PaymentOptionsViewModel @Inject constructor(
     }
 
     private fun processExistingPaymentMethod(paymentSelection: PaymentSelection) {
-        prefsRepository.savePaymentSelection(paymentSelection)
         _paymentOptionResult.tryEmit(
             PaymentOptionResult.Succeeded(
                 paymentSelection = paymentSelection,
@@ -292,7 +291,6 @@ internal class PaymentOptionsViewModel @Inject constructor(
     }
 
     private fun processNewPaymentMethod(paymentSelection: PaymentSelection) {
-        prefsRepository.savePaymentSelection(paymentSelection)
         _paymentOptionResult.tryEmit(
             PaymentOptionResult.Succeeded(
                 paymentSelection = paymentSelection,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -28,11 +28,11 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncher
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
-import com.stripe.android.payments.paymentlauncher.toInternalPaymentResultCallback
 import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.PaymentOptionCallback
 import com.stripe.android.paymentsheet.PaymentOptionContract
@@ -40,6 +40,7 @@ import com.stripe.android.paymentsheet.PaymentOptionResult
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
+import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -52,6 +53,7 @@ import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.paymentsheet.ui.SepaMandateContract
 import com.stripe.android.paymentsheet.ui.SepaMandateResult
+import com.stripe.android.paymentsheet.utils.canSave
 import com.stripe.android.utils.AnimationConstants
 import dagger.Lazy
 import kotlinx.coroutines.CoroutineScope
@@ -70,6 +72,7 @@ internal class DefaultFlowController @Inject internal constructor(
     private val paymentOptionFactory: PaymentOptionFactory,
     private val paymentOptionCallback: PaymentOptionCallback,
     private val paymentResultCallback: PaymentSheetResultCallback,
+    private val prefsRepositoryFactory: @JvmSuppressWildcards (PaymentSheet.CustomerConfiguration?) -> PrefsRepository,
     activityResultRegistryOwner: ActivityResultRegistryOwner,
     // Properties provided through injection
     private val eventReporter: EventReporter,
@@ -119,7 +122,7 @@ internal class DefaultFlowController @Inject internal constructor(
     init {
         val paymentLauncherActivityResultLauncher = activityResultRegistryOwner.register(
             PaymentLauncherContract(),
-            toInternalPaymentResultCallback(::onPaymentResult)
+            ::onInternalPaymentResult
         )
 
         paymentOptionActivityLauncher = activityResultRegistryOwner.register(
@@ -499,6 +502,40 @@ internal class DefaultFlowController @Inject internal constructor(
                 paymentOptionCallback.onPaymentOption(null)
             }
         }
+    }
+
+    internal fun onInternalPaymentResult(internalPaymentResult: InternalPaymentResult) {
+        val paymentResult = when (internalPaymentResult) {
+            is InternalPaymentResult.Completed -> {
+                val stripeIntent = internalPaymentResult.intent
+                val currentSelection = viewModel.paymentSelection
+                val currentInitializationMode = initializationMode
+
+                /*
+                 * Sets current selection as default payment method in future payment sheet usage. New payment
+                 * methods are only saved if the payment sheet is in setup mode, is in payment intent with setup
+                 * for usage, or the customer has requested the payment method be saved.
+                 */
+                when (currentSelection) {
+                    is PaymentSelection.New -> stripeIntent.paymentMethod.takeIf {
+                        currentInitializationMode != null && currentSelection.canSave(
+                            initializationMode = currentInitializationMode
+                        )
+                    }?.let { method ->
+                        PaymentSelection.Saved(method)
+                    }
+                    else -> currentSelection
+                }?.let {
+                    prefsRepositoryFactory(viewModel.state?.config?.customer).savePaymentSelection(it)
+                }
+
+                PaymentResult.Completed
+            }
+            is InternalPaymentResult.Failed -> PaymentResult.Failed(internalPaymentResult.throwable)
+            is InternalPaymentResult.Canceled -> PaymentResult.Canceled
+        }
+
+        onPaymentResult(paymentResult)
     }
 
     internal fun onPaymentResult(paymentResult: PaymentResult) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -35,6 +35,7 @@ import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncher
@@ -43,6 +44,7 @@ import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.DelicatePaymentSheetApi
+import com.stripe.android.paymentsheet.FakePrefsRepository
 import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.PaymentOptionCallback
 import com.stripe.android.paymentsheet.PaymentOptionContract
@@ -58,6 +60,7 @@ import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
 import com.stripe.android.paymentsheet.model.PaymentOption
 import com.stripe.android.paymentsheet.model.PaymentOptionFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetState
@@ -127,6 +130,8 @@ internal class DefaultFlowControllerTest {
         mock<ActivityResultLauncher<SepaMandateContract.Args>>()
 
     private val linkPaymentLauncher = mock<LinkPaymentLauncher>()
+
+    private val prefsRepository = FakePrefsRepository()
 
     private val lifeCycleOwner = mock<LifecycleOwner>()
 
@@ -1522,6 +1527,124 @@ internal class DefaultFlowControllerTest {
         )
     }
 
+    @Test
+    fun `On complete internal payment result in PI mode & should reuse, should save payment selection`() = runTest {
+        selectionSavedTest(
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
+        ) { flowController ->
+            flowController.configureWithPaymentIntent(
+                paymentIntentClientSecret = "pi_12345"
+            ) { _, _ -> }
+        }
+    }
+
+    @Test
+    fun `On complete internal payment result in PI mode & should not reuse, should not save payment selection`() = runTest {
+        selectionSavedTest(shouldSave = false) { flowController ->
+            flowController.configureWithPaymentIntent(
+                paymentIntentClientSecret = "pi_12345"
+            ) { _, _ -> }
+        }
+    }
+
+    @Test
+    fun `On complete internal payment result in SI mode, should save payment selection`() = runTest {
+        selectionSavedTest { flowController ->
+            flowController.configureWithSetupIntent(
+                setupIntentClientSecret = "si_123456"
+            ) { _, _ -> }
+        }
+    }
+
+    @Test
+    fun `On complete internal payment result with intent config in PI mode, should not save payment selection`() = runTest {
+        selectionSavedTest(shouldSave = false) { flowController ->
+            flowController.configureWithIntentConfiguration(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                        amount = 10L,
+                        currency = "USD"
+                    )
+                )
+            ) { _, _ -> }
+        }
+    }
+
+    @Test
+    fun `On complete internal payment result with intent config in PI+SFU mode, should save payment selection`() = runTest {
+        selectionSavedTest { flowController ->
+            flowController.configureWithIntentConfiguration(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                        amount = 10L,
+                        currency = "USD",
+                        setupFutureUse = PaymentSheet.IntentConfiguration.SetupFutureUse.OffSession
+                    )
+                )
+            ) { _, _ -> }
+        }
+    }
+
+    @Test
+    fun `On complete internal payment result with intent config in SI mode, should save payment selection`() = runTest {
+        selectionSavedTest { flowController ->
+            flowController.configureWithIntentConfiguration(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Setup(
+                        currency = "USD"
+                    )
+                )
+            ) { _, _ -> }
+        }
+    }
+
+    private suspend fun selectionSavedTest(
+        customerRequestedSave: PaymentSelection.CustomerRequestedSave =
+            PaymentSelection.CustomerRequestedSave.NoRequest,
+        shouldSave: Boolean = true,
+        configure: (PaymentSheet.FlowController) -> Unit
+    ) {
+        val paymentIntent = PaymentIntentFixtures.PI_WITH_PAYMENT_METHOD!!
+        val flowController = createFlowController()
+
+        configure(flowController)
+
+        val selection = PaymentSelection.New.Card(
+            brand = CardBrand.Visa,
+            customerRequestedSave = customerRequestedSave,
+            paymentMethodCreateParams = PaymentMethodCreateParams.create(
+                card = PaymentMethodCreateParams.Card()
+            )
+        )
+
+        flowController.onPaymentOptionResult(PaymentOptionResult.Succeeded(selection))
+        flowController.onInternalPaymentResult(InternalPaymentResult.Completed(paymentIntent))
+
+        val savedSelection = PaymentSelection.Saved(paymentIntent.paymentMethod!!)
+
+        if (shouldSave) {
+            assertThat(prefsRepository.paymentSelectionArgs).containsExactly(savedSelection)
+
+            assertThat(
+                prefsRepository.getSavedSelection(
+                    isGooglePayAvailable = true,
+                    isLinkAvailable = true
+                )
+            ).isEqualTo(
+                SavedSelection.PaymentMethod(savedSelection.paymentMethod.id.orEmpty())
+            )
+        } else {
+            assertThat(prefsRepository.paymentSelectionArgs).isEmpty()
+
+            assertThat(
+                prefsRepository.getSavedSelection(
+                    isGooglePayAvailable = true,
+                    isLinkAvailable = true
+                )
+            ).isEqualTo(SavedSelection.None)
+        }
+    }
+
     private fun createAndConfigureFlowControllerForDeferredIntent(
         paymentIntent: PaymentIntent = PaymentIntentFixtures.PI_SUCCEEDED,
     ): DefaultFlowController {
@@ -1588,6 +1711,7 @@ internal class DefaultFlowControllerTest {
         enableLogging = ENABLE_LOGGING,
         productUsage = PRODUCT_USAGE,
         googlePayPaymentMethodLauncherFactory = createGooglePayPaymentMethodLauncherFactory(),
+        prefsRepositoryFactory = { prefsRepository },
         linkLauncher = linkPaymentLauncher,
         configurationHandler = FlowControllerConfigurationHandler(
             paymentSheetLoader = paymentSheetLoader,


### PR DESCRIPTION
# Summary
Fixes a bug in `FlowController` where the default payment method is not set properly after adding a new one and buying a product with it.

# Motivation
Ensures payment method is properly set as default after usage in payment.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
