### PR TITLE
Increase timeouts in `TestCard` to account for `PaymentSheet` loading time

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
@@ -96,9 +96,10 @@ internal class TestCard : BasePlaygroundTest() {
             testParameters = testParameters,
             beforeBuyAction = { selectors ->
                 selectors.composeTestRule.waitUntilExactlyOneExists(
-                    hasTestTag(SAVED_PAYMENT_OPTION_TEST_TAG)
+                    matcher = hasTestTag(SAVED_PAYMENT_OPTION_TEST_TAG)
                         .and(isSelected())
-                        .and(hasText(cardNumber.takeLast(4), substring = true))
+                        .and(hasText(cardNumber.takeLast(4), substring = true)),
+                    timeoutMillis = 5000L
                 )
             },
         )
@@ -142,9 +143,10 @@ internal class TestCard : BasePlaygroundTest() {
             testParameters = testParameters,
             beforeBuyAction = { selectors ->
                 selectors.composeTestRule.waitUntilExactlyOneExists(
-                    hasTestTag(SAVED_PAYMENT_OPTION_TEST_TAG)
+                    matcher = hasTestTag(SAVED_PAYMENT_OPTION_TEST_TAG)
                         .and(isSelected())
-                        .and(hasText(secondCardNumber.takeLast(4), substring = true))
+                        .and(hasText(secondCardNumber.takeLast(4), substring = true)),
+                    timeoutMillis = 5000L
                 )
             },
         )
@@ -179,8 +181,9 @@ internal class TestCard : BasePlaygroundTest() {
             testParameters = testParameters,
             beforeBuyAction = { selectors ->
                 selectors.composeTestRule.waitUntilExactlyOneExists(
-                    hasTestTag(PAYMENT_METHOD_SELECTOR_TEST_TAG)
-                        .and(hasText(cardNumber.takeLast(4), substring = true))
+                    matcher = hasTestTag(PAYMENT_METHOD_SELECTOR_TEST_TAG)
+                        .and(hasText(cardNumber.takeLast(4), substring = true)),
+                    timeoutMillis = 5000L
                 )
             },
         )
@@ -226,8 +229,9 @@ internal class TestCard : BasePlaygroundTest() {
             testParameters = testParameters,
             beforeBuyAction = { selectors ->
                 selectors.composeTestRule.waitUntilExactlyOneExists(
-                    hasTestTag(PAYMENT_METHOD_SELECTOR_TEST_TAG)
-                        .and(hasText(secondCardNumber.takeLast(4), substring = true))
+                    matcher = hasTestTag(PAYMENT_METHOD_SELECTOR_TEST_TAG)
+                        .and(hasText(secondCardNumber.takeLast(4), substring = true)),
+                    timeoutMillis = 5000L
                 )
             },
         )


### PR DESCRIPTION
# Summary
Increase timeouts in `TestCard` to account for `PaymentSheet` loading time

# Motivation
Helps reduce E2E test failures

[RUN_MOBILESDK-2810](https://jira.corp.stripe.com/projects/RUN_MOBILESDK/issues/RUN_MOBILESDK-2810)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
