### PR TITLE
Remove `LiveData` from `AddPaymentMethod` flow.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/AddPaymentMethodViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/AddPaymentMethodViewModel.kt
@@ -1,8 +1,6 @@
 package com.stripe.android.view
 
 import androidx.annotation.VisibleForTesting
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.ApiResultCallback
@@ -14,6 +12,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.view.i18n.ErrorMessageTranslator
 import com.stripe.android.view.i18n.TranslatorManager
+import kotlinx.coroutines.suspendCancellableCoroutine
 
 internal class AddPaymentMethodViewModel(
     private val stripe: Stripe,
@@ -27,23 +26,21 @@ internal class AddPaymentMethodViewModel(
         PaymentSession.PRODUCT_TOKEN.takeIf { args.isPaymentSessionActive }
     ).toSet()
 
-    internal fun createPaymentMethod(
+    internal suspend fun createPaymentMethod(
         params: PaymentMethodCreateParams
-    ): LiveData<Result<PaymentMethod>> {
-        val resultData = MutableLiveData<Result<PaymentMethod>>()
+    ): Result<PaymentMethod> = suspendCancellableCoroutine { continuation ->
         stripe.createPaymentMethod(
             paymentMethodCreateParams = updatedPaymentMethodCreateParams(params),
             callback = object : ApiResultCallback<PaymentMethod> {
                 override fun onSuccess(result: PaymentMethod) {
-                    resultData.value = Result.success(result)
+                    continuation.resume(Result.success(result), onCancellation = null)
                 }
 
                 override fun onError(e: Exception) {
-                    resultData.value = Result.failure(e)
+                    continuation.resume(Result.failure(e), onCancellation = null)
                 }
             }
         )
-        return resultData
     }
 
     @VisibleForTesting
@@ -52,17 +49,16 @@ internal class AddPaymentMethodViewModel(
     ) = params.copy(productUsage = productUsage)
 
     @JvmSynthetic
-    internal fun attachPaymentMethod(
+    internal suspend fun attachPaymentMethod(
         customerSession: CustomerSession,
         paymentMethod: PaymentMethod
-    ): LiveData<Result<PaymentMethod>> {
-        val resultData = MutableLiveData<Result<PaymentMethod>>()
+    ): Result<PaymentMethod> = suspendCancellableCoroutine { continuation ->
         customerSession.attachPaymentMethod(
             paymentMethodId = paymentMethod.id.orEmpty(),
             productUsage = productUsage,
             listener = object : CustomerSession.PaymentMethodRetrievalListener {
                 override fun onPaymentMethodRetrieved(paymentMethod: PaymentMethod) {
-                    resultData.value = Result.success(paymentMethod)
+                    continuation.resume(Result.success(paymentMethod), onCancellation = null)
                 }
 
                 override fun onError(
@@ -70,19 +66,21 @@ internal class AddPaymentMethodViewModel(
                     errorMessage: String,
                     stripeError: StripeError?
                 ) {
-                    resultData.value = Result.failure(
-                        RuntimeException(
-                            errorMessageTranslator.translate(
-                                errorCode,
-                                errorMessage,
-                                stripeError
+                    continuation.resume(
+                        Result.failure(
+                            RuntimeException(
+                                errorMessageTranslator.translate(
+                                    errorCode,
+                                    errorMessage,
+                                    stripeError
+                                )
                             )
-                        )
+                        ),
+                        onCancellation = null
                     )
                 }
             }
         )
-        return resultData
     }
 
     internal class Factory(

--- a/payments-core/src/main/java/com/stripe/android/view/AddPaymentMethodViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/AddPaymentMethodViewModel.kt
@@ -12,7 +12,8 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.view.i18n.ErrorMessageTranslator
 import com.stripe.android.view.i18n.TranslatorManager
-import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 internal class AddPaymentMethodViewModel(
     private val stripe: Stripe,
@@ -28,16 +29,16 @@ internal class AddPaymentMethodViewModel(
 
     internal suspend fun createPaymentMethod(
         params: PaymentMethodCreateParams
-    ): Result<PaymentMethod> = suspendCancellableCoroutine { continuation ->
+    ): Result<PaymentMethod> = suspendCoroutine { continuation ->
         stripe.createPaymentMethod(
             paymentMethodCreateParams = updatedPaymentMethodCreateParams(params),
             callback = object : ApiResultCallback<PaymentMethod> {
                 override fun onSuccess(result: PaymentMethod) {
-                    continuation.resume(Result.success(result), onCancellation = null)
+                    continuation.resume(Result.success(result))
                 }
 
                 override fun onError(e: Exception) {
-                    continuation.resume(Result.failure(e), onCancellation = null)
+                    continuation.resume(Result.failure(e))
                 }
             }
         )
@@ -52,13 +53,13 @@ internal class AddPaymentMethodViewModel(
     internal suspend fun attachPaymentMethod(
         customerSession: CustomerSession,
         paymentMethod: PaymentMethod
-    ): Result<PaymentMethod> = suspendCancellableCoroutine { continuation ->
+    ): Result<PaymentMethod> = suspendCoroutine { continuation ->
         customerSession.attachPaymentMethod(
             paymentMethodId = paymentMethod.id.orEmpty(),
             productUsage = productUsage,
             listener = object : CustomerSession.PaymentMethodRetrievalListener {
                 override fun onPaymentMethodRetrieved(paymentMethod: PaymentMethod) {
-                    continuation.resume(Result.success(paymentMethod), onCancellation = null)
+                    continuation.resume(Result.success(paymentMethod))
                 }
 
                 override fun onError(
@@ -75,8 +76,7 @@ internal class AddPaymentMethodViewModel(
                                     stripeError
                                 )
                             )
-                        ),
-                        onCancellation = null
+                        )
                     )
                 }
             }


### PR DESCRIPTION
# Summary
Remove `LiveData` from `AddPaymentMethod` flow.

# Motivation
Allows us to get closer to our goal of removing `LiveData` usage in the SDK

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
