### PR TITLE
Add event for PM update calls

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodUpdateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodUpdateParams.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
+import androidx.annotation.RestrictTo
 import kotlinx.parcelize.Parcelize
 import java.util.Objects
 
@@ -14,6 +15,7 @@ sealed class PaymentMethodUpdateParams(
 ) : StripeParamsModel, Parcelable {
 
     internal abstract val billingDetails: PaymentMethod.BillingDetails?
+    internal abstract val productUsageTokens: Set<String>
 
     internal abstract fun generateTypeParams(): Map<String, Any>
 
@@ -33,6 +35,7 @@ sealed class PaymentMethodUpdateParams(
         val expiryYear: Int? = null,
         val networks: Networks? = null,
         override val billingDetails: PaymentMethod.BillingDetails?,
+        override val productUsageTokens: Set<String> = emptySet(),
     ) : PaymentMethodUpdateParams(PaymentMethod.Type.Card) {
 
         override fun generateTypeParams(): Map<String, Any> {
@@ -118,6 +121,19 @@ sealed class PaymentMethodUpdateParams(
             billingDetails: PaymentMethod.BillingDetails? = null,
         ): PaymentMethodUpdateParams {
             return Card(expiryMonth, expiryYear, networks, billingDetails)
+        }
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @JvmStatic
+        @JvmOverloads
+        fun createCard(
+            expiryMonth: Int? = null,
+            expiryYear: Int? = null,
+            networks: Card.Networks? = null,
+            billingDetails: PaymentMethod.BillingDetails? = null,
+            productUsageTokens: Set<String>,
+        ): PaymentMethodUpdateParams {
+            return Card(expiryMonth, expiryYear, networks, billingDetails, productUsageTokens)
         }
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsEvent.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsEvent.kt
@@ -9,6 +9,7 @@ internal enum class PaymentAnalyticsEvent(val code: String) : AnalyticsEvent {
 
     // Payment Methods
     PaymentMethodCreate("payment_method_creation"),
+    PaymentMethodUpdate("payment_method_update"),
 
     // Customer
     CustomerRetrieve("retrieve_customer"),

--- a/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsRequestFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsRequestFactory.kt
@@ -98,13 +98,25 @@ class PaymentAnalyticsRequestFactory @VisibleForTesting internal constructor(
 
     @JvmSynthetic
     internal fun createPaymentMethodCreation(
-        paymentMethodCode: PaymentMethodCode?,
+        paymentMethodCode: PaymentMethodCode,
         productUsageTokens: Set<String>
     ): AnalyticsRequest {
         return createRequest(
             PaymentAnalyticsEvent.PaymentMethodCreate,
             sourceType = paymentMethodCode,
             productUsageTokens = productUsageTokens
+        )
+    }
+
+    @JvmSynthetic
+    internal fun createPaymentMethodUpdate(
+        paymentMethodCode: PaymentMethodCode?,
+        productUsageTokens: Set<String>,
+    ): AnalyticsRequest {
+        return createRequest(
+            PaymentAnalyticsEvent.PaymentMethodUpdate,
+            sourceType = paymentMethodCode,
+            productUsageTokens = productUsageTokens,
         )
     }
 

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -557,7 +557,14 @@ class StripeApiRepository @JvmOverloads internal constructor(
                 params = paymentMethodUpdateParams.toParamMap(),
             ),
             jsonParser = PaymentMethodJsonParser()
-        )
+        ) {
+            fireAnalyticsRequest(
+                paymentAnalyticsRequestFactory.createPaymentMethodUpdate(
+                    paymentMethodCode = paymentMethodUpdateParams.type.code,
+                    productUsageTokens = paymentMethodUpdateParams.productUsageTokens,
+                )
+            )
+        }
     }
 
     /**

--- a/payments-core/src/test/java/com/stripe/android/PaymentAnalyticsRequestFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentAnalyticsRequestFactoryTest.kt
@@ -129,6 +129,36 @@ class PaymentAnalyticsRequestFactoryTest {
     }
 
     @Test
+    fun getPaymentMethodUpdateParams() {
+        assertThat(
+            analyticsRequestFactory
+                .createPaymentMethodUpdate(
+                    PaymentMethod.Type.Card.code,
+                    ATTRIBUTION
+                ).params
+        ).isEqualTo(
+            mapOf(
+                "analytics_ua" to "analytics.stripe_android-1.0",
+                "event" to "stripe_android.payment_method_update",
+                "publishable_key" to "pk_abc123",
+                "os_name" to "REL",
+                "os_release" to "11",
+                "os_version" to 30,
+                "device_type" to "robolectric_robolectric_robolectric",
+                "bindings_version" to StripeSdkVersion.VERSION_NAME,
+                "app_name" to "com.stripe.android.test",
+                "app_version" to 0,
+                "product_usage" to ATTRIBUTION.toList(),
+                "source_type" to "card",
+                "is_development" to true,
+                "session_id" to AnalyticsRequestFactory.sessionId,
+                "network_type" to "2G",
+                "locale" to "en_US",
+            )
+        )
+    }
+
+    @Test
     fun createPaymentIntentConfirmationParams_withValidInput_createsCorrectMap() {
         val loggingParams =
             analyticsRequestFactory.createPaymentIntentConfirmation(

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -438,7 +438,8 @@ internal class CustomerSheetViewModel @Inject constructor(
             params = PaymentMethodUpdateParams.createCard(
                 networks = PaymentMethodUpdateParams.Card.Networks(
                     preferred = brand.code
-                )
+                ),
+                productUsageTokens = setOf("CustomerSheet"),
             )
         ).onSuccess { updatedMethod ->
             onBackPressed()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -503,7 +503,8 @@ internal abstract class BaseSheetViewModel(
             params = PaymentMethodUpdateParams.createCard(
                 networks = PaymentMethodUpdateParams.Card.Networks(
                     preferred = brand.code
-                )
+                ),
+                productUsageTokens = setOf("PaymentSheet"),
             )
         ).onSuccess { updatedMethod ->
             savedStateHandle[SAVE_PAYMENT_METHODS] = paymentMethods


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds an event for payment method update calls. This is to align with the create calls and with iOS.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
