### PR TITLE
Mark `Networks.selectionMandatory` as deprecated

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -804,6 +804,7 @@ constructor(
         @Parcelize
         data class Networks(
             val available: Set<String> = emptySet(),
+            @Deprecated("This field is deprecated and will be removed in a future release.")
             val selectionMandatory: Boolean = false,
             val preferred: String? = null
         ) : StripeModel


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request marks `PaymentMethodCreateParams.Card.Networks.selectionMandatory` as deprecated. We don’t use this field, iOS doesn’t use this field, and the backend doesn’t list this field.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
