### PR TITLE
Make the `Dropdown` in `TextField` unfocusable by `FocusManager`.

### DIFF
--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.autofill.AutofillNode
 import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.KeyEventType
@@ -414,9 +415,8 @@ private fun TrailingDropdown(
 
     Box(
         modifier = Modifier
-            .clickable(enabled = show) {
-                expanded = true
-            }
+            .focusProperties { canFocus = false }
+            .clickable(enabled = show) { expanded = true }
             .testTag(DROPDOWN_MENU_CLICKABLE_TEST_TAG)
     ) {
         Row(


### PR DESCRIPTION
# Summary
Make the `Dropdown` in `TextField` unfocusable by `FocusManager`.

# Motivation
Moves focus to next text element rather than highlight the `Dropdown` menu.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
