### PR TITLE
Add Card Brand Choice eventing support in edit screen for `PaymentSheet` & `CustomerSheet`

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -85,6 +85,8 @@
     <ID>NestedBlockDepth:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest$private fun generatePaymentIntentScenarios(): List&lt;PaymentIntentTestInput></ID>
     <ID>ReturnCount:AddressUtils.kt$internal fun CharSequence.levenshtein(other: CharSequence): Int</ID>
     <ID>ThrowsCount:PaymentSheetConfigurationKtx.kt$internal fun PaymentSheet.Configuration.validate()</ID>
+    <ID>TooManyFunctions:CustomerSheetEventReporter.kt$CustomerSheetEventReporter</ID>
+    <ID>TooManyFunctions:DefaultCustomerSheetEventReporter.kt$DefaultCustomerSheetEventReporter : CustomerSheetEventReporter</ID>
     <ID>TooManyFunctions:DefaultEventReporter.kt$DefaultEventReporter : EventReporter</ID>
     <ID>TooManyFunctions:DefaultFlowController.kt$DefaultFlowController : FlowController</ID>
     <ID>TooManyFunctions:EventReporter.kt$EventReporter</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -331,16 +331,8 @@ internal class CustomerSheetViewModel @Inject constructor(
             )
         } else {
             backStack.update {
-                it.lastOrNull()?.let { viewState ->
-                    when (viewState) {
-                        is CustomerSheetViewState.AddPaymentMethod ->
-                            eventReporter.onScreenHidden(CustomerSheetEventReporter.Screen.AddPaymentMethod)
-                        is CustomerSheetViewState.SelectPaymentMethod ->
-                            eventReporter.onScreenHidden(CustomerSheetEventReporter.Screen.SelectPaymentMethod)
-                        is CustomerSheetViewState.EditPaymentMethod ->
-                            eventReporter.onScreenHidden(CustomerSheetEventReporter.Screen.EditPaymentMethod)
-                        else -> Unit
-                    }
+                it.last().eventReporterScreen?.let { screen ->
+                    eventReporter.onScreenHidden(screen)
                 }
 
                 it.dropLast(1)
@@ -543,7 +535,10 @@ internal class CustomerSheetViewModel @Inject constructor(
                                 )
                             }
                             is EditPaymentMethodViewInteractor.Event.HideBrands -> {
-                                eventReporter.onHidePaymentOptionBrands(event.brand)
+                                eventReporter.onHidePaymentOptionBrands(
+                                    source = CustomerSheetEventReporter.CardBrandChoiceEventSource.Edit,
+                                    selectedBrand = event.brand
+                                )
                             }
                         }
                     },
@@ -1193,6 +1188,14 @@ internal class CustomerSheetViewModel @Inject constructor(
             }
         }
     }
+
+    private val CustomerSheetViewState.eventReporterScreen: CustomerSheetEventReporter.Screen?
+        get() = when (this) {
+            is CustomerSheetViewState.AddPaymentMethod -> CustomerSheetEventReporter.Screen.AddPaymentMethod
+            is CustomerSheetViewState.SelectPaymentMethod -> CustomerSheetEventReporter.Screen.SelectPaymentMethod
+            is CustomerSheetViewState.EditPaymentMethod -> CustomerSheetEventReporter.Screen.EditPaymentMethod
+            else -> null
+        }
 
     object Factory : ViewModelProvider.Factory {
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEvent.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.analytics
 
 import com.stripe.android.core.networking.AnalyticsEvent
+import com.stripe.android.model.CardBrand
 
 internal sealed class CustomerSheetEvent : AnalyticsEvent {
 
@@ -15,6 +16,21 @@ internal sealed class CustomerSheetEvent : AnalyticsEvent {
                 CS_ADD_PAYMENT_METHOD_SCREEN_PRESENTED
             CustomerSheetEventReporter.Screen.SelectPaymentMethod ->
                 CS_SELECT_PAYMENT_METHOD_SCREEN_PRESENTED
+            CustomerSheetEventReporter.Screen.EditPaymentMethod ->
+                CS_SHOW_EDITABLE_PAYMENT_OPTION
+        }
+    }
+
+    class ScreenHidden(
+        screen: CustomerSheetEventReporter.Screen,
+    ) : CustomerSheetEvent() {
+        override val additionalParams: Map<String, Any?> = mapOf()
+        override val eventName: String = when (screen) {
+            CustomerSheetEventReporter.Screen.EditPaymentMethod ->
+                CS_HIDE_EDITABLE_PAYMENT_OPTION
+            else -> throw IllegalArgumentException(
+                "${screen.name} has no supported event for hiding screen!"
+            )
         }
     }
 
@@ -85,6 +101,55 @@ internal sealed class CustomerSheetEvent : AnalyticsEvent {
         }
     }
 
+    class ShowPaymentOptionBrands(
+        source: Source,
+        selectedBrand: CardBrand
+    ) : CustomerSheetEvent() {
+        override val eventName: String = CS_SHOW_PAYMENT_OPTION_BRANDS
+
+        override val additionalParams: Map<String, Any?> = mapOf(
+            FIELD_CBC_EVENT_SOURCE to source.value,
+            FIELD_SELECTED_CARD_BRAND to selectedBrand.code
+        )
+
+        enum class Source(val value: String) {
+            Edit(VALUE_EDIT_CBC_EVENT_SOURCE), Add(VALUE_ADD_CBC_EVENT_SOURCE)
+        }
+    }
+
+    class HidePaymentOptionBrands(
+        selectedBrand: CardBrand?
+    ) : CustomerSheetEvent() {
+        override val eventName: String = CS_HIDE_PAYMENT_OPTION_BRANDS
+
+        override val additionalParams: Map<String, Any?> = mapOf(
+            FIELD_CBC_EVENT_SOURCE to VALUE_EDIT_CBC_EVENT_SOURCE,
+            FIELD_SELECTED_CARD_BRAND to selectedBrand?.code
+        )
+    }
+
+    class UpdatePaymentOptionSucceeded(
+        selectedBrand: CardBrand,
+    ) : CustomerSheetEvent() {
+        override val eventName: String = CS_UPDATE_PAYMENT_METHOD
+
+        override val additionalParams: Map<String, Any?> = mapOf(
+            FIELD_SELECTED_CARD_BRAND to selectedBrand.code
+        )
+    }
+
+    class UpdatePaymentOptionFailed(
+        selectedBrand: CardBrand,
+        error: Throwable,
+    ) : CustomerSheetEvent() {
+        override val eventName: String = CS_UPDATE_PAYMENT_METHOD_FAILED
+
+        override val additionalParams: Map<String, Any?> = mapOf(
+            FIELD_SELECTED_CARD_BRAND to selectedBrand.code,
+            FIELD_ERROR_MESSAGE to error.message,
+        )
+    }
+
     internal companion object {
         const val CS_ADD_PAYMENT_METHOD_SCREEN_PRESENTED =
             "cs_add_payment_method_screen_presented"
@@ -118,6 +183,21 @@ internal sealed class CustomerSheetEvent : AnalyticsEvent {
         const val CS_ADD_PAYMENT_METHOD_VIA_CREATE_ATTACH_FAILED =
             "cs_add_payment_method_via_createAttach_failure"
 
+        const val CS_SHOW_EDITABLE_PAYMENT_OPTION = "cs_open_edit_screen"
+        const val CS_HIDE_EDITABLE_PAYMENT_OPTION = "cs_cancel_edit_screen"
+
+        const val CS_SHOW_PAYMENT_OPTION_BRANDS = "cs_open_cbc_dropdown"
+        const val CS_HIDE_PAYMENT_OPTION_BRANDS = "cs_close_cbc_dropdown"
+
+        const val CS_UPDATE_PAYMENT_METHOD = "cs_update_card"
+        const val CS_UPDATE_PAYMENT_METHOD_FAILED = "cs_update_card_failed"
+
+        const val FIELD_CBC_EVENT_SOURCE = "cbc_event_source"
+        const val FIELD_SELECTED_CARD_BRAND = "selected_card_brand"
+        const val FIELD_ERROR_MESSAGE = "error_message"
         const val FIELD_PAYMENT_METHOD_TYPE = "payment_method_type"
+
+        const val VALUE_EDIT_CBC_EVENT_SOURCE = "edit"
+        const val VALUE_ADD_CBC_EVENT_SOURCE = "add"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEvent.kt
@@ -118,14 +118,19 @@ internal sealed class CustomerSheetEvent : AnalyticsEvent {
     }
 
     class HidePaymentOptionBrands(
+        source: Source,
         selectedBrand: CardBrand?
     ) : CustomerSheetEvent() {
         override val eventName: String = CS_HIDE_PAYMENT_OPTION_BRANDS
 
         override val additionalParams: Map<String, Any?> = mapOf(
-            FIELD_CBC_EVENT_SOURCE to VALUE_EDIT_CBC_EVENT_SOURCE,
+            FIELD_CBC_EVENT_SOURCE to source.value,
             FIELD_SELECTED_CARD_BRAND to selectedBrand?.code
         )
+
+        enum class Source(val value: String) {
+            Edit(VALUE_EDIT_CBC_EVENT_SOURCE), Add(VALUE_ADD_CBC_EVENT_SOURCE)
+        }
     }
 
     class UpdatePaymentOptionSucceeded(

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEventReporter.kt
@@ -1,11 +1,19 @@
 package com.stripe.android.customersheet.analytics
 
+import com.stripe.android.model.CardBrand
+
+@Suppress("TooManyFunctions")
 internal interface CustomerSheetEventReporter {
 
     /**
      * [Screen] was presented to user
      */
     fun onScreenPresented(screen: Screen)
+
+    /**
+     * [Screen] was hidden to user
+     */
+    fun onScreenHidden(screen: Screen)
 
     /**
      * User attempted to confirm their saved payment method selection and succeeded
@@ -52,13 +60,52 @@ internal interface CustomerSheetEventReporter {
      */
     fun onAttachPaymentMethodFailed(style: AddPaymentMethodStyle)
 
+    /**
+     * User attempted to show payment option brands if payment
+     * option support card brand choice selection.
+     */
+    fun onShowPaymentOptionBrands(
+        source: CardBrandChoiceEventSource,
+        selectedBrand: CardBrand,
+    )
+
+    /**
+     * User attempted to hide payment option brands if payment
+     * option support card brand choice selection.
+     */
+    fun onHidePaymentOptionBrands(
+        selectedBrand: CardBrand?,
+    )
+
+    /**
+     * User successfully updated the card brand choice selection for
+     * a payment method.
+     */
+    fun onUpdatePaymentMethodSucceeded(
+        selectedBrand: CardBrand,
+    )
+
+    /**
+     * User failed to updated the card brand choice selection for
+     * a payment method.
+     */
+    fun onUpdatePaymentMethodFailed(
+        selectedBrand: CardBrand,
+        error: Throwable,
+    )
+
     enum class Screen(val value: String) {
         AddPaymentMethod("add_payment_method"),
         SelectPaymentMethod("select_payment_method"),
+        EditPaymentMethod("edit_payment_method"),
     }
 
     enum class AddPaymentMethodStyle(val value: String) {
         SetupIntent("setup_intent"),
         CreateAttach("create_attach")
+    }
+
+    enum class CardBrandChoiceEventSource {
+        Add, Edit
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEventReporter.kt
@@ -2,7 +2,6 @@ package com.stripe.android.customersheet.analytics
 
 import com.stripe.android.model.CardBrand
 
-@Suppress("TooManyFunctions")
 internal interface CustomerSheetEventReporter {
 
     /**
@@ -74,6 +73,7 @@ internal interface CustomerSheetEventReporter {
      * option support card brand choice selection.
      */
     fun onHidePaymentOptionBrands(
+        source: CardBrandChoiceEventSource,
         selectedBrand: CardBrand?,
     )
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/DefaultCustomerSheetEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/DefaultCustomerSheetEventReporter.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
-@Suppress("TooManyFunctions")
 internal class DefaultCustomerSheetEventReporter @Inject constructor(
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val analyticsRequestFactory: AnalyticsRequestFactory,
@@ -123,9 +122,18 @@ internal class DefaultCustomerSheetEventReporter @Inject constructor(
         )
     }
 
-    override fun onHidePaymentOptionBrands(selectedBrand: CardBrand?) {
+    override fun onHidePaymentOptionBrands(
+        source: CustomerSheetEventReporter.CardBrandChoiceEventSource,
+        selectedBrand: CardBrand?
+    ) {
         fireEvent(
             CustomerSheetEvent.HidePaymentOptionBrands(
+                source = when (source) {
+                    CustomerSheetEventReporter.CardBrandChoiceEventSource.Add ->
+                        CustomerSheetEvent.HidePaymentOptionBrands.Source.Add
+                    CustomerSheetEventReporter.CardBrandChoiceEventSource.Edit ->
+                        CustomerSheetEvent.HidePaymentOptionBrands.Source.Edit
+                },
                 selectedBrand = selectedBrand
             )
         )

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/DefaultCustomerSheetEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/DefaultCustomerSheetEventReporter.kt
@@ -3,11 +3,13 @@ package com.stripe.android.customersheet.analytics
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.AnalyticsRequestFactory
+import com.stripe.android.model.CardBrand
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
+@Suppress("TooManyFunctions")
 internal class DefaultCustomerSheetEventReporter @Inject constructor(
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val analyticsRequestFactory: AnalyticsRequestFactory,
@@ -19,6 +21,19 @@ internal class DefaultCustomerSheetEventReporter @Inject constructor(
                 screen = screen
             )
         )
+    }
+
+    override fun onScreenHidden(screen: CustomerSheetEventReporter.Screen) {
+        when (screen) {
+            CustomerSheetEventReporter.Screen.EditPaymentMethod -> {
+                fireEvent(
+                    CustomerSheetEvent.ScreenHidden(
+                        screen = screen
+                    )
+                )
+            }
+            else -> Unit
+        }
     }
 
     override fun onConfirmPaymentMethodSucceeded(type: String) {
@@ -87,6 +102,53 @@ internal class DefaultCustomerSheetEventReporter @Inject constructor(
         fireEvent(
             CustomerSheetEvent.AttachPaymentMethodFailed(
                 style = style
+            )
+        )
+    }
+
+    override fun onShowPaymentOptionBrands(
+        source: CustomerSheetEventReporter.CardBrandChoiceEventSource,
+        selectedBrand: CardBrand
+    ) {
+        fireEvent(
+            CustomerSheetEvent.ShowPaymentOptionBrands(
+                source = when (source) {
+                    CustomerSheetEventReporter.CardBrandChoiceEventSource.Add ->
+                        CustomerSheetEvent.ShowPaymentOptionBrands.Source.Add
+                    CustomerSheetEventReporter.CardBrandChoiceEventSource.Edit ->
+                        CustomerSheetEvent.ShowPaymentOptionBrands.Source.Edit
+                },
+                selectedBrand = selectedBrand
+            )
+        )
+    }
+
+    override fun onHidePaymentOptionBrands(selectedBrand: CardBrand?) {
+        fireEvent(
+            CustomerSheetEvent.HidePaymentOptionBrands(
+                selectedBrand = selectedBrand
+            )
+        )
+    }
+
+    override fun onUpdatePaymentMethodSucceeded(
+        selectedBrand: CardBrand,
+    ) {
+        fireEvent(
+            CustomerSheetEvent.UpdatePaymentOptionSucceeded(
+                selectedBrand = selectedBrand
+            )
+        )
+    }
+
+    override fun onUpdatePaymentMethodFailed(
+        selectedBrand: CardBrand,
+        error: Throwable,
+    ) {
+        fireEvent(
+            CustomerSheetEvent.UpdatePaymentOptionFailed(
+                selectedBrand = selectedBrand,
+                error = error
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.analytics
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.utils.DurationProvider
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
@@ -211,6 +212,73 @@ internal class DefaultEventReporter @Inject internal constructor(
             PaymentSheetEvent.AutofillEvent(
                 type = type,
                 isDeferred = isDeferred,
+            )
+        )
+    }
+
+    override fun onShowEditablePaymentOption() {
+        fireEvent(
+            PaymentSheetEvent.ShowEditablePaymentOption(
+                isDeferred = isDeferred
+            )
+        )
+    }
+
+    override fun onHideEditablePaymentOption() {
+        fireEvent(
+            PaymentSheetEvent.HideEditablePaymentOption(
+                isDeferred = isDeferred
+            )
+        )
+    }
+
+    override fun onShowPaymentOptionBrands(
+        source: EventReporter.CardBrandChoiceEventSource,
+        selectedBrand: CardBrand
+    ) {
+        fireEvent(
+            PaymentSheetEvent.ShowPaymentOptionBrands(
+                selectedBrand = selectedBrand,
+                source = when (source) {
+                    EventReporter.CardBrandChoiceEventSource.Add ->
+                        PaymentSheetEvent.ShowPaymentOptionBrands.Source.Add
+                    EventReporter.CardBrandChoiceEventSource.Edit ->
+                        PaymentSheetEvent.ShowPaymentOptionBrands.Source.Edit
+                },
+                isDeferred = isDeferred
+            )
+        )
+    }
+
+    override fun onHidePaymentOptionBrands(selectedBrand: CardBrand?) {
+        fireEvent(
+            PaymentSheetEvent.HidePaymentOptionBrands(
+                selectedBrand = selectedBrand,
+                isDeferred = isDeferred
+            )
+        )
+    }
+
+    override fun onUpdatePaymentMethodSucceeded(
+        selectedBrand: CardBrand
+    ) {
+        fireEvent(
+            PaymentSheetEvent.UpdatePaymentOptionSucceeded(
+                selectedBrand = selectedBrand,
+                isDeferred = isDeferred
+            )
+        )
+    }
+
+    override fun onUpdatePaymentMethodFailed(
+        selectedBrand: CardBrand,
+        error: Throwable,
+    ) {
+        fireEvent(
+            PaymentSheetEvent.UpdatePaymentOptionFailed(
+                selectedBrand = selectedBrand,
+                error = error,
+                isDeferred = isDeferred
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -250,10 +250,19 @@ internal class DefaultEventReporter @Inject internal constructor(
         )
     }
 
-    override fun onHidePaymentOptionBrands(selectedBrand: CardBrand?) {
+    override fun onHidePaymentOptionBrands(
+        source: EventReporter.CardBrandChoiceEventSource,
+        selectedBrand: CardBrand?
+    ) {
         fireEvent(
             PaymentSheetEvent.HidePaymentOptionBrands(
                 selectedBrand = selectedBrand,
+                source = when (source) {
+                    EventReporter.CardBrandChoiceEventSource.Add ->
+                        PaymentSheetEvent.HidePaymentOptionBrands.Source.Add
+                    EventReporter.CardBrandChoiceEventSource.Edit ->
+                        PaymentSheetEvent.HidePaymentOptionBrands.Source.Edit
+                },
                 isDeferred = isDeferred
             )
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -127,6 +127,7 @@ internal interface EventReporter {
      * have also chosen a new card brand selection as well.
      */
     fun onHidePaymentOptionBrands(
+        source: CardBrandChoiceEventSource,
         selectedBrand: CardBrand?,
     )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.analytics
 
 import androidx.annotation.Keep
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -103,11 +104,56 @@ internal interface EventReporter {
         type: String,
     )
 
+    /**
+     * The customer has chosen to show the edit screen for an editable payment option.
+     */
+    fun onShowEditablePaymentOption()
+
+    /**
+     * The customer has chosen to hide the edit screen for an editable payment option.
+     */
+    fun onHideEditablePaymentOption()
+
+    /**
+     * The customer has chosen to show the payment option brands for an editable payment option.
+     */
+    fun onShowPaymentOptionBrands(
+        source: CardBrandChoiceEventSource,
+        selectedBrand: CardBrand,
+    )
+
+    /**
+     * The customer has chosen to hide the payment option brands for an editable payment option. The customer may
+     * have also chosen a new card brand selection as well.
+     */
+    fun onHidePaymentOptionBrands(
+        selectedBrand: CardBrand?,
+    )
+
+    /**
+     * The customer has successfully updated a payment method with a new card brand selection.
+     */
+    fun onUpdatePaymentMethodSucceeded(
+        selectedBrand: CardBrand,
+    )
+
+    /**
+     * The customer has failed to update a payment method with a new card brand selection.
+     */
+    fun onUpdatePaymentMethodFailed(
+        selectedBrand: CardBrand,
+        error: Throwable,
+    )
+
     enum class Mode(val code: String) {
         Complete("complete"),
         Custom("custom");
 
         @Keep
         override fun toString(): String = code
+    }
+
+    enum class CardBrandChoiceEventSource {
+        Edit, Add
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -345,15 +345,20 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     }
 
     class HidePaymentOptionBrands(
+        source: Source,
         selectedBrand: CardBrand?,
         override val isDeferred: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_close_cbc_dropdown"
 
         override val additionalParams: Map<String, Any?> = mapOf(
-            FIELD_CBC_EVENT_SOURCE to VALUE_EDIT_CBC_EVENT_SOURCE,
+            FIELD_CBC_EVENT_SOURCE to source.value,
             FIELD_SELECTED_CARD_BRAND to selectedBrand?.code
         )
+
+        enum class Source(val value: String) {
+            Edit(VALUE_EDIT_CBC_EVENT_SOURCE), Add(VALUE_ADD_CBC_EVENT_SOURCE)
+        }
     }
 
     class UpdatePaymentOptionSucceeded(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.analytics
 
 import com.stripe.android.core.networking.AnalyticsEvent
+import com.stripe.android.model.CardBrand
 import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -140,6 +141,12 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
                         .name,
                 )
 
+                val preferredNetworks = configuration.preferredNetworks.takeIf { brands ->
+                    brands.isNotEmpty()
+                }?.joinToString { brand ->
+                    brand.code
+                }
+
                 @Suppress("DEPRECATION")
                 val configurationMap = mapOf(
                     FIELD_CUSTOMER to (configuration.customer != null),
@@ -150,6 +157,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
                     FIELD_APPEARANCE to appearanceConfigMap,
                     FIELD_BILLING_DETAILS_COLLECTION_CONFIGURATION to
                         billingDetailsCollectionConfigMap,
+                    FIELD_PREFERRED_NETWORKS to preferredNetworks
                 )
                 return mapOf(
                     FIELD_MOBILE_PAYMENT_ELEMENT_CONFIGURATION to configurationMap,
@@ -303,6 +311,75 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         override val additionalParams: Map<String, Any?> = emptyMap()
     }
 
+    class ShowEditablePaymentOption(
+        override val isDeferred: Boolean,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = "mc_open_edit_screen"
+
+        override val additionalParams: Map<String, Any?> = emptyMap()
+    }
+
+    class HideEditablePaymentOption(
+        override val isDeferred: Boolean,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = "mc_cancel_edit_screen"
+
+        override val additionalParams: Map<String, Any?> = emptyMap()
+    }
+
+    class ShowPaymentOptionBrands(
+        source: Source,
+        selectedBrand: CardBrand,
+        override val isDeferred: Boolean,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = "mc_open_cbc_dropdown"
+
+        override val additionalParams: Map<String, Any?> = mapOf(
+            FIELD_CBC_EVENT_SOURCE to source.value,
+            FIELD_SELECTED_CARD_BRAND to selectedBrand.code
+        )
+
+        enum class Source(val value: String) {
+            Edit(VALUE_EDIT_CBC_EVENT_SOURCE), Add(VALUE_ADD_CBC_EVENT_SOURCE)
+        }
+    }
+
+    class HidePaymentOptionBrands(
+        selectedBrand: CardBrand?,
+        override val isDeferred: Boolean,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = "mc_close_cbc_dropdown"
+
+        override val additionalParams: Map<String, Any?> = mapOf(
+            FIELD_CBC_EVENT_SOURCE to VALUE_EDIT_CBC_EVENT_SOURCE,
+            FIELD_SELECTED_CARD_BRAND to selectedBrand?.code
+        )
+    }
+
+    class UpdatePaymentOptionSucceeded(
+        selectedBrand: CardBrand,
+        override val isDeferred: Boolean,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = "mc_update_card"
+
+        override val additionalParams: Map<String, Any?> = mapOf(
+            FIELD_SELECTED_CARD_BRAND to selectedBrand.code
+        )
+    }
+
+    class UpdatePaymentOptionFailed(
+        selectedBrand: CardBrand,
+        error: Throwable,
+        override val isDeferred: Boolean,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = "mc_update_card_failed"
+
+        override val additionalParams: Map<String, Any?> = mapOf(
+            FIELD_SELECTED_CARD_BRAND to selectedBrand.code,
+            FIELD_ERROR_MESSAGE to error.message,
+        )
+    }
+
     private fun standardParams(
         isDecoupled: Boolean,
     ): Map<String, Any?> = mapOf(
@@ -329,6 +406,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_GOOGLE_PAY = "googlepay"
         const val FIELD_PRIMARY_BUTTON_COLOR = "primary_button_color"
         const val FIELD_BILLING = "default_billing_details"
+        const val FIELD_PREFERRED_NETWORKS = "preferred_networks"
         const val FIELD_DELAYED_PMS = "allows_delayed_payment_methods"
         const val FIELD_MOBILE_PAYMENT_ELEMENT_CONFIGURATION = "mpe_config"
         const val FIELD_APPEARANCE = "appearance"
@@ -354,6 +432,11 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_CURRENCY = "currency"
         const val FIELD_SELECTED_LPM = "selected_lpm"
         const val FIELD_ERROR_MESSAGE = "error_message"
+        const val FIELD_CBC_EVENT_SOURCE = "cbc_event_source"
+        const val FIELD_SELECTED_CARD_BRAND = "selected_card_brand"
+
+        const val VALUE_EDIT_CBC_EVENT_SOURCE = "edit"
+        const val VALUE_ADD_CBC_EVENT_SOURCE = "add"
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditPaymentMethod.kt
@@ -231,7 +231,11 @@ private fun Dropdown(
     Box(
         modifier = Modifier
             .clickable {
-                expanded = true
+                if (!expanded) {
+                    expanded = true
+
+                    viewActionHandler.invoke(EditPaymentMethodViewAction.OnBrandChoiceOptionsShown)
+                }
             }
             .testTag(DROPDOWN_MENU_CLICKABLE_TEST_TAG)
     ) {
@@ -271,6 +275,8 @@ private fun Dropdown(
             },
             onDismiss = {
                 expanded = false
+
+                viewActionHandler.invoke(EditPaymentMethodViewAction.OnBrandChoiceOptionsDismissed)
             }
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditPaymentMethodViewAction.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditPaymentMethodViewAction.kt
@@ -1,6 +1,10 @@
 package com.stripe.android.paymentsheet.ui
 
 internal sealed interface EditPaymentMethodViewAction {
+    object OnBrandChoiceOptionsShown : EditPaymentMethodViewAction
+
+    object OnBrandChoiceOptionsDismissed : EditPaymentMethodViewAction
+
     data class OnBrandChoiceChanged(
         val choice: EditPaymentMethodViewState.CardBrandChoice
     ) : EditPaymentMethodViewAction

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -38,6 +38,7 @@ import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.state.GooglePayState
 import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.paymentsheet.toPaymentSelection
+import com.stripe.android.paymentsheet.ui.EditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.ui.HeaderTextFactory
 import com.stripe.android.paymentsheet.ui.ModifiableEditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.ui.PaymentMethodRemovalDelayMillis
@@ -267,7 +268,7 @@ internal abstract class BaseSheetViewModel(
 
     private fun reportPaymentSheetShown(currentScreen: PaymentSheetScreen) {
         when (currentScreen) {
-            is PaymentSheetScreen.Loading, AddAnotherPaymentMethod -> {
+            is PaymentSheetScreen.Loading, AddAnotherPaymentMethod, is PaymentSheetScreen.EditPaymentMethod -> {
                 // Nothing to do here
             }
             is PaymentSheetScreen.SelectSavedPaymentMethods -> {
@@ -276,8 +277,16 @@ internal abstract class BaseSheetViewModel(
             is AddFirstPaymentMethod -> {
                 eventReporter.onShowNewPaymentOptionForm()
             }
+        }
+    }
+
+    private fun reportPaymentSheetHidden(hiddenScreen: PaymentSheetScreen) {
+        when (hiddenScreen) {
             is PaymentSheetScreen.EditPaymentMethod -> {
-                // TODO(tillh-stripe) Add reporting
+                eventReporter.onHideEditablePaymentOption()
+            }
+            else -> {
+                // Events for hiding other screens not supported
             }
         }
     }
@@ -447,10 +456,25 @@ internal abstract class BaseSheetViewModel(
     }
 
     fun modifyPaymentMethod(paymentMethod: PaymentMethod) {
+        eventReporter.onShowEditablePaymentOption()
+
         transitionTo(
             PaymentSheetScreen.EditPaymentMethod(
                 editInteractorFactory.create(
                     initialPaymentMethod = paymentMethod,
+                    eventHandler = { event ->
+                        when (event) {
+                            is EditPaymentMethodViewInteractor.Event.ShowBrands -> {
+                                eventReporter.onShowPaymentOptionBrands(
+                                    source = EventReporter.CardBrandChoiceEventSource.Edit,
+                                    selectedBrand = event.brand
+                                )
+                            }
+                            is EditPaymentMethodViewInteractor.Event.HideBrands -> {
+                                eventReporter.onHidePaymentOptionBrands(event.brand)
+                            }
+                        }
+                    },
                     displayName = providePaymentMethodName(paymentMethod.type?.code),
                     removeExecutor = { method ->
                         removePaymentMethodInEditScreen(method)
@@ -510,6 +534,15 @@ internal abstract class BaseSheetViewModel(
                 }
 
             handleBackPressed()
+
+            eventReporter.onUpdatePaymentMethodSucceeded(
+                selectedBrand = brand
+            )
+        }.onFailure { error ->
+            eventReporter.onUpdatePaymentMethodFailed(
+                selectedBrand = brand,
+                error = error,
+            )
         }
     }
 
@@ -568,7 +601,11 @@ internal abstract class BaseSheetViewModel(
         backStack.update { screens ->
             val modifiableScreens = screens.toMutableList()
 
-            modifiableScreens.removeLast().onClose()
+            val lastScreen = modifiableScreens.removeLast()
+
+            lastScreen.onClose()
+
+            reportPaymentSheetHidden(lastScreen)
 
             modifiableScreens.toList()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -471,7 +471,10 @@ internal abstract class BaseSheetViewModel(
                                 )
                             }
                             is EditPaymentMethodViewInteractor.Event.HideBrands -> {
-                                eventReporter.onHidePaymentOptionBrands(event.brand)
+                                eventReporter.onHidePaymentOptionBrands(
+                                    source = EventReporter.CardBrandChoiceEventSource.Edit,
+                                    selectedBrand = event.brand
+                                )
                             }
                         }
                     },

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetEventReporterTest.kt
@@ -12,6 +12,8 @@ import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.C
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_ADD_PAYMENT_METHOD_VIA_SETUP_INTENT_CANCELED
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_ADD_PAYMENT_METHOD_VIA_SETUP_INTENT_FAILED
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_ADD_PAYMENT_METHOD_VIA_SETUP_INTENT_SUCCEEDED
+import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_HIDE_EDITABLE_PAYMENT_OPTION
+import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_HIDE_PAYMENT_OPTION_BRANDS
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_SELECT_PAYMENT_METHOD_CONFIRMED_SAVED_PM_FAILED
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_SELECT_PAYMENT_METHOD_CONFIRMED_SAVED_PM_SUCCEEDED
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_SELECT_PAYMENT_METHOD_DONE_TAPPED
@@ -19,9 +21,14 @@ import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.C
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_SELECT_PAYMENT_METHOD_REMOVE_PM_FAILED
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_SELECT_PAYMENT_METHOD_REMOVE_PM_SUCCEEDED
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_SELECT_PAYMENT_METHOD_SCREEN_PRESENTED
+import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_SHOW_EDITABLE_PAYMENT_OPTION
+import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_SHOW_PAYMENT_OPTION_BRANDS
+import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_UPDATE_PAYMENT_METHOD
+import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_UPDATE_PAYMENT_METHOD_FAILED
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.FIELD_PAYMENT_METHOD_TYPE
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.analytics.DefaultCustomerSheetEventReporter
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -66,6 +73,23 @@ class CustomerSheetEventReporterTest {
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
                 req.params["event"] == CS_SELECT_PAYMENT_METHOD_SCREEN_PRESENTED
+            }
+        )
+
+        eventReporter.onScreenPresented(screen = CustomerSheetEventReporter.Screen.EditPaymentMethod)
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == CS_SHOW_EDITABLE_PAYMENT_OPTION
+            }
+        )
+    }
+
+    @Test
+    fun `onScreenHidden should fire analytics request with expected event value`() {
+        eventReporter.onScreenHidden(screen = CustomerSheetEventReporter.Screen.EditPaymentMethod)
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == CS_HIDE_EDITABLE_PAYMENT_OPTION
             }
         )
     }
@@ -187,6 +211,67 @@ class CustomerSheetEventReporterTest {
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
                 req.params["event"] == CS_ADD_PAYMENT_METHOD_VIA_CREATE_ATTACH_FAILED
+            }
+        )
+    }
+
+    @Test
+    fun `onShowPaymentOptionBrands() should fire analytics request with expected event value`() {
+        eventReporter.onShowPaymentOptionBrands(
+            source = CustomerSheetEventReporter.CardBrandChoiceEventSource.Edit,
+            selectedBrand = CardBrand.Visa
+        )
+
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == CS_SHOW_PAYMENT_OPTION_BRANDS &&
+                    req.params["cbc_event_source"] == "edit" &&
+                    req.params["selected_card_brand"] == "visa"
+            }
+        )
+    }
+
+    @Test
+    fun `onHidePaymentOptionBrands() should fire analytics request with expected event value`() {
+        eventReporter.onHidePaymentOptionBrands(
+            selectedBrand = CardBrand.CartesBancaires,
+        )
+
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == CS_HIDE_PAYMENT_OPTION_BRANDS &&
+                    req.params["cbc_event_source"] == "edit" &&
+                    req.params["selected_card_brand"] == "cartes_bancaires"
+            }
+        )
+    }
+
+    @Test
+    fun `onUpdatePaymentMethodSucceeded() should fire analytics request with expected event value`() {
+        eventReporter.onUpdatePaymentMethodSucceeded(
+            selectedBrand = CardBrand.CartesBancaires,
+        )
+
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == CS_UPDATE_PAYMENT_METHOD &&
+                    req.params["selected_card_brand"] == "cartes_bancaires"
+            }
+        )
+    }
+
+    @Test
+    fun `onUpdatePaymentMethodFailed() should fire analytics request with expected event value`() {
+        eventReporter.onUpdatePaymentMethodFailed(
+            selectedBrand = CardBrand.CartesBancaires,
+            error = Exception("No network available!")
+        )
+
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == CS_UPDATE_PAYMENT_METHOD_FAILED &&
+                    req.params["selected_card_brand"] == "cartes_bancaires" &&
+                    req.params["error_message"] == "No network available!"
             }
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetEventReporterTest.kt
@@ -234,6 +234,7 @@ class CustomerSheetEventReporterTest {
     @Test
     fun `onHidePaymentOptionBrands() should fire analytics request with expected event value`() {
         eventReporter.onHidePaymentOptionBrands(
+            source = CustomerSheetEventReporter.CardBrandChoiceEventSource.Edit,
             selectedBrand = CardBrand.CartesBancaires,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -384,6 +384,7 @@ internal class CustomerSheetScreenshotTest {
                 displayName = "Card",
                 removeExecutor = { null },
                 updateExecutor = { pm, _ -> Result.success(pm) },
+                eventHandler = {}
             ),
             isLiveMode = true,
             cbcEligibility = CardBrandChoiceEligibility.Eligible(preferredNetworks = emptyList()),

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -2757,7 +2757,10 @@ class CustomerSheetViewModelTest {
                 EditPaymentMethodViewAction.OnBrandChoiceOptionsDismissed
             )
 
-            verify(eventReporter).onHidePaymentOptionBrands(null)
+            verify(eventReporter).onHidePaymentOptionBrands(
+                source = CustomerSheetEventReporter.CardBrandChoiceEventSource.Edit,
+                selectedBrand = null
+            )
         }
     }
 
@@ -2788,7 +2791,10 @@ class CustomerSheetViewModelTest {
                 )
             )
 
-            verify(eventReporter).onHidePaymentOptionBrands(CardBrand.Visa)
+            verify(eventReporter).onHidePaymentOptionBrands(
+                source = CustomerSheetEventReporter.CardBrandChoiceEventSource.Edit,
+                selectedBrand = CardBrand.Visa
+            )
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.customersheet.CustomerSheetViewState.SelectPaymentMeth
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.injection.CustomerSheetViewModelModule
 import com.stripe.android.customersheet.utils.CustomerSheetTestHelper.addPaymentMethodViewState
+import com.stripe.android.customersheet.utils.CustomerSheetTestHelper.createModifiableEditPaymentMethodViewInteractorFactory
 import com.stripe.android.customersheet.utils.CustomerSheetTestHelper.createViewModel
 import com.stripe.android.customersheet.utils.CustomerSheetTestHelper.selectPaymentMethodViewState
 import com.stripe.android.customersheet.utils.FakeCustomerSheetLoader
@@ -22,6 +23,7 @@ import com.stripe.android.financialconnections.model.PaymentAccount
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
+import com.stripe.android.model.PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD
 import com.stripe.android.model.PaymentMethodFixtures.US_BANK_ACCOUNT
 import com.stripe.android.model.PaymentMethodFixtures.US_BANK_ACCOUNT_VERIFIED
 import com.stripe.android.model.SetupIntentFixtures
@@ -32,6 +34,7 @@ import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormScreenState
+import com.stripe.android.paymentsheet.ui.EditPaymentMethodViewAction
 import com.stripe.android.paymentsheet.ui.EditPaymentMethodViewAction.OnBrandChoiceChanged
 import com.stripe.android.paymentsheet.ui.EditPaymentMethodViewAction.OnRemoveConfirmed
 import com.stripe.android.paymentsheet.ui.EditPaymentMethodViewAction.OnRemovePressed
@@ -52,6 +55,8 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -1262,6 +1267,40 @@ class CustomerSheetViewModelTest {
         viewModel.handleViewAction(CustomerSheetViewAction.OnAddCardPressed)
 
         verify(eventReporter).onScreenPresented(CustomerSheetEventReporter.Screen.AddPaymentMethod)
+    }
+
+    @Test
+    fun `When edit payment screen is presented, event is reported`() {
+        val eventReporter: CustomerSheetEventReporter = mock()
+
+        val viewModel = createViewModel(
+            workContext = testDispatcher,
+            eventReporter = eventReporter,
+        )
+
+        viewModel.handleViewAction(
+            CustomerSheetViewAction.OnModifyItem(paymentMethod = CARD_PAYMENT_METHOD)
+        )
+
+        verify(eventReporter).onScreenPresented(CustomerSheetEventReporter.Screen.EditPaymentMethod)
+    }
+
+    @Test
+    fun `When edit payment screen is hidden, event is reported`() {
+        val eventReporter: CustomerSheetEventReporter = mock()
+
+        val viewModel = createViewModel(
+            workContext = testDispatcher,
+            eventReporter = eventReporter,
+        )
+
+        viewModel.handleViewAction(
+            CustomerSheetViewAction.OnModifyItem(paymentMethod = CARD_PAYMENT_METHOD)
+        )
+
+        viewModel.handleViewAction(CustomerSheetViewAction.OnBackPressed)
+
+        verify(eventReporter).onScreenHidden(CustomerSheetEventReporter.Screen.EditPaymentMethod)
     }
 
     @Test
@@ -2536,24 +2575,87 @@ class CustomerSheetViewModelTest {
     }
 
     @Test
-    fun `Updating payment method in edit screen goes through expected states`() = runTest(testDispatcher) {
+    fun `Updating payment method in edit screen goes through expected states & reports event`() =
+        runTest(testDispatcher) {
+            val eventReporter: CustomerSheetEventReporter = mock()
+            val paymentMethods = PaymentMethodFactory.cards(size = 1)
+
+            val firstMethod = paymentMethods.single()
+
+            val updatedMethod = firstMethod.copy(
+                card = firstMethod.card?.copy(
+                    networks = PaymentMethod.Card.Networks(
+                        available = setOf("visa", "cartes_bancaires"),
+                        preferred = "visa"
+                    )
+                )
+            )
+
+            val customerAdapter = FakeCustomerAdapter(
+                paymentMethods = CustomerAdapter.Result.Success(paymentMethods),
+                onUpdatePaymentMethod = { _, _ ->
+                    CustomerAdapter.Result.Success(updatedMethod)
+                }
+            )
+
+            val viewModel = createViewModel(
+                workContext = testDispatcher,
+                initialBackStack = listOf(
+                    selectPaymentMethodViewState.copy(
+                        savedPaymentMethods = paymentMethods,
+                    )
+                ),
+                eventReporter = eventReporter,
+                customerPaymentMethods = paymentMethods,
+                customerAdapter = customerAdapter,
+                editInteractorFactory = createModifiableEditPaymentMethodViewInteractorFactory(
+                    workContext = testDispatcher
+                ),
+            )
+
+            viewModel.viewState.test {
+                assertThat(awaitItem()).isInstanceOf(SelectPaymentMethod::class.java)
+                viewModel.handleViewAction(CustomerSheetViewAction.OnModifyItem(firstMethod))
+
+                val editViewState = awaitViewState<CustomerSheetViewState.EditPaymentMethod>()
+                editViewState.editPaymentMethodInteractor.handleViewAction(
+                    OnBrandChoiceChanged(
+                        EditPaymentMethodViewState.CardBrandChoice(
+                            brand = CardBrand.Visa
+                        )
+                    )
+                )
+                editViewState.editPaymentMethodInteractor.handleViewAction(OnUpdatePressed)
+
+                // Confirm that nothing has changed yet. We're waiting to update the payment method
+                // once we return to the SPM screen.
+                val updatedViewState = awaitViewState<SelectPaymentMethod>()
+                assertThat(updatedViewState.savedPaymentMethods).containsExactlyElementsIn(paymentMethods)
+
+                // Simulate the delay
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                verify(eventReporter).onUpdatePaymentMethodSucceeded(CardBrand.Visa)
+
+                val finalViewState = awaitViewState<SelectPaymentMethod>()
+                assertThat(finalViewState.savedPaymentMethods).containsExactlyElementsIn(listOf(updatedMethod))
+            }
+        }
+
+    @Test
+    fun `Failed update payment method in edit screen reports event`() = runTest(testDispatcher) {
+        val eventReporter: CustomerSheetEventReporter = mock()
         val paymentMethods = PaymentMethodFactory.cards(size = 1)
 
         val firstMethod = paymentMethods.single()
 
-        val updatedMethod = firstMethod.copy(
-            card = firstMethod.card?.copy(
-                networks = PaymentMethod.Card.Networks(
-                    available = setOf("visa", "cartes_bancaires"),
-                    preferred = "visa"
-                )
-            )
-        )
-
         val customerAdapter = FakeCustomerAdapter(
             paymentMethods = CustomerAdapter.Result.Success(paymentMethods),
             onUpdatePaymentMethod = { _, _ ->
-                CustomerAdapter.Result.Success(updatedMethod)
+                CustomerAdapter.Result.failure(
+                    Exception("No network found!"),
+                    "No network found!"
+                )
             }
         )
 
@@ -2564,8 +2666,12 @@ class CustomerSheetViewModelTest {
                     savedPaymentMethods = paymentMethods,
                 )
             ),
+            eventReporter = eventReporter,
             customerPaymentMethods = paymentMethods,
             customerAdapter = customerAdapter,
+            editInteractorFactory = createModifiableEditPaymentMethodViewInteractorFactory(
+                workContext = testDispatcher
+            ),
         )
 
         viewModel.viewState.test {
@@ -2582,16 +2688,107 @@ class CustomerSheetViewModelTest {
             )
             editViewState.editPaymentMethodInteractor.handleViewAction(OnUpdatePressed)
 
-            // Confirm that nothing has changed yet. We're waiting to update the payment method
-            // once we return to the SPM screen.
-            val updatedViewState = awaitViewState<SelectPaymentMethod>()
-            assertThat(updatedViewState.savedPaymentMethods).containsExactlyElementsIn(paymentMethods)
-
             // Simulate the delay
             testDispatcher.scheduler.advanceUntilIdle()
 
-            val finalViewState = awaitViewState<SelectPaymentMethod>()
-            assertThat(finalViewState.savedPaymentMethods).containsExactlyElementsIn(listOf(updatedMethod))
+            verify(eventReporter).onUpdatePaymentMethodFailed(
+                eq(CardBrand.Visa),
+                argThat {
+                    message == "No network found!"
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `Showing payment option brands in edit screen reports event`() = runTest(testDispatcher) {
+        val eventReporter: CustomerSheetEventReporter = mock()
+        val paymentMethods = listOf(CARD_WITH_NETWORKS_PAYMENT_METHOD)
+
+        val viewModel = createViewModel(
+            workContext = testDispatcher,
+            eventReporter = eventReporter,
+            initialBackStack = listOf(
+                selectPaymentMethodViewState.copy(
+                    savedPaymentMethods = paymentMethods,
+                )
+            ),
+            customerPaymentMethods = paymentMethods
+        )
+
+        viewModel.viewState.test {
+            assertThat(awaitItem()).isInstanceOf(SelectPaymentMethod::class.java)
+            viewModel.handleViewAction(CustomerSheetViewAction.OnModifyItem(paymentMethods.single()))
+
+            val editViewState = awaitViewState<CustomerSheetViewState.EditPaymentMethod>()
+            editViewState.editPaymentMethodInteractor.handleViewAction(
+                EditPaymentMethodViewAction.OnBrandChoiceOptionsShown
+            )
+
+            verify(eventReporter).onShowPaymentOptionBrands(
+                source = CustomerSheetEventReporter.CardBrandChoiceEventSource.Edit,
+                selectedBrand = CardBrand.CartesBancaires
+            )
+        }
+    }
+
+    @Test
+    fun `Hiding payment option brands in edit screen reports event`() = runTest(testDispatcher) {
+        val eventReporter: CustomerSheetEventReporter = mock()
+        val paymentMethods = listOf(CARD_WITH_NETWORKS_PAYMENT_METHOD)
+
+        val viewModel = createViewModel(
+            workContext = testDispatcher,
+            eventReporter = eventReporter,
+            initialBackStack = listOf(
+                selectPaymentMethodViewState.copy(
+                    savedPaymentMethods = paymentMethods,
+                )
+            ),
+            customerPaymentMethods = paymentMethods,
+        )
+
+        viewModel.viewState.test {
+            assertThat(awaitItem()).isInstanceOf(SelectPaymentMethod::class.java)
+            viewModel.handleViewAction(CustomerSheetViewAction.OnModifyItem(paymentMethods.single()))
+
+            val editViewState = awaitViewState<CustomerSheetViewState.EditPaymentMethod>()
+            editViewState.editPaymentMethodInteractor.handleViewAction(
+                EditPaymentMethodViewAction.OnBrandChoiceOptionsDismissed
+            )
+
+            verify(eventReporter).onHidePaymentOptionBrands(null)
+        }
+    }
+
+    @Test
+    fun `Changing payment option brand in edit screen reports event`() = runTest(testDispatcher) {
+        val eventReporter: CustomerSheetEventReporter = mock()
+        val paymentMethods = listOf(CARD_WITH_NETWORKS_PAYMENT_METHOD)
+
+        val viewModel = createViewModel(
+            workContext = testDispatcher,
+            eventReporter = eventReporter,
+            initialBackStack = listOf(
+                selectPaymentMethodViewState.copy(
+                    savedPaymentMethods = paymentMethods,
+                )
+            ),
+            customerPaymentMethods = paymentMethods,
+        )
+
+        viewModel.viewState.test {
+            assertThat(awaitItem()).isInstanceOf(SelectPaymentMethod::class.java)
+            viewModel.handleViewAction(CustomerSheetViewAction.OnModifyItem(paymentMethods.single()))
+
+            val editViewState = awaitViewState<CustomerSheetViewState.EditPaymentMethod>()
+            editViewState.editPaymentMethodInteractor.handleViewAction(
+                OnBrandChoiceChanged(
+                    EditPaymentMethodViewState.CardBrandChoice(brand = CardBrand.Visa)
+                )
+            )
+
+            verify(eventReporter).onHidePaymentOptionBrands(CardBrand.Visa)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FakeEditPaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FakeEditPaymentMethodInteractor.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.ui.EditPaymentMethodViewAction
+import com.stripe.android.paymentsheet.ui.EditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.ui.EditPaymentMethodViewState
 import com.stripe.android.paymentsheet.ui.ModifiableEditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.ui.PaymentMethodRemoveOperation
@@ -39,6 +40,7 @@ internal class FakeEditPaymentMethodInteractor(
     object Factory : ModifiableEditPaymentMethodViewInteractor.Factory {
         override fun create(
             initialPaymentMethod: PaymentMethod,
+            eventHandler: (EditPaymentMethodViewInteractor.Event) -> Unit,
             removeExecutor: PaymentMethodRemoveOperation,
             updateExecutor: PaymentMethodUpdateOperation,
             displayName: String

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -251,7 +251,10 @@ internal class PaymentSheetViewModelTest {
                     EditPaymentMethodViewAction.OnBrandChoiceOptionsDismissed
                 )
 
-                verify(eventReporter).onHidePaymentOptionBrands(null)
+                verify(eventReporter).onHidePaymentOptionBrands(
+                    source = EventReporter.CardBrandChoiceEventSource.Edit,
+                    selectedBrand = null
+                )
             }
         }
     }
@@ -282,7 +285,10 @@ internal class PaymentSheetViewModelTest {
                     )
                 )
 
-                verify(eventReporter).onHidePaymentOptionBrands(CardBrand.Visa)
+                verify(eventReporter).onHidePaymentOptionBrands(
+                    source = EventReporter.CardBrandChoiceEventSource.Edit,
+                    selectedBrand = CardBrand.Visa
+                )
             }
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -7,6 +7,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -213,6 +214,113 @@ class DefaultEventReporterTest {
                 req.params["event"] == "mc_custom_paymentoption_savedpm_select" &&
                     req.params["currency"] == "usd" &&
                     req.params["locale"] == "en_US"
+            }
+        )
+    }
+
+    @Test
+    fun `onShowEditablePaymentOption() should fire analytics request with expected event value`() {
+        val customEventReporter = createEventReporter(EventReporter.Mode.Custom) {
+            simulateSuccessfulSetup()
+        }
+
+        customEventReporter.onShowEditablePaymentOption()
+
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == "mc_open_edit_screen"
+            }
+        )
+    }
+
+    @Test
+    fun `onHideEditablePaymentOption() should fire analytics request with expected event value`() {
+        val customEventReporter = createEventReporter(EventReporter.Mode.Custom) {
+            simulateSuccessfulSetup()
+        }
+
+        customEventReporter.onHideEditablePaymentOption()
+
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == "mc_cancel_edit_screen"
+            }
+        )
+    }
+
+    @Test
+    fun `onShowPaymentOptionBrands() should fire analytics request with expected event value`() {
+        val customEventReporter = createEventReporter(EventReporter.Mode.Custom) {
+            simulateSuccessfulSetup()
+        }
+
+        customEventReporter.onShowPaymentOptionBrands(
+            source = EventReporter.CardBrandChoiceEventSource.Edit,
+            selectedBrand = CardBrand.Visa
+        )
+
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == "mc_open_cbc_dropdown" &&
+                    req.params["cbc_event_source"] == "edit" &&
+                    req.params["selected_card_brand"] == "visa"
+            }
+        )
+    }
+
+    @Test
+    fun `onHidePaymentOptionBrands() should fire analytics request with expected event value`() {
+        val customEventReporter = createEventReporter(EventReporter.Mode.Custom) {
+            simulateSuccessfulSetup()
+        }
+
+        customEventReporter.onHidePaymentOptionBrands(
+            selectedBrand = CardBrand.CartesBancaires,
+        )
+
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == "mc_close_cbc_dropdown" &&
+                    req.params["cbc_event_source"] == "edit" &&
+                    req.params["selected_card_brand"] == "cartes_bancaires"
+            }
+        )
+    }
+
+    @Test
+    fun `onUpdatePaymentMethodSucceeded() should fire analytics request with expected event value`() {
+        val customEventReporter = createEventReporter(EventReporter.Mode.Custom) {
+            simulateSuccessfulSetup()
+        }
+
+        customEventReporter.onUpdatePaymentMethodSucceeded(
+            selectedBrand = CardBrand.CartesBancaires,
+        )
+
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == "mc_update_card" &&
+                    req.params["selected_card_brand"] == "cartes_bancaires"
+            }
+        )
+    }
+
+    @Test
+    fun `onUpdatePaymentMethodFailed() should fire analytics request with expected event value`() {
+        val customEventReporter = createEventReporter(EventReporter.Mode.Custom) {
+            simulateSuccessfulSetup()
+        }
+
+        customEventReporter.onUpdatePaymentMethodFailed(
+            selectedBrand = CardBrand.CartesBancaires,
+            error = Exception("No network available!")
+        )
+
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == "mc_update_card_failed" &&
+                    req.params["selected_card_brand"] == "cartes_bancaires" &&
+                    req.params["error_message"] == "No network available!"
             }
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -275,6 +275,7 @@ class DefaultEventReporterTest {
         }
 
         customEventReporter.onHidePaymentOptionBrands(
+            source = EventReporter.CardBrandChoiceEventSource.Edit,
             selectedBrand = CardBrand.CartesBancaires,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -598,9 +598,33 @@ class PaymentSheetEventTest {
     }
 
     @Test
-    fun `HidePaymentOptionBrands event should return expected toString()`() {
+    fun `HidePaymentOptionBrands event with add source should return expected toString()`() {
         val event = PaymentSheetEvent.HidePaymentOptionBrands(
             selectedBrand = CardBrand.CartesBancaires,
+            source = PaymentSheetEvent.HidePaymentOptionBrands.Source.Add,
+            isDeferred = false,
+        )
+        assertThat(
+            event.eventName
+        ).isEqualTo(
+            "mc_close_cbc_dropdown"
+        )
+        assertThat(
+            event.params
+        ).isEqualTo(
+            mapOf(
+                "cbc_event_source" to "add",
+                "selected_card_brand" to "cartes_bancaires",
+                "is_decoupled" to false,
+            )
+        )
+    }
+
+    @Test
+    fun `HidePaymentOptionBrands event with edit source should return expected toString()`() {
+        val event = PaymentSheetEvent.HidePaymentOptionBrands(
+            selectedBrand = CardBrand.CartesBancaires,
+            source = PaymentSheetEvent.HidePaymentOptionBrands.Source.Edit,
             isDeferred = false,
         )
         assertThat(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/FakeEditPaymentMethodInteractorFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/FakeEditPaymentMethodInteractorFactory.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.utils
 
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.ui.DefaultEditPaymentMethodViewInteractor
+import com.stripe.android.paymentsheet.ui.EditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.ui.ModifiableEditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.ui.PaymentMethodRemoveOperation
 import com.stripe.android.paymentsheet.ui.PaymentMethodUpdateOperation
@@ -14,12 +15,14 @@ internal class FakeEditPaymentMethodInteractorFactory(
 ) : ModifiableEditPaymentMethodViewInteractor.Factory {
     override fun create(
         initialPaymentMethod: PaymentMethod,
+        eventHandler: (EditPaymentMethodViewInteractor.Event) -> Unit,
         removeExecutor: PaymentMethodRemoveOperation,
         updateExecutor: PaymentMethodUpdateOperation,
         displayName: String
     ): ModifiableEditPaymentMethodViewInteractor {
         return DefaultEditPaymentMethodViewInteractor(
             initialPaymentMethod = initialPaymentMethod,
+            eventHandler = eventHandler,
             removeExecutor = removeExecutor,
             updateExecutor = updateExecutor,
             displayName = displayName,


### PR DESCRIPTION
# Summary
Add Card Brand Choice eventing support in edit screen for `PaymentSheet` & `CustomerSheet`

# Motivation
Allows us to track usage of Card Brand Choice within the new edit screen.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
