### PR TITLE
Add support for `PaymentMethodExtraParams`

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4473,6 +4473,14 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Upi$Creato
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/model/PaymentMethodExtraParams$BacsDebit$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodExtraParams$BacsDebit;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodExtraParams$BacsDebit;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/model/PaymentMethodMessage$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodMessage;

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodExtraParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodExtraParams.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.model
+
+import android.os.Parcelable
+import androidx.annotation.RestrictTo
+import kotlinx.parcelize.Parcelize
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+sealed class PaymentMethodExtraParams(
+    val type: PaymentMethod.Type
+) : StripeParamsModel, Parcelable {
+    internal abstract fun createTypeParams(): List<Pair<String, Any?>>
+
+    final override fun toParamMap(): Map<String, Any> {
+        val typeParams: Map<String, Any> = createTypeParams()
+            .fold(emptyMap()) { acc, (key, value) ->
+                acc.plus(
+                    value?.let { mapOf(key to it) }.orEmpty()
+                )
+            }
+
+        return when {
+            typeParams.isNotEmpty() -> mapOf(type.code to typeParams)
+            else -> emptyMap()
+        }
+    }
+
+    @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class BacsDebit(
+        var confirmed: Boolean? = null
+    ) : PaymentMethodExtraParams(PaymentMethod.Type.BacsDebit) {
+        override fun createTypeParams(): List<Pair<String, Any?>> {
+            return listOf(
+                PARAM_CONFIRMED to confirmed?.toString()
+            )
+        }
+
+        internal companion object {
+            const val PARAM_CONFIRMED = "confirmed"
+        }
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodExtraParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodExtraParamsTest.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.model
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class PaymentMethodExtraParamsTest {
+    @Test
+    fun createFromBacs() {
+        assertThat(
+            PaymentMethodExtraParams.BacsDebit(
+                confirmed = true
+            ).toParamMap()
+        ).isEqualTo(
+            mapOf(
+                "bacs_debit" to mapOf(
+                    "confirmed" to "true"
+                )
+            )
+        )
+    }
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
@@ -5,6 +5,7 @@ import androidx.annotation.VisibleForTesting
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry
@@ -60,6 +61,19 @@ class FieldValuesToParamsMapConverter {
                 }
             }
             return null
+        }
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        fun transformToPaymentMethodExtraParams(
+            fieldValuePairs: Map<IdentifierSpec, FormFieldEntry>,
+            code: PaymentMethodCode,
+        ): PaymentMethodExtraParams? {
+            return when (code) {
+                PaymentMethod.Type.BacsDebit.code -> PaymentMethodExtraParams.BacsDebit(
+                    confirmed = fieldValuePairs[IdentifierSpec.BacsDebitConfirmed]?.value?.toBoolean()
+                )
+                else -> null
+            }
         }
 
         /**

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
@@ -108,6 +108,28 @@ class FieldValuesToParamsMapConverterTest {
     }
 
     @Test
+    fun `transform to extra params if bacs`() {
+        val paymentMethodParams = FieldValuesToParamsMapConverter
+            .transformToPaymentMethodExtraParams(
+                mapOf(
+                    IdentifierSpec.Name to FormFieldEntry(
+                        "joe",
+                        true
+                    ),
+                    IdentifierSpec.BacsDebitConfirmed to FormFieldEntry(
+                        "true",
+                        true
+                    )
+                ),
+                PaymentMethod.Type.BacsDebit.code
+            )
+
+        assertThat(
+            paymentMethodParams?.toParamMap().toString()
+        ).isEqualTo("{bacs_debit={confirmed=true}}")
+    }
+
+    @Test
     fun `test ignored fields`() {
         val paymentMethodParams = FieldValuesToParamsMapConverter
             .transformToPaymentMethodCreateParams(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -11,6 +11,7 @@ import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethod.Type.USBankAccount
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.ACHText
@@ -118,6 +119,7 @@ internal sealed class PaymentSelection : Parcelable {
 
         abstract val paymentMethodCreateParams: PaymentMethodCreateParams
         abstract val paymentMethodOptionsParams: PaymentMethodOptionsParams?
+        abstract val paymentMethodExtraParams: PaymentMethodExtraParams?
         abstract val customerRequestedSave: CustomerRequestedSave
 
         override val requiresConfirmation: Boolean
@@ -138,6 +140,7 @@ internal sealed class PaymentSelection : Parcelable {
             val brand: CardBrand,
             override val customerRequestedSave: CustomerRequestedSave,
             override val paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,
+            override val paymentMethodExtraParams: PaymentMethodExtraParams? = null,
         ) : New() {
             @IgnoredOnParcel
             val last4: String = paymentMethodCreateParams.cardLast4().orEmpty()
@@ -152,6 +155,7 @@ internal sealed class PaymentSelection : Parcelable {
             override val paymentMethodCreateParams: PaymentMethodCreateParams,
             override val customerRequestedSave: CustomerRequestedSave,
             override val paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,
+            override val paymentMethodExtraParams: PaymentMethodExtraParams? = null,
         ) : New() {
 
             override fun mandateText(
@@ -188,6 +192,9 @@ internal sealed class PaymentSelection : Parcelable {
             override val paymentMethodOptionsParams = null
 
             @IgnoredOnParcel
+            override val paymentMethodExtraParams = null
+
+            @IgnoredOnParcel
             @DrawableRes
             val iconResource = R.drawable.stripe_ic_paymentsheet_link
 
@@ -213,6 +220,7 @@ internal sealed class PaymentSelection : Parcelable {
             override val paymentMethodCreateParams: PaymentMethodCreateParams,
             override val customerRequestedSave: CustomerRequestedSave,
             override val paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,
+            override val paymentMethodExtraParams: PaymentMethodExtraParams? = null,
         ) : New()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArguments.kt
@@ -9,8 +9,8 @@ import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.forms.convertToFormValuesMap
-import com.stripe.android.uicore.elements.ApiParameterDestination
 import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.ParameterDestination
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -38,7 +38,7 @@ internal fun FormArguments.getInitialValuesMap(): Map<IdentifierSpec, String?> {
 
     val initialExtras = initialPaymentMethodExtraParams?.let {
         convertToFormValuesMap(it.toParamMap()).mapKeys { entry ->
-            entry.key.copy(apiParameterDestination = ApiParameterDestination.Extras)
+            entry.key.copy(destination = ParameterDestination.Local.Extras)
         }
     } ?: emptyMap()
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArguments.kt
@@ -3,11 +3,13 @@ package com.stripe.android.paymentsheet.paymentdatacollection
 import android.os.Parcelable
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.forms.convertToFormValuesMap
+import com.stripe.android.uicore.elements.ApiParameterDestination
 import com.stripe.android.uicore.elements.IdentifierSpec
 import kotlinx.parcelize.Parcelize
 
@@ -22,6 +24,7 @@ internal data class FormArguments(
     val billingDetails: PaymentSheet.BillingDetails? = null,
     val shippingDetails: AddressDetails? = null,
     val initialPaymentMethodCreateParams: PaymentMethodCreateParams? = null,
+    val initialPaymentMethodExtraParams: PaymentMethodExtraParams? = null,
     val billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration =
         PaymentSheet.BillingDetailsCollectionConfiguration(),
     val requiresMandate: Boolean = false,
@@ -31,6 +34,12 @@ internal data class FormArguments(
 internal fun FormArguments.getInitialValuesMap(): Map<IdentifierSpec, String?> {
     val initialValues = initialPaymentMethodCreateParams?.let {
         convertToFormValuesMap(it.toParamMap())
+    } ?: emptyMap()
+
+    val initialExtras = initialPaymentMethodExtraParams?.let {
+        convertToFormValuesMap(it.toParamMap()).mapKeys { entry ->
+            entry.key.copy(apiParameterDestination = ApiParameterDestination.Extras)
+        }
     } ?: emptyMap()
 
     return mapOf(
@@ -43,5 +52,5 @@ internal fun FormArguments.getInitialValuesMap(): Map<IdentifierSpec, String?> {
         IdentifierSpec.State to this.billingDetails?.address?.state,
         IdentifierSpec.Country to this.billingDetails?.address?.country,
         IdentifierSpec.PostalCode to this.billingDetails?.address?.postalCode
-    ).plus(initialValues)
+    ).plus(initialValues).plus(initialExtras)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -21,6 +21,7 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetViewModel
@@ -196,12 +197,24 @@ internal fun FormFieldValues.transformToPaymentMethodOptionsParams(
     )
 }
 
+internal fun FormFieldValues.transformToExtraParams(
+    paymentMethod: LpmRepository.SupportedPaymentMethod
+): PaymentMethodExtraParams? {
+    return FieldValuesToParamsMapConverter.transformToPaymentMethodExtraParams(
+        fieldValuePairs = fieldValuePairs.filter { entry ->
+            entry.key.apiParameterDestination == ApiParameterDestination.Extras
+        },
+        code = paymentMethod.code,
+    )
+}
+
 internal fun FormFieldValues.transformToPaymentSelection(
     resources: Resources,
     paymentMethod: LpmRepository.SupportedPaymentMethod
 ): PaymentSelection.New {
     val params = transformToPaymentMethodCreateParams(paymentMethod)
     val options = transformToPaymentMethodOptionsParams(paymentMethod)
+    val extras = transformToExtraParams(paymentMethod)
     return if (paymentMethod.code == PaymentMethod.Type.Card.code) {
         PaymentSelection.New.Card(
             paymentMethodOptionsParams = PaymentMethodOptionsParams.Card(
@@ -219,6 +232,7 @@ internal fun FormFieldValues.transformToPaymentSelection(
             darkThemeIconUrl = paymentMethod.darkThemeIconUrl,
             paymentMethodCreateParams = params,
             paymentMethodOptionsParams = options,
+            paymentMethodExtraParams = extras,
             customerRequestedSave = userRequestedReuse,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -31,9 +31,9 @@ import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFo
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.FieldValuesToParamsMapConverter
 import com.stripe.android.ui.core.forms.resources.LpmRepository
-import com.stripe.android.uicore.elements.ApiParameterDestination
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.LocalAutofillEventReporter
+import com.stripe.android.uicore.elements.ParameterDestination
 import kotlinx.coroutines.flow.MutableStateFlow
 
 @Composable
@@ -177,7 +177,7 @@ internal fun FormFieldValues.transformToPaymentMethodCreateParams(
 ): PaymentMethodCreateParams {
     return FieldValuesToParamsMapConverter.transformToPaymentMethodCreateParams(
         fieldValuePairs = fieldValuePairs.filter { entry ->
-            entry.key.apiParameterDestination == ApiParameterDestination.Params
+            entry.key.destination == ParameterDestination.Api.Params
         }.filterNot { entry ->
             entry.key == IdentifierSpec.SaveForFutureUse || entry.key == IdentifierSpec.CardBrand
         },
@@ -191,7 +191,7 @@ internal fun FormFieldValues.transformToPaymentMethodOptionsParams(
 ): PaymentMethodOptionsParams? {
     return FieldValuesToParamsMapConverter.transformToPaymentMethodOptionsParams(
         fieldValuePairs = fieldValuePairs.filter { entry ->
-            entry.key.apiParameterDestination == ApiParameterDestination.Options
+            entry.key.destination == ParameterDestination.Api.Options
         },
         code = paymentMethod.code,
     )
@@ -202,7 +202,7 @@ internal fun FormFieldValues.transformToExtraParams(
 ): PaymentMethodExtraParams? {
     return FieldValuesToParamsMapConverter.transformToPaymentMethodExtraParams(
         fieldValuePairs = fieldValuePairs.filter { entry ->
-            entry.key.apiParameterDestination == ApiParameterDestination.Extras
+            entry.key.destination == ParameterDestination.Local.Extras
         },
         code = paymentMethod.code,
     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArgumentsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArgumentsTest.kt
@@ -1,8 +1,10 @@
 package com.stripe.android.paymentsheet.paymentdatacollection
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
@@ -110,6 +112,58 @@ class FormArgumentsTest {
                 IdentifierSpec.State to "Co. Dublin",
                 IdentifierSpec.PostalCode to "T37 F8HK",
                 IdentifierSpec.Country to "IE"
+            )
+        )
+    }
+
+    @Test
+    fun `Verify extra parameters are included if passed in`() {
+        val formArguments = FormArguments(
+            PaymentMethod.Type.BacsDebit.code,
+            showCheckbox = true,
+            showCheckboxControlledFields = true,
+            merchantName = "Merchant, Inc.",
+            amount = Amount(50, "USD"),
+            billingDetails = null,
+            initialPaymentMethodCreateParams = PaymentMethodCreateParams.create(
+                bacsDebit = PaymentMethodCreateParams.BacsDebit(
+                    accountNumber = "00012345",
+                    sortCode = "10-88-00"
+                ),
+                billingDetails = PaymentMethod.BillingDetails(
+                    name = "Jenny Rosen",
+                    email = "jenny.rosen@example.com",
+                    address = Address(
+                        line1 = "123 Main Street",
+                        line2 = "APt 1",
+                        city = "Dublin",
+                        state = "Co. Dublin",
+                        postalCode = "T37 F8HK",
+                        country = "IE"
+                    )
+                )
+            ),
+            initialPaymentMethodExtraParams = PaymentMethodExtraParams.BacsDebit(
+                confirmed = true
+            ),
+            cbcEligibility = CardBrandChoiceEligibility.Ineligible
+        )
+
+        assertThat(formArguments.getInitialValuesMap()).isEqualTo(
+            mapOf(
+                IdentifierSpec.Name to "Jenny Rosen",
+                IdentifierSpec.Email to "jenny.rosen@example.com",
+                IdentifierSpec.Phone to null,
+                IdentifierSpec.Line1 to "123 Main Street",
+                IdentifierSpec.Line2 to "APt 1",
+                IdentifierSpec.City to "Dublin",
+                IdentifierSpec.State to "Co. Dublin",
+                IdentifierSpec.PostalCode to "T37 F8HK",
+                IdentifierSpec.Country to "IE",
+                IdentifierSpec.Generic("type") to "bacs_debit",
+                IdentifierSpec.Generic("bacs_debit[account_number]") to "00012345",
+                IdentifierSpec.Generic("bacs_debit[sort_code]") to "10-88-00",
+                IdentifierSpec.BacsDebitConfirmed to "true"
             )
         )
     }

--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -171,6 +171,22 @@ public final class com/stripe/android/uicore/elements/IdentifierSpec$Creator : a
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/uicore/elements/ParameterDestination$Api$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/uicore/elements/ParameterDestination$Api;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/uicore/elements/ParameterDestination$Api;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/uicore/elements/ParameterDestination$Local$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/uicore/elements/ParameterDestination$Local;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/uicore/elements/ParameterDestination$Local;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/uicore/elements/PhoneNumberState$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/IdentifierSpec.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/IdentifierSpec.kt
@@ -6,10 +6,19 @@ import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-enum class ApiParameterDestination {
-    Params,
-    Extras,
-    Options
+sealed interface ParameterDestination : Parcelable {
+    @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    enum class Api : ParameterDestination {
+        Params,
+        Options
+    }
+
+    @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    enum class Local : ParameterDestination {
+        Extras
+    }
 }
 
 /**
@@ -24,7 +33,7 @@ enum class ApiParameterDestination {
 data class IdentifierSpec(
     val v1: String,
     val ignoreField: Boolean = false,
-    val apiParameterDestination: ApiParameterDestination = ApiParameterDestination.Params,
+    val destination: ParameterDestination = ParameterDestination.Api.Params,
 ) : Parcelable {
     constructor() : this("")
 
@@ -76,21 +85,21 @@ data class IdentifierSpec(
         val Vpa = IdentifierSpec("upi[vpa]")
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        val Blik = IdentifierSpec("blik", apiParameterDestination = ApiParameterDestination.Options)
+        val Blik = IdentifierSpec("blik", destination = ParameterDestination.Api.Options)
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        val BlikCode = IdentifierSpec("blik[code]", apiParameterDestination = ApiParameterDestination.Options)
+        val BlikCode = IdentifierSpec("blik[code]", destination = ParameterDestination.Api.Options)
 
         @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         val KonbiniConfirmationNumber = IdentifierSpec(
             v1 = "konbini[confirmation_number]",
-            apiParameterDestination = ApiParameterDestination.Options
+            destination = ParameterDestination.Api.Options
         )
 
         @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         val BacsDebitConfirmed = IdentifierSpec(
             "bacs_debit[confirmed]",
-            apiParameterDestination = ApiParameterDestination.Extras
+            destination = ParameterDestination.Local.Extras
         )
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/IdentifierSpec.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/IdentifierSpec.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.Serializable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 enum class ApiParameterDestination {
     Params,
+    Extras,
     Options
 }
 
@@ -84,6 +85,12 @@ data class IdentifierSpec(
         val KonbiniConfirmationNumber = IdentifierSpec(
             v1 = "konbini[confirmation_number]",
             apiParameterDestination = ApiParameterDestination.Options
+        )
+
+        @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        val BacsDebitConfirmed = IdentifierSpec(
+            "bacs_debit[confirmed]",
+            apiParameterDestination = ApiParameterDestination.Extras
         )
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)


### PR DESCRIPTION
# Summary
Add support for `PaymentMethodExtraParams`.

# Motivation
Some parameters in the LPMs are not sent to the backend however are required in order for the LPM to be used. For example, a checkbox for `Billing address is same as shipping` or the Bacs mandate checkbox. Adding `PaymentMethodExtraParams` allows us to keep these parameters stored until the user has completed the payment process. This will be useful for both process death and the complete flow controller flow (where you can exit and return to `PaymentSheet` with existing state.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified
