### PR TITLE
Improve stability of end to end tests.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSepaDebit.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSepaDebit.kt
@@ -3,7 +3,6 @@ package com.stripe.android.lpm
 import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
@@ -15,6 +14,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.CountrySettin
 import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymentMethodsSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.GooglePaySettingsDefinition
 import com.stripe.android.test.core.TestParameters
+import com.stripe.android.test.core.ui.ComposeButton
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -99,8 +99,9 @@ internal class TestSepaDebit : BasePlaygroundTest() {
             customerId = playgroundState?.customerConfig?.id,
             testParameters = testParameters,
             afterBuyAction = {
-                rules.compose.onNode(hasTestTag("SEPA_MANDATE_CONTINUE_BUTTON"))
-                    .performClick()
+                ComposeButton(rules.compose, hasTestTag("SEPA_MANDATE_CONTINUE_BUTTON"))
+                    .waitForEnabled()
+                    .click()
             }
         )
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.lpm
 
-import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.isEnabled
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
 import com.stripe.android.paymentsheet.example.playground.settings.Country
@@ -12,6 +12,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymen
 import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.TestParameters
+import com.stripe.android.test.core.ui.ComposeButton
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -32,8 +33,8 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
                 authorizationAction = AuthorizeAction.Cancel,
             ),
             afterAuthorization = {
-                rules.compose.onNode(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
-                    .assertIsEnabled()
+                ComposeButton(rules.compose, hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
+                    .waitFor(isEnabled())
             }
         )
     }
@@ -45,8 +46,8 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
                 authorizationAction = AuthorizeAction.Cancel,
             ),
             afterAuthorization = {
-                rules.compose.onNode(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
-                    .assertIsEnabled()
+                ComposeButton(rules.compose, hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
+                    .waitFor(isEnabled())
             }
         )
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -555,7 +555,7 @@ internal class PlaygroundTestDriver(
     private fun waitForScreenToLoad(testParameters: TestParameters) {
         when (testParameters.playgroundSettingsSnapshot[CustomerSettingsDefinition]) {
             is CustomerType.GUEST, is CustomerType.NEW -> {
-                composeTestRule.waitUntil {
+                composeTestRule.waitUntil(timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
                     composeTestRule.onAllNodesWithText("Card number")
                         .fetchSemanticsNodes()
                         .size == 1
@@ -568,7 +568,7 @@ internal class PlaygroundTestDriver(
                 }
             }
             is CustomerType.Existing, is CustomerType.RETURNING -> {
-                composeTestRule.waitUntil {
+                composeTestRule.waitUntil(timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
                     composeTestRule.onAllNodesWithTag("AddCard")
                         .fetchSemanticsNodes()
                         .size == 1
@@ -582,7 +582,7 @@ internal class PlaygroundTestDriver(
     }
 
     internal fun pressEdit() {
-        composeTestRule.waitUntil {
+        composeTestRule.waitUntil(timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
             composeTestRule
                 .onAllNodesWithText("EDIT")
                 .fetchSemanticsNodes()
@@ -762,7 +762,7 @@ internal class PlaygroundTestDriver(
                         }
 
                         // The text comes after the buy button animation is complete
-                        composeTestRule.waitUntil {
+                        composeTestRule.waitUntil(timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
                             runCatching {
                                 composeTestRule
                                     .onNodeWithText(authAction.expectedError)

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestConstants.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestConstants.kt
@@ -1,4 +1,9 @@
 package com.stripe.android.test.core
 
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
 const val INDIVIDUAL_TEST_TIMEOUT_SECONDS = 90L
 const val HOOKS_PAGE_LOAD_TIMEOUT = 60L
+
+val DEFAULT_UI_TIMEOUT: Duration = 15.seconds

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/BuyButton.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/BuyButton.kt
@@ -7,12 +7,12 @@ import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
+import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 
 class BuyButton(
     private val composeTestRule: ComposeTestRule,
-    private val processingCompleteTimeout: Duration = 5.seconds,
+    private val processingCompleteTimeout: Duration = DEFAULT_UI_TIMEOUT,
 ) {
 
     fun click() {

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/ComposeButton.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/ComposeButton.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.test.isEnabled
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
-import kotlin.time.Duration.Companion.seconds
+import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 
 internal class ComposeButton(
     private val composeTestRule: ComposeTestRule,
@@ -19,11 +19,20 @@ internal class ComposeButton(
         composeTestRule.onNode(matcher).tryPerformScrollTo().performClick()
     }
 
-    fun waitForEnabled() {
-        composeTestRule.waitUntil(timeoutMillis = 5.seconds.inWholeMilliseconds) {
+    fun waitForEnabled(): ComposeButton {
+        composeTestRule.waitUntil(timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
             val combinedMatcher = matcher.and(isEnabled()).and(hasClickAction())
             composeTestRule.onAllNodes(combinedMatcher).fetchSemanticsNodes().isNotEmpty()
         }
+        return this
+    }
+
+    fun waitFor(semanticsMatcher: SemanticsMatcher): ComposeButton {
+        composeTestRule.waitUntil(timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
+            val combinedMatcher = matcher.and(semanticsMatcher)
+            composeTestRule.onAllNodes(combinedMatcher).fetchSemanticsNodes().isNotEmpty()
+        }
+        return this
     }
 
     private fun SemanticsNodeInteraction.tryPerformScrollTo(): SemanticsNodeInteraction {

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/PaymentSelection.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/PaymentSelection.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
 import androidx.test.platform.app.InstrumentationRegistry
 import com.stripe.android.paymentsheet.TEST_TAG_LIST
+import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 
 class PaymentSelection(val composeTestRule: ComposeTestRule, @StringRes val label: Int) {
     fun click() {
@@ -20,7 +21,7 @@ class PaymentSelection(val composeTestRule: ComposeTestRule, @StringRes val labe
         try {
             // If we don't find the node, it means that there's only one payment method available
             // and we don't show the payment method carousel as a result.
-            composeTestRule.waitUntil(5000) {
+            composeTestRule.waitUntil(timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
                 composeTestRule
                     .onAllNodesWithTag(TEST_TAG_LIST)
                     .fetchSemanticsNodes().size == 1


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Increase timeouts from 5 seconds to 15 seconds.

Add waits for things that depend on the network that weren't being waited for before.

I ran this a bunch of times on older android devices to try and sus out the problems. I'm still getting some weird crashes on browserstack, but overall it's been much more stable! I've got a thread out to browserstack in order to identify the devices issues.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-1542
