### PR TITLE
Make payment method serializable.

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -1972,7 +1972,7 @@ public final class com/stripe/android/model/AccountRange$Creator : android/os/Pa
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/model/Address : com/stripe/android/core/model/StripeModel, com/stripe/android/model/StripeParamsModel {
+public final class com/stripe/android/model/Address : com/stripe/android/core/model/StripeModel, com/stripe/android/model/StripeParamsModel, java/io/Serializable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/Address$Companion;
@@ -3285,7 +3285,7 @@ public final class com/stripe/android/model/PaymentIntent$Shipping$Creator : and
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/model/PaymentMethod : com/stripe/android/core/model/StripeModel {
+public final class com/stripe/android/model/PaymentMethod : com/stripe/android/core/model/StripeModel, java/io/Serializable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/PaymentMethod$Companion;
@@ -3387,7 +3387,7 @@ public final class com/stripe/android/model/PaymentMethod$BacsDebit$Creator : an
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/model/PaymentMethod$BillingDetails : com/stripe/android/core/model/StripeModel, com/stripe/android/model/StripeParamsModel {
+public final class com/stripe/android/model/PaymentMethod$BillingDetails : com/stripe/android/core/model/StripeModel, com/stripe/android/model/StripeParamsModel, java/io/Serializable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final field address Lcom/stripe/android/model/Address;

--- a/payments-core/src/main/java/com/stripe/android/model/Address.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/Address.kt
@@ -7,6 +7,7 @@ import com.stripe.android.core.model.StripeModel
 import com.stripe.android.model.parsers.AddressJsonParser
 import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
+import java.io.Serializable
 
 /**
  * Model for an owner [address](https://stripe.com/docs/api#source_object-owner-address)
@@ -20,7 +21,7 @@ data class Address @VisibleForTesting constructor(
     val line2: String? = null,
     val postalCode: String? = null,
     val state: String? = null
-) : StripeModel, StripeParamsModel {
+) : StripeModel, StripeParamsModel, Serializable {
     internal val countryCode: CountryCode?
         get() = country?.takeUnless { it.isBlank() }?.let { CountryCode.create(it) }
 
@@ -88,6 +89,8 @@ data class Address @VisibleForTesting constructor(
     }
 
     companion object {
+        private const val serialVersionUID: Long = 3803581706318748613L
+
         private const val PARAM_CITY = "city"
 
         // 2 Character Country Code

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -8,6 +8,7 @@ import com.stripe.android.model.wallets.Wallet
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
+import java.io.Serializable
 
 typealias PaymentMethodCode = String
 
@@ -143,7 +144,7 @@ constructor(
      * [us_bank_account](https://stripe.com/docs/api/payment_methods/object#payment_method_object-us_bank_account)
      */
     @JvmField val usBankAccount: USBankAccount? = null
-) : StripeModel {
+) : StripeModel, Serializable {
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet
     fun hasExpectedDetails(): Boolean =
@@ -578,7 +579,7 @@ constructor(
          * [billing_details.phone](https://stripe.com/docs/api/payment_methods/object#payment_method_object-billing_details-phone)
          */
         @JvmField val phone: String? = null
-    ) : StripeModel, StripeParamsModel {
+    ) : StripeModel, StripeParamsModel, Serializable {
 
         fun toBuilder(): Builder {
             return Builder()
@@ -640,6 +641,8 @@ constructor(
         }
 
         internal companion object {
+            private const val serialVersionUID: Long = 3803581706318748612L
+
             internal const val PARAM_ADDRESS = "address"
             internal const val PARAM_EMAIL = "email"
             internal const val PARAM_NAME = "name"
@@ -1066,6 +1069,8 @@ constructor(
     }
 
     companion object {
+        private const val serialVersionUID: Long = 3803581706318748611L
+
         @JvmStatic
         fun fromJson(paymentMethod: JSONObject?): PaymentMethod? {
             return paymentMethod?.let {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fixes https://github.com/stripe/stripe-android/issues/7827

This was causing issues when serializing `PaymentSheetLoadingException.PaymentIntentInTerminalState`.
Originally introduced in https://github.com/stripe/stripe-android/pull/7704