### PR TITLE
[Identity] Reset scanner state when disposed

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/ui/LiveCaptureLaunchedEffect.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/LiveCaptureLaunchedEffect.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.identity.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.LifecycleOwner
 import androidx.navigation.NavController
@@ -15,7 +16,8 @@ import com.stripe.android.identity.viewmodel.IdentityScanViewModel
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 
 /**
- * LaunchedEffect to notify [IdentityViewModel] based on [IdentityScanViewModel.State].
+ * Effect to notify [IdentityViewModel] based on [IdentityScanViewModel.State] and reset
+ * [IdentityScanViewModel.scannerState].
  * TODO(IDPROD-6662) - decouple any logic related to IdentityViewModel and handle them inside IdentityScanViewModel.
  */
 @Composable
@@ -65,6 +67,12 @@ internal fun LiveCaptureLaunchedEffect(
             navController.navigateTo(
                 CouldNotCaptureDestination(fromSelfie = scannerState.fromSelfie)
             )
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            identityScanViewModel.resetScannerState()
         }
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityScanViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityScanViewModel.kt
@@ -162,6 +162,10 @@ internal class IdentityScanViewModel(
         _scannerState.update { State.Scanning() }
     }
 
+    fun resetScannerState() {
+        _scannerState.update { State.Initializing }
+    }
+
     internal class IdentityScanViewModelFactory @Inject constructor(
         private val context: Context,
         private val modelPerformanceTracker: ModelPerformanceTracker,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add a function to reset scanner state to Initializing when the compose view is disposed.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This ensures the view would restart from a fresh state and avoid a crash when selfie is retried.


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
