### PR TITLE
Clean up EventReporter API

### DIFF
--- a/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -5,7 +5,6 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.ActivityResultRegistry
 import androidx.annotation.RestrictTo
 import com.stripe.android.link.injection.LinkAnalyticsComponent
-import com.stripe.android.model.ConsumerPaymentDetails
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -64,13 +63,5 @@ class LinkPaymentLauncher @Inject internal constructor(
         )
         linkActivityResultLauncher?.launch(args)
         analyticsHelper.onLinkLaunched()
-    }
-
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    companion object {
-        val supportedFundingSources = setOf(
-            ConsumerPaymentDetails.Card.type,
-            ConsumerPaymentDetails.BankAccount.type,
-        )
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -2,7 +2,10 @@ package com.stripe.android.model
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
+import com.stripe.android.model.PaymentMethod.Type.Link
 import kotlinx.parcelize.Parcelize
+
+private val LinkSupportedFundingSources = setOf("card", "bank_account")
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Parcelize
@@ -15,6 +18,16 @@ data class ElementsSession(
     val isGooglePayEnabled: Boolean,
     val sessionsError: Throwable? = null,
 ) : StripeModel {
+
+    val linkPassthroughModeEnabled: Boolean
+        get() = linkSettings?.linkPassthroughModeEnabled ?: false
+
+    val isLinkEnabled: Boolean
+        get() {
+            val allowsLink = Link.code in stripeIntent.paymentMethodTypes
+            val hasValidFundingSource = stripeIntent.linkFundingSources.any { it in LinkSupportedFundingSources }
+            return (allowsLink && hasValidFundingSource) || linkPassthroughModeEnabled
+        }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -17,7 +17,6 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.injection.DaggerPaymentOptionsViewModelFactoryComponent
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddFirstPaymentMethod
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods
@@ -105,9 +104,6 @@ internal class PaymentOptionsViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(),
         initialValue = null,
     )
-
-    private val isDecoupling: Boolean
-        get() = args.state.stripeIntent.clientSecret == null
 
     init {
         savedStateHandle[SAVE_GOOGLE_PAY_STATE] = if (args.state.isGooglePayReady) {
@@ -200,7 +196,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     }
 
     override fun onUserCancel() {
-        reportDismiss(isDecoupling)
+        reportDismiss()
         _paymentOptionResult.tryEmit(
             PaymentOptionResult.Canceled(
                 mostRecentError = mostRecentError,
@@ -242,11 +238,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
 
         selection.value?.let { paymentSelection ->
             // TODO(michelleb-stripe): Should the payment selection in the event be the saved or new item?
-            eventReporter.onSelectPaymentOption(
-                paymentSelection = paymentSelection,
-                currency = stripeIntent.value?.currency,
-                isDecoupling = isDecoupling,
-            )
+            eventReporter.onSelectPaymentOption(paymentSelection)
 
             when (paymentSelection) {
                 is PaymentSelection.Saved,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -13,73 +13,54 @@ internal interface EventReporter {
      */
     fun onInit(
         configuration: PaymentSheet.Configuration,
-        isDecoupling: Boolean,
+        isDeferred: Boolean,
     )
 
     /**
      * PaymentSheet or FlowController have started loading.
      */
-    fun onLoadStarted(
-        isDecoupling: Boolean,
-    )
+    fun onLoadStarted()
 
     /**
      * PaymentSheet or FlowController have successfully loaded the information required to be
      * rendered.
      */
     fun onLoadSucceeded(
-        isDecoupling: Boolean,
+        linkEnabled: Boolean,
+        currency: String?,
     )
 
     /**
      * PaymentSheet or FlowController have failed to load.
      */
-    fun onLoadFailed(
-        isDecoupling: Boolean,
-        error: Throwable,
-    )
+    fun onLoadFailed(error: Throwable)
 
     /**
      * PaymentSheet or FlowController have failed to load from the Elements session endpoint.
      */
-    fun onElementsSessionLoadFailed(
-        isDecoupling: Boolean,
-        error: Throwable,
-    )
+    fun onElementsSessionLoadFailed(error: Throwable)
 
     /**
      * PaymentSheet has been dismissed by pressing the close button.
      */
-    fun onDismiss(
-        isDecoupling: Boolean,
-    )
+    fun onDismiss()
 
     /**
      * PaymentSheet is now being displayed and its first screen shows the customer's saved payment
      * methods.
      */
-    fun onShowExistingPaymentOptions(
-        linkEnabled: Boolean,
-        currency: String?,
-        isDecoupling: Boolean,
-    )
+    fun onShowExistingPaymentOptions()
 
     /**
      * PaymentSheet is now being displayed and its first screen shows the payment method form.
      */
-    fun onShowNewPaymentOptionForm(
-        linkEnabled: Boolean,
-        currency: String?,
-        isDecoupling: Boolean,
-    )
+    fun onShowNewPaymentOptionForm()
 
     /**
      * The customer has selected one of the available payment methods in the payment method form.
      */
     fun onSelectPaymentMethod(
         code: PaymentMethodCode,
-        currency: String?,
-        isDecoupling: Boolean,
     )
 
     /**
@@ -87,24 +68,18 @@ internal interface EventReporter {
      */
     fun onSelectPaymentOption(
         paymentSelection: PaymentSelection,
-        currency: String?,
-        isDecoupling: Boolean,
     )
 
     /**
      * The customer has pressed the confirm button.
      */
-    fun onPressConfirmButton(
-        currency: String?,
-        isDecoupling: Boolean,
-    )
+    fun onPressConfirmButton()
 
     /**
      * Payment or setup have succeeded.
      */
     fun onPaymentSuccess(
         paymentSelection: PaymentSelection?,
-        currency: String?,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
     )
 
@@ -113,24 +88,19 @@ internal interface EventReporter {
      */
     fun onPaymentFailure(
         paymentSelection: PaymentSelection?,
-        currency: String?,
-        isDecoupling: Boolean,
         error: PaymentSheetConfirmationError,
     )
 
     /**
      * The client was unable to parse the response from LUXE.
      */
-    fun onLpmSpecFailure(
-        isDecoupling: Boolean,
-    )
+    fun onLpmSpecFailure()
 
     /**
      * The user has auto-filled a text field.
      */
     fun onAutofill(
         type: String,
-        isDecoupling: Boolean,
     )
 
     enum class Mode(val code: String) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -11,13 +11,13 @@ import kotlin.time.DurationUnit
 internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
     val params: Map<String, Any?>
-        get() = standardParams(isDecoupled) + additionalParams
+        get() = standardParams(isDeferred) + additionalParams
 
-    protected abstract val isDecoupled: Boolean
+    protected abstract val isDeferred: Boolean
     protected abstract val additionalParams: Map<String, Any?>
 
     class LoadStarted(
-        override val isDecoupled: Boolean,
+        override val isDeferred: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_load_started"
         override val additionalParams: Map<String, Any?> = emptyMap()
@@ -25,7 +25,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
     class LoadSucceeded(
         duration: Duration?,
-        override val isDecoupled: Boolean,
+        override val isDeferred: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_load_succeeded"
         override val additionalParams: Map<String, Any?> = mapOf(
@@ -36,7 +36,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     class LoadFailed(
         duration: Duration?,
         error: String,
-        override val isDecoupled: Boolean,
+        override val isDeferred: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_load_failed"
         override val additionalParams: Map<String, Any?> = mapOf(
@@ -47,7 +47,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
     class ElementsSessionLoadFailed(
         error: String,
-        override val isDecoupled: Boolean,
+        override val isDeferred: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_elements_session_load_failed"
         override val additionalParams: Map<String, Any?> = mapOf(
@@ -58,7 +58,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     class Init(
         private val mode: EventReporter.Mode,
         private val configuration: PaymentSheet.Configuration,
-        override val isDecoupled: Boolean,
+        override val isDeferred: Boolean,
     ) : PaymentSheetEvent() {
 
         override val eventName: String
@@ -158,7 +158,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     }
 
     class Dismiss(
-        override val isDecoupled: Boolean,
+        override val isDeferred: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_dismiss"
         override val additionalParams: Map<String, Any> = emptyMap()
@@ -168,7 +168,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         mode: EventReporter.Mode,
         linkEnabled: Boolean,
         currency: String?,
-        override val isDecoupled: Boolean,
+        override val isDeferred: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = formatEventName(mode, "sheet_newpm_show")
         override val additionalParams: Map<String, Any?> = mapOf(
@@ -181,7 +181,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         mode: EventReporter.Mode,
         linkEnabled: Boolean,
         currency: String?,
-        override val isDecoupled: Boolean,
+        override val isDeferred: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = formatEventName(mode, "sheet_savedpm_show")
         override val additionalParams: Map<String, Any?> = mapOf(
@@ -193,7 +193,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     class SelectPaymentMethod(
         code: String,
         currency: String?,
-        override val isDecoupled: Boolean,
+        override val isDeferred: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_carousel_payment_method_tapped"
         override val additionalParams: Map<String, Any?> = mapOf(
@@ -206,7 +206,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         mode: EventReporter.Mode,
         paymentSelection: PaymentSelection?,
         currency: String?,
-        override val isDecoupled: Boolean,
+        override val isDeferred: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String =
             formatEventName(mode, "paymentoption_${analyticsValue(paymentSelection)}_select")
@@ -217,7 +217,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
     class PressConfirmButton(
         currency: String?,
-        override val isDecoupled: Boolean,
+        override val isDeferred: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_confirm_button_tapped"
         override val additionalParams: Map<String, Any?> = mapOf(
@@ -231,7 +231,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         duration: Duration?,
         private val paymentSelection: PaymentSelection?,
         currency: String?,
-        override val isDecoupled: Boolean,
+        override val isDeferred: Boolean,
         private val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
     ) : PaymentSheetEvent() {
 
@@ -284,7 +284,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     }
 
     class LpmSerializeFailureEvent(
-        override val isDecoupled: Boolean,
+        override val isDeferred: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "luxe_serialize_failure"
         override val additionalParams: Map<String, Any?> = emptyMap()
@@ -292,7 +292,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
     class AutofillEvent(
         type: String,
-        override val isDecoupled: Boolean,
+        override val isDeferred: Boolean,
     ) : PaymentSheetEvent() {
         private fun String.toSnakeCase() = replace(
             "(?<=.)(?=\\p{Upper})".toRegex(),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -50,7 +50,6 @@ import com.stripe.android.paymentsheet.intercept
 import com.stripe.android.paymentsheet.model.PaymentOption
 import com.stripe.android.paymentsheet.model.PaymentOptionFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationContract
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncher
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncherFactory
@@ -114,9 +113,6 @@ internal class DefaultFlowController @Inject internal constructor(
 
     private val initializationMode: PaymentSheet.InitializationMode?
         get() = viewModel.previousConfigureRequest?.initializationMode
-
-    private val isDecoupling: Boolean
-        get() = initializationMode is PaymentSheet.InitializationMode.DeferredIntent
 
     override var shippingDetails: AddressDetails?
         get() = viewModel.state?.config?.shippingDetails
@@ -442,8 +438,6 @@ internal class DefaultFlowController @Inject internal constructor(
                     onFailure = { error ->
                         eventReporter.onPaymentFailure(
                             paymentSelection = PaymentSelection.GooglePay,
-                            currency = viewModel.state?.stripeIntent?.currency,
-                            isDecoupling = isDecoupling,
                             error = PaymentSheetConfirmationError.InvalidState,
                         )
                         paymentResultCallback.onPaymentSheetResult(
@@ -455,8 +449,6 @@ internal class DefaultFlowController @Inject internal constructor(
             is GooglePayPaymentMethodLauncher.Result.Failed -> {
                 eventReporter.onPaymentFailure(
                     paymentSelection = PaymentSelection.GooglePay,
-                    currency = viewModel.state?.stripeIntent?.currency,
-                    isDecoupling = isDecoupling,
                     error = PaymentSheetConfirmationError.GooglePay(googlePayResult.errorCode),
                 )
                 paymentResultCallback.onPaymentSheetResult(
@@ -533,8 +525,6 @@ internal class DefaultFlowController @Inject internal constructor(
                 onFailure = { error ->
                     eventReporter.onPaymentFailure(
                         paymentSelection = PaymentSelection.Link,
-                        currency = viewModel.state?.stripeIntent?.currency,
-                        isDecoupling = isDecoupling,
                         error = PaymentSheetConfirmationError.InvalidState,
                     )
                     paymentResultCallback.onPaymentSheetResult(
@@ -644,7 +634,6 @@ internal class DefaultFlowController @Inject internal constructor(
             is PaymentResult.Completed -> {
                 eventReporter.onPaymentSuccess(
                     paymentSelection = viewModel.paymentSelection,
-                    currency = viewModel.state?.stripeIntent?.currency,
                     deferredIntentConfirmationType = viewModel.deferredIntentConfirmationType,
                 )
                 viewModel.deferredIntentConfirmationType = null
@@ -652,8 +641,6 @@ internal class DefaultFlowController @Inject internal constructor(
             is PaymentResult.Failed -> {
                 eventReporter.onPaymentFailure(
                     paymentSelection = viewModel.paymentSelection,
-                    currency = viewModel.state?.stripeIntent?.currency,
-                    isDecoupling = isDecoupling,
                     error = PaymentSheetConfirmationError.Stripe(paymentResult.throwable),
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
@@ -106,7 +106,7 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
 
         eventReporter.onInit(
             configuration = state.config,
-            isDecoupling = isDecoupling,
+            isDeferred = isDecoupling,
         )
 
         viewModel.paymentSelection = paymentSelectionUpdater(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -5,11 +5,9 @@ import com.stripe.android.core.injection.IOContext
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.link.LinkConfiguration
-import com.stripe.android.link.LinkPaymentLauncher.Companion.supportedFundingSources
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.model.PaymentMethod.Type.Link
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.InitializationMode.DeferredIntent
@@ -19,6 +17,7 @@ import com.stripe.android.paymentsheet.addresselement.toIdentifierMap
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
+import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.paymentsheet.model.getPMsToAdd
 import com.stripe.android.paymentsheet.model.getSupportedSavedCustomerPMs
 import com.stripe.android.paymentsheet.model.requireValidOrThrow
@@ -64,16 +63,14 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         initializationMode: PaymentSheet.InitializationMode,
         paymentSheetConfiguration: PaymentSheet.Configuration
     ): Result<PaymentSheetState.Full> = withContext(workContext) {
-        val isDecoupling = initializationMode is DeferredIntent
-
-        eventReporter.onLoadStarted(isDecoupling = isDecoupling)
+        eventReporter.onLoadStarted()
 
         val elementsSessionResult = retrieveElementsSession(
             initializationMode = initializationMode,
             configuration = paymentSheetConfiguration,
         )
 
-        reportLoadResult(elementsSessionResult, isDecoupling)
+        reportLoadResult(elementsSessionResult)
 
         elementsSessionResult.mapCatching { elementsSession ->
             create(
@@ -115,16 +112,10 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         val stripeIntent = elementsSession.stripeIntent
         val merchantCountry = elementsSession.merchantCountry
 
-        val linkPassthroughModeEnabled = elementsSession.linkSettings?.linkPassthroughModeEnabled ?: false
-        val isLinkAvailable = (
-            stripeIntent.paymentMethodTypes.contains(Link.code) &&
-                stripeIntent.linkFundingSources.intersect(supportedFundingSources).isNotEmpty()
-            ) || linkPassthroughModeEnabled
-
         val savedSelection = async {
             prefsRepository.getSavedSelection(
                 isGooglePayAvailable = isGooglePayReady,
-                isLinkAvailable = isLinkAvailable,
+                isLinkAvailable = elementsSession.isLinkEnabled,
             )
         }
 
@@ -166,12 +157,12 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         }
 
         val linkState = async {
-            if (isLinkAvailable) {
+            if (elementsSession.isLinkEnabled) {
                 loadLinkState(
                     config = config,
                     stripeIntent = stripeIntent,
                     merchantCountry = merchantCountry,
-                    passthroughModeEnabled = linkPassthroughModeEnabled,
+                    passthroughModeEnabled = elementsSession.linkPassthroughModeEnabled,
                 )
             } else {
                 null
@@ -241,9 +232,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             )
 
             if (!didParseServerResponse) {
-                eventReporter.onLpmSpecFailure(
-                    isDecoupling = initializationMode is DeferredIntent,
-                )
+                eventReporter.onLpmSpecFailure()
             }
 
             elementsSession.requireValidOrThrow()
@@ -346,22 +335,20 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
 
     private fun reportLoadResult(
         loaderResult: Result<ElementsSession>,
-        isDecoupling: Boolean,
     ) {
         loaderResult.fold(
             onSuccess = { elementsSession ->
                 elementsSession.sessionsError?.let { sessionsError ->
-                    eventReporter.onElementsSessionLoadFailed(isDecoupling, sessionsError)
+                    eventReporter.onElementsSessionLoadFailed(sessionsError)
                 }
-
-                eventReporter.onLoadSucceeded(isDecoupling = isDecoupling)
+                eventReporter.onLoadSucceeded(
+                    linkEnabled = elementsSession.isLinkEnabled,
+                    currency = elementsSession.stripeIntent.currency,
+                )
             },
             onFailure = { error ->
                 logger.error("Failure loading PaymentSheetState", error)
-                eventReporter.onLoadFailed(
-                    isDecoupling = isDecoupling,
-                    error = error,
-                )
+                eventReporter.onLoadFailed(error)
             }
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -29,7 +29,6 @@ import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.MandateText
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSelection.CustomerRequestedSave.RequestReuse
-import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.paymentsheet.model.getPMsToAdd
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddAnotherPaymentMethod
@@ -269,18 +268,10 @@ internal abstract class BaseSheetViewModel(
                 // Nothing to do here
             }
             is PaymentSheetScreen.SelectSavedPaymentMethods -> {
-                eventReporter.onShowExistingPaymentOptions(
-                    linkEnabled = linkHandler.isLinkEnabled.value == true,
-                    currency = stripeIntent.value?.currency,
-                    isDecoupling = stripeIntent.value?.clientSecret == null,
-                )
+                eventReporter.onShowExistingPaymentOptions()
             }
             is AddFirstPaymentMethod -> {
-                eventReporter.onShowNewPaymentOptionForm(
-                    linkEnabled = linkHandler.isLinkEnabled.value == true,
-                    currency = stripeIntent.value?.currency,
-                    isDecoupling = stripeIntent.value?.clientSecret == null,
-                )
+                eventReporter.onShowNewPaymentOptionForm()
             }
             is PaymentSheetScreen.EditPaymentMethod -> {
                 // TODO(tillh-stripe) Add reporting
@@ -289,10 +280,7 @@ internal abstract class BaseSheetViewModel(
     }
 
     protected fun reportConfirmButtonPressed() {
-        eventReporter.onPressConfirmButton(
-            currency = stripeIntent.value?.currency,
-            isDecoupling = stripeIntent.value?.clientSecret == null,
-        )
+        eventReporter.onPressConfirmButton()
     }
 
     protected fun setStripeIntent(stripeIntent: StripeIntent?) {
@@ -307,16 +295,12 @@ internal abstract class BaseSheetViewModel(
         }
     }
 
-    protected fun reportDismiss(isDecoupling: Boolean) {
-        eventReporter.onDismiss(isDecoupling = isDecoupling)
+    protected fun reportDismiss() {
+        eventReporter.onDismiss()
     }
 
     fun reportPaymentMethodTypeSelected(code: PaymentMethodCode) {
-        eventReporter.onSelectPaymentMethod(
-            code = code,
-            isDecoupling = stripeIntent.value?.clientSecret == null,
-            currency = stripeIntent.value?.currency,
-        )
+        eventReporter.onSelectPaymentMethod(code)
     }
 
     abstract fun clearErrorMessages()
@@ -615,7 +599,7 @@ internal abstract class BaseSheetViewModel(
     }
 
     fun reportAutofillEvent(type: String) {
-        eventReporter.onAutofill(type, isDecoupling = stripeIntent.value?.clientSecret == null)
+        eventReporter.onAutofill(type)
     }
 
     abstract fun onPaymentResult(paymentResult: PaymentResult)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -55,7 +55,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -343,14 +342,10 @@ internal class PaymentOptionsActivityTest {
         // We don't want the initial selection to be reported, as it's not a user selection
         verify(eventReporter, never()).onSelectPaymentMethod(
             code = eq(PaymentMethod.Type.Card.code),
-            currency = anyOrNull(),
-            isDecoupling = any(),
         )
 
         verify(eventReporter).onSelectPaymentMethod(
             code = eq(PaymentMethod.Type.CashAppPay.code),
-            currency = anyOrNull(),
-            isDecoupling = any(),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -88,8 +88,6 @@ internal class PaymentOptionsViewModelTest {
             verify(eventReporter)
                 .onSelectPaymentOption(
                     paymentSelection = SELECTION_SAVED_PAYMENT_METHOD,
-                    currency = "usd",
-                    isDecoupling = false,
                 )
         }
 
@@ -113,8 +111,6 @@ internal class PaymentOptionsViewModelTest {
             verify(eventReporter)
                 .onSelectPaymentOption(
                     paymentSelection = NEW_REQUEST_DONT_SAVE_PAYMENT_SELECTION,
-                    currency = "usd",
-                    isDecoupling = false,
                 )
             assertThat(prefsRepository.getSavedSelection(true, true))
                 .isEqualTo(SavedSelection.None)
@@ -134,8 +130,6 @@ internal class PaymentOptionsViewModelTest {
                 verify(eventReporter)
                     .onSelectPaymentOption(
                         paymentSelection = paymentOptionResultSucceeded.paymentSelection,
-                        currency = "usd",
-                        isDecoupling = false,
                     )
                 ensureAllEventsConsumed()
             }
@@ -517,7 +511,7 @@ internal class PaymentOptionsViewModelTest {
     fun `Sends dismiss event when the user cancels the flow with non-deferred intent`() = runTest {
         val viewModel = createViewModel()
         viewModel.onUserCancel()
-        verify(eventReporter).onDismiss(isDecoupling = false)
+        verify(eventReporter).onDismiss()
     }
 
     @Test
@@ -528,7 +522,7 @@ internal class PaymentOptionsViewModelTest {
 
         val viewModel = createViewModel(args = deferredIntentArgs)
         viewModel.onUserCancel()
-        verify(eventReporter).onDismiss(isDecoupling = true)
+        verify(eventReporter).onDismiss()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -940,10 +940,7 @@ internal class PaymentSheetActivityTest {
             composeTestRule.waitForIdle()
         }
 
-        verify(eventReporter).onPressConfirmButton(
-            currency = "CAD",
-            isDecoupling = false,
-        )
+        verify(eventReporter).onPressConfirmButton()
     }
 
     private fun activityScenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -171,7 +171,7 @@ internal class PaymentSheetViewModelTest {
         createViewModel()
         verify(eventReporter).onInit(
             configuration = eq(PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY),
-            isDecoupling = eq(false),
+            isDeferred = eq(false),
         )
 
         // Creating the view model should regenerate the analytics sessionId.
@@ -1180,7 +1180,7 @@ internal class PaymentSheetViewModelTest {
             customerPaymentMethods = PaymentMethodFixtures.createCards(1),
         )
 
-        verify(eventReporter).onInit(configuration = anyOrNull(), isDecoupling = any())
+        verify(eventReporter).onInit(configuration = anyOrNull(), isDeferred = any())
 
         verify(eventReporter).onShowExistingPaymentOptions(
             linkEnabled = eq(false),
@@ -1446,7 +1446,7 @@ internal class PaymentSheetViewModelTest {
 
         verify(eventReporter).onInit(
             configuration = anyOrNull(),
-            isDecoupling = eq(false),
+            isDeferred = eq(false),
         )
     }
 
@@ -1460,7 +1460,7 @@ internal class PaymentSheetViewModelTest {
 
         verify(eventReporter).onInit(
             configuration = anyOrNull(),
-            isDecoupling = eq(true),
+            isDeferred = eq(true),
         )
     }
 
@@ -1475,7 +1475,7 @@ internal class PaymentSheetViewModelTest {
 
         verify(eventReporter).onInit(
             configuration = anyOrNull(),
-            isDecoupling = eq(true),
+            isDeferred = eq(true),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -531,7 +531,6 @@ internal class PaymentSheetViewModelTest {
             verify(eventReporter)
                 .onPaymentSuccess(
                     paymentSelection = selection,
-                    currency = "usd",
                     deferredIntentConfirmationType = null,
                 )
             assertThat(prefsRepository.paymentSelectionArgs)
@@ -580,7 +579,6 @@ internal class PaymentSheetViewModelTest {
             verify(eventReporter)
                 .onPaymentSuccess(
                     paymentSelection = selection,
-                    currency = "usd",
                     deferredIntentConfirmationType = null,
                 )
 
@@ -609,8 +607,6 @@ internal class PaymentSheetViewModelTest {
             verify(eventReporter)
                 .onPaymentFailure(
                     paymentSelection = selection,
-                    currency = "usd",
-                    isDecoupling = false,
                     error = PaymentSheetConfirmationError.Stripe(error),
                 )
 
@@ -1118,11 +1114,7 @@ internal class PaymentSheetViewModelTest {
 
         val receiver = viewModel.currentScreen.testIn(this)
 
-        verify(eventReporter).onShowNewPaymentOptionForm(
-            linkEnabled = eq(false),
-            currency = eq("usd"),
-            isDecoupling = eq(false),
-        )
+        verify(eventReporter).onShowNewPaymentOptionForm()
 
         receiver.cancelAndIgnoreRemainingEvents()
     }
@@ -1141,11 +1133,7 @@ internal class PaymentSheetViewModelTest {
 
         val receiver = viewModel.currentScreen.testIn(this)
 
-        verify(eventReporter).onShowNewPaymentOptionForm(
-            linkEnabled = eq(true),
-            currency = eq("usd"),
-            isDecoupling = eq(false),
-        )
+        verify(eventReporter).onShowNewPaymentOptionForm()
 
         receiver.cancelAndIgnoreRemainingEvents()
     }
@@ -1164,11 +1152,7 @@ internal class PaymentSheetViewModelTest {
 
         val receiver = viewModel.currentScreen.testIn(this)
 
-        verify(eventReporter).onShowNewPaymentOptionForm(
-            linkEnabled = eq(true),
-            currency = eq("usd"),
-            isDecoupling = eq(false),
-        )
+        verify(eventReporter).onShowNewPaymentOptionForm()
 
         receiver.cancelAndIgnoreRemainingEvents()
     }
@@ -1182,11 +1166,7 @@ internal class PaymentSheetViewModelTest {
 
         verify(eventReporter).onInit(configuration = anyOrNull(), isDeferred = any())
 
-        verify(eventReporter).onShowExistingPaymentOptions(
-            linkEnabled = eq(false),
-            currency = eq("usd"),
-            isDecoupling = eq(false),
-        )
+        verify(eventReporter).onShowExistingPaymentOptions()
 
         viewModel.transitionToAddPaymentScreen()
 
@@ -1503,7 +1483,6 @@ internal class PaymentSheetViewModelTest {
 
             verify(eventReporter).onPaymentSuccess(
                 paymentSelection = eq(savedSelection),
-                currency = anyOrNull(),
                 deferredIntentConfirmationType = eq(deferredIntentConfirmationType),
             )
         }
@@ -1529,7 +1508,6 @@ internal class PaymentSheetViewModelTest {
 
         verify(eventReporter).onPaymentSuccess(
             paymentSelection = eq(savedSelection),
-            currency = anyOrNull(),
             deferredIntentConfirmationType = isNull(),
         )
     }
@@ -1557,7 +1535,6 @@ internal class PaymentSheetViewModelTest {
 
         verify(eventReporter).onPaymentSuccess(
             paymentSelection = eq(savedSelection),
-            currency = anyOrNull(),
             deferredIntentConfirmationType = eq(DeferredIntentConfirmationType.Client),
         )
     }
@@ -1577,7 +1554,6 @@ internal class PaymentSheetViewModelTest {
 
         verify(eventReporter).onPaymentSuccess(
             paymentSelection = eq(savedSelection),
-            currency = anyOrNull(),
             deferredIntentConfirmationType = eq(DeferredIntentConfirmationType.Server),
         )
     }
@@ -1586,14 +1562,14 @@ internal class PaymentSheetViewModelTest {
     fun `Sends dismiss event when the user cancels the flow with non-deferred intent`() = runTest {
         val viewModel = createViewModel()
         viewModel.onUserCancel()
-        verify(eventReporter).onDismiss(isDecoupling = false)
+        verify(eventReporter).onDismiss()
     }
 
     @Test
     fun `Sends dismiss event when the user cancels the flow with deferred intent`() = runTest {
         val viewModel = createViewModelForDeferredIntent()
         viewModel.onUserCancel()
-        verify(eventReporter).onDismiss(isDecoupling = true)
+        verify(eventReporter).onDismiss()
     }
 
     @Test
@@ -1624,10 +1600,7 @@ internal class PaymentSheetViewModelTest {
 
         viewModel.handleConfirmUSBankAccount(newPaymentSelection)
 
-        verify(eventReporter).onPressConfirmButton(
-            currency = "usd",
-            isDecoupling = false,
-        )
+        verify(eventReporter).onPressConfirmButton()
     }
 
     @Test
@@ -1666,10 +1639,7 @@ internal class PaymentSheetViewModelTest {
 
         viewModel.checkout()
 
-        verify(eventReporter, never()).onPressConfirmButton(
-            currency = "usd",
-            isDecoupling = false,
-        )
+        verify(eventReporter, never()).onPressConfirmButton()
     }
 
     @Test
@@ -2060,7 +2030,6 @@ internal class PaymentSheetViewModelTest {
         private val ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP =
             PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP
         private val ARGS_CUSTOMER_WITH_GOOGLEPAY = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY
-        private val ARGS_WITHOUT_CUSTOMER = PaymentSheetFixtures.ARGS_WITHOUT_CUSTOMER
 
         private val PAYMENT_METHODS = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -53,7 +53,7 @@ class DefaultEventReporterTest {
     fun `onInit() should fire analytics request with expected event value`() {
         completeEventReporter.onInit(
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
-            isDecoupling = false,
+            isDeferred = false,
         )
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.utils.FakeDurationProvider
@@ -23,6 +24,7 @@ import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 import java.io.IOException
 import kotlin.test.Test
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -36,25 +38,18 @@ class DefaultEventReporterTest {
         ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
     )
 
-    private val eventReporterFactory: (EventReporter.Mode) -> EventReporter = { mode ->
-        DefaultEventReporter(
-            mode,
-            analyticsRequestExecutor,
-            analyticsRequestFactory,
-            durationProvider,
-            testDispatcher
-        )
-    }
-
-    private val completeEventReporter = eventReporterFactory(EventReporter.Mode.Complete)
-    private val customEventReporter = eventReporterFactory(EventReporter.Mode.Custom)
+    private val configuration: PaymentSheet.Configuration
+        get() = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
 
     @Test
     fun `onInit() should fire analytics request with expected event value`() {
+        val completeEventReporter = createEventReporter(EventReporter.Mode.Complete)
+
         completeEventReporter.onInit(
-            configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
+            configuration = configuration,
             isDeferred = false,
         )
+
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
                 req.params["event"] == "mc_complete_init_customer_googlepay" &&
@@ -65,11 +60,11 @@ class DefaultEventReporterTest {
 
     @Test
     fun `onShowExistingPaymentOptions() should fire analytics request with expected event value`() {
-        completeEventReporter.onShowExistingPaymentOptions(
-            linkEnabled = true,
-            currency = "usd",
-            isDecoupling = false,
-        )
+        val completeEventReporter = createEventReporter(EventReporter.Mode.Complete) {
+            simulateSuccessfulSetup()
+        }
+
+        completeEventReporter.onShowExistingPaymentOptions()
 
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
@@ -83,11 +78,11 @@ class DefaultEventReporterTest {
 
     @Test
     fun `onShowNewPaymentOptionForm() should fire analytics request with expected event value`() {
-        completeEventReporter.onShowNewPaymentOptionForm(
-            linkEnabled = false,
-            currency = "usd",
-            isDecoupling = false,
-        )
+        val completeEventReporter = createEventReporter(EventReporter.Mode.Complete) {
+            simulateSuccessfulSetup(linkEnabled = false)
+        }
+
+        completeEventReporter.onShowNewPaymentOptionForm()
 
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
@@ -101,20 +96,14 @@ class DefaultEventReporterTest {
 
     @Test
     fun `onPaymentSuccess() should fire analytics request with expected event value`() {
-        durationProvider.enqueueDuration(1.seconds)
-
         // Log initial event so that duration is tracked
-        completeEventReporter.onShowExistingPaymentOptions(
-            linkEnabled = false,
-            currency = "usd",
-            isDecoupling = false,
-        )
-
-        reset(analyticsRequestExecutor)
+        val completeEventReporter = createEventReporter(EventReporter.Mode.Complete) {
+            simulateSuccessfulSetup()
+            onShowExistingPaymentOptions()
+        }
 
         completeEventReporter.onPaymentSuccess(
             paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
-            currency = "usd",
             deferredIntentConfirmationType = null,
         )
 
@@ -130,23 +119,20 @@ class DefaultEventReporterTest {
 
     @Test
     fun `onPaymentSuccess() for Google Pay payment should fire analytics request with expected event value`() {
-        durationProvider.enqueueDuration(2.seconds)
-
         // Log initial event so that duration is tracked
-        completeEventReporter.onShowExistingPaymentOptions(
-            linkEnabled = false,
-            currency = "usd",
-            isDecoupling = false,
-        )
-
-        reset(analyticsRequestExecutor)
+        val completeEventReporter = createEventReporter(
+            mode = EventReporter.Mode.Complete,
+            duration = 2.seconds,
+        ) {
+            simulateSuccessfulSetup()
+            onShowExistingPaymentOptions()
+        }
 
         completeEventReporter.onPaymentSuccess(
             paymentSelection = PaymentSelection.Saved(
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 walletType = PaymentSelection.Saved.WalletType.GooglePay,
             ),
-            currency = "usd",
             deferredIntentConfirmationType = null,
         )
 
@@ -160,23 +146,20 @@ class DefaultEventReporterTest {
 
     @Test
     fun `onPaymentSuccess() for Link payment should fire analytics request with expected event value`() {
-        durationProvider.enqueueDuration(123.milliseconds)
-
         // Log initial event so that duration is tracked
-        completeEventReporter.onShowExistingPaymentOptions(
-            linkEnabled = true,
-            currency = "usd",
-            isDecoupling = false,
-        )
-
-        reset(analyticsRequestExecutor)
+        val completeEventReporter = createEventReporter(
+            mode = EventReporter.Mode.Complete,
+            duration = 123.milliseconds,
+        ) {
+            simulateSuccessfulSetup()
+            onShowExistingPaymentOptions()
+        }
 
         completeEventReporter.onPaymentSuccess(
             paymentSelection = PaymentSelection.Saved(
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 walletType = PaymentSelection.Saved.WalletType.Link,
             ),
-            currency = "usd",
             deferredIntentConfirmationType = null,
         )
 
@@ -190,21 +173,17 @@ class DefaultEventReporterTest {
 
     @Test
     fun `onPaymentFailure() should fire analytics request with expected event value`() {
-        durationProvider.enqueueDuration(456.milliseconds)
-
         // Log initial event so that duration is tracked
-        completeEventReporter.onShowExistingPaymentOptions(
-            linkEnabled = false,
-            currency = "usd",
-            isDecoupling = false,
-        )
-
-        reset(analyticsRequestExecutor)
+        val completeEventReporter = createEventReporter(
+            mode = EventReporter.Mode.Complete,
+            duration = 456.milliseconds,
+        ) {
+            simulateSuccessfulSetup()
+            onShowExistingPaymentOptions()
+        }
 
         completeEventReporter.onPaymentFailure(
             paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
-            currency = "usd",
-            isDecoupling = false,
             error = PaymentSheetConfirmationError.Stripe(APIException())
         )
 
@@ -221,11 +200,14 @@ class DefaultEventReporterTest {
 
     @Test
     fun `onSelectPaymentOption() should fire analytics request with expected event value`() {
+        val customEventReporter = createEventReporter(EventReporter.Mode.Custom) {
+            simulateSuccessfulSetup()
+        }
+
         customEventReporter.onSelectPaymentOption(
             paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
-            currency = "usd",
-            isDecoupling = false,
         )
+
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
                 req.params["event"] == "mc_custom_paymentoption_savedpm_select" &&
@@ -250,8 +232,11 @@ class DefaultEventReporterTest {
 
     @Test
     fun `Send correct error_message for server errors`() {
+        val completeEventReporter = createEventReporter(EventReporter.Mode.Complete) {
+            simulateInit()
+        }
+
         completeEventReporter.onLoadFailed(
-            isDecoupling = false,
             error = JSONException("Server did something bad"),
         )
 
@@ -264,8 +249,11 @@ class DefaultEventReporterTest {
 
     @Test
     fun `Send correct error_message for network errors`() {
+        val completeEventReporter = createEventReporter(EventReporter.Mode.Complete) {
+            simulateInit()
+        }
+
         completeEventReporter.onLoadFailed(
-            isDecoupling = false,
             error = IOException("Internet no good"),
         )
 
@@ -278,8 +266,11 @@ class DefaultEventReporterTest {
 
     @Test
     fun `Send correct error_message for invalid requests`() {
+        val completeEventReporter = createEventReporter(EventReporter.Mode.Complete) {
+            simulateInit()
+        }
+
         completeEventReporter.onLoadFailed(
-            isDecoupling = false,
             error = IllegalArgumentException("This ain't valid"),
         )
 
@@ -288,5 +279,38 @@ class DefaultEventReporterTest {
 
         val errorType = argumentCaptor.firstValue.params["error_message"] as String
         assertThat(errorType).isEqualTo("invalidRequestError")
+    }
+
+    private fun createEventReporter(
+        mode: EventReporter.Mode,
+        duration: Duration = 1.seconds,
+        configure: EventReporter.() -> Unit = {},
+    ): EventReporter {
+        val reporter = DefaultEventReporter(
+            mode = mode,
+            analyticsRequestExecutor = analyticsRequestExecutor,
+            paymentAnalyticsRequestFactory = analyticsRequestFactory,
+            durationProvider = FakeDurationProvider(duration),
+            workContext = testDispatcher,
+        )
+
+        reporter.configure()
+
+        reset(analyticsRequestExecutor)
+
+        return reporter
+    }
+
+    private fun EventReporter.simulateInit() {
+        onInit(configuration, isDeferred = false)
+    }
+
+    private fun EventReporter.simulateSuccessfulSetup(
+        linkEnabled: Boolean = true,
+        currency: String? = "usd",
+    ) {
+        onInit(configuration, isDeferred = false)
+        onLoadStarted()
+        onLoadSucceeded(linkEnabled, currency)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -22,7 +22,7 @@ class PaymentSheetEventTest {
         val event = PaymentSheetEvent.Init(
             mode = EventReporter.Mode.Complete,
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
-            isDecoupled = false,
+            isDeferred = false,
         )
 
         assertThat(
@@ -73,7 +73,7 @@ class PaymentSheetEventTest {
         val event = PaymentSheetEvent.Init(
             mode = EventReporter.Mode.Complete,
             configuration = PaymentSheetFixtures.CONFIG_MINIMUM,
-            isDecoupled = false,
+            isDeferred = false,
         )
 
         assertThat(
@@ -131,7 +131,7 @@ class PaymentSheetEventTest {
             duration = 1.milliseconds,
             result = PaymentSheetEvent.Payment.Result.Success,
             currency = "usd",
-            isDecoupled = false,
+            isDeferred = false,
             deferredIntentConfirmationType = null,
         )
         assertThat(
@@ -159,7 +159,7 @@ class PaymentSheetEventTest {
             duration = 1.milliseconds,
             result = PaymentSheetEvent.Payment.Result.Success,
             currency = "usd",
-            isDecoupled = false,
+            isDeferred = false,
             deferredIntentConfirmationType = null,
         )
         assertThat(
@@ -187,7 +187,7 @@ class PaymentSheetEventTest {
             duration = 1.milliseconds,
             result = PaymentSheetEvent.Payment.Result.Success,
             currency = "usd",
-            isDecoupled = false,
+            isDeferred = false,
             deferredIntentConfirmationType = null,
         )
         assertThat(
@@ -215,7 +215,7 @@ class PaymentSheetEventTest {
             duration = 1.milliseconds,
             result = PaymentSheetEvent.Payment.Result.Success,
             currency = "usd",
-            isDecoupled = false,
+            isDeferred = false,
             deferredIntentConfirmationType = null,
         )
         assertThat(
@@ -249,7 +249,7 @@ class PaymentSheetEventTest {
             duration = 1.milliseconds,
             result = PaymentSheetEvent.Payment.Result.Success,
             currency = "usd",
-            isDecoupled = false,
+            isDeferred = false,
             deferredIntentConfirmationType = null,
         )
         assertThat(
@@ -282,7 +282,7 @@ class PaymentSheetEventTest {
                 error = PaymentSheetConfirmationError.Stripe(APIException()),
             ),
             currency = "usd",
-            isDecoupled = false,
+            isDeferred = false,
             deferredIntentConfirmationType = null,
         )
         assertThat(
@@ -313,7 +313,7 @@ class PaymentSheetEventTest {
                 error = PaymentSheetConfirmationError.Stripe(APIException()),
             ),
             currency = "usd",
-            isDecoupled = false,
+            isDeferred = false,
             deferredIntentConfirmationType = null,
         )
         assertThat(
@@ -344,7 +344,7 @@ class PaymentSheetEventTest {
                 error = PaymentSheetConfirmationError.Stripe(APIException()),
             ),
             currency = "usd",
-            isDecoupled = false,
+            isDeferred = false,
             deferredIntentConfirmationType = null,
         )
         assertThat(
@@ -375,7 +375,7 @@ class PaymentSheetEventTest {
                 error = PaymentSheetConfirmationError.Stripe(APIException()),
             ),
             currency = "usd",
-            isDecoupled = false,
+            isDeferred = false,
             deferredIntentConfirmationType = null,
         )
         assertThat(
@@ -412,7 +412,7 @@ class PaymentSheetEventTest {
                 error = PaymentSheetConfirmationError.Stripe(APIException()),
             ),
             currency = "usd",
-            isDecoupled = false,
+            isDeferred = false,
             deferredIntentConfirmationType = null,
         )
         assertThat(
@@ -438,7 +438,7 @@ class PaymentSheetEventTest {
             mode = EventReporter.Mode.Custom,
             paymentSelection = PaymentSelection.GooglePay,
             currency = "usd",
-            isDecoupled = false,
+            isDeferred = false,
         )
         assertThat(
             event.eventName
@@ -494,7 +494,7 @@ class PaymentSheetEventTest {
             PaymentSheetEvent.Init(
                 mode = EventReporter.Mode.Complete,
                 configuration = PaymentSheetFixtures.CONFIG_MINIMUM,
-                isDecoupled = false,
+                isDeferred = false,
             ).params
         ).isEqualTo(
             mapOf(
@@ -543,7 +543,7 @@ class PaymentSheetEventTest {
             PaymentSheetEvent.Init(
                 mode = EventReporter.Mode.Complete,
                 configuration = PaymentSheetFixtures.CONFIG_WITH_EVERYTHING,
-                isDecoupled = false,
+                isDeferred = false,
             ).params
         ).isEqualTo(
             mapOf(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -250,7 +250,6 @@ internal class DefaultFlowControllerTest {
         verify(eventReporter)
             .onPaymentSuccess(
                 paymentSelection = isA<PaymentSelection.New>(),
-                currency = eq("usd"),
                 deferredIntentConfirmationType = isNull(),
             )
     }
@@ -274,8 +273,6 @@ internal class DefaultFlowControllerTest {
         verify(eventReporter)
             .onPaymentFailure(
                 paymentSelection = isA<PaymentSelection.New>(),
-                currency = eq("usd"),
-                isDecoupling = eq(false),
                 error = eq(PaymentSheetConfirmationError.Stripe(error)),
             )
     }
@@ -300,8 +297,6 @@ internal class DefaultFlowControllerTest {
 
         verify(eventReporter).onPaymentFailure(
             paymentSelection = isA<PaymentSelection.GooglePay>(),
-            currency = eq("usd"),
-            isDecoupling = eq(false),
             error = eq(PaymentSheetConfirmationError.GooglePay(errorCode)),
         )
     }
@@ -323,8 +318,6 @@ internal class DefaultFlowControllerTest {
 
         verify(eventReporter).onPaymentFailure(
             paymentSelection = isA<PaymentSelection.GooglePay>(),
-            currency = isNull(),
-            isDecoupling = eq(false),
             error = eq(PaymentSheetConfirmationError.InvalidState),
         )
     }
@@ -1386,7 +1379,6 @@ internal class DefaultFlowControllerTest {
 
             verify(eventReporter).onPaymentSuccess(
                 paymentSelection = eq(savedSelection),
-                currency = anyOrNull(),
                 deferredIntentConfirmationType = eq(deferredIntentConfirmationType),
             )
         }
@@ -1416,7 +1408,6 @@ internal class DefaultFlowControllerTest {
 
         verify(eventReporter).onPaymentSuccess(
             paymentSelection = eq(savedSelection),
-            currency = anyOrNull(),
             deferredIntentConfirmationType = isNull(),
         )
     }
@@ -1446,7 +1437,6 @@ internal class DefaultFlowControllerTest {
 
         verify(eventReporter).onPaymentSuccess(
             paymentSelection = eq(savedSelection),
-            currency = anyOrNull(),
             deferredIntentConfirmationType = eq(DeferredIntentConfirmationType.Client),
         )
     }
@@ -1468,7 +1458,6 @@ internal class DefaultFlowControllerTest {
 
         verify(eventReporter).onPaymentSuccess(
             paymentSelection = eq(savedSelection),
-            currency = anyOrNull(),
             deferredIntentConfirmationType = eq(DeferredIntentConfirmationType.Server),
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
@@ -98,7 +98,7 @@ class FlowControllerConfigurationHandlerTest {
         assertThat(viewModel.state).isNotNull()
         verify(eventReporter).onInit(
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
-            isDecoupling = false,
+            isDeferred = false,
         )
         // Configure should regenerate the analytics sessionId.
         assertThat(beforeSessionId).isNotEqualTo(AnalyticsRequestFactory.sessionId)
@@ -136,7 +136,7 @@ class FlowControllerConfigurationHandlerTest {
         // We're running ONLY the second config run, so we don't expect any interactions.
         verify(eventReporter, never()).onInit(
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
-            isDecoupling = false,
+            isDeferred = false,
         )
 
         // Configure should not regenerate the analytics sessionId when using the same configuration.
@@ -176,7 +176,7 @@ class FlowControllerConfigurationHandlerTest {
         // We're running a new config, so we DO expect an interaction.
         verify(eventReporter).onInit(
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
-            isDecoupling = false,
+            isDeferred = false,
         )
     }
 
@@ -214,7 +214,7 @@ class FlowControllerConfigurationHandlerTest {
         // We're running a new config, so we DO expect an interaction.
         verify(eventReporter).onInit(
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
-            isDecoupling = false,
+            isDeferred = false,
         )
     }
 
@@ -430,7 +430,7 @@ class FlowControllerConfigurationHandlerTest {
 
         verify(eventReporter).onInit(
             configuration = any(),
-            isDecoupling = eq(false),
+            isDeferred = eq(false),
         )
     }
 
@@ -462,7 +462,7 @@ class FlowControllerConfigurationHandlerTest {
 
         verify(eventReporter).onInit(
             configuration = any(),
-            isDecoupling = eq(true),
+            isDeferred = eq(true),
         )
     }
 
@@ -495,7 +495,7 @@ class FlowControllerConfigurationHandlerTest {
 
         verify(eventReporter).onInit(
             configuration = any(),
-            isDecoupling = eq(true),
+            isDeferred = eq(true),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -42,7 +42,6 @@ import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.capture
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -664,8 +663,8 @@ internal class DefaultPaymentSheetLoaderTest {
             paymentSheetConfiguration = PaymentSheet.Configuration("Some Name"),
         )
 
-        verify(eventReporter).onLoadStarted(isDecoupling = false)
-        verify(eventReporter).onLoadSucceeded(isDecoupling = false)
+        verify(eventReporter).onLoadStarted()
+        verify(eventReporter).onLoadSucceeded(linkEnabled = true, currency = "usd")
     }
 
     @Test
@@ -684,8 +683,8 @@ internal class DefaultPaymentSheetLoaderTest {
             paymentSheetConfiguration = PaymentSheet.Configuration("Some Name"),
         )
 
-        verify(eventReporter).onLoadStarted(isDecoupling = true)
-        verify(eventReporter).onLoadSucceeded(isDecoupling = true)
+        verify(eventReporter).onLoadStarted()
+        verify(eventReporter).onLoadSucceeded(linkEnabled = true, currency = "usd")
     }
 
     @Test
@@ -698,12 +697,8 @@ internal class DefaultPaymentSheetLoaderTest {
             paymentSheetConfiguration = PaymentSheet.Configuration("Some Name"),
         )
 
-        verify(eventReporter).onLoadStarted(isDecoupling = false)
-
-        verify(eventReporter).onLoadFailed(
-            isDecoupling = eq(false),
-            error = eq(error),
-        )
+        verify(eventReporter).onLoadStarted()
+        verify(eventReporter).onLoadFailed(error)
     }
 
     @Test
@@ -723,12 +718,8 @@ internal class DefaultPaymentSheetLoaderTest {
             paymentSheetConfiguration = PaymentSheet.Configuration("Some Name"),
         )
 
-        verify(eventReporter).onLoadStarted(isDecoupling = true)
-
-        verify(eventReporter).onLoadFailed(
-            isDecoupling = eq(true),
-            error = eq(error),
-        )
+        verify(eventReporter).onLoadStarted()
+        verify(eventReporter).onLoadFailed(error)
     }
 
     @Test
@@ -751,12 +742,8 @@ internal class DefaultPaymentSheetLoaderTest {
             paymentSheetConfiguration = PaymentSheet.Configuration("Some Name"),
         )
 
-        verify(eventReporter).onLoadStarted(isDecoupling = true)
-
-        verify(eventReporter).onLoadFailed(
-            isDecoupling = true,
-            error = PaymentSheetLoadingException.InvalidConfirmationMethod(Manual),
-        )
+        verify(eventReporter).onLoadStarted()
+        verify(eventReporter).onLoadFailed(PaymentSheetLoadingException.InvalidConfirmationMethod(Manual))
     }
 
     @Test
@@ -773,11 +760,8 @@ internal class DefaultPaymentSheetLoaderTest {
             paymentSheetConfiguration = PaymentSheet.Configuration("Some Name"),
         )
 
-        verify(eventReporter).onLoadStarted(isDecoupling = false)
-        verify(eventReporter).onElementsSessionLoadFailed(
-            isDecoupling = false,
-            error = error,
-        )
+        verify(eventReporter).onLoadStarted()
+        verify(eventReporter).onElementsSessionLoadFailed(error)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeDurationProvider.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeDurationProvider.kt
@@ -5,22 +5,14 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 internal class FakeDurationProvider(
-    private val originalDuration: Duration = 1.seconds,
+    private val duration: Duration = 1.seconds,
 ) : DurationProvider {
-
-    private var overrideDuration: Duration? = null
-
-    fun enqueueDuration(duration: Duration?) {
-        overrideDuration = duration
-    }
 
     override fun start(key: DurationProvider.Key) {
         // Nothing to do here
     }
 
     override fun end(key: DurationProvider.Key): Duration {
-        val result = overrideDuration ?: originalDuration
-        overrideDuration = null
-        return result
+        return duration
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request cleans up the `EventReporter` API by keeping a reference to `isDeferred`, `currency`, and `linkEnabled` instead of passing them into various event methods.

The `onInit()` and `onLoadSucceeded()` methods will be called again after process death, so there shouldn’t be any risk of us reporting incomplete events.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
