### PR TITLE
Remove flaky device from nightly tests.

### DIFF
--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -188,7 +188,6 @@ def executeTests(appUrl, testUrl, isNightly):
         devices = [
             "Google Pixel 7-13.0",
             "Samsung Galaxy S22-12.0",
-            "Google Pixel 3-9.0",
         ]
     else:
         devices = [


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Our nightly tests have been consistently failing on this device, remove it.

I'm on run this week, and will look into supporting an older device without the flakes. 