### PR TITLE
Remove `LiveData` from `PaymentSession` flow.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/PaymentSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/PaymentSession.kt
@@ -282,14 +282,13 @@ class PaymentSession @VisibleForTesting internal constructor(
     }
 
     private fun fetchCustomer(isInitialFetch: Boolean = false) {
-        viewModel.fetchCustomer(isInitialFetch).observe(
-            lifecycleOwner,
-            { result ->
-                if (result is PaymentSessionViewModel.FetchCustomerResult.Error) {
-                    listener?.onError(result.errorCode, result.errorMessage)
-                }
+        lifecycleOwner.lifecycleScope.launch {
+            val result = viewModel.fetchCustomer(isInitialFetch)
+
+            if (result is PaymentSessionViewModel.FetchCustomerResult.Error) {
+                listener?.onError(result.errorCode, result.errorMessage)
             }
-        )
+        }
     }
 
     /**


### PR DESCRIPTION
# Summary
Remove `LiveData` from `PaymentSession` flow.

# Motivation
Gets us closer to our goal of removing `LiveData` usage across the SDK.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
