### PR TITLE
Use correct address format for Germany

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddress.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddress.kt
@@ -30,10 +30,11 @@ internal data class Address(
 // of "King Street 123" instead of "123 King Street"
 // Reference for country formats:
 // https://docs.google.com/spreadsheets/d/1tIZO0-Iqvs_8CA9UL3S9qYvoTzjPdrHZr-hdetz6Uuo/edit#gid=696373988
-internal val STREET_NAME_FIRST_COUNTRIES = listOf(
+internal val STREET_NAME_FIRST_COUNTRIES = setOf(
     "BE",
     "BR",
     "CH",
+    "DE",
     "ES",
     "ID",
     "IT",
@@ -42,7 +43,7 @@ internal val STREET_NAME_FIRST_COUNTRIES = listOf(
     "NO",
     "PL",
     "RU",
-    "SE"
+    "SE",
 )
 
 internal fun Place.filter(type: Place.Type): AddressComponent? {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds Germany to the list of countries where addresses are formatted as `{street name} {number}` instead of `{number} {street name}`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Resolves https://github.com/stripe/stripe-android/issues/7741

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
