### PR TITLE
[POC] Add Sail colors to ui core module and StripeTheme

### DIFF
--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/StripeTheme.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/StripeTheme.kt
@@ -41,6 +41,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.ColorUtils
+import com.stripe.android.uicore.theme.LocalSailColors
+import com.stripe.android.uicore.theme.sailColors
 import java.lang.Float.max
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -335,6 +337,7 @@ fun StripeTheme(
         LocalColors provides colors,
         LocalShapes provides shapes,
         LocalTypography provides typography,
+        LocalSailColors provides sailColors,
         LocalInspectionMode provides inspectionMode,
     ) {
         MaterialTheme(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldUI.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.platform.LocalInputModeManager
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -95,7 +94,6 @@ fun DropDown(
     Box(
         modifier = modifier
             .wrapContentSize(Alignment.TopStart)
-            .background(MaterialTheme.stripeColors.component)
     ) {
         // Click handling happens on the box, so that it is a single accessible item
         Box(
@@ -116,14 +114,6 @@ fun DropDown(
                         selectedItemLabel,
                         color = currentTextColor
                     )
-                    if (!shouldDisableDropdownWithSingleItem) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.stripe_ic_chevron_down),
-                            contentDescription = null,
-                            modifier = Modifier.height(24.dp),
-                            tint = MaterialTheme.stripeColors.placeholderText
-                        )
-                    }
                 }
             } else {
                 Row(
@@ -147,16 +137,6 @@ fun DropDown(
                             Text(
                                 selectedItemLabel,
                                 color = currentTextColor
-                            )
-                        }
-                    }
-                    if (!shouldDisableDropdownWithSingleItem) {
-                        Column(modifier = Modifier.align(Alignment.CenterVertically)) {
-                            Icon(
-                                painter = painterResource(id = R.drawable.stripe_ic_chevron_down),
-                                contentDescription = null,
-                                modifier = Modifier.height(24.dp),
-                                tint = currentTextColor
                             )
                         }
                     }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberElementUI.kt
@@ -5,10 +5,12 @@ package com.stripe.android.uicore.elements
 import androidx.annotation.RestrictTo
 import androidx.annotation.StringRes
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.relocation.bringIntoViewRequester
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Text
@@ -36,6 +38,8 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.stripe.android.uicore.R
+import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.theme.SailTheme
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import com.stripe.android.core.R as CoreR
@@ -46,10 +50,12 @@ const val PHONE_NUMBER_TEXT_FIELD_TAG = "PhoneNumberTextField"
 @Preview
 @Composable
 private fun PhoneNumberCollectionPreview() {
-    PhoneNumberCollectionSection(
-        enabled = true,
-        phoneNumberController = PhoneNumberController.createPhoneNumberController("6508989787")
-    )
+    StripeTheme {
+        PhoneNumberCollectionSection(
+            enabled = true,
+            phoneNumberController = PhoneNumberController.createPhoneNumberController()
+        )
+    }
 }
 
 @Composable
@@ -140,7 +146,12 @@ fun PhoneNumberElementUI(
             DropDown(
                 controller = controller.countryDropdownController,
                 enabled = enabled,
-                modifier = Modifier.padding(start = 16.dp, end = 8.dp)
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .background(
+                        color = SailTheme.colors.backgroundOffset,
+                        shape = RoundedCornerShape(8.dp)
+                    ).padding(12.dp)
             )
         },
         visualTransformation = visualTransformation,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/theme/SailColors.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/theme/SailColors.kt
@@ -1,0 +1,60 @@
+package com.stripe.android.uicore.theme
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+
+/**
+ * This class reflects the colors used in the Sail theme.
+ * They should be kept in sync with the color declaration in Figma:
+ * https://www.figma.com/file/WAFvoybps5uk3FL4tftaee/Sail?type=design
+ */
+@Immutable
+internal data class SailColors(
+    val textDefault: Color,
+    val textSubdued: Color,
+    val textDisabled: Color,
+    val textWhite: Color,
+    val textBrand: Color,
+    val textCritical: Color,
+    val iconDefault: Color,
+    val iconSubdued: Color,
+    val iconWhite: Color,
+    val iconBrand: Color,
+    val buttonPrimary: Color,
+    val buttonPrimaryHover: Color,
+    val buttonPrimaryPressed: Color,
+    val buttonSecondary: Color,
+    val buttonSecondaryHover: Color,
+    val buttonSecondaryPressed: Color,
+    val backgroundSurface: Color,
+    val background: Color,
+    val backgroundOffset: Color,
+    val backgroundBrand: Color,
+    val border: Color,
+    val borderBrand: Color
+)
+
+internal val sailColors = SailColors(
+    textDefault = Color(0xFF353A44),
+    textSubdued = Color(0xFF596171),
+    textDisabled = Color(0xFF818DA0),
+    textWhite = Color(0xFFFFFFFF),
+    textBrand = Color(0xFF533AFD),
+    textCritical = Color(0xFFC0123C),
+    iconDefault = Color(0xFF474E5A),
+    iconSubdued = Color(0xFF6C7688),
+    iconWhite = Color(0xFFFFFFFF),
+    iconBrand = Color(0xFF675DFF),
+    buttonPrimary = Color(0xFF675DFF),
+    buttonPrimaryHover = Color(0xFF857AFE),
+    buttonPrimaryPressed = Color(0xFF533AFD),
+    buttonSecondary = Color(0xFFF5F6F8),
+    buttonSecondaryHover = Color(0xFFF5F6F8),
+    buttonSecondaryPressed = Color(0xFFEBEEF1),
+    background = Color(0xFFF5F6F8),
+    backgroundSurface = Color(0xFFFFFFFF),
+    backgroundOffset = Color(0xFFF6F8FA),
+    backgroundBrand = Color(0xFFF5F6F8),
+    border = Color(0xFFD8DEE4),
+    borderBrand = Color(0xFF675DFF)
+)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/theme/SailTheme.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/theme/SailTheme.kt
@@ -1,0 +1,14 @@
+package com.stripe.android.uicore.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.staticCompositionLocalOf
+
+internal object SailTheme {
+    val colors: SailColors
+        @Composable
+        get() = LocalSailColors.current
+}
+
+internal val LocalSailColors = staticCompositionLocalOf<SailColors> {
+    error("No SailColors provided")
+}


### PR DESCRIPTION
# Summary
- Introduces `SailColors` on the `ui-core` module, so that base components used across SDKs can make use of them
- Provides `SailColors` via StripeTheme together with the existing theme values. 

Also showcases its usage on the `PhoneInput` component:

<img width="668" alt="image" src="https://github.com/stripe/stripe-android/assets/99293320/46eed1e1-a7ed-4fb2-83b8-f0b5842d82b1">

# Motivation
:notebook_with_decorative_cover: &nbsp;**Add Sail colors to ui core module and StripeTheme**
:globe_with_meridians: &nbsp;[BANKCON-8927](https://jira.corp.stripe.com/browse/BANKCON-8927)
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->