### PR TITLE
Move LPM repository to PaymentSheet.

### DIFF
--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -1,19 +1,3 @@
-public final class com/stripe/android/paymentsheet/forms/PaymentMethodRequirements$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field $stable I
-	public static final field INSTANCE Lcom/stripe/android/paymentsheet/forms/PaymentMethodRequirements$$serializer;
-	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/paymentsheet/forms/PaymentMethodRequirements;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/paymentsheet/forms/PaymentMethodRequirements;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class com/stripe/android/paymentsheet/forms/PaymentMethodRequirements$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
 public final class com/stripe/android/ui/core/Amount$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/Amount;
@@ -746,6 +730,22 @@ public final class com/stripe/android/ui/core/elements/SaveForFutureUseSpec$Comp
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/SelectorIcon$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/SelectorIcon$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/ui/core/elements/SelectorIcon;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/ui/core/elements/SelectorIcon;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/SelectorIcon$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/stripe/android/ui/core/elements/SepaMandateTextSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/SepaMandateTextSpec$$serializer;
@@ -759,6 +759,22 @@ public final class com/stripe/android/ui/core/elements/SepaMandateTextSpec$$seri
 }
 
 public final class com/stripe/android/ui/core/elements/SepaMandateTextSpec$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/SharedDataSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/SharedDataSpec$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/ui/core/elements/SharedDataSpec;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/ui/core/elements/SharedDataSpec;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/SharedDataSpec$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -873,20 +889,6 @@ public final class com/stripe/android/ui/core/forms/ConvertToFormValuesMapKt {
 }
 
 public final class com/stripe/android/ui/core/forms/LinkCardFormKt {
-}
-
-public final class com/stripe/android/ui/core/forms/resources/LpmRepository$Companion {
-	public final fun getHardcodedCard ()Lcom/stripe/android/ui/core/forms/resources/LpmRepository$SupportedPaymentMethod;
-	public final fun getInstance (Lcom/stripe/android/ui/core/forms/resources/LpmRepository$LpmRepositoryArguments;)Lcom/stripe/android/ui/core/forms/resources/LpmRepository;
-}
-
-public final class com/stripe/android/ui/core/forms/resources/LpmRepository$LpmInitialFormData {
-	public static final field $stable I
-	public fun <init> ()V
-	public final fun containsKey (Ljava/lang/String;)Z
-	public final fun fromCode (Ljava/lang/String;)Lcom/stripe/android/ui/core/forms/resources/LpmRepository$SupportedPaymentMethod;
-	public final fun putAll (Ljava/util/Map;)V
-	public final fun values ()Ljava/util/List;
 }
 
 public abstract interface class com/stripe/android/ui/core/injection/FormControllerSubcomponent$Builder {

--- a/payments-ui-core/detekt-baseline.xml
+++ b/payments-ui-core/detekt-baseline.xml
@@ -5,11 +5,9 @@
     <ID>ConstructorParameterNaming:CardNumberElement.kt$CardNumberElement$val _identifier: IdentifierSpec</ID>
     <ID>ConstructorParameterNaming:CvcElement.kt$CvcElement$val _identifier: IdentifierSpec</ID>
     <ID>CyclomaticComplexMethod:FormItemSpec.kt$FormItemSpecSerializer$override fun selectDeserializer(element: JsonElement): DeserializationStrategy&lt;out FormItemSpec></ID>
-    <ID>CyclomaticComplexMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration, isDeferred: Boolean = false, )</ID>
     <ID>CyclomaticComplexMethod:TransformGoogleToStripeAddress.kt$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun Place.transformGoogleToStripeAddress( context: Context ): com.stripe.android.model.Address</ID>
     <ID>CyclomaticComplexMethod:TransformSpecToElements.kt$TransformSpecToElements$fun transform(list: List&lt;FormItemSpec>): List&lt;FormElement></ID>
     <ID>ForbiddenComment:Menu.kt$// TODO: Make sure this gets the rounded corner values</ID>
-    <ID>LongMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration, isDeferred: Boolean = false, )</ID>
     <ID>LongMethod:Menu.kt$@Suppress("ModifierParameter") @Composable internal fun DropdownMenuContent( expandedStates: MutableTransitionState&lt;Boolean>, transformOriginState: MutableState&lt;TransformOrigin>, initialFirstVisibleItemIndex: Int, modifier: Modifier = Modifier, content: LazyListScope.() -> Unit )</ID>
     <ID>LongMethod:TransformGoogleToStripeAddress.kt$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun Place.transformGoogleToStripeAddress( context: Context ): com.stripe.android.model.Address</ID>
     <ID>LongMethod:TransformGoogleToStripeAddressTest.kt$TransformGoogleToStripeAddressTest$@Test fun `test JP address`()</ID>
@@ -55,8 +53,6 @@
     <ID>MaxLineLength:CardNumberConfigTest.kt$CardNumberConfigTest$val state = cardNumberConfig.determineState(CardBrand.Visa, "4242424242424242", CardBrand.Visa.getMaxLengthForCardNumber("4242424242424242"))</ID>
     <ID>MaxLineLength:CardNumberConfigTest.kt$CardNumberConfigTest$val state = cardNumberConfig.determineState(CardBrand.Visa, "4242424242424243", CardBrand.Visa.getMaxLengthForCardNumber("4242424242424243"))</ID>
     <ID>MaxLineLength:CardNumberControllerTest.kt$CardNumberControllerTest$fun</ID>
-    <ID>MaxLineLength:LpmRepository.kt$LpmRepository.SupportedPaymentMethod$/** This describes the image in the LPM selector. These can be found internally [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0) */</ID>
-    <ID>MaxLineLength:LpmRepositoryTest.kt$LpmRepositoryTest$fun</ID>
     <ID>MaxLineLength:NextActionSpec.kt$PostConfirmHandlingPiStatusSpecsSerializer$override</ID>
     <ID>MaximumLineLength:com.stripe.android.ui.core.elements.NextActionSpec.kt:63</ID>
     <ID>ReturnCount:AuBankAccountNumberConfig.kt$AuBankAccountNumberConfig$override fun determineState(input: String): TextFieldState</ID>

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement.kt
@@ -54,6 +54,7 @@ data class AfterpayClearpayHeaderElement(
         const val url = "https://static.afterpay.com/modal/%s.html"
         const val NO_BREAK_SPACE = "\u00A0"
 
-        internal fun isClearpay() = setOf("GB", "ES", "FR", "IT").contains(Locale.current.region)
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        fun isClearpay() = setOf("GB", "ES", "FR", "IT").contains(Locale.current.region)
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/LpmSerializer.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/LpmSerializer.kt
@@ -1,11 +1,13 @@
 package com.stripe.android.ui.core.elements
 
 import android.util.Log
+import androidx.annotation.RestrictTo
 import androidx.annotation.WorkerThread
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
 
-internal object LpmSerializer {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+object LpmSerializer {
 
     private val format = Json {
         ignoreUnknownKeys = true

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SelectorIcon.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SelectorIcon.kt
@@ -1,11 +1,13 @@
 package com.stripe.android.ui.core.elements
 
+import androidx.annotation.RestrictTo
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 @SerialName("next_action_spec")
-internal data class SelectorIcon internal constructor(
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class SelectorIcon internal constructor(
     @SerialName("light_theme_png") val lightThemePng: String? = null,
     @SerialName("dark_theme_png") val darkThemePng: String? = null,
 )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SharedDataSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SharedDataSpec.kt
@@ -1,10 +1,12 @@
 package com.stripe.android.ui.core.elements
 
+import androidx.annotation.RestrictTo
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class SharedDataSpec(
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class SharedDataSpec(
     @SerialName("type")
     val type: String,
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/injection/ResourceRepositoryModule.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/injection/ResourceRepositoryModule.kt
@@ -3,7 +3,6 @@ package com.stripe.android.ui.core.forms.resources.injection
 import android.content.Context
 import android.content.res.Resources
 import androidx.annotation.RestrictTo
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import dagger.Module
 import dagger.Provides
 import javax.inject.Singleton
@@ -15,11 +14,5 @@ object ResourceRepositoryModule {
     @Singleton
     fun provideResources(context: Context): Resources {
         return context.resources
-    }
-
-    @Provides
-    @Singleton
-    fun providesLpmRepository(resources: Resources): LpmRepository {
-        return LpmRepository.getInstance(LpmRepository.LpmRepositoryArguments(resources))
     }
 }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
@@ -16,7 +16,6 @@ import com.stripe.android.paymentsheet.example.samples.ui.shared.PAYMENT_METHOD_
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
 import com.stripe.android.test.core.FieldPopulator
 import com.stripe.android.test.core.TestParameters
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -26,7 +25,7 @@ internal class TestCard : BasePlaygroundTest() {
     fun testCard() {
         testDriver.confirmNewOrGuestComplete(
             TestParameters.create(
-                paymentMethod = LpmRepository.HardcodedCard,
+                paymentMethodCode = "card",
             ).copy(
                 authorizationAction = null,
                 saveForFutureUseCheckboxVisible = true,
@@ -38,7 +37,7 @@ internal class TestCard : BasePlaygroundTest() {
     fun testCardWithCustomBillingDetailsCollection() {
         testDriver.confirmNewOrGuestComplete(
             TestParameters.create(
-                paymentMethod = LpmRepository.HardcodedCard,
+                paymentMethodCode = "card",
             ) { settings ->
                 settings[DefaultBillingAddressSettingsDefinition] = true
                 settings[CollectNameSettingsDefinition] =
@@ -60,7 +59,7 @@ internal class TestCard : BasePlaygroundTest() {
     fun testCardInCustomFlow() {
         testDriver.confirmCustom(
             TestParameters.create(
-                paymentMethod = LpmRepository.HardcodedCard,
+                paymentMethodCode = "card",
             ).copy(
                 authorizationAction = null,
                 saveForFutureUseCheckboxVisible = true,
@@ -77,7 +76,7 @@ internal class TestCard : BasePlaygroundTest() {
     fun testDefaultSavedPaymentMethodUsedAfterSingleSave() {
         val cardNumber = "6011111111111117"
         val testParameters = TestParameters.create(
-            paymentMethod = LpmRepository.HardcodedCard,
+            paymentMethodCode = "card",
         ).copy(
             authorizationAction = null,
             saveForFutureUseCheckboxVisible = true,
@@ -116,7 +115,7 @@ internal class TestCard : BasePlaygroundTest() {
         val secondCardNumber = "6011000990139424"
 
         val testParameters = TestParameters.create(
-            paymentMethod = LpmRepository.HardcodedCard,
+            paymentMethodCode = "card",
         ).copy(
             authorizationAction = null,
             saveForFutureUseCheckboxVisible = true,
@@ -162,7 +161,7 @@ internal class TestCard : BasePlaygroundTest() {
         val cardNumber = "6011111111111117"
 
         val testParameters = TestParameters.create(
-            paymentMethod = LpmRepository.HardcodedCard,
+            paymentMethodCode = "card",
         ).copy(
             authorizationAction = null,
             saveForFutureUseCheckboxVisible = true,
@@ -200,7 +199,7 @@ internal class TestCard : BasePlaygroundTest() {
         val secondCardNumber = "6011000990139424"
 
         val testParameters = TestParameters.create(
-            paymentMethod = LpmRepository.HardcodedCard,
+            paymentMethodCode = "card",
         ).copy(
             authorizationAction = null,
             saveForFutureUseCheckboxVisible = true,

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
@@ -11,7 +11,6 @@ import com.stripe.android.paymentsheet.example.playground.settings.CustomerSetti
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
 import com.stripe.android.paymentsheet.example.playground.settings.PrimaryButtonLabelSettingsDefinition
 import com.stripe.android.test.core.TestParameters
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -21,7 +20,7 @@ import org.junit.runner.RunWith
 internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimations = false) {
 
     private val testParams = TestParameters.create(
-        paymentMethod = LpmRepository.HardcodedCard,
+        paymentMethodCode = "card",
     ).copy(
         saveForFutureUseCheckboxVisible = true,
         authorizationAction = null,

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/FieldPopulator.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/FieldPopulator.kt
@@ -35,7 +35,7 @@ internal class FieldPopulator(
     private val verifyCustomLpmFields: () -> Unit = {},
     private val values: Values,
 ) {
-    private val formSpec = testParameters.paymentMethod.formSpec
+    private val formSpec = testParameters.formSpec
 
     fun verifyFields() {
         // Need to verify the value of save for future usage

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
@@ -13,14 +13,15 @@ import com.stripe.android.paymentsheet.example.playground.settings.DefaultShippi
 import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymentMethodsSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.LinkSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettings
-import com.stripe.android.ui.core.forms.resources.LpmRepository
+import com.stripe.android.ui.core.elements.LayoutSpec
 import com.stripe.android.utils.initializedLpmRepository
 
 /**
  * This is the data class that represents the parameters used to run the test.
  */
 internal data class TestParameters(
-    val paymentMethod: LpmRepository.SupportedPaymentMethod,
+    val paymentMethodCode: String,
+    val formSpec: LayoutSpec,
     val saveCheckboxValue: Boolean,
     val saveForFutureUseCheckboxVisible: Boolean,
     val useBrowser: Browser? = null,
@@ -39,18 +40,9 @@ internal data class TestParameters(
             paymentMethodCode: String,
             playgroundSettingsBlock: (PlaygroundSettings) -> Unit = {},
         ): TestParameters {
-            return create(
-                paymentMethod = lpmRepository.fromCode(paymentMethodCode)!!,
-                playgroundSettingsBlock = playgroundSettingsBlock,
-            )
-        }
-
-        fun create(
-            paymentMethod: LpmRepository.SupportedPaymentMethod,
-            playgroundSettingsBlock: (PlaygroundSettings) -> Unit = {},
-        ): TestParameters {
             return TestParameters(
-                paymentMethod = paymentMethod,
+                paymentMethodCode = paymentMethodCode,
+                formSpec = lpmRepository.fromCode(paymentMethodCode)!!.formSpec,
                 saveCheckboxValue = false,
                 saveForFutureUseCheckboxVisible = false,
                 authorizationAction = AuthorizeAction.AuthorizePayment,

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/PaymentSelection.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/PaymentSelection.kt
@@ -1,10 +1,9 @@
 package com.stripe.android.test.core.ui
 
-import androidx.annotation.StringRes
 import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
-import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
@@ -14,7 +13,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.stripe.android.paymentsheet.TEST_TAG_LIST
 import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 
-class PaymentSelection(val composeTestRule: ComposeTestRule, @StringRes val label: Int) {
+class PaymentSelection(val composeTestRule: ComposeTestRule, val paymentMethodCode: String) {
     fun click() {
         val resource = InstrumentationRegistry.getInstrumentation().targetContext.resources
 
@@ -30,11 +29,12 @@ class PaymentSelection(val composeTestRule: ComposeTestRule, @StringRes val labe
             return
         }
 
+        val paymentMethodMatcher = hasTestTag(TEST_TAG_LIST + paymentMethodCode)
         composeTestRule.onNodeWithTag(TEST_TAG_LIST, true)
-            .performScrollToNode(hasText(resource.getString(label)))
+            .performScrollToNode(paymentMethodMatcher)
         composeTestRule.waitForIdle()
         composeTestRule
-            .onNodeWithTag(TEST_TAG_LIST + resource.getString(label))
+            .onNode(paymentMethodMatcher)
             .assertIsDisplayed()
             .assertIsEnabled()
             .performClick()

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -55,16 +55,16 @@ internal class Selectors(
 
     val paymentSelection = PaymentSelection(
         composeTestRule,
-        testParameters.paymentMethod.displayNameResource
+        testParameters.paymentMethodCode
     )
 
     val buyButton = BuyButton(
         composeTestRule = composeTestRule,
-        processingCompleteTimeout = if (testParameters.paymentMethod.code == CashAppPay.code) {
+        processingCompleteTimeout = if (testParameters.paymentMethodCode == CashAppPay.code) {
             // We're using a longer timeout for Cash App Pay until we fix an issue where we
             // needlessly poll after a canceled payment attempt.
             15.seconds
-        } else if (testParameters.paymentMethod.code == Blik.code) {
+        } else if (testParameters.paymentMethodCode == Blik.code) {
             30.seconds
         } else {
             5.seconds

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/LpmRepositoryKtx.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/LpmRepositoryKtx.kt
@@ -1,9 +1,9 @@
 package com.stripe.android.utils
 
 import android.content.Context
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.testing.PaymentIntentFactory
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 
 internal fun initializedLpmRepository(context: Context): LpmRepository {
     val repository = LpmRepository(

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -190,6 +190,22 @@ public abstract interface class com/stripe/android/customersheet/SetupIntentClie
 	public abstract fun provideSetupIntentClientSecret (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/stripe/android/lpmfoundations/luxe/PaymentMethodRequirements$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/stripe/android/lpmfoundations/luxe/PaymentMethodRequirements$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/lpmfoundations/luxe/PaymentMethodRequirements;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/lpmfoundations/luxe/PaymentMethodRequirements;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/lpmfoundations/luxe/PaymentMethodRequirements$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata;

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -3,6 +3,7 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>CyclomaticComplexMethod:CustomerSheetViewModel.kt$CustomerSheetViewModel$fun handleViewAction(viewAction: CustomerSheetViewAction)</ID>
+    <ID>CyclomaticComplexMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration, isDeferred: Boolean = false, )</ID>
     <ID>CyclomaticComplexMethod:PlaceholderHelper.kt$PlaceholderHelper$@VisibleForTesting internal fun specForPlaceholderField( field: PlaceholderField, placeholderOverrideList: List&lt;IdentifierSpec>, requiresMandate: Boolean, configuration: PaymentSheet.BillingDetailsCollectionConfiguration, )</ID>
     <ID>EmptyFunctionBlock:PrimaryButtonAnimator.kt$PrimaryButtonAnimator.&lt;no name provided>${ }</ID>
     <ID>ForbiddenComment:PaymentOptionFactory.kt$PaymentOptionFactory$// TODO: Should use labelResource paymentMethodCreateParams or extension function</ID>
@@ -30,6 +31,7 @@
     <ID>LongMethod:EditPaymentMethod.kt$@Composable internal fun EditPaymentMethodUi( viewState: EditPaymentMethodViewState, viewActionHandler: (action: EditPaymentMethodViewAction) -> Unit, modifier: Modifier = Modifier )</ID>
     <ID>LongMethod:FormViewModelTest.kt$FormViewModelTest$@Test fun `Verify params are set when element address fields are complete`()</ID>
     <ID>LongMethod:FormViewModelTest.kt$FormViewModelTest$@Test fun `Verify params are set when required address fields are complete`()</ID>
+    <ID>LongMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration, isDeferred: Boolean = false, )</ID>
     <ID>LongMethod:PaymentElement.kt$@Composable internal fun PaymentElement( formViewModelSubComponentBuilderProvider: Provider&lt;FormViewModelSubcomponent.Builder>, enabled: Boolean, supportedPaymentMethods: List&lt;LpmRepository.SupportedPaymentMethod>, selectedItem: LpmRepository.SupportedPaymentMethod, linkSignupMode: LinkSignupMode?, linkConfigurationCoordinator: LinkConfigurationCoordinator?, showCheckboxFlow: Flow&lt;Boolean>, onItemSelectedListener: (LpmRepository.SupportedPaymentMethod) -> Unit, onLinkSignupStateChanged: (LinkConfiguration, InlineSignupViewState) -> Unit, formArguments: FormArguments, usBankAccountFormArguments: USBankAccountFormArguments, onFormFieldValuesChanged: (FormFieldValues?) -> Unit, )</ID>
     <ID>LongMethod:PaymentOptionFactory.kt$PaymentOptionFactory$fun create(selection: PaymentSelection): PaymentOption</ID>
     <ID>LongMethod:PaymentSheetConfigurationKtx.kt$internal fun PaymentSheet.Appearance.parseAppearance()</ID>
@@ -68,6 +70,8 @@
     <ID>MaxLineLength:InjectableActivityScenario.kt$InjectableActivityScenario$delegate ?: throw IllegalStateException("Cannot move to state $newState since the activity hasn't been launched.")</ID>
     <ID>MaxLineLength:InjectableActivityScenario.kt$InjectableActivityScenario$val d = delegate ?: throw IllegalStateException("Cannot run onActivity since the activity hasn't been launched.")</ID>
     <ID>MaxLineLength:LinkHandlerTest.kt$whenever(linkConfigurationCoordinator.attachNewCardToAccount(eq(linkConfiguration), any())).thenReturn(attachNewCardToAccountResult)</ID>
+    <ID>MaxLineLength:LpmRepository.kt$LpmRepository.SupportedPaymentMethod$/** This describes the image in the LPM selector. These can be found internally [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0) */</ID>
+    <ID>MaxLineLength:LpmRepositoryTest.kt$LpmRepositoryTest$fun</ID>
     <ID>MaxLineLength:PaymentSheet.kt$PaymentSheet.Address$*</ID>
     <ID>MaxLineLength:PaymentSheet.kt$PaymentSheet.BillingDetails$*</ID>
     <ID>MaxLineLength:PaymentSheet.kt$PaymentSheet.Configuration$*</ID>

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentMethodsUITest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentMethodsUITest.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.ui.core.forms.resources.LpmRepository
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.uicore.image.StripeImageLoader
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Ignore
@@ -33,14 +33,10 @@ internal class PaymentMethodsUITest {
     val composeTestRule = createAndroidComposeRule<MainActivity>()
 
     private val bancontactTestTag by lazy {
-        TEST_TAG_LIST + composeTestRule.activity.resources.getString(
-            Bancontact.displayNameResource
-        )
+        TEST_TAG_LIST + Bancontact.code
     }
     private val epsTestTag by lazy {
-        TEST_TAG_LIST + composeTestRule.activity.resources.getString(
-            Eps.displayNameResource
-        )
+        TEST_TAG_LIST + Eps.code
     }
 
     @Test

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -3,6 +3,7 @@ package com.stripe.android.customersheet
 import com.stripe.android.core.injection.IS_LIVE_MODE
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayRepository
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAvailable
@@ -12,7 +13,6 @@ import com.stripe.android.paymentsheet.model.requireValidOrThrow
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.paymentsheet.state.toInternal
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.utils.FeatureFlags.customerSheetACHv2
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetState.kt
@@ -1,10 +1,10 @@
 package com.stripe.android.customersheet
 
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 internal sealed interface CustomerSheetState {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewAction.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewAction.kt
@@ -1,11 +1,11 @@
 package com.stripe.android.customersheet
 
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResultInternal
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.PrimaryButton
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 
 internal sealed class CustomerSheetViewAction {
     object OnDismissed : CustomerSheetViewAction()

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -18,6 +18,7 @@ import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.injection.CustomerSheetViewModelScope
 import com.stripe.android.customersheet.util.isUnverifiedUSBankAccount
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
@@ -55,7 +56,6 @@ import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
 import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
 import com.stripe.android.paymentsheet.utils.mapAsStateFlow
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
@@ -2,6 +2,7 @@ package com.stripe.android.customersheet
 
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResultInternal
@@ -16,7 +17,6 @@ import com.stripe.android.paymentsheet.ui.PaymentSheetTopBarState
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBarStateFactory
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 
 internal sealed class CustomerSheetViewState(
     open val savedPaymentMethods: List<PaymentMethod>,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -21,6 +21,7 @@ import com.stripe.android.customersheet.CustomerSheetViewState
 import com.stripe.android.customersheet.DefaultCustomerSheetLoader
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.analytics.DefaultCustomerSheetEventReporter
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.financialconnections.DefaultIsFinancialConnectionsAvailable
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAvailable
@@ -33,7 +34,6 @@ import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.paymentsheet.repositories.RealElementsSessionRepository
 import com.stripe.android.paymentsheet.ui.DefaultEditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.ui.ModifiableEditPaymentMethodViewInteractor
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import dagger.Binds
 import dagger.Module
 import dagger.Provides

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/LpmRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/LpmRepository.kt
@@ -646,6 +646,7 @@ class LpmRepository(
      * FormSpec is optionally null only because Card is not converted to the
      * compose model.
      */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class SupportedPaymentMethod(
         /**
          * This describes the PaymentMethod Type as described
@@ -699,6 +700,7 @@ class LpmRepository(
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class LpmInitialFormData {
 
         private val codeToSupportedPaymentMethod = mutableMapOf<String, SupportedPaymentMethod>()
@@ -720,6 +722,7 @@ class LpmRepository(
         }
     }
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
         @Volatile
         private var INSTANCE: LpmRepository? = null
@@ -776,6 +779,7 @@ class LpmRepository(
             )
     }
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class LpmRepositoryArguments(
         val resources: Resources,
         val isFinancialConnectionsAvailable: IsFinancialConnectionsAvailable =

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/LpmRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/LpmRepository.kt
@@ -1,11 +1,10 @@
-package com.stripe.android.ui.core.forms.resources
+package com.stripe.android.lpmfoundations.luxe
 
 import android.content.res.Resources
 import androidx.annotation.DrawableRes
 import androidx.annotation.RestrictTo
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
-import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.LuxePostConfirmActionRepository
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
@@ -14,47 +13,15 @@ import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.financialconnections.DefaultIsFinancialConnectionsAvailable
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAvailable
-import com.stripe.android.paymentsheet.forms.AffirmRequirement
-import com.stripe.android.paymentsheet.forms.AfterpayClearpayRequirement
-import com.stripe.android.paymentsheet.forms.AlipayRequirement
-import com.stripe.android.paymentsheet.forms.AlmaRequirement
-import com.stripe.android.paymentsheet.forms.AmazonPayRequirement
-import com.stripe.android.paymentsheet.forms.AuBecsDebitRequirement
-import com.stripe.android.paymentsheet.forms.BacsDebitRequirement
-import com.stripe.android.paymentsheet.forms.BancontactRequirement
-import com.stripe.android.paymentsheet.forms.BlikRequirement
-import com.stripe.android.paymentsheet.forms.BoletoRequirement
-import com.stripe.android.paymentsheet.forms.CardRequirement
-import com.stripe.android.paymentsheet.forms.CashAppPayRequirement
-import com.stripe.android.paymentsheet.forms.EpsRequirement
-import com.stripe.android.paymentsheet.forms.FpxRequirement
-import com.stripe.android.paymentsheet.forms.GiropayRequirement
-import com.stripe.android.paymentsheet.forms.GrabPayRequirement
-import com.stripe.android.paymentsheet.forms.IdealRequirement
-import com.stripe.android.paymentsheet.forms.KlarnaRequirement
-import com.stripe.android.paymentsheet.forms.KonbiniRequirement
-import com.stripe.android.paymentsheet.forms.MobilePayRequirement
-import com.stripe.android.paymentsheet.forms.OxxoRequirement
-import com.stripe.android.paymentsheet.forms.P24Requirement
-import com.stripe.android.paymentsheet.forms.PaymentMethodRequirements
-import com.stripe.android.paymentsheet.forms.PaypalRequirement
-import com.stripe.android.paymentsheet.forms.RevolutPayRequirement
-import com.stripe.android.paymentsheet.forms.SepaDebitRequirement
-import com.stripe.android.paymentsheet.forms.SofortRequirement
-import com.stripe.android.paymentsheet.forms.SwishRequirement
-import com.stripe.android.paymentsheet.forms.USBankAccountRequirement
-import com.stripe.android.paymentsheet.forms.UpiRequirement
-import com.stripe.android.paymentsheet.forms.ZipRequirement
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.R
-import com.stripe.android.ui.core.elements.AfterpayClearpayHeaderElement.Companion.isClearpay
+import com.stripe.android.ui.core.elements.AfterpayClearpayHeaderElement
 import com.stripe.android.ui.core.elements.BacsDebitBankAccountSpec
 import com.stripe.android.ui.core.elements.BacsDebitConfirmSpec
 import com.stripe.android.ui.core.elements.CardBillingSpec
 import com.stripe.android.ui.core.elements.CardDetailsSectionSpec
 import com.stripe.android.ui.core.elements.CashAppPayMandateTextSpec
 import com.stripe.android.ui.core.elements.ContactInformationSpec
-import com.stripe.android.ui.core.elements.EmptyFormSpec
 import com.stripe.android.ui.core.elements.FormItemSpec
 import com.stripe.android.ui.core.elements.LayoutSpec
 import com.stripe.android.ui.core.elements.LpmSerializer
@@ -65,6 +32,8 @@ import com.stripe.android.ui.core.elements.SharedDataSpec
 import com.stripe.android.ui.core.elements.transform
 import com.stripe.android.uicore.elements.IdentifierSpec
 import java.io.InputStream
+import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * This class is responsible for loading the LPM UI Specification for all LPMs, and returning
@@ -75,12 +44,19 @@ import java.io.InputStream
  * repository is not a singleton.  Additionally every time you create a new
  * form view model a new repository is created and thus needs to be initialized.
  */
+@Singleton
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class LpmRepository constructor(
+class LpmRepository(
     private val arguments: LpmRepositoryArguments,
     private val lpmInitialFormData: LpmInitialFormData = LpmInitialFormData.Instance,
-    private val lpmPostConfirmData: LuxePostConfirmActionRepository = LuxePostConfirmActionRepository.Instance
+    private val lpmPostConfirmData: LuxePostConfirmActionRepository = LuxePostConfirmActionRepository.Instance,
 ) {
+
+    @Inject
+    constructor(resources: Resources) : this(
+        arguments = LpmRepositoryArguments(resources),
+    )
+
     fun fromCode(code: PaymentMethodCode?) = lpmInitialFormData.fromCode(code)
 
     fun values(): List<SupportedPaymentMethod> = lpmInitialFormData.values()
@@ -98,7 +74,6 @@ class LpmRepository constructor(
      * Reading the server spec is all or nothing, any error means none will be read
      * so it is important that the json on disk is successful.
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun update(
         stripeIntent: StripeIntent,
         serverLpmSpecs: String?,
@@ -169,14 +144,12 @@ class LpmRepository constructor(
     /**
      * This method can be used to initialize the LpmRepository with a given map of payment methods.
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun initializeWithPaymentMethods(
         paymentMethods: Map<String, SupportedPaymentMethod>
     ) {
         lpmInitialFormData.putAll(paymentMethods)
     }
 
-    @VisibleForTesting
     fun updateFromDisk(stripeIntent: StripeIntent) {
         update(stripeIntent, readFromDisk())
     }
@@ -240,11 +213,7 @@ class LpmRepository constructor(
             darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
             tintIconOnSelection = true,
             requirement = CardRequirement,
-            formSpec = if (sharedDataSpec.fields.isEmpty() || sharedDataSpec.fields == listOf(EmptyFormSpec)) {
-                hardcodedCardSpec(billingDetailsCollectionConfiguration).formSpec
-            } else {
-                LayoutSpec(sharedDataSpec.fields)
-            }
+            formSpec = hardcodedCardSpec(billingDetailsCollectionConfiguration).formSpec
         )
         PaymentMethod.Type.Bancontact.code -> SupportedPaymentMethod(
             code = "bancontact",
@@ -343,7 +312,7 @@ class LpmRepository constructor(
         PaymentMethod.Type.AfterpayClearpay.code -> SupportedPaymentMethod(
             code = "afterpay_clearpay",
             requiresMandate = false,
-            displayNameResource = if (isClearpay()) {
+            displayNameResource = if (AfterpayClearpayHeaderElement.isClearpay()) {
                 R.string.stripe_paymentsheet_payment_method_clearpay
             } else {
                 R.string.stripe_paymentsheet_payment_method_afterpay
@@ -677,7 +646,6 @@ class LpmRepository constructor(
      * FormSpec is optionally null only because Card is not converted to the
      * compose model.
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
     data class SupportedPaymentMethod(
         /**
          * This describes the PaymentMethod Type as described
@@ -760,10 +728,8 @@ class LpmRepository constructor(
                 INSTANCE ?: LpmRepository(args).also { INSTANCE = it }
             }
 
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         val HardcodedCard = hardcodedCardSpec(BillingDetailsCollectionConfiguration())
 
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         fun hardcodedCardSpec(
             billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration
         ): SupportedPaymentMethod {
@@ -796,7 +762,6 @@ class LpmRepository constructor(
             )
         }
 
-        @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         val hardCodedUsBankAccount: SupportedPaymentMethod =
             SupportedPaymentMethod(
                 code = "us_bank_account",
@@ -811,7 +776,6 @@ class LpmRepository constructor(
             )
     }
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class LpmRepositoryArguments(
         val resources: Resources,
         val isFinancialConnectionsAvailable: IsFinancialConnectionsAvailable =

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/PaymentMethodRequirements.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/PaymentMethodRequirements.kt
@@ -88,42 +88,12 @@ internal val BancontactRequirement = PaymentMethodRequirements(
      * PM will be attached as a SEPA Debit payment method and have the requirements
      * of that PaymentMethod.
      */
-
-    /**
-     * PM will be attached as a SEPA Debit payment method and have the requirements
-     * of that PaymentMethod.
-     */
-
-    /**
-     * PM will be attached as a SEPA Debit payment method and have the requirements
-     * of that PaymentMethod.
-     */
-
-    /**
-     * PM will be attached as a SEPA Debit payment method and have the requirements
-     * of that PaymentMethod.
-     */
     confirmPMFromCustomer = true,
 )
 
 internal val SofortRequirement = PaymentMethodRequirements(
     piRequirements = setOf(Delayed),
     siRequirements = setOf(Delayed),
-
-    /**
-     * PM will be attached as a SEPA Debit payment method and have the requirements
-     * of that PaymentMethod.
-     */
-
-    /**
-     * PM will be attached as a SEPA Debit payment method and have the requirements
-     * of that PaymentMethod.
-     */
-
-    /**
-     * PM will be attached as a SEPA Debit payment method and have the requirements
-     * of that PaymentMethod.
-     */
 
     /**
      * PM will be attached as a SEPA Debit payment method and have the requirements
@@ -140,66 +110,12 @@ internal val IdealRequirement = PaymentMethodRequirements(
      * PM will be attached as a SEPA Debit payment method and have the requirements
      * of that PaymentMethod.
      */
-
-    /**
-     * PM will be attached as a SEPA Debit payment method and have the requirements
-     * of that PaymentMethod.
-     */
-
-    /**
-     * PM will be attached as a SEPA Debit payment method and have the requirements
-     * of that PaymentMethod.
-     */
-
-    /**
-     * PM will be attached as a SEPA Debit payment method and have the requirements
-     * of that PaymentMethod.
-     */
     confirmPMFromCustomer = true,
 )
 
 internal val SepaDebitRequirement = PaymentMethodRequirements(
     piRequirements = setOf(Delayed),
     siRequirements = setOf(Delayed),
-
-    /**
-     * Here we explain the details
-     * - if PI w/SFU set or SI with a customer, or
-     * - if PI w/SFU set or SI with/out a customer and later attached when used with a webhook
-     * (Note: from the client there is no way to detect if a PI or SI is associated with a customer)
-     *
-     * then, this payment method would be attached to the customer as a SEPA payment method.
-     * (Note: Bancontact, iDEAL, and Sofort require authentication, but SEPA does not.
-     * also Bancontact, iDEAL are not delayed, but Sofort and SEPA are delayed.)
-     *
-     * The SEPA payment method requires a mandate when confirmed.
-     */
-
-    /**
-     * Here we explain the details
-     * - if PI w/SFU set or SI with a customer, or
-     * - if PI w/SFU set or SI with/out a customer and later attached when used with a webhook
-     * (Note: from the client there is no way to detect if a PI or SI is associated with a customer)
-     *
-     * then, this payment method would be attached to the customer as a SEPA payment method.
-     * (Note: Bancontact, iDEAL, and Sofort require authentication, but SEPA does not.
-     * also Bancontact, iDEAL are not delayed, but Sofort and SEPA are delayed.)
-     *
-     * The SEPA payment method requires a mandate when confirmed.
-     */
-
-    /**
-     * Here we explain the details
-     * - if PI w/SFU set or SI with a customer, or
-     * - if PI w/SFU set or SI with/out a customer and later attached when used with a webhook
-     * (Note: from the client there is no way to detect if a PI or SI is associated with a customer)
-     *
-     * then, this payment method would be attached to the customer as a SEPA payment method.
-     * (Note: Bancontact, iDEAL, and Sofort require authentication, but SEPA does not.
-     * also Bancontact, iDEAL are not delayed, but Sofort and SEPA are delayed.)
-     *
-     * The SEPA payment method requires a mandate when confirmed.
-     */
 
     /**
      * Here we explain the details
@@ -229,18 +145,6 @@ internal val P24Requirement = PaymentMethodRequirements(
     /**
      * This cannot be saved to a customer object.
      */
-
-    /**
-     * This cannot be saved to a customer object.
-     */
-
-    /**
-     * This cannot be saved to a customer object.
-     */
-
-    /**
-     * This cannot be saved to a customer object.
-     */
     confirmPMFromCustomer = null
 )
 
@@ -255,18 +159,6 @@ internal val GiropayRequirement = PaymentMethodRequirements(
  */
 internal val AfterpayClearpayRequirement = PaymentMethodRequirements(
     piRequirements = setOf(ShippingAddress),
-    /**
-     * SetupIntents are not supported by this payment method, in addition,
-     * setup intents do not have shipping information
-     */
-    /**
-     * SetupIntents are not supported by this payment method, in addition,
-     * setup intents do not have shipping information
-     */
-    /**
-     * SetupIntents are not supported by this payment method, in addition,
-     * setup intents do not have shipping information
-     */
     /**
      * SetupIntents are not supported by this payment method, in addition,
      * setup intents do not have shipping information

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/PaymentMethodRequirements.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/PaymentMethodRequirements.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.paymentsheet.forms
+package com.stripe.android.lpmfoundations.luxe
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.model.PaymentMethod
@@ -88,12 +88,42 @@ internal val BancontactRequirement = PaymentMethodRequirements(
      * PM will be attached as a SEPA Debit payment method and have the requirements
      * of that PaymentMethod.
      */
+
+    /**
+     * PM will be attached as a SEPA Debit payment method and have the requirements
+     * of that PaymentMethod.
+     */
+
+    /**
+     * PM will be attached as a SEPA Debit payment method and have the requirements
+     * of that PaymentMethod.
+     */
+
+    /**
+     * PM will be attached as a SEPA Debit payment method and have the requirements
+     * of that PaymentMethod.
+     */
     confirmPMFromCustomer = true,
 )
 
 internal val SofortRequirement = PaymentMethodRequirements(
     piRequirements = setOf(Delayed),
     siRequirements = setOf(Delayed),
+
+    /**
+     * PM will be attached as a SEPA Debit payment method and have the requirements
+     * of that PaymentMethod.
+     */
+
+    /**
+     * PM will be attached as a SEPA Debit payment method and have the requirements
+     * of that PaymentMethod.
+     */
+
+    /**
+     * PM will be attached as a SEPA Debit payment method and have the requirements
+     * of that PaymentMethod.
+     */
 
     /**
      * PM will be attached as a SEPA Debit payment method and have the requirements
@@ -110,12 +140,66 @@ internal val IdealRequirement = PaymentMethodRequirements(
      * PM will be attached as a SEPA Debit payment method and have the requirements
      * of that PaymentMethod.
      */
+
+    /**
+     * PM will be attached as a SEPA Debit payment method and have the requirements
+     * of that PaymentMethod.
+     */
+
+    /**
+     * PM will be attached as a SEPA Debit payment method and have the requirements
+     * of that PaymentMethod.
+     */
+
+    /**
+     * PM will be attached as a SEPA Debit payment method and have the requirements
+     * of that PaymentMethod.
+     */
     confirmPMFromCustomer = true,
 )
 
 internal val SepaDebitRequirement = PaymentMethodRequirements(
     piRequirements = setOf(Delayed),
     siRequirements = setOf(Delayed),
+
+    /**
+     * Here we explain the details
+     * - if PI w/SFU set or SI with a customer, or
+     * - if PI w/SFU set or SI with/out a customer and later attached when used with a webhook
+     * (Note: from the client there is no way to detect if a PI or SI is associated with a customer)
+     *
+     * then, this payment method would be attached to the customer as a SEPA payment method.
+     * (Note: Bancontact, iDEAL, and Sofort require authentication, but SEPA does not.
+     * also Bancontact, iDEAL are not delayed, but Sofort and SEPA are delayed.)
+     *
+     * The SEPA payment method requires a mandate when confirmed.
+     */
+
+    /**
+     * Here we explain the details
+     * - if PI w/SFU set or SI with a customer, or
+     * - if PI w/SFU set or SI with/out a customer and later attached when used with a webhook
+     * (Note: from the client there is no way to detect if a PI or SI is associated with a customer)
+     *
+     * then, this payment method would be attached to the customer as a SEPA payment method.
+     * (Note: Bancontact, iDEAL, and Sofort require authentication, but SEPA does not.
+     * also Bancontact, iDEAL are not delayed, but Sofort and SEPA are delayed.)
+     *
+     * The SEPA payment method requires a mandate when confirmed.
+     */
+
+    /**
+     * Here we explain the details
+     * - if PI w/SFU set or SI with a customer, or
+     * - if PI w/SFU set or SI with/out a customer and later attached when used with a webhook
+     * (Note: from the client there is no way to detect if a PI or SI is associated with a customer)
+     *
+     * then, this payment method would be attached to the customer as a SEPA payment method.
+     * (Note: Bancontact, iDEAL, and Sofort require authentication, but SEPA does not.
+     * also Bancontact, iDEAL are not delayed, but Sofort and SEPA are delayed.)
+     *
+     * The SEPA payment method requires a mandate when confirmed.
+     */
 
     /**
      * Here we explain the details
@@ -145,6 +229,18 @@ internal val P24Requirement = PaymentMethodRequirements(
     /**
      * This cannot be saved to a customer object.
      */
+
+    /**
+     * This cannot be saved to a customer object.
+     */
+
+    /**
+     * This cannot be saved to a customer object.
+     */
+
+    /**
+     * This cannot be saved to a customer object.
+     */
     confirmPMFromCustomer = null
 )
 
@@ -159,6 +255,18 @@ internal val GiropayRequirement = PaymentMethodRequirements(
  */
 internal val AfterpayClearpayRequirement = PaymentMethodRequirements(
     piRequirements = setOf(ShippingAddress),
+    /**
+     * SetupIntents are not supported by this payment method, in addition,
+     * setup intents do not have shipping information
+     */
+    /**
+     * SetupIntents are not supported by this payment method, in addition,
+     * setup intents do not have shipping information
+     */
+    /**
+     * SetupIntents are not supported by this payment method, in addition,
+     * setup intents do not have shipping information
+     */
     /**
      * SetupIntents are not supported by this payment method, in addition,
      * setup intents do not have shipping information

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
@@ -32,8 +32,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.stripe.android.lpmfoundations.luxe.LpmRepository.SupportedPaymentMethod
 import com.stripe.android.paymentsheet.ui.LpmSelectorText
-import com.stripe.android.ui.core.forms.resources.LpmRepository.SupportedPaymentMethod
 import com.stripe.android.uicore.getBorderStroke
 import com.stripe.android.uicore.image.StripeImage
 import com.stripe.android.uicore.image.StripeImageLoader
@@ -95,7 +95,7 @@ internal fun PaymentMethodsUI(
                 }
                 PaymentMethodUI(
                     modifier = Modifier.testTag(
-                        TEST_TAG_LIST + stringResource(item.displayNameResource)
+                        TEST_TAG_LIST + item.code
                     ),
                     minViewWidth = viewWidth,
                     iconRes = item.iconResource,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.link.LinkConfigurationCoordinator
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -30,7 +31,6 @@ import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.PrimaryButtonUiStateMapper
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.utils.requireApplication
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -23,6 +23,7 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.link.LinkConfigurationCoordinator
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
@@ -64,7 +65,6 @@ import com.stripe.android.paymentsheet.utils.combineStateFlows
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.PrimaryButtonUiStateMapper
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.utils.requireApplication
 import dagger.Lazy
 import kotlinx.coroutines.CoroutineScope

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
@@ -1,10 +1,10 @@
 package com.stripe.android.paymentsheet.flowcontroller
 
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.getPMsToAdd
 import com.stripe.android.paymentsheet.state.PaymentSheetState
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import javax.inject.Inject
 
 internal fun interface PaymentSelectionUpdater {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.forms
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.link.LinkPaymentDetails
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -10,7 +11,6 @@ import com.stripe.android.paymentsheet.model.getPMAddForm
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 
 internal object FormArgumentsFactory {
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
@@ -5,6 +5,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.addresselement.toIdentifierMap
 import com.stripe.android.paymentsheet.forms.PlaceholderHelper.connectBillingDetailsFields
@@ -17,7 +18,6 @@ import com.stripe.android.ui.core.elements.CardBillingAddressElement
 import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.forms.TransformSpecToElements
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.uicore.address.AddressRepository
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodKtx.kt
@@ -1,5 +1,11 @@
 package com.stripe.android.paymentsheet.model
 
+import com.stripe.android.lpmfoundations.luxe.Delayed
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
+import com.stripe.android.lpmfoundations.luxe.LpmRepository.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.luxe.PIRequirement
+import com.stripe.android.lpmfoundations.luxe.SIRequirement
+import com.stripe.android.lpmfoundations.luxe.ShippingAddress
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
@@ -7,13 +13,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.financialconnections.DefaultIsFinancialConnectionsAvailable
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAvailable
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.forms.Delayed
-import com.stripe.android.paymentsheet.forms.PIRequirement
-import com.stripe.android.paymentsheet.forms.SIRequirement
-import com.stripe.android.paymentsheet.forms.ShippingAddress
 import com.stripe.android.ui.core.elements.LayoutFormDescriptor
-import com.stripe.android.ui.core.forms.resources.LpmRepository
-import com.stripe.android.ui.core.forms.resources.LpmRepository.SupportedPaymentMethod
 
 /**
  * This file hold functions that extend the functionality of the SupportedPaymentMethod

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -8,6 +8,7 @@ import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.account.LinkStore
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.LinkSignupMode
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
@@ -27,7 +28,6 @@ import com.stripe.android.paymentsheet.model.requireValidOrThrow
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import com.stripe.android.link.ui.inline.InlineSignupViewState
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
@@ -29,7 +30,6 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.FieldValuesToParamsMapConverter
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.LocalAutofillEventReporter
 import com.stripe.android.uicore.elements.ParameterDestination

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
@@ -18,6 +18,7 @@ import com.stripe.android.link.ui.inline.InlineSignupViewState
 import com.stripe.android.link.ui.inline.LinkInlineSignup
 import com.stripe.android.link.ui.inline.LinkOptionalInlineSignup
 import com.stripe.android.link.ui.inline.LinkSignupMode
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentMethodsUI
 import com.stripe.android.paymentsheet.R
@@ -26,7 +27,6 @@ import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountForm
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.uicore.image.StripeImageLoader
 import kotlinx.coroutines.flow.Flow
 import java.util.UUID

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -10,6 +10,7 @@ import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.ui.inline.InlineSignupViewState
 import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.link.ui.inline.UserInput
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
@@ -49,7 +50,6 @@ import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.utils.combineStateFlows
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.customersheet.ui.CustomerSheetScreen
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
@@ -18,7 +19,6 @@ import com.stripe.android.paymentsheet.ui.DefaultEditPaymentMethodViewInteractor
 import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.utils.FeatureFlags

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.customersheet.utils.FakeCustomerSheetLoader
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.financialconnections.model.PaymentAccount
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
@@ -44,7 +45,6 @@ import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentMethodFactory
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.customersheet.FakeCustomerAdapter
 import com.stripe.android.customersheet.utils.CustomerSheetTestHelper
 import com.stripe.android.googlepaylauncher.GooglePayRepository
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
@@ -23,7 +24,6 @@ import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.utils.FakeElementsSessionRepository
 import com.stripe.android.utils.FeatureFlags
 import kotlinx.coroutines.flow.flow

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -16,6 +16,7 @@ import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.customersheet.FakeCustomerAdapter
 import com.stripe.android.customersheet.FakeStripeRepository
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
 import com.stripe.android.networking.StripeRepository
@@ -38,7 +39,6 @@ import com.stripe.android.paymentsheet.ui.PaymentMethodRemoveOperation
 import com.stripe.android.paymentsheet.ui.PaymentMethodUpdateOperation
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.uicore.address.AddressRepository
 import com.stripe.android.utils.DummyActivityResultCaller
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
@@ -4,12 +4,12 @@ import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetLoader
 import com.stripe.android.customersheet.CustomerSheetState
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import kotlinx.coroutines.delay
 import kotlin.time.Duration
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/LpmRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/LpmRepositoryTest.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.ui.core.forms.resources
+package com.stripe.android.lpmfoundations.luxe
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
@@ -7,7 +7,6 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethod.Type.Card
 import com.stripe.android.model.PaymentMethod.Type.CashAppPay
 import com.stripe.android.model.PaymentMethod.Type.USBankAccount
-import com.stripe.android.paymentsheet.forms.Delayed
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.R

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/PaymentMethodRequirementsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/PaymentMethodRequirementsTest.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.paymentsheet.forms
+package com.stripe.android.lpmfoundations.luxe
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -28,6 +28,7 @@ import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.model.AccountStatus
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
@@ -39,7 +40,6 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.getLabel
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils.idleLooper
@@ -332,7 +332,7 @@ internal class PaymentOptionsActivityTest {
         runActivityScenario(args) {
             it.onActivity {
                 composeTestRule
-                    .onNodeWithTag(TEST_TAG_LIST + "Cash App Pay")
+                    .onNodeWithTag(TEST_TAG_LIST + PaymentMethod.Type.CashAppPay.code)
                     .performClick()
 
                 composeTestRule.waitForIdle()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -10,6 +10,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.R
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.APIConnectionException
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
@@ -36,7 +37,6 @@ import com.stripe.android.paymentsheet.ui.ModifiableEditPaymentMethodViewInterac
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -31,6 +31,7 @@ import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLaun
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.LinkButtonTestTag
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
@@ -55,7 +56,6 @@ import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.PrimaryButtonAnimator
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor
 import com.stripe.android.utils.FakePaymentSheetLoader

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.model.AccountStatus
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
@@ -72,7 +73,6 @@ import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.S
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.UserErrorMessage
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.Amount
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.utils.DummyActivityResultCaller
 import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.flowcontroller
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
@@ -13,7 +14,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.testing.PaymentMethodFactory
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.forms
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
@@ -14,7 +15,6 @@ import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -7,6 +7,8 @@ import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.test
 import app.cash.turbine.testIn
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
+import com.stripe.android.lpmfoundations.luxe.PaymentMethodRequirements
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.COMPOSE_FRAGMENT_ARGS
@@ -27,7 +29,6 @@ import com.stripe.android.ui.core.elements.PhoneSpec
 import com.stripe.android.ui.core.elements.PlaceholderSpec
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.elements.SaveForFutureUseSpec
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.uicore.address.AddressRepository
 import com.stripe.android.uicore.elements.AddressElement
 import com.stripe.android.uicore.elements.CountryElement

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodTest.kt
@@ -5,6 +5,8 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
+import com.stripe.android.lpmfoundations.luxe.LpmRepository.SupportedPaymentMethod
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_CARD_SFU_SET
@@ -14,8 +16,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.CONFIG_CUSTOMER
 import com.stripe.android.testing.PaymentIntentFactory
-import com.stripe.android.ui.core.forms.resources.LpmRepository
-import com.stripe.android.ui.core.forms.resources.LpmRepository.SupportedPaymentMethod
 import kotlinx.serialization.Serializable
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.LinkSignupMode.AlongsideSaveForFutureUse
 import com.stripe.android.link.ui.inline.LinkSignupMode.InsteadOfSaveForFutureUse
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentIntent.ConfirmationMethod.Manual
 import com.stripe.android.model.PaymentIntentFixtures
@@ -30,7 +31,6 @@ import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException.PaymentIntentInTerminalState
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.FakeElementsSessionRepository
 import kotlinx.coroutines.flow.flow

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUIScreenshotTest.kt
@@ -1,9 +1,9 @@
 package com.stripe.android.paymentsheet.ui
 
 import androidx.compose.foundation.lazy.LazyListState
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.paymentsheet.PaymentMethodsUI
 import com.stripe.android.ui.core.R
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.utils.MockPaymentMethodsFactory
 import com.stripe.android.utils.screenshots.FontSize
 import com.stripe.android.utils.screenshots.PaparazziRule

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeFormViewModelSubcomponentBuilder.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeFormViewModelSubcomponentBuilder.kt
@@ -1,10 +1,10 @@
 package com.stripe.android.utils
 
 import android.content.Context
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.uicore.address.AddressRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow

--- a/paymentsheet/src/test/java/com/stripe/android/utils/MockPaymentMethodsFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/MockPaymentMethodsFactory.kt
@@ -1,11 +1,11 @@
 package com.stripe.android.utils
 
-import com.stripe.android.paymentsheet.forms.PaymentMethodRequirements
+import com.stripe.android.lpmfoundations.luxe.LpmRepository
+import com.stripe.android.lpmfoundations.luxe.PaymentMethodRequirements
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.LayoutSpec
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 
-object MockPaymentMethodsFactory {
+internal object MockPaymentMethodsFactory {
 
     fun create(): List<LpmRepository.SupportedPaymentMethod> {
         return listOf(

--- a/stripe-ui-core/detekt-baseline.xml
+++ b/stripe-ui-core/detekt-baseline.xml
@@ -11,9 +11,7 @@
     <ID>CyclomaticComplexMethod:TextFieldUI.kt$@OptIn(ExperimentalComposeUiApi::class) @Composable fun TextField( textFieldController: TextFieldController, enabled: Boolean, imeAction: ImeAction, modifier: Modifier = Modifier, onTextStateChanged: (TextFieldState?) -> Unit = {}, nextFocusDirection: FocusDirection = FocusDirection.Next, previousFocusDirection: FocusDirection = FocusDirection.Previous )</ID>
     <ID>EmptyFunctionBlock:DrawablePainter.kt$EmptyPainter${}</ID>
     <ID>FunctionParameterNaming:IdentifierSpec.kt$IdentifierSpec.Companion$_value: String</ID>
-    <ID>LongMethod:DropdownFieldUI.kt$@Composable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun DropDown( controller: DropdownFieldController, enabled: Boolean, modifier: Modifier = Modifier )</ID>
     <ID>LongMethod:Html.kt$@Composable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun annotatedStringResource( text: String, imageGetter: Map&lt;String, EmbeddableImage> = emptyMap(), urlSpanStyle: SpanStyle = SpanStyle(textDecoration = TextDecoration.Underline) ): AnnotatedString</ID>
-    <ID>LongMethod:OTPElementUI.kt$@Composable @OptIn(ExperimentalMaterialApi::class) private fun OTPInputBox( value: String, isSelected: Boolean, element: OTPElement, index: Int, focusManager: FocusManager, modifier: Modifier, enabled: Boolean, colors: OTPElementColors )</ID>
     <ID>LongMethod:TextFieldUI.kt$@OptIn(ExperimentalComposeUiApi::class) @Composable fun TextField( textFieldController: TextFieldController, enabled: Boolean, imeAction: ImeAction, modifier: Modifier = Modifier, onTextStateChanged: (TextFieldState?) -> Unit = {}, nextFocusDirection: FocusDirection = FocusDirection.Next, previousFocusDirection: FocusDirection = FocusDirection.Previous )</ID>
     <ID>MagicNumber:DateConfig.kt$DateConfig$4</ID>
     <ID>MagicNumber:DateConfig.kt$DateConfig.Companion$100</ID>


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This changes moves the LpmRepository class to the paymentsheet module. This change also decouples a little more of our end to end tests from LpmRepository.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We will need to decouple more of the implementation from LpmRepository, and these concepts are payment sheet concepts.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [] Added tests
- [x] Modified tests
- [ ] Manually verified

