### PR TITLE
Add distinctUntilChanged for flows that reemit when we don't need them to.

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -19,6 +19,7 @@ import com.stripe.android.uicore.elements.SimpleTextElement
 import com.stripe.android.uicore.elements.SimpleTextFieldConfig
 import com.stripe.android.uicore.elements.SimpleTextFieldController
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import java.util.UUID
 
 internal class CardDetailsController(
@@ -105,7 +106,7 @@ internal class CardDetailsController(
             .map { it.error }
     ) {
         it.filterNotNull().firstOrNull()
-    }
+    }.distinctUntilChanged()
 
     @Composable
     override fun ComposeUI(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
@@ -16,6 +16,7 @@ import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import com.stripe.android.R as StripeR
 
@@ -63,7 +64,7 @@ class CvcController constructor(
     override val visibleError: Flow<Boolean> =
         combine(_fieldState, _hasFocus) { fieldState, hasFocus ->
             fieldState.shouldShowError(hasFocus)
-        }
+        }.distinctUntilChanged()
 
     /**
      * An error must be emitted if it is visible or not visible.

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
@@ -9,7 +9,6 @@ import com.stripe.android.stripecardscan.R
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.utils.TestUtils.idleLooper
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -27,7 +26,7 @@ class CardDetailsControllerTest {
     fun `Verify the first field in error is returned in error flow`() = runTest {
         val cardController = CardDetailsController(context, emptyMap())
 
-        cardController.error.distinctUntilChanged().test {
+        cardController.error.test {
             assertThat(awaitItem()).isNull()
 
             cardController.numberElement.controller.onValueChange("4242424242424243")

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CvcControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CvcControllerTest.kt
@@ -5,7 +5,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.CardBrand
 import com.stripe.android.utils.TestUtils.idleLooper
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -58,7 +57,7 @@ internal class CvcControllerTest {
     @Test
     fun `Verify error is visible based on the focus`() = runTest {
         // incomplete
-        cvcController.visibleError.distinctUntilChanged().test {
+        cvcController.visibleError.test {
             cvcController.onFocusChange(true)
             cvcController.onValueChange("12")
             idleLooper()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Follow up to #7676 moving the distinctUntilChanged into the production code path.

We don't rely on the re-emit behavior, and it simplifies the tests to have it.
