### PR TITLE
Force `analyticsValue` on all StripeException subclasses

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/AppInitializationError.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/AppInitializationError.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.exception
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.core.exception.StripeException
 
 class AppInitializationError(message: String) : StripeException(
@@ -9,5 +10,6 @@ class AppInitializationError(message: String) : StripeException(
     statusCode = 0,
     stripeError = null
 ) {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     override fun analyticsValue(): String? = null
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/AppInitializationError.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/AppInitializationError.kt
@@ -8,4 +8,6 @@ class AppInitializationError(message: String) : StripeException(
     requestId = null,
     statusCode = 0,
     stripeError = null
-)
+) {
+    override fun analyticsValue(): String? = null
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/CustomManualEntryRequiredError.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/CustomManualEntryRequiredError.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.exception
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.core.exception.StripeException
 
 /**
@@ -7,5 +8,6 @@ import com.stripe.android.core.exception.StripeException
  *
  */
 class CustomManualEntryRequiredError : StripeException() {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     override fun analyticsValue(): String? = null
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/CustomManualEntryRequiredError.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/CustomManualEntryRequiredError.kt
@@ -6,4 +6,6 @@ import com.stripe.android.core.exception.StripeException
  * The AuthFlow was prematurely cancelled due to user requesting manual entry.
  *
  */
-class CustomManualEntryRequiredError : StripeException()
+class CustomManualEntryRequiredError : StripeException() {
+    override fun analyticsValue(): String? = null
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/FinancialConnectionsError.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/FinancialConnectionsError.kt
@@ -14,4 +14,6 @@ internal abstract class FinancialConnectionsError(
     stripeException.statusCode,
     stripeException.cause,
     stripeException.message
-)
+) {
+    override fun analyticsValue(): String? = null
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/FinancialConnectionsError.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/FinancialConnectionsError.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.exception
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.core.exception.StripeException
 
 /**
@@ -15,5 +16,6 @@ internal abstract class FinancialConnectionsError(
     stripeException.cause,
     stripeException.message
 ) {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     override fun analyticsValue(): String? = null
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/Errors.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/Errors.kt
@@ -56,7 +56,9 @@ internal class PollingReachedMaxRetriesException(
 ) : StripeException(
     message = "reached max number of retries ${pollingOptions.maxNumberOfRetries}.",
     statusCode = HttpURLConnection.HTTP_ACCEPTED
-)
+) {
+    override fun analyticsValue(): String = "pollingReachedMaxRetriesError"
+}
 
 /**
  * returns true if exception represents a [HttpURLConnection.HTTP_ACCEPTED] API response.

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/Errors.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/Errors.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.utils
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.core.exception.StripeException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
@@ -57,6 +58,7 @@ internal class PollingReachedMaxRetriesException(
     message = "reached max number of retries ${pollingOptions.maxNumberOfRetries}.",
     statusCode = HttpURLConnection.HTTP_ACCEPTED
 ) {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     override fun analyticsValue(): String = "pollingReachedMaxRetriesError"
 }
 

--- a/payments-core/src/main/java/com/stripe/android/exception/CardException.kt
+++ b/payments-core/src/main/java/com/stripe/android/exception/CardException.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.exception
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.StripeException
 import java.net.HttpURLConnection
@@ -22,5 +23,6 @@ class CardException(
     val declineCode: String? = stripeError.declineCode
     val charge: String? = stripeError.charge
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     override fun analyticsValue(): String = "cardError"
 }

--- a/payments-core/src/main/java/com/stripe/android/exception/CardException.kt
+++ b/payments-core/src/main/java/com/stripe/android/exception/CardException.kt
@@ -21,4 +21,6 @@ class CardException(
     val param: String? = stripeError.param
     val declineCode: String? = stripeError.declineCode
     val charge: String? = stripeError.charge
+
+    override fun analyticsValue(): String = "cardError"
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
@@ -100,7 +100,10 @@ internal class StripeBrowserLauncherViewModel(
 
     fun getFailureIntent(args: PaymentBrowserAuthContract.Args): Intent {
         val url = Uri.parse(args.url)
-        val exception = LocalStripeException(displayMessage = resolveErrorMessage)
+        val exception = LocalStripeException(
+            displayMessage = resolveErrorMessage,
+            analyticsValue = "failedBrowserLaunchError",
+        )
 
         return Intent().putExtras(
             PaymentFlowResult.Unvalidated(

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -234,17 +234,26 @@ internal class PaymentLauncherViewModel @Inject constructor(
                     InternalPaymentResult.Completed(stripeIntentResult.intent)
                 StripeIntentResult.Outcome.FAILED ->
                     InternalPaymentResult.Failed(
-                        LocalStripeException(displayMessage = stripeIntentResult.failureMessage)
+                        LocalStripeException(
+                            displayMessage = stripeIntentResult.failureMessage,
+                            analyticsValue = "failedIntentOutcomeError",
+                        )
                     )
                 StripeIntentResult.Outcome.CANCELED ->
                     InternalPaymentResult.Canceled
                 StripeIntentResult.Outcome.TIMEDOUT ->
                     InternalPaymentResult.Failed(
-                        LocalStripeException(displayMessage = TIMEOUT_ERROR + stripeIntentResult.failureMessage)
+                        LocalStripeException(
+                            displayMessage = TIMEOUT_ERROR + stripeIntentResult.failureMessage,
+                            analyticsValue = "timedOutIntentOutcomeError",
+                        )
                     )
                 else ->
                     InternalPaymentResult.Failed(
-                        LocalStripeException(displayMessage = UNKNOWN_ERROR + stripeIntentResult.failureMessage)
+                        LocalStripeException(
+                            displayMessage = UNKNOWN_ERROR + stripeIntentResult.failureMessage,
+                            analyticsValue = "unknownIntentOutcomeError",
+                        )
                     )
             }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetConfirmationError.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetConfirmationError.kt
@@ -1,8 +1,5 @@
 package com.stripe.android.paymentsheet.analytics
 
-import com.stripe.android.core.exception.APIConnectionException
-import com.stripe.android.core.exception.APIException
-import com.stripe.android.core.exception.InvalidRequestException
 import com.stripe.android.core.exception.StripeException
 
 internal sealed class PaymentSheetConfirmationError : Throwable() {
@@ -12,7 +9,7 @@ internal sealed class PaymentSheetConfirmationError : Throwable() {
     data class Stripe(override val cause: Throwable) : PaymentSheetConfirmationError() {
 
         override val analyticsValue: String
-            get() = StripeException.create(cause).analyticsValue
+            get() = StripeException.create(cause).analyticsValue() ?: "unknown"
     }
 
     data class GooglePay(val errorCode: Int) : PaymentSheetConfirmationError() {
@@ -27,11 +24,3 @@ internal sealed class PaymentSheetConfirmationError : Throwable() {
             get() = "invalidState"
     }
 }
-
-internal val StripeException.analyticsValue: String
-    get() = when (this) {
-        is APIException -> "apiError"
-        is APIConnectionException -> "connectionError"
-        is InvalidRequestException -> "invalidRequestError"
-        else -> "unknown"
-    }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoadingException.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoadingException.kt
@@ -4,7 +4,6 @@ import com.stripe.android.core.exception.StripeException
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.paymentsheet.analytics.analyticsValue
 import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException.Unknown
 
 internal sealed class PaymentSheetLoadingException : Throwable() {
@@ -80,7 +79,7 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
     ) : PaymentSheetLoadingException() {
 
         override val type: String
-            get() = StripeException.create(cause).analyticsValue
+            get() = StripeException.create(cause).analyticsValue() ?: "unknown"
 
         override val message: String? = cause.message
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/exception/StripeErrorMessageTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/exception/StripeErrorMessageTest.kt
@@ -30,7 +30,7 @@ internal class StripeErrorMessageTest {
 
     @Test
     fun testLocalStripeException() {
-        assertThatStripeErrorMessage(LocalStripeException("Hi mom"))
+        assertThatStripeErrorMessage(LocalStripeException("Hi mom", null))
             .isEqualTo("Hi mom")
     }
 
@@ -60,7 +60,7 @@ internal class StripeErrorMessageTest {
 
     @Test
     fun testLocalStripeExceptionWithResolvableString() {
-        assertThatResolvableStripeErrorMessage(LocalStripeException("Hi mom"))
+        assertThatResolvableStripeErrorMessage(LocalStripeException("Hi mom", null))
             .isEqualTo(resolvableString("Hi mom"))
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditPaymentMethodViewInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditPaymentMethodViewInteractorTest.kt
@@ -169,7 +169,7 @@ class DefaultEditPaymentMethodViewInteractorTest {
     fun `on remove pressed, should fail removal process`() = runTest {
         val onRemove: (paymentMethod: PaymentMethod) -> Throwable? = mock {
             onGeneric { invoke(any()) }.thenAnswer {
-                LocalStripeException("Failed to remove")
+                LocalStripeException("Failed to remove", null)
             }
         }
 
@@ -237,7 +237,7 @@ class DefaultEditPaymentMethodViewInteractorTest {
         val onUpdate: (paymentMethod: PaymentMethod, brand: CardBrand) -> Result<PaymentMethod> = mock {
             onGeneric { invoke(any(), any()) }.thenAnswer {
                 Result.failure<PaymentMethod>(
-                    LocalStripeException("Failed to update")
+                    LocalStripeException("Failed to update", null)
                 )
             }
         }

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/APIConnectionException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/APIConnectionException.kt
@@ -13,6 +13,7 @@ class APIConnectionException(
     cause = cause,
     message = message
 ) {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     override fun analyticsValue(): String = "connectionError"
 
     companion object {

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/APIConnectionException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/APIConnectionException.kt
@@ -13,6 +13,8 @@ class APIConnectionException(
     cause = cause,
     message = message
 ) {
+    override fun analyticsValue(): String = "connectionError"
+
     companion object {
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @JvmSynthetic

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/APIException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/APIException.kt
@@ -24,4 +24,6 @@ class APIException(
         message = throwable.message,
         cause = throwable
     )
+
+    override fun analyticsValue(): String = "apiError"
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/APIException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/APIException.kt
@@ -25,5 +25,6 @@ class APIException(
         cause = throwable
     )
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     override fun analyticsValue(): String = "apiError"
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/AuthenticationException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/AuthenticationException.kt
@@ -19,5 +19,6 @@ constructor(
     requestId,
     HttpURLConnection.HTTP_UNAUTHORIZED
 ) {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     override fun analyticsValue(): String = "authError"
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/AuthenticationException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/AuthenticationException.kt
@@ -18,4 +18,6 @@ constructor(
     stripeError,
     requestId,
     HttpURLConnection.HTTP_UNAUTHORIZED
-)
+) {
+    override fun analyticsValue(): String = "authError"
+}

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/InvalidRequestException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/InvalidRequestException.kt
@@ -17,4 +17,6 @@ class InvalidRequestException(
     statusCode,
     cause,
     message
-)
+) {
+    override fun analyticsValue(): String = "invalidRequestError"
+}

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/InvalidRequestException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/InvalidRequestException.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.core.exception
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.core.StripeError
 
 /**
@@ -18,5 +19,6 @@ class InvalidRequestException(
     cause,
     message
 ) {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     override fun analyticsValue(): String = "invalidRequestError"
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/InvalidResponseException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/InvalidResponseException.kt
@@ -21,4 +21,6 @@ class InvalidResponseException(
     statusCode,
     cause,
     message
-)
+) {
+    override fun analyticsValue(): String = "invalidResponseError"
+}

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/InvalidResponseException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/InvalidResponseException.kt
@@ -22,5 +22,6 @@ class InvalidResponseException(
     cause,
     message
 ) {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     override fun analyticsValue(): String = "invalidResponseError"
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/LocalStripeException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/LocalStripeException.kt
@@ -9,5 +9,6 @@ class LocalStripeException(
 ) : StripeException(
     message = displayMessage
 ) {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     override fun analyticsValue(): String = analyticsValue ?: "unknown"
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/LocalStripeException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/LocalStripeException.kt
@@ -4,7 +4,10 @@ import androidx.annotation.RestrictTo
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class LocalStripeException(
-    val displayMessage: String?
+    val displayMessage: String?,
+    val analyticsValue: String?,
 ) : StripeException(
     message = displayMessage
-)
+) {
+    override fun analyticsValue(): String = analyticsValue ?: "unknown"
+}

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/MaxRetryReachedException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/MaxRetryReachedException.kt
@@ -6,5 +6,6 @@ import androidx.annotation.RestrictTo
  * An [Exception] that represents max retry is reached when making a request.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class MaxRetryReachedException(message: String? = null) :
-    StripeException(message = message)
+class MaxRetryReachedException(message: String? = null) : StripeException(message = message) {
+    override fun analyticsValue(): String = "maxRetryReachedError"
+}

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/MaxRetryReachedException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/MaxRetryReachedException.kt
@@ -7,5 +7,6 @@ import androidx.annotation.RestrictTo
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class MaxRetryReachedException(message: String? = null) : StripeException(message = message) {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     override fun analyticsValue(): String = "maxRetryReachedError"
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/PermissionException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/PermissionException.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.core.exception
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.core.StripeError
 import java.net.HttpURLConnection
 
@@ -15,5 +16,6 @@ class PermissionException(
     requestId,
     HttpURLConnection.HTTP_FORBIDDEN
 ) {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     override fun analyticsValue(): String = "permissionError"
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/PermissionException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/PermissionException.kt
@@ -14,4 +14,6 @@ class PermissionException(
     stripeError,
     requestId,
     HttpURLConnection.HTTP_FORBIDDEN
-)
+) {
+    override fun analyticsValue(): String = "permissionError"
+}

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/RateLimitException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/RateLimitException.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.core.exception
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.networking.HTTP_TOO_MANY_REQUESTS
 
@@ -18,5 +19,6 @@ class RateLimitException(
     cause,
     message
 ) {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     override fun analyticsValue(): String = "rateLimitError"
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/RateLimitException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/RateLimitException.kt
@@ -17,4 +17,6 @@ class RateLimitException(
     HTTP_TOO_MANY_REQUESTS,
     cause,
     message
-)
+) {
+    override fun analyticsValue(): String = "rateLimitError"
+}

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/StripeException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/StripeException.kt
@@ -19,6 +19,9 @@ abstract class StripeException(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     val isClientError = statusCode in 400..499
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    abstract fun analyticsValue(): String?
+
     override fun toString(): String {
         return listOfNotNull(
             requestId?.let { "Request-id: $it" },


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request enforces that all `StripeException` subclasses have an error reason. (cc @yuki-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
