### PR TITLE
Make `GooglePayButton` full width.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/GooglePayButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/GooglePayButton.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.ui
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -57,7 +58,9 @@ internal fun GooglePayButton(
     when (state) {
         null,
         is PrimaryButton.State.Ready -> PayButton(
-            modifier = modifier.testTag(GOOGLE_PAY_BUTTON_TEST_TAG),
+            modifier = modifier
+                .fillMaxWidth()
+                .testTag(GOOGLE_PAY_BUTTON_TEST_TAG),
             allowedPaymentMethods = allowedPaymentMethods,
             type = buttonType.toComposeButtonType(),
             theme = buttonTheme,


### PR DESCRIPTION
# Summary
Make `GooglePayButton` full width.

# Motivation
Fixes an issue where the `GooglePayButton` is not shown in full width in `PaymentSheet`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
