### PR TITLE
Fix CustomerSheet bugs

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -225,14 +225,16 @@ internal class CustomerSheetViewModel @Inject constructor(
                     unconfirmedPaymentMethod?.let { method ->
                         unconfirmedPaymentMethod = null
 
+                        val newPaymentSelection = PaymentSelection.Saved(paymentMethod = method)
+
                         viewState.copy(
                             savedPaymentMethods = listOf(method) + viewState.savedPaymentMethods,
-                            paymentSelection = PaymentSelection.Saved(paymentMethod = method),
+                            paymentSelection = newPaymentSelection,
                             primaryButtonVisible = true,
                             primaryButtonLabel = resources.getString(
                                 R.string.stripe_paymentsheet_confirm
                             ),
-                            mandateText = viewState.paymentSelection?.mandateText(
+                            mandateText = newPaymentSelection.mandateText(
                                 context = application,
                                 merchantName = configuration.merchantDisplayName,
                                 isSaveForFutureUseSelected = false,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -2554,6 +2554,35 @@ class CustomerSheetViewModelTest {
         }
     }
 
+    @Test
+    fun `Removing the current and original payment selection results in the selection being null`() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            workContext = testDispatcher,
+            isFinancialConnectionsAvailable = { true },
+            savedPaymentSelection = PaymentSelection.Saved(CARD_PAYMENT_METHOD),
+            initialBackStack = listOf(
+                selectPaymentMethodViewState.copy(
+                    savedPaymentMethods = listOf(CARD_PAYMENT_METHOD, US_BANK_ACCOUNT),
+                    paymentSelection = PaymentSelection.Saved(CARD_PAYMENT_METHOD),
+                ),
+            ),
+        )
+
+        viewModel.viewState.test {
+            val initialViewState = awaitViewState<SelectPaymentMethod>()
+            assertThat(initialViewState.savedPaymentMethods)
+                .containsExactly(CARD_PAYMENT_METHOD, US_BANK_ACCOUNT).inOrder()
+            assertThat(initialViewState.paymentSelection)
+                .isEqualTo(PaymentSelection.Saved(CARD_PAYMENT_METHOD))
+
+            viewModel.handleViewAction(CustomerSheetViewAction.OnItemRemoved(CARD_PAYMENT_METHOD))
+
+            val finalViewState = awaitViewState<SelectPaymentMethod>()
+            assertThat(finalViewState.savedPaymentMethods).containsExactly(US_BANK_ACCOUNT).inOrder()
+            assertThat(finalViewState.paymentSelection).isNull()
+        }
+    }
+
     private fun mockUSBankAccountResult(
         isVerified: Boolean
     ): CollectBankAccountResultInternal.Completed {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -227,7 +227,7 @@ internal object CustomerSheetTestHelper {
             application = application,
             initialBackStack = initialBackStack,
             workContext = workContext,
-            savedPaymentSelection = savedPaymentSelection,
+            originalPaymentSelection = savedPaymentSelection,
             paymentConfigurationProvider = { paymentConfiguration },
             formViewModelSubcomponentBuilderProvider = formViewModelSubcomponentBuilderProvider,
             resources = application.resources,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue from the implementation review, and another issue I found during that work:
1. Removing the original payment selection and then dismissing the sheet now returns a `null` payment selection instead of the original payment selection.
2. When having a US Bank Account as the current selection and then adding a card, we no longer display the mandate once the card is selected.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
