### PR TITLE
Remove `LiveData` from examples.

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/ComposeExampleActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/ComposeExampleActivity.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.lifecycleScope
 import com.stripe.android.model.Address
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -29,6 +30,7 @@ import com.stripe.android.payments.paymentlauncher.rememberPaymentLauncher
 import com.stripe.example.R
 import com.stripe.example.Settings
 import com.stripe.example.module.StripeIntentViewModel
+import kotlinx.coroutines.launch
 
 /**
  * An Activity to demonstrate [PaymentLauncher] with Jetpack Compose.
@@ -137,10 +139,8 @@ class ComposeExampleActivity : AppCompatActivity() {
         params: PaymentMethodCreateParams,
         onConfirm: (ConfirmPaymentIntentParams) -> Unit
     ) {
-        viewModel.createPaymentIntent("us").observe(
-            this
-        ) {
-            it.onSuccess { responseData ->
+        lifecycleScope.launch {
+            viewModel.createPaymentIntent("us").onSuccess { responseData ->
                 val confirmPaymentIntentParams =
                     ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
                         paymentMethodCreateParams = params,

--- a/example/src/main/java/com/stripe/example/activity/FragmentExamplesViewModel.kt
+++ b/example/src/main/java/com/stripe/example/activity/FragmentExamplesViewModel.kt
@@ -1,10 +1,9 @@
 package com.stripe.example.activity
 
 import android.app.Application
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.liveData
 import com.stripe.android.PaymentIntentResult
 import com.stripe.android.SetupIntentResult
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.withContext
 import okhttp3.ResponseBody
 import org.json.JSONObject
@@ -12,26 +11,34 @@ import org.json.JSONObject
 internal class FragmentExamplesViewModel(
     application: Application
 ) : BaseViewModel(application) {
-    val paymentIntentResultLiveData = MutableLiveData<Result<PaymentIntentResult>>()
-    val setupIntentResultLiveData = MutableLiveData<Result<SetupIntentResult>>()
+    val paymentIntentResult = MutableStateFlow<FragmentExamplesIntentResult<PaymentIntentResult>>(
+        FragmentExamplesIntentResult.None()
+    )
+    val setupIntentResult = MutableStateFlow<FragmentExamplesIntentResult<SetupIntentResult>>(
+        FragmentExamplesIntentResult.None()
+    )
 
-    fun createPaymentIntent() = createIntent { backendApi.createPaymentIntent(PARAMS) }
+    suspend fun createPaymentIntent() = createIntent { backendApi.createPaymentIntent(PARAMS) }
 
-    fun createSetupIntent() = createIntent { backendApi.createSetupIntent(PARAMS) }
+    suspend fun createSetupIntent() = createIntent { backendApi.createSetupIntent(PARAMS) }
 
-    private fun createIntent(
+    private suspend fun createIntent(
         apiMethod: suspend () -> ResponseBody
-    ) = liveData {
-        withContext(workContext) {
-            emit(
-                runCatching {
-                    JSONObject(apiMethod().string())
-                }
-            )
+    ): Result<JSONObject> {
+        return withContext(workContext) {
+            runCatching {
+                JSONObject(apiMethod().string())
+            }
         }
     }
 
     private companion object {
         private val PARAMS = mutableMapOf("country" to "us")
+    }
+
+    internal sealed interface FragmentExamplesIntentResult<Intent> {
+        class None<Intent> : FragmentExamplesIntentResult<Intent>
+
+        data class Available<Intent>(val result: Result<Intent>) : FragmentExamplesIntentResult<Intent>
     }
 }

--- a/example/src/main/java/com/stripe/example/activity/SourceViewModel.kt
+++ b/example/src/main/java/com/stripe/example/activity/SourceViewModel.kt
@@ -2,7 +2,6 @@ package com.stripe.example.activity
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
-import androidx.lifecycle.liveData
 import com.stripe.android.createSource
 import com.stripe.android.model.Source
 import com.stripe.android.model.SourceParams
@@ -16,30 +15,24 @@ internal class SourceViewModel(
 
     internal var source: Source? = null
 
-    internal fun createSource(sourceParams: SourceParams) = liveData {
-        emit(
-            runCatching {
-                stripe.createSource(sourceParams)
-            }
-        )
+    internal suspend fun createSource(sourceParams: SourceParams): Result<Source> {
+        return runCatching {
+            stripe.createSource(sourceParams)
+        }
     }
 
-    internal fun fetchSource(source: Source?) = liveData {
-        if (source == null) {
-            emit(
-                Result.failure<Source>(
-                    IllegalArgumentException("Create and authenticate a Source before fetching it.")
-                )
+    internal suspend fun fetchSource(source: Source?): Result<Source> {
+        return if (source == null) {
+            Result.failure(
+                IllegalArgumentException("Create and authenticate a Source before fetching it.")
             )
         } else {
-            emit(
-                runCatching {
-                    stripe.retrieveSource(
-                        source.id.orEmpty(),
-                        source.clientSecret.orEmpty()
-                    )
-                }
-            )
+            runCatching {
+                stripe.retrieveSource(
+                    source.id.orEmpty(),
+                    source.clientSecret.orEmpty()
+                )
+            }
         }
     }
 }

--- a/example/src/main/java/com/stripe/example/activity/StripeIntentActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/StripeIntentActivity.kt
@@ -3,6 +3,7 @@ package com.stripe.example.activity
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
@@ -13,6 +14,7 @@ import com.stripe.android.payments.paymentlauncher.PaymentLauncher
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.example.Settings
 import com.stripe.example.module.StripeIntentViewModel
+import kotlinx.coroutines.launch
 import org.json.JSONObject
 
 /**
@@ -90,15 +92,13 @@ abstract class StripeIntentActivity : AppCompatActivity() {
 
         keyboardController.hide()
 
-        viewModel.createPaymentIntent(
-            country = country,
-            supportedPaymentMethods = supportedPaymentMethods,
-            customerId = customerId,
-            currency = currency,
-        ).observe(
-            this
-        ) { result ->
-            result.onSuccess {
+        lifecycleScope.launch {
+            viewModel.createPaymentIntent(
+                country = country,
+                supportedPaymentMethods = supportedPaymentMethods,
+                customerId = customerId,
+                currency = currency,
+            ).onSuccess {
                 handleCreatePaymentIntentResponse(
                     it,
                     paymentMethodCreateParams,
@@ -125,14 +125,12 @@ abstract class StripeIntentActivity : AppCompatActivity() {
     ) {
         keyboardController.hide()
 
-        viewModel.createSetupIntent(
-            country = country,
-            supportedPaymentMethods = supportedPaymentMethods,
-            customerId = customerId,
-        ).observe(
-            this
-        ) { result ->
-            result.onSuccess {
+        lifecycleScope.launch {
+            viewModel.createSetupIntent(
+                country = country,
+                supportedPaymentMethods = supportedPaymentMethods,
+                customerId = customerId,
+            ).onSuccess {
                 handleCreateSetupIntentResponse(
                     it,
                     params,

--- a/example/src/main/java/com/stripe/example/module/StripeIntentViewModel.kt
+++ b/example/src/main/java/com/stripe/example/module/StripeIntentViewModel.kt
@@ -3,7 +3,6 @@ package com.stripe.example.module
 import android.app.Application
 import androidx.annotation.StringRes
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.liveData
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.example.R
 import com.stripe.example.activity.BaseViewModel
@@ -20,7 +19,7 @@ internal class StripeIntentViewModel(
 
     val paymentResultLiveData = MutableLiveData<PaymentResult>()
 
-    fun createPaymentIntent(
+    suspend fun createPaymentIntent(
         country: String,
         customerId: String? = null,
         supportedPaymentMethods: String? = null,
@@ -48,7 +47,7 @@ internal class StripeIntentViewModel(
         )
     }
 
-    fun createSetupIntent(
+    suspend fun createSetupIntent(
         country: String,
         customerId: String? = null,
         supportedPaymentMethods: String? = null,
@@ -71,11 +70,11 @@ internal class StripeIntentViewModel(
         )
     }
 
-    private fun makeBackendRequest(
+    private suspend fun makeBackendRequest(
         @StringRes creatingStringRes: Int,
         @StringRes resultStringRes: Int,
         apiMethod: suspend () -> ResponseBody
-    ) = liveData {
+    ): Result<JSONObject> {
         inProgress.postValue(true)
         status.postValue(resources.getString(creatingStringRes))
 
@@ -116,6 +115,6 @@ internal class StripeIntentViewModel(
             }
         )
 
-        emit(result)
+        return result
     }
 }


### PR DESCRIPTION
# Summary
Remove `LiveData` from examples.

# Motivation
Gets us closer to our goal of removing `LiveData` usage within the SDK.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified