### PR TITLE
Enable CBC on all surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
-=======
 ### PaymentSheet
 * [ADDED][7713](https://github.com/stripe/stripe-android/pull/7713) PaymentSheet now supports card brand choice for eligible merchants and transactions. To provide a list of preferred networks, use `PaymentSheet.Configuration.preferredNetworks`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+=======
+### PaymentSheet
+* [ADDED][7713](https://github.com/stripe/stripe-android/pull/7713) PaymentSheet now supports card brand choice for eligible merchants and transactions. To provide a list of preferred networks, use `PaymentSheet.Configuration.preferredNetworks`.
+
+### CustomerSheet
+* [ADDED][7713](https://github.com/stripe/stripe-android/pull/7713) CustomerSheet now supports card brand choice for eligible merchants and transactions. To provide a list of preferred networks, use `PaymentSheet.Configuration.preferredNetworks`.
+
+### Payments
+* [ADDED][7713](https://github.com/stripe/stripe-android/pull/7713) `CardInputWidget`, `CardMultilineWidget`, and `CardFormView` now support card brand choice for eligible merchants. To provide a list of preferred networks, use `setPreferredNetworks()`.
+
 ## 20.35.2 - 2023-12-11
 
 ### PaymentSheet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 ## XX.XX.XX - 2023-XX-XX
 
 ### PaymentSheet
-* [ADDED][7713](https://github.com/stripe/stripe-android/pull/7713) PaymentSheet now supports card brand choice for eligible merchants and transactions. To provide a list of preferred networks, use `PaymentSheet.Configuration.preferredNetworks`.
+* [ADDED][7713](https://github.com/stripe/stripe-android/pull/7713) PaymentSheet now supports [card brand choice](https://stripe.com/docs/card-brand-choice) for eligible merchants and transactions. To provide a list of preferred networks, use `PaymentSheet.Configuration.preferredNetworks`.
 
 ### CustomerSheet
-* [ADDED][7713](https://github.com/stripe/stripe-android/pull/7713) CustomerSheet now supports card brand choice for eligible merchants and transactions. To provide a list of preferred networks, use `PaymentSheet.Configuration.preferredNetworks`.
+* [ADDED][7713](https://github.com/stripe/stripe-android/pull/7713) CustomerSheet now supports [card brand choice](https://stripe.com/docs/card-brand-choice) for eligible merchants and transactions. To provide a list of preferred networks, use `PaymentSheet.Configuration.preferredNetworks`.
 
 ### Payments
-* [ADDED][7713](https://github.com/stripe/stripe-android/pull/7713) `CardInputWidget`, `CardMultilineWidget`, and `CardFormView` now support card brand choice for eligible merchants. To provide a list of preferred networks, use `setPreferredNetworks()`.
+* [ADDED][7713](https://github.com/stripe/stripe-android/pull/7713) `CardInputWidget`, `CardMultilineWidget`, and `CardFormView` now support [card brand choice](https://stripe.com/docs/card-brand-choice) for eligible merchants. To provide a list of preferred networks, use `setPreferredNetworks()`.
 
 ## 20.35.2 - 2023-12-11
 

--- a/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/PaymentAuthActivity.kt
@@ -8,7 +8,6 @@ import com.stripe.android.Stripe
 import com.stripe.android.model.Address
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.android.utils.FeatureFlags
 import com.stripe.example.Settings
 import com.stripe.example.databinding.PaymentAuthActivityBinding
 
@@ -27,8 +26,6 @@ class PaymentAuthActivity : StripeIntentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(viewBinding.root)
-
-        FeatureFlags.cardBrandChoice.setEnabled(false)
 
         viewModel.inProgress.observe(this, { enableUi(!it) })
         viewModel.status.observe(this, Observer(viewBinding.status::setText))
@@ -91,11 +88,6 @@ class PaymentAuthActivity : StripeIntentActivity() {
         viewBinding.confirmWith3ds1Button.isEnabled = enable
         viewBinding.confirmWithNewCardButton.isEnabled = enable
         viewBinding.setupButton.isEnabled = enable
-    }
-
-    override fun onDestroy() {
-        FeatureFlags.cardBrandChoice.reset()
-        super.onDestroy()
     }
 
     private companion object {

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4096,6 +4096,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Card$Build
 	public final fun setCvc (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Builder;
 	public final fun setExpiryMonth (Ljava/lang/Integer;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Builder;
 	public final fun setExpiryYear (Ljava/lang/Integer;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Builder;
+	public final fun setNetworks (Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Networks;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Builder;
 	public final fun setNumber (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Builder;
 }
 
@@ -4109,6 +4110,22 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Card$Creat
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethodCreateParams$Card$Networks : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field PARAM_PREFERRED Ljava/lang/String;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPreferred ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/stripe/android/model/PaymentMethodCreateParams$Card$Networks$Creator : android/os/Parcelable$Creator {
@@ -7267,6 +7284,7 @@ public final class com/stripe/android/view/CardFormView : android/widget/LinearL
 	public final fun getPaymentMethodCreateParams ()Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun setCardValidCallback (Lcom/stripe/android/view/CardValidCallback;)V
 	public fun setEnabled (Z)V
+	public final fun setPreferredNetworks (Ljava/util/List;)V
 }
 
 public abstract interface class com/stripe/android/view/CardInputListener {
@@ -7316,6 +7334,7 @@ public final class com/stripe/android/view/CardInputWidget : android/widget/Line
 	public final fun setPostalCodeEnabled (Z)V
 	public final fun setPostalCodeRequired (Z)V
 	public fun setPostalCodeTextWatcher (Landroid/text/TextWatcher;)V
+	public final fun setPreferredNetworks (Ljava/util/List;)V
 	public final fun setUsZipCodeRequired (Z)V
 }
 
@@ -7350,6 +7369,7 @@ public final class com/stripe/android/view/CardMultilineWidget : android/widget/
 	public fun setExpiryDateTextWatcher (Landroid/text/TextWatcher;)V
 	public final fun setPostalCodeRequired (Z)V
 	public fun setPostalCodeTextWatcher (Landroid/text/TextWatcher;)V
+	public final fun setPreferredNetworks (Ljava/util/List;)V
 	public final fun setShouldShowPostalCode (Z)V
 	public final fun setUsZipCodeRequired (Z)V
 	public final fun validateAllFields ()Z

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -296,8 +296,6 @@ data class PaymentMethodCreateParams internal constructor(
         internal val networks: Networks? = null,
     ) : StripeParamsModel, Parcelable {
 
-        // TODO(tillh-stripe) Add docs and make public
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @Parcelize
         class Networks(
             val preferred: String? = null,
@@ -370,8 +368,7 @@ data class PaymentMethodCreateParams internal constructor(
                 this.cvc = cvc
             }
 
-            // TODO(tillh-stripe) Make public
-            internal fun setNetworks(networks: Networks?): Builder = apply {
+            fun setNetworks(networks: Networks?): Builder = apply {
                 this.networks = networks
             }
 

--- a/payments-core/src/main/java/com/stripe/android/utils/FeatureFlags.kt
+++ b/payments-core/src/main/java/com/stripe/android/utils/FeatureFlags.kt
@@ -5,7 +5,6 @@ import com.stripe.android.BuildConfig
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object FeatureFlags {
-    val cardBrandChoice = FeatureFlag()
     val customerSheetACHv2 = FeatureFlag()
 }
 

--- a/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -39,7 +39,6 @@ import com.stripe.android.model.CardBrand.Unknown
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.uicore.elements.SingleChoiceDropdown
 import com.stripe.android.utils.AppCompatOrMdcTheme
-import com.stripe.android.utils.FeatureFlags
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.parcelize.Parcelize
@@ -180,7 +179,7 @@ internal class CardBrandView @JvmOverloads constructor(
         return PaymentMethodCreateParams.Card.Networks(
             preferred = brand.takeIf { it != Unknown }?.code,
         ).takeIf {
-            FeatureFlags.cardBrandChoice.isEnabled && isCbcEligible && possibleBrands.size > 1
+            isCbcEligible && possibleBrands.size > 1
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
@@ -410,8 +410,13 @@ class CardFormView @JvmOverloads constructor(
         }
     }
 
-    // TODO(tillh-stripe) Add docs and make public
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    /**
+     * A list of preferred networks that should be used to process payments made with a co-branded
+     * card if your user hasn't selected a network themselves.
+     *
+     * The first preferred network that matches any available network will be used. If no preferred
+     * network is applicable, Stripe will select the network.
+     */
     fun setPreferredNetworks(preferredNetworks: List<CardBrand>) {
         cardMultilineWidget.cardBrandView.merchantPreferredNetworks = preferredNetworks
     }

--- a/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
@@ -12,7 +12,6 @@ import android.view.LayoutInflater
 import android.view.inputmethod.EditorInfo
 import android.widget.FrameLayout
 import android.widget.LinearLayout
-import androidx.annotation.RestrictTo
 import androidx.core.content.ContextCompat
 import androidx.core.content.withStyledAttributes
 import androidx.core.os.bundleOf

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -20,7 +20,6 @@ import android.widget.LinearLayout
 import androidx.annotation.ColorInt
 import androidx.annotation.IdRes
 import androidx.annotation.IntRange
-import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.withStyledAttributes
 import androidx.core.os.bundleOf
@@ -475,8 +474,13 @@ class CardInputWidget @JvmOverloads constructor(
         postalCodeEditText.setText(postalCode)
     }
 
-    // TODO(tillh-stripe) Add docs and make public
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    /**
+     * A list of preferred networks that should be used to process payments made with a co-branded
+     * card if your user hasn't selected a network themselves.
+     *
+     * The first preferred network that matches any available network will be used. If no preferred
+     * network is applicable, Stripe will select the network.
+     */
     fun setPreferredNetworks(preferredNetworks: List<CardBrand>) {
         cardBrandView.merchantPreferredNetworks = preferredNetworks
     }

--- a/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -330,8 +330,13 @@ class CardMultilineWidget @JvmOverloads constructor(
         postalCodeErrorListener = listener
     }
 
-    // TODO(tillh-stripe) Add docs and make public
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    /**
+     * A list of preferred networks that should be used to process payments made with a co-branded
+     * card if your user hasn't selected a network themselves.
+     *
+     * The first preferred network that matches any available network will be used. If no preferred
+     * network is applicable, Stripe will select the network.
+     */
     fun setPreferredNetworks(preferredNetworks: List<CardBrand>) {
         cardBrandView.merchantPreferredNetworks = preferredNetworks
     }

--- a/payments-core/src/main/java/com/stripe/android/view/CardWidgetViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardWidgetViewModel.kt
@@ -17,7 +17,6 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.networking.StripeRepository
-import com.stripe.android.utils.FeatureFlags
 import com.stripe.android.utils.requireApplication
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -38,7 +37,7 @@ internal class CardWidgetViewModel(
 
     init {
         viewModelScope.launch(dispatcher) {
-            _isCbcEligible.value = FeatureFlags.cardBrandChoice.isEnabled && determineCbcEligibility()
+            _isCbcEligible.value = determineCbcEligibility()
         }
     }
 

--- a/payments-core/src/test/java/com/stripe/android/view/CardFormViewTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardFormViewTest.kt
@@ -23,9 +23,7 @@ import com.stripe.android.databinding.StripeCardFormViewBinding
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardParams
-import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.utils.CardElementTestHelper
-import com.stripe.android.utils.FeatureFlags
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.utils.createTestActivityRule
 import com.stripe.android.view.CardFormViewTestActivity.Companion.VIEW_ID

--- a/payments-core/src/test/java/com/stripe/android/view/CardFormViewTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardFormViewTest.kt
@@ -46,12 +46,6 @@ internal class CardFormViewTest {
     @get:Rule
     val testActivityRule = createTestActivityRule<CardFormViewTestActivity>(useMaterial = true)
 
-    @get:Rule
-    val featureFlagTestRule = FeatureFlagTestRule(
-        featureFlag = FeatureFlags.cardBrandChoice,
-        isEnabled = false,
-    )
-
     @Before
     fun setup() {
         PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
@@ -352,8 +346,6 @@ internal class CardFormViewTest {
 
     @Test
     fun `Returns the correct create params when user selects no brand in CBC flow`() {
-        featureFlagTestRule.setEnabled(true)
-
         runCardFormViewTest(isCbcEligible = true) {
             binding.populate(
                 visa = "4000002500001001",
@@ -370,8 +362,6 @@ internal class CardFormViewTest {
 
     @Test
     fun `Returns the correct create params when user selects a brand in CBC flow`() {
-        featureFlagTestRule.setEnabled(true)
-
         runCardFormViewTest(isCbcEligible = true) {
             binding.populate(
                 visa = "4000002500001001",

--- a/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -34,9 +34,7 @@ import com.stripe.android.model.CardParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.testharness.ViewTestUtils
-import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.utils.CardElementTestHelper
-import com.stripe.android.utils.FeatureFlags
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.utils.createTestActivityRule
 import com.stripe.android.view.CardInputWidget.Companion.LOGGING_TOKEN
@@ -60,12 +58,6 @@ import kotlin.test.Test
 
 @RunWith(RobolectricTestRunner::class)
 internal class CardInputWidgetTest {
-
-    @get:Rule
-    val featureFlagTestRule = FeatureFlagTestRule(
-        featureFlag = FeatureFlags.cardBrandChoice,
-        isEnabled = false,
-    )
 
     @get:Rule
     val testActivityRule = createTestActivityRule<CardInputWidgetTestActivity>()
@@ -1690,8 +1682,6 @@ internal class CardInputWidgetTest {
 
     @Test
     fun `Adds no Networks field to card PM params if not CBC eligible`() {
-        featureFlagTestRule.setEnabled(true)
-
         runCardInputWidgetTest(isCbcEligible = false) {
             postalCodeEnabled = false
 
@@ -1707,8 +1697,6 @@ internal class CardInputWidgetTest {
 
     @Test
     fun `Adds correct Networks field to card PM params if customer does not select a network`() {
-        featureFlagTestRule.setEnabled(true)
-
         runCardInputWidgetTest(isCbcEligible = true) {
             postalCodeEnabled = false
 
@@ -1726,8 +1714,6 @@ internal class CardInputWidgetTest {
 
     @Test
     fun `Adds correct Networks field to card PM params if customer selects a network`() {
-        featureFlagTestRule.setEnabled(true)
-
         runCardInputWidgetTest(isCbcEligible = true) {
             postalCodeEnabled = false
 
@@ -1749,8 +1735,6 @@ internal class CardInputWidgetTest {
 
     @Test
     fun `Restores brand state correctly on activity recreation`() {
-        featureFlagTestRule.setEnabled(true)
-
         runCardInputWidgetTest(
             isCbcEligible = true,
             block = {

--- a/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -68,12 +68,6 @@ internal class CardMultilineWidgetTest {
     private val accountRangeStore = DefaultCardAccountRangeStore(context)
 
     @get:Rule
-    val featureFlagTestRule = FeatureFlagTestRule(
-        featureFlag = FeatureFlags.cardBrandChoice,
-        isEnabled = false,
-    )
-
-    @get:Rule
     val testActivityRule = createTestActivityRule<CardMultilineWidgetTestActivity>()
 
     @BeforeTest
@@ -1207,8 +1201,6 @@ internal class CardMultilineWidgetTest {
 
     @Test
     fun `Returns the correct create params when user selects no brand in CBC flow`() {
-        featureFlagTestRule.setEnabled(true)
-
         runCardMultilineWidgetTest(isCbcEligible = true) {
             cardMultilineWidget.setCardNumber("4000002500001001")
             cardMultilineWidget.setExpiryDate(12, 2030)
@@ -1221,8 +1213,6 @@ internal class CardMultilineWidgetTest {
 
     @Test
     fun `Returns the correct create params when user selects a brand in CBC flow`() {
-        featureFlagTestRule.setEnabled(true)
-
         runCardMultilineWidgetTest(isCbcEligible = true) {
             cardMultilineWidget.setCardNumber("4000002500001001")
             cardMultilineWidget.setExpiryDate(12, 2030)

--- a/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -33,9 +33,7 @@ import com.stripe.android.model.CardParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.testharness.ViewTestUtils
-import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.utils.CardElementTestHelper
-import com.stripe.android.utils.FeatureFlags
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.utils.createTestActivityRule
 import kotlinx.coroutines.test.StandardTestDispatcher

--- a/payments-core/src/test/java/com/stripe/android/view/CardWidgetViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardWidgetViewModelTest.kt
@@ -3,12 +3,9 @@ package com.stripe.android.view
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.utils.FakeCardElementConfigRepository
-import com.stripe.android.utils.FeatureFlags
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.Rule
 import org.junit.Test
 
 private val paymentConfig = PaymentConfiguration(
@@ -18,19 +15,11 @@ private val paymentConfig = PaymentConfiguration(
 
 class CardWidgetViewModelTest {
 
-    @get:Rule
-    val featureFlagTestRule = FeatureFlagTestRule(
-        featureFlag = FeatureFlags.cardBrandChoice,
-        isEnabled = false,
-    )
-
     private val testDispatcher = UnconfinedTestDispatcher()
 
     @Test
     fun `Emits correct CBC eligibility when the feature is enabled and merchant is eligible`() =
         runTest(testDispatcher) {
-            featureFlagTestRule.setEnabled(true)
-
             val stripeRepository = FakeCardElementConfigRepository()
 
             val viewModel = CardWidgetViewModel(
@@ -47,28 +36,8 @@ class CardWidgetViewModelTest {
         }
 
     @Test
-    fun `Emits correct CBC eligibility when the feature is disabled even if merchant is eligible`() =
-        runTest(testDispatcher) {
-            val stripeRepository = FakeCardElementConfigRepository()
-
-            val viewModel = CardWidgetViewModel(
-                paymentConfigProvider = { paymentConfig },
-                stripeRepository = stripeRepository,
-                dispatcher = testDispatcher,
-            )
-
-            viewModel.isCbcEligible.test {
-                assertThat(awaitItem()).isFalse()
-                stripeRepository.enqueueEligible()
-                expectNoEvents()
-            }
-        }
-
-    @Test
     fun `Emits correct CBC eligibility when the feature is enabled and merchant is not eligible`() =
         runTest(testDispatcher) {
-            featureFlagTestRule.setEnabled(true)
-
             val stripeRepository = FakeCardElementConfigRepository()
 
             val viewModel = CardWidgetViewModel(
@@ -86,8 +55,6 @@ class CardWidgetViewModelTest {
 
     @Test
     fun `Emits correct CBC eligibility when query fails`() = runTest(testDispatcher) {
-        featureFlagTestRule.setEnabled(true)
-
         val stripeRepository = FakeCardElementConfigRepository()
 
         val viewModel = CardWidgetViewModel(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.ui.core.elements
 
 import android.content.Context
-import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.autofill.AutofillType
@@ -17,7 +16,6 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.AccountRange
 import com.stripe.android.model.CardBrand
 import com.stripe.android.stripecardscan.cardscan.CardScanSheetResult
-import com.stripe.android.ui.core.BuildConfig
 import com.stripe.android.ui.core.asIndividualDigits
 import com.stripe.android.uicore.elements.FieldError
 import com.stripe.android.uicore.elements.SectionFieldErrorController
@@ -282,11 +280,6 @@ internal class DefaultCardNumberController(
 
     init {
         onRawValueChange(initialValue ?: "")
-
-        // TODO(tillh-stripe)
-        if (BuildConfig.DEBUG) {
-            Log.d("CardNumberController", "Is eligible for CBC: $isEligibleForCardBrandChoice")
-        }
     }
 
     /**

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -96,6 +96,7 @@ public final class com/stripe/android/customersheet/CustomerSheet$Configuration 
 	public final fun getGooglePayEnabled ()Z
 	public final fun getHeaderTextForSelectionScreen ()Ljava/lang/String;
 	public final fun getMerchantDisplayName ()Ljava/lang/String;
+	public final fun getPreferredNetworks ()Ljava/util/List;
 	public final fun newBuilder ()Lcom/stripe/android/customersheet/CustomerSheet$Configuration$Builder;
 }
 
@@ -107,6 +108,7 @@ public final class com/stripe/android/customersheet/CustomerSheet$Configuration$
 	public final fun defaultBillingDetails (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;)Lcom/stripe/android/customersheet/CustomerSheet$Configuration$Builder;
 	public final fun googlePayEnabled (Z)Lcom/stripe/android/customersheet/CustomerSheet$Configuration$Builder;
 	public final fun headerTextForSelectionScreen (Ljava/lang/String;)Lcom/stripe/android/customersheet/CustomerSheet$Configuration$Builder;
+	public final fun preferredNetworks (Ljava/util/List;)Lcom/stripe/android/customersheet/CustomerSheet$Configuration$Builder;
 }
 
 public final class com/stripe/android/customersheet/CustomerSheet$Configuration$Companion {
@@ -549,7 +551,8 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration : 
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;)V
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Ljava/lang/String;
 	public final fun component11 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;
@@ -595,6 +598,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration$Bu
 	public final fun defaultBillingDetails (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun googlePay (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun merchantDisplayName (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
+	public final fun preferredNetworks (Ljava/util/List;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun primaryButtonColor (Landroid/content/res/ColorStateList;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun primaryButtonLabel (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun shippingDetails (Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -3,7 +3,6 @@ package com.stripe.android.customersheet
 import android.app.Application
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultRegistryOwner
-import androidx.annotation.RestrictTo
 import androidx.core.app.ActivityOptionsCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -161,8 +160,14 @@ class CustomerSheet @Inject internal constructor(
          */
         val merchantDisplayName: String,
 
-        // TODO(tillh-stripe) Add docs
-        internal val preferredNetworks: List<CardBrand> = emptyList(),
+        /**
+         * A list of preferred networks that should be used to process payments made with a co-branded card if your user
+         * hasn't selected a network themselves.
+         *
+         * The first preferred network that matches an available network will be used. If no preferred network is
+         * applicable, Stripe will select the network.
+         */
+        val preferredNetworks: List<CardBrand> = emptyList(),
     ) {
 
         // Hide no-argument constructor init
@@ -217,8 +222,6 @@ class CustomerSheet @Inject internal constructor(
                 this.billingDetailsCollectionConfiguration = configuration
             }
 
-            // TODO(tillh-stripe): Make this function public prior to release
-            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             fun preferredNetworks(
                 preferredNetworks: List<CardBrand>
             ) = apply {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -13,7 +13,6 @@ import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.paymentsheet.state.toInternal
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.forms.resources.LpmRepository
-import com.stripe.android.utils.FeatureFlags
 import com.stripe.android.utils.FeatureFlags.customerSheetACHv2
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -131,11 +130,7 @@ internal class DefaultCustomerSheetLoader @Inject constructor(
                     isFinancialConnectionsAvailable,
                 )
 
-                val isCbcEligible = if (FeatureFlags.cardBrandChoice.isEnabled) {
-                    true
-                } else {
-                    (elementsSession?.isEligibleForCardBrandChoice ?: false) && FeatureFlags.cardBrandChoice.isEnabled
-                }
+                val isCbcEligible = elementsSession?.isEligibleForCardBrandChoice ?: false
 
                 Result.success(
                     CustomerSheetState.Full(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -6,7 +6,6 @@ import android.os.Parcelable
 import androidx.activity.ComponentActivity
 import androidx.annotation.ColorInt
 import androidx.annotation.FontRes
-import androidx.annotation.RestrictTo
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.fragment.app.Fragment
@@ -321,7 +320,7 @@ class PaymentSheet internal constructor(
 
     /** Configuration for [PaymentSheet] **/
     @Parcelize
-    data class Configuration(
+    data class Configuration @JvmOverloads constructor(
         /**
          * Your customer-facing business name.
          *

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -321,7 +321,7 @@ class PaymentSheet internal constructor(
 
     /** Configuration for [PaymentSheet] **/
     @Parcelize
-    data class Configuration internal constructor(
+    data class Configuration(
         /**
          * Your customer-facing business name.
          *
@@ -430,36 +430,8 @@ class PaymentSheet internal constructor(
          * be used. If no preferred network is applicable, Stripe will select
          * the network.
          */
-        val preferredNetworks: List<CardBrand> = listOf(),
+        val preferredNetworks: List<CardBrand> = emptyList(),
     ) : Parcelable {
-        @JvmOverloads
-        constructor(
-            merchantDisplayName: String,
-            customer: CustomerConfiguration? = null,
-            googlePay: GooglePayConfiguration? = null,
-            primaryButtonColor: ColorStateList? = null,
-            defaultBillingDetails: BillingDetails? = null,
-            shippingDetails: AddressDetails? = null,
-            allowsDelayedPaymentMethods: Boolean = false,
-            allowsPaymentMethodsRequiringShippingAddress: Boolean = false,
-            appearance: Appearance = Appearance(),
-            primaryButtonLabel: String? = null,
-            billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
-                BillingDetailsCollectionConfiguration(),
-        ) : this(
-            merchantDisplayName = merchantDisplayName,
-            customer = customer,
-            googlePay = googlePay,
-            primaryButtonColor = primaryButtonColor,
-            defaultBillingDetails = defaultBillingDetails,
-            shippingDetails = shippingDetails,
-            allowsDelayedPaymentMethods = allowsDelayedPaymentMethods,
-            allowsPaymentMethodsRequiringShippingAddress = allowsPaymentMethodsRequiringShippingAddress,
-            appearance = appearance,
-            primaryButtonLabel = primaryButtonLabel,
-            billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
-            preferredNetworks = listOf()
-        )
 
         /**
          * [Configuration] builder for cleaner object creation from Java.
@@ -528,10 +500,6 @@ class PaymentSheet internal constructor(
                 this.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration
             }
 
-            /*
-             * TODO(samer-stripe): Make this function public prior to release
-             */
-            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             fun preferredNetworks(
                 preferredNetworks: List<CardBrand>
             ) = apply {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -25,7 +25,6 @@ import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.forms.resources.LpmRepository
-import com.stripe.android.utils.FeatureFlags
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
@@ -178,8 +177,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
                 customerPaymentMethods = sortedPaymentMethods.await(),
                 isGooglePayReady = isGooglePayReady,
                 linkState = linkState.await(),
-                isEligibleForCardBrandChoice = FeatureFlags.cardBrandChoice.isEnabled &&
-                    elementsSession.isEligibleForCardBrandChoice,
+                isEligibleForCardBrandChoice = elementsSession.isEligibleForCardBrandChoice,
                 paymentSelection = initialPaymentSelection.await(),
             )
         } else {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -66,12 +66,6 @@ class DefaultCustomerSheetLoaderTest {
     private val readyGooglePayRepository = mock<GooglePayRepository>()
     private val unreadyGooglePayRepository = mock<GooglePayRepository>()
 
-    @get:Rule
-    val cbcFeatureFlagTestRule = FeatureFlagTestRule(
-        featureFlag = FeatureFlags.cardBrandChoice,
-        isEnabled = false,
-    )
-
     @Before
     fun setup() {
         MockitoAnnotations.openMocks(this)
@@ -500,7 +494,6 @@ class DefaultCustomerSheetLoaderTest {
 
     @Test
     fun `Loads correct CBC eligibility if feature enabled`() = runTest {
-        cbcFeatureFlagTestRule.setEnabled(true)
         val loader = createCustomerSheetLoader(isCbcEligible = true)
         val state = loader.load(CustomerSheet.Configuration(merchantDisplayName = "Example")).getOrThrow()
         assertThat(state.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Eligible(emptyList()))
@@ -508,7 +501,6 @@ class DefaultCustomerSheetLoaderTest {
 
     @Test
     fun `Loads correct CBC eligibility and merchant-preferred networks if feature enabled`() = runTest {
-        cbcFeatureFlagTestRule.setEnabled(true)
         val loader = createCustomerSheetLoader(isCbcEligible = true)
 
         val state = loader.load(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -493,14 +493,14 @@ class DefaultCustomerSheetLoaderTest {
     }
 
     @Test
-    fun `Loads correct CBC eligibility if feature enabled`() = runTest {
+    fun `Loads correct CBC eligibility`() = runTest {
         val loader = createCustomerSheetLoader(isCbcEligible = true)
         val state = loader.load(CustomerSheet.Configuration(merchantDisplayName = "Example")).getOrThrow()
         assertThat(state.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Eligible(emptyList()))
     }
 
     @Test
-    fun `Loads correct CBC eligibility and merchant-preferred networks if feature enabled`() = runTest {
+    fun `Loads correct CBC eligibility and merchant-preferred networks`() = runTest {
         val loader = createCustomerSheetLoader(isCbcEligible = true)
 
         val state = loader.load(
@@ -513,13 +513,6 @@ class DefaultCustomerSheetLoaderTest {
         assertThat(state.cbcEligibility).isEqualTo(
             CardBrandChoiceEligibility.Eligible(preferredNetworks = listOf(CardBrand.CartesBancaires))
         )
-    }
-
-    @Test
-    fun `Does not load CBC eligibility if feature disabled`() = runTest {
-        val loader = createCustomerSheetLoader(isCbcEligible = true)
-        val state = loader.load(CustomerSheet.Configuration(merchantDisplayName = "Example")).getOrThrow()
-        assertThat(state.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
     }
 
     private fun createCustomerSheetLoader(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -26,17 +26,14 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException.PaymentIntentInTerminalState
-import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.FakeElementsSessionRepository
-import com.stripe.android.utils.FeatureFlags
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.Rule
 import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
 import org.mockito.Captor
@@ -53,12 +50,6 @@ import kotlin.test.Test
 
 @RunWith(RobolectricTestRunner::class)
 internal class DefaultPaymentSheetLoaderTest {
-
-    @get:Rule
-    val featureFlagTestRule = FeatureFlagTestRule(
-        featureFlag = FeatureFlags.cardBrandChoice,
-        isEnabled = false,
-    )
 
     private val testDispatcher = UnconfinedTestDispatcher()
     private val eventReporter = mock<EventReporter>()
@@ -770,23 +761,7 @@ internal class DefaultPaymentSheetLoaderTest {
     }
 
     @Test
-    fun `Doesn't include card brand choice state if feature is disabled`() = runTest {
-        val loader = createPaymentSheetLoader(isCbcEligible = true)
-
-        val result = loader.load(
-            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
-                clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
-            ),
-            paymentSheetConfiguration = PaymentSheet.Configuration("Some Name"),
-        ).getOrThrow()
-
-        assertThat(result.isEligibleForCardBrandChoice).isFalse()
-    }
-
-    @Test
     fun `Includes card brand choice state if feature is enabled`() = runTest {
-        featureFlagTestRule.setEnabled(true)
-
         val loader = createPaymentSheetLoader(isCbcEligible = true)
 
         val result = loader.load(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request enables card brand choice in all our surfaces and removes the associated feature flag.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
