### PR TITLE
Remove hacky payment options params in paymentsheet.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/ConfirmStripeIntentParamsFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/ConfirmStripeIntentParamsFactory.kt
@@ -22,7 +22,6 @@ sealed class ConfirmStripeIntentParamsFactory<out T : ConfirmStripeIntentParams>
     abstract fun create(
         createParams: PaymentMethodCreateParams,
         optionsParams: PaymentMethodOptionsParams? = null,
-        setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage? = null,
     ): T
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -78,40 +77,11 @@ internal class ConfirmPaymentIntentParamsFactory(
     override fun create(
         createParams: PaymentMethodCreateParams,
         optionsParams: PaymentMethodOptionsParams?,
-        setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?,
     ): ConfirmPaymentIntentParams {
         return ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
             paymentMethodCreateParams = createParams,
             clientSecret = clientSecret,
-
-            /**
-             Sets `payment_method_options[card][setup_future_usage]`
-             - Note: PaymentSheet uses this `setup_future_usage` (SFU) value very differently from the top-level one:
-             We read the top-level SFU to know the merchant’s desired save behavior
-             We write payment method options SFU to set the customer’s desired save behavior
-             */
-            // At this time, paymentMethodOptions card and us_bank_account is the only PM that
-            // supports setup future usage
-            paymentMethodOptions = when (createParams.typeCode) {
-                PaymentMethod.Type.Card.code -> {
-                    PaymentMethodOptionsParams.Card(setupFutureUsage = setupFutureUsage)
-                }
-                PaymentMethod.Type.USBankAccount.code -> {
-                    PaymentMethodOptionsParams.USBankAccount(setupFutureUsage = setupFutureUsage)
-                }
-                PaymentMethod.Type.Blik.code -> {
-                    optionsParams
-                }
-                PaymentMethod.Type.Konbini.code -> {
-                    optionsParams
-                }
-                PaymentMethod.Type.Link.code -> {
-                    null
-                }
-                else -> {
-                    PaymentMethodOptionsParams.Card(setupFutureUsage = null)
-                }
-            },
+            paymentMethodOptions = optionsParams,
             shipping = shipping,
         )
     }
@@ -133,7 +103,6 @@ internal class ConfirmSetupIntentParamsFactory(
     override fun create(
         createParams: PaymentMethodCreateParams,
         optionsParams: PaymentMethodOptionsParams?,
-        setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?,
     ): ConfirmSetupIntentParams {
         return ConfirmSetupIntentParams.create(
             paymentMethodCreateParams = createParams,

--- a/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
@@ -20,7 +20,9 @@ class ConfirmPaymentIntentParamsFactoryTest {
         assertThat(
             factory.create(
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession,
+                optionsParams = PaymentMethodOptionsParams.Card(
+                    setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+                )
             )
         ).isEqualTo(
             ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
@@ -39,7 +41,9 @@ class ConfirmPaymentIntentParamsFactoryTest {
         assertThat(
             factory.create(
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.Blank,
+                optionsParams = PaymentMethodOptionsParams.Card(
+                    setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.Blank
+                )
             )
         ).isEqualTo(
             ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
@@ -58,7 +62,7 @@ class ConfirmPaymentIntentParamsFactoryTest {
         assertThat(
             factory.create(
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                setupFutureUsage = null,
+                optionsParams = PaymentMethodOptionsParams.Card(),
             )
         ).isEqualTo(
             ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
@@ -108,7 +112,6 @@ class ConfirmPaymentIntentParamsFactoryTest {
 
         val result = factoryWithConfig.create(
             createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-            setupFutureUsage = null,
         )
 
         assertThat(result.shipping).isEqualTo(shippingDetails)

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -18,7 +18,6 @@ import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.injection.CustomerSheetViewModelScope
 import com.stripe.android.customersheet.util.isUnverifiedUSBankAccount
-import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.PaymentMethod
@@ -780,7 +779,7 @@ internal class CustomerSheetViewModel @Inject constructor(
             ),
             paymentMethod = paymentMethod,
             shippingValues = null,
-            setupForFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession,
+            customerRequestedSave = true,
         )
 
         unconfirmedPaymentMethod = paymentMethod

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet
 
 import com.stripe.android.model.ConfirmPaymentIntentParams
-import com.stripe.android.model.ConfirmPaymentIntentParams.SetupFutureUsage
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSelection.CustomerRequestedSave
 
@@ -12,18 +11,13 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
 ): IntentConfirmationInterceptor.NextStep {
     return when (paymentSelection) {
         is PaymentSelection.New -> {
-            val setupFutureUsage = when (paymentSelection.customerRequestedSave) {
-                CustomerRequestedSave.RequestReuse -> SetupFutureUsage.OffSession
-                CustomerRequestedSave.RequestNoReuse -> SetupFutureUsage.Blank
-                CustomerRequestedSave.NoRequest -> null
-            }
-
+            // TODO: We might still be missing something here.
             intercept(
                 initializationMode = initializationMode,
                 paymentMethodOptionsParams = paymentSelection.paymentMethodOptionsParams,
                 paymentMethodCreateParams = paymentSelection.paymentMethodCreateParams,
                 shippingValues = shippingValues,
-                setupForFutureUsage = setupFutureUsage,
+                customerRequestedSave = paymentSelection.customerRequestedSave == CustomerRequestedSave.RequestReuse,
             )
         }
         is PaymentSelection.Saved -> {
@@ -31,7 +25,7 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
                 initializationMode = initializationMode,
                 paymentMethod = paymentSelection.paymentMethod,
                 shippingValues = shippingValues,
-                setupForFutureUsage = null,
+                customerRequestedSave = false,
             )
         }
         else -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
@@ -11,7 +11,6 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
 ): IntentConfirmationInterceptor.NextStep {
     return when (paymentSelection) {
         is PaymentSelection.New -> {
-            // TODO: We might still be missing something here.
             intercept(
                 initializationMode = initializationMode,
                 paymentMethodOptionsParams = paymentSelection.paymentMethodOptionsParams,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/ConfirmStripeIntentParamsFactoryKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/ConfirmStripeIntentParamsFactoryKtx.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.model
 
 import com.stripe.android.ConfirmStripeIntentParamsFactory
-import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 
 internal fun <T : ConfirmStripeIntentParams> ConfirmStripeIntentParamsFactory<T>.create(
@@ -13,20 +12,8 @@ internal fun <T : ConfirmStripeIntentParams> ConfirmStripeIntentParamsFactory<T>
 internal fun <T : ConfirmStripeIntentParams> ConfirmStripeIntentParamsFactory<T>.create(
     paymentSelection: PaymentSelection.New,
 ): T {
-    val setupFutureUsage = when (paymentSelection.customerRequestedSave) {
-        PaymentSelection.CustomerRequestedSave.RequestReuse -> {
-            ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
-        }
-        PaymentSelection.CustomerRequestedSave.RequestNoReuse -> {
-            ConfirmPaymentIntentParams.SetupFutureUsage.Blank
-        }
-        PaymentSelection.CustomerRequestedSave.NoRequest -> {
-            null
-        }
-    }
-
     return create(
         createParams = paymentSelection.paymentMethodCreateParams,
-        setupFutureUsage = setupFutureUsage,
+        optionsParams = paymentSelection.paymentMethodOptionsParams,
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -132,7 +132,7 @@ internal sealed class PaymentSelection : Parcelable {
         }
 
         @Parcelize
-        data class Card(
+        data class Card constructor(
             override val paymentMethodCreateParams: PaymentMethodCreateParams,
             val brand: CardBrand,
             override val customerRequestedSave: CustomerRequestedSave,
@@ -204,7 +204,7 @@ internal sealed class PaymentSelection : Parcelable {
         }
 
         @Parcelize
-        data class GenericPaymentMethod(
+        data class GenericPaymentMethod constructor(
             val labelResource: String,
             @DrawableRes val iconResource: Int,
             val lightThemeIconUrl: String?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -6,6 +6,7 @@ import androidx.annotation.DrawableRes
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethod.Type.USBankAccount
@@ -107,10 +108,10 @@ internal sealed class PaymentSelection : Parcelable {
         }
     }
 
-    enum class CustomerRequestedSave {
-        RequestReuse,
-        RequestNoReuse,
-        NoRequest
+    enum class CustomerRequestedSave(val setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?) {
+        RequestReuse(ConfirmPaymentIntentParams.SetupFutureUsage.OffSession),
+        RequestNoReuse(ConfirmPaymentIntentParams.SetupFutureUsage.Blank),
+        NoRequest(null)
     }
 
     sealed class New : PaymentSelection() {
@@ -132,7 +133,7 @@ internal sealed class PaymentSelection : Parcelable {
         }
 
         @Parcelize
-        data class Card constructor(
+        data class Card(
             override val paymentMethodCreateParams: PaymentMethodCreateParams,
             val brand: CardBrand,
             override val customerRequestedSave: CustomerRequestedSave,
@@ -204,7 +205,7 @@ internal sealed class PaymentSelection : Parcelable {
         }
 
         @Parcelize
-        data class GenericPaymentMethod constructor(
+        data class GenericPaymentMethod(
             val labelResource: String,
             @DrawableRes val iconResource: Int,
             val lightThemeIconUrl: String?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.platform.LocalContext
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.InlineSignupViewState
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
@@ -203,8 +204,19 @@ internal fun FormFieldValues.transformToPaymentSelection(
     val params = transformToPaymentMethodCreateParams(paymentMethod)
     val options = transformToPaymentMethodOptionsParams(paymentMethod)
     return if (paymentMethod.code == PaymentMethod.Type.Card.code) {
+        val setupFutureUsage = when (userRequestedReuse) {
+            PaymentSelection.CustomerRequestedSave.RequestReuse -> {
+                ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+            }
+            PaymentSelection.CustomerRequestedSave.RequestNoReuse -> {
+                ConfirmPaymentIntentParams.SetupFutureUsage.Blank
+            }
+            PaymentSelection.CustomerRequestedSave.NoRequest -> {
+                null
+            }
+        }
         PaymentSelection.New.Card(
-            paymentMethodOptionsParams = options,
+            paymentMethodOptionsParams = PaymentMethodOptionsParams.Card(setupFutureUsage = setupFutureUsage),
             paymentMethodCreateParams = params,
             brand = CardBrand.fromCode(fieldValuePairs[IdentifierSpec.CardBrand]?.value),
             customerRequestedSave = userRequestedReuse,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.platform.LocalContext
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.InlineSignupViewState
 import com.stripe.android.model.CardBrand
-import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
@@ -204,19 +203,10 @@ internal fun FormFieldValues.transformToPaymentSelection(
     val params = transformToPaymentMethodCreateParams(paymentMethod)
     val options = transformToPaymentMethodOptionsParams(paymentMethod)
     return if (paymentMethod.code == PaymentMethod.Type.Card.code) {
-        val setupFutureUsage = when (userRequestedReuse) {
-            PaymentSelection.CustomerRequestedSave.RequestReuse -> {
-                ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
-            }
-            PaymentSelection.CustomerRequestedSave.RequestNoReuse -> {
-                ConfirmPaymentIntentParams.SetupFutureUsage.Blank
-            }
-            PaymentSelection.CustomerRequestedSave.NoRequest -> {
-                null
-            }
-        }
         PaymentSelection.New.Card(
-            paymentMethodOptionsParams = PaymentMethodOptionsParams.Card(setupFutureUsage = setupFutureUsage),
+            paymentMethodOptionsParams = PaymentMethodOptionsParams.Card(
+                setupFutureUsage = userRequestedReuse.setupFutureUsage
+            ),
             paymentMethodCreateParams = params,
             brand = CardBrand.fromCode(fieldValuePairs[IdentifierSpec.CardBrand]?.value),
             customerRequestedSave = userRequestedReuse,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
@@ -52,7 +52,7 @@ class DefaultIntentConfirmationInterceptorTest {
             initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),
             paymentMethod = paymentMethod,
             shippingValues = null,
-            setupForFutureUsage = null,
+            customerRequestedSave = false,
         )
 
         val confirmNextStep = nextStep as? IntentConfirmationInterceptor.NextStep.Confirm
@@ -78,7 +78,7 @@ class DefaultIntentConfirmationInterceptorTest {
             initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),
             paymentMethodCreateParams = createParams,
             shippingValues = null,
-            setupForFutureUsage = null,
+            customerRequestedSave = false,
         )
 
         val confirmNextStep = nextStep as? IntentConfirmationInterceptor.NextStep.Confirm
@@ -110,7 +110,7 @@ class DefaultIntentConfirmationInterceptorTest {
                 ),
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 shippingValues = null,
-                setupForFutureUsage = null,
+                customerRequestedSave = false,
             )
         }
 
@@ -141,7 +141,7 @@ class DefaultIntentConfirmationInterceptorTest {
                 initializationMode = InitializationMode.DeferredIntent(mock()),
                 paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 shippingValues = null,
-                setupForFutureUsage = null,
+                customerRequestedSave = false,
             )
         }
 
@@ -177,7 +177,7 @@ class DefaultIntentConfirmationInterceptorTest {
             initializationMode = InitializationMode.DeferredIntent(mock()),
             paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
             shippingValues = null,
-            setupForFutureUsage = null,
+            customerRequestedSave = false,
         )
 
         assertThat(nextStep).isEqualTo(
@@ -220,7 +220,7 @@ class DefaultIntentConfirmationInterceptorTest {
             initializationMode = InitializationMode.DeferredIntent(mock()),
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             shippingValues = null,
-            setupForFutureUsage = null,
+            customerRequestedSave = false,
         )
 
         assertThat(nextStep).isEqualTo(
@@ -249,7 +249,7 @@ class DefaultIntentConfirmationInterceptorTest {
             initializationMode = InitializationMode.DeferredIntent(mock()),
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             shippingValues = null,
-            setupForFutureUsage = null,
+            customerRequestedSave = false,
         )
 
         assertThat(nextStep).isEqualTo(
@@ -276,7 +276,7 @@ class DefaultIntentConfirmationInterceptorTest {
             initializationMode = InitializationMode.DeferredIntent(mock()),
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             shippingValues = null,
-            setupForFutureUsage = null,
+            customerRequestedSave = false,
         )
 
         assertThat(nextStep).isEqualTo(
@@ -324,7 +324,7 @@ class DefaultIntentConfirmationInterceptorTest {
             ),
             paymentMethod = paymentMethod,
             shippingValues = null,
-            setupForFutureUsage = null,
+            customerRequestedSave = false,
         )
 
         assertThat(nextStep).isInstanceOf(IntentConfirmationInterceptor.NextStep.Confirm::class.java)
@@ -363,7 +363,7 @@ class DefaultIntentConfirmationInterceptorTest {
             ),
             paymentMethod = paymentMethod,
             shippingValues = null,
-            setupForFutureUsage = null,
+            customerRequestedSave = false,
         )
 
         assertThat(nextStep).isEqualTo(
@@ -408,7 +408,7 @@ class DefaultIntentConfirmationInterceptorTest {
             ),
             paymentMethod = paymentMethod,
             shippingValues = null,
-            setupForFutureUsage = null,
+            customerRequestedSave = false,
         )
 
         assertThat(nextStep).isEqualTo(
@@ -437,12 +437,7 @@ class DefaultIntentConfirmationInterceptorTest {
             isFlowController = false,
         )
 
-        val inputs = listOf(
-            null,
-            ConfirmPaymentIntentParams.SetupFutureUsage.Blank,
-            ConfirmPaymentIntentParams.SetupFutureUsage.OffSession,
-            ConfirmPaymentIntentParams.SetupFutureUsage.OnSession,
-        )
+        val inputs = listOf(true, false)
 
         for (input in inputs) {
             IntentConfirmationInterceptor.createIntentCallback =
@@ -462,11 +457,11 @@ class DefaultIntentConfirmationInterceptorTest {
                 ),
                 paymentMethod = paymentMethod,
                 shippingValues = null,
-                setupForFutureUsage = input,
+                customerRequestedSave = input,
             )
         }
 
-        assertThat(observedValues).containsExactly(false, false, true, false).inOrder()
+        assertThat(observedValues).containsExactly(true, false).inOrder()
     }
 
     @Test
@@ -497,7 +492,7 @@ class DefaultIntentConfirmationInterceptorTest {
             ),
             paymentMethod = paymentMethod,
             shippingValues = null,
-            setupForFutureUsage = null,
+            customerRequestedSave = false,
         )
 
         verify(stripeRepository, never()).retrieveStripeIntent(any(), any(), any())

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
@@ -48,7 +48,7 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
         paymentMethodCreateParams: PaymentMethodCreateParams,
         paymentMethodOptionsParams: PaymentMethodOptionsParams?,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
-        setupForFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?,
+        customerRequestedSave: Boolean,
     ): IntentConfirmationInterceptor.NextStep {
         return channel.receive()
     }
@@ -57,7 +57,7 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
         initializationMode: PaymentSheet.InitializationMode,
         paymentMethod: PaymentMethod,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
-        setupForFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?,
+        customerRequestedSave: Boolean,
     ): IntentConfirmationInterceptor.NextStep {
         return channel.receive()
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When I was prototyping the LPM refactor. I needed to dig into how payment options params were being passed to the confirm call. This led me to uncover a lot of unnecessary edge cases I ran into a while ago while implementing konbini. Now new LPMs that require sending data via payment options will no longer need to do this work around. This will also enable us to proceed with the LPM refactor in a way that allows each LPM to apply related payment method data and options.
