### PR TITLE
Extract SupportedPaymentMethod to it's own top level class.

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -18,7 +18,6 @@
     <ID>LargeClass:CustomerSheetViewModelTest.kt$CustomerSheetViewModelTest</ID>
     <ID>LargeClass:DefaultFlowControllerTest.kt$DefaultFlowControllerTest</ID>
     <ID>LargeClass:DefaultPaymentSheetLoaderTest.kt$DefaultPaymentSheetLoaderTest</ID>
-    <ID>LargeClass:PaymentIntentFixtures.kt$PaymentIntentFixtures</ID>
     <ID>LargeClass:PaymentSheetActivityTest.kt$PaymentSheetActivityTest</ID>
     <ID>LargeClass:PaymentSheetViewModelTest.kt$PaymentSheetViewModelTest</ID>
     <ID>LargeClass:USBankAccountFormViewModelTest.kt$USBankAccountFormViewModelTest</ID>
@@ -32,7 +31,7 @@
     <ID>LongMethod:FormViewModelTest.kt$FormViewModelTest$@Test fun `Verify params are set when element address fields are complete`()</ID>
     <ID>LongMethod:FormViewModelTest.kt$FormViewModelTest$@Test fun `Verify params are set when required address fields are complete`()</ID>
     <ID>LongMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration, isDeferred: Boolean = false, )</ID>
-    <ID>LongMethod:PaymentElement.kt$@Composable internal fun PaymentElement( formViewModelSubComponentBuilderProvider: Provider&lt;FormViewModelSubcomponent.Builder>, enabled: Boolean, supportedPaymentMethods: List&lt;LpmRepository.SupportedPaymentMethod>, selectedItem: LpmRepository.SupportedPaymentMethod, linkSignupMode: LinkSignupMode?, linkConfigurationCoordinator: LinkConfigurationCoordinator?, showCheckboxFlow: Flow&lt;Boolean>, onItemSelectedListener: (LpmRepository.SupportedPaymentMethod) -> Unit, onLinkSignupStateChanged: (LinkConfiguration, InlineSignupViewState) -> Unit, formArguments: FormArguments, usBankAccountFormArguments: USBankAccountFormArguments, onFormFieldValuesChanged: (FormFieldValues?) -> Unit, )</ID>
+    <ID>LongMethod:PaymentElement.kt$@Composable internal fun PaymentElement( formViewModelSubComponentBuilderProvider: Provider&lt;FormViewModelSubcomponent.Builder>, enabled: Boolean, supportedPaymentMethods: List&lt;SupportedPaymentMethod>, selectedItem: SupportedPaymentMethod, linkSignupMode: LinkSignupMode?, linkConfigurationCoordinator: LinkConfigurationCoordinator?, showCheckboxFlow: Flow&lt;Boolean>, onItemSelectedListener: (SupportedPaymentMethod) -> Unit, onLinkSignupStateChanged: (LinkConfiguration, InlineSignupViewState) -> Unit, formArguments: FormArguments, usBankAccountFormArguments: USBankAccountFormArguments, onFormFieldValuesChanged: (FormFieldValues?) -> Unit, )</ID>
     <ID>LongMethod:PaymentOptionFactory.kt$PaymentOptionFactory$fun create(selection: PaymentSelection): PaymentOption</ID>
     <ID>LongMethod:PaymentSheetConfigurationKtx.kt$internal fun PaymentSheet.Appearance.parseAppearance()</ID>
     <ID>LongMethod:PaymentSheetLoader.kt$DefaultPaymentSheetLoader$private suspend fun create( elementsSession: ElementsSession, config: PaymentSheet.Configuration, isGooglePayReady: Boolean, ): PaymentSheetState.Full</ID>
@@ -70,7 +69,6 @@
     <ID>MaxLineLength:InjectableActivityScenario.kt$InjectableActivityScenario$delegate ?: throw IllegalStateException("Cannot move to state $newState since the activity hasn't been launched.")</ID>
     <ID>MaxLineLength:InjectableActivityScenario.kt$InjectableActivityScenario$val d = delegate ?: throw IllegalStateException("Cannot run onActivity since the activity hasn't been launched.")</ID>
     <ID>MaxLineLength:LinkHandlerTest.kt$whenever(linkConfigurationCoordinator.attachNewCardToAccount(eq(linkConfiguration), any())).thenReturn(attachNewCardToAccountResult)</ID>
-    <ID>MaxLineLength:LpmRepository.kt$LpmRepository.SupportedPaymentMethod$/** This describes the image in the LPM selector. These can be found internally [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0) */</ID>
     <ID>MaxLineLength:LpmRepositoryTest.kt$LpmRepositoryTest$fun</ID>
     <ID>MaxLineLength:PaymentSheet.kt$PaymentSheet.Address$*</ID>
     <ID>MaxLineLength:PaymentSheet.kt$PaymentSheet.BillingDetails$*</ID>
@@ -82,6 +80,7 @@
     <ID>MaxLineLength:PaymentSheet.kt$PaymentSheet.IntentConfiguration.SetupFutureUse$*</ID>
     <ID>MaxLineLength:PaymentSheetViewModelTest.kt$PaymentSheetViewModelTest$fun</ID>
     <ID>MaxLineLength:PrimaryButtonTest.kt$PrimaryButtonTest$primaryButton.setAppearanceConfiguration(StripeThemeDefaults.primaryButtonStyle, ColorStateList.valueOf(Color.BLACK))</ID>
+    <ID>MaxLineLength:SupportedPaymentMethod.kt$SupportedPaymentMethod$/** This describes the image in the LPM selector. These can be found internally [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0) */</ID>
     <ID>MaxLineLength:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest$* This will generate payment intent scenarios for all combinations of customers, lpm types in the intent, shipping, and SFU states</ID>
     <ID>MaxLineLength:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest$val formDescriptor = lpm.getSpecWithFullfilledRequirements(testInput.getIntent(lpm), testInput.getConfig())</ID>
     <ID>MaxLineLength:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest.PaymentIntentTestInput$fun toCsv()</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -4,6 +4,7 @@ import com.stripe.android.core.injection.IS_LIVE_MODE
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAvailable
@@ -157,9 +158,9 @@ internal class DefaultCustomerSheetLoader @Inject constructor(
     }
 
     private fun filterSupportedPaymentMethods(
-        supportedPaymentMethods: List<LpmRepository.SupportedPaymentMethod>,
+        supportedPaymentMethods: List<SupportedPaymentMethod>,
         isFinancialConnectionsAvailable: IsFinancialConnectionsAvailable,
-    ): List<LpmRepository.SupportedPaymentMethod> {
+    ): List<SupportedPaymentMethod> {
         val supported = setOfNotNull(
             PaymentMethod.Type.Card.code,
             PaymentMethod.Type.USBankAccount.code.takeIf {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetState.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.customersheet
 
-import com.stripe.android.lpmfoundations.luxe.LpmRepository
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -14,7 +14,7 @@ internal sealed interface CustomerSheetState {
         val config: CustomerSheet.Configuration?,
         val stripeIntent: StripeIntent?,
         val customerPaymentMethods: List<PaymentMethod>,
-        val supportedPaymentMethods: List<LpmRepository.SupportedPaymentMethod>,
+        val supportedPaymentMethods: List<SupportedPaymentMethod>,
         val isGooglePayReady: Boolean,
         val paymentSelection: PaymentSelection?,
         val cbcEligibility: CardBrandChoiceEligibility,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewAction.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewAction.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.customersheet
 
-import com.stripe.android.lpmfoundations.luxe.LpmRepository
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResultInternal
 import com.stripe.android.paymentsheet.forms.FormFieldValues
@@ -18,7 +18,7 @@ internal sealed class CustomerSheetViewAction {
     class OnModifyItem(val paymentMethod: PaymentMethod) : CustomerSheetViewAction()
     class OnItemRemoved(val paymentMethod: PaymentMethod) : CustomerSheetViewAction()
     class OnAddPaymentMethodItemChanged(
-        val paymentMethod: LpmRepository.SupportedPaymentMethod,
+        val paymentMethod: SupportedPaymentMethod,
     ) : CustomerSheetViewAction()
     class OnFormFieldValuesCompleted(
         val formFieldValues: FormFieldValues?,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -19,6 +19,7 @@ import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.injection.CustomerSheetViewModelScope
 import com.stripe.android.customersheet.util.isUnverifiedUSBankAccount
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
@@ -104,10 +105,10 @@ internal class CustomerSheetViewModel @Inject constructor(
     private var isGooglePayReadyAndEnabled: Boolean = false
     private var paymentLauncher: PaymentLauncher? = null
 
-    private var previouslySelectedPaymentMethod: LpmRepository.SupportedPaymentMethod? = null
+    private var previouslySelectedPaymentMethod: SupportedPaymentMethod? = null
     private var unconfirmedPaymentMethod: PaymentMethod? = null
     private var stripeIntent: StripeIntent? = null
-    private var supportedPaymentMethods = mutableListOf<LpmRepository.SupportedPaymentMethod>()
+    private var supportedPaymentMethods = mutableListOf<SupportedPaymentMethod>()
 
     private val card = LpmRepository.hardcodedCardSpec(
         billingDetailsCollectionConfiguration = configuration.billingDetailsCollectionConfiguration.toInternal()
@@ -364,7 +365,7 @@ internal class CustomerSheetViewModel @Inject constructor(
         }
     }
 
-    private fun onAddPaymentMethodItemChanged(paymentMethod: LpmRepository.SupportedPaymentMethod) {
+    private fun onAddPaymentMethodItemChanged(paymentMethod: SupportedPaymentMethod) {
         (viewState.value as? CustomerSheetViewState.AddPaymentMethod)?.let {
             if (it.paymentMethodCode == paymentMethod.code) {
                 return

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
@@ -2,7 +2,7 @@ package com.stripe.android.customersheet
 
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
-import com.stripe.android.lpmfoundations.luxe.LpmRepository
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResultInternal
@@ -85,11 +85,11 @@ internal sealed class CustomerSheetViewState(
 
     data class AddPaymentMethod(
         val paymentMethodCode: PaymentMethodCode,
-        val supportedPaymentMethods: List<LpmRepository.SupportedPaymentMethod>,
+        val supportedPaymentMethods: List<SupportedPaymentMethod>,
         val formViewData: FormViewModel.ViewData,
         val formArguments: FormArguments,
         val usBankAccountFormArguments: USBankAccountFormArguments,
-        val selectedPaymentMethod: LpmRepository.SupportedPaymentMethod,
+        val selectedPaymentMethod: SupportedPaymentMethod,
         val draftPaymentSelection: PaymentSelection?,
         val enabled: Boolean,
         override val isLiveMode: Boolean,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/LpmRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/LpmRepository.kt
@@ -1,9 +1,7 @@
 package com.stripe.android.lpmfoundations.luxe
 
 import android.content.res.Resources
-import androidx.annotation.DrawableRes
 import androidx.annotation.RestrictTo
-import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.model.LuxePostConfirmActionRepository
 import com.stripe.android.model.PaymentIntent
@@ -637,66 +635,6 @@ class LpmRepository(
             formSpec = LayoutSpec(sharedDataSpec.fields),
         )
         else -> null
-    }
-
-    /**
-     * Enum defining all payment method types for which Payment Sheet can collect
-     * payment data.
-     *
-     * FormSpec is optionally null only because Card is not converted to the
-     * compose model.
-     */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    data class SupportedPaymentMethod(
-        /**
-         * This describes the PaymentMethod Type as described
-         * https://stripe.com/docs/api/payment_intents/create#create_payment_intent-payment_method_types
-         */
-        val code: PaymentMethodCode,
-
-        /** This describes if the LPM requires a mandate see [ConfirmPaymentIntentParams.mandateDataParams]. */
-        val requiresMandate: Boolean,
-
-        /** This describes the name that appears under the selector. */
-        @StringRes val displayNameResource: Int,
-
-        /** This describes the image in the LPM selector.  These can be found internally [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0) */
-        @DrawableRes val iconResource: Int,
-
-        /** An optional light theme icon url if it's supported. */
-        val lightThemeIconUrl: String?,
-
-        /** An optional dark theme icon url if it's supported. */
-        val darkThemeIconUrl: String?,
-
-        /** Indicates if the lpm icon in the selector is a single color and should be tinted
-         * on selection.
-         */
-        val tintIconOnSelection: Boolean,
-
-        /**
-         * This describes the requirements of the LPM including if it is supported with
-         * PaymentIntents w/ or w/out SetupFutureUsage set, SetupIntent, or on-session when attached
-         * to the customer object.
-         */
-        val requirement: PaymentMethodRequirements,
-
-        /**
-         * This describes how the UI should look.
-         */
-        val formSpec: LayoutSpec,
-
-        /**
-         * This forces the UI to render the required fields
-         */
-        val placeholderOverrideList: List<IdentifierSpec> = emptyList()
-    ) {
-        /**
-         * Returns true if the payment method supports confirming from a saved
-         * payment method of this type.  See [PaymentMethodRequirements] for
-         * description of the values
-         */
-        fun supportsCustomerSavedPM() = requirement.getConfirmPMFromCustomer(code)
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SupportedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SupportedPaymentMethod.kt
@@ -1,0 +1,61 @@
+package com.stripe.android.lpmfoundations.luxe
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.RestrictTo
+import androidx.annotation.StringRes
+import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.ui.core.elements.LayoutSpec
+import com.stripe.android.uicore.elements.IdentifierSpec
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class SupportedPaymentMethod(
+    /**
+     * This describes the PaymentMethod Type as described
+     * https://stripe.com/docs/api/payment_intents/create#create_payment_intent-payment_method_types
+     */
+    val code: PaymentMethodCode,
+
+    /** This describes if the LPM requires a mandate see [ConfirmPaymentIntentParams.mandateDataParams]. */
+    val requiresMandate: Boolean,
+
+    /** This describes the name that appears under the selector. */
+    @StringRes val displayNameResource: Int,
+
+    /** This describes the image in the LPM selector.  These can be found internally [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0) */
+    @DrawableRes val iconResource: Int,
+
+    /** An optional light theme icon url if it's supported. */
+    val lightThemeIconUrl: String?,
+
+    /** An optional dark theme icon url if it's supported. */
+    val darkThemeIconUrl: String?,
+
+    /** Indicates if the lpm icon in the selector is a single color and should be tinted
+     * on selection.
+     */
+    val tintIconOnSelection: Boolean,
+
+    /**
+     * This describes the requirements of the LPM including if it is supported with
+     * PaymentIntents w/ or w/out SetupFutureUsage set, SetupIntent, or on-session when attached
+     * to the customer object.
+     */
+    val requirement: PaymentMethodRequirements,
+
+    /**
+     * This describes how the UI should look.
+     */
+    val formSpec: LayoutSpec,
+
+    /**
+     * This forces the UI to render the required fields
+     */
+    val placeholderOverrideList: List<IdentifierSpec> = emptyList()
+) {
+    /**
+     * Returns true if the payment method supports confirming from a saved
+     * payment method of this type.  See [PaymentMethodRequirements] for
+     * description of the values
+     */
+    fun supportsCustomerSavedPM() = requirement.getConfirmPMFromCustomer(code)
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.stripe.android.lpmfoundations.luxe.LpmRepository.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.paymentsheet.ui.LpmSelectorText
 import com.stripe.android.uicore.getBorderStroke
 import com.stripe.android.uicore.image.StripeImage

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
@@ -3,7 +3,7 @@ package com.stripe.android.paymentsheet.forms
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.link.LinkPaymentDetails
-import com.stripe.android.lpmfoundations.luxe.LpmRepository
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -15,7 +15,7 @@ import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 internal object FormArgumentsFactory {
 
     fun create(
-        paymentMethod: LpmRepository.SupportedPaymentMethod,
+        paymentMethod: SupportedPaymentMethod,
         stripeIntent: StripeIntent,
         config: PaymentSheet.Configuration,
         merchantName: String,
@@ -77,7 +77,7 @@ internal object FormArgumentsFactory {
 
     @OptIn(ExperimentalCustomerSheetApi::class)
     fun create(
-        paymentMethod: LpmRepository.SupportedPaymentMethod,
+        paymentMethod: SupportedPaymentMethod,
         configuration: CustomerSheet.Configuration,
         merchantName: String,
         cbcEligibility: CardBrandChoiceEligibility,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodKtx.kt
@@ -2,10 +2,10 @@ package com.stripe.android.paymentsheet.model
 
 import com.stripe.android.lpmfoundations.luxe.Delayed
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
-import com.stripe.android.lpmfoundations.luxe.LpmRepository.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.luxe.PIRequirement
 import com.stripe.android.lpmfoundations.luxe.SIRequirement
 import com.stripe.android.lpmfoundations.luxe.ShippingAddress
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -15,7 +15,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import com.stripe.android.link.ui.inline.InlineSignupViewState
-import com.stripe.android.lpmfoundations.luxe.LpmRepository
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
@@ -154,7 +154,7 @@ private val BaseSheetViewModel.initiallySelectedPaymentMethodType: PaymentMethod
     }
 
 internal fun FormFieldValues.transformToPaymentMethodCreateParams(
-    paymentMethod: LpmRepository.SupportedPaymentMethod
+    paymentMethod: SupportedPaymentMethod
 ): PaymentMethodCreateParams {
     return FieldValuesToParamsMapConverter.transformToPaymentMethodCreateParams(
         fieldValuePairs = fieldValuePairs.filter { entry ->
@@ -168,7 +168,7 @@ internal fun FormFieldValues.transformToPaymentMethodCreateParams(
 }
 
 internal fun FormFieldValues.transformToPaymentMethodOptionsParams(
-    paymentMethod: LpmRepository.SupportedPaymentMethod
+    paymentMethod: SupportedPaymentMethod
 ): PaymentMethodOptionsParams? {
     return FieldValuesToParamsMapConverter.transformToPaymentMethodOptionsParams(
         fieldValuePairs = fieldValuePairs.filter { entry ->
@@ -179,7 +179,7 @@ internal fun FormFieldValues.transformToPaymentMethodOptionsParams(
 }
 
 internal fun FormFieldValues.transformToExtraParams(
-    paymentMethod: LpmRepository.SupportedPaymentMethod
+    paymentMethod: SupportedPaymentMethod
 ): PaymentMethodExtraParams? {
     return FieldValuesToParamsMapConverter.transformToPaymentMethodExtraParams(
         fieldValuePairs = fieldValuePairs.filter { entry ->
@@ -191,7 +191,7 @@ internal fun FormFieldValues.transformToExtraParams(
 
 internal fun FormFieldValues.transformToPaymentSelection(
     resources: Resources,
-    paymentMethod: LpmRepository.SupportedPaymentMethod
+    paymentMethod: SupportedPaymentMethod
 ): PaymentSelection.New {
     val params = transformToPaymentMethodCreateParams(paymentMethod)
     val options = transformToPaymentMethodOptionsParams(paymentMethod)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
@@ -18,7 +18,7 @@ import com.stripe.android.link.ui.inline.InlineSignupViewState
 import com.stripe.android.link.ui.inline.LinkInlineSignup
 import com.stripe.android.link.ui.inline.LinkOptionalInlineSignup
 import com.stripe.android.link.ui.inline.LinkSignupMode
-import com.stripe.android.lpmfoundations.luxe.LpmRepository
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentMethodsUI
 import com.stripe.android.paymentsheet.R
@@ -36,12 +36,12 @@ import javax.inject.Provider
 internal fun PaymentElement(
     formViewModelSubComponentBuilderProvider: Provider<FormViewModelSubcomponent.Builder>,
     enabled: Boolean,
-    supportedPaymentMethods: List<LpmRepository.SupportedPaymentMethod>,
-    selectedItem: LpmRepository.SupportedPaymentMethod,
+    supportedPaymentMethods: List<SupportedPaymentMethod>,
+    selectedItem: SupportedPaymentMethod,
     linkSignupMode: LinkSignupMode?,
     linkConfigurationCoordinator: LinkConfigurationCoordinator?,
     showCheckboxFlow: Flow<Boolean>,
-    onItemSelectedListener: (LpmRepository.SupportedPaymentMethod) -> Unit,
+    onItemSelectedListener: (SupportedPaymentMethod) -> Unit,
     onLinkSignupStateChanged: (LinkConfiguration, InlineSignupViewState) -> Unit,
     formArguments: FormArguments,
     usBankAccountFormArguments: USBankAccountFormArguments,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -11,6 +11,7 @@ import com.stripe.android.link.ui.inline.InlineSignupViewState
 import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
@@ -103,7 +104,7 @@ internal abstract class BaseSheetViewModel(
     private val _stripeIntent = MutableStateFlow<StripeIntent?>(null)
     internal val stripeIntent: StateFlow<StripeIntent?> = _stripeIntent
 
-    internal var supportedPaymentMethods: List<LpmRepository.SupportedPaymentMethod> = emptyList()
+    internal var supportedPaymentMethods: List<SupportedPaymentMethod> = emptyList()
         set(value) {
             field = value
             _supportedPaymentMethodsFlow.tryEmit(value.map { it.code })
@@ -589,7 +590,7 @@ internal abstract class BaseSheetViewModel(
     }
 
     fun createFormArguments(
-        selectedItem: LpmRepository.SupportedPaymentMethod,
+        selectedItem: SupportedPaymentMethod,
     ): FormArguments = FormArgumentsFactory.create(
         paymentMethod = selectedItem,
         stripeIntent = requireNotNull(stripeIntent.value),

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -17,6 +17,7 @@ import com.stripe.android.customersheet.FakeCustomerAdapter
 import com.stripe.android.customersheet.FakeStripeRepository
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
 import com.stripe.android.networking.StripeRepository
@@ -178,7 +179,7 @@ internal object CustomerSheetTestHelper {
         ),
         isGooglePayAvailable: Boolean = true,
         customerPaymentMethods: List<PaymentMethod> = listOf(CARD_PAYMENT_METHOD),
-        supportedPaymentMethods: List<LpmRepository.SupportedPaymentMethod> = listOf(
+        supportedPaymentMethods: List<SupportedPaymentMethod> = listOf(
             LpmRepository.HardcodedCard,
             LpmRepository.hardCodedUsBankAccount,
         ),

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
@@ -5,6 +5,7 @@ import com.stripe.android.customersheet.CustomerSheetLoader
 import com.stripe.android.customersheet.CustomerSheetState
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
@@ -18,7 +19,7 @@ internal class FakeCustomerSheetLoader(
     private val stripeIntent: StripeIntent = PaymentIntentFixtures.PI_SUCCEEDED,
     private val shouldFail: Boolean = false,
     private val customerPaymentMethods: List<PaymentMethod> = emptyList(),
-    private val supportedPaymentMethods: List<LpmRepository.SupportedPaymentMethod> = listOf(
+    private val supportedPaymentMethods: List<SupportedPaymentMethod> = listOf(
         LpmRepository.HardcodedCard,
         LpmRepository.hardCodedUsBankAccount,
     ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -9,6 +9,7 @@ import app.cash.turbine.testIn
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.lpmfoundations.luxe.PaymentMethodRequirements
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.COMPOSE_FRAGMENT_ARGS
@@ -74,7 +75,7 @@ internal class FormViewModelTest {
         val mockLpmRepository = mock<LpmRepository>()
 
         whenever(mockLpmRepository.fromCode(paymentMethodType.code)).thenReturn(
-            LpmRepository.SupportedPaymentMethod(
+            SupportedPaymentMethod(
                 code = paymentMethodType.code,
                 requiresMandate = false,
                 displayNameResource = R.string.stripe_paymentsheet_payment_method_card,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodTest.kt
@@ -6,7 +6,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
-import com.stripe.android.lpmfoundations.luxe.LpmRepository.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_CARD_SFU_SET

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUIScreenshotTest.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.paymentsheet.ui
 
 import androidx.compose.foundation.lazy.LazyListState
-import com.stripe.android.lpmfoundations.luxe.LpmRepository
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.paymentsheet.PaymentMethodsUI
 import com.stripe.android.ui.core.R
 import com.stripe.android.utils.MockPaymentMethodsFactory
@@ -22,7 +22,7 @@ class PaymentMethodsUIScreenshotTest {
         arrayOf(FontSize.LargeFont),
     )
 
-    private val paymentMethods: List<LpmRepository.SupportedPaymentMethod> by lazy {
+    private val paymentMethods: List<SupportedPaymentMethod> by lazy {
         MockPaymentMethodsFactory.create()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/utils/MockPaymentMethodsFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/MockPaymentMethodsFactory.kt
@@ -1,13 +1,13 @@
 package com.stripe.android.utils
 
-import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.lpmfoundations.luxe.PaymentMethodRequirements
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.LayoutSpec
 
 internal object MockPaymentMethodsFactory {
 
-    fun create(): List<LpmRepository.SupportedPaymentMethod> {
+    fun create(): List<SupportedPaymentMethod> {
         return listOf(
             mockPaymentMethod(
                 code = "card",
@@ -38,8 +38,8 @@ internal object MockPaymentMethodsFactory {
         displayNameResource: Int,
         iconResource: Int,
         tintIconOnSelection: Boolean = false
-    ): LpmRepository.SupportedPaymentMethod {
-        return LpmRepository.SupportedPaymentMethod(
+    ): SupportedPaymentMethod {
+        return SupportedPaymentMethod(
             code = code,
             requiresMandate = false,
             displayNameResource = displayNameResource,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
SupportedPaymentMethod lives on it's own! And will be transforming and even changing to a different class later on. Pulling it to a top level type to communicate it's scope.

