### PR TITLE
Add `LinearRetryDelaySupplier` and use it in `3DS2` & `PaymentFlowResultProcessor`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -230,11 +230,11 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
         }
 
         while (shouldRetry(stripeIntentResult) && remainingRetries > 1) {
-            val delayMs = retryDelaySupplier.getDelayMillis(
+            val delayDuration = retryDelaySupplier.getDelay(
                 MAX_RETRIES,
                 remainingRetries
             )
-            delay(delayMs)
+            delay(delayDuration)
             stripeIntentResult = if (shouldCallRefreshIntent(originalIntent)) {
                 refreshStripeIntent(
                     clientSecret = clientSecret,

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -12,6 +12,7 @@ import com.stripe.android.core.exception.MaxRetryReachedException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.core.networking.LinearRetryDelaySupplier
 import com.stripe.android.core.networking.RetryDelaySupplier
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
@@ -36,7 +37,7 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
     protected val stripeRepository: StripeRepository,
     private val logger: Logger,
     private val workContext: CoroutineContext,
-    private val retryDelaySupplier: RetryDelaySupplier = RetryDelaySupplier()
+    private val retryDelaySupplier: RetryDelaySupplier = LinearRetryDelaySupplier()
 ) {
     private val failureMessageFactory = PaymentFlowFailureMessageFactory(context)
 
@@ -290,7 +291,7 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
 
     internal companion object {
         val EXPAND_PAYMENT_METHOD = listOf("payment_method")
-        const val MAX_RETRIES = 3
+        const val MAX_RETRIES = 5
     }
 }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2ChallengeResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2ChallengeResultProcessor.kt
@@ -174,7 +174,7 @@ internal class DefaultStripe3ds2ChallengeResultProcessor @Inject constructor(
      * and [remainingRetries] is greater than 0, retry after a delay.
      * After [remainingRetries] are exhausted, stop attempts.
      *
-     * The delay logic can be found in [RetryDelaySupplier.getDelayMillis].
+     * The delay logic can be found in [RetryDelaySupplier.getDelay].
      *
      * @param challengeResult the result of the 3DS2 challenge flow.
      * @param remainingRetries the number of retry attempts remaining. Defaults to [MAX_RETRIES].
@@ -198,7 +198,7 @@ internal class DefaultStripe3ds2ChallengeResultProcessor @Inject constructor(
 
         return if (shouldRetry) {
             delay(
-                retryDelaySupplier.getDelayMillis(
+                retryDelaySupplier.getDelay(
                     MAX_RETRIES,
                     remainingRetries
                 )

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2ChallengeResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2ChallengeResultProcessor.kt
@@ -4,6 +4,7 @@ import com.stripe.android.StripeIntentResult
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
+import com.stripe.android.core.injection.LINEAR_DELAY
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.RetryDelaySupplier
@@ -15,6 +16,7 @@ import com.stripe.android.stripe3ds2.transaction.ChallengeResult
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -27,7 +29,7 @@ internal class DefaultStripe3ds2ChallengeResultProcessor @Inject constructor(
     private val stripeRepository: StripeRepository,
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
-    private val retryDelaySupplier: RetryDelaySupplier,
+    @Named(LINEAR_DELAY) private val retryDelaySupplier: RetryDelaySupplier,
     private val logger: Logger,
     @IOContext private val workContext: CoroutineContext
 ) : Stripe3ds2ChallengeResultProcessor {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelFactoryComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelFactoryComponent.kt
@@ -5,6 +5,7 @@ import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
+import com.stripe.android.core.injection.RetryDelayModule
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Named
@@ -16,7 +17,8 @@ import javax.inject.Singleton
         StripeRepositoryModule::class,
         Stripe3ds2TransactionModule::class,
         CoroutineContextModule::class,
-        CoreCommonModule::class
+        CoreCommonModule::class,
+        RetryDelayModule::class
     ]
 )
 internal interface Stripe3ds2TransactionViewModelFactoryComponent {

--- a/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
@@ -311,6 +311,8 @@ internal class PaymentIntentFlowResultProcessorTest {
             Result.success(processingIntent),
             Result.failure(APIConnectionException()),
             Result.failure(APIConnectionException()),
+            Result.failure(APIConnectionException()),
+            Result.failure(APIConnectionException()),
             Result.success(succeededIntent),
         )
 

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/DefaultStripe3ds2ChallengeResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/DefaultStripe3ds2ChallengeResultProcessorTest.kt
@@ -11,7 +11,7 @@ import com.stripe.android.core.exception.InvalidRequestException
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.ApiRequest
-import com.stripe.android.core.networking.RetryDelaySupplier
+import com.stripe.android.core.networking.LinearRetryDelaySupplier
 import com.stripe.android.model.Stripe3ds2AuthResult
 import com.stripe.android.model.Stripe3ds2AuthResultFixtures
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
@@ -52,7 +52,7 @@ class DefaultStripe3ds2ChallengeResultProcessorTest {
         stripeRepository,
         analyticsRequestExecutor,
         analyticsRequestFactory,
-        RetryDelaySupplier(),
+        LinearRetryDelaySupplier(),
         Logger.noop(),
         testDispatcher
     )

--- a/stripe-core/src/main/java/com/stripe/android/core/injection/NamedConstants.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/injection/NamedConstants.kt
@@ -37,3 +37,15 @@ const val SHIPPING_VALUES = "shippingValues"
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 const val IS_LIVE_MODE = "isLiveMode"
+
+/**
+ * Name for linear delay supplier
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val LINEAR_DELAY = "linearDelaySupplier"
+
+/**
+ * Name for exponential backoff delay supplier
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val EXPONENTIAL_BACKOFF_DELAY = "exponentialBackoffDelaySupplier"

--- a/stripe-core/src/main/java/com/stripe/android/core/injection/RetryDelayModule.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/injection/RetryDelayModule.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.core.injection
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.core.networking.ExponentialBackoffRetryDelaySupplier
+import com.stripe.android.core.networking.LinearRetryDelaySupplier
+import com.stripe.android.core.networking.RetryDelaySupplier
+import dagger.Binds
+import dagger.Module
+import javax.inject.Named
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Module
+interface RetryDelayModule {
+    @Binds
+    fun bindsDefaultRetryDelaySupplier(
+        retryDelaySupplier: ExponentialBackoffRetryDelaySupplier
+    ): RetryDelaySupplier
+
+    @Binds
+    @Named(LINEAR_DELAY)
+    fun bindsLinearRetryDelaySupplier(
+        retryDelaySupplier: LinearRetryDelaySupplier
+    ): RetryDelaySupplier
+
+    @Binds
+    @Named(EXPONENTIAL_BACKOFF_DELAY)
+    fun bindsExponentialBackoffRetryDelaySupplier(
+        retryDelaySupplier: ExponentialBackoffRetryDelaySupplier
+    ): RetryDelaySupplier
+}

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/DefaultStripeNetworkClient.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/DefaultStripeNetworkClient.kt
@@ -48,7 +48,7 @@ class DefaultStripeNetworkClient @JvmOverloads constructor(
             )
 
             delay(
-                retryDelaySupplier.getDelayMillis(
+                retryDelaySupplier.getDelay(
                     DEFAULT_MAX_RETRIES,
                     remainingRetries
                 )

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/DefaultStripeNetworkClient.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/DefaultStripeNetworkClient.kt
@@ -15,7 +15,7 @@ import kotlin.coroutines.CoroutineContext
 class DefaultStripeNetworkClient @JvmOverloads constructor(
     private val workContext: CoroutineContext = Dispatchers.IO,
     private val connectionFactory: ConnectionFactory = ConnectionFactory.Default,
-    private val retryDelaySupplier: RetryDelaySupplier = RetryDelaySupplier(),
+    private val retryDelaySupplier: RetryDelaySupplier = ExponentialBackoffRetryDelaySupplier(),
     private val maxRetries: Int = DEFAULT_MAX_RETRIES,
     private val logger: Logger = Logger.noop()
 ) : StripeNetworkClient {

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/ExponentialBackoffRetryDelaySupplier.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/ExponentialBackoffRetryDelaySupplier.kt
@@ -1,0 +1,43 @@
+package com.stripe.android.core.networking
+
+import androidx.annotation.RestrictTo
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.math.pow
+
+@Singleton
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class ExponentialBackoffRetryDelaySupplier(
+    private val incrementSeconds: Long
+) : RetryDelaySupplier {
+
+    @Inject
+    constructor() : this(DEFAULT_INCREMENT_SECONDS)
+
+    /**
+     * Calculate an exponential backoff delay before retrying the next completion request
+     * using the equation:
+     * ```
+     * incrementSeconds ^ ((maxRetries - remainingRetries) + 1)
+     * ```
+     *
+     * For example, if [maxRetries] is 3:
+     * - Delay 2 seconds before the first retry
+     * - Delay 4 seconds before the second retry
+     * - Delay 8 seconds before the third retry
+     */
+    override fun getDelayMillis(
+        maxRetries: Int,
+        remainingRetries: Int
+    ): Long {
+        val retryAttempt = maxRetries - remainingRetries.coerceIn(1, maxRetries) + 1
+        return TimeUnit.SECONDS.toMillis(
+            incrementSeconds.toDouble().pow(retryAttempt).toLong()
+        )
+    }
+
+    private companion object {
+        private const val DEFAULT_INCREMENT_SECONDS = 2L
+    }
+}

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/LinearRetryDelaySupplier.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/LinearRetryDelaySupplier.kt
@@ -1,29 +1,31 @@
 package com.stripe.android.core.networking
 
 import androidx.annotation.RestrictTo
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 @Singleton
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class LinearRetryDelaySupplier(
-    private val delay: Long
+    private val delay: Duration
 ) : RetryDelaySupplier {
 
     @Inject
-    constructor() : this(DEFAULT_DELAY)
+    constructor() : this(DEFAULT_DELAY.toDuration(DurationUnit.SECONDS))
 
     /**
      * Gets a linear delay time regardless of provided parameters
      *
-     * @return static delay in milliseconds
+     * @return static delay as a [Duration] object
      */
-    override fun getDelayMillis(
+    override fun getDelay(
         maxRetries: Int,
         remainingRetries: Int
-    ): Long {
-        return TimeUnit.SECONDS.toMillis(delay)
+    ): Duration {
+        return delay
     }
 
     private companion object {

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/LinearRetryDelaySupplier.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/LinearRetryDelaySupplier.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.core.networking
+
+import androidx.annotation.RestrictTo
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class LinearRetryDelaySupplier(
+    private val delay: Long
+) : RetryDelaySupplier {
+
+    @Inject
+    constructor() : this(DEFAULT_DELAY)
+
+    /**
+     * Gets a linear delay time regardless of provided parameters
+     *
+     * @return static delay in milliseconds
+     */
+    override fun getDelayMillis(
+        maxRetries: Int,
+        remainingRetries: Int
+    ): Long {
+        return TimeUnit.SECONDS.toMillis(delay)
+    }
+
+    private companion object {
+        private const val DEFAULT_DELAY = 3L
+    }
+}

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/RetryDelaySupplier.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/RetryDelaySupplier.kt
@@ -1,43 +1,20 @@
 package com.stripe.android.core.networking
 
 import androidx.annotation.RestrictTo
-import java.util.concurrent.TimeUnit
-import javax.inject.Inject
-import javax.inject.Singleton
-import kotlin.math.pow
 
-@Singleton
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class RetryDelaySupplier(
-    private val incrementSeconds: Long
-) {
-
-    @Inject
-    constructor() : this(DEFAULT_INCREMENT_SECONDS)
+interface RetryDelaySupplier {
 
     /**
-     * Calculate an exponential backoff delay before retrying the next completion request
-     * using the equation:
-     * ```
-     * incrementSeconds ^ ((maxRetries - remainingRetries) + 1)
-     * ```
+     * Gets a delay in milliseconds based on the max retries and remaining retries
      *
-     * For example, if [maxRetries] is 3:
-     * - Delay 2 seconds before the first retry
-     * - Delay 4 seconds before the second retry
-     * - Delay 8 seconds before the third retry
+     * @param maxRetries maximum amount of available retries
+     * @param remainingRetries remaining number of retries available
+     *
+     * @return new delay in milliseconds
      */
     fun getDelayMillis(
         maxRetries: Int,
         remainingRetries: Int
-    ): Long {
-        val retryAttempt = maxRetries - remainingRetries.coerceIn(1, maxRetries) + 1
-        return TimeUnit.SECONDS.toMillis(
-            incrementSeconds.toDouble().pow(retryAttempt).toLong()
-        )
-    }
-
-    private companion object {
-        private const val DEFAULT_INCREMENT_SECONDS = 2L
-    }
+    ): Long
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/RetryDelaySupplier.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/RetryDelaySupplier.kt
@@ -1,20 +1,21 @@
 package com.stripe.android.core.networking
 
 import androidx.annotation.RestrictTo
+import kotlin.time.Duration
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface RetryDelaySupplier {
 
     /**
-     * Gets a delay in milliseconds based on the max retries and remaining retries
+     * Gets a delay based on the max retries and remaining retries
      *
      * @param maxRetries maximum amount of available retries
      * @param remainingRetries remaining number of retries available
      *
-     * @return new delay in milliseconds
+     * @return new delay as a [Duration] object
      */
-    fun getDelayMillis(
+    fun getDelay(
         maxRetries: Int,
         remainingRetries: Int
-    ): Long
+    ): Duration
 }

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/DefaultStripeNetworkClientTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/DefaultStripeNetworkClientTest.kt
@@ -29,6 +29,7 @@ import java.net.UnknownHostException
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.time.Duration
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
@@ -138,7 +139,7 @@ internal class DefaultStripeNetworkClientTest {
             val client = DefaultStripeNetworkClient(
                 workContext = testDispatcher,
                 connectionFactory = connectionFactory,
-                retryDelaySupplier = ExponentialBackoffRetryDelaySupplier(0)
+                retryDelaySupplier = ExponentialBackoffRetryDelaySupplier(Duration.ZERO)
             )
 
             val response = client.executeRequest(FakeStripeRequest())
@@ -161,7 +162,7 @@ internal class DefaultStripeNetworkClientTest {
             val client = DefaultStripeNetworkClient(
                 workContext = testDispatcher,
                 connectionFactory = connectionFactory,
-                retryDelaySupplier = ExponentialBackoffRetryDelaySupplier(0),
+                retryDelaySupplier = ExponentialBackoffRetryDelaySupplier(Duration.ZERO),
                 logger = mockLogger
             )
 
@@ -182,7 +183,7 @@ internal class DefaultStripeNetworkClientTest {
             val executor = DefaultStripeNetworkClient(
                 workContext = testDispatcher,
                 connectionFactory = connectionFactory,
-                retryDelaySupplier = ExponentialBackoffRetryDelaySupplier(0)
+                retryDelaySupplier = ExponentialBackoffRetryDelaySupplier(Duration.ZERO)
             )
 
             val response = executor.executeRequest(FakeStripeRequest())

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/DefaultStripeNetworkClientTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/DefaultStripeNetworkClientTest.kt
@@ -138,7 +138,7 @@ internal class DefaultStripeNetworkClientTest {
             val client = DefaultStripeNetworkClient(
                 workContext = testDispatcher,
                 connectionFactory = connectionFactory,
-                retryDelaySupplier = RetryDelaySupplier(0)
+                retryDelaySupplier = ExponentialBackoffRetryDelaySupplier(0)
             )
 
             val response = client.executeRequest(FakeStripeRequest())
@@ -161,7 +161,7 @@ internal class DefaultStripeNetworkClientTest {
             val client = DefaultStripeNetworkClient(
                 workContext = testDispatcher,
                 connectionFactory = connectionFactory,
-                retryDelaySupplier = RetryDelaySupplier(0),
+                retryDelaySupplier = ExponentialBackoffRetryDelaySupplier(0),
                 logger = mockLogger
             )
 
@@ -182,7 +182,7 @@ internal class DefaultStripeNetworkClientTest {
             val executor = DefaultStripeNetworkClient(
                 workContext = testDispatcher,
                 connectionFactory = connectionFactory,
-                retryDelaySupplier = RetryDelaySupplier(0)
+                retryDelaySupplier = ExponentialBackoffRetryDelaySupplier(0)
             )
 
             val response = executor.executeRequest(FakeStripeRequest())

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/ExponentialBackoffRetryDelaySupplierTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/ExponentialBackoffRetryDelaySupplierTest.kt
@@ -3,11 +3,11 @@ package com.stripe.android.core.networking
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
-class RetryDelaySupplierTest {
+class ExponentialBackoffRetryDelaySupplierTest {
 
     @Test
     fun `getDelayMillis() should return expected value`() {
-        val supplier = RetryDelaySupplier()
+        val supplier = ExponentialBackoffRetryDelaySupplier()
 
         // coerce to 3 remaining retries
         assertThat(

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/ExponentialBackoffRetryDelaySupplierTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/ExponentialBackoffRetryDelaySupplierTest.kt
@@ -2,56 +2,58 @@ package com.stripe.android.core.networking
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 class ExponentialBackoffRetryDelaySupplierTest {
 
     @Test
-    fun `getDelayMillis() should return expected value`() {
+    fun `getDelay() should return expected value`() {
         val supplier = ExponentialBackoffRetryDelaySupplier()
 
         // coerce to 3 remaining retries
         assertThat(
-            supplier.getDelayMillis(
+            supplier.getDelay(
                 maxRetries = 3,
                 remainingRetries = 999
             )
-        ).isEqualTo(2000L)
+        ).isEqualTo((2L).toDuration(DurationUnit.SECONDS))
 
         assertThat(
-            supplier.getDelayMillis(
+            supplier.getDelay(
                 maxRetries = 3,
                 remainingRetries = 3
             )
-        ).isEqualTo(2000L)
+        ).isEqualTo((2L).toDuration(DurationUnit.SECONDS))
 
         assertThat(
-            supplier.getDelayMillis(
+            supplier.getDelay(
                 maxRetries = 3,
                 remainingRetries = 2
             )
-        ).isEqualTo(4000L)
+        ).isEqualTo((4L).toDuration(DurationUnit.SECONDS))
 
         assertThat(
-            supplier.getDelayMillis(
+            supplier.getDelay(
                 maxRetries = 3,
                 remainingRetries = 1
             )
-        ).isEqualTo(8000L)
+        ).isEqualTo((8L).toDuration(DurationUnit.SECONDS))
 
         // coerce to 1 remaining retry
         assertThat(
-            supplier.getDelayMillis(
+            supplier.getDelay(
                 maxRetries = 3,
                 remainingRetries = -100
             )
-        ).isEqualTo(8000L)
+        ).isEqualTo((8L).toDuration(DurationUnit.SECONDS))
 
         // coerce to 1 remaining retry
         assertThat(
-            supplier.getDelayMillis(
+            supplier.getDelay(
                 maxRetries = 3,
                 remainingRetries = 0
             )
-        ).isEqualTo(8000L)
+        ).isEqualTo((8L).toDuration(DurationUnit.SECONDS))
     }
 }

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/LinearRetryDelaySupplierTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/LinearRetryDelaySupplierTest.kt
@@ -1,0 +1,56 @@
+package com.stripe.android.core.networking
+
+import com.google.common.truth.Truth
+import org.junit.Test
+
+class LinearRetryDelaySupplierTest {
+    @Test
+    fun `getDelayMillis() should return expected value`() {
+        val supplier = LinearRetryDelaySupplier()
+
+        // coerce to 3 remaining retries
+        Truth.assertThat(
+            supplier.getDelayMillis(
+                maxRetries = 3,
+                remainingRetries = 999
+            )
+        ).isEqualTo(3000L)
+
+        Truth.assertThat(
+            supplier.getDelayMillis(
+                maxRetries = 3,
+                remainingRetries = 3
+            )
+        ).isEqualTo(3000L)
+
+        Truth.assertThat(
+            supplier.getDelayMillis(
+                maxRetries = 3,
+                remainingRetries = 2
+            )
+        ).isEqualTo(3000L)
+
+        Truth.assertThat(
+            supplier.getDelayMillis(
+                maxRetries = 3,
+                remainingRetries = 1
+            )
+        ).isEqualTo(3000L)
+
+        // coerce to 1 remaining retry
+        Truth.assertThat(
+            supplier.getDelayMillis(
+                maxRetries = 3,
+                remainingRetries = -100
+            )
+        ).isEqualTo(3000L)
+
+        // coerce to 1 remaining retry
+        Truth.assertThat(
+            supplier.getDelayMillis(
+                maxRetries = 3,
+                remainingRetries = 0
+            )
+        ).isEqualTo(3000L)
+    }
+}

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/LinearRetryDelaySupplierTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/LinearRetryDelaySupplierTest.kt
@@ -1,56 +1,58 @@
 package com.stripe.android.core.networking
 
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 class LinearRetryDelaySupplierTest {
     @Test
-    fun `getDelayMillis() should return expected value`() {
+    fun `getDelay() should return expected value`() {
         val supplier = LinearRetryDelaySupplier()
 
         // coerce to 3 remaining retries
-        Truth.assertThat(
-            supplier.getDelayMillis(
+        assertThat(
+            supplier.getDelay(
                 maxRetries = 3,
                 remainingRetries = 999
             )
-        ).isEqualTo(3000L)
+        ).isEqualTo((3L).toDuration(DurationUnit.SECONDS))
 
-        Truth.assertThat(
-            supplier.getDelayMillis(
+        assertThat(
+            supplier.getDelay(
                 maxRetries = 3,
                 remainingRetries = 3
             )
-        ).isEqualTo(3000L)
+        ).isEqualTo((3L).toDuration(DurationUnit.SECONDS))
 
-        Truth.assertThat(
-            supplier.getDelayMillis(
+        assertThat(
+            supplier.getDelay(
                 maxRetries = 3,
                 remainingRetries = 2
             )
-        ).isEqualTo(3000L)
+        ).isEqualTo((3L).toDuration(DurationUnit.SECONDS))
 
-        Truth.assertThat(
-            supplier.getDelayMillis(
+        assertThat(
+            supplier.getDelay(
                 maxRetries = 3,
                 remainingRetries = 1
             )
-        ).isEqualTo(3000L)
+        ).isEqualTo((3L).toDuration(DurationUnit.SECONDS))
 
         // coerce to 1 remaining retry
-        Truth.assertThat(
-            supplier.getDelayMillis(
+        assertThat(
+            supplier.getDelay(
                 maxRetries = 3,
                 remainingRetries = -100
             )
-        ).isEqualTo(3000L)
+        ).isEqualTo((3L).toDuration(DurationUnit.SECONDS))
 
         // coerce to 1 remaining retry
-        Truth.assertThat(
-            supplier.getDelayMillis(
+        assertThat(
+            supplier.getDelay(
                 maxRetries = 3,
                 remainingRetries = 0
             )
-        ).isEqualTo(3000L)
+        ).isEqualTo((3L).toDuration(DurationUnit.SECONDS))
     }
 }


### PR DESCRIPTION
# Summary
Add `LinearRetryDelaySupplier` and use it in `3DS2` & `PaymentFlowResultProcessor`

# Motivation
Resolves [MOBILESDK-1522](https://jira.corp.stripe.com/browse/MOBILESDK-1522)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
