### PR TITLE
Correct mandate for continue and show after linking bank account

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -232,6 +232,11 @@ internal class CustomerSheetViewModel @Inject constructor(
                             primaryButtonLabel = resources.getString(
                                 R.string.stripe_paymentsheet_confirm
                             ),
+                            mandateText = viewState.paymentSelection?.mandateText(
+                                context = application,
+                                merchantName = configuration.merchantDisplayName,
+                                isSaveForFutureUseSelected = false,
+                                isSetupFlow = false)
                         )
                     } ?: viewState
                 }
@@ -571,7 +576,7 @@ internal class CustomerSheetViewModel @Inject constructor(
                             context = application,
                             merchantName = configuration.merchantDisplayName,
                             isSaveForFutureUseSelected = false,
-                            isSetupFlow = true,
+                            isSetupFlow = false,
                         )?.takeIf { primaryButtonVisible },
                     )
                 }


### PR DESCRIPTION
# Summary
This fixes two bugs
1.  We were showing the wrong mandate when selecting a saved bank account
2. We weren't showing any mandate on the selection screen of the newly added saved bank account.

# Motivation
Parity with iOS

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![Screenshot 2023-11-30 at 11 33 29 AM](https://github.com/stripe/stripe-android/assets/99628984/e973db11-8268-4837-9276-2139d7740ec6)  | ![Screenshot 2023-11-30 at 11 32 41 AM](https://github.com/stripe/stripe-android/assets/99628984/6ce7e0d6-d670-483c-889f-bb6193316a7e) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
