### PR TITLE
Fix issue where CustomerSheet used unattached PaymentMethod

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -811,7 +811,7 @@ internal class CustomerSheetViewModel @Inject constructor(
             if (customerAdapter.canCreateSetupIntents) {
                 attachWithSetupIntent(paymentMethod = paymentMethod)
             } else {
-                attachPaymentMethod(paymentMethod = paymentMethod)
+                attachPaymentMethod(id = paymentMethod.id!!)
             }
         }
     }
@@ -961,16 +961,16 @@ internal class CustomerSheetViewModel @Inject constructor(
         )
     }
 
-    private suspend fun attachPaymentMethod(paymentMethod: PaymentMethod) {
-        customerAdapter.attachPaymentMethod(paymentMethod.id!!)
-            .onSuccess {
+    private suspend fun attachPaymentMethod(id: String) {
+        customerAdapter.attachPaymentMethod(id)
+            .onSuccess { attachedPaymentMethod ->
                 eventReporter.onAttachPaymentMethodSucceeded(
                     style = CustomerSheetEventReporter.AddPaymentMethodStyle.CreateAttach
                 )
                 safeUpdateSelectPaymentMethodState {
                     it.copy(
-                        savedPaymentMethods = listOf(paymentMethod) + it.savedPaymentMethods,
-                        paymentSelection = PaymentSelection.Saved(paymentMethod = paymentMethod),
+                        savedPaymentMethods = listOf(attachedPaymentMethod) + it.savedPaymentMethods,
+                        paymentSelection = PaymentSelection.Saved(attachedPaymentMethod),
                         primaryButtonVisible = true,
                         primaryButtonLabel = resources.getString(
                             R.string.stripe_paymentsheet_confirm
@@ -983,7 +983,7 @@ internal class CustomerSheetViewModel @Inject constructor(
                     style = CustomerSheetEventReporter.AddPaymentMethodStyle.CreateAttach
                 )
                 logger.error(
-                    msg = "Failed to attach payment method to Customer: $paymentMethod",
+                    msg = "Failed to attach payment method $id to customer",
                     t = cause,
                 )
                 updateViewState<CustomerSheetViewState.AddPaymentMethod> {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes another issue in CustomerSheet: Instead of using the attached `PaymentMethod` and adding it to the list of saved payment methods, we added the unattached `PaymentMethod`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
