### PR TITLE
Enable CBC for deferred and setup intents

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
@@ -53,12 +53,8 @@ internal class ElementsSessionJsonParser(
         )
 
         val merchantCountry = json.optString(FIELD_MERCHANT_COUNTRY)
-        val isEligibleForCardBrandChoice = if (params is ElementsSessionParams.PaymentIntentType) {
-            parseCardBrandChoiceEligibility(json)
-        } else {
-            false
-        }
 
+        val isEligibleForCardBrandChoice = parseCardBrandChoiceEligibility(json)
         val googlePayPreference = json.optString(FIELD_GOOGLE_PAY_PREFERENCE)
 
         return if (stripeIntent != null) {

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -374,19 +374,6 @@ class ElementsSessionJsonParserTest {
     }
 
     @Test
-    fun `Is not eligible for CBC if not client-side payment intent`() {
-        val parser = ElementsSessionJsonParser(
-            params = ElementsSessionParams.SetupIntentType(clientSecret = "secret"),
-            apiKey = "test",
-        )
-
-        val intent = ElementsSessionFixtures.EXPANDED_SETUP_INTENT_JSON_WITH_CBC_ELIGIBLE
-        val session = parser.parse(intent)
-
-        assertThat(session?.isEligibleForCardBrandChoice).isFalse()
-    }
-
-    @Test
     fun parsePaymentIntent_shouldCreateObjectWithCorrectGooglePayEnabled() {
         val parser = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request enables CBC for setup intents and deferred intents. This wasn’t supported when we began the feature work, but it is now.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
