### PR TITLE
Support update functionality in `PaymentSheet`.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodUpdateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodUpdateParams.kt
@@ -13,7 +13,7 @@ import java.util.Objects
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Parcelize
 class PaymentMethodUpdateParams private constructor(
-    @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val paymentMethodId: String,
+    val paymentMethodId: String,
     private val card: Card? = null,
     private val billingDetails: PaymentMethod.BillingDetails? = null,
     private val metadata: Map<String, String>? = null,

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodUpdateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodUpdateParams.kt
@@ -13,7 +13,7 @@ import java.util.Objects
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Parcelize
 class PaymentMethodUpdateParams private constructor(
-    internal val paymentMethodId: String,
+    @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val paymentMethodId: String,
     private val card: Card? = null,
     private val billingDetails: PaymentMethod.BillingDetails? = null,
     private val metadata: Map<String, String>? = null,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
@@ -7,6 +7,7 @@ import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.Customer
 import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
@@ -128,5 +129,19 @@ internal class CustomerApiRepository @Inject constructor(
             )
         ).onFailure {
             logger.error("Failed to attach payment method $paymentMethodId.", it)
+        }
+
+    override suspend fun updatePaymentMethod(
+        customerConfig: PaymentSheet.CustomerConfiguration,
+        params: PaymentMethodUpdateParams
+    ): Result<PaymentMethod> =
+        stripeRepository.updatePaymentMethod(
+            paymentMethodUpdateParams = params,
+            options = ApiRequest.Options(
+                apiKey = customerConfig.ephemeralKeySecret,
+                stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+            )
+        ).onFailure {
+            logger.error("Failed to update payment method ${params.paymentMethodId}.", it)
         }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerRepository.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.repositories
 
 import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.paymentsheet.PaymentSheet
 
 /**
@@ -41,5 +42,10 @@ internal interface CustomerRepository {
     suspend fun attachPaymentMethod(
         customerConfig: PaymentSheet.CustomerConfiguration,
         paymentMethodId: String
+    ): Result<PaymentMethod>
+
+    suspend fun updatePaymentMethod(
+        customerConfig: PaymentSheet.CustomerConfiguration,
+        params: PaymentMethodUpdateParams
     ): Result<PaymentMethod>
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditPaymentMethodViewInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditPaymentMethodViewInteractor.kt
@@ -123,8 +123,6 @@ internal class DefaultEditPaymentMethodViewInteractor constructor(
 
                 updateResult.onSuccess { method ->
                     paymentMethod.emit(method)
-                }.onFailure {
-                    // TODO(samer-stripe): Display toast on update method failure?
                 }
 
                 status.emit(EditPaymentMethodViewState.Status.Idle)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -479,41 +479,34 @@ internal abstract class BaseSheetViewModel(
         val customerConfig = config.customer
         val paymentMethodId = paymentMethod.id
 
-        return if (customerConfig != null && paymentMethodId != null) {
-            customerRepository.updatePaymentMethod(
-                customerConfig = customerConfig,
-                params = PaymentMethodUpdateParams.createCard(
-                    paymentMethodId = paymentMethodId,
-                    networks = PaymentMethodUpdateParams.Card.Networks(
-                        preferred = brand.code
-                    )
+        return customerRepository.updatePaymentMethod(
+            customerConfig = customerConfig!!,
+            params = PaymentMethodUpdateParams.createCard(
+                paymentMethodId = paymentMethodId!!,
+                networks = PaymentMethodUpdateParams.Card.Networks(
+                    preferred = brand.code
                 )
-            ).onSuccess { updatedMethod ->
-                savedStateHandle[SAVE_PAYMENT_METHODS] = paymentMethods
-                    .value
-                    ?.let { savedPaymentMethods ->
-                        savedPaymentMethods.map { savedMethod ->
-                            val savedId = savedMethod.id
-                            val updatedId = updatedMethod.id
+            )
+        ).onSuccess { updatedMethod ->
+            savedStateHandle[SAVE_PAYMENT_METHODS] = paymentMethods
+                .value
+                ?.let { savedPaymentMethods ->
+                    savedPaymentMethods.map { savedMethod ->
+                        val savedId = savedMethod.id
+                        val updatedId = updatedMethod.id
 
-                            if (updatedId != null && savedId != null && updatedId == savedId) {
-                                updatedMethod
-                            } else {
-                                paymentMethod
-                            }
+                        if (updatedId != null && savedId != null && updatedId == savedId) {
+                            updatedMethod
+                        } else {
+                            paymentMethod
                         }
                     }
-            }.onFailure {
-                // TODO(samer-stripe): Localize error message with proper strings.
-                onError("Failed to update payment method")
-            }
-        } else {
+                }
+
+            handleBackPressed()
+        }.onFailure {
             // TODO(samer-stripe): Localize error message with proper strings.
             onError("Failed to update payment method")
-
-            Result.failure(
-                IllegalStateException("Customer configuration & existing payment method must be available!")
-            )
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -229,6 +229,8 @@ internal class PaymentSheetViewModelTest {
 
                 interactor.handleViewAction(EditPaymentMethodViewAction.OnUpdatePressed)
             }
+
+            assertThat(awaitItem()).isInstanceOf(SelectSavedPaymentMethods::class.java)
         }
 
         val paramsCaptor = argumentCaptor<PaymentMethodUpdateParams>()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -33,6 +33,7 @@ import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD
 import com.stripe.android.model.PaymentMethodOptionsParams
+import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
@@ -48,6 +49,7 @@ import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.model.SavedSelection
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddAnotherPaymentMethod
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddFirstPaymentMethod
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods
@@ -55,7 +57,10 @@ import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFo
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.state.GooglePayState
 import com.stripe.android.paymentsheet.state.LinkState
+import com.stripe.android.paymentsheet.ui.EditPaymentMethodViewAction
+import com.stripe.android.paymentsheet.ui.EditPaymentMethodViewState
 import com.stripe.android.paymentsheet.ui.PrimaryButton
+import com.stripe.android.paymentsheet.utils.FakeEditPaymentMethodInteractorFactory
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.SAVE_PROCESSING
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.UserErrorMessage
 import com.stripe.android.testing.PaymentIntentFactory
@@ -137,6 +142,7 @@ internal class PaymentSheetViewModelTest {
         on { create(any(), any(), any(), any(), any()) } doReturn googlePayLauncher
     }
     private val fakeIntentConfirmationInterceptor = FakeIntentConfirmationInterceptor()
+    private val fakeEditPaymentMethodInteractorFactory = FakeEditPaymentMethodInteractorFactory(testDispatcher)
 
     private val linkConfigurationCoordinator = mock<LinkConfigurationCoordinator> {
         on { getAccountStatusFlow(any()) } doReturn flowOf(AccountStatus.SignedOut)
@@ -178,6 +184,72 @@ internal class PaymentSheetViewModelTest {
             any(),
             eq(PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!)
         )
+    }
+
+    @Test
+    fun `modifyPaymentMethod updates payment methods on successful update`() = runTest {
+        val paymentMethod = PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD
+        val updatedPaymentMethod = paymentMethod.copy(
+            card = paymentMethod.card?.copy(
+                networks = paymentMethod.card?.networks?.copy(
+                    preferred = CardBrand.Visa.code
+                )
+            )
+        )
+
+        val customerRepository = spy(
+            FakeCustomerRepository(
+                onUpdatePaymentMethod = {
+                    Result.success(updatedPaymentMethod)
+                }
+            )
+        )
+        val viewModel = createViewModel(
+            customerPaymentMethods = listOf(paymentMethod),
+            customerRepository = customerRepository
+        )
+
+        viewModel.currentScreen.test {
+            awaitItem()
+
+            viewModel.modifyPaymentMethod(PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD)
+
+            val currentScreen = awaitItem()
+
+            assertThat(currentScreen).isInstanceOf(PaymentSheetScreen.EditPaymentMethod::class.java)
+
+            if (currentScreen is PaymentSheetScreen.EditPaymentMethod) {
+                val interactor = currentScreen.interactor
+
+                interactor.handleViewAction(
+                    EditPaymentMethodViewAction.OnBrandChoiceChanged(
+                        EditPaymentMethodViewState.CardBrandChoice(CardBrand.Visa)
+                    )
+                )
+
+                interactor.handleViewAction(EditPaymentMethodViewAction.OnUpdatePressed)
+            }
+        }
+
+        val paramsCaptor = argumentCaptor<PaymentMethodUpdateParams>()
+
+        verify(customerRepository).updatePaymentMethod(
+            any(),
+            paramsCaptor.capture()
+        )
+
+        assertThat(
+            paramsCaptor.firstValue.toParamMap()
+        ).isEqualTo(
+            PaymentMethodUpdateParams.createCard(
+                paymentMethodId = PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!,
+                networks = PaymentMethodUpdateParams.Card.Networks(
+                    preferred = CardBrand.Visa.code
+                )
+            ).toParamMap()
+        )
+
+        assertThat(viewModel.paymentMethods.value).contains(updatedPaymentMethod)
     }
 
     @Test
@@ -1801,7 +1873,7 @@ internal class PaymentSheetViewModelTest {
                 linkConfigurationCoordinator = linkInteractor,
                 intentConfirmationInterceptor = fakeIntentConfirmationInterceptor,
                 formViewModelSubComponentBuilderProvider = mock(),
-                editInteractorFactory = mock()
+                editInteractorFactory = fakeEditPaymentMethodInteractorFactory
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
@@ -7,6 +7,7 @@ import com.stripe.android.core.Logger
 import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -305,6 +306,44 @@ internal class CustomerRepositoryTest {
             assertThat(result).isEqualTo(error)
         }
 
+    @Test
+    fun `updatePaymentMethod() should return payment method on success`() =
+        runTest {
+            val success = Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+            givenUpdatePaymentMethodReturns(success)
+
+            val result = repository.updatePaymentMethod(
+                PaymentSheet.CustomerConfiguration(
+                    "customer_id",
+                    "ephemeral_key"
+                ),
+                PaymentMethodUpdateParams.createCard(
+                    paymentMethodId = "payment_method_id"
+                )
+            )
+
+            assertThat(result).isEqualTo(success)
+        }
+
+    @Test
+    fun `updatePaymentMethod() should return failure`() =
+        runTest {
+            val error = Result.failure<PaymentMethod>(InvalidParameterException("error"))
+            givenUpdatePaymentMethodReturns(error)
+
+            val result = repository.updatePaymentMethod(
+                PaymentSheet.CustomerConfiguration(
+                    "customer_id",
+                    "ephemeral_key"
+                ),
+                PaymentMethodUpdateParams.createCard(
+                    paymentMethodId = "payment_method_id"
+                )
+            )
+
+            assertThat(result).isEqualTo(error)
+        }
+
     private suspend fun failsOnceStripeRepository(): StripeRepository {
         val repository = mock<StripeRepository>()
         whenever(
@@ -357,6 +396,19 @@ internal class CustomerRepositoryTest {
                     productUsageTokens = any(),
                     paymentMethodId = anyString(),
                     requestOptions = any(),
+                )
+            }.doReturn(result)
+        }
+    }
+
+    private fun givenUpdatePaymentMethodReturns(
+        result: Result<PaymentMethod>
+    ) {
+        stripeRepository.stub {
+            onBlocking {
+                updatePaymentMethod(
+                    paymentMethodUpdateParams = any(),
+                    options = any(),
                 )
             }.doReturn(result)
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/FakeEditPaymentMethodInteractorFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/FakeEditPaymentMethodInteractorFactory.kt
@@ -15,12 +15,14 @@ internal class FakeEditPaymentMethodInteractorFactory(
     override fun create(
         initialPaymentMethod: PaymentMethod,
         removeExecutor: PaymentMethodRemoveOperation,
-        updateExecutor: PaymentMethodUpdateOperation
+        updateExecutor: PaymentMethodUpdateOperation,
+        displayName: String
     ): ModifiableEditPaymentMethodViewInteractor {
         return DefaultEditPaymentMethodViewInteractor(
             initialPaymentMethod = initialPaymentMethod,
             removeExecutor = removeExecutor,
             updateExecutor = updateExecutor,
+            displayName = displayName,
             workContext = context,
             viewStateSharingStarted = SharingStarted.Eagerly
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/FakeEditPaymentMethodInteractorFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/FakeEditPaymentMethodInteractorFactory.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.paymentsheet.utils
+
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.ui.DefaultEditPaymentMethodViewInteractor
+import com.stripe.android.paymentsheet.ui.ModifiableEditPaymentMethodViewInteractor
+import com.stripe.android.paymentsheet.ui.PaymentMethodRemoveOperation
+import com.stripe.android.paymentsheet.ui.PaymentMethodUpdateOperation
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.SharingStarted
+import kotlin.coroutines.CoroutineContext
+
+internal class FakeEditPaymentMethodInteractorFactory(
+    private val context: CoroutineContext = Dispatchers.Main
+) : ModifiableEditPaymentMethodViewInteractor.Factory {
+    override fun create(
+        initialPaymentMethod: PaymentMethod,
+        removeExecutor: PaymentMethodRemoveOperation,
+        updateExecutor: PaymentMethodUpdateOperation
+    ): ModifiableEditPaymentMethodViewInteractor {
+        return DefaultEditPaymentMethodViewInteractor(
+            initialPaymentMethod = initialPaymentMethod,
+            removeExecutor = removeExecutor,
+            updateExecutor = updateExecutor,
+            workContext = context,
+            viewStateSharingStarted = SharingStarted.Eagerly
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
@@ -2,6 +2,7 @@ package com.stripe.android.utils
 
 import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 
@@ -14,6 +15,9 @@ internal open class FakeCustomerRepository(
     private val onAttachPaymentMethod: () -> Result<PaymentMethod> = {
         Result.failure(NotImplementedError())
     },
+    private val onUpdatePaymentMethod: () -> Result<PaymentMethod> = {
+        Result.failure(NotImplementedError())
+    }
 ) : CustomerRepository {
     lateinit var savedPaymentMethod: PaymentMethod
     var error: Throwable? = null
@@ -38,4 +42,9 @@ internal open class FakeCustomerRepository(
         customerConfig: PaymentSheet.CustomerConfiguration,
         paymentMethodId: String
     ): Result<PaymentMethod> = onAttachPaymentMethod()
+
+    override suspend fun updatePaymentMethod(
+        customerConfig: PaymentSheet.CustomerConfiguration,
+        params: PaymentMethodUpdateParams
+    ): Result<PaymentMethod> = onUpdatePaymentMethod()
 }


### PR DESCRIPTION
# Summary
Support update functionality in `PaymentSheet`.

**Note**: The update API call is currently not returning a success result. This will be changed in near future.

# Motivation
Allows merchants to update their card brand choice for their payment method.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified