### PR TITLE
Update to the latest 3DS2 release - 6.1.8.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -62,7 +62,7 @@ ext.versions = [
         robolectric                 : '4.11.1',
         shot                        : '5.14.1',
         showkase                    : '1.0.0-beta18',
-        stripe3ds2                  : '6.1.7',
+        stripe3ds2                  : '6.1.8',
         tensorflowLite              : '2.11.0',
         tensorflowLiteSupport       : '0.4.3',
         testParameterInjector       : '1.12',

--- a/example/dependencies/dependencies.txt
+++ b/example/dependencies/dependencies.txt
@@ -3,9 +3,9 @@
 |         \--- androidx.annotation:annotation-jvm:1.7.1
 |              \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.9.22
 |                   +--- org.jetbrains:annotations:13.0 -> 23.0.0
-|                   +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.0 (c)
+|                   +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.10 (c)
 |                   +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22 (c)
-|                   \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.0 (c)
+|                   \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.10 (c)
 +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
 +--- project :payments
 |    +--- project :payments-core
@@ -47,12 +47,12 @@
 |    |    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 (c)
 |    |    |    |    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22
 |    |    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
-|    |    |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0
-|    |    |    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
-|    |    |    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0
-|    |    |    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
+|    |    |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10
+|    |    |    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
+|    |    |    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10
+|    |    |    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
 |    |    |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
-|    |    |    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|    |    |    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1 -> 1.7.3 (*)
 |    |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common-java8:2.7.0 (c)
 |    |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (c)
@@ -584,9 +584,9 @@
 |    |    |    |    \--- com.google.android.material:material:1.8.0 -> 1.11.0
 |    |    |    |         +--- org.jetbrains.kotlin:kotlin-bom:1.8.22
 |    |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (c)
-|    |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.0 (c)
-|    |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.0 (c)
-|    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22 -> 1.9.22 (c)
+|    |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.10 (c)
+|    |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22 -> 1.9.22 (c)
+|    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.10 (c)
 |    |    |    |         +--- com.google.errorprone:error_prone_annotations:2.15.0
 |    |    |    |         +--- androidx.activity:activity:1.8.0 -> 1.8.2 (*)
 |    |    |    |         +--- androidx.annotation:annotation:1.2.0 -> 1.7.1 (*)
@@ -641,11 +641,11 @@
 |    |    |    |              +--- androidx.fragment:fragment:1.1.0 -> 1.6.2 (*)
 |    |    |    |              \--- androidx.recyclerview:recyclerview:1.3.1-rc01 -> 1.3.2 (*)
 |    |    |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    |    +--- com.google.accompanist:accompanist-themeadapter-material:0.32.0
 |    |    |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
 |    |    |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    |    +--- com.google.accompanist:accompanist-themeadapter-material3:0.32.0
 |    |    |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
 |    |    |    +--- androidx.compose.material3:material3:1.0.1
@@ -663,7 +663,7 @@
 |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.3.0 -> 2.7.0 (*)
 |    |    |    |    +--- androidx.savedstate:savedstate-ktx:1.2.0 -> 1.2.1 (*)
 |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.10 -> 1.9.22 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    |    +--- androidx.activity:activity-ktx:1.8.2 (*)
 |    |    +--- androidx.annotation:annotation:1.7.1 (*)
 |    |    +--- androidx.appcompat:appcompat:1.6.1 (*)
@@ -723,13 +723,11 @@
 |    |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    |    +--- com.stripe:stripe-3ds2-android:6.1.7
-|    |    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.7.20 -> 1.9.22 (*)
-|    |    |    +--- androidx.databinding:viewbinding:7.4.2 -> 8.2.2 (*)
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.9.0 (*)
-|    |    |    +--- androidx.appcompat:appcompat:1.5.1 -> 1.6.1 (*)
-|    |    |    +--- com.google.android.material:material:1.4.0 -> 1.11.0 (*)
-|    |    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.5.1 -> 2.7.0
+|    |    +--- com.stripe:stripe-3ds2-android:6.1.8
+|    |    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.10 -> 1.9.22 (*)
+|    |    |    +--- androidx.appcompat:appcompat:1.6.1 (*)
+|    |    |    +--- com.google.android.material:material:1.11.0 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.7.0
 |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (*)
 |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.7.0 (*)
 |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (*)
@@ -746,14 +744,16 @@
 |    |    |    |    +--- androidx.lifecycle:lifecycle-common-java8:2.7.0 (c)
 |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.7.0 (c)
 |    |    |    |    \--- androidx.lifecycle:lifecycle-process:2.7.0 (c)
-|    |    |    +--- androidx.core:core-ktx:1.9.0 -> 1.12.0 (*)
-|    |    |    +--- androidx.activity:activity-ktx:1.6.1 -> 1.8.2 (*)
-|    |    |    +--- androidx.fragment:fragment-ktx:1.5.5 -> 1.6.2 (*)
-|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.7.3 (*)
-|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
+|    |    |    +--- androidx.core:core-ktx:1.12.0 (*)
+|    |    |    +--- androidx.activity:activity-ktx:1.8.2 (*)
+|    |    |    +--- androidx.fragment:fragment-ktx:1.6.2 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
 |    |    |    +--- org.bouncycastle:bcprov-jdk15to18:1.69
-|    |    |    \--- com.nimbusds:nimbus-jose-jwt:9.21
-|    |    |         \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    |    +--- com.nimbusds:nimbus-jose-jwt:9.21
+|    |    |    |    \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    |    +--- androidx.databinding:viewbinding:8.2.1 -> 8.2.2 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10 (*)
 |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 |    +--- project :paymentsheet
 |    |    +--- project :payments-core (*)
@@ -784,7 +784,7 @@
 |    |    |    |    |    +--- androidx.compose.foundation:foundation:1.5.0 -> 1.5.4 (*)
 |    |    |    |    |    +--- androidx.compose.ui:ui-util:1.5.0 -> 1.5.4 (*)
 |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
-|    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
 |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
@@ -792,7 +792,7 @@
 |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
 |    |    |    |    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1 (*)
-|    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2 (*)
 |    |    |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 |    |    |    +--- project :stripe-ui-core (*)
@@ -939,14 +939,14 @@
 |    |    |    +--- androidx.core:core-ktx:1.8.0 -> 1.12.0 (*)
 |    |    |    +--- androidx.compose.ui:ui:1.5.0 -> 1.5.4 (*)
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    |    +--- com.google.android.gms:play-services-wallet:19.2.1 (*)
 |    |    +--- com.google.pay.button:compose-pay-button:0.1.3
 |    |    |    +--- com.google.android.gms:play-services-wallet:19.2.1 (*)
 |    |    |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    |    |    +--- androidx.compose.material:material:1.5.4 (*)
 |    |    |    +--- androidx.core:core-ktx:1.12.0 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    |    +--- com.google.android.material:material:1.11.0 (*)
 |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
 |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
@@ -970,7 +970,7 @@
 |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
 |    +--- com.airbnb.android:showkase-annotation:1.0.0-beta18
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.10 -> 1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.10 -> 1.9.10 (*)
 |    +--- com.google.dagger:dagger:2.50 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
@@ -986,9 +986,9 @@
 |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:{require 2.6.1; reject _} -> 2.7.0 (*)
 |    |    +--- com.airbnb.android:mavericks-common:3.0.9
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{require 1.6.4; reject _} -> 1.7.3 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.0 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.10 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{require 1.6.4; reject _} -> 1.7.3 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.10 (*)
 |    +--- com.airbnb.android:mavericks-compose:3.0.9
 |    |    +--- androidx.lifecycle:lifecycle-common-java8:{require 2.6.1; reject _} -> 2.7.0 (*)
 |    |    +--- androidx.fragment:fragment:{require 1.5.2; reject _} -> 1.6.2 (*)
@@ -997,7 +997,7 @@
 |    |    +--- androidx.compose.ui:ui:{require 1.2.1; reject _} -> 1.5.4 (*)
 |    |    +--- androidx.lifecycle:lifecycle-viewmodel-compose:{require 2.6.1; reject _} -> 2.7.0 (*)
 |    |    +--- com.airbnb.android:mavericks:3.0.9 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.10 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 +--- com.google.accompanist:accompanist-themeadapter-material:0.32.0 (*)
 +--- com.alipay.sdk:alipaysdk-android:15.8.12
@@ -1041,8 +1041,8 @@
 |    |    +--- com.squareup.okio:okio:3.6.0 -> 3.7.0
 |    |    |    \--- com.squareup.okio:okio-jvm:3.7.0
 |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.21 -> 1.9.22 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.21 -> 1.9.0 (*)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.21 -> 1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.21 -> 1.9.10 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.21 -> 1.9.10 (*)
 +--- com.google.android.material:material:1.11.0 (*)
 +--- com.google.android.gms:play-services-wallet:19.2.1 (*)
 +--- com.squareup.okio:okio:3.7.0 (*)

--- a/financial-connections-example/dependencies/dependencies.txt
+++ b/financial-connections-example/dependencies/dependencies.txt
@@ -843,13 +843,11 @@
 |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    +--- com.stripe:stripe-3ds2-android:6.1.7
-|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.7.20 -> 1.9.22 (*)
-|    |    +--- androidx.databinding:viewbinding:7.4.2 -> 8.2.2 (*)
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.9.10 (*)
-|    |    +--- androidx.appcompat:appcompat:1.5.1 -> 1.6.1 (*)
-|    |    +--- com.google.android.material:material:1.4.0 -> 1.11.0 (*)
-|    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.5.1 -> 2.7.0
+|    +--- com.stripe:stripe-3ds2-android:6.1.8
+|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.10 -> 1.9.22 (*)
+|    |    +--- androidx.appcompat:appcompat:1.6.1 (*)
+|    |    +--- com.google.android.material:material:1.11.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.7.0
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (*)
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.7.0 (*)
 |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (*)
@@ -866,14 +864,16 @@
 |    |    |    +--- androidx.lifecycle:lifecycle-common-java8:2.7.0 (c)
 |    |    |    +--- androidx.lifecycle:lifecycle-common:2.7.0 (c)
 |    |    |    \--- androidx.lifecycle:lifecycle-process:2.7.0 (c)
-|    |    +--- androidx.core:core-ktx:1.9.0 -> 1.12.0 (*)
-|    |    +--- androidx.activity:activity-ktx:1.6.1 -> 1.8.2 (*)
-|    |    +--- androidx.fragment:fragment-ktx:1.5.5 -> 1.6.2 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.7.3 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
+|    |    +--- androidx.core:core-ktx:1.12.0 (*)
+|    |    +--- androidx.activity:activity-ktx:1.8.2 (*)
+|    |    +--- androidx.fragment:fragment-ktx:1.6.2 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
 |    |    +--- org.bouncycastle:bcprov-jdk15to18:1.69
-|    |    \--- com.nimbusds:nimbus-jose-jwt:9.21
-|    |         \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    +--- com.nimbusds:nimbus-jose-jwt:9.21
+|    |    |    \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    +--- androidx.databinding:viewbinding:8.2.1 -> 8.2.2 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 +--- androidx.activity:activity-ktx:1.8.2 (*)
 +--- androidx.appcompat:appcompat:1.6.1 (*)

--- a/financial-connections/consumer-rules.txt
+++ b/financial-connections/consumer-rules.txt
@@ -20,8 +20,6 @@
    *;
 }
 
--dontwarn com.google.crypto.tink.subtle.XChaCha20Poly1305
-
 # The MavericksState object and the names classes that implement the MavericksState interface need to be
 # kept as they are accessed via reflection.
 -keepnames class com.airbnb.mvrx.MavericksState

--- a/link/dependencies/dependencies.txt
+++ b/link/dependencies/dependencies.txt
@@ -1,8 +1,8 @@
 +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22
 |    +--- org.jetbrains:annotations:13.0 -> 23.0.0
-|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.10 (c)
 |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22 (c)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.0 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.10 (c)
 +--- project :payments-core
 |    +--- project :stripe-core
 |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
@@ -44,12 +44,12 @@
 |    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 (c)
 |    |    |    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22
 |    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
-|    |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0
-|    |    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
-|    |    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0
-|    |    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
+|    |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10
+|    |    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
+|    |    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10
+|    |    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
 |    |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
-|    |    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|    |    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1 -> 1.7.3 (*)
 |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common-java8:2.7.0 (c)
 |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (c)
@@ -575,9 +575,9 @@
 |    |    |    \--- com.google.android.material:material:1.8.0 -> 1.11.0
 |    |    |         +--- org.jetbrains.kotlin:kotlin-bom:1.8.22
 |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (c)
-|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.0 (c)
+|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.10 (c)
 |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22 -> 1.9.22 (c)
-|    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.0 (c)
+|    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.10 (c)
 |    |    |         +--- com.google.errorprone:error_prone_annotations:2.15.0
 |    |    |         +--- androidx.activity:activity:1.8.0 -> 1.8.2 (*)
 |    |    |         +--- androidx.annotation:annotation:1.2.0 -> 1.7.1 (*)
@@ -632,11 +632,11 @@
 |    |    |              +--- androidx.fragment:fragment:1.1.0 -> 1.6.2 (*)
 |    |    |              \--- androidx.recyclerview:recyclerview:1.3.1-rc01 -> 1.3.2 (*)
 |    |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- com.google.accompanist:accompanist-themeadapter-material:0.32.0
 |    |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
 |    |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- com.google.accompanist:accompanist-themeadapter-material3:0.32.0
 |    |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
 |    |    +--- androidx.compose.material3:material3:1.0.1
@@ -654,7 +654,7 @@
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.3.0 -> 2.7.0 (*)
 |    |    |    +--- androidx.savedstate:savedstate-ktx:1.2.0 -> 1.2.1 (*)
 |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.10 -> 1.9.22 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- androidx.activity:activity-ktx:1.8.2 (*)
 |    +--- androidx.annotation:annotation:1.7.1 (*)
 |    +--- androidx.appcompat:appcompat:1.6.1 (*)
@@ -714,13 +714,11 @@
 |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    +--- com.stripe:stripe-3ds2-android:6.1.7
-|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.7.20 -> 1.9.22 (*)
-|    |    +--- androidx.databinding:viewbinding:7.4.2 -> 8.2.2 (*)
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.9.0 (*)
-|    |    +--- androidx.appcompat:appcompat:1.5.1 -> 1.6.1 (*)
-|    |    +--- com.google.android.material:material:1.4.0 -> 1.11.0 (*)
-|    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.5.1 -> 2.7.0
+|    +--- com.stripe:stripe-3ds2-android:6.1.8
+|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.10 -> 1.9.22 (*)
+|    |    +--- androidx.appcompat:appcompat:1.6.1 (*)
+|    |    +--- com.google.android.material:material:1.11.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.7.0
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (*)
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.7.0 (*)
 |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (*)
@@ -737,14 +735,16 @@
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0 (c)
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.7.0 (c)
 |    |    |    \--- androidx.lifecycle:lifecycle-process:2.7.0 (c)
-|    |    +--- androidx.core:core-ktx:1.9.0 -> 1.12.0 (*)
-|    |    +--- androidx.activity:activity-ktx:1.6.1 -> 1.8.2 (*)
-|    |    +--- androidx.fragment:fragment-ktx:1.5.5 -> 1.6.2 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.7.3 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
+|    |    +--- androidx.core:core-ktx:1.12.0 (*)
+|    |    +--- androidx.activity:activity-ktx:1.8.2 (*)
+|    |    +--- androidx.fragment:fragment-ktx:1.6.2 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
 |    |    +--- org.bouncycastle:bcprov-jdk15to18:1.69
-|    |    \--- com.nimbusds:nimbus-jose-jwt:9.21
-|    |         \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    +--- com.nimbusds:nimbus-jose-jwt:9.21
+|    |    |    \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    +--- androidx.databinding:viewbinding:8.2.1 -> 8.2.2 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 +--- project :stripe-core (*)
 +--- project :payments-ui-core
@@ -768,7 +768,7 @@
 |    |    +--- androidx.compose.foundation:foundation:1.5.0 -> 1.5.4 (*)
 |    |    +--- androidx.compose.ui:ui-util:1.5.0 -> 1.5.4 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
@@ -776,7 +776,7 @@
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
 |    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 +--- project :stripe-ui-core (*)

--- a/network-testing/dependencies/dependencies.txt
+++ b/network-testing/dependencies/dependencies.txt
@@ -700,13 +700,11 @@
 |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    +--- com.stripe:stripe-3ds2-android:6.1.7
-|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.7.20 -> 1.9.22 (*)
-|    |    +--- androidx.databinding:viewbinding:7.4.2 -> 8.2.2 (*)
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.9.10 (*)
-|    |    +--- androidx.appcompat:appcompat:1.5.1 -> 1.6.1 (*)
-|    |    +--- com.google.android.material:material:1.4.0 -> 1.11.0 (*)
-|    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.5.1 -> 2.7.0
+|    +--- com.stripe:stripe-3ds2-android:6.1.8
+|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.10 -> 1.9.22 (*)
+|    |    +--- androidx.appcompat:appcompat:1.6.1 (*)
+|    |    +--- com.google.android.material:material:1.11.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.7.0
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (*)
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.7.0 (*)
 |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (*)
@@ -721,14 +719,16 @@
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0 (c)
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.7.0 (c)
 |    |    |    \--- androidx.lifecycle:lifecycle-process:2.7.0 (c)
-|    |    +--- androidx.core:core-ktx:1.9.0 -> 1.12.0 (*)
-|    |    +--- androidx.activity:activity-ktx:1.6.1 -> 1.8.2 (*)
-|    |    +--- androidx.fragment:fragment-ktx:1.5.5 -> 1.6.2 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.7.3 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
+|    |    +--- androidx.core:core-ktx:1.12.0 (*)
+|    |    +--- androidx.activity:activity-ktx:1.8.2 (*)
+|    |    +--- androidx.fragment:fragment-ktx:1.6.2 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
 |    |    +--- org.bouncycastle:bcprov-jdk15to18:1.69
-|    |    \--- com.nimbusds:nimbus-jose-jwt:9.21
-|    |         \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    +--- com.nimbusds:nimbus-jose-jwt:9.21
+|    |    |    \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    +--- androidx.databinding:viewbinding:8.2.1 -> 8.2.2 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 +--- junit:junit:4.13.2 (*)
 \--- com.squareup.okhttp3:okhttp-tls:4.12.0

--- a/payment-method-messaging/dependencies/dependencies.txt
+++ b/payment-method-messaging/dependencies/dependencies.txt
@@ -1,8 +1,8 @@
 +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22
 |    +--- org.jetbrains:annotations:13.0 -> 23.0.0
-|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.10 (c)
 |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22 (c)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.0 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.10 (c)
 +--- project :stripe-core
 |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
 |    +--- androidx.browser:browser:1.7.0
@@ -43,12 +43,12 @@
 |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 (c)
 |    |    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22
 |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
-|    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0
-|    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
-|    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0
-|    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
+|    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10
+|    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
+|    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10
+|    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
 |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
-|    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1 -> 1.7.3 (*)
 |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common-java8:2.7.0 (c)
 |    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (c)
@@ -574,9 +574,9 @@
 |    |    |    \--- com.google.android.material:material:1.8.0 -> 1.11.0
 |    |    |         +--- org.jetbrains.kotlin:kotlin-bom:1.8.22
 |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (c)
-|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.0 (c)
-|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.0 (c)
-|    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22 -> 1.9.22 (c)
+|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.10 (c)
+|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22 -> 1.9.22 (c)
+|    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.10 (c)
 |    |    |         +--- com.google.errorprone:error_prone_annotations:2.15.0
 |    |    |         +--- androidx.activity:activity:1.8.0 -> 1.8.2 (*)
 |    |    |         +--- androidx.annotation:annotation:1.2.0 -> 1.7.1 (*)
@@ -631,11 +631,11 @@
 |    |    |              +--- androidx.fragment:fragment:1.1.0 -> 1.6.2 (*)
 |    |    |              \--- androidx.recyclerview:recyclerview:1.3.1-rc01 -> 1.3.2 (*)
 |    |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- com.google.accompanist:accompanist-themeadapter-material:0.32.0
 |    |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
 |    |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- com.google.accompanist:accompanist-themeadapter-material3:0.32.0
 |    |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
 |    |    +--- androidx.compose.material3:material3:1.0.1
@@ -653,7 +653,7 @@
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.3.0 -> 2.7.0 (*)
 |    |    |    +--- androidx.savedstate:savedstate-ktx:1.2.0 -> 1.2.1 (*)
 |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.10 -> 1.9.22 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- androidx.activity:activity-ktx:1.8.2 (*)
 |    +--- androidx.annotation:annotation:1.7.1 (*)
 |    +--- androidx.appcompat:appcompat:1.6.1 (*)
@@ -713,13 +713,11 @@
 |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    +--- com.stripe:stripe-3ds2-android:6.1.7
-|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.7.20 -> 1.9.22 (*)
-|    |    +--- androidx.databinding:viewbinding:7.4.2 -> 8.2.2 (*)
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.9.0 (*)
-|    |    +--- androidx.appcompat:appcompat:1.5.1 -> 1.6.1 (*)
-|    |    +--- com.google.android.material:material:1.4.0 -> 1.11.0 (*)
-|    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.5.1 -> 2.7.0
+|    +--- com.stripe:stripe-3ds2-android:6.1.8
+|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.10 -> 1.9.22 (*)
+|    |    +--- androidx.appcompat:appcompat:1.6.1 (*)
+|    |    +--- com.google.android.material:material:1.11.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.7.0
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (*)
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.7.0 (*)
 |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (*)
@@ -736,14 +734,16 @@
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0 (c)
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.7.0 (c)
 |    |    |    \--- androidx.lifecycle:lifecycle-process:2.7.0 (c)
-|    |    +--- androidx.core:core-ktx:1.9.0 -> 1.12.0 (*)
-|    |    +--- androidx.activity:activity-ktx:1.6.1 -> 1.8.2 (*)
-|    |    +--- androidx.fragment:fragment-ktx:1.5.5 -> 1.6.2 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.7.3 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
+|    |    +--- androidx.core:core-ktx:1.12.0 (*)
+|    |    +--- androidx.activity:activity-ktx:1.8.2 (*)
+|    |    +--- androidx.fragment:fragment-ktx:1.6.2 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
 |    |    +--- org.bouncycastle:bcprov-jdk15to18:1.69
-|    |    \--- com.nimbusds:nimbus-jose-jwt:9.21
-|    |         \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    +--- com.nimbusds:nimbus-jose-jwt:9.21
+|    |    |    \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    +--- androidx.databinding:viewbinding:8.2.1 -> 8.2.2 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 +--- project :payments-ui-core
 |    +--- androidx.databinding:viewbinding:8.2.2 (*)
@@ -766,7 +766,7 @@
 |    |    +--- androidx.compose.foundation:foundation:1.5.0 -> 1.5.4 (*)
 |    |    +--- androidx.compose.ui:ui-util:1.5.0 -> 1.5.4 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
@@ -774,7 +774,7 @@
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
 |    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 +--- project :stripe-ui-core (*)

--- a/payments-core-testing/dependencies/dependencies.txt
+++ b/payments-core-testing/dependencies/dependencies.txt
@@ -1,8 +1,8 @@
 +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22
 |    +--- org.jetbrains:annotations:13.0 -> 23.0.0
-|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.10 (c)
 |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22 (c)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.0 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.10 (c)
 +--- project :payments-core
 |    +--- project :stripe-core
 |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
@@ -45,12 +45,12 @@
 |    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3 (c)
 |    |    |    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22
 |    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
-|    |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0
-|    |    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
-|    |    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0
-|    |    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
+|    |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10
+|    |    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
+|    |    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10
+|    |    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
 |    |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
-|    |    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|    |    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1 -> 1.7.3 (*)
 |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (c)
 |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.7.0 (c)
@@ -553,9 +553,9 @@
 |    |    |    \--- com.google.android.material:material:1.8.0 -> 1.11.0
 |    |    |         +--- org.jetbrains.kotlin:kotlin-bom:1.8.22
 |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (c)
-|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.0 (c)
-|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.0 (c)
-|    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22 -> 1.9.22 (c)
+|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.10 (c)
+|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22 -> 1.9.22 (c)
+|    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.10 (c)
 |    |    |         +--- com.google.errorprone:error_prone_annotations:2.15.0
 |    |    |         +--- androidx.activity:activity:1.8.0 -> 1.8.2 (*)
 |    |    |         +--- androidx.annotation:annotation:1.2.0 -> 1.7.1 (*)
@@ -610,11 +610,11 @@
 |    |    |              +--- androidx.fragment:fragment:1.1.0 -> 1.6.2 (*)
 |    |    |              \--- androidx.recyclerview:recyclerview:1.3.1-rc01 -> 1.3.2 (*)
 |    |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- com.google.accompanist:accompanist-themeadapter-material:0.32.0
 |    |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
 |    |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- com.google.accompanist:accompanist-themeadapter-material3:0.32.0
 |    |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
 |    |    +--- androidx.compose.material3:material3:1.0.1
@@ -632,7 +632,7 @@
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.3.0 -> 2.7.0 (*)
 |    |    |    +--- androidx.savedstate:savedstate-ktx:1.2.0 -> 1.2.1 (*)
 |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.10 -> 1.9.22 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- androidx.activity:activity-ktx:1.8.2 (*)
 |    +--- androidx.annotation:annotation:1.7.1 (*)
 |    +--- androidx.appcompat:appcompat:1.6.1 (*)
@@ -692,13 +692,11 @@
 |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    +--- com.stripe:stripe-3ds2-android:6.1.7
-|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.7.20 -> 1.9.22 (*)
-|    |    +--- androidx.databinding:viewbinding:7.4.2 -> 8.2.2 (*)
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.9.0 (*)
-|    |    +--- androidx.appcompat:appcompat:1.5.1 -> 1.6.1 (*)
-|    |    +--- com.google.android.material:material:1.4.0 -> 1.11.0 (*)
-|    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.5.1 -> 2.7.0
+|    +--- com.stripe:stripe-3ds2-android:6.1.8
+|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.10 -> 1.9.22 (*)
+|    |    +--- androidx.appcompat:appcompat:1.6.1 (*)
+|    |    +--- com.google.android.material:material:1.11.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.7.0
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (*)
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.7.0 (*)
 |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (*)
@@ -713,14 +711,16 @@
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0 (c)
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.7.0 (c)
 |    |    |    \--- androidx.lifecycle:lifecycle-process:2.7.0 (c)
-|    |    +--- androidx.core:core-ktx:1.9.0 -> 1.12.0 (*)
-|    |    +--- androidx.activity:activity-ktx:1.6.1 -> 1.8.2 (*)
-|    |    +--- androidx.fragment:fragment-ktx:1.5.5 -> 1.6.2 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.7.3 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
+|    |    +--- androidx.core:core-ktx:1.12.0 (*)
+|    |    +--- androidx.activity:activity-ktx:1.8.2 (*)
+|    |    +--- androidx.fragment:fragment-ktx:1.6.2 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
 |    |    +--- org.bouncycastle:bcprov-jdk15to18:1.69
-|    |    \--- com.nimbusds:nimbus-jose-jwt:9.21
-|    |         \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    +--- com.nimbusds:nimbus-jose-jwt:9.21
+|    |    |    \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    +--- androidx.databinding:viewbinding:8.2.1 -> 8.2.2 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 +--- androidx.activity:activity-ktx:1.8.2 (*)
 +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0 (*)
@@ -732,6 +732,6 @@
      \--- org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm:1.7.3
           +--- org.jetbrains:annotations:23.0.0
           +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
-          +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+          +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
           +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
           \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22 (*)

--- a/payments-core/dependencies/dependencies.txt
+++ b/payments-core/dependencies/dependencies.txt
@@ -1,9 +1,9 @@
 +--- project :stripe-core
 |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22
 |    |    +--- org.jetbrains:annotations:13.0 -> 23.0.0
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.0 (c)
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.0 (c)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22 (c)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.10 (c)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22 (c)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.10 (c)
 |    +--- androidx.browser:browser:1.7.0
 |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.7.1
 |    |    |    \--- androidx.annotation:annotation-jvm:1.7.1
@@ -41,12 +41,12 @@
 |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (c)
 |    |    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22
 |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
-|    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0
-|    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
-|    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0
-|    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
+|    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10
+|    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
+|    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10
+|    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
 |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
-|    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1 -> 1.7.3 (*)
 |    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (c)
 |    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.7.0 (c)
@@ -549,9 +549,9 @@
 |    |    \--- com.google.android.material:material:1.8.0 -> 1.11.0
 |    |         +--- org.jetbrains.kotlin:kotlin-bom:1.8.22
 |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (c)
-|    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.0 (c)
-|    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.0 (c)
-|    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22 -> 1.9.22 (c)
+|    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.10 (c)
+|    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22 -> 1.9.22 (c)
+|    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.10 (c)
 |    |         +--- com.google.errorprone:error_prone_annotations:2.15.0
 |    |         +--- androidx.activity:activity:1.8.0 -> 1.8.2 (*)
 |    |         +--- androidx.annotation:annotation:1.2.0 -> 1.7.1 (*)
@@ -606,11 +606,11 @@
 |    |              +--- androidx.fragment:fragment:1.1.0 -> 1.6.2 (*)
 |    |              \--- androidx.recyclerview:recyclerview:1.3.1-rc01 -> 1.3.2 (*)
 |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 +--- com.google.accompanist:accompanist-themeadapter-material:0.32.0
 |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
 |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 +--- com.google.accompanist:accompanist-themeadapter-material3:0.32.0
 |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
 |    +--- androidx.compose.material3:material3:1.0.1
@@ -628,7 +628,7 @@
 |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.3.0 -> 2.7.0 (*)
 |    |    +--- androidx.savedstate:savedstate-ktx:1.2.0 -> 1.2.1 (*)
 |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.10 -> 1.9.22 (*)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 +--- androidx.activity:activity-ktx:1.8.2 (*)
 +--- androidx.annotation:annotation:1.7.1 (*)
 +--- androidx.appcompat:appcompat:1.6.1 (*)
@@ -688,13 +688,11 @@
 |    |    \--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 +--- com.google.android.instantapps:instantapps:1.1.0
-+--- com.stripe:stripe-3ds2-android:6.1.7
-|    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.7.20 -> 1.9.22 (*)
-|    +--- androidx.databinding:viewbinding:7.4.2 -> 8.2.2 (*)
-|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.9.0 (*)
-|    +--- androidx.appcompat:appcompat:1.5.1 -> 1.6.1 (*)
-|    +--- com.google.android.material:material:1.4.0 -> 1.11.0 (*)
-|    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.5.1 -> 2.7.0
++--- com.stripe:stripe-3ds2-android:6.1.8
+|    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.10 -> 1.9.22 (*)
+|    +--- androidx.appcompat:appcompat:1.6.1 (*)
+|    +--- com.google.android.material:material:1.11.0 (*)
+|    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.7.0
 |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (*)
 |    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.7.0 (*)
 |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (*)
@@ -709,12 +707,14 @@
 |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0 (c)
 |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.7.0 (c)
 |    |    \--- androidx.lifecycle:lifecycle-process:2.7.0 (c)
-|    +--- androidx.core:core-ktx:1.9.0 -> 1.12.0 (*)
-|    +--- androidx.activity:activity-ktx:1.6.1 -> 1.8.2 (*)
-|    +--- androidx.fragment:fragment-ktx:1.5.5 -> 1.6.2 (*)
-|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.7.3 (*)
-|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
+|    +--- androidx.core:core-ktx:1.12.0 (*)
+|    +--- androidx.activity:activity-ktx:1.8.2 (*)
+|    +--- androidx.fragment:fragment-ktx:1.6.2 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
 |    +--- org.bouncycastle:bcprov-jdk15to18:1.69
-|    \--- com.nimbusds:nimbus-jose-jwt:9.21
-|         \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    +--- com.nimbusds:nimbus-jose-jwt:9.21
+|    |    \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    +--- androidx.databinding:viewbinding:8.2.1 -> 8.2.2 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10 (*)
 \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)

--- a/payments-ui-core/dependencies/dependencies.txt
+++ b/payments-ui-core/dependencies/dependencies.txt
@@ -3,9 +3,9 @@
 |         \--- androidx.annotation:annotation-jvm:1.7.1
 |              \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.9.22
 |                   +--- org.jetbrains:annotations:13.0 -> 23.0.0
-|                   +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.0 (c)
+|                   +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.10 (c)
 |                   +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22 (c)
-|                   \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.0 (c)
+|                   \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.10 (c)
 +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
 +--- project :stripe-core
 |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
@@ -45,12 +45,12 @@
 |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 (c)
 |    |    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22
 |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
-|    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0
-|    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
-|    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0
-|    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
+|    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10
+|    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
+|    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10
+|    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
 |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
-|    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1 -> 1.7.3 (*)
 |    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (c)
 |    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.7.0 (c)
@@ -554,9 +554,9 @@
 |    |    |    \--- com.google.android.material:material:1.8.0 -> 1.11.0
 |    |    |         +--- org.jetbrains.kotlin:kotlin-bom:1.8.22
 |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (c)
-|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.0 (c)
+|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.10 (c)
 |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22 -> 1.9.22 (c)
-|    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.0 (c)
+|    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.10 (c)
 |    |    |         +--- com.google.errorprone:error_prone_annotations:2.15.0
 |    |    |         +--- androidx.activity:activity:1.8.0 -> 1.8.2 (*)
 |    |    |         +--- androidx.annotation:annotation:1.2.0 -> 1.7.1 (*)
@@ -611,11 +611,11 @@
 |    |    |              +--- androidx.fragment:fragment:1.1.0 -> 1.6.2 (*)
 |    |    |              \--- androidx.recyclerview:recyclerview:1.3.1-rc01 -> 1.3.2 (*)
 |    |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- com.google.accompanist:accompanist-themeadapter-material:0.32.0
 |    |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
 |    |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- com.google.accompanist:accompanist-themeadapter-material3:0.32.0
 |    |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
 |    |    +--- androidx.compose.material3:material3:1.0.1
@@ -633,7 +633,7 @@
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.3.0 -> 2.7.0 (*)
 |    |    |    +--- androidx.savedstate:savedstate-ktx:1.2.0 -> 1.2.1 (*)
 |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.10 -> 1.9.22 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- androidx.activity:activity-ktx:1.8.2 (*)
 |    +--- androidx.annotation:annotation:1.7.1 (*)
 |    +--- androidx.appcompat:appcompat:1.6.1 (*)
@@ -693,13 +693,11 @@
 |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    +--- com.stripe:stripe-3ds2-android:6.1.7
-|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.7.20 -> 1.9.22 (*)
-|    |    +--- androidx.databinding:viewbinding:7.4.2 -> 8.2.2 (*)
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.9.0 (*)
-|    |    +--- androidx.appcompat:appcompat:1.5.1 -> 1.6.1 (*)
-|    |    +--- com.google.android.material:material:1.4.0 -> 1.11.0 (*)
-|    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.5.1 -> 2.7.0
+|    +--- com.stripe:stripe-3ds2-android:6.1.8
+|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.10 -> 1.9.22 (*)
+|    |    +--- androidx.appcompat:appcompat:1.6.1 (*)
+|    |    +--- com.google.android.material:material:1.11.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.7.0
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (*)
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.7.0 (*)
 |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (*)
@@ -714,14 +712,16 @@
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0 (c)
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.7.0 (c)
 |    |    |    \--- androidx.lifecycle:lifecycle-process:2.7.0 (c)
-|    |    +--- androidx.core:core-ktx:1.9.0 -> 1.12.0 (*)
-|    |    +--- androidx.activity:activity-ktx:1.6.1 -> 1.8.2 (*)
-|    |    +--- androidx.fragment:fragment-ktx:1.5.5 -> 1.6.2 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.7.3 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
+|    |    +--- androidx.core:core-ktx:1.12.0 (*)
+|    |    +--- androidx.activity:activity-ktx:1.8.2 (*)
+|    |    +--- androidx.fragment:fragment-ktx:1.6.2 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
 |    |    +--- org.bouncycastle:bcprov-jdk15to18:1.69
-|    |    \--- com.nimbusds:nimbus-jose-jwt:9.21
-|    |         \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    +--- com.nimbusds:nimbus-jose-jwt:9.21
+|    |    |    \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    +--- androidx.databinding:viewbinding:8.2.1 -> 8.2.2 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 +--- project :stripe-ui-core (*)
 +--- androidx.constraintlayout:constraintlayout:2.1.4 (*)
@@ -739,7 +739,7 @@
 |    +--- androidx.compose.foundation:foundation:1.5.0 -> 1.5.4 (*)
 |    +--- androidx.compose.ui:ui-util:1.5.0 -> 1.5.4 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
 +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
@@ -747,6 +747,6 @@
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
 |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1 (*)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2 (*)
 \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)

--- a/payments/dependencies/dependencies.txt
+++ b/payments/dependencies/dependencies.txt
@@ -2,9 +2,9 @@
 |    +--- project :stripe-core
 |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22
 |    |    |    +--- org.jetbrains:annotations:13.0 -> 23.0.0
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.0 (c)
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.0 (c)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.10 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22 (c)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.10 (c)
 |    |    +--- androidx.browser:browser:1.7.0
 |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.7.1
 |    |    |    |    \--- androidx.annotation:annotation-jvm:1.7.1
@@ -43,12 +43,12 @@
 |    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 (c)
 |    |    |    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22
 |    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
-|    |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0
-|    |    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
-|    |    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0
-|    |    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
+|    |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10
+|    |    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
+|    |    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10
+|    |    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
 |    |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
-|    |    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|    |    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1 -> 1.7.3 (*)
 |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common-java8:2.7.0 (c)
 |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (c)
@@ -581,9 +581,9 @@
 |    |    |    \--- com.google.android.material:material:1.8.0 -> 1.11.0
 |    |    |         +--- org.jetbrains.kotlin:kotlin-bom:1.8.22
 |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (c)
-|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.0 (c)
-|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.0 (c)
-|    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22 -> 1.9.22 (c)
+|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.10 (c)
+|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22 -> 1.9.22 (c)
+|    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.10 (c)
 |    |    |         +--- com.google.errorprone:error_prone_annotations:2.15.0
 |    |    |         +--- androidx.activity:activity:1.8.0 -> 1.8.2 (*)
 |    |    |         +--- androidx.annotation:annotation:1.2.0 -> 1.7.1 (*)
@@ -638,11 +638,11 @@
 |    |    |              +--- androidx.fragment:fragment:1.1.0 -> 1.6.2 (*)
 |    |    |              \--- androidx.recyclerview:recyclerview:1.3.1-rc01 -> 1.3.2 (*)
 |    |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- com.google.accompanist:accompanist-themeadapter-material:0.32.0
 |    |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
 |    |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- com.google.accompanist:accompanist-themeadapter-material3:0.32.0
 |    |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
 |    |    +--- androidx.compose.material3:material3:1.0.1
@@ -660,7 +660,7 @@
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.3.0 -> 2.7.0 (*)
 |    |    |    +--- androidx.savedstate:savedstate-ktx:1.2.0 -> 1.2.1 (*)
 |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.10 -> 1.9.22 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- androidx.activity:activity-ktx:1.8.2 (*)
 |    +--- androidx.annotation:annotation:1.7.1 (*)
 |    +--- androidx.appcompat:appcompat:1.6.1 (*)
@@ -720,13 +720,11 @@
 |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    +--- com.stripe:stripe-3ds2-android:6.1.7
-|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.7.20 -> 1.9.22 (*)
-|    |    +--- androidx.databinding:viewbinding:7.4.2 -> 8.2.2 (*)
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.9.0 (*)
-|    |    +--- androidx.appcompat:appcompat:1.5.1 -> 1.6.1 (*)
-|    |    +--- com.google.android.material:material:1.4.0 -> 1.11.0 (*)
-|    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.5.1 -> 2.7.0
+|    +--- com.stripe:stripe-3ds2-android:6.1.8
+|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.10 -> 1.9.22 (*)
+|    |    +--- androidx.appcompat:appcompat:1.6.1 (*)
+|    |    +--- com.google.android.material:material:1.11.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.7.0
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (*)
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.7.0 (*)
 |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (*)
@@ -743,14 +741,16 @@
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.7.0 (c)
 |    |    |    +--- androidx.lifecycle:lifecycle-common-java8:2.7.0 (c)
 |    |    |    \--- androidx.lifecycle:lifecycle-process:2.7.0 (c)
-|    |    +--- androidx.core:core-ktx:1.9.0 -> 1.12.0 (*)
-|    |    +--- androidx.activity:activity-ktx:1.6.1 -> 1.8.2 (*)
-|    |    +--- androidx.fragment:fragment-ktx:1.5.5 -> 1.6.2 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.7.3 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
+|    |    +--- androidx.core:core-ktx:1.12.0 (*)
+|    |    +--- androidx.activity:activity-ktx:1.8.2 (*)
+|    |    +--- androidx.fragment:fragment-ktx:1.6.2 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
 |    |    +--- org.bouncycastle:bcprov-jdk15to18:1.69
-|    |    \--- com.nimbusds:nimbus-jose-jwt:9.21
-|    |         \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    +--- com.nimbusds:nimbus-jose-jwt:9.21
+|    |    |    \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    +--- androidx.databinding:viewbinding:8.2.1 -> 8.2.2 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 +--- project :paymentsheet
 |    +--- project :payments-core (*)
@@ -781,7 +781,7 @@
 |    |    |    |    +--- androidx.compose.foundation:foundation:1.5.0 -> 1.5.4 (*)
 |    |    |    |    +--- androidx.compose.ui:ui-util:1.5.0 -> 1.5.4 (*)
 |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
-|    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
@@ -789,7 +789,7 @@
 |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
 |    |    |    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1 (*)
-|    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2 (*)
 |    |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 |    |    +--- project :stripe-ui-core (*)
@@ -936,14 +936,14 @@
 |    |    +--- androidx.core:core-ktx:1.8.0 -> 1.12.0 (*)
 |    |    +--- androidx.compose.ui:ui:1.5.0 -> 1.5.4 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- com.google.android.gms:play-services-wallet:19.2.1 (*)
 |    +--- com.google.pay.button:compose-pay-button:0.1.3
 |    |    +--- com.google.android.gms:play-services-wallet:19.2.1 (*)
 |    |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    |    +--- androidx.compose.material:material:1.5.4 (*)
 |    |    +--- androidx.core:core-ktx:1.12.0 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    +--- com.google.android.material:material:1.11.0 (*)
 |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)

--- a/paymentsheet-example/dependencies/dependencies.txt
+++ b/paymentsheet-example/dependencies/dependencies.txt
@@ -3,9 +3,9 @@
 |         \--- androidx.annotation:annotation-jvm:1.7.1
 |              \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.9.22
 |                   +--- org.jetbrains:annotations:13.0 -> 23.0.0
-|                   +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.0 (c)
+|                   +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.10 (c)
 |                   +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22 (c)
-|                   \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.0 (c)
+|                   \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.10 (c)
 +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
 +--- project :payments
 |    +--- project :payments-core
@@ -47,12 +47,12 @@
 |    |    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 (c)
 |    |    |    |    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22
 |    |    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
-|    |    |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0
-|    |    |    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
-|    |    |    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0
-|    |    |    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
+|    |    |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10
+|    |    |    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
+|    |    |    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10
+|    |    |    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
 |    |    |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
-|    |    |    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|    |    |    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1 -> 1.7.3 (*)
 |    |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common-java8:2.7.0 (c)
 |    |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (c)
@@ -601,9 +601,9 @@
 |    |    |    |    \--- com.google.android.material:material:1.8.0 -> 1.11.0
 |    |    |    |         +--- org.jetbrains.kotlin:kotlin-bom:1.8.22
 |    |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (c)
-|    |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.0 (c)
+|    |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.10 (c)
 |    |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22 -> 1.9.22 (c)
-|    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.0 (c)
+|    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.10 (c)
 |    |    |    |         +--- com.google.errorprone:error_prone_annotations:2.15.0
 |    |    |    |         +--- androidx.activity:activity:1.8.0 -> 1.8.2 (*)
 |    |    |    |         +--- androidx.annotation:annotation:1.2.0 -> 1.7.1 (*)
@@ -658,11 +658,11 @@
 |    |    |    |              +--- androidx.fragment:fragment:1.1.0 -> 1.6.2 (*)
 |    |    |    |              \--- androidx.recyclerview:recyclerview:1.3.1-rc01 -> 1.3.2 (*)
 |    |    |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    |    +--- com.google.accompanist:accompanist-themeadapter-material:0.32.0
 |    |    |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
 |    |    |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    |    +--- com.google.accompanist:accompanist-themeadapter-material3:0.32.0
 |    |    |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
 |    |    |    +--- androidx.compose.material3:material3:1.0.1
@@ -680,7 +680,7 @@
 |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.3.0 -> 2.7.0 (*)
 |    |    |    |    +--- androidx.savedstate:savedstate-ktx:1.2.0 -> 1.2.1 (*)
 |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.10 -> 1.9.22 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    |    +--- androidx.activity:activity-ktx:1.8.2 (*)
 |    |    +--- androidx.annotation:annotation:1.7.1 (*)
 |    |    +--- androidx.appcompat:appcompat:1.6.1 (*)
@@ -740,13 +740,11 @@
 |    |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    |    +--- com.stripe:stripe-3ds2-android:6.1.7
-|    |    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.7.20 -> 1.9.22 (*)
-|    |    |    +--- androidx.databinding:viewbinding:7.4.2 -> 8.2.2 (*)
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.9.0 (*)
-|    |    |    +--- androidx.appcompat:appcompat:1.5.1 -> 1.6.1 (*)
-|    |    |    +--- com.google.android.material:material:1.4.0 -> 1.11.0 (*)
-|    |    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.5.1 -> 2.7.0
+|    |    +--- com.stripe:stripe-3ds2-android:6.1.8
+|    |    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.10 -> 1.9.22 (*)
+|    |    |    +--- androidx.appcompat:appcompat:1.6.1 (*)
+|    |    |    +--- com.google.android.material:material:1.11.0 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.7.0
 |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (*)
 |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.7.0 (*)
 |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (*)
@@ -763,14 +761,16 @@
 |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.7.0 (c)
 |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.7.0 (c)
 |    |    |    |    \--- androidx.lifecycle:lifecycle-process:2.7.0 (c)
-|    |    |    +--- androidx.core:core-ktx:1.9.0 -> 1.12.0 (*)
-|    |    |    +--- androidx.activity:activity-ktx:1.6.1 -> 1.8.2 (*)
-|    |    |    +--- androidx.fragment:fragment-ktx:1.5.5 -> 1.6.2 (*)
-|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.7.3 (*)
-|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
+|    |    |    +--- androidx.core:core-ktx:1.12.0 (*)
+|    |    |    +--- androidx.activity:activity-ktx:1.8.2 (*)
+|    |    |    +--- androidx.fragment:fragment-ktx:1.6.2 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
 |    |    |    +--- org.bouncycastle:bcprov-jdk15to18:1.69
-|    |    |    \--- com.nimbusds:nimbus-jose-jwt:9.21
-|    |    |         \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    |    +--- com.nimbusds:nimbus-jose-jwt:9.21
+|    |    |    |    \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    |    +--- androidx.databinding:viewbinding:8.2.1 -> 8.2.2 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10 (*)
 |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 |    +--- project :paymentsheet
 |    |    +--- project :payments-core (*)
@@ -801,7 +801,7 @@
 |    |    |    |    |    +--- androidx.compose.foundation:foundation:1.5.0 -> 1.5.4 (*)
 |    |    |    |    |    +--- androidx.compose.ui:ui-util:1.5.0 -> 1.5.4 (*)
 |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
-|    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
 |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
@@ -809,7 +809,7 @@
 |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
 |    |    |    |    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1 (*)
-|    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2 (*)
 |    |    |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 |    |    |    +--- project :stripe-ui-core (*)
@@ -978,14 +978,14 @@
 |    |    |    +--- androidx.core:core-ktx:1.8.0 -> 1.12.0 (*)
 |    |    |    +--- androidx.compose.ui:ui:1.5.0 -> 1.5.4 (*)
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    |    +--- com.google.android.gms:play-services-wallet:19.2.1 (*)
 |    |    +--- com.google.pay.button:compose-pay-button:0.1.3
 |    |    |    +--- com.google.android.gms:play-services-wallet:19.2.1 (*)
 |    |    |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    |    |    +--- androidx.compose.material:material:1.5.4 (*)
 |    |    |    +--- androidx.core:core-ktx:1.12.0 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    |    +--- com.google.android.material:material:1.11.0 (*)
 |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
 |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
@@ -1099,7 +1099,7 @@
 |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
 |    +--- com.airbnb.android:showkase-annotation:1.0.0-beta18
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.10 -> 1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.10 -> 1.9.10 (*)
 |    +--- com.google.dagger:dagger:2.50 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
@@ -1115,9 +1115,9 @@
 |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:{require 2.6.1; reject _} -> 2.7.0 (*)
 |    |    +--- com.airbnb.android:mavericks-common:3.0.9
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{require 1.6.4; reject _} -> 1.7.3 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.0 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.10 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{require 1.6.4; reject _} -> 1.7.3 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.10 (*)
 |    +--- com.airbnb.android:mavericks-compose:3.0.9
 |    |    +--- androidx.lifecycle:lifecycle-common-java8:{require 2.6.1; reject _} -> 2.7.0 (*)
 |    |    +--- androidx.fragment:fragment:{require 1.5.2; reject _} -> 1.6.2 (*)
@@ -1126,7 +1126,7 @@
 |    |    +--- androidx.compose.ui:ui:{require 1.2.1; reject _} -> 1.5.4 (*)
 |    |    +--- androidx.lifecycle:lifecycle-viewmodel-compose:{require 2.6.1; reject _} -> 2.7.0 (*)
 |    |    +--- com.airbnb.android:mavericks:3.0.9 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.10 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 +--- androidx.activity:activity-ktx:1.8.2 (*)
 +--- androidx.appcompat:appcompat:1.6.1 (*)
@@ -1261,7 +1261,7 @@
 |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 -> 1.9.22 (*)
 |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.10 -> 1.9.22 (*)
 +--- com.godaddy.android.colorpicker:compose-color-picker-android:0.7.0
-|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.9.0 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.9.10 (*)
 |    +--- org.jetbrains.compose.runtime:runtime:1.3.0
 |    |    \--- androidx.compose.runtime:runtime:1.3.3 -> 1.5.4 (*)
 |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.20 -> 1.9.22 (*)
@@ -1269,15 +1269,15 @@
 |    |    \--- androidx.compose.material:material:1.3.1 -> 1.5.4 (*)
 |    \--- com.github.ajalt.colormath:colormath:3.2.0
 |         \--- com.github.ajalt.colormath:colormath-jvm:3.2.0
-|              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.0 -> 1.9.0 (*)
+|              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.0 -> 1.9.10 (*)
 +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2 (*)
 +--- com.squareup.okhttp3:logging-interceptor:4.12.0
 |    +--- com.squareup.okhttp3:okhttp:4.12.0
 |    |    +--- com.squareup.okio:okio:3.6.0 -> 3.7.0
 |    |    |    \--- com.squareup.okio:okio-jvm:3.7.0
 |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.21 -> 1.9.22 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.21 -> 1.9.0 (*)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.21 -> 1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.21 -> 1.9.10 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.21 -> 1.9.10 (*)
 +--- com.google.android.material:material:1.11.0 (*)
 +--- com.squareup.okio:okio:3.7.0 (*)
 +--- com.google.android.libraries.places:places:3.3.0
@@ -1315,5 +1315,5 @@
 |    +--- com.squareup.retrofit2:retrofit:2.9.0
 |    |    \--- com.squareup.okhttp3:okhttp:3.14.9 -> 4.12.0 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-serialization-core:1.5.0 -> 1.6.2 (*)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10 -> 1.9.0 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10 -> 1.9.10 (*)
 \--- com.google.zxing:core:3.5.2

--- a/paymentsheet/dependencies/dependencies.txt
+++ b/paymentsheet/dependencies/dependencies.txt
@@ -2,9 +2,9 @@
 |    +--- project :stripe-core
 |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22
 |    |    |    +--- org.jetbrains:annotations:13.0 -> 23.0.0
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.0 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.10 (c)
 |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22 (c)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.0 (c)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.10 (c)
 |    |    +--- androidx.browser:browser:1.7.0
 |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.7.1
 |    |    |    |    \--- androidx.annotation:annotation-jvm:1.7.1
@@ -43,12 +43,12 @@
 |    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 (c)
 |    |    |    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22
 |    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
-|    |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0
-|    |    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
-|    |    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0
-|    |    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
+|    |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10
+|    |    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
+|    |    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10
+|    |    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
 |    |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
-|    |    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|    |    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1 -> 1.7.3 (*)
 |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common-java8:2.7.0 (c)
 |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (c)
@@ -581,9 +581,9 @@
 |    |    |    \--- com.google.android.material:material:1.8.0 -> 1.11.0
 |    |    |         +--- org.jetbrains.kotlin:kotlin-bom:1.8.22
 |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (c)
-|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.0 (c)
-|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.0 (c)
-|    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22 -> 1.9.22 (c)
+|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.10 (c)
+|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22 -> 1.9.22 (c)
+|    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.10 (c)
 |    |    |         +--- com.google.errorprone:error_prone_annotations:2.15.0
 |    |    |         +--- androidx.activity:activity:1.8.0 -> 1.8.2 (*)
 |    |    |         +--- androidx.annotation:annotation:1.2.0 -> 1.7.1 (*)
@@ -638,11 +638,11 @@
 |    |    |              +--- androidx.fragment:fragment:1.1.0 -> 1.6.2 (*)
 |    |    |              \--- androidx.recyclerview:recyclerview:1.3.1-rc01 -> 1.3.2 (*)
 |    |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- com.google.accompanist:accompanist-themeadapter-material:0.32.0
 |    |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
 |    |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- com.google.accompanist:accompanist-themeadapter-material3:0.32.0
 |    |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
 |    |    +--- androidx.compose.material3:material3:1.0.1
@@ -660,7 +660,7 @@
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.3.0 -> 2.7.0 (*)
 |    |    |    +--- androidx.savedstate:savedstate-ktx:1.2.0 -> 1.2.1 (*)
 |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.10 -> 1.9.22 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- androidx.activity:activity-ktx:1.8.2 (*)
 |    +--- androidx.annotation:annotation:1.7.1 (*)
 |    +--- androidx.appcompat:appcompat:1.6.1 (*)
@@ -720,13 +720,11 @@
 |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    +--- com.stripe:stripe-3ds2-android:6.1.7
-|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.7.20 -> 1.9.22 (*)
-|    |    +--- androidx.databinding:viewbinding:7.4.2 -> 8.2.2 (*)
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.9.0 (*)
-|    |    +--- androidx.appcompat:appcompat:1.5.1 -> 1.6.1 (*)
-|    |    +--- com.google.android.material:material:1.4.0 -> 1.11.0 (*)
-|    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.5.1 -> 2.7.0
+|    +--- com.stripe:stripe-3ds2-android:6.1.8
+|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.10 -> 1.9.22 (*)
+|    |    +--- androidx.appcompat:appcompat:1.6.1 (*)
+|    |    +--- com.google.android.material:material:1.11.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.7.0
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (*)
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.7.0 (*)
 |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (*)
@@ -743,14 +741,16 @@
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0 (c)
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.7.0 (c)
 |    |    |    \--- androidx.lifecycle:lifecycle-process:2.7.0 (c)
-|    |    +--- androidx.core:core-ktx:1.9.0 -> 1.12.0 (*)
-|    |    +--- androidx.activity:activity-ktx:1.6.1 -> 1.8.2 (*)
-|    |    +--- androidx.fragment:fragment-ktx:1.5.5 -> 1.6.2 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.7.3 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
+|    |    +--- androidx.core:core-ktx:1.12.0 (*)
+|    |    +--- androidx.activity:activity-ktx:1.8.2 (*)
+|    |    +--- androidx.fragment:fragment-ktx:1.6.2 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
 |    |    +--- org.bouncycastle:bcprov-jdk15to18:1.69
-|    |    \--- com.nimbusds:nimbus-jose-jwt:9.21
-|    |         \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    +--- com.nimbusds:nimbus-jose-jwt:9.21
+|    |    |    \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    +--- androidx.databinding:viewbinding:8.2.1 -> 8.2.2 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 +--- androidx.databinding:viewbinding:8.2.2 (*)
 +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
@@ -779,7 +779,7 @@
 |    |    |    +--- androidx.compose.foundation:foundation:1.5.0 -> 1.5.4 (*)
 |    |    |    +--- androidx.compose.ui:ui-util:1.5.0 -> 1.5.4 (*)
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
@@ -787,7 +787,7 @@
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
 |    |    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2 (*)
 |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 |    +--- project :stripe-ui-core (*)
@@ -934,14 +934,14 @@
 |    +--- androidx.core:core-ktx:1.8.0 -> 1.12.0 (*)
 |    +--- androidx.compose.ui:ui:1.5.0 -> 1.5.4 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 +--- com.google.android.gms:play-services-wallet:19.2.1 (*)
 +--- com.google.pay.button:compose-pay-button:0.1.3
 |    +--- com.google.android.gms:play-services-wallet:19.2.1 (*)
 |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    +--- androidx.compose.material:material:1.5.4 (*)
 |    +--- androidx.core:core-ktx:1.12.0 (*)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 +--- com.google.android.material:material:1.11.0 (*)
 +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
 \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)

--- a/stripe-test-e2e/dependencies/dependencies.txt
+++ b/stripe-test-e2e/dependencies/dependencies.txt
@@ -1,8 +1,8 @@
 +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22
 |    +--- org.jetbrains:annotations:13.0 -> 23.0.0
-|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.0 (c)
-|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.0 (c)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.10 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.10 (c)
 \--- project :payments
      +--- project :payments-core
      |    +--- project :stripe-core
@@ -45,12 +45,12 @@
      |    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 (c)
      |    |    |    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22
      |    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
-     |    |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0
-     |    |    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
-     |    |    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0
-     |    |    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
+     |    |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10
+     |    |    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
+     |    |    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10
+     |    |    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
      |    |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
-     |    |    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+     |    |    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
      |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1 -> 1.7.3 (*)
      |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common-java8:2.7.0 (c)
      |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (c)
@@ -583,9 +583,9 @@
      |    |    |    \--- com.google.android.material:material:1.8.0 -> 1.11.0
      |    |    |         +--- org.jetbrains.kotlin:kotlin-bom:1.8.22
      |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (c)
-     |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.0 (c)
-     |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.0 (c)
-     |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22 -> 1.9.22 (c)
+     |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.10 (c)
+     |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22 -> 1.9.22 (c)
+     |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.10 (c)
      |    |    |         +--- com.google.errorprone:error_prone_annotations:2.15.0
      |    |    |         +--- androidx.activity:activity:1.8.0 -> 1.8.2 (*)
      |    |    |         +--- androidx.annotation:annotation:1.2.0 -> 1.7.1 (*)
@@ -640,11 +640,11 @@
      |    |    |              +--- androidx.fragment:fragment:1.1.0 -> 1.6.2 (*)
      |    |    |              \--- androidx.recyclerview:recyclerview:1.3.1-rc01 -> 1.3.2 (*)
      |    |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
      |    +--- com.google.accompanist:accompanist-themeadapter-material:0.32.0
      |    |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
      |    |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
      |    +--- com.google.accompanist:accompanist-themeadapter-material3:0.32.0
      |    |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
      |    |    +--- androidx.compose.material3:material3:1.0.1
@@ -662,7 +662,7 @@
      |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.3.0 -> 2.7.0 (*)
      |    |    |    +--- androidx.savedstate:savedstate-ktx:1.2.0 -> 1.2.1 (*)
      |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.10 -> 1.9.22 (*)
-     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
      |    +--- androidx.activity:activity-ktx:1.8.2 (*)
      |    +--- androidx.annotation:annotation:1.7.1 (*)
      |    +--- androidx.appcompat:appcompat:1.6.1 (*)
@@ -722,13 +722,11 @@
      |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 (*)
      |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
      |    +--- com.google.android.instantapps:instantapps:1.1.0
-     |    +--- com.stripe:stripe-3ds2-android:6.1.7
-     |    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.7.20 -> 1.9.22 (*)
-     |    |    +--- androidx.databinding:viewbinding:7.4.2 -> 8.2.2 (*)
-     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.9.0 (*)
-     |    |    +--- androidx.appcompat:appcompat:1.5.1 -> 1.6.1 (*)
-     |    |    +--- com.google.android.material:material:1.4.0 -> 1.11.0 (*)
-     |    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.5.1 -> 2.7.0
+     |    +--- com.stripe:stripe-3ds2-android:6.1.8
+     |    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.10 -> 1.9.22 (*)
+     |    |    +--- androidx.appcompat:appcompat:1.6.1 (*)
+     |    |    +--- com.google.android.material:material:1.11.0 (*)
+     |    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.7.0
      |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (*)
      |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.7.0 (*)
      |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (*)
@@ -745,14 +743,16 @@
      |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.7.0 (c)
      |    |    |    +--- androidx.lifecycle:lifecycle-common-java8:2.7.0 (c)
      |    |    |    \--- androidx.lifecycle:lifecycle-process:2.7.0 (c)
-     |    |    +--- androidx.core:core-ktx:1.9.0 -> 1.12.0 (*)
-     |    |    +--- androidx.activity:activity-ktx:1.6.1 -> 1.8.2 (*)
-     |    |    +--- androidx.fragment:fragment-ktx:1.5.5 -> 1.6.2 (*)
-     |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.7.3 (*)
-     |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
+     |    |    +--- androidx.core:core-ktx:1.12.0 (*)
+     |    |    +--- androidx.activity:activity-ktx:1.8.2 (*)
+     |    |    +--- androidx.fragment:fragment-ktx:1.6.2 (*)
+     |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+     |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
      |    |    +--- org.bouncycastle:bcprov-jdk15to18:1.69
-     |    |    \--- com.nimbusds:nimbus-jose-jwt:9.21
-     |    |         \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+     |    |    +--- com.nimbusds:nimbus-jose-jwt:9.21
+     |    |    |    \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+     |    |    +--- androidx.databinding:viewbinding:8.2.1 -> 8.2.2 (*)
+     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10 (*)
      |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
      +--- project :paymentsheet
      |    +--- project :payments-core (*)
@@ -783,7 +783,7 @@
      |    |    |    |    +--- androidx.compose.foundation:foundation:1.5.0 -> 1.5.4 (*)
      |    |    |    |    +--- androidx.compose.ui:ui-util:1.5.0 -> 1.5.4 (*)
      |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
-     |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+     |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
      |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
      |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
      |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
@@ -791,7 +791,7 @@
      |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
      |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
      |    |    |    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1 (*)
-     |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+     |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
      |    |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2 (*)
      |    |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
      |    |    +--- project :stripe-ui-core (*)
@@ -938,14 +938,14 @@
      |    |    +--- androidx.core:core-ktx:1.8.0 -> 1.12.0 (*)
      |    |    +--- androidx.compose.ui:ui:1.5.0 -> 1.5.4 (*)
      |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
-     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
      |    +--- com.google.android.gms:play-services-wallet:19.2.1 (*)
      |    +--- com.google.pay.button:compose-pay-button:0.1.3
      |    |    +--- com.google.android.gms:play-services-wallet:19.2.1 (*)
      |    |    +--- androidx.compose.ui:ui:1.5.4 (*)
      |    |    +--- androidx.compose.material:material:1.5.4 (*)
      |    |    +--- androidx.core:core-ktx:1.12.0 (*)
-     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
      |    +--- com.google.android.material:material:1.11.0 (*)
      |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
      |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)

--- a/wechatpay/dependencies/dependencies.txt
+++ b/wechatpay/dependencies/dependencies.txt
@@ -1,8 +1,8 @@
 +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22
 |    +--- org.jetbrains:annotations:13.0 -> 23.0.0
-|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.0 (c)
-|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.0 (c)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.10 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.10 (c)
 +--- project :payments-core
 |    +--- project :stripe-core
 |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
@@ -43,12 +43,12 @@
 |    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (c)
 |    |    |    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22
 |    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
-|    |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0
-|    |    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
-|    |    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0
-|    |    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.0 -> 1.9.22 (*)
+|    |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10
+|    |    |    |    |    |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
+|    |    |    |    |    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10
+|    |    |    |    |    |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 -> 1.9.22 (*)
 |    |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
-|    |    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.0 (*)
+|    |    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1 -> 1.7.3 (*)
 |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (c)
 |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.7.0 (c)
@@ -551,9 +551,9 @@
 |    |    |    \--- com.google.android.material:material:1.8.0 -> 1.11.0
 |    |    |         +--- org.jetbrains.kotlin:kotlin-bom:1.8.22
 |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (c)
-|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.0 (c)
-|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.0 (c)
-|    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22 -> 1.9.22 (c)
+|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.10 (c)
+|    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22 -> 1.9.22 (c)
+|    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22 -> 1.9.10 (c)
 |    |    |         +--- com.google.errorprone:error_prone_annotations:2.15.0
 |    |    |         +--- androidx.activity:activity:1.8.0 -> 1.8.2 (*)
 |    |    |         +--- androidx.annotation:annotation:1.2.0 -> 1.7.1 (*)
@@ -608,11 +608,11 @@
 |    |    |              +--- androidx.fragment:fragment:1.1.0 -> 1.6.2 (*)
 |    |    |              \--- androidx.recyclerview:recyclerview:1.3.1-rc01 -> 1.3.2 (*)
 |    |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- com.google.accompanist:accompanist-themeadapter-material:0.32.0
 |    |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
 |    |    +--- androidx.compose.material:material:1.5.0 -> 1.5.4 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- com.google.accompanist:accompanist-themeadapter-material3:0.32.0
 |    |    +--- com.google.accompanist:accompanist-themeadapter-core:0.32.0 (*)
 |    |    +--- androidx.compose.material3:material3:1.0.1
@@ -630,7 +630,7 @@
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.3.0 -> 2.7.0 (*)
 |    |    |    +--- androidx.savedstate:savedstate-ktx:1.2.0 -> 1.2.1 (*)
 |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.10 -> 1.9.22 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.10 (*)
 |    +--- androidx.activity:activity-ktx:1.8.2 (*)
 |    +--- androidx.annotation:annotation:1.7.1 (*)
 |    +--- androidx.appcompat:appcompat:1.6.1 (*)
@@ -690,13 +690,11 @@
 |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    +--- com.stripe:stripe-3ds2-android:6.1.7
-|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.7.20 -> 1.9.22 (*)
-|    |    +--- androidx.databinding:viewbinding:7.4.2 -> 8.2.2 (*)
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 -> 1.9.0 (*)
-|    |    +--- androidx.appcompat:appcompat:1.5.1 -> 1.6.1 (*)
-|    |    +--- com.google.android.material:material:1.4.0 -> 1.11.0 (*)
-|    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.5.1 -> 2.7.0
+|    +--- com.stripe:stripe-3ds2-android:6.1.8
+|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.10 -> 1.9.22 (*)
+|    |    +--- androidx.appcompat:appcompat:1.6.1 (*)
+|    |    +--- com.google.android.material:material:1.11.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.7.0
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.7.0 (*)
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.7.0 (*)
 |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.22 (*)
@@ -711,14 +709,16 @@
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0 (c)
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.7.0 (c)
 |    |    |    \--- androidx.lifecycle:lifecycle-process:2.7.0 (c)
-|    |    +--- androidx.core:core-ktx:1.9.0 -> 1.12.0 (*)
-|    |    +--- androidx.activity:activity-ktx:1.6.1 -> 1.8.2 (*)
-|    |    +--- androidx.fragment:fragment-ktx:1.5.5 -> 1.6.2 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.7.3 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
+|    |    +--- androidx.core:core-ktx:1.12.0 (*)
+|    |    +--- androidx.activity:activity-ktx:1.8.2 (*)
+|    |    +--- androidx.fragment:fragment-ktx:1.6.2 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
 |    |    +--- org.bouncycastle:bcprov-jdk15to18:1.69
-|    |    \--- com.nimbusds:nimbus-jose-jwt:9.21
-|    |         \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    +--- com.nimbusds:nimbus-jose-jwt:9.21
+|    |    |    \--- com.github.stephenc.jcip:jcip-annotations:1.0-1
+|    |    +--- androidx.databinding:viewbinding:8.2.1 -> 8.2.2 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 +--- androidx.appcompat:appcompat:1.6.1 (*)
 +--- androidx.core:core-ktx:1.12.0 (*)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Closes #7823

This brings in a change from our internal repo which simply adds `-dontwarn com.google.crypto.tink.subtle.XChaCha20Poly1305` to consumer proguard rules.
