### PR TITLE
Add `google_pay_enabled` to `PaymentSheet` events.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -27,6 +27,7 @@ internal class DefaultEventReporter @Inject internal constructor(
 
     private var isDeferred: Boolean = false
     private var linkEnabled: Boolean = false
+    private var googlePaySupported: Boolean = false
     private var currency: String? = null
 
     override fun onInit(
@@ -41,22 +42,25 @@ internal class DefaultEventReporter @Inject internal constructor(
                 configuration = configuration,
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
             )
         )
     }
 
     override fun onLoadStarted() {
         durationProvider.start(DurationProvider.Key.Loading)
-        fireEvent(PaymentSheetEvent.LoadStarted(isDeferred, linkEnabled))
+        fireEvent(PaymentSheetEvent.LoadStarted(isDeferred, linkEnabled, googlePaySupported))
     }
 
     override fun onLoadSucceeded(
         paymentSelection: PaymentSelection?,
         linkEnabled: Boolean,
+        googlePaySupported: Boolean,
         currency: String?,
     ) {
         this.currency = currency
         this.linkEnabled = linkEnabled
+        this.googlePaySupported = googlePaySupported
 
         val duration = durationProvider.end(DurationProvider.Key.Loading)
 
@@ -66,6 +70,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 duration = duration,
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
             )
         )
     }
@@ -80,6 +85,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 error = error.asPaymentSheetLoadingException.type,
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
             )
         )
     }
@@ -90,6 +96,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 error = error.asPaymentSheetLoadingException.type,
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
             )
         )
     }
@@ -99,6 +106,7 @@ internal class DefaultEventReporter @Inject internal constructor(
             PaymentSheetEvent.Dismiss(
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
             )
         )
     }
@@ -110,6 +118,7 @@ internal class DefaultEventReporter @Inject internal constructor(
             PaymentSheetEvent.ShowExistingPaymentOptions(
                 mode = mode,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
                 currency = currency,
                 isDeferred = isDeferred,
             )
@@ -123,6 +132,7 @@ internal class DefaultEventReporter @Inject internal constructor(
             PaymentSheetEvent.ShowNewPaymentOptionForm(
                 mode = mode,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
                 currency = currency,
                 isDeferred = isDeferred,
             )
@@ -138,6 +148,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 isDeferred = isDeferred,
                 currency = currency,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
             )
         )
     }
@@ -150,6 +161,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 code = code,
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
             )
         )
     }
@@ -160,6 +172,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 code = code,
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
             )
         )
     }
@@ -169,6 +182,7 @@ internal class DefaultEventReporter @Inject internal constructor(
             PaymentSheetEvent.CardNumberCompleted(
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
             )
         )
     }
@@ -183,6 +197,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 currency = currency,
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
             )
         )
     }
@@ -197,6 +212,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 selectedLpm = paymentSelection.code(),
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
             )
         )
     }
@@ -221,6 +237,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 currency = currency,
                 isDeferred = deferredIntentConfirmationType != null,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
                 deferredIntentConfirmationType = deferredIntentConfirmationType,
             )
         )
@@ -241,6 +258,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 currency = currency,
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
                 deferredIntentConfirmationType = null,
             )
         )
@@ -251,6 +269,7 @@ internal class DefaultEventReporter @Inject internal constructor(
             PaymentSheetEvent.LpmSerializeFailureEvent(
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
             )
         )
     }
@@ -263,6 +282,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 type = type,
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
             )
         )
     }
@@ -272,6 +292,7 @@ internal class DefaultEventReporter @Inject internal constructor(
             PaymentSheetEvent.ShowEditablePaymentOption(
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
             )
         )
     }
@@ -281,6 +302,7 @@ internal class DefaultEventReporter @Inject internal constructor(
             PaymentSheetEvent.HideEditablePaymentOption(
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
             )
         )
     }
@@ -300,6 +322,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 },
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
             )
         )
     }
@@ -319,6 +342,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 },
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
             )
         )
     }
@@ -331,6 +355,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 selectedBrand = selectedBrand,
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
             )
         )
     }
@@ -345,6 +370,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 error = error,
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -29,6 +29,7 @@ internal interface EventReporter {
     fun onLoadSucceeded(
         paymentSelection: PaymentSelection?,
         linkEnabled: Boolean,
+        googlePaySupported: Boolean,
         currency: String?,
     )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -13,15 +13,17 @@ import kotlin.time.DurationUnit
 internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
     val params: Map<String, Any?>
-        get() = standardParams(isDeferred, linkEnabled) + additionalParams
+        get() = standardParams(isDeferred, linkEnabled, googlePaySupported) + additionalParams
 
     protected abstract val isDeferred: Boolean
     protected abstract val linkEnabled: Boolean
+    protected abstract val googlePaySupported: Boolean
     protected abstract val additionalParams: Map<String, Any?>
 
     class LoadStarted(
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_load_started"
         override val additionalParams: Map<String, Any?> = emptyMap()
@@ -32,6 +34,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         duration: Duration?,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_load_succeeded"
         override val additionalParams: Map<String, Any?> = mapOf(
@@ -53,6 +56,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         error: String,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_load_failed"
         override val additionalParams: Map<String, Any?> = mapOf(
@@ -65,6 +69,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         error: String,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_elements_session_load_failed"
         override val additionalParams: Map<String, Any?> = mapOf(
@@ -77,6 +82,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         private val configuration: PaymentSheet.Configuration,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
 
         override val eventName: String
@@ -185,6 +191,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     class Dismiss(
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_dismiss"
         override val additionalParams: Map<String, Any> = emptyMap()
@@ -195,6 +202,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         currency: String?,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = formatEventName(mode, "sheet_newpm_show")
         override val additionalParams: Map<String, Any?> = mapOf(
@@ -207,6 +215,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         currency: String?,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = formatEventName(mode, "sheet_savedpm_show")
         override val additionalParams: Map<String, Any?> = mapOf(
@@ -219,6 +228,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         currency: String?,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_carousel_payment_method_tapped"
         override val additionalParams: Map<String, Any?> = mapOf(
@@ -233,6 +243,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         currency: String?,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String =
             formatEventName(mode, "paymentoption_${analyticsValue(paymentSelection)}_select")
@@ -245,6 +256,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         code: String,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_form_shown"
         override val additionalParams: Map<String, Any?> = mapOf(
@@ -256,6 +268,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         code: String,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_form_interacted"
         override val additionalParams: Map<String, Any?> = mapOf(
@@ -266,6 +279,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     class CardNumberCompleted(
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_card_number_completed"
         override val additionalParams: Map<String, Any?> = mapOf()
@@ -277,6 +291,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         selectedLpm: String?,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_confirm_button_tapped"
         override val additionalParams: Map<String, Any?> = mapOf(
@@ -294,6 +309,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         currency: String?,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
         private val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
     ) : PaymentSheetEvent() {
 
@@ -334,6 +350,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     class LpmSerializeFailureEvent(
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "luxe_serialize_failure"
         override val additionalParams: Map<String, Any?> = emptyMap()
@@ -343,6 +360,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         type: String,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         private fun String.toSnakeCase() = replace(
             "(?<=.)(?=\\p{Upper})".toRegex(),
@@ -356,6 +374,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     class ShowEditablePaymentOption(
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_open_edit_screen"
 
@@ -365,6 +384,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     class HideEditablePaymentOption(
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_cancel_edit_screen"
 
@@ -376,6 +396,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         selectedBrand: CardBrand,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_open_cbc_dropdown"
 
@@ -394,6 +415,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         selectedBrand: CardBrand?,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_close_cbc_dropdown"
 
@@ -411,6 +433,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         selectedBrand: CardBrand,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_update_card"
 
@@ -424,6 +447,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         error: Throwable,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_update_card_failed"
 
@@ -436,9 +460,11 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     private fun standardParams(
         isDecoupled: Boolean,
         linkEnabled: Boolean,
+        googlePaySupported: Boolean,
     ): Map<String, Any?> = mapOf(
         FIELD_IS_DECOUPLED to isDecoupled,
         FIELD_LINK_ENABLED to linkEnabled,
+        FIELD_GOOGLE_PAY_ENABLED to googlePaySupported,
     )
 
     internal companion object {
@@ -459,6 +485,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
         const val FIELD_CUSTOMER = "customer"
         const val FIELD_GOOGLE_PAY = "googlepay"
+        const val FIELD_GOOGLE_PAY_ENABLED = "google_pay_enabled"
         const val FIELD_PRIMARY_BUTTON_COLOR = "primary_button_color"
         const val FIELD_BILLING = "default_billing_details"
         const val FIELD_PREFERRED_NETWORKS = "preferred_networks"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -86,6 +86,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
                     elementsSession = elementsSession,
                     state = state,
                     isReloadingAfterProcessDeath = isReloadingAfterProcessDeath,
+                    isGooglePaySupported = isGooglePaySupported(),
                 )
 
                 return@let state
@@ -111,6 +112,10 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
                 }
             )
         }?.isReady()?.first() ?: false
+    }
+
+    private suspend fun isGooglePaySupported(): Boolean {
+        return googlePayRepositoryFactory(GooglePayEnvironment.Production).isReady().first()
     }
 
     private suspend fun create(
@@ -385,6 +390,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         elementsSession: ElementsSession,
         state: PaymentSheetState.Full,
         isReloadingAfterProcessDeath: Boolean,
+        isGooglePaySupported: Boolean,
     ) {
         elementsSession.sessionsError?.let { sessionsError ->
             eventReporter.onElementsSessionLoadFailed(sessionsError)
@@ -397,6 +403,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         } else {
             eventReporter.onLoadSucceeded(
                 linkEnabled = elementsSession.isLinkEnabled,
+                googlePaySupported = isGooglePaySupported,
                 currency = elementsSession.stripeIntent.currency,
                 paymentSelection = state.paymentSelection,
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -90,6 +90,7 @@ class DefaultEventReporterTest {
             argWhere { req ->
                 req.params["event"] == "mc_complete_sheet_savedpm_show" &&
                     req.params["link_enabled"] == true &&
+                    req.params["google_pay_enabled"] == true &&
                     req.params["currency"] == "usd" &&
                     req.params["locale"] == "en_US"
             }
@@ -99,7 +100,7 @@ class DefaultEventReporterTest {
     @Test
     fun `onShowNewPaymentOptionForm() should fire analytics request with expected event value`() {
         val completeEventReporter = createEventReporter(EventReporter.Mode.Complete) {
-            simulateSuccessfulSetup(linkEnabled = false)
+            simulateSuccessfulSetup(linkEnabled = false, googlePayReady = false)
         }
 
         completeEventReporter.onShowNewPaymentOptionForm()
@@ -108,6 +109,7 @@ class DefaultEventReporterTest {
             argWhere { req ->
                 req.params["event"] == "mc_complete_sheet_newpm_show" &&
                     req.params["link_enabled"] == false &&
+                    req.params["google_pay_enabled"] == false &&
                     req.params["currency"] == "usd" &&
                     req.params["locale"] == "en_US"
             }
@@ -513,12 +515,14 @@ class DefaultEventReporterTest {
     private fun EventReporter.simulateSuccessfulSetup(
         paymentSelection: PaymentSelection = PaymentSelection.GooglePay,
         linkEnabled: Boolean = true,
+        googlePayReady: Boolean = true,
         currency: String? = "usd",
     ) {
         onInit(configuration, isDeferred = false)
         onLoadStarted()
         onLoadSucceeded(
             paymentSelection = paymentSelection,
+            googlePaySupported = googlePayReady,
             linkEnabled = linkEnabled,
             currency = currency
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -27,6 +27,7 @@ class PaymentSheetEventTest {
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
         )
 
         assertThat(
@@ -69,6 +70,7 @@ class PaymentSheetEventTest {
 
         assertThat(event.params).run {
             containsEntry("link_enabled", false)
+            containsEntry("google_pay_enabled", false)
             containsEntry("is_decoupled", false)
             containsEntry("mpe_config", expectedConfig)
         }
@@ -83,6 +85,7 @@ class PaymentSheetEventTest {
             ),
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
         )
 
         assertThat(
@@ -124,6 +127,8 @@ class PaymentSheetEventTest {
         )
 
         assertThat(event.params).run {
+            containsEntry("link_enabled", false)
+            containsEntry("google_pay_enabled", false)
             containsEntry("is_decoupled", false)
             containsEntry("mpe_config", expectedConfig)
         }
@@ -136,6 +141,7 @@ class PaymentSheetEventTest {
             configuration = PaymentSheetFixtures.CONFIG_MINIMUM,
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
         )
 
         assertThat(
@@ -178,6 +184,7 @@ class PaymentSheetEventTest {
 
         assertThat(event.params).run {
             containsEntry("link_enabled", false)
+            containsEntry("google_pay_enabled", false)
             containsEntry("is_decoupled", false)
             containsEntry("mpe_config", expectedConfig)
         }
@@ -188,6 +195,7 @@ class PaymentSheetEventTest {
         val event = PaymentSheetEvent.LoadSucceeded(
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
             duration = (5L).seconds,
             paymentSelection = null
         )
@@ -197,6 +205,7 @@ class PaymentSheetEventTest {
             mapOf(
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
                 "duration" to 5f,
                 "selected_lpm" to "none"
             )
@@ -208,6 +217,7 @@ class PaymentSheetEventTest {
         val event = PaymentSheetEvent.LoadSucceeded(
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
             duration = (5L).seconds,
             paymentSelection = PaymentSelection.GooglePay
         )
@@ -220,6 +230,7 @@ class PaymentSheetEventTest {
         val event = PaymentSheetEvent.LoadSucceeded(
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
             duration = (5L).seconds,
             paymentSelection = PaymentSelection.Link
         )
@@ -232,6 +243,7 @@ class PaymentSheetEventTest {
         val event = PaymentSheetEvent.LoadSucceeded(
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
             duration = (5L).seconds,
             paymentSelection = PaymentSelection.Saved(
                 paymentMethod = PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD
@@ -255,6 +267,7 @@ class PaymentSheetEventTest {
             currency = "usd",
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
             deferredIntentConfirmationType = null,
         )
         assertThat(
@@ -270,6 +283,7 @@ class PaymentSheetEventTest {
                 "duration" to 0.001F,
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
                 "selected_lpm" to "card",
             )
         )
@@ -285,6 +299,7 @@ class PaymentSheetEventTest {
             currency = "usd",
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
             deferredIntentConfirmationType = null,
         )
         assertThat(
@@ -300,6 +315,7 @@ class PaymentSheetEventTest {
                 "duration" to 0.001F,
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
                 "selected_lpm" to "card",
             )
         )
@@ -315,6 +331,7 @@ class PaymentSheetEventTest {
             currency = "usd",
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
             deferredIntentConfirmationType = null,
         )
         assertThat(
@@ -330,6 +347,7 @@ class PaymentSheetEventTest {
                 "duration" to 0.001F,
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
                 "selected_lpm" to "google_pay",
             )
         )
@@ -345,6 +363,7 @@ class PaymentSheetEventTest {
             currency = "usd",
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
             deferredIntentConfirmationType = null,
         )
         assertThat(
@@ -360,6 +379,7 @@ class PaymentSheetEventTest {
                 "duration" to 0.001F,
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
                 "selected_lpm" to "link",
             )
         )
@@ -381,6 +401,7 @@ class PaymentSheetEventTest {
             currency = "usd",
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
             deferredIntentConfirmationType = null,
         )
         assertThat(
@@ -396,6 +417,7 @@ class PaymentSheetEventTest {
                 "duration" to 0.001F,
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
             )
         )
     }
@@ -416,6 +438,7 @@ class PaymentSheetEventTest {
             currency = "usd",
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
             deferredIntentConfirmationType = null,
         )
         assertThat(
@@ -431,6 +454,7 @@ class PaymentSheetEventTest {
                 "duration" to 0.001F,
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
                 "selected_lpm" to "card",
                 "error_message" to "apiError",
             )
@@ -449,6 +473,7 @@ class PaymentSheetEventTest {
             currency = "usd",
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
             deferredIntentConfirmationType = null,
         )
         assertThat(
@@ -464,6 +489,7 @@ class PaymentSheetEventTest {
                 "duration" to 0.001F,
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
                 "selected_lpm" to "card",
                 "error_message" to "apiError",
             )
@@ -482,6 +508,7 @@ class PaymentSheetEventTest {
             currency = "usd",
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
             deferredIntentConfirmationType = null,
         )
         assertThat(
@@ -497,6 +524,7 @@ class PaymentSheetEventTest {
                 "duration" to 0.001F,
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
                 "selected_lpm" to "google_pay",
                 "error_message" to "apiError",
             )
@@ -515,6 +543,7 @@ class PaymentSheetEventTest {
             currency = "usd",
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
             deferredIntentConfirmationType = null,
         )
         assertThat(
@@ -530,6 +559,7 @@ class PaymentSheetEventTest {
                 "duration" to 0.001F,
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
                 "selected_lpm" to "link",
                 "error_message" to "apiError",
             )
@@ -554,6 +584,7 @@ class PaymentSheetEventTest {
             currency = "usd",
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
             deferredIntentConfirmationType = null,
         )
         assertThat(
@@ -569,6 +600,7 @@ class PaymentSheetEventTest {
                 "duration" to 0.001F,
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
                 "error_message" to "apiError",
             )
         )
@@ -582,6 +614,7 @@ class PaymentSheetEventTest {
             currency = "usd",
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
         )
         assertThat(
             event.eventName
@@ -595,6 +628,7 @@ class PaymentSheetEventTest {
                 "currency" to "usd",
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
             )
         )
     }
@@ -605,6 +639,7 @@ class PaymentSheetEventTest {
             code = "card",
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
         )
         assertThat(
             event.eventName
@@ -618,6 +653,7 @@ class PaymentSheetEventTest {
                 "selected_lpm" to "card",
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
             )
         )
     }
@@ -628,6 +664,7 @@ class PaymentSheetEventTest {
             code = "card",
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
         )
         assertThat(
             event.eventName
@@ -641,6 +678,7 @@ class PaymentSheetEventTest {
                 "selected_lpm" to "card",
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
             )
         )
     }
@@ -650,6 +688,7 @@ class PaymentSheetEventTest {
         val event = PaymentSheetEvent.CardNumberCompleted(
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
         )
         assertThat(
             event.eventName
@@ -662,6 +701,7 @@ class PaymentSheetEventTest {
             mapOf(
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
             )
         )
     }
@@ -671,6 +711,7 @@ class PaymentSheetEventTest {
         val event = PaymentSheetEvent.ShowEditablePaymentOption(
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
         )
         assertThat(
             event.eventName
@@ -683,6 +724,7 @@ class PaymentSheetEventTest {
             mapOf(
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
             )
         )
     }
@@ -692,6 +734,7 @@ class PaymentSheetEventTest {
         val event = PaymentSheetEvent.HideEditablePaymentOption(
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
         )
         assertThat(
             event.eventName
@@ -704,6 +747,7 @@ class PaymentSheetEventTest {
             mapOf(
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
             )
         )
     }
@@ -715,6 +759,7 @@ class PaymentSheetEventTest {
             source = PaymentSheetEvent.ShowPaymentOptionBrands.Source.Edit,
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
         )
         assertThat(
             event.eventName
@@ -729,6 +774,7 @@ class PaymentSheetEventTest {
                 "selected_card_brand" to "visa",
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
             )
         )
     }
@@ -740,6 +786,7 @@ class PaymentSheetEventTest {
             source = PaymentSheetEvent.ShowPaymentOptionBrands.Source.Add,
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
         )
         assertThat(
             event.eventName
@@ -754,6 +801,7 @@ class PaymentSheetEventTest {
                 "selected_card_brand" to "visa",
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
             )
         )
     }
@@ -765,6 +813,7 @@ class PaymentSheetEventTest {
             source = PaymentSheetEvent.HidePaymentOptionBrands.Source.Add,
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
         )
         assertThat(
             event.eventName
@@ -779,6 +828,7 @@ class PaymentSheetEventTest {
                 "selected_card_brand" to "cartes_bancaires",
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
             )
         )
     }
@@ -790,6 +840,7 @@ class PaymentSheetEventTest {
             source = PaymentSheetEvent.HidePaymentOptionBrands.Source.Edit,
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
         )
         assertThat(
             event.eventName
@@ -804,6 +855,7 @@ class PaymentSheetEventTest {
                 "selected_card_brand" to "cartes_bancaires",
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
             )
         )
     }
@@ -814,6 +866,7 @@ class PaymentSheetEventTest {
             selectedBrand = CardBrand.CartesBancaires,
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
         )
         assertThat(
             event.eventName
@@ -827,6 +880,7 @@ class PaymentSheetEventTest {
                 "selected_card_brand" to "cartes_bancaires",
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
             )
         )
     }
@@ -838,6 +892,7 @@ class PaymentSheetEventTest {
             error = Exception("No network available!"),
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
         )
         assertThat(
             event.eventName
@@ -852,6 +907,7 @@ class PaymentSheetEventTest {
                 "error_message" to "No network available!",
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
             )
         )
     }
@@ -898,12 +954,14 @@ class PaymentSheetEventTest {
                 configuration = PaymentSheetFixtures.CONFIG_MINIMUM,
                 isDeferred = false,
                 linkEnabled = false,
+                googlePaySupported = false,
             ).params
         ).isEqualTo(
             mapOf(
                 "mpe_config" to expectedConfigMap,
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
             )
         )
     }
@@ -950,12 +1008,14 @@ class PaymentSheetEventTest {
                 configuration = PaymentSheetFixtures.CONFIG_WITH_EVERYTHING,
                 isDeferred = false,
                 linkEnabled = false,
+                googlePaySupported = false,
             ).params
         ).isEqualTo(
             mapOf(
                 "mpe_config" to expectedConfigMap,
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
             )
         )
     }
@@ -968,6 +1028,7 @@ class PaymentSheetEventTest {
             duration = 60.seconds,
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
         )
         assertThat(
             event.eventName
@@ -981,6 +1042,7 @@ class PaymentSheetEventTest {
                 "selected_lpm" to "card",
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
                 "duration" to 60f,
                 "currency" to "USD",
             )
@@ -995,6 +1057,7 @@ class PaymentSheetEventTest {
             duration = null,
             isDeferred = false,
             linkEnabled = false,
+            googlePaySupported = false,
         )
         assertThat(
             event.eventName
@@ -1007,6 +1070,7 @@ class PaymentSheetEventTest {
             mapOf(
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "google_pay_enabled" to false,
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -720,6 +720,7 @@ internal class DefaultPaymentSheetLoaderTest {
                 paymentMethod = PAYMENT_METHODS.first()
             ),
             linkEnabled = true,
+            googlePaySupported = true,
             currency = "usd",
         )
     }
@@ -767,6 +768,7 @@ internal class DefaultPaymentSheetLoaderTest {
         verify(eventReporter).onLoadSucceeded(
             paymentSelection = null,
             linkEnabled = true,
+            googlePaySupported = true,
             currency = "usd",
         )
     }
@@ -939,6 +941,7 @@ internal class DefaultPaymentSheetLoaderTest {
         verify(eventReporter).onLoadSucceeded(
             paymentSelection = paymentSelection,
             linkEnabled = true,
+            googlePaySupported = true,
             currency = "usd",
         )
     }


### PR DESCRIPTION
# Summary
Add `google_pay_enabled` to `PaymentSheet` events.

# Motivation
Resolves [MOBILESDK-1541](https://jira.corp.stripe.com/browse/MOBILESDK-1541)

This parameter is very specific in what it defines as Google Pay being enabled. It is only supposed to check if the device supports Google Pay as well as the provided payment methods. See the issue for more details on how iOS uses `apple_pay_enabled`. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
