### PR TITLE
Update animated icons to not animate during screenshot tests.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
@@ -12,7 +12,6 @@ import com.stripe.android.paymentsheet.example.playground.settings.CollectEmailS
 import com.stripe.android.paymentsheet.example.playground.settings.CollectNameSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CollectPhoneSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillingAddressSettingsDefinition
-import com.stripe.android.paymentsheet.example.playground.settings.LinkSettingsDefinition
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PAYMENT_METHOD_SELECTOR_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
 import com.stripe.android.test.core.FieldPopulator
@@ -168,9 +167,7 @@ internal class TestCard : BasePlaygroundTest() {
             authorizationAction = null,
             saveForFutureUseCheckboxVisible = true,
             saveCheckboxValue = true,
-        ).copyPlaygroundSettings { playgroundSettings ->
-            playgroundSettings[LinkSettingsDefinition] = false
-        }
+        )
 
         val state = testDriver.confirmCustomAndBuy(
             testParameters = testParameters,

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
@@ -12,6 +12,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.CollectEmailS
 import com.stripe.android.paymentsheet.example.playground.settings.CollectNameSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CollectPhoneSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillingAddressSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.LinkSettingsDefinition
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PAYMENT_METHOD_SELECTOR_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
 import com.stripe.android.test.core.FieldPopulator
@@ -167,7 +168,9 @@ internal class TestCard : BasePlaygroundTest() {
             authorizationAction = null,
             saveForFutureUseCheckboxVisible = true,
             saveCheckboxValue = true,
-        )
+        ).copyPlaygroundSettings { playgroundSettings ->
+            playgroundSettings[LinkSettingsDefinition] = false
+        }
 
         val state = testDriver.confirmCustomAndBuy(
             testParameters = testParameters,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/StripeTheme.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/StripeTheme.kt
@@ -311,6 +311,7 @@ fun StripeTypography.toComposeTypography(): Typography {
 val LocalColors = staticCompositionLocalOf { StripeTheme.getColors(false) }
 val LocalShapes = staticCompositionLocalOf { StripeTheme.shapesMutable }
 val LocalTypography = staticCompositionLocalOf { StripeTheme.typographyMutable }
+
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 val LocalInstrumentationTest = staticCompositionLocalOf { false }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/StripeTheme.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/StripeTheme.kt
@@ -331,7 +331,7 @@ fun StripeTheme(
 
     val isInstrumentationTest = runCatching {
         BuildConfig.DEBUG && run {
-            // InstrumentationRegistry.getInstrumentation().context != null
+            // InstrumentationRegistry.getInstrumentation()
             val registry = Class.forName("androidx.test.platform.app.InstrumentationRegistry")
             val instrumentationMethod = registry.getDeclaredMethod("getInstrumentation")
             instrumentationMethod.invoke(null) // This will throw if we're not in an instrumentation test.

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/StripeTheme.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/StripeTheme.kt
@@ -311,6 +311,8 @@ fun StripeTypography.toComposeTypography(): Typography {
 val LocalColors = staticCompositionLocalOf { StripeTheme.getColors(false) }
 val LocalShapes = staticCompositionLocalOf { StripeTheme.shapesMutable }
 val LocalTypography = staticCompositionLocalOf { StripeTheme.typographyMutable }
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+val LocalInstrumentationTest = staticCompositionLocalOf { false }
 
 /**
  * Base Theme for Stripe Composables.
@@ -339,13 +341,14 @@ fun StripeTheme(
         }
     }.getOrDefault(false)
 
-    val inspectionMode = LocalInspectionMode.current || isRobolectricTest || isInstrumentationTest
+    val inspectionMode = LocalInspectionMode.current || isRobolectricTest
 
     CompositionLocalProvider(
         LocalColors provides colors,
         LocalShapes provides shapes,
         LocalTypography provides typography,
         LocalInspectionMode provides inspectionMode,
+        LocalInstrumentationTest provides isInstrumentationTest,
     ) {
         MaterialTheme(
             colors = colors.materialColors,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
@@ -50,7 +50,6 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalAutofill
 import androidx.compose.ui.platform.LocalAutofillTree
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -63,6 +62,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.stripe.android.core.Logger
 import com.stripe.android.uicore.BuildConfig
+import com.stripe.android.uicore.LocalInstrumentationTest
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.stripeColors
 import kotlinx.coroutines.delay
@@ -335,7 +335,7 @@ fun AnimatedIcons(
 
     val composableScope = rememberCoroutineScope()
 
-    val isRunningInTestHarness = LocalInspectionMode.current
+    val isRunningInTestHarness = LocalInstrumentationTest.current
 
     val target by produceState(initialValue = icons.first()) {
         if (!isRunningInTestHarness) {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalAutofill
 import androidx.compose.ui.platform.LocalAutofillTree
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -334,12 +335,16 @@ fun AnimatedIcons(
 
     val composableScope = rememberCoroutineScope()
 
+    val isRunningInTestHarness = LocalInspectionMode.current
+
     val target by produceState(initialValue = icons.first()) {
-        composableScope.launch {
-            while (true) {
-                icons.forEach {
-                    delay(1000)
-                    value = it
+        if (!isRunningInTestHarness) {
+            composableScope.launch {
+                while (true) {
+                    icons.forEach {
+                        delay(1000)
+                        value = it
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Don't animate icons during screenshot tests. This will make the card brands shown always be the initial value.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-1527
