### PR TITLE
Add `financial_connections_account` field to `PaymentMethod` & replace in `CustomerSheet`.

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -3809,9 +3809,8 @@ public final class com/stripe/android/model/PaymentMethod$USBankAccount : com/st
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;
 	public final fun component8 ()Ljava/lang/String;
-	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$USBankAccount;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$USBankAccount;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$USBankAccount;
+	public final fun copy (Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$USBankAccount;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$USBankAccount;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$USBankAccount;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getType ()Lcom/stripe/android/model/PaymentMethod$Type;

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -3795,6 +3795,7 @@ public final class com/stripe/android/model/PaymentMethod$USBankAccount : com/st
 	public final field accountHolderType Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;
 	public final field accountType Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;
 	public final field bankName Ljava/lang/String;
+	public final field financialConnectionsAccount Ljava/lang/String;
 	public final field fingerprint Ljava/lang/String;
 	public final field last4 Ljava/lang/String;
 	public final field linkedAccount Ljava/lang/String;
@@ -3808,8 +3809,9 @@ public final class com/stripe/android/model/PaymentMethod$USBankAccount : com/st
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;
 	public final fun component8 ()Ljava/lang/String;
-	public final fun copy (Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$USBankAccount;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$USBankAccount;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$USBankAccount;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$USBankAccount;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$USBankAccount;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$USBankAccount;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getType ()Lcom/stripe/android/model/PaymentMethod$Type;

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -5,6 +5,7 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.model.parsers.PaymentMethodJsonParser
 import com.stripe.android.model.wallets.Wallet
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 
@@ -999,17 +1000,11 @@ constructor(
         @JvmField val last4: String?,
 
         /**
-         * The token of the Linked Account used to create the payment method
+         * The ID of the Financial Connections Account used to create the payment method
          *
-         * [us_bank_account.linkedAccount](https://stripe.com/docs/api/payment_methods/object#payment_method_object-us_bank_account-linked_account)
+         * [us_bank_account.financial_connections_account](https://stripe.com/docs/api/payment_methods/object#payment_method_object-us_bank_account-financial_connections_account)
          */
-        @Deprecated(
-            message = "Renamed to 'financialConnectionsAccount', " +
-                "'linkedAccount' will be removed in a future major update",
-            replaceWith = ReplaceWith(expression = "financialConnectionsAccount")
-        )
-        @JvmField
-        val linkedAccount: String?,
+        @JvmField val financialConnectionsAccount: String?,
 
         /**
          * Contains information about US bank account networks that can be used
@@ -1024,14 +1019,21 @@ constructor(
          * [us_bank_account.routingNumber](https://stripe.com/docs/api/payment_methods/object#payment_method_object-us_bank_account-routing_number)
          */
         @JvmField val routingNumber: String?,
-
-        /**
-         * The ID of the Financial Connections Account used to create the payment method
-         *
-         * [us_bank_account.financial_connections_account](https://stripe.com/docs/api/payment_methods/object#payment_method_object-us_bank_account-financial_connections_account)
-         */
-        @JvmField val financialConnectionsAccount: String?,
     ) : TypeData() {
+        /**
+         * The token of the Linked Account used to create the payment method
+         *
+         * [us_bank_account.linkedAccount](https://stripe.com/docs/api/payment_methods/object#payment_method_object-us_bank_account-linked_account)
+         */
+        @Deprecated(
+            message = "Renamed to 'financialConnectionsAccount', " +
+                "'linkedAccount' will be removed in a future major update",
+            replaceWith = ReplaceWith(expression = "financialConnectionsAccount")
+        )
+        @IgnoredOnParcel
+        @JvmField
+        val linkedAccount: String? = financialConnectionsAccount
+
         override val type: Type get() = Type.USBankAccount
 
         @Parcelize

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -1003,7 +1003,13 @@ constructor(
          *
          * [us_bank_account.linkedAccount](https://stripe.com/docs/api/payment_methods/object#payment_method_object-us_bank_account-linked_account)
          */
-        @JvmField val linkedAccount: String?,
+        @Deprecated(
+            message = "Renamed to 'financialConnectionsAccount', " +
+                "'linkedAccount' will be removed in a future major update",
+            replaceWith = ReplaceWith(expression = "financialConnectionsAccount")
+        )
+        @JvmField
+        val linkedAccount: String?,
 
         /**
          * Contains information about US bank account networks that can be used
@@ -1017,7 +1023,14 @@ constructor(
          *
          * [us_bank_account.routingNumber](https://stripe.com/docs/api/payment_methods/object#payment_method_object-us_bank_account-routing_number)
          */
-        @JvmField val routingNumber: String?
+        @JvmField val routingNumber: String?,
+
+        /**
+         * The ID of the Financial Connections Account used to create the payment method
+         *
+         * [us_bank_account.financial_connections_account](https://stripe.com/docs/api/payment_methods/object#payment_method_object-us_bank_account-financial_connections_account)
+         */
+        @JvmField val financialConnectionsAccount: String?,
     ) : TypeData() {
         override val type: Type get() = Type.USBankAccount
 

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodJsonParser.kt
@@ -278,7 +278,9 @@ class PaymentMethodJsonParser : ModelJsonParser<PaymentMethod> {
                 bankName = StripeJsonUtils.optString(json, FIELD_BANK_NAME),
                 fingerprint = StripeJsonUtils.optString(json, FIELD_FINGERPRINT),
                 last4 = StripeJsonUtils.optString(json, FIELD_LAST4),
-                linkedAccount = StripeJsonUtils.optString(json, FIELD_LINKED_ACCOUNT),
+                linkedAccount = StripeJsonUtils.optString(json, FIELD_LINKED_ACCOUNT)
+                    ?: StripeJsonUtils.optString(json, FIELD_FINANCIAL_CONNECTIONS_ACCOUNT),
+                financialConnectionsAccount = StripeJsonUtils.optString(json, FIELD_FINANCIAL_CONNECTIONS_ACCOUNT),
                 networks = if (json.has(FIELD_NETWORKS)) {
                     PaymentMethod.USBankAccount.USBankNetworks(
                         StripeJsonUtils.optString(json.optJSONObject(FIELD_NETWORKS), FIELD_NETWORKS_PREFERRED),
@@ -300,6 +302,7 @@ class PaymentMethodJsonParser : ModelJsonParser<PaymentMethod> {
             private const val FIELD_FINGERPRINT = "fingerprint"
             private const val FIELD_LAST4 = "last4"
             private const val FIELD_LINKED_ACCOUNT = "linked_account"
+            private const val FIELD_FINANCIAL_CONNECTIONS_ACCOUNT = "financial_connections_account"
             private const val FIELD_NETWORKS = "networks"
             private const val FIELD_NETWORKS_PREFERRED = "preferred"
             private const val FIELD_NETWORKS_SUPPORTED = "supported"

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodJsonParser.kt
@@ -278,8 +278,6 @@ class PaymentMethodJsonParser : ModelJsonParser<PaymentMethod> {
                 bankName = StripeJsonUtils.optString(json, FIELD_BANK_NAME),
                 fingerprint = StripeJsonUtils.optString(json, FIELD_FINGERPRINT),
                 last4 = StripeJsonUtils.optString(json, FIELD_LAST4),
-                linkedAccount = StripeJsonUtils.optString(json, FIELD_LINKED_ACCOUNT)
-                    ?: StripeJsonUtils.optString(json, FIELD_FINANCIAL_CONNECTIONS_ACCOUNT),
                 financialConnectionsAccount = StripeJsonUtils.optString(json, FIELD_FINANCIAL_CONNECTIONS_ACCOUNT),
                 networks = if (json.has(FIELD_NETWORKS)) {
                     PaymentMethod.USBankAccount.USBankNetworks(
@@ -301,7 +299,6 @@ class PaymentMethodJsonParser : ModelJsonParser<PaymentMethod> {
             private const val FIELD_BANK_NAME = "bank_name"
             private const val FIELD_FINGERPRINT = "fingerprint"
             private const val FIELD_LAST4 = "last4"
-            private const val FIELD_LINKED_ACCOUNT = "linked_account"
             private const val FIELD_FINANCIAL_CONNECTIONS_ACCOUNT = "financial_connections_account"
             private const val FIELD_NETWORKS = "networks"
             private const val FIELD_NETWORKS_PREFERRED = "preferred"

--- a/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
@@ -110,6 +110,7 @@ internal class PaymentMethodEndToEndTest {
                 fingerprint = "FFDMA0xfhBjWSZLu",
                 last4 = "6789",
                 linkedAccount = null,
+                financialConnectionsAccount = null,
                 networks = PaymentMethod.USBankAccount.USBankNetworks(
                     preferred = "ach",
                     supported = listOf("ach", "us_domestic_wire")

--- a/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
@@ -109,7 +109,6 @@ internal class PaymentMethodEndToEndTest {
                 bankName = "STRIPE TEST BANK",
                 fingerprint = "FFDMA0xfhBjWSZLu",
                 last4 = "6789",
-                linkedAccount = null,
                 financialConnectionsAccount = null,
                 networks = PaymentMethod.USBankAccount.USBankNetworks(
                     preferred = "ach",

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
@@ -107,7 +107,6 @@ internal object PaymentMethodFixtures {
             bankName = "Stripe Bank",
             fingerprint = "UkSG0Hf",
             last4 = "2345",
-            linkedAccount = null,
             financialConnectionsAccount = null,
             networks = null,
             routingNumber = "110000000"
@@ -425,48 +424,7 @@ internal object PaymentMethodFixtures {
         """.trimIndent()
     )
 
-    val US_BANK_ACCOUNT_WITH_FCA_AND_LA = JSONObject(
-        """
-        {
-            "id": "pm_123456",
-            "object": "payment_method",
-            "billing_details": {
-                "address": {
-                    "city": "Seattle",
-                    "country": "US",
-                    "line1": "123 Main St.",
-                    "line2": null,
-                    "postal_code": "99999",
-                    "state": "AL"
-                },
-                "email": "jenny@example.com",
-                "name": "Jenny Rosen",
-                "phone": null
-            },
-            "created": 1706132691,
-            "customer": null,
-            "livemode": false,
-            "type": "us_bank_account",
-            "us_bank_account": {
-                "account_holder_type": "individual",
-                "account_type": "checking",
-                "bank_name": "STRIPE TEST BANK",
-                "financial_connections_account": "fca_111",
-                "fingerprint": "FFDMA0xfhBjWSZLu",
-                "last4": "6789",
-                "linked_account": "fca_111",
-                "networks":{ 
-                    "preferred": "ach",
-                    "supported": ["ach","us_domestic_wire"]},
-                    "routing_number": "110000000", 
-                    "status_details": null
-                }
-            }
-        }
-        """.trimIndent()
-    )
-
-    val US_BANK_ACCOUNT_WITH_FCA_WITHOUT_LA = JSONObject(
+    val US_BANK_ACCOUNT_WITH_FCA = JSONObject(
         """
         {
             "id": "pm_123456",

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
@@ -108,6 +108,7 @@ internal object PaymentMethodFixtures {
             fingerprint = "UkSG0Hf",
             last4 = "2345",
             linkedAccount = null,
+            financialConnectionsAccount = null,
             networks = null,
             routingNumber = "110000000"
         ),
@@ -420,6 +421,87 @@ internal object PaymentMethodFixtures {
             "livemode": false,
             "metadata": null,
             "type": "bacs_debit"
+        }
+        """.trimIndent()
+    )
+
+    val US_BANK_ACCOUNT_WITH_FCA_AND_LA = JSONObject(
+        """
+        {
+            "id": "pm_123456",
+            "object": "payment_method",
+            "billing_details": {
+                "address": {
+                    "city": "Seattle",
+                    "country": "US",
+                    "line1": "123 Main St.",
+                    "line2": null,
+                    "postal_code": "99999",
+                    "state": "AL"
+                },
+                "email": "jenny@example.com",
+                "name": "Jenny Rosen",
+                "phone": null
+            },
+            "created": 1706132691,
+            "customer": null,
+            "livemode": false,
+            "type": "us_bank_account",
+            "us_bank_account": {
+                "account_holder_type": "individual",
+                "account_type": "checking",
+                "bank_name": "STRIPE TEST BANK",
+                "financial_connections_account": "fca_111",
+                "fingerprint": "FFDMA0xfhBjWSZLu",
+                "last4": "6789",
+                "linked_account": "fca_111",
+                "networks":{ 
+                    "preferred": "ach",
+                    "supported": ["ach","us_domestic_wire"]},
+                    "routing_number": "110000000", 
+                    "status_details": null
+                }
+            }
+        }
+        """.trimIndent()
+    )
+
+    val US_BANK_ACCOUNT_WITH_FCA_WITHOUT_LA = JSONObject(
+        """
+        {
+            "id": "pm_123456",
+            "object": "payment_method",
+            "billing_details": {
+                "address": {
+                    "city": "Seattle",
+                    "country": "US",
+                    "line1": "123 Main St.",
+                    "line2": null,
+                    "postal_code": "99999",
+                    "state": "AL"
+                },
+                "email": "jenny@example.com",
+                "name": "Jenny Rosen",
+                "phone": null
+            },
+            "created": 1706132691,
+            "customer": null,
+            "livemode": false,
+            "type": "us_bank_account",
+            "us_bank_account": {
+                "account_holder_type": "individual",
+                "account_type": "checking",
+                "bank_name": "STRIPE TEST BANK",
+                "financial_connections_account": "fca_111",
+                "fingerprint": "FFDMA0xfhBjWSZLu",
+                "last4": "6789",
+                "networks":{ 
+                    "preferred": "ach",
+                    "supported": ["ach","us_domestic_wire"]},
+                    "routing_number": "110000000", 
+                    "status_details": null
+                }
+            }
         }
         """.trimIndent()
     )

--- a/payments-core/src/test/java/com/stripe/android/model/SetupIntentTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/SetupIntentTest.kt
@@ -73,7 +73,6 @@ class SetupIntentTest {
                 bankName = "STRIPE TEST BANK",
                 fingerprint = "FFDMA0xfhBjWSZLu",
                 last4 = "6789",
-                linkedAccount = null,
                 financialConnectionsAccount = null,
                 networks = PaymentMethod.USBankAccount.USBankNetworks("ach", listOf("ach")),
                 routingNumber = "110000000"

--- a/payments-core/src/test/java/com/stripe/android/model/SetupIntentTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/SetupIntentTest.kt
@@ -74,6 +74,7 @@ class SetupIntentTest {
                 fingerprint = "FFDMA0xfhBjWSZLu",
                 last4 = "6789",
                 linkedAccount = null,
+                financialConnectionsAccount = null,
                 networks = PaymentMethod.USBankAccount.USBankNetworks("ach", listOf("ach")),
                 routingNumber = "110000000"
             ),

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentMethodJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentMethodJsonParserTest.kt
@@ -114,4 +114,32 @@ class PaymentMethodJsonParserTest {
         assertThat(PaymentMethodJsonParser().parse(PaymentMethodFixtures.IDEAL_JSON).type)
             .isEqualTo(PaymentMethod.Type.Ideal)
     }
+
+    @Test
+    fun parse_withUsBankAccountWithFcaAndLa_returnsExpectedObject() {
+        val usBankAccount = PaymentMethodJsonParser().parse(
+            PaymentMethodFixtures.US_BANK_ACCOUNT_WITH_FCA_AND_LA
+        )
+
+        assertThat(usBankAccount.type)
+            .isEqualTo(PaymentMethod.Type.USBankAccount)
+        assertThat(usBankAccount.usBankAccount?.linkedAccount)
+            .isEqualTo("fca_111")
+        assertThat(usBankAccount.usBankAccount?.financialConnectionsAccount)
+            .isEqualTo("fca_111")
+    }
+
+    @Test
+    fun parse_withUsBankAccountWithFcaWithoutLa_returnsExpectedObject() {
+        val usBankAccount = PaymentMethodJsonParser().parse(
+            PaymentMethodFixtures.US_BANK_ACCOUNT_WITH_FCA_WITHOUT_LA
+        )
+
+        assertThat(usBankAccount.type)
+            .isEqualTo(PaymentMethod.Type.USBankAccount)
+        assertThat(usBankAccount.usBankAccount?.linkedAccount)
+            .isEqualTo("fca_111")
+        assertThat(usBankAccount.usBankAccount?.financialConnectionsAccount)
+            .isEqualTo("fca_111")
+    }
 }

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentMethodJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentMethodJsonParserTest.kt
@@ -116,23 +116,9 @@ class PaymentMethodJsonParserTest {
     }
 
     @Test
-    fun parse_withUsBankAccountWithFcaAndLa_returnsExpectedObject() {
+    fun parse_withUsBankAccount_returnsExpectedObject() {
         val usBankAccount = PaymentMethodJsonParser().parse(
-            PaymentMethodFixtures.US_BANK_ACCOUNT_WITH_FCA_AND_LA
-        )
-
-        assertThat(usBankAccount.type)
-            .isEqualTo(PaymentMethod.Type.USBankAccount)
-        assertThat(usBankAccount.usBankAccount?.linkedAccount)
-            .isEqualTo("fca_111")
-        assertThat(usBankAccount.usBankAccount?.financialConnectionsAccount)
-            .isEqualTo("fca_111")
-    }
-
-    @Test
-    fun parse_withUsBankAccountWithFcaWithoutLa_returnsExpectedObject() {
-        val usBankAccount = PaymentMethodJsonParser().parse(
-            PaymentMethodFixtures.US_BANK_ACCOUNT_WITH_FCA_WITHOUT_LA
+            PaymentMethodFixtures.US_BANK_ACCOUNT_WITH_FCA
         )
 
         assertThat(usBankAccount.type)

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/util/PaymentMethodKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/util/PaymentMethodKtx.kt
@@ -3,5 +3,5 @@ package com.stripe.android.customersheet.util
 import com.stripe.android.model.PaymentMethod
 
 internal fun PaymentMethod.isUnverifiedUSBankAccount(): Boolean {
-    return type == PaymentMethod.Type.USBankAccount && usBankAccount?.linkedAccount == null
+    return type == PaymentMethod.Type.USBankAccount && usBankAccount?.financialConnectionsAccount == null
 }

--- a/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
@@ -334,7 +334,8 @@ internal object PaymentMethodFixtures {
                 "fingerprint": "FFDMA0xfhBjWSZLu",
                 "last4": "6789",
                 "routing_number": "110000000",
-                "linked_account": "la_account_123"
+                "linked_account": "la_account_123",
+                "financial_connections_account": "la_account_123"
             },
             "billing_details": {
                 "address": {


### PR DESCRIPTION
# Summary
Add `financial_connections_account` field to `PaymentMethod` & replace in `CustomerSheet`.

# Motivation
Resolves [MOBILESDK-1546](https://jira.corp.stripe.com/browse/MOBILESDK-1546)

`linked_account` is a deprecated field on the Stripe API. I've deprecated here as well in favor of `financial_connections_account`. `PaymentMethod.linkedAccount` will default to `financial_connections_account` if it can't find `linked_account`.

If you would like to test, I can provide a server URL to run the Customer Sheet playground against in DMs.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified