### PR TITLE
Fix copy/paste error for updatePin doc comment

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/IssuingCardPinService.kt
+++ b/payments-core/src/main/java/com/stripe/android/IssuingCardPinService.kt
@@ -108,14 +108,14 @@ class IssuingCardPinService @VisibleForTesting internal constructor(
     }
 
     /**
-     * Retrieves a PIN for a given card
+     * Updates a PIN for a given card
      *
      * @param cardId the ID of the card (looks like ic_abcdef1234)
      * @param newPin the new desired PIN
      * @param verificationId the ID of the verification that was sent to the cardholder
      * (typically server-side, through /v1/issuing/verifications)
      * @param userOneTimeCode the one-time code that was sent to the cardholder through sms or email
-     * @param listener a listener for either the PIN, or any error that can occur
+     * @param listener a listener for either success or any error that can occur
      */
     fun updatePin(
         cardId: String,


### PR DESCRIPTION
This also appears in the [public api docs](https://stripe.dev/stripe-android/payments-core/com.stripe.android/-issuing-card-pin-service/update-pin.html?query=fun%20updatePin(cardId:%20String,%20newPin:%20String,%20verificationId:%20String,%20userOneTimeCode:%20String,%20listener:%20IssuingCardPinService.IssuingCardPinUpdateListener))