### PR TITLE
Keep reference to pending payment result

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -332,7 +332,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         if (pendingResult is InternalPaymentResult.Completed) {
             // If we just received a transaction result after process death, we don't error. Instead, we dismiss
             // PaymentSheet and return a `Completed` result to the caller.
-            val usedPaymentMethod = error.asPaymentSheetLoadingException.paymentMethod
+            val usedPaymentMethod = error.asPaymentSheetLoadingException.usedPaymentMethod
             handlePaymentCompleted(usedPaymentMethod, finishImmediately = true)
         } else {
             setStripeIntent(null)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -338,6 +338,8 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             setStripeIntent(null)
             onFatal(error)
         }
+
+        pendingPaymentResult = null
     }
 
     private fun handlePaymentSheetStateLoaded(state: PaymentSheetState.Full) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/StripeIntentValidator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/StripeIntentValidator.kt
@@ -23,18 +23,20 @@ internal object StripeIntentValidator {
     fun requireValid(
         stripeIntent: StripeIntent
     ): StripeIntent {
+        val paymentMethod = stripeIntent.paymentMethod
+
         val exception = when {
             stripeIntent is PaymentIntent && stripeIntent.confirmationMethod != Automatic -> {
-                PaymentSheetLoadingException.InvalidConfirmationMethod(stripeIntent.confirmationMethod)
+                PaymentSheetLoadingException.InvalidConfirmationMethod(paymentMethod, stripeIntent.confirmationMethod)
             }
             stripeIntent is PaymentIntent && stripeIntent.isInTerminalState -> {
-                PaymentSheetLoadingException.PaymentIntentInTerminalState(stripeIntent.status)
+                PaymentSheetLoadingException.PaymentIntentInTerminalState(paymentMethod, stripeIntent.status)
             }
             stripeIntent is PaymentIntent && (stripeIntent.amount == null || stripeIntent.currency == null) -> {
-                PaymentSheetLoadingException.MissingAmountOrCurrency
+                PaymentSheetLoadingException.MissingAmountOrCurrency(paymentMethod)
             }
             stripeIntent is SetupIntent && stripeIntent.isInTerminalState -> {
-                PaymentSheetLoadingException.SetupIntentInTerminalState(stripeIntent.status)
+                PaymentSheetLoadingException.SetupIntentInTerminalState(paymentMethod, stripeIntent.status)
             }
             else -> {
                 // valid

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/StripeIntentValidator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/StripeIntentValidator.kt
@@ -27,13 +27,13 @@ internal object StripeIntentValidator {
 
         val exception = when {
             stripeIntent is PaymentIntent && stripeIntent.confirmationMethod != Automatic -> {
-                PaymentSheetLoadingException.InvalidConfirmationMethod(paymentMethod, stripeIntent.confirmationMethod)
+                PaymentSheetLoadingException.InvalidConfirmationMethod(stripeIntent.confirmationMethod)
             }
             stripeIntent is PaymentIntent && stripeIntent.isInTerminalState -> {
                 PaymentSheetLoadingException.PaymentIntentInTerminalState(paymentMethod, stripeIntent.status)
             }
             stripeIntent is PaymentIntent && (stripeIntent.amount == null || stripeIntent.currency == null) -> {
-                PaymentSheetLoadingException.MissingAmountOrCurrency(paymentMethod)
+                PaymentSheetLoadingException.MissingAmountOrCurrency
             }
             stripeIntent is SetupIntent && stripeIntent.isInTerminalState -> {
                 PaymentSheetLoadingException.SetupIntentInTerminalState(paymentMethod, stripeIntent.status)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -186,7 +186,11 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             val requested = stripeIntent.paymentMethodTypes.joinToString(separator = ", ")
             val supported = lpmRepository.values().joinToString(separator = ", ") { it.code }
 
-            throw PaymentSheetLoadingException.NoPaymentMethodTypesAvailable(requested, supported)
+            throw PaymentSheetLoadingException.NoPaymentMethodTypesAvailable(
+                paymentMethod = stripeIntent.paymentMethod,
+                requested = requested,
+                supported = supported,
+            )
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -186,11 +186,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             val requested = stripeIntent.paymentMethodTypes.joinToString(separator = ", ")
             val supported = lpmRepository.values().joinToString(separator = ", ") { it.code }
 
-            throw PaymentSheetLoadingException.NoPaymentMethodTypesAvailable(
-                paymentMethod = stripeIntent.paymentMethod,
-                requested = requested,
-                supported = supported,
-            )
+            throw PaymentSheetLoadingException.NoPaymentMethodTypesAvailable(requested, supported)
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoadingException.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoadingException.kt
@@ -10,12 +10,13 @@ import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException.Unknow
 internal sealed class PaymentSheetLoadingException : Throwable() {
 
     abstract val type: String
-    abstract val paymentMethod: PaymentMethod?
+    abstract val usedPaymentMethod: PaymentMethod?
 
     data class InvalidConfirmationMethod(
-        override val paymentMethod: PaymentMethod?,
         private val confirmationMethod: PaymentIntent.ConfirmationMethod,
     ) : PaymentSheetLoadingException() {
+
+        override val usedPaymentMethod: PaymentMethod? = null
 
         override val type: String = "invalidConfirmationMethod"
 
@@ -27,10 +28,11 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
     }
 
     data class NoPaymentMethodTypesAvailable(
-        override val paymentMethod: PaymentMethod?,
         private val requested: String,
         private val supported: String,
     ) : PaymentSheetLoadingException() {
+
+        override val usedPaymentMethod: PaymentMethod? = null
 
         override val type: String = "noPaymentMethodTypesAvailable"
 
@@ -40,7 +42,7 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
     }
 
     data class PaymentIntentInTerminalState(
-        override val paymentMethod: PaymentMethod?,
+        override val usedPaymentMethod: PaymentMethod?,
         private val status: StripeIntent.Status?,
     ) : PaymentSheetLoadingException() {
 
@@ -54,7 +56,7 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
     }
 
     data class SetupIntentInTerminalState(
-        override val paymentMethod: PaymentMethod?,
+        override val usedPaymentMethod: PaymentMethod?,
         private val status: StripeIntent.Status?,
     ) : PaymentSheetLoadingException() {
 
@@ -67,9 +69,8 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
             """.trimIndent()
     }
 
-    data class MissingAmountOrCurrency(
-        override val paymentMethod: PaymentMethod?,
-    ) : PaymentSheetLoadingException() {
+    object MissingAmountOrCurrency : PaymentSheetLoadingException() {
+        override val usedPaymentMethod: PaymentMethod? = null
         override val type: String = "missingAmountOrCurrency"
         override val message: String = "PaymentIntent must contain amount and currency."
     }
@@ -83,7 +84,7 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
 
         override val message: String? = cause.message
 
-        override val paymentMethod: PaymentMethod? = null
+        override val usedPaymentMethod: PaymentMethod? = null
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoadingException.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoadingException.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.state
 
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.analytics.analyticsValue
 import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException.Unknown
@@ -9,8 +10,10 @@ import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException.Unknow
 internal sealed class PaymentSheetLoadingException : Throwable() {
 
     abstract val type: String
+    abstract val paymentMethod: PaymentMethod?
 
     data class InvalidConfirmationMethod(
+        override val paymentMethod: PaymentMethod?,
         private val confirmationMethod: PaymentIntent.ConfirmationMethod,
     ) : PaymentSheetLoadingException() {
 
@@ -24,6 +27,7 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
     }
 
     data class NoPaymentMethodTypesAvailable(
+        override val paymentMethod: PaymentMethod?,
         private val requested: String,
         private val supported: String,
     ) : PaymentSheetLoadingException() {
@@ -36,6 +40,7 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
     }
 
     data class PaymentIntentInTerminalState(
+        override val paymentMethod: PaymentMethod?,
         private val status: StripeIntent.Status?,
     ) : PaymentSheetLoadingException() {
 
@@ -49,6 +54,7 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
     }
 
     data class SetupIntentInTerminalState(
+        override val paymentMethod: PaymentMethod?,
         private val status: StripeIntent.Status?,
     ) : PaymentSheetLoadingException() {
 
@@ -61,7 +67,9 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
             """.trimIndent()
     }
 
-    object MissingAmountOrCurrency : PaymentSheetLoadingException() {
+    data class MissingAmountOrCurrency(
+        override val paymentMethod: PaymentMethod?,
+    ) : PaymentSheetLoadingException() {
         override val type: String = "missingAmountOrCurrency"
         override val message: String = "PaymentIntent must contain amount and currency."
     }
@@ -74,6 +82,8 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
             get() = StripeException.create(cause).analyticsValue
 
         override val message: String? = cause.message
+
+        override val paymentMethod: PaymentMethod? = null
     }
 }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request makes a first improvement to how we handle process death during the auth flow, with more improvements such as full state restoration still to come.

In the case of process death, the `paymentLauncher` used in `PaymentSheetViewModel` will return an `InternalPaymentResult` upon process recreation. However, the ViewModel is not yet in the correct state to handle this, as it hasn’t reloaded the `StripeIntent`. The `requireNotNull(stripeIntent.value)` will throw.

With this change, we’re delaying the handling of the `InternalPaymentResult` until the intent has been loaded again. If the intent has been confirmed by the user, then loading the intent will fail with a `PaymentIntentInTerminalState` exception. This is where we intercept: Instead of returning a fatal error to the caller, we handle the completed payment and return a `PaymentResult.Completed`.

Due to how `PaymentLauncher` works, this is unfortunately very difficult to test 😔

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Resolves https://github.com/stripe/stripe-android/issues/7590

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
