### PR TITLE
[Identity] Butter M1 UX tweaks

### DIFF
--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -346,8 +346,22 @@ public final class com/stripe/android/identity/ui/ComposableSingletons$BottomShe
 	public final fun getLambda-2$identity_release ()Lkotlin/jvm/functions/Function2;
 }
 
+public final class com/stripe/android/identity/ui/ComposableSingletons$ConsentLinesKt {
+	public static final field INSTANCE Lcom/stripe/android/identity/ui/ComposableSingletons$ConsentLinesKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$identity_release ()Lkotlin/jvm/functions/Function2;
+}
+
 public final class com/stripe/android/identity/ui/ComposableSingletons$ConsentScreenKt {
 	public static final field INSTANCE Lcom/stripe/android/identity/ui/ComposableSingletons$ConsentScreenKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$identity_release ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class com/stripe/android/identity/ui/ComposableSingletons$ConsentWelcomeHeaderKt {
+	public static final field INSTANCE Lcom/stripe/android/identity/ui/ComposableSingletons$ConsentWelcomeHeaderKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$identity_release ()Lkotlin/jvm/functions/Function2;

--- a/identity/res/drawable/stripe_ellipsis_icon.xml
+++ b/identity/res/drawable/stripe_ellipsis_icon.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="4dp"
+    android:viewportWidth="16"
+    android:viewportHeight="4">
+  <path
+      android:pathData="M2,2m-2,0a2,2 0,1 1,4 0a2,2 0,1 1,-4 0"
+      android:fillColor="#EBEEF1"/>
+  <path
+      android:pathData="M8,2m-2,0a2,2 0,1 1,4 0a2,2 0,1 1,-4 0"
+      android:fillColor="#C0C8D2"/>
+  <path
+      android:pathData="M14,2m-2,0a2,2 0,1 1,4 0a2,2 0,1 1,-4 0"
+      android:fillColor="#87909F"/>
+</vector>

--- a/identity/res/values-night/colors.xml
+++ b/identity/res/values-night/colors.xml
@@ -6,4 +6,6 @@
 
     <color name="stripe_selfie_warmup_icon_tint">#F7FAFC</color>
     <color name="stripe_doc_warmup_icon_tint">#F7FAFC</color>
+
+    <color name="stripe_html_line">#D8DEE4</color>
 </resources>

--- a/identity/res/values/colors.xml
+++ b/identity/res/values/colors.xml
@@ -13,4 +13,6 @@
 
     <color name="stripe_selfie_warmup_icon_tint">#1A1B25</color>
     <color name="stripe_doc_warmup_icon_tint">#1A1B25</color>
+
+    <color name="stripe_html_line">#687385</color>
 </resources>

--- a/identity/res/values/strings.xml
+++ b/identity/res/values/strings.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <!-- title for accepted types of ids -->
-  <string name="stripe_accepted_forms_of_id">Accepted forms of ID include</string>
+  <string name="stripe_accepted_forms_of_id">Accepted forms of ID</string>
+  <!-- title for accepted types of ids prefix -->
+  <string name="stripe_accepted_forms_of_id_include">Accepted forms of ID include</string>
   <!-- Opens the app's settings in the Settings app -->
   <string name="stripe_app_settings">App Settings</string>
   <!-- Description of back of driver's license image -->
@@ -47,6 +49,8 @@
   <string name="stripe_description_dispute_protection">dispute_protection icon</string>
   <!-- Content description for document icon -->
   <string name="stripe_description_document">document icon</string>
+  <!-- Content description for ellipsis icon -->
+  <string name="stripe_description_ellipsis">ellipsis icon</string>
   <!-- Content description for exclamation icon -->
   <string name="stripe_description_exclamation">exclamation icon</string>
   <!-- Content description for back button -->
@@ -111,6 +115,8 @@
   <string name="stripe_id_card">ID</string>
   <!-- Label for ID number section -->
   <string name="stripe_id_number">ID Number</string>
+  <!-- I'm ready button text -->
+  <string name="stripe_im_ready">I\'m ready</string>
   <!-- An error message. -->
   <string name="stripe_incomplete_id_number">The ID number you entered is incomplete.</string>
   <!-- Label for the ID field to collect individual CPF for Brazilian ID -->
@@ -193,8 +199,4 @@
   <string name="stripe_upload_file_text">Alternatively, you may manually upload a photo of your %1$s</string>
   <!-- Title of document upload screen -->
   <string name="stripe_upload_your_photo_id">Upload your photo ID</string>
-  <!-- Content description for ellipsis icon -->
-  <string name="stripe_description_ellipsis">ellipsis icon</string>
-  <!-- I'm ready button text -->
-  <string name="stripe_im_ready">I\'m ready</string>
 </resources>

--- a/identity/res/values/strings.xml
+++ b/identity/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <!-- title for accepted types of ids -->
-  <string name="stripe_accepted_forms_of_id">Accepted forms of ID</string>
+  <string name="stripe_accepted_forms_of_id">Accepted forms of ID include</string>
   <!-- Opens the app's settings in the Settings app -->
   <string name="stripe_app_settings">App Settings</string>
   <!-- Description of back of driver's license image -->
@@ -193,4 +193,8 @@
   <string name="stripe_upload_file_text">Alternatively, you may manually upload a photo of your %1$s</string>
   <!-- Title of document upload screen -->
   <string name="stripe_upload_your_photo_id">Upload your photo ID</string>
+  <!-- Content description for ellipsis icon -->
+  <string name="stripe_description_ellipsis">ellipsis icon</string>
+  <!-- I'm ready button text -->
+  <string name="stripe_im_ready">I\'m ready</string>
 </resources>

--- a/identity/src/main/java/com/stripe/android/identity/ui/BottomSheet.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/BottomSheet.kt
@@ -152,9 +152,10 @@ private fun BottomSheetLine(line: VerificationPageStaticContentBottomSheetLineCo
 }
 
 private fun String.tryParseUl(): List<String>? {
+    val trimmed = this.trim()
     // Detect if string is an unordered HTML list
-    val ulPattern = Pattern.compile("<ul>.*</ul>", Pattern.DOTALL)
-    val ulMatcher = ulPattern.matcher(this)
+    val ulPattern = Pattern.compile("^<ul>.*</ul>$", Pattern.DOTALL)
+    val ulMatcher = ulPattern.matcher(trimmed)
     if (!ulMatcher.find()) {
         return null
     }
@@ -162,7 +163,7 @@ private fun String.tryParseUl(): List<String>? {
     // Extract list items
     val items: MutableList<String> = mutableListOf()
     val liPattern = Pattern.compile("<li>(.*?)</li>", Pattern.DOTALL)
-    val liMatcher = liPattern.matcher(this)
+    val liMatcher = liPattern.matcher(trimmed)
 
     while (liMatcher.find()) {
         items.add(requireNotNull(liMatcher.group(1)))

--- a/identity/src/main/java/com/stripe/android/identity/ui/BottomSheet.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/BottomSheet.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -22,9 +23,11 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.stripe.android.identity.R
 import com.stripe.android.identity.networking.models.VerificationPageIconType
@@ -34,6 +37,7 @@ import com.stripe.android.identity.networking.models.getContentDescriptionId
 import com.stripe.android.identity.networking.models.getResourceId
 import com.stripe.android.identity.viewmodel.BottomSheetViewModel
 import com.stripe.android.uicore.text.Html
+import java.util.regex.Pattern
 
 @Composable
 @ExperimentalMaterialApi
@@ -111,23 +115,59 @@ private fun BottomSheetLine(line: VerificationPageStaticContentBottomSheetLineCo
         ) {
             Text(
                 text = line.title,
-                style = MaterialTheme.typography.h5,
+                fontWeight = FontWeight.Bold,
                 modifier = Modifier.padding(
                     bottom = 4.dp
-                )
-            )
-            Html(
-                html = line.content,
-                color = MaterialTheme.colors.onSurface.copy(
-                    alpha = 0.6f
                 ),
-                urlSpanStyle = SpanStyle(
-                    textDecoration = TextDecoration.Underline,
-                    color = MaterialTheme.colors.secondary
-                )
             )
+
+            line.content.tryParseUl()?.let { bulletStrings ->
+                // [HTML] uses HtmlCompat.fromHtml, which automatically adds an additional line break for <li> items.
+                // We would like to build our line break instead.
+                for (bulletString in bulletStrings) {
+                    Text(
+                        modifier = Modifier.padding(bottom = 2.dp),
+                        text = "• $bulletString",
+                        color = MaterialTheme.colors.onSurface,
+                        style = LocalTextStyle.current.merge(
+                            lineHeight = 20.sp
+                        )
+                    )
+                }
+            } ?: run {
+                Html(
+                    html = line.content,
+                    color = MaterialTheme.colors.onSurface,
+                    style = LocalTextStyle.current.merge(
+                        lineHeight = 20.sp
+                    ),
+                    urlSpanStyle = SpanStyle(
+                        textDecoration = TextDecoration.Underline,
+                        color = MaterialTheme.colors.onSurface
+                    )
+                )
+            }
         }
     }
+}
+
+private fun String.tryParseUl(): List<String>? {
+    // Detect if string is an unordered HTML list
+    val ulPattern = Pattern.compile("<ul>.*</ul>", Pattern.DOTALL)
+    val ulMatcher = ulPattern.matcher(this)
+    if (!ulMatcher.find()) {
+        return null
+    }
+
+    // Extract list items
+    val items: MutableList<String> = mutableListOf()
+    val liPattern = Pattern.compile("<li>(.*?)</li>", Pattern.DOTALL)
+    val liMatcher = liPattern.matcher(this)
+
+    while (liMatcher.find()) {
+        items.add(requireNotNull(liMatcher.group(1)))
+    }
+    return items
 }
 
 @Preview
@@ -153,8 +193,14 @@ internal fun ButtonSheetPreview() {
                     VerificationPageStaticContentBottomSheetLineContent(
                         icon = VerificationPageIconType.CLOUD,
                         title = "cloud line",
-                        content = "cloud line content with another " +
+                        content = "Drivers license cloud line content with another " +
                             "<a href='https://stripe.com'>link</a>, with multiline content"
+                    ),
+                    VerificationPageStaticContentBottomSheetLineContent(
+                        icon = VerificationPageIconType.WALLET,
+                        title = "bullets line",
+                        content = "<ul><li>Drivers license</li><li>Passport</li><li>National ID</li>" +
+                            "<li>Valid government-issued identification that clearly shows your face</li><ul>"
                     )
                 )
             )

--- a/identity/src/main/java/com/stripe/android/identity/ui/ConsentLines.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/ConsentLines.kt
@@ -1,12 +1,12 @@
 package com.stripe.android.identity.ui
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.LocalTextStyle
-import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -15,13 +15,16 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.stripe.android.identity.R
+import com.stripe.android.identity.networking.models.VerificationPageIconType
 import com.stripe.android.identity.networking.models.VerificationPageStaticConsentLineContent
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentBottomSheetContent
 import com.stripe.android.identity.networking.models.getContentDescriptionId
 import com.stripe.android.identity.networking.models.getResourceId
+import com.stripe.android.identity.ui.theme.htmlLineColor
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -33,7 +36,11 @@ internal fun ConsentLines(
         Row(
             modifier = Modifier
                 .testTag(CONSENT_LINE_TAG)
-                .padding(top = dimensionResource(id = R.dimen.stripe_item_vertical_margin))
+                .padding(
+                    top = dimensionResource(id = R.dimen.stripe_item_vertical_margin),
+                    start = dimensionResource(id = R.dimen.stripe_page_horizontal_margin),
+                    end = dimensionResource(id = R.dimen.stripe_page_horizontal_margin)
+                )
         ) {
             Image(
                 painter = painterResource(id = line.icon.getResourceId()),
@@ -44,14 +51,12 @@ internal fun ConsentLines(
             )
             BottomSheetHTML(
                 html = line.content,
-                color = MaterialTheme.colors.onSurface.copy(
-                    alpha = 0.6f
-                ),
+                color = htmlLineColor,
                 style = LocalTextStyle.current.merge(fontSize = 16.sp),
                 bottomSheets = bottomSheets,
                 urlSpanStyle = SpanStyle(
                     textDecoration = TextDecoration.Underline,
-                    color = MaterialTheme.colors.secondary
+                    color = htmlLineColor
                 )
             )
         }
@@ -59,3 +64,37 @@ internal fun ConsentLines(
 }
 
 internal const val CONSENT_LINE_TAG = "consentLineTag"
+
+@Preview
+@Composable
+@ExperimentalMaterialApi
+internal fun ConsentLinePreview() {
+    IdentityPreview {
+        Column {
+            ConsentLines(
+                lines = listOf(
+                    VerificationPageStaticConsentLineContent(
+                        icon = VerificationPageIconType.PHONE,
+                        content = "This is the line content with phone icon"
+                    ),
+                    VerificationPageStaticConsentLineContent(
+                        icon = VerificationPageIconType.CAMERA,
+                        content = "This is the line content with camera icon"
+                    ),
+                    VerificationPageStaticConsentLineContent(
+                        icon = VerificationPageIconType.CLOUD,
+                        content = "This is the line content with cloud icon and a " +
+                            "<a href='https://stripe.com'>web link</a>"
+                    ),
+                    VerificationPageStaticConsentLineContent(
+                        icon = VerificationPageIconType.WALLET,
+                        content = "This is the line content with wallet icon and a <a " +
+                            "href='stripe_bottomsheet://open/consent_verification_data'>" +
+                            "bottomsheet link</a>"
+                    )
+                ),
+                bottomSheets = mapOf()
+            )
+        }
+    }
+}

--- a/identity/src/main/java/com/stripe/android/identity/ui/ConsentLines.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/ConsentLines.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.LocalTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -24,7 +25,6 @@ import com.stripe.android.identity.networking.models.VerificationPageStaticConse
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentBottomSheetContent
 import com.stripe.android.identity.networking.models.getContentDescriptionId
 import com.stripe.android.identity.networking.models.getResourceId
-import com.stripe.android.identity.ui.theme.htmlLineColor
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -51,12 +51,12 @@ internal fun ConsentLines(
             )
             BottomSheetHTML(
                 html = line.content,
-                color = htmlLineColor,
+                color = colorResource(id = R.color.stripe_html_line),
                 style = LocalTextStyle.current.merge(fontSize = 16.sp),
                 bottomSheets = bottomSheets,
                 urlSpanStyle = SpanStyle(
                     textDecoration = TextDecoration.Underline,
-                    color = htmlLineColor
+                    color = colorResource(id = R.color.stripe_html_line)
                 )
             )
         }

--- a/identity/src/main/java/com/stripe/android/identity/ui/ConsentScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/ConsentScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -40,6 +39,7 @@ import com.stripe.android.identity.networking.models.VerificationPageIconType
 import com.stripe.android.identity.networking.models.VerificationPageStaticConsentLineContent
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentBottomSheetContent
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentConsentPage
+import com.stripe.android.identity.ui.theme.htmlLineColor
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import com.stripe.android.uicore.text.Html
 import kotlinx.coroutines.launch
@@ -168,10 +168,10 @@ private fun SuccessUI(
                 .semantics {
                     testTag = PRIVACY_POLICY_TAG
                 },
-            color = MaterialTheme.colors.onBackground,
+            color = htmlLineColor,
             urlSpanStyle = SpanStyle(
                 textDecoration = TextDecoration.Underline,
-                color = MaterialTheme.colors.secondary
+                color = htmlLineColor
             )
         )
 

--- a/identity/src/main/java/com/stripe/android/identity/ui/ConsentScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/ConsentScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
@@ -39,7 +40,6 @@ import com.stripe.android.identity.networking.models.VerificationPageIconType
 import com.stripe.android.identity.networking.models.VerificationPageStaticConsentLineContent
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentBottomSheetContent
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentConsentPage
-import com.stripe.android.identity.ui.theme.htmlLineColor
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import com.stripe.android.uicore.text.Html
 import kotlinx.coroutines.launch
@@ -168,10 +168,10 @@ private fun SuccessUI(
                 .semantics {
                     testTag = PRIVACY_POLICY_TAG
                 },
-            color = htmlLineColor,
+            color = colorResource(id = R.color.stripe_html_line),
             urlSpanStyle = SpanStyle(
                 textDecoration = TextDecoration.Underline,
-                color = htmlLineColor
+                color = colorResource(id = R.color.stripe_html_line)
             )
         )
 
@@ -196,7 +196,7 @@ private fun SuccessUI(
             onConsentAgreed()
         }
 
-        LoadingButton(
+        LoadingTextButton(
             modifier = Modifier
                 .semantics { testTag = DECLINE_BUTTON_TAG },
             text = consentPage.declineButtonText.uppercase(),

--- a/identity/src/main/java/com/stripe/android/identity/ui/ConsentWelcomeHeader.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/ConsentWelcomeHeader.kt
@@ -3,11 +3,13 @@ package com.stripe.android.identity.ui
 import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -21,6 +23,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.stripe.android.identity.R
@@ -72,11 +75,11 @@ internal fun ConsentWelcomeHeader(
                 )
             }
             Image(
-                painter = painterResource(id = R.drawable.stripe_plus_icon),
+                painter = painterResource(id = R.drawable.stripe_ellipsis_icon),
                 modifier = Modifier
                     .width(16.dp)
                     .height(16.dp),
-                contentDescription = stringResource(id = R.string.stripe_description_plus)
+                contentDescription = stringResource(id = R.string.stripe_description_ellipsis)
             )
 
             Image(
@@ -105,4 +108,20 @@ internal fun ConsentWelcomeHeader(
         textAlign = TextAlign.Center
 
     )
+}
+
+@Preview
+@Composable
+@ExperimentalMaterialApi
+internal fun ConsentWelcomeHeaderPreview() {
+    IdentityPreview {
+        Column {
+            ConsentWelcomeHeader(
+                modifier = Modifier,
+                merchantLogoUri = Uri.EMPTY,
+                title = "TEST TITLE",
+                showLogos = true
+            )
+        }
+    }
 }

--- a/identity/src/main/java/com/stripe/android/identity/ui/DocWarmupScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/DocWarmupScreen.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.identity.ui
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,7 +8,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.MaterialTheme
@@ -21,7 +19,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
@@ -29,6 +26,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.stripe.android.camera.CameraPermissionEnsureable
 import com.stripe.android.identity.R
@@ -101,55 +99,53 @@ internal fun DocWarmupView(
                         top = dimensionResource(id = R.dimen.stripe_item_vertical_margin)
                     ),
                 style = MaterialTheme.typography.h4,
+                fontSize = 26.sp,
                 textAlign = TextAlign.Center
             )
+
+            val driverLicense = stringResource(id = R.string.stripe_driver_license)
+            val governmentId = stringResource(id = R.string.stripe_government_id)
+            val passport = stringResource(id = R.string.stripe_passport)
+            val formsOfId = stringResource(id = R.string.stripe_accepted_forms_of_id)
+
+            val allowedListString = remember(documentSelectPage) {
+                "$formsOfId " + documentSelectPage.idDocumentTypeAllowlist.keys.mapNotNull {
+                    when (it) {
+                        DRIVING_LICENSE_KEY -> driverLicense
+                        ID_CARD_KEY -> governmentId
+                        PASSPORT_KEY -> passport
+                        else -> null
+                    }
+                }.joinToString(", ") + "."
+            }
+
             Text(
-                text = stringResource(id = R.string.stripe_doc_front_warmup_body),
+                text = allowedListString,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(
                         top = dimensionResource(id = R.dimen.stripe_item_vertical_margin),
-                    ),
-                style = MaterialTheme.typography.subtitle1,
+                    )
+                    .testTag(DOC_FRONT_ACCEPTED_IDS_TAG),
+                style = MaterialTheme.typography.subtitle1.merge(lineHeight = 22.sp),
                 textAlign = TextAlign.Center
             )
-
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 40.dp, bottom = 20.dp)
-                    .border(
-                        width = 2.dp,
-                        color = Color.LightGray,
-                        shape = RoundedCornerShape(10.dp)
-                    )
-                    .padding(10.dp)
-                    .testTag(DOC_FRONT_ACCEPTED_IDS_TAG)
-            ) {
-                Text(
-                    text = stringResource(id = R.string.stripe_accepted_forms_of_id),
-                    style = MaterialTheme.typography.subtitle1,
-                    modifier = Modifier.padding(start = 4.dp, top = 4.dp, bottom = 4.dp),
-                )
-                documentSelectPage.idDocumentTypeAllowlist.keys.mapNotNull {
-                    when (it) {
-                        DRIVING_LICENSE_KEY -> stringResource(id = R.string.stripe_driver_license)
-                        ID_CARD_KEY -> stringResource(id = R.string.stripe_government_id)
-                        PASSPORT_KEY -> stringResource(id = R.string.stripe_passport)
-                        else -> null
-                    }
-                }.forEach { idType ->
-                    Text(
-                        text = "• $idType",
-                        modifier = Modifier.padding(start = 10.dp, top = 4.dp, bottom = 4.dp),
-                    )
-                }
-            }
         }
+
+        Text(
+            text = stringResource(id = R.string.stripe_doc_front_warmup_body),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    vertical = dimensionResource(id = R.dimen.stripe_item_vertical_margin),
+                ),
+            style = MaterialTheme.typography.subtitle1,
+            textAlign = TextAlign.Center
+        )
 
         LoadingButton(
             modifier = Modifier.testTag(DOC_FRONT_CONTINUE_BUTTON_TAG),
-            text = stringResource(id = R.string.stripe_kontinue).uppercase(),
+            text = stringResource(id = R.string.stripe_im_ready).uppercase(),
             state = continueButtonState
         ) {
             continueButtonState = LoadingButtonState.Loading

--- a/identity/src/main/java/com/stripe/android/identity/ui/DocWarmupScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/DocWarmupScreen.kt
@@ -106,7 +106,7 @@ internal fun DocWarmupView(
             val driverLicense = stringResource(id = R.string.stripe_driver_license)
             val governmentId = stringResource(id = R.string.stripe_government_id)
             val passport = stringResource(id = R.string.stripe_passport)
-            val formsOfId = stringResource(id = R.string.stripe_accepted_forms_of_id)
+            val formsOfId = stringResource(id = R.string.stripe_accepted_forms_of_id_include)
 
             val allowedListString = remember(documentSelectPage) {
                 "$formsOfId " + documentSelectPage.idDocumentTypeAllowlist.keys.mapNotNull {

--- a/identity/src/main/java/com/stripe/android/identity/ui/theme/Colors.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/theme/Colors.kt
@@ -1,0 +1,5 @@
+package com.stripe.android.identity.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+internal val htmlLineColor = Color(0xff687385)

--- a/identity/src/main/java/com/stripe/android/identity/ui/theme/Colors.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/theme/Colors.kt
@@ -1,5 +1,0 @@
-package com.stripe.android.identity.ui.theme
-
-import androidx.compose.ui.graphics.Color
-
-internal val htmlLineColor = Color(0xff687385)

--- a/identity/src/test/java/com/stripe/android/identity/ui/DocWarmupScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/DocWarmupScreenTest.kt
@@ -46,12 +46,12 @@ class DocWarmupScreenTest {
         }
         with(composeTestRule) {
             onNodeWithTag(DOC_FRONT_ACCEPTED_IDS_TAG).assertExists()
-            onNodeWithTag(DOC_FRONT_ACCEPTED_IDS_TAG).onChildAt(1)
-                .assertTextEquals("• " + context.getString(R.string.stripe_passport))
-            onNodeWithTag(DOC_FRONT_ACCEPTED_IDS_TAG).onChildAt(2)
-                .assertTextEquals("• " + context.getString(R.string.stripe_driver_license))
-            onNodeWithTag(DOC_FRONT_ACCEPTED_IDS_TAG).onChildAt(3)
-                .assertTextEquals("• " + context.getString(R.string.stripe_government_id))
+            onNodeWithTag(DOC_FRONT_ACCEPTED_IDS_TAG).assertTextEquals(
+                "${context.getString(R.string.stripe_accepted_forms_of_id)} " +
+                    "${context.getString(R.string.stripe_passport)}, " +
+                    "${context.getString(R.string.stripe_driver_license)}, " +
+                    "${context.getString(R.string.stripe_government_id)}."
+            )
             onNodeWithTag(DOC_FRONT_CONTINUE_BUTTON_TAG).onChildAt(0).performClick()
             verify(onContinueClickMock).invoke()
         }

--- a/identity/src/test/java/com/stripe/android/identity/ui/DocWarmupScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/DocWarmupScreenTest.kt
@@ -47,7 +47,7 @@ class DocWarmupScreenTest {
         with(composeTestRule) {
             onNodeWithTag(DOC_FRONT_ACCEPTED_IDS_TAG).assertExists()
             onNodeWithTag(DOC_FRONT_ACCEPTED_IDS_TAG).assertTextEquals(
-                "${context.getString(R.string.stripe_accepted_forms_of_id)} " +
+                "${context.getString(R.string.stripe_accepted_forms_of_id_include)} " +
                     "${context.getString(R.string.stripe_passport)}, " +
                     "${context.getString(R.string.stripe_driver_license)}, " +
                     "${context.getString(R.string.stripe_government_id)}."


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
UX teaks for butter M1

* consent
	* text/link color changed
	* vertical padding added
	* plus icon replaced by ellipsis icon
* bottomsheet
	* subtitle color, content color, content line spacing
	* fixed bullet points padding
* docwarmup
	* removed instructions box, instead built a string
		* note we didn't add the "and" there, since this would make translations hard, as we are hardcoding "accepted forms of ID" from client, but getting the actual ID names from server.
	* moved instructions to top of button.
* docwarmup
	* title font - increased size
	* removed instructions box, instead built a string
		* note we didn't add the "and" there, since this would make translations hard, as we are hardcoding "accepted forms of ID" from client, but getting the actual ID names from server.
	* moved instructions to top of button.

iOS: https://github.com/stripe/stripe-ios/pull/3070

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
UX tweaks

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![androidBefore](https://github.com/stripe/stripe-android/assets/79880926/e64673a0-b64a-4b04-a886-c437f5a7f1ab)  | ![androidAfter](https://github.com/stripe/stripe-android/assets/79880926/3d851689-8f3c-427e-aed0-08612078bf4f) |












# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
