### PR TITLE
Allow landscape mode again in PaymentSheet

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.googlepaylauncher
 
-import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
@@ -39,7 +38,6 @@ internal class GooglePayLauncherActivity : AppCompatActivity() {
 
     private lateinit var args: GooglePayLauncherContract.Args
 
-    @SuppressLint("SourceLockedOrientationActivity")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.payments.paymentlauncher
 
-import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
@@ -32,7 +31,6 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
     @VisibleForTesting
     internal val viewModel: PaymentLauncherViewModel by viewModels { viewModelFactory }
 
-    @SuppressLint("SourceLockedOrientationActivity")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationActivity.kt
@@ -1,8 +1,6 @@
 package com.stripe.android.paymentsheet.paymentdatacollection.bacs
 
-import android.annotation.SuppressLint
 import android.app.Activity
-import android.content.pm.ActivityInfo
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.addCallback
@@ -36,16 +34,9 @@ internal class BacsMandateConfirmationActivity : AppCompatActivity() {
         BacsMandateConfirmationViewModel.Factory(starterArgs)
     }
 
-    @SuppressLint("SourceLockedOrientationActivity")
     @OptIn(ExperimentalMaterialApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        if (Build.VERSION.SDK_INT != Build.VERSION_CODES.O) {
-            // In Oreo, Activities where `android:windowIsTranslucent=true` can't request
-            // orientation. See https://stackoverflow.com/a/50832408/11103900
-            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        }
 
         renderEdgeToEdge()
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.ui
 
-import android.content.pm.ActivityInfo
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.addCallback
@@ -25,12 +24,6 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
 
         if (earlyExitDueToIllegalState) {
             return
-        }
-
-        if (Build.VERSION.SDK_INT != Build.VERSION_CODES.O) {
-            // In Oreo, Activities where `android:windowIsTranslucent=true` can't request
-            // orientation. See https://stackoverflow.com/a/50832408/11103900
-            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         }
 
         renderEdgeToEdge()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request re-enables landscape mode in `PaymentSheet`. This is helpful when the host app runs on a tablet, where landscape usage is more common there.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Resolves: https://github.com/stripe/stripe-android/issues/6311
Resolves: https://github.com/stripe/stripe-android/issues/7764

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
