### PR TITLE
Fix `author` & `committer` in translations PR workflow.

### DIFF
--- a/.github/workflows/fetch_translations.yml
+++ b/.github/workflows/fetch_translations.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           token: ${{ steps.generate-translations-app-token.outputs.token }}
           commit-message: Fetch latest Lokalize translations
+          author: ${{ secrets.ANDROID_TRANSLATIONS_APP_AUTHOR }}
+          committer: ${{ secrets.ANDROID_TRANSLATIONS_APP_AUTHOR }}
           title: Update translations
           body: This pull request contains the latest translations from Lokalize.
           branch: update-translations-${{ steps.timestamp.outputs.TIMESTAMP }}


### PR DESCRIPTION
# Summary
Fix `author` & `committer` in translations PR workflow.

# Motivation
Sets the commit author to be the translations GitHub app rather than the workflow creator.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
