### PR TITLE
[FC] Update proguard rules to support dexguard


### DIFF
--- a/financial-connections/consumer-rules.txt
+++ b/financial-connections/consumer-rules.txt
@@ -3,17 +3,9 @@
     *;
 }
 
-# Without this, MavericksViewModel implementations were missing the MemberClass dalvik annotation
-# which preventedMavericks from finding its companion object which has its factory.
--keep,allowobfuscation class ** extends com.airbnb.mvrx.MavericksViewModel {
-    <clinit>();
-}
-
-# MavericksViewModel companion object factories
--keep,allowobfuscation class ** implements com.airbnb.mvrx.MavericksViewModelFactory
-
--dontwarn com.google.crypto.tink.subtle.XChaCha20Poly1305
-
+# ------------------------
+#  MvRx Config
+# -----------------------
 
 # MavericksViewModel loads the Companion class via reflection and thus we need to make sure we keep
 # the name of the Companion object.
@@ -27,6 +19,8 @@
 -keepclassmembers,includedescriptorclasses,allowobfuscation class ** implements com.airbnb.mvrx.MavericksState {
    *;
 }
+
+-dontwarn com.google.crypto.tink.subtle.XChaCha20Poly1305
 
 # The MavericksState object and the names classes that implement the MavericksState interface need to be
 # kept as they are accessed via reflection.


### PR DESCRIPTION
# Summary

- Updates Mavericks related proguard rules based on [their docs](https://github.com/airbnb/mavericks/blob/376ca5761acbd029f583b7dbd2ba5bd414b710e8/docs/proguard.md#kotlin-reflection-with-proguarddexguardr8).

# Motivation
:notebook_with_decorative_cover: &nbsp;**Update proguard rules to support dexguard**
:globe_with_meridians: &nbsp;[BANKCON-8904](https://jira.corp.stripe.com/browse/BANKCON-8904)

> See <https://github.com/stripe/stripe-android/issues/7684>
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Manually verified: Ran all maestro tests in release (R8 full) mode. 

<img width="533" alt="image" src="https://github.com/stripe/stripe-android/assets/99293320/898abef8-a4e1-4a49-8098-5e17432ad9e7">

# Changelog
    - [Fixed] (Financial Connections) Updated proguard rules to support dexguard.