### PR TITLE
Fix payment selection not persisting across all `PaymentSheet.Configuration` changes

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
@@ -136,7 +136,8 @@ private fun PaymentSheet.Configuration.toVolatileConfiguration(): VolatilePaymen
         allowsDelayedPaymentMethods = allowsDelayedPaymentMethods,
         allowsPaymentMethodsRequiringShippingAddress = allowsPaymentMethodsRequiringShippingAddress,
         billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
-        preferredNetworks = preferredNetworks
+        preferredNetworks = preferredNetworks,
+        allowsRemovalOfLastSavedPaymentMethod = allowsRemovalOfLastSavedPaymentMethod,
     )
 }
 
@@ -145,7 +146,7 @@ private fun PaymentSheet.GooglePayConfiguration.toVolatileConfiguration():
     return VolatilePaymentSheetConfiguration.GooglePayConfiguration(
         environment = environment,
         countryCode = countryCode,
-        currencyCode = currencyCode
+        currencyCode = currencyCode,
     )
 }
 
@@ -158,6 +159,7 @@ private data class VolatilePaymentSheetConfiguration(
     val allowsPaymentMethodsRequiringShippingAddress: Boolean,
     val billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration,
     val preferredNetworks: List<CardBrand>,
+    val allowsRemovalOfLastSavedPaymentMethod: Boolean,
 ) {
     data class GooglePayConfiguration(
         val environment: PaymentSheet.GooglePayConfiguration.Environment,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
@@ -4,6 +4,8 @@ import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.sp
+import com.stripe.android.model.CardBrand
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.uicore.PrimaryButtonColors
 import com.stripe.android.uicore.PrimaryButtonShape
 import com.stripe.android.uicore.PrimaryButtonTypography
@@ -33,6 +35,12 @@ internal fun PaymentSheet.Configuration.validate() {
             )
         }
     }
+}
+
+internal fun PaymentSheet.Configuration.containsVolatileDifferences(
+    other: PaymentSheet.Configuration
+): Boolean {
+    return toVolatileConfiguration() != other.toVolatileConfiguration()
 }
 
 internal fun PaymentSheet.Appearance.parseAppearance() {
@@ -103,5 +111,44 @@ internal fun PaymentSheet.Appearance.parseAppearance() {
             fontSize = primaryButton.typography.fontSizeSp?.sp
                 ?: (StripeThemeDefaults.typography.largeFontSize * typography.sizeScaleFactor)
         )
+    )
+}
+
+private fun PaymentSheet.Configuration.toVolatileConfiguration(): VolatilePaymentSheetConfiguration {
+    return VolatilePaymentSheetConfiguration(
+        customer = customer,
+        googlePay = googlePay?.toVolatileConfiguration(),
+        defaultBillingDetails = defaultBillingDetails,
+        shippingDetails = shippingDetails,
+        allowsDelayedPaymentMethods = allowsDelayedPaymentMethods,
+        allowsPaymentMethodsRequiringShippingAddress = allowsPaymentMethodsRequiringShippingAddress,
+        billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
+        preferredNetworks = preferredNetworks
+    )
+}
+
+private fun PaymentSheet.GooglePayConfiguration.toVolatileConfiguration():
+    VolatilePaymentSheetConfiguration.GooglePayConfiguration {
+    return VolatilePaymentSheetConfiguration.GooglePayConfiguration(
+        environment = environment,
+        countryCode = countryCode,
+        currencyCode = currencyCode
+    )
+}
+
+private data class VolatilePaymentSheetConfiguration(
+    val customer: PaymentSheet.CustomerConfiguration?,
+    val googlePay: GooglePayConfiguration?,
+    val defaultBillingDetails: PaymentSheet.BillingDetails?,
+    val shippingDetails: AddressDetails?,
+    val allowsDelayedPaymentMethods: Boolean,
+    val allowsPaymentMethodsRequiringShippingAddress: Boolean,
+    val billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration,
+    val preferredNetworks: List<CardBrand>,
+) {
+    data class GooglePayConfiguration(
+        val environment: PaymentSheet.GooglePayConfiguration.Environment,
+        val countryCode: String,
+        val currencyCode: String? = null,
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
@@ -114,6 +114,19 @@ internal fun PaymentSheet.Appearance.parseAppearance() {
     )
 }
 
+/**
+ * Creates a subset of the [PaymentSheet.Configuration] of values that affect the functional behavior of
+ * [PaymentSheet]. The items not included mainly affect how [PaymentSheet] will look but not affect what
+ * payment options are available to the customer:
+ * - UI elements in [PaymentSheet.GooglePayConfiguration]:
+ *   - [PaymentSheet.GooglePayConfiguration.amount]
+ *   - [PaymentSheet.GooglePayConfiguration.label]
+ *   - [PaymentSheet.GooglePayConfiguration.buttonType]
+ * - [PaymentSheet.Configuration.merchantDisplayName]
+ * - [PaymentSheet.Configuration.primaryButtonColor]
+ * - [PaymentSheet.Configuration.appearance]
+ * - [PaymentSheet.Configuration.primaryButtonLabel]
+ */
 private fun PaymentSheet.Configuration.toVolatileConfiguration(): VolatilePaymentSheetConfiguration {
     return VolatilePaymentSheetConfiguration(
         customer = customer,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.flowcontroller
 
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.containsVolatileDifferences
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.getPMsToAdd
 import com.stripe.android.paymentsheet.state.PaymentSheetState
@@ -24,10 +25,10 @@ internal class DefaultPaymentSelectionUpdater @Inject constructor(
         previousConfig: PaymentSheet.Configuration?,
         newState: PaymentSheetState.Full,
     ): PaymentSelection? {
-        val didConfigChange = previousConfig != newState.config
-
         return currentSelection?.takeIf { selection ->
-            canUseSelection(selection, newState) && !didConfigChange
+            canUseSelection(selection, newState) && previousConfig?.let { previousConfig ->
+                !previousConfig.containsVolatileDifferences(newState.config)
+            } ?: true
         } ?: newState.paymentSelection
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
@@ -1,0 +1,97 @@
+package com.stripe.android.paymentsheet
+
+import android.content.res.ColorStateList
+import android.graphics.Color
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import org.junit.Test
+
+class PaymentSheetConfigurationKtxTest {
+    @Test
+    fun `'containVolatileDifferences' should return false when no volatile differences are found`() {
+        val changedConfiguration = configuration.copy(
+            merchantDisplayName = "New merchant, Inc.",
+            primaryButtonColor = ColorStateList.valueOf(Color.GREEN),
+            googlePay = PaymentSheet.GooglePayConfiguration(
+                environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                countryCode = "CA",
+                currencyCode = "CAD",
+                amount = 6899,
+                label = "New merchant, Inc.",
+                buttonType = PaymentSheet.GooglePayConfiguration.ButtonType.Plain,
+            ),
+            primaryButtonLabel = "Pay",
+        )
+
+        assertThat(configuration.containsVolatileDifferences(changedConfiguration)).isFalse()
+    }
+
+    @Test
+    fun `'containVolatileDifferences' should return true when volatile differences are found`() {
+        val configWithGooglePayChanges = configuration.copy(
+            googlePay = PaymentSheet.GooglePayConfiguration(
+                environment = PaymentSheet.GooglePayConfiguration.Environment.Production,
+                countryCode = "US",
+                currencyCode = "USD",
+                amount = 6899,
+                label = "New merchant, Inc.",
+                buttonType = PaymentSheet.GooglePayConfiguration.ButtonType.Plain,
+            ),
+        )
+
+        assertThat(configuration.containsVolatileDifferences(configWithGooglePayChanges)).isTrue()
+
+        val configWithBillingDetailsChanges = configuration.copy(
+            defaultBillingDetails = PaymentSheet.BillingDetails(
+                name = "Jenny Richards",
+            ),
+        )
+
+        assertThat(configuration.containsVolatileDifferences(configWithBillingDetailsChanges)).isTrue()
+
+        val configWithShippingDetailsChanges = configuration.copy(
+            shippingDetails = AddressDetails(
+                name = "Jenny Richards",
+            ),
+        )
+
+        assertThat(configuration.containsVolatileDifferences(configWithShippingDetailsChanges)).isTrue()
+
+        val configWithBillingConfigChanges = configuration.copy(
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+            ),
+        )
+
+        assertThat(configuration.containsVolatileDifferences(configWithBillingConfigChanges)).isTrue()
+    }
+
+    private companion object {
+        val configuration = PaymentSheet.Configuration(
+            merchantDisplayName = "Merchant, Inc.",
+            customer = PaymentSheet.CustomerConfiguration(
+                id = "1",
+                ephemeralKeySecret = "secret",
+            ),
+            googlePay = PaymentSheet.GooglePayConfiguration(
+                environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                countryCode = "CA",
+                currencyCode = "CAD",
+                amount = 5099,
+                label = "Merchant, Inc.",
+                buttonType = PaymentSheet.GooglePayConfiguration.ButtonType.Checkout,
+            ),
+            primaryButtonColor = ColorStateList.valueOf(Color.BLUE),
+            defaultBillingDetails = PaymentSheet.BillingDetails(
+                name = "Jenny Rosen",
+            ),
+            shippingDetails = AddressDetails(
+                name = "Jenny Rosen",
+            ),
+            primaryButtonLabel = "Buy",
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            ),
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
@@ -64,6 +64,30 @@ class PaymentSheetConfigurationKtxTest {
         )
 
         assertThat(configuration.containsVolatileDifferences(configWithBillingConfigChanges)).isTrue()
+
+        val configWithAllowsDelayedPaymentMethodChanges = configuration.copy(
+            allowsDelayedPaymentMethods = true,
+        )
+
+        assertThat(
+            configuration.containsVolatileDifferences(configWithAllowsDelayedPaymentMethodChanges)
+        ).isTrue()
+
+        val configWithAllowsPaymentMethodsRequiringShippingAddressChanges = configuration.copy(
+            allowsPaymentMethodsRequiringShippingAddress = true,
+        )
+
+        assertThat(
+            configuration.containsVolatileDifferences(configWithAllowsPaymentMethodsRequiringShippingAddressChanges)
+        ).isTrue()
+
+        val configWithAllowRemovalOfLastPaymentMethodChanges = configuration.copy(
+            allowsRemovalOfLastSavedPaymentMethod = false,
+        )
+
+        assertThat(
+            configuration.containsVolatileDifferences(configWithAllowRemovalOfLastPaymentMethodChanges)
+        ).isTrue()
     }
 
     private companion object {


### PR DESCRIPTION
# Summary
Fix payment selection not persisting across all `PaymentSheet.Configuration` changes

# Motivation
Resolves [MOBILESDK-1549](https://jira.corp.stripe.com/browse/MOBILESDK-1549)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
