### PR TITLE
Support updating payment method in `CustomerSheet`.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -554,7 +554,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
             apiRequest = apiRequestFactory.createPost(
                 url = getPaymentMethodUrl(paymentMethodId),
                 options = options,
-                params = paymentMethodUpdateParams.toParamMap() + fraudDetectionData?.params.orEmpty(),
+                params = paymentMethodUpdateParams.toParamMap(),
             ),
             jsonParser = PaymentMethodJsonParser()
         )

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -15,7 +15,7 @@ public abstract interface class com/stripe/android/customersheet/CustomerAdapter
 	public abstract fun retrieveSelectedPaymentOption (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun setSelectedPaymentOption (Lcom/stripe/android/customersheet/CustomerAdapter$PaymentOption;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun setupIntentClientSecretForCustomerAttach (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun updatePaymentMethod (Lcom/stripe/android/model/PaymentMethodUpdateParams;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updatePaymentMethod (Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodUpdateParams;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/stripe/android/customersheet/CustomerAdapter$Companion {

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -15,6 +15,7 @@ public abstract interface class com/stripe/android/customersheet/CustomerAdapter
 	public abstract fun retrieveSelectedPaymentOption (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun setSelectedPaymentOption (Lcom/stripe/android/customersheet/CustomerAdapter$PaymentOption;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun setupIntentClientSecretForCustomerAttach (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updatePaymentMethod (Lcom/stripe/android/model/PaymentMethodUpdateParams;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/stripe/android/customersheet/CustomerAdapter$Companion {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
@@ -51,11 +51,12 @@ interface CustomerAdapter {
     suspend fun detachPaymentMethod(paymentMethodId: String): Result<PaymentMethod>
 
     /**
-     * Detaches the given payment method from a customer
+     * Updates the given payment method from a customer
+     * @param paymentMethodId, the payment method to update that is attached to the customer
      * @param params, parameters for updating a payment method
      * @return the modified [PaymentMethod].
      */
-    suspend fun updatePaymentMethod(params: PaymentMethodUpdateParams): Result<PaymentMethod>
+    suspend fun updatePaymentMethod(paymentMethodId: String, params: PaymentMethodUpdateParams): Result<PaymentMethod>
 
     /**
      * Saves the payment option to a data store.

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
@@ -51,10 +51,11 @@ interface CustomerAdapter {
     suspend fun detachPaymentMethod(paymentMethodId: String): Result<PaymentMethod>
 
     /**
-     * Updates the given payment method from a customer
-     * @param paymentMethodId, the payment method to update that is attached to the customer
-     * @param params, parameters for updating a payment method
-     * @return the modified [PaymentMethod].
+     * Updates a payment method with the provided [PaymentMethodUpdateParams].
+     *
+     * @param paymentMethodId The payment method to update
+     * @param paymentMethodUpdateParams The [PaymentMethodUpdateParams]
+     * @return The updated [PaymentMethod]
      */
     suspend fun updatePaymentMethod(paymentMethodId: String, params: PaymentMethodUpdateParams): Result<PaymentMethod>
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
@@ -3,6 +3,7 @@ package com.stripe.android.customersheet
 import android.content.Context
 import com.stripe.android.customersheet.injection.DaggerStripeCustomerAdapterComponent
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 
@@ -48,6 +49,13 @@ interface CustomerAdapter {
      * @return the modified [PaymentMethod].
      */
     suspend fun detachPaymentMethod(paymentMethodId: String): Result<PaymentMethod>
+
+    /**
+     * Detaches the given payment method from a customer
+     * @param params, parameters for updating a payment method
+     * @return the modified [PaymentMethod].
+     */
+    suspend fun updatePaymentMethod(params: PaymentMethodUpdateParams): Result<PaymentMethod>
 
     /**
      * Saves the payment option to a data store.

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -433,11 +433,9 @@ internal class CustomerSheetViewModel @Inject constructor(
         paymentMethod: PaymentMethod,
         brand: CardBrand
     ): CustomerAdapter.Result<PaymentMethod> {
-        val paymentMethodId = paymentMethod.id
-
         return customerAdapter.updatePaymentMethod(
+            paymentMethodId = paymentMethod.id!!,
             params = PaymentMethodUpdateParams.createCard(
-                paymentMethodId = paymentMethodId!!,
                 networks = PaymentMethodUpdateParams.Card.Networks(
                     preferred = brand.code
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -18,11 +18,13 @@ import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.injection.CustomerSheetViewModelScope
 import com.stripe.android.customersheet.util.isUnverifiedUSBankAccount
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
@@ -66,8 +68,6 @@ import javax.inject.Named
 import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 import com.stripe.android.ui.core.R as UiCoreR
-
-private const val TempDelay = 2000L
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 @CustomerSheetViewModelScope
@@ -429,6 +429,25 @@ internal class CustomerSheetViewModel @Inject constructor(
         }
     }
 
+    private suspend fun modifyCardPaymentMethod(
+        paymentMethod: PaymentMethod,
+        brand: CardBrand
+    ): CustomerAdapter.Result<PaymentMethod> {
+        val paymentMethodId = paymentMethod.id
+
+        return customerAdapter.updatePaymentMethod(
+            params = PaymentMethodUpdateParams.createCard(
+                paymentMethodId = paymentMethodId!!,
+                networks = PaymentMethodUpdateParams.Card.Networks(
+                    preferred = brand.code
+                )
+            )
+        ).onSuccess { updatedMethod ->
+            onBackPressed()
+            updatePaymentMethodInState(updatedMethod)
+        }
+    }
+
     private fun handlePaymentMethodRemoved(paymentMethod: PaymentMethod) {
         val currentViewState = viewState.value
         val newSavedPaymentMethods = currentViewState.savedPaymentMethods.filter { it.id != paymentMethod.id!! }
@@ -484,10 +503,11 @@ internal class CustomerSheetViewModel @Inject constructor(
                         }
                         result is CustomerAdapter.Result.Success
                     },
-                    updateExecutor = { _, _ ->
-                        // TODO(tillh-stripe): Replace with update operation
-                        delay(TempDelay)
-                        Result.success(paymentMethod)
+                    updateExecutor = { method, brand ->
+                        when (val result = modifyCardPaymentMethod(method, brand)) {
+                            is CustomerAdapter.Result.Success -> Result.success(result.value)
+                            is CustomerAdapter.Result.Failure -> Result.failure(result.cause)
+                        }
                     },
                 ),
                 isLiveMode = currentViewState.isLiveMode,
@@ -509,6 +529,25 @@ internal class CustomerSheetViewModel @Inject constructor(
                 updateViewState<CustomerSheetViewState.SelectPaymentMethod> {
                     it.copy(savedPaymentMethods = newSavedPaymentMethods)
                 }
+            }
+        }
+    }
+
+    private fun updatePaymentMethodInState(updatedMethod: PaymentMethod) {
+        viewModelScope.launch {
+            val newSavedPaymentMethods = viewState.value.savedPaymentMethods.map { savedMethod ->
+                val savedId = savedMethod.id
+                val updatedId = updatedMethod.id
+
+                if (updatedId != null && savedId != null && updatedId == savedId) {
+                    updatedMethod
+                } else {
+                    savedMethod
+                }
+            }
+
+            updateViewState<CustomerSheetViewState.SelectPaymentMethod> {
+                it.copy(savedPaymentMethods = newSavedPaymentMethods)
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
@@ -103,6 +103,7 @@ internal class StripeCustomerAdapter @Inject constructor(
     }
 
     override suspend fun updatePaymentMethod(
+        paymentMethodId: String,
         params: PaymentMethodUpdateParams
     ): CustomerAdapter.Result<PaymentMethod> {
         return getCustomerEphemeralKey().mapCatching { customerEphemeralKey ->
@@ -111,6 +112,7 @@ internal class StripeCustomerAdapter @Inject constructor(
                     id = customerEphemeralKey.customerId,
                     ephemeralKeySecret = customerEphemeralKey.ephemeralKey
                 ),
+                paymentMethodId = paymentMethodId,
                 params = params
             ).getOrElse {
                 return CustomerAdapter.Result.failure(

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
@@ -5,6 +5,7 @@ import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.R
@@ -92,6 +93,25 @@ internal class StripeCustomerAdapter @Inject constructor(
                     ephemeralKeySecret = customerEphemeralKey.ephemeralKey
                 ),
                 paymentMethodId = paymentMethodId
+            ).getOrElse {
+                return CustomerAdapter.Result.failure(
+                    cause = it,
+                    displayMessage = it.stripeErrorMessage(context),
+                )
+            }
+        }
+    }
+
+    override suspend fun updatePaymentMethod(
+        params: PaymentMethodUpdateParams
+    ): CustomerAdapter.Result<PaymentMethod> {
+        return getCustomerEphemeralKey().mapCatching { customerEphemeralKey ->
+            customerRepository.updatePaymentMethod(
+                customerConfig = PaymentSheet.CustomerConfiguration(
+                    id = customerEphemeralKey.customerId,
+                    ephemeralKeySecret = customerEphemeralKey.ephemeralKey
+                ),
+                params = params
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -299,9 +299,8 @@ class CustomerAdapterTest {
             )
         )
         val result = adapter.updatePaymentMethod(
-            PaymentMethodUpdateParams.createCard(
-                paymentMethodId = "pm_1234"
-            )
+            paymentMethodId = "pm_1234",
+            params = PaymentMethodUpdateParams.createCard()
         )
         assertThat(result.getOrNull()).isEqualTo(
             PaymentMethodFixtures.CARD_PAYMENT_METHOD
@@ -322,9 +321,8 @@ class CustomerAdapterTest {
             )
         )
         val result = adapter.updatePaymentMethod(
-            PaymentMethodUpdateParams.createCard(
-                paymentMethodId = "pm_1234"
-            )
+            paymentMethodId = "pm_1234",
+            params = PaymentMethodUpdateParams.createCard()
         )
         assertThat(result.failureOrNull()?.displayMessage)
             .isEqualTo("Something went wrong")
@@ -345,9 +343,8 @@ class CustomerAdapterTest {
             )
         )
         val result = adapter.updatePaymentMethod(
-            PaymentMethodUpdateParams.createCard(
-                paymentMethodId = "pm_1234"
-            )
+            paymentMethodId = "pm_1234",
+            params = PaymentMethodUpdateParams.createCard()
         )
         assertThat(result.failureOrNull()?.displayMessage)
             .isEqualTo("Unable to update payment method")

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -2504,7 +2504,7 @@ class CustomerSheetViewModelTest {
 
         val customerAdapter = FakeCustomerAdapter(
             paymentMethods = CustomerAdapter.Result.Success(paymentMethods),
-            onUpdatePaymentMethod = {
+            onUpdatePaymentMethod = { _, _ ->
                 CustomerAdapter.Result.Success(updatedMethod)
             }
         )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeCustomerAdapter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeCustomerAdapter.kt
@@ -2,6 +2,7 @@ package com.stripe.android.customersheet
 
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
+import com.stripe.android.model.PaymentMethodUpdateParams
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 internal class FakeCustomerAdapter(
@@ -14,6 +15,8 @@ internal class FakeCustomerAdapter(
         ((paymentOption: CustomerAdapter.PaymentOption?) -> CustomerAdapter.Result<Unit>)? = null,
     private val onAttachPaymentMethod: ((paymentMethodId: String) -> CustomerAdapter.Result<PaymentMethod>)? = null,
     private val onDetachPaymentMethod: ((paymentMethodId: String) -> CustomerAdapter.Result<PaymentMethod>)? = null,
+    private val onUpdatePaymentMethod:
+        ((params: PaymentMethodUpdateParams) -> CustomerAdapter.Result<PaymentMethod>)? = null,
     private val onSetupIntentClientSecretForCustomerAttach: (() -> CustomerAdapter.Result<String>)? = null
 ) : CustomerAdapter {
 
@@ -29,6 +32,17 @@ internal class FakeCustomerAdapter(
     override suspend fun detachPaymentMethod(paymentMethodId: String): CustomerAdapter.Result<PaymentMethod> {
         return onDetachPaymentMethod?.invoke(paymentMethodId)
             ?: CustomerAdapter.Result.success(paymentMethods.getOrNull()?.find { it.id!! == paymentMethodId }!!)
+    }
+
+    override suspend fun updatePaymentMethod(
+        params: PaymentMethodUpdateParams
+    ): CustomerAdapter.Result<PaymentMethod> {
+        return onUpdatePaymentMethod?.invoke(params)
+            ?: CustomerAdapter.Result.success(
+                paymentMethods.getOrNull()?.find {
+                    it.id!! == params.paymentMethodId
+                }!!
+            )
     }
 
     override suspend fun setSelectedPaymentOption(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeCustomerAdapter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeCustomerAdapter.kt
@@ -16,7 +16,7 @@ internal class FakeCustomerAdapter(
     private val onAttachPaymentMethod: ((paymentMethodId: String) -> CustomerAdapter.Result<PaymentMethod>)? = null,
     private val onDetachPaymentMethod: ((paymentMethodId: String) -> CustomerAdapter.Result<PaymentMethod>)? = null,
     private val onUpdatePaymentMethod:
-        ((params: PaymentMethodUpdateParams) -> CustomerAdapter.Result<PaymentMethod>)? = null,
+        ((paymentMethodId: String, params: PaymentMethodUpdateParams) -> CustomerAdapter.Result<PaymentMethod>)? = null,
     private val onSetupIntentClientSecretForCustomerAttach: (() -> CustomerAdapter.Result<String>)? = null
 ) : CustomerAdapter {
 
@@ -35,12 +35,13 @@ internal class FakeCustomerAdapter(
     }
 
     override suspend fun updatePaymentMethod(
+        paymentMethodId: String,
         params: PaymentMethodUpdateParams
     ): CustomerAdapter.Result<PaymentMethod> {
-        return onUpdatePaymentMethod?.invoke(params)
+        return onUpdatePaymentMethod?.invoke(paymentMethodId, params)
             ?: CustomerAdapter.Result.success(
                 paymentMethods.getOrNull()?.find {
-                    it.id!! == params.paymentMethodId
+                    it.id!! == paymentMethodId
                 }!!
             )
     }


### PR DESCRIPTION
# Summary
Support updating payment method in `CustomerSheet`.

# Motivation
Allows merchant to update their Card Brand Choice through `CustomerSheet`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified