### PR TITLE
Fix `Add card` button in legacy payment methods screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 Dependencies updated:
 * [7603](https://github.com/stripe/stripe-android/pull/7603) Bumped compile SDK from 33 to 34.
 
+### Payments
+* [FIXED][7777](https://github.com/stripe/stripe-android/pull/7777) Fixed an issue in `PaymentSession` where tapping the `Add card` button stopped working after it was clicked once.
+
 ## 20.36.1 - 2024-01-08
 
 ### Identity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # CHANGELOG
 
 ## XX.XX.XX - 2023-XX-XX
-* [CHANGED][7722](https://github.com/stripe/stripe-android/pull/7722) Added passive hcaptcha on radar session creation endpoint. In order to enable hCaptcha on this endpoint, you must provide an activity to this method call (see the new optional activity parameter).
+
+### Payments
+* [CHANGED][7722](https://github.com/stripe/stripe-android/pull/7722) Added passive hCaptcha on Radar session creation endpoint. In order to enable hCaptcha on this endpoint, you must provide an activity to this method call (see the new optional activity parameter).
+* [FIXED][7777](https://github.com/stripe/stripe-android/pull/7777) Fixed an issue in `PaymentSession` where tapping the `Add card` button stopped working after it was clicked once.
 
 Dependencies updated:
 * [7603](https://github.com/stripe/stripe-android/pull/7603) Bumped compile SDK from 33 to 34.
-
-### Payments
-* [FIXED][7777](https://github.com/stripe/stripe-android/pull/7777) Fixed an issue in `PaymentSession` where tapping the `Add card` button stopped working after it was clicked once.
 
 ## 20.36.1 - 2024-01-08
 

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     testImplementation testLibs.androidx.fragment
     testImplementation testLibs.androidx.junit
     testImplementation testLibs.androidx.lifecycle
+    testImplementation testLibs.espresso.contrib
     testImplementation testLibs.espresso.intents
     testImplementation testLibs.json
     testImplementation testLibs.junit

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
@@ -10,6 +10,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.activity.addCallback
+import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
@@ -121,22 +122,14 @@ class PaymentMethodsActivity : AppCompatActivity() {
             }
         }
 
-        observePaymentMethodData()
-
-        setupRecyclerView()
-
         val addPaymentMethodLauncher = registerForActivityResult(
             AddPaymentMethodContract(),
             ::onAddPaymentMethodResult
         )
 
-        lifecycleScope.launch {
-            adapter.addPaymentMethodArgs.collect { args ->
-                if (args != null) {
-                    addPaymentMethodLauncher.launch(args)
-                }
-            }
-        }
+        observePaymentMethodData()
+
+        setupRecyclerView(addPaymentMethodLauncher)
 
         setSupportActionBar(viewBinding.toolbar)
 
@@ -158,7 +151,9 @@ class PaymentMethodsActivity : AppCompatActivity() {
         viewBinding.recycler.requestFocusFromTouch()
     }
 
-    private fun setupRecyclerView() {
+    private fun setupRecyclerView(
+        addPaymentMethodLauncher: ActivityResultLauncher<AddPaymentMethodActivityStarter.Args>,
+    ) {
         val deletePaymentMethodDialogFactory = DeletePaymentMethodDialogFactory(
             this,
             adapter,
@@ -170,6 +165,10 @@ class PaymentMethodsActivity : AppCompatActivity() {
         adapter.listener = object : PaymentMethodsAdapter.Listener {
             override fun onPaymentMethodClick(paymentMethod: PaymentMethod) {
                 viewBinding.recycler.tappedPaymentMethod = paymentMethod
+            }
+
+            override fun onAddPaymentMethodClick(args: AddPaymentMethodActivityStarter.Args) {
+                addPaymentMethodLauncher.launch(args)
             }
 
             override fun onGooglePayClick() {

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsAdapter.kt
@@ -13,9 +13,6 @@ import com.stripe.android.databinding.StripeAddPaymentMethodRowBinding
 import com.stripe.android.databinding.StripeGooglePayRowBinding
 import com.stripe.android.databinding.StripeMaskedCardRowBinding
 import com.stripe.android.model.PaymentMethod
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * A [RecyclerView.Adapter] that holds a set of [MaskedCardView] items for a given set
@@ -41,9 +38,6 @@ internal class PaymentMethodsAdapter constructor(
 
     internal var listener: Listener? = null
     private val googlePayCount = 1.takeIf { shouldShowGooglePay } ?: 0
-
-    private val _addPaymentMethodArgs = MutableStateFlow<AddPaymentMethodActivityStarter.Args?>(null)
-    val addPaymentMethodArgs: StateFlow<AddPaymentMethodActivityStarter.Args?> = _addPaymentMethodArgs.asStateFlow()
 
     internal val addCardArgs = AddPaymentMethodActivityStarter.Args.Builder()
         .setBillingAddressFields(intentArgs.billingAddressFields)
@@ -145,12 +139,12 @@ internal class PaymentMethodsAdapter constructor(
             }
             is ViewHolder.AddCardPaymentMethodViewHolder -> {
                 holder.itemView.setOnClickListener {
-                    _addPaymentMethodArgs.value = addCardArgs
+                    listener?.onAddPaymentMethodClick(addCardArgs)
                 }
             }
             is ViewHolder.AddFpxPaymentMethodViewHolder -> {
                 holder.itemView.setOnClickListener {
-                    _addPaymentMethodArgs.value = addFpxArgs
+                    listener?.onAddPaymentMethodClick(addFpxArgs)
                 }
             }
         }
@@ -371,6 +365,7 @@ internal class PaymentMethodsAdapter constructor(
     internal interface Listener {
         fun onPaymentMethodClick(paymentMethod: PaymentMethod)
         fun onGooglePayClick()
+        fun onAddPaymentMethodClick(args: AddPaymentMethodActivityStarter.Args)
         fun onDeletePaymentMethodAction(paymentMethod: PaymentMethod)
     }
 

--- a/payments-core/src/test/java/com/stripe/android/view/PaymentMethodsAdapterTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/PaymentMethodsAdapterTest.kt
@@ -4,12 +4,10 @@ import android.widget.FrameLayout
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
-import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.R
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
-import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.mockito.Mockito.times
 import org.mockito.kotlin.mock
@@ -257,47 +255,43 @@ class PaymentMethodsAdapterTest {
     }
 
     @Test
-    fun `click on add card view should emit args`() = runTest {
+    fun `click on add card view should emit args`() {
         val adapter = PaymentMethodsAdapter(
             ARGS,
             shouldShowGooglePay = true
         )
 
-        adapter.addPaymentMethodArgs.test {
-            assertThat(awaitItem()).isNull() // Initial value.
+        val listener = mock<PaymentMethodsAdapter.Listener>()
+        adapter.listener = listener
 
-            val viewHolder = adapter.createViewHolder(
-                FrameLayout(context),
-                PaymentMethodsAdapter.ViewType.AddCard.ordinal
-            )
-            adapter.onBindViewHolder(viewHolder, 0)
-            viewHolder.itemView.performClick()
+        val viewHolder = adapter.createViewHolder(
+            FrameLayout(context),
+            PaymentMethodsAdapter.ViewType.AddCard.ordinal
+        )
+        adapter.onBindViewHolder(viewHolder, 0)
+        viewHolder.itemView.performClick()
 
-            assertThat(awaitItem())
-                .isEqualTo(adapter.addCardArgs)
-        }
+        verify(listener).onAddPaymentMethodClick(adapter.addCardArgs)
     }
 
     @Test
-    fun `click on add FPX view should emit args`() = runTest {
+    fun `click on add FPX view should emit args`() {
         val adapter = PaymentMethodsAdapter(
             ARGS,
             shouldShowGooglePay = true
         )
 
-        adapter.addPaymentMethodArgs.test {
-            assertThat(awaitItem()).isNull() // Initial value.
+        val listener = mock<PaymentMethodsAdapter.Listener>()
+        adapter.listener = listener
 
-            val viewHolder = adapter.createViewHolder(
-                FrameLayout(context),
-                PaymentMethodsAdapter.ViewType.AddFpx.ordinal
-            )
-            adapter.onBindViewHolder(viewHolder, 0)
-            viewHolder.itemView.performClick()
+        val viewHolder = adapter.createViewHolder(
+            FrameLayout(context),
+            PaymentMethodsAdapter.ViewType.AddFpx.ordinal
+        )
+        adapter.onBindViewHolder(viewHolder, 0)
+        viewHolder.itemView.performClick()
 
-            assertThat(awaitItem())
-                .isEqualTo(adapter.addFpxArgs)
-        }
+        verify(listener).onAddPaymentMethodClick(adapter.addFpxArgs)
     }
 
     private companion object {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the `Add new card…` button in the legacy SDK didn’t work when tapped a second time.

The issue happened because the mechanism uses a `StateFlow`, which doesn’t re-emit for the same value (here: for the same instance of the starter args). Switched it to a simple callback instead.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Resolves: https://github.com/stripe/stripe-android/issues/7745

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

[FIXED] Fixed an issue in `PaymentSession` where tapping the `Add card` button stopped working after it was clicked once.