### PR TITLE
Collect phone and email in PaymentSheet's Google Pay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## XX.XX.XX - 2023-XX-XX
 
 ### PaymentSheet
-* [CHANGED][7683](https://github.com/stripe/stripe-android/pull/7683) A PaymentIntent or SetupIntent confirmed with Google Pay now includes your customer's email address and phone number if the respective `CollectionMode` in `BillingDetailsCollectionConfiguration` is set to `Always`.
+* [FIXED][7683](https://github.com/stripe/stripe-android/pull/7683) Fixed an issue where PaymentSheet didn't correctly consider `BillingDetailsCollectionConfiguration` when transacting with Google Pay.
 
 ## 20.35.1 - 2023-12-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+### PaymentSheet
+* [CHANGED][7683](https://github.com/stripe/stripe-android/pull/7683) A PaymentIntent or SetupIntent confirmed with Google Pay now includes your customer's email address and phone number if the respective `CollectionMode` in `BillingDetailsCollectionConfiguration` is set to `Always`.
+
 ## 20.35.1 - 2023-12-04
 
 ### Identity

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -249,14 +249,7 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
          *
          * Default: The credit card class is supported for the card networks specified.
          */
-        var allowCreditCards: Boolean = true,
-
-        /**
-         * Flag to indicate whether Google Pay collect the customer's phone number.
-         *
-         * Default to `false`.
-         */
-        val isPhoneRequired: Boolean = false,
+        var allowCreditCards: Boolean = true
     ) : Parcelable {
 
         internal val isJcbEnabled: Boolean

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -249,7 +249,14 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
          *
          * Default: The credit card class is supported for the card networks specified.
          */
-        var allowCreditCards: Boolean = true
+        var allowCreditCards: Boolean = true,
+
+        /**
+         * Flag to indicate whether Google Pay collect the customer's phone number.
+         *
+         * Default to `false`.
+         */
+        val isPhoneRequired: Boolean = false,
     ) : Parcelable {
 
         internal val isJcbEnabled: Boolean

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -1378,3 +1378,9 @@ class PaymentSheet internal constructor(
         }
     }
 }
+
+internal val PaymentSheet.BillingDetailsCollectionConfiguration.collectsEmail: Boolean
+    get() = email == PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always
+
+internal val PaymentSheet.BillingDetailsCollectionConfiguration.collectsPhone: Boolean
+    get() = phone == PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -10,6 +10,7 @@ import androidx.annotation.RestrictTo
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.fragment.app.Fragment
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.link.account.CookieStore
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntent
@@ -1046,6 +1047,20 @@ class PaymentSheet internal constructor(
         val attachDefaultsToPaymentMethod: Boolean = false,
     ) : Parcelable {
 
+        internal val collectsEmail: Boolean
+            get() = email == CollectionMode.Always
+
+        internal fun toBillingAddressConfig(): GooglePayPaymentMethodLauncher.BillingAddressConfig {
+            val collectAddress = address != AddressCollectionMode.Never
+            val collectPhone = phone == CollectionMode.Always
+
+            return GooglePayPaymentMethodLauncher.BillingAddressConfig(
+                isRequired = collectAddress || collectPhone,
+                format = GooglePayPaymentMethodLauncher.BillingAddressConfig.Format.Full,
+                isPhoneNumberRequired = collectPhone,
+            )
+        }
+
         /**
          * Billing details fields collection options.
          */
@@ -1378,9 +1393,3 @@ class PaymentSheet internal constructor(
         }
     }
 }
-
-internal val PaymentSheet.BillingDetailsCollectionConfiguration.collectsEmail: Boolean
-    get() = email == PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always
-
-internal val PaymentSheet.BillingDetailsCollectionConfiguration.collectsPhone: Boolean
-    get() = phone == PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -1051,12 +1051,22 @@ class PaymentSheet internal constructor(
             get() = email == CollectionMode.Always
 
         internal fun toBillingAddressConfig(): GooglePayPaymentMethodLauncher.BillingAddressConfig {
-            val collectAddress = address != AddressCollectionMode.Never
+            val collectAddress = address == AddressCollectionMode.Full
             val collectPhone = phone == CollectionMode.Always
+
+            val format = when (address) {
+                AddressCollectionMode.Never,
+                AddressCollectionMode.Automatic -> {
+                    GooglePayPaymentMethodLauncher.BillingAddressConfig.Format.Min
+                }
+                AddressCollectionMode.Full -> {
+                    GooglePayPaymentMethodLauncher.BillingAddressConfig.Format.Full
+                }
+            }
 
             return GooglePayPaymentMethodLauncher.BillingAddressConfig(
                 isRequired = collectAddress || collectPhone,
-                format = GooglePayPaymentMethodLauncher.BillingAddressConfig.Format.Full,
+                format = format,
                 isPhoneNumberRequired = collectPhone,
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -190,13 +190,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 )
                 null
             } else {
-                val collectPhone = args.config.billingDetailsCollectionConfiguration.collectsPhone
-                val billingAddressConfig = GooglePayPaymentMethodLauncher.BillingAddressConfig(
-                    isRequired = collectPhone,
-                    format = GooglePayPaymentMethodLauncher.BillingAddressConfig.Format.Full,
-                    isPhoneNumberRequired = collectPhone,
-                )
-
                 GooglePayPaymentMethodLauncher.Config(
                     environment = when (config.environment) {
                         PaymentSheet.GooglePayConfiguration.Environment.Production ->
@@ -207,7 +200,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     merchantCountryCode = config.countryCode,
                     merchantName = merchantName,
                     isEmailRequired = args.config.billingDetailsCollectionConfiguration.collectsEmail,
-                    billingAddressConfig = billingAddressConfig,
+                    billingAddressConfig = args.config.billingDetailsCollectionConfiguration.toBillingAddressConfig(),
                 )
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -198,7 +198,9 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                             GooglePayEnvironment.Test
                     },
                     merchantCountryCode = config.countryCode,
-                    merchantName = merchantName
+                    merchantName = merchantName,
+                    isEmailRequired = args.config.billingDetailsCollectionConfiguration.collectsEmail,
+                    isPhoneRequired = args.config.billingDetailsCollectionConfiguration.collectsPhone,
                 )
             }
         }
@@ -785,3 +787,9 @@ private val PaymentSheet.InitializationMode.isProcessingPayment: Boolean
             intentConfiguration.mode is PaymentSheet.IntentConfiguration.Mode.Payment
         }
     }
+
+private val PaymentSheet.BillingDetailsCollectionConfiguration.collectsEmail: Boolean
+    get() = email == PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always
+
+private val PaymentSheet.BillingDetailsCollectionConfiguration.collectsPhone: Boolean
+    get() = phone == PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -190,6 +190,13 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 )
                 null
             } else {
+                val collectPhone = args.config.billingDetailsCollectionConfiguration.collectsPhone
+                val billingAddressConfig = GooglePayPaymentMethodLauncher.BillingAddressConfig(
+                    isRequired = collectPhone,
+                    format = GooglePayPaymentMethodLauncher.BillingAddressConfig.Format.Full,
+                    isPhoneNumberRequired = collectPhone,
+                )
+
                 GooglePayPaymentMethodLauncher.Config(
                     environment = when (config.environment) {
                         PaymentSheet.GooglePayConfiguration.Environment.Production ->
@@ -200,7 +207,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     merchantCountryCode = config.countryCode,
                     merchantName = merchantName,
                     isEmailRequired = args.config.billingDetailsCollectionConfiguration.collectsEmail,
-                    isPhoneRequired = args.config.billingDetailsCollectionConfiguration.collectsPhone,
+                    billingAddressConfig = billingAddressConfig,
                 )
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -787,9 +787,3 @@ private val PaymentSheet.InitializationMode.isProcessingPayment: Boolean
             intentConfiguration.mode is PaymentSheet.IntentConfiguration.Mode.Payment
         }
     }
-
-private val PaymentSheet.BillingDetailsCollectionConfiguration.collectsEmail: Boolean
-    get() = email == PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always
-
-private val PaymentSheet.BillingDetailsCollectionConfiguration.collectsPhone: Boolean
-    get() = phone == PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -46,8 +46,6 @@ import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
-import com.stripe.android.paymentsheet.collectsEmail
-import com.stripe.android.paymentsheet.collectsPhone
 import com.stripe.android.paymentsheet.intercept
 import com.stripe.android.paymentsheet.model.PaymentOption
 import com.stripe.android.paymentsheet.model.PaymentOptionFactory
@@ -671,13 +669,6 @@ internal class DefaultFlowController @Inject internal constructor(
         // state.config.googlePay is guaranteed not to be null or GooglePay would be disabled
         val googlePayConfig = requireNotNull(state.config.googlePay)
 
-        val collectPhone = state.config.billingDetailsCollectionConfiguration.collectsPhone
-        val billingAddressConfig = GooglePayPaymentMethodLauncher.BillingAddressConfig(
-            isRequired = collectPhone,
-            format = GooglePayPaymentMethodLauncher.BillingAddressConfig.Format.Full,
-            isPhoneNumberRequired = collectPhone,
-        )
-
         val googlePayPaymentLauncherConfig = GooglePayPaymentMethodLauncher.Config(
             environment = when (googlePayConfig.environment) {
                 PaymentSheet.GooglePayConfiguration.Environment.Production ->
@@ -688,7 +679,7 @@ internal class DefaultFlowController @Inject internal constructor(
             merchantCountryCode = googlePayConfig.countryCode,
             merchantName = state.config.merchantDisplayName,
             isEmailRequired = state.config.billingDetailsCollectionConfiguration.collectsEmail,
-            billingAddressConfig = billingAddressConfig,
+            billingAddressConfig = state.config.billingDetailsCollectionConfiguration.toBillingAddressConfig(),
         )
 
         googlePayPaymentMethodLauncherFactory.create(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -46,6 +46,8 @@ import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
+import com.stripe.android.paymentsheet.collectsEmail
+import com.stripe.android.paymentsheet.collectsPhone
 import com.stripe.android.paymentsheet.intercept
 import com.stripe.android.paymentsheet.model.PaymentOption
 import com.stripe.android.paymentsheet.model.PaymentOptionFactory
@@ -676,7 +678,9 @@ internal class DefaultFlowController @Inject internal constructor(
                     GooglePayEnvironment.Test
             },
             merchantCountryCode = googlePayConfig.countryCode,
-            merchantName = state.config.merchantDisplayName
+            merchantName = state.config.merchantDisplayName,
+            isEmailRequired = state.config.billingDetailsCollectionConfiguration.collectsEmail,
+            isPhoneRequired = state.config.billingDetailsCollectionConfiguration.collectsPhone,
         )
 
         googlePayPaymentMethodLauncherFactory.create(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -670,6 +670,14 @@ internal class DefaultFlowController @Inject internal constructor(
     private fun launchGooglePay(state: PaymentSheetState.Full) {
         // state.config.googlePay is guaranteed not to be null or GooglePay would be disabled
         val googlePayConfig = requireNotNull(state.config.googlePay)
+
+        val collectPhone = state.config.billingDetailsCollectionConfiguration.collectsPhone
+        val billingAddressConfig = GooglePayPaymentMethodLauncher.BillingAddressConfig(
+            isRequired = collectPhone,
+            format = GooglePayPaymentMethodLauncher.BillingAddressConfig.Format.Full,
+            isPhoneNumberRequired = collectPhone,
+        )
+
         val googlePayPaymentLauncherConfig = GooglePayPaymentMethodLauncher.Config(
             environment = when (googlePayConfig.environment) {
                 PaymentSheet.GooglePayConfiguration.Environment.Production ->
@@ -680,7 +688,7 @@ internal class DefaultFlowController @Inject internal constructor(
             merchantCountryCode = googlePayConfig.countryCode,
             merchantName = state.config.merchantDisplayName,
             isEmailRequired = state.config.billingDetailsCollectionConfiguration.collectsEmail,
-            isPhoneRequired = state.config.billingDetailsCollectionConfiguration.collectsPhone,
+            billingAddressConfig = billingAddressConfig,
         )
 
         googlePayPaymentMethodLauncherFactory.create(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/BillingDetailsCollectionConfigurationTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/BillingDetailsCollectionConfigurationTest.kt
@@ -1,0 +1,74 @@
+package com.stripe.android.paymentsheet
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher.BillingAddressConfig.Format
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always
+import org.junit.Test
+
+class BillingDetailsCollectionConfigurationTest {
+
+    @Test
+    fun `Creates correct Google Pay billing address config with default collection configuration`() {
+        val collectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration()
+
+        val billingAddressConfig = collectionConfiguration.toBillingAddressConfig()
+
+        assertThat(billingAddressConfig).isEqualTo(
+            GooglePayPaymentMethodLauncher.BillingAddressConfig(
+                isRequired = false,
+                format = Format.Min,
+                isPhoneNumberRequired = false,
+            )
+        )
+    }
+
+    @Test
+    fun `Creates correct Google Pay billing address config when collecting full address`() {
+        val collectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(address = Full)
+
+        val billingAddressConfig = collectionConfiguration.toBillingAddressConfig()
+
+        assertThat(billingAddressConfig).isEqualTo(
+            GooglePayPaymentMethodLauncher.BillingAddressConfig(
+                isRequired = true,
+                format = Format.Full,
+                isPhoneNumberRequired = false,
+            )
+        )
+    }
+
+    @Test
+    fun `Creates correct Google Pay billing address config when collecting full address and phone`() {
+        val collectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+            phone = Always,
+            address = Full,
+        )
+
+        val billingAddressConfig = collectionConfiguration.toBillingAddressConfig()
+
+        assertThat(billingAddressConfig).isEqualTo(
+            GooglePayPaymentMethodLauncher.BillingAddressConfig(
+                isRequired = true,
+                format = Format.Full,
+                isPhoneNumberRequired = true,
+            )
+        )
+    }
+
+    @Test
+    fun `Creates correct Google Pay billing address config when collecting only phone`() {
+        val collectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(phone = Always)
+
+        val billingAddressConfig = collectionConfiguration.toBillingAddressConfig()
+
+        assertThat(billingAddressConfig).isEqualTo(
+            GooglePayPaymentMethodLauncher.BillingAddressConfig(
+                isRequired = true,
+                format = Format.Min,
+                isPhoneNumberRequired = true,
+            )
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1778,6 +1778,74 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
+    fun `Requires email and phone with Google Pay when collection mode is set to always`() {
+        val expectedLabel = "My custom label"
+        val expectedAmount = 1234L
+
+        val args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
+            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.copy(
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                ),
+                googlePay = PaymentSheet.GooglePayConfiguration(
+                    environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                    countryCode = "CA",
+                    currencyCode = "CAD",
+                    amount = expectedAmount,
+                    label = expectedLabel,
+                )
+            )
+        )
+
+        val viewModel = createViewModel(
+            args = args,
+            isGooglePayReady = true,
+            stripeIntent = SETUP_INTENT,
+        )
+
+        val isEmailRequired = viewModel.googlePayLauncherConfig?.isEmailRequired
+        val isPhoneRequired = viewModel.googlePayLauncherConfig?.billingAddressConfig?.isPhoneNumberRequired
+
+        assertThat(isEmailRequired).isTrue()
+        assertThat(isPhoneRequired).isTrue()
+    }
+
+    @Test
+    fun `Does not require email and phone with Google Pay when collection mode is not set to always`() {
+        val expectedLabel = "My custom label"
+        val expectedAmount = 1234L
+
+        val args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
+            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.copy(
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+                    email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+                ),
+                googlePay = PaymentSheet.GooglePayConfiguration(
+                    environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                    countryCode = "CA",
+                    currencyCode = "CAD",
+                    amount = expectedAmount,
+                    label = expectedLabel,
+                )
+            )
+        )
+
+        val viewModel = createViewModel(
+            args = args,
+            isGooglePayReady = true,
+            stripeIntent = SETUP_INTENT,
+        )
+
+        val isEmailRequired = viewModel.googlePayLauncherConfig?.isEmailRequired
+        val isPhoneRequired = viewModel.googlePayLauncherConfig?.billingAddressConfig?.isPhoneNumberRequired
+
+        assertThat(isEmailRequired).isFalse()
+        assertThat(isPhoneRequired).isFalse()
+    }
+
+    @Test
     fun `On complete payment launcher result in PI mode & should reuse, should save payment selection`() = runTest {
         selectionSavedTest(
             initializationMode = InitializationMode.PaymentIntent(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1805,10 +1805,47 @@ internal class PaymentSheetViewModelTest {
         )
 
         val isEmailRequired = viewModel.googlePayLauncherConfig?.isEmailRequired
+        val isBillingRequired = viewModel.googlePayLauncherConfig?.billingAddressConfig?.isRequired
         val isPhoneRequired = viewModel.googlePayLauncherConfig?.billingAddressConfig?.isPhoneNumberRequired
 
         assertThat(isEmailRequired).isTrue()
+        assertThat(isBillingRequired).isTrue()
         assertThat(isPhoneRequired).isTrue()
+    }
+
+    @Test
+    fun `Requires full billing details with Google Pay when collection mode is set to full`() {
+        val expectedLabel = "My custom label"
+        val expectedAmount = 1234L
+
+        val args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
+            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.copy(
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                ),
+                googlePay = PaymentSheet.GooglePayConfiguration(
+                    environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                    countryCode = "CA",
+                    currencyCode = "CAD",
+                    amount = expectedAmount,
+                    label = expectedLabel,
+                )
+            )
+        )
+
+        val viewModel = createViewModel(
+            args = args,
+            isGooglePayReady = true,
+            stripeIntent = SETUP_INTENT,
+        )
+
+        val isBillingRequired = viewModel.googlePayLauncherConfig?.billingAddressConfig?.isRequired
+        val format = viewModel.googlePayLauncherConfig?.billingAddressConfig?.format
+        val isPhoneRequired = viewModel.googlePayLauncherConfig?.billingAddressConfig?.isPhoneNumberRequired
+
+        assertThat(isBillingRequired).isTrue()
+        assertThat(format).isEqualTo(GooglePayPaymentMethodLauncher.BillingAddressConfig.Format.Full)
+        assertThat(isPhoneRequired).isFalse()
     }
 
     @Test
@@ -1820,7 +1857,7 @@ internal class PaymentSheetViewModelTest {
             config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.copy(
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                     phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
-                    email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+                    email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
                 ),
                 googlePay = PaymentSheet.GooglePayConfiguration(
                     environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
@@ -1839,9 +1876,41 @@ internal class PaymentSheetViewModelTest {
         )
 
         val isEmailRequired = viewModel.googlePayLauncherConfig?.isEmailRequired
+        val isBillingRequired = viewModel.googlePayLauncherConfig?.billingAddressConfig?.isRequired
         val isPhoneRequired = viewModel.googlePayLauncherConfig?.billingAddressConfig?.isPhoneNumberRequired
 
         assertThat(isEmailRequired).isFalse()
+        assertThat(isBillingRequired).isFalse()
+        assertThat(isPhoneRequired).isFalse()
+    }
+
+    @Test
+    fun `Does not require billing details with Google Pay when collection mode is set to never`() {
+        val args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
+            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.copy(
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
+                ),
+                googlePay = PaymentSheet.GooglePayConfiguration(
+                    environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                    countryCode = "CA",
+                    currencyCode = "CAD",
+                )
+            )
+        )
+
+        val viewModel = createViewModel(
+            args = args,
+            isGooglePayReady = true,
+            stripeIntent = SETUP_INTENT,
+        )
+
+        val isEmailRequired = viewModel.googlePayLauncherConfig?.isEmailRequired
+        val isBillingRequired = viewModel.googlePayLauncherConfig?.billingAddressConfig?.isRequired
+        val isPhoneRequired = viewModel.googlePayLauncherConfig?.billingAddressConfig?.isPhoneNumberRequired
+
+        assertThat(isEmailRequired).isFalse()
+        assertThat(isBillingRequired).isFalse()
         assertThat(isPhoneRequired).isFalse()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1779,9 +1779,6 @@ internal class PaymentSheetViewModelTest {
 
     @Test
     fun `Requires email and phone with Google Pay when collection mode is set to always`() {
-        val expectedLabel = "My custom label"
-        val expectedAmount = 1234L
-
         val args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
             config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.copy(
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
@@ -1792,8 +1789,6 @@ internal class PaymentSheetViewModelTest {
                     environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
                     countryCode = "CA",
                     currencyCode = "CAD",
-                    amount = expectedAmount,
-                    label = expectedLabel,
                 )
             )
         )
@@ -1815,9 +1810,6 @@ internal class PaymentSheetViewModelTest {
 
     @Test
     fun `Requires full billing details with Google Pay when collection mode is set to full`() {
-        val expectedLabel = "My custom label"
-        val expectedAmount = 1234L
-
         val args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
             config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.copy(
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
@@ -1827,8 +1819,6 @@ internal class PaymentSheetViewModelTest {
                     environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
                     countryCode = "CA",
                     currencyCode = "CAD",
-                    amount = expectedAmount,
-                    label = expectedLabel,
                 )
             )
         )
@@ -1850,9 +1840,6 @@ internal class PaymentSheetViewModelTest {
 
     @Test
     fun `Does not require email and phone with Google Pay when collection mode is not set to always`() {
-        val expectedLabel = "My custom label"
-        val expectedAmount = 1234L
-
         val args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
             config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.copy(
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
@@ -1863,8 +1850,6 @@ internal class PaymentSheetViewModelTest {
                     environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
                     countryCode = "CA",
                     currencyCode = "CAD",
-                    amount = expectedAmount,
-                    label = expectedLabel,
                 )
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/RecordingGooglePayPaymentMethodLauncherFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/RecordingGooglePayPaymentMethodLauncherFactory.kt
@@ -1,0 +1,26 @@
+package com.stripe.android.paymentsheet.utils
+
+import androidx.activity.result.ActivityResultLauncher
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
+import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
+import kotlinx.coroutines.CoroutineScope
+
+internal class RecordingGooglePayPaymentMethodLauncherFactory(
+    private val googlePayPaymentMethodLauncher: GooglePayPaymentMethodLauncher,
+) : GooglePayPaymentMethodLauncherFactory {
+
+    var config: GooglePayPaymentMethodLauncher.Config? = null
+        private set
+
+    override fun create(
+        lifecycleScope: CoroutineScope,
+        config: GooglePayPaymentMethodLauncher.Config,
+        readyCallback: GooglePayPaymentMethodLauncher.ReadyCallback,
+        activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
+        skipReadyCheck: Boolean
+    ): GooglePayPaymentMethodLauncher {
+        this.config = config
+        return googlePayPaymentMethodLauncher
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates Google Pay to take the phone and email collection configuration into account. When collection mode is set to `Always`, we now set the correct `isEmailRequired` and `isPhoneNumberRequired` value.

The collected values are eventually accessible via the Charge’s `billing_details.email` and `billing_details.phone` fields:
- Before this change: `pi_3OHzrSLu5o3P18Zp1p1Zn1qP`
- After this change: `pi_3OHztFLu5o3P18Zp0cZBwYwz`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Resolves https://github.com/stripe/stripe-android/issues/7662

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
