### PR TITLE
Fix issue where `Context` leaked in `NetworkTypeDetector`

### DIFF
--- a/stripe-core/src/main/java/com/stripe/android/core/networking/NetworkTypeDetector.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/NetworkTypeDetector.kt
@@ -12,7 +12,7 @@ class NetworkTypeDetector private constructor(
 ) {
 
     constructor(context: Context) : this(
-        connectivityManager = context.getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager,
+        connectivityManager = context.applicationContext.getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager,
     )
 
     @Suppress("DEPRECATION")


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Resolves: https://github.com/stripe/stripe-android/issues/7754

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
