### PR TITLE
[Identity] Start to count retry from 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+## 20.3610 - 2024-01-08
+*** Identity
+* [FIXED][7756](https://github.com/stripe/stripe-android/pull/7756) Fixed a issue where the retry counter is not set correctly.
+
 ## 20.36.0 - 2023-12-18
 
 ### PaymentSheet

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
@@ -1306,21 +1306,21 @@ internal class IdentityViewModel constructor(
                 IdentityScanState.ScanType.DOC_FRONT -> {
                     oldState.copy(
                         docFrontRetryTimes =
-                        oldState.docFrontRetryTimes?.let { it + 1 } ?: 1
+                        oldState.docFrontRetryTimes?.let { it + 1 } ?: 0
                     )
                 }
 
                 IdentityScanState.ScanType.DOC_BACK -> {
                     oldState.copy(
                         docBackRetryTimes =
-                        oldState.docBackRetryTimes?.let { it + 1 } ?: 1
+                        oldState.docBackRetryTimes?.let { it + 1 } ?: 0
                     )
                 }
 
                 IdentityScanState.ScanType.SELFIE -> {
                     oldState.copy(
                         selfieRetryTimes =
-                        oldState.selfieRetryTimes?.let { it + 1 } ?: 1
+                        oldState.selfieRetryTimes?.let { it + 1 } ?: 0
                     )
                 }
             }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We should count from 0 instead of 1 for the retry, this would fix a dashboard discrepancy with ios

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
