### PR TITLE
[DO NOT MERGE] Call refresh endpoint for cashapp.

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -96,6 +96,13 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         TODO("Not yet implemented")
     }
 
+    override suspend fun refreshSetupIntent(
+        clientSecret: String,
+        options: ApiRequest.Options,
+    ): Result<SetupIntent> {
+        TODO("Not yet implemented")
+    }
+
     override suspend fun cancelSetupIntentSource(
         setupIntentId: String,
         sourceId: String,

--- a/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsEvent.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsEvent.kt
@@ -41,6 +41,7 @@ internal enum class PaymentAnalyticsEvent(val code: String) : AnalyticsEvent {
     SetupIntentRetrieve("setup_intent_retrieval"),
     SetupIntentRetrieveOrdered("setup_intent_retrieval_ordered"),
     SetupIntentCancelSource("setup_intent_cancel_source"),
+    SetupIntentRefresh("setup_intent_refresh"),
 
     // File
     FileCreate("create_file"),

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -336,11 +336,11 @@ class StripeApiRepository @JvmOverloads internal constructor(
     }
 
     /**
-     * Refresh a [PaymentIntent] using its client_secret
+     * Refresh a [SetupIntent] using its client_secret
      *
-     * Analytics event: [PaymentAnalyticsEvent.PaymentIntentRefresh]
+     * Analytics event: [PaymentAnalyticsEvent.SetupIntentRefresh]
      *
-     * @param clientSecret client_secret of the PaymentIntent to retrieve
+     * @param clientSecret client_secret of the SetupIntent to retrieve
      */
     override suspend fun refreshSetupIntent(
         clientSecret: String,

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -94,6 +94,12 @@ interface StripeRepository {
     ): Result<SetupIntent>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun refreshSetupIntent(
+        clientSecret: String,
+        options: ApiRequest.Options,
+    ): Result<SetupIntent>
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun cancelSetupIntentSource(
         setupIntentId: String,
         sourceId: String,

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -181,7 +181,8 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
      */
     private fun shouldCallRefreshIntent(stripeIntent: StripeIntent): Boolean {
         return stripeIntent.paymentMethod?.type == PaymentMethod.Type.WeChatPay ||
-            stripeIntent.paymentMethod?.type == PaymentMethod.Type.Upi
+            stripeIntent.paymentMethod?.type == PaymentMethod.Type.Upi ||
+            stripeIntent.paymentMethod?.type == PaymentMethod.Type.CashAppPay
     }
 
     protected abstract suspend fun retrieveStripeIntent(
@@ -393,10 +394,9 @@ internal class SetupIntentFlowResultProcessor @Inject constructor(
         requestOptions: ApiRequest.Options,
         expandFields: List<String>
     ): Result<SetupIntent> {
-        return stripeRepository.retrieveSetupIntent(
+        return stripeRepository.refreshSetupIntent(
             clientSecret,
             requestOptions,
-            expandFields
         )
     }
 

--- a/payments-core/src/test/java/com/stripe/android/model/SetupIntentFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/SetupIntentFixtures.kt
@@ -672,4 +672,39 @@ internal object SetupIntentFixtures {
         }
         """.trimIndent()
     )
+
+    val CASH_APP_PAY_REQUIRES_ACTION_JSON by lazy {
+        JSONObject(
+            """
+            {
+              "id": "seti_1234",
+              "object": "setup_intent",
+              "cancellation_reason": null,
+              "client_secret": "seti_1234_secret_5678",
+              "created": 1561677666,
+              "description": "a description",
+              "last_setup_error": null,
+              "livemode": false,
+              "next_action": {
+                "cashapp_handle_redirect_or_display_qr_code": {
+                  "hosted_instructions_url": "https://payments.stripe.com/cashapp/instructions/CCUaFwoVYWNjdF8xSHZUSTdMdTVvM1AxOFpwKJaloJ4GMgZcsN7zB3I6L2wvyPfW8B6gy0_BsHb7Q21FYoKjIGxNvVsVYjJ6pbAIw_28VE2MVWcJQHMaEObM",
+                  "mobile_auth_url": "https://pm-redirects.stripe.com/authorize/acct_1HvTI7Lu5o3P18Zp/pa_nonce_NC1mezV544wpYmFaXyJpnleeurKO3TZ",
+                  "qr_code": {
+                    "expires_at": 1674056362,
+                    "image_url_png": "https://qr.stripe.com/test_YWNjdF8xSHZUSTdMdTVvM1AxOFpwLF9OQzFtSUpKYkMwaVBZTldRMW5BelF0OWNiWkk3a25o0100dYmSjOJt.png",
+                    "image_url_svg": "https://qr.stripe.com/test_YWNjdF8xSHZUSTdMdTVvM1AxOFpwLF9OQzFtSUpKYkMwaVBZTldRMW5BelF0OWNiWkk3a25o0100dYmSjOJt.svg"
+                  }
+                },
+                "type": "cashapp_handle_redirect_or_display_qr_code"
+              },
+              "payment_method": "pm_1MRdj7Lu5o3P18Zp41wd191i",
+              "payment_method_types": [
+                "cashapp"
+              ],
+              "status": "requires_action",
+              "usage": "off_session"
+            }
+            """.trimIndent()
+        )
+    }
 }

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -228,6 +228,14 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
+    fun testGetRefreshSetupIntentUrl() {
+        assertEquals(
+            "https://api.stripe.com/v1/setup_intents/pi123/refresh",
+            StripeApiRepository.getRefreshSetupIntentUrl("pi123")
+        )
+    }
+
+    @Test
     fun testConfirmPaymentIntentUrl() {
         assertEquals(
             "https://api.stripe.com/v1/payment_intents/pi123/confirm",
@@ -1594,6 +1602,34 @@ internal class StripeApiRepositoryTest {
             )
 
             verifyFraudDetectionDataAndAnalyticsRequests(PaymentAnalyticsEvent.PaymentIntentRefresh)
+        }
+
+    @Test
+    fun verifyRefreshSetupIntent() =
+        runTest {
+            val clientSecret = "seti_1234_secret_5678"
+            whenever(stripeNetworkClient.executeRequest(any<ApiRequest>()))
+                .thenReturn(
+                    StripeResponse(
+                        200,
+                        SetupIntentFixtures.CASH_APP_PAY_REQUIRES_ACTION_JSON.toString(),
+                        emptyMap()
+                    )
+                )
+
+            create().refreshSetupIntent(
+                clientSecret,
+                ApiRequest.Options(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
+            ).getOrThrow()
+
+            verify(stripeNetworkClient).executeRequest(
+                argWhere<ApiRequest> {
+                    it.options.apiKey == ApiKeyFixtures.FAKE_PUBLISHABLE_KEY &&
+                        it.params?.get("client_secret") == clientSecret
+                }
+            )
+
+            verifyFraudDetectionDataAndAnalyticsRequests(PaymentAnalyticsEvent.SetupIntentRefresh)
         }
 
     @Test

--- a/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
@@ -357,6 +357,9 @@ internal class PaymentIntentFlowResultProcessorTest {
 
             whenever(mockStripeRepository.retrievePaymentIntent(any(), any(), any())).thenReturn(
                 Result.success(requiresActionIntent),
+            )
+
+            whenever(mockStripeRepository.refreshPaymentIntent(any(), any())).thenReturn(
                 Result.success(requiresActionIntent),
                 Result.success(succeededIntent),
             )

--- a/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
@@ -189,6 +189,9 @@ internal class SetupIntentFlowResultProcessorTest {
 
             whenever(mockStripeRepository.retrieveSetupIntent(any(), any(), any())).thenReturn(
                 Result.success(requiresActionIntent),
+            )
+
+            whenever(mockStripeRepository.refreshSetupIntent(any(), any())).thenReturn(
                 Result.success(requiresActionIntent),
                 Result.success(succeededIntent),
             )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Call an internal refresh API for cashapp pay when the status is requires action.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
ir-away-stack
