### PR TITLE
Don't use payment method in the exception.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -56,7 +56,6 @@ import com.stripe.android.paymentsheet.state.GooglePayState
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.paymentsheet.state.WalletsState
-import com.stripe.android.paymentsheet.state.asPaymentSheetLoadingException
 import com.stripe.android.paymentsheet.ui.HeaderTextFactory
 import com.stripe.android.paymentsheet.ui.ModifiableEditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.ui.PrimaryButton
@@ -341,7 +340,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         if (pendingResult is InternalPaymentResult.Completed) {
             // If we just received a transaction result after process death, we don't error. Instead, we dismiss
             // PaymentSheet and return a `Completed` result to the caller.
-            val usedPaymentMethod = error.asPaymentSheetLoadingException.usedPaymentMethod
+            val usedPaymentMethod = stripeIntent.value?.paymentMethod
             handlePaymentCompleted(usedPaymentMethod, finishImmediately = true)
         } else {
             setStripeIntent(null)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/StripeIntentValidator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/StripeIntentValidator.kt
@@ -23,20 +23,18 @@ internal object StripeIntentValidator {
     fun requireValid(
         stripeIntent: StripeIntent
     ): StripeIntent {
-        val paymentMethod = stripeIntent.paymentMethod
-
         val exception = when {
             stripeIntent is PaymentIntent && stripeIntent.confirmationMethod != Automatic -> {
                 PaymentSheetLoadingException.InvalidConfirmationMethod(stripeIntent.confirmationMethod)
             }
             stripeIntent is PaymentIntent && stripeIntent.isInTerminalState -> {
-                PaymentSheetLoadingException.PaymentIntentInTerminalState(paymentMethod, stripeIntent.status)
+                PaymentSheetLoadingException.PaymentIntentInTerminalState(stripeIntent.status)
             }
             stripeIntent is PaymentIntent && (stripeIntent.amount == null || stripeIntent.currency == null) -> {
                 PaymentSheetLoadingException.MissingAmountOrCurrency
             }
             stripeIntent is SetupIntent && stripeIntent.isInTerminalState -> {
-                PaymentSheetLoadingException.SetupIntentInTerminalState(paymentMethod, stripeIntent.status)
+                PaymentSheetLoadingException.SetupIntentInTerminalState(stripeIntent.status)
             }
             else -> {
                 // valid

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoadingException.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoadingException.kt
@@ -2,20 +2,16 @@ package com.stripe.android.paymentsheet.state
 
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.model.PaymentIntent
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException.Unknown
 
 internal sealed class PaymentSheetLoadingException : Throwable() {
 
     abstract val type: String
-    abstract val usedPaymentMethod: PaymentMethod?
 
     data class InvalidConfirmationMethod(
         private val confirmationMethod: PaymentIntent.ConfirmationMethod,
     ) : PaymentSheetLoadingException() {
-
-        override val usedPaymentMethod: PaymentMethod? = null
 
         override val type: String = "invalidConfirmationMethod"
 
@@ -31,8 +27,6 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
         private val supported: String,
     ) : PaymentSheetLoadingException() {
 
-        override val usedPaymentMethod: PaymentMethod? = null
-
         override val type: String = "noPaymentMethodTypesAvailable"
 
         override val message: String
@@ -41,7 +35,6 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
     }
 
     data class PaymentIntentInTerminalState(
-        override val usedPaymentMethod: PaymentMethod?,
         private val status: StripeIntent.Status?,
     ) : PaymentSheetLoadingException() {
 
@@ -55,7 +48,6 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
     }
 
     data class SetupIntentInTerminalState(
-        override val usedPaymentMethod: PaymentMethod?,
         private val status: StripeIntent.Status?,
     ) : PaymentSheetLoadingException() {
 
@@ -69,7 +61,6 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
     }
 
     object MissingAmountOrCurrency : PaymentSheetLoadingException() {
-        override val usedPaymentMethod: PaymentMethod? = null
         override val type: String = "missingAmountOrCurrency"
         override val message: String = "PaymentIntent must contain amount and currency."
     }
@@ -82,8 +73,6 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
             get() = StripeException.create(cause).analyticsValue()
 
         override val message: String? = cause.message
-
-        override val usedPaymentMethod: PaymentMethod? = null
     }
 }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fixes https://github.com/stripe/stripe-android/issues/7827

This was causing issues when serializing PaymentSheetLoadingException.PaymentIntentInTerminalState.
Originally introduced in https://github.com/stripe/stripe-android/pull/7704