### PR TITLE
[FC] Revert emulator update for Connections

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,8 +5,8 @@ project_type: android
 trigger_map:
   - push_branch: 'master'
     pipeline: main-trigger-pipeline
-  - pull_request_source_branch: '*'
-    pipeline: main-trigger-pipeline
+  - pull_request_source_branch: 'carlosmuvi/fix-finbank-maestro-tests'
+    pipeline: pipeline-connections-e2e-debug-tests
 app:
   envs:
     - GRADLE_OPTS: -Dkotlin.incremental=false
@@ -374,9 +374,9 @@ workflows:
     steps:
       - avd-manager@1:
           inputs:
-            - profile: "pixel_6"
+            - profile: "pixel_3a"
             - abi: "x86_64"
-            - api_level: 33
+            - api_level: 32
             - tag: "google_apis"
             - start_command_flags: >
                -camera-back none

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,8 +5,8 @@ project_type: android
 trigger_map:
   - push_branch: 'master'
     pipeline: main-trigger-pipeline
-  - pull_request_source_branch: 'carlosmuvi/fix-finbank-maestro-tests'
-    pipeline: pipeline-connections-e2e-debug-tests
+  - pull_request_source_branch: '*'
+    pipeline: main-trigger-pipeline
 app:
   envs:
     - GRADLE_OPTS: -Dkotlin.incremental=false

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -345,9 +345,9 @@ workflows:
     steps:
       - avd-manager@1:
           inputs:
-            - profile: "pixel_6"
+            - profile: "pixel_3a"
             - abi: "x86_64"
-            - api_level: 33
+            - api_level: 32
             - tag: "google_apis"
             - start_command_flags: >
                 -camera-back none

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -347,7 +347,7 @@ workflows:
           inputs:
             - profile: "pixel_3a"
             - abi: "x86_64"
-            - api_level: 32
+            - api_level: 33
             - tag: "google_apis"
             - start_command_flags: >
                 -camera-back none

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -118,7 +118,7 @@ workflows:
       - _run-connections-e2e-tests
   _run-connections-e2e-tests:
     before_run:
-      - start_emulator
+      - start_connections_emulator
       - prepare_all
     after_run:
       - conclude_all
@@ -146,35 +146,6 @@ workflows:
           inputs:
             - event_description: Android E2E tests failing! $BITRISE_BUILD_URL
             - integration_key: $AUX_PAGERDUTY_INTEGRATION_KEY
-  maestro-edge-financial-connections:
-    before_run:
-      - start_emulator
-      - prepare_all
-    after_run:
-      - conclude_all
-    steps:
-      - wait-for-android-emulator@1:
-          inputs:
-            - boot_timeout: 600
-      - android-build@1:
-          inputs:
-            - arguments: -PSTRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL=$STRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL
-            - module: financial-connections-example
-            - variant: debug
-            - build_type: apk
-            - cache_level: all
-      - script@1:
-          title: Execute Maestro tests
-          inputs:
-            - content: |-
-                #!/usr/bin/env bash
-                bash ./scripts/execute_maestro_tests.sh -t edge
-      - slack@3:
-          is_always_run: true
-          inputs:
-            - webhook_url: $WEBHOOK_SLACK_CARLOSMUVI_MAESTRO
-            - webhook_url_on_error: $WEBHOOK_SLACK_CARLOSMUVI_MAESTRO
-      - deploy-to-bitrise-io@2: { }
   maestro-paymentsheet:
     before_run:
       - start_emulator
@@ -370,13 +341,30 @@ workflows:
       - script@1:
           inputs:
             - content: python3 scripts/browserstack.py --test --apk paymentsheet-example/build/outputs/apk/debug/paymentsheet-example-debug.apk --espresso paymentsheet-example/build/outputs/apk/androidTest/debug/paymentsheet-example-debug-androidTest.apk
-  start_emulator:
+  start_connections_emulator:
     steps:
       - avd-manager@1:
           inputs:
             - profile: "pixel_3a"
             - abi: "x86_64"
             - api_level: 32
+            - tag: "google_apis"
+            - start_command_flags: >
+                -camera-back none
+                -camera-front none
+                -netdelay none
+                -netspeed full
+                -memory 2048
+                -no-snapshot
+                -no-audio
+                -no-window
+  start_emulator:
+    steps:
+      - avd-manager@1:
+          inputs:
+            - profile: "pixel_6"
+            - abi: "x86_64"
+            - api_level: 33
             - tag: "google_apis"
             - start_command_flags: >
                -camera-back none

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -345,7 +345,7 @@ workflows:
     steps:
       - avd-manager@1:
           inputs:
-            - profile: "pixel_3a"
+            - profile: "pixel_6"
             - abi: "x86_64"
             - api_level: 33
             - tag: "google_apis"

--- a/scripts/execute_maestro_tests.sh
+++ b/scripts/execute_maestro_tests.sh
@@ -22,7 +22,7 @@ then
   exit 1
 fi
 
-export MAESTRO_VERSION=1.33.1
+export MAESTRO_VERSION=1.35.0
 
 # Retry mechanism for Maestro installation
 MAX_RETRIES=5


### PR DESCRIPTION
# Summary
- The [emulator bump](https://github.com/stripe/stripe-android/pull/7818) recently merged breaks Financial Connections livemode tests (matchers within the web browser don't seem to work)
- This PR keeps the previous emulator for connections until figuring out the root cause. 

# Testing
- Tests passing after revert: https://app.bitrise.io/build/202352c9-8c7a-4bcc-ac04-2f58112227b8

