### PR TITLE
Send saved selection with `LoadSucceeded` event.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -6,6 +6,8 @@ import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.SavedSelection
+import kotlinx.coroutines.Deferred
 
 internal interface EventReporter {
 
@@ -27,6 +29,7 @@ internal interface EventReporter {
      * rendered.
      */
     fun onLoadSucceeded(
+        savedSelection: Deferred<SavedSelection>,
         linkEnabled: Boolean,
         currency: String?,
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -6,8 +6,6 @@ import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.SavedSelection
-import kotlinx.coroutines.Deferred
 
 internal interface EventReporter {
 
@@ -29,7 +27,7 @@ internal interface EventReporter {
      * rendered.
      */
     fun onLoadSucceeded(
-        savedSelection: Deferred<SavedSelection>,
+        paymentSelection: PaymentSelection?,
         linkEnabled: Boolean,
         currency: String?,
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -5,7 +5,6 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.uicore.StripeThemeDefaults
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
@@ -28,7 +27,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     }
 
     class LoadSucceeded(
-        savedSelection: SavedSelection,
+        paymentSelection: PaymentSelection?,
         duration: Duration?,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
@@ -36,15 +35,15 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         override val eventName: String = "mc_load_succeeded"
         override val additionalParams: Map<String, Any?> = mapOf(
             FIELD_DURATION to duration?.asSeconds,
-            FIELD_SELECTED_LPM to savedSelection.defaultAnalyticsValue,
+            FIELD_SELECTED_LPM to paymentSelection.defaultAnalyticsValue,
         )
 
-        private val SavedSelection.defaultAnalyticsValue: String
+        private val PaymentSelection?.defaultAnalyticsValue: String
             get() = when (this) {
-                is SavedSelection.GooglePay -> "google_pay"
-                is SavedSelection.Link -> "link"
-                is SavedSelection.PaymentMethod -> id
-                is SavedSelection.None -> "none"
+                is PaymentSelection.GooglePay -> "google_pay"
+                is PaymentSelection.Link -> "link"
+                is PaymentSelection.Saved -> paymentMethod.type?.code ?: "unknown"
+                else -> "none"
             }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -5,6 +5,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.uicore.StripeThemeDefaults
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
@@ -27,6 +28,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     }
 
     class LoadSucceeded(
+        savedSelection: SavedSelection,
         duration: Duration?,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
@@ -34,7 +36,16 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         override val eventName: String = "mc_load_succeeded"
         override val additionalParams: Map<String, Any?> = mapOf(
             FIELD_DURATION to duration?.asSeconds,
+            FIELD_SELECTED_LPM to savedSelection.defaultAnalyticsValue,
         )
+
+        private val SavedSelection.defaultAnalyticsValue: String
+            get() = when (this) {
+                is SavedSelection.GooglePay -> "google_pay"
+                is SavedSelection.Link -> "link"
+                is SavedSelection.PaymentMethod -> id
+                is SavedSelection.None -> "none"
+            }
     }
 
     class LoadFailed(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -42,7 +42,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
             get() = when (this) {
                 is PaymentSelection.GooglePay -> "google_pay"
                 is PaymentSelection.Link -> "link"
-                is PaymentSelection.Saved -> paymentMethod.type?.code ?: "unknown"
+                is PaymentSelection.Saved -> paymentMethod.type?.code ?: "saved"
                 else -> "none"
             }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -13,10 +13,7 @@ import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.utils.FakeDurationProvider
-import kotlinx.coroutines.async
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.json.JSONException
 import org.junit.runner.RunWith
@@ -66,7 +63,11 @@ class DefaultEventReporterTest {
     fun `on completed loading operation, should fire analytics request with expected event value`() {
         val eventReporter = createEventReporter(EventReporter.Mode.Complete)
 
-        eventReporter.simulateSuccessfulSetup(SavedSelection.PaymentMethod(id = "card"))
+        eventReporter.simulateSuccessfulSetup(
+            PaymentSelection.Saved(
+                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+            )
+        )
 
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
@@ -432,18 +433,14 @@ class DefaultEventReporterTest {
     }
 
     private fun EventReporter.simulateSuccessfulSetup(
-        savedSelection: SavedSelection = SavedSelection.GooglePay,
+        paymentSelection: PaymentSelection = PaymentSelection.GooglePay,
         linkEnabled: Boolean = true,
         currency: String? = "usd",
     ) {
         onInit(configuration, isDeferred = false)
         onLoadStarted()
         onLoadSucceeded(
-            savedSelection = runBlocking {
-                async {
-                    savedSelection
-                }
-            },
+            paymentSelection = paymentSelection,
             linkEnabled = linkEnabled,
             currency = currency
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -9,7 +9,6 @@ import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.SavedSelection
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
@@ -190,7 +189,7 @@ class PaymentSheetEventTest {
             isDeferred = false,
             linkEnabled = false,
             duration = (5L).seconds,
-            savedSelection = SavedSelection.None
+            paymentSelection = null
         )
 
         assertThat(event.eventName).isEqualTo("mc_load_succeeded")
@@ -210,7 +209,7 @@ class PaymentSheetEventTest {
             isDeferred = false,
             linkEnabled = false,
             duration = (5L).seconds,
-            savedSelection = SavedSelection.GooglePay
+            paymentSelection = PaymentSelection.GooglePay
         )
 
         assertThat(event.params).containsEntry("selected_lpm", "google_pay")
@@ -222,7 +221,7 @@ class PaymentSheetEventTest {
             isDeferred = false,
             linkEnabled = false,
             duration = (5L).seconds,
-            savedSelection = SavedSelection.Link
+            paymentSelection = PaymentSelection.Link
         )
 
         assertThat(event.params).containsEntry("selected_lpm", "link")
@@ -234,7 +233,9 @@ class PaymentSheetEventTest {
             isDeferred = false,
             linkEnabled = false,
             duration = (5L).seconds,
-            savedSelection = SavedSelection.PaymentMethod(id = "sepa_debit")
+            paymentSelection = PaymentSelection.Saved(
+                paymentMethod = PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD
+            )
         )
 
         assertThat(event.params).containsEntry("selected_lpm", "sepa_debit")

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -9,11 +9,13 @@ import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.SavedSelection
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 @RunWith(RobolectricTestRunner::class)
 @Suppress("LargeClass")
@@ -180,6 +182,62 @@ class PaymentSheetEventTest {
             containsEntry("is_decoupled", false)
             containsEntry("mpe_config", expectedConfig)
         }
+    }
+
+    @Test
+    fun `LoadSucceeded event should return expected toString()`() {
+        val event = PaymentSheetEvent.LoadSucceeded(
+            isDeferred = false,
+            linkEnabled = false,
+            duration = (5L).seconds,
+            savedSelection = SavedSelection.None
+        )
+
+        assertThat(event.eventName).isEqualTo("mc_load_succeeded")
+        assertThat(event.params).isEqualTo(
+            mapOf(
+                "is_decoupled" to false,
+                "link_enabled" to false,
+                "duration" to 5f,
+                "selected_lpm" to "none"
+            )
+        )
+    }
+
+    @Test
+    fun `LoadSucceeded event should return 'google_pay' for selected lpm when saved selection is Google Pay`() {
+        val event = PaymentSheetEvent.LoadSucceeded(
+            isDeferred = false,
+            linkEnabled = false,
+            duration = (5L).seconds,
+            savedSelection = SavedSelection.GooglePay
+        )
+
+        assertThat(event.params).containsEntry("selected_lpm", "google_pay")
+    }
+
+    @Test
+    fun `LoadSucceeded event should return 'link' for selected lpm when saved selection is Link`() {
+        val event = PaymentSheetEvent.LoadSucceeded(
+            isDeferred = false,
+            linkEnabled = false,
+            duration = (5L).seconds,
+            savedSelection = SavedSelection.Link
+        )
+
+        assertThat(event.params).containsEntry("selected_lpm", "link")
+    }
+
+    @Test
+    fun `LoadSucceeded event should return id for selected lpm when saved selection is a payment method`() {
+        val event = PaymentSheetEvent.LoadSucceeded(
+            isDeferred = false,
+            linkEnabled = false,
+            duration = (5L).seconds,
+            savedSelection = SavedSelection.PaymentMethod(id = "sepa_debit")
+        )
+
+        assertThat(event.params).containsEntry("selected_lpm", "sepa_debit")
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -659,15 +659,35 @@ internal class DefaultPaymentSheetLoaderTest {
 
     @Test
     fun `Emits correct events when loading succeeds for non-deferred intent`() = runTest {
-        testSuccessfulLoadSendsEventsCorrectly(
-            paymentSelection = null
+        val loader = createPaymentSheetLoader()
+
+        loader.load(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent("secret"),
+            paymentSheetConfiguration = PaymentSheet.Configuration(
+                merchantDisplayName = "Some Name",
+                customer = PaymentSheet.CustomerConfiguration(
+                    id = "cus_123",
+                    ephemeralKeySecret = "some_secret",
+                ),
+            ),
+        )
+
+        verify(eventReporter).onLoadStarted()
+        verify(eventReporter).onLoadSucceeded(
+            paymentSelection = PaymentSelection.Saved(
+                paymentMethod = PAYMENT_METHODS.first()
+            ),
+            linkEnabled = true,
+            currency = "usd",
         )
     }
 
     @Test
     fun `Emits correct events when loading succeeds with saved LPM selection`() = runTest {
         testSuccessfulLoadSendsEventsCorrectly(
-            paymentSelection = PaymentSelection.Link
+            paymentSelection = PaymentSelection.Saved(
+                paymentMethod = PAYMENT_METHODS.last()
+            )
         )
     }
 
@@ -904,7 +924,13 @@ internal class DefaultPaymentSheetLoaderTest {
 
         loader.load(
             initializationMode = PaymentSheet.InitializationMode.PaymentIntent("secret"),
-            paymentSheetConfiguration = PaymentSheet.Configuration("Some Name"),
+            paymentSheetConfiguration = PaymentSheet.Configuration(
+                merchantDisplayName = "Some Name",
+                customer = PaymentSheet.CustomerConfiguration(
+                    id = "cus_123",
+                    ephemeralKeySecret = "some_secret",
+                ),
+            ),
         )
 
         verify(eventReporter).onLoadStarted()


### PR DESCRIPTION
# Summary
Send saved selection with `LoadSucceeded` event.

# Motivation
For the Crumbl investigation, we want to see what type of payment method customers have saved as their default choice when using either Basic Integration & Payment Sheet. This PR adds support for sending the event field on `PaymentSheet`. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified
