### PR TITLE
Add `PaymentOption.iconPainter` for easier Compose integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+### PaymentSheet
+* [Added][7719](https://github.com/stripe/stripe-android/pull/7719) Added `PaymentOption.iconPainter` to simplify `FlowController` usage in Compose.
+
 ## 20.39.0 - 2024-03-04
 
 ### PaymentSheet

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/FlowControllerState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/FlowControllerState.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.example.playground
 
-import android.graphics.drawable.Drawable
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.painter.Painter
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.model.PaymentOption
 
@@ -18,6 +19,7 @@ internal fun FlowControllerState?.paymentMethodLabel(): String {
     }
 }
 
-internal fun FlowControllerState?.paymentMethodIcon(): Drawable? {
-    return this?.selectedPaymentOption?.icon()
+@Composable
+internal fun FlowControllerState?.paymentMethodPainter(): Painter? {
+    return this?.selectedPaymentOption?.iconPainter
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -282,7 +282,7 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
         PaymentMethodSelector(
             isEnabled = flowControllerState != null,
             paymentMethodLabel = flowControllerState.paymentMethodLabel(),
-            paymentMethodIcon = flowControllerState.paymentMethodIcon(),
+            paymentMethodPainter = flowControllerState.paymentMethodPainter(),
             onClick = flowController::presentPaymentOptions
         )
         BuyButton(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/CustomerSheetExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/CustomerSheetExampleActivity.kt
@@ -32,7 +32,6 @@ import com.stripe.android.customersheet.rememberCustomerSheet
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.R
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentSheetExampleTheme
-import com.stripe.android.paymentsheet.example.utils.rememberDrawablePainter
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 internal class CustomerSheetExampleActivity : AppCompatActivity() {
@@ -134,11 +133,9 @@ private fun CustomerPaymentMethods(
                 onClick = onUpdateDefaultPaymentMethod,
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    state.selection?.paymentOption?.icon()?.let {
+                    state.selection?.paymentOption?.let {
                         Image(
-                            painter = rememberDrawablePainter(
-                                drawable = it
-                            ),
+                            painter = it.iconPainter,
                             contentDescription = "Payment Method Icon",
                             modifier = Modifier.height(32.dp)
                         )

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/playground/CustomerSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/playground/CustomerSheetPlaygroundActivity.kt
@@ -52,7 +52,6 @@ import com.stripe.android.paymentsheet.example.R
 import com.stripe.android.paymentsheet.example.samples.ui.customersheet.playground.CustomerSheetPlaygroundViewAction.UpdateMerchantCountryCode
 import com.stripe.android.paymentsheet.example.samples.ui.shared.MultiToggleButton
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentSheetExampleTheme
-import com.stripe.android.paymentsheet.example.utils.rememberDrawablePainter
 import com.stripe.android.paymentsheet.rememberPaymentSheet
 import java.util.Locale
 
@@ -197,11 +196,9 @@ class CustomerSheetPlaygroundActivity : AppCompatActivity() {
                     onClick = onUpdateDefaultPaymentMethod,
                 ) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
-                        state.selection?.paymentOption?.icon()?.let {
+                        state.selection?.paymentOption?.let {
                             Image(
-                                painter = rememberDrawablePainter(
-                                    drawable = it
-                                ),
+                                painter = it.iconPainter,
                                 contentDescription = "Payment Method Icon",
                                 modifier = Modifier.height(32.dp)
                             )

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/custom_flow/CustomFlowActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/custom_flow/CustomFlowActivity.kt
@@ -74,7 +74,7 @@ internal class CustomFlowActivity : AppCompatActivity() {
                         PaymentMethodSelector(
                             isEnabled = uiState.isPaymentMethodButtonEnabled,
                             paymentMethodLabel = paymentMethodLabel,
-                            paymentMethodIcon = uiState.paymentOption?.icon(),
+                            paymentMethodPainter = uiState.paymentOption?.iconPainter,
                             onClick = flowController::presentPaymentOptions,
                         )
                         BuyButton(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/server_side_confirm/custom_flow/ServerSideConfirmationCustomFlowActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/server_side_confirm/custom_flow/ServerSideConfirmationCustomFlowActivity.kt
@@ -78,7 +78,7 @@ internal class ServerSideConfirmationCustomFlowActivity : AppCompatActivity() {
                         PaymentMethodSelector(
                             isEnabled = uiState.isPaymentMethodButtonEnabled,
                             paymentMethodLabel = paymentMethodLabel,
-                            paymentMethodIcon = uiState.paymentOption?.icon(),
+                            paymentMethodPainter = uiState.paymentOption?.iconPainter,
                             onClick = flowController::presentPaymentOptions,
                         )
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/shared/Payment.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/shared/Payment.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.example.samples.ui.shared
 
-import android.graphics.drawable.Drawable
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -16,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
@@ -26,13 +26,12 @@ import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentsheet.example.R
 import com.stripe.android.paymentsheet.example.samples.ui.MAIN_FONT_SIZE
 import com.stripe.android.paymentsheet.example.samples.ui.PADDING
-import com.stripe.android.paymentsheet.example.utils.rememberDrawablePainter
 
 @Composable
 fun PaymentMethodSelector(
     isEnabled: Boolean,
     paymentMethodLabel: String,
-    paymentMethodIcon: Drawable?,
+    paymentMethodPainter: Painter?,
     onClick: () -> Unit,
 ) {
     Row(
@@ -57,9 +56,9 @@ fun PaymentMethodSelector(
                 text = AnnotatedString(paymentMethodLabel)
             },
         ) {
-            if (paymentMethodIcon != null) {
+            if (paymentMethodPainter != null) {
                 Icon(
-                    painter = rememberDrawablePainter(paymentMethodIcon),
+                    painter = paymentMethodPainter,
                     contentDescription = null, // decorative element
                     modifier = Modifier.padding(horizontal = 4.dp),
                     tint = Color.Unspecified,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/utils/DrawablePainter.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/utils/DrawablePainter.kt
@@ -17,29 +17,21 @@
 package com.stripe.android.paymentsheet.example.utils
 
 import android.graphics.drawable.Animatable
-import android.graphics.drawable.BitmapDrawable
-import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.view.View
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.RememberObserver
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.asAndroidColorFilter
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
-import androidx.compose.ui.graphics.painter.BitmapPainter
-import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.withSave
 import androidx.compose.ui.unit.LayoutDirection
@@ -52,8 +44,6 @@ private val MAIN_HANDLER by lazy(LazyThreadSafetyMode.NONE) {
 /**
  * A [Painter] which draws an Android [Drawable] and supports [Animatable] drawables. Instances
  * should be remembered to be able to start and stop [Animatable] animations.
- *
- * Instances are usually retrieved from [rememberDrawablePainter].
  */
 class DrawablePainter(
     val drawable: Drawable
@@ -137,27 +127,6 @@ class DrawablePainter(
                 drawable.draw(canvas.nativeCanvas)
             }
         }
-    }
-}
-
-/**
- * Remembers [Drawable] wrapped up as a [Painter]. This function attempts to un-wrap the
- * drawable contents and use Compose primitives where possible.
- *
- * If the provided [drawable] is `null`, an empty no-op painter is returned.
- *
- * This function tries to dispatch lifecycle events to [drawable] as much as possible from
- * within Compose.
- */
-@Composable
-fun rememberDrawablePainter(drawable: Drawable?): Painter = remember(drawable) {
-    when (drawable) {
-        null -> EmptyPainter
-        is BitmapDrawable -> BitmapPainter(drawable.bitmap.asImageBitmap())
-        is ColorDrawable -> ColorPainter(Color(drawable.color))
-        // Since the DrawablePainter will be remembered and it implements RememberObserver, it
-        // will receive the necessary events
-        else -> DrawablePainter(drawable.mutate())
     }
 }
 

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1539,6 +1539,7 @@ public final class com/stripe/android/paymentsheet/model/PaymentOption {
 	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/model/PaymentOption;ILjava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/model/PaymentOption;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDrawableResourceId ()I
+	public final fun getIconPainter (Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/graphics/painter/Painter;
 	public final fun getLabel ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun icon ()Landroid/graphics/drawable/Drawable;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOption.kt
@@ -15,6 +15,9 @@ import android.graphics.drawable.ShapeDrawable
 import android.os.Build
 import androidx.annotation.DrawableRes
 import androidx.annotation.RequiresApi
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.painter.Painter
+import com.stripe.android.uicore.image.rememberDrawablePainter
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -64,6 +67,10 @@ constructor(
         this.darkThemeIconUrl = darkThemeIconUrl
         this.imageLoader = imageLoader
     }
+
+    val iconPainter: Painter
+        @Composable
+        get() = rememberDrawablePainter(icon())
 
     /**
      * Fetches the icon associated with this [PaymentOption].

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOption.kt
@@ -68,6 +68,9 @@ constructor(
         this.imageLoader = imageLoader
     }
 
+    /**
+     * A [Painter] to draw the icon associated with this [PaymentOption].
+     */
     val iconPainter: Painter
         @Composable
         get() = rememberDrawablePainter(icon())

--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -255,10 +255,6 @@ public final class com/stripe/android/uicore/image/ComposableSingletons$StripeIm
 	public final fun getLambda-2$stripe_ui_core_release ()Lkotlin/jvm/functions/Function3;
 }
 
-public final class com/stripe/android/uicore/image/DrawablePainterKt {
-	public static final fun rememberDrawablePainter (Landroid/graphics/drawable/Drawable;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/graphics/painter/Painter;
-}
-
 public final class com/stripe/android/uicore/text/EmbeddableImage$Bitmap : com/stripe/android/uicore/text/EmbeddableImage {
 	public static final field $stable I
 	public fun <init> (Landroid/graphics/Bitmap;)V

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/DrawablePainter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/DrawablePainter.kt
@@ -1,3 +1,5 @@
+@file:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+
 package com.stripe.android.uicore.image
 
 import android.graphics.drawable.Animatable
@@ -141,7 +143,6 @@ internal class DrawablePainter(
  * This function tries to dispatch lifecycle events to [drawable] as much as possible from
  * within Compose.
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Composable
 fun rememberDrawablePainter(drawable: Drawable?): Painter = remember(drawable) {
     when (drawable) {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/DrawablePainter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/DrawablePainter.kt
@@ -8,6 +8,7 @@ import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.view.View
+import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.RememberObserver
 import androidx.compose.runtime.getValue
@@ -140,6 +141,7 @@ internal class DrawablePainter(
  * This function tries to dispatch lifecycle events to [drawable] as much as possible from
  * within Compose.
  */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Composable
 fun rememberDrawablePainter(drawable: Drawable?): Painter = remember(drawable) {
     when (drawable) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Adds a new public API for easier compose integration.

API Review: https://jira.corp.stripe.com/browse/MOBILE_APIREVIEW-70
