### PR TITLE
Add link to artifacts tab for failed screenshot tests.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
@@ -105,7 +105,6 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
     @Test
     fun testPaymentSheetNewCustomerDarkAppearance() {
         AppearanceStore.state = appearance
-        forceDarkMode()
         testDriver.screenshotRegression(
             testParams
         )

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
@@ -105,6 +105,7 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
     @Test
     fun testPaymentSheetNewCustomerDarkAppearance() {
         AppearanceStore.state = appearance
+        forceDarkMode()
         testDriver.screenshotRegression(
             testParams
         )

--- a/scripts/check_for_changed_paymentsheet_screenshots.rb
+++ b/scripts/check_for_changed_paymentsheet_screenshots.rb
@@ -10,5 +10,6 @@ if stdout.empty?
     exit true
 end
 
-puts "Screenshot tests failed.\n\n#{stdout}\n\nScreenshots are in the artifacts tab in bitrise."
+artifacts_link = "#{BITRISE_BUILD_URL}?tab=artifacts"
+puts "Screenshot tests failed.\n\n#{stdout}\n\nScreenshots are in the artifacts tab in bitrise - #{artifacts_link}"
 exit false

--- a/scripts/check_for_changed_paymentsheet_screenshots.rb
+++ b/scripts/check_for_changed_paymentsheet_screenshots.rb
@@ -10,7 +10,8 @@ if stdout.empty?
     exit true
 end
 
-artifacts_link = "#{BITRISE_BUILD_URL}?tab=artifacts"
+bitrise_build_url = ENV["BITRISE_BUILD_URL"]
+artifacts_link = "#{bitrise_build_url}?tab=artifacts"
 puts "Screenshot tests failed.\n\n#{stdout}\n\nUpdated screenshots here:"
 puts artifacts_link
 exit false

--- a/scripts/check_for_changed_paymentsheet_screenshots.rb
+++ b/scripts/check_for_changed_paymentsheet_screenshots.rb
@@ -11,5 +11,6 @@ if stdout.empty?
 end
 
 artifacts_link = "#{BITRISE_BUILD_URL}?tab=artifacts"
-puts "Screenshot tests failed.\n\n#{stdout}\n\nScreenshots are in the artifacts tab in bitrise - #{artifacts_link}"
+puts "Screenshot tests failed.\n\n#{stdout}\n\nUpdated screenshots here:"
+puts artifacts_link
 exit false


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Follow up to https://github.com/stripe/stripe-android/pull/7817#discussion_r1466546435

Makes it easier for a developer to see the differences.

