### PR TITLE
Refactor validation errors from Payment- & CustomerSheetLoader

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -3,7 +3,6 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>CyclomaticComplexMethod:CustomerSheetViewModel.kt$CustomerSheetViewModel$fun handleViewAction(viewAction: CustomerSheetViewAction)</ID>
-    <ID>CyclomaticComplexMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration, isDeferred: Boolean = false, )</ID>
     <ID>CyclomaticComplexMethod:PlaceholderHelper.kt$PlaceholderHelper$@VisibleForTesting internal fun specForPlaceholderField( field: PlaceholderField, placeholderOverrideList: List&lt;IdentifierSpec>, requiresMandate: Boolean, configuration: PaymentSheet.BillingDetailsCollectionConfiguration, )</ID>
     <ID>EmptyFunctionBlock:PrimaryButtonAnimator.kt$PrimaryButtonAnimator.&lt;no name provided>${ }</ID>
     <ID>ForbiddenComment:PaymentOptionFactory.kt$PaymentOptionFactory$// TODO: Should use labelResource paymentMethodCreateParams or extension function</ID>
@@ -31,11 +30,10 @@
     <ID>LongMethod:EditPaymentMethod.kt$@Composable internal fun EditPaymentMethodUi( viewState: EditPaymentMethodViewState, viewActionHandler: (action: EditPaymentMethodViewAction) -> Unit, modifier: Modifier = Modifier )</ID>
     <ID>LongMethod:FormViewModelTest.kt$FormViewModelTest$@Test fun `Verify params are set when element address fields are complete`()</ID>
     <ID>LongMethod:FormViewModelTest.kt$FormViewModelTest$@Test fun `Verify params are set when required address fields are complete`()</ID>
-    <ID>LongMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration, isDeferred: Boolean = false, )</ID>
     <ID>LongMethod:PaymentElement.kt$@Composable internal fun PaymentElement( formViewModelSubComponentBuilderProvider: Provider&lt;FormViewModelSubcomponent.Builder>, enabled: Boolean, supportedPaymentMethods: List&lt;SupportedPaymentMethod>, selectedItem: SupportedPaymentMethod, linkSignupMode: LinkSignupMode?, linkConfigurationCoordinator: LinkConfigurationCoordinator?, showCheckboxFlow: Flow&lt;Boolean>, onItemSelectedListener: (SupportedPaymentMethod) -> Unit, onLinkSignupStateChanged: (LinkConfiguration, InlineSignupViewState) -> Unit, formArguments: FormArguments, usBankAccountFormArguments: USBankAccountFormArguments, onFormFieldValuesChanged: (FormFieldValues?) -> Unit, )</ID>
     <ID>LongMethod:PaymentOptionFactory.kt$PaymentOptionFactory$fun create(selection: PaymentSelection): PaymentOption</ID>
     <ID>LongMethod:PaymentSheetConfigurationKtx.kt$internal fun PaymentSheet.Appearance.parseAppearance()</ID>
-    <ID>LongMethod:PaymentSheetLoader.kt$DefaultPaymentSheetLoader$private suspend fun create( elementsSession: ElementsSession, config: PaymentSheet.Configuration, isGooglePayReady: Boolean, ): PaymentSheetState.Full</ID>
+    <ID>LongMethod:PaymentSheetLoader.kt$DefaultPaymentSheetLoader$private suspend fun create( elementsSession: ElementsSession, config: PaymentSheet.Configuration, ): PaymentSheetState.Full</ID>
     <ID>LongMethod:PaymentSheetScreen.kt$@Composable internal fun PaymentSheetScreenContent( viewModel: BaseSheetViewModel, type: PaymentSheetFlowType, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:PlaceholderHelperTest.kt$PlaceholderHelperTest$@Test fun `Test correct placeholder is removed for placeholder spec`()</ID>
     <ID>LongMethod:USBankAccountEmitters.kt$@Composable internal fun USBankAccountEmitters( viewModel: USBankAccountFormViewModel, usBankAccountFormArgs: USBankAccountFormArguments, )</ID>
@@ -69,7 +67,6 @@
     <ID>MaxLineLength:FlowControllerConfigurationHandlerTest.kt$FlowControllerConfigurationHandlerTest$.</ID>
     <ID>MaxLineLength:InjectableActivityScenario.kt$InjectableActivityScenario$delegate ?: throw IllegalStateException("Cannot move to state $newState since the activity hasn't been launched.")</ID>
     <ID>MaxLineLength:InjectableActivityScenario.kt$InjectableActivityScenario$val d = delegate ?: throw IllegalStateException("Cannot run onActivity since the activity hasn't been launched.")</ID>
-    <ID>MaxLineLength:LinkHandlerTest.kt$whenever(linkConfigurationCoordinator.attachNewCardToAccount(eq(linkConfiguration), any())).thenReturn(attachNewCardToAccountResult)</ID>
     <ID>MaxLineLength:LpmRepositoryTest.kt$LpmRepositoryTest$fun</ID>
     <ID>MaxLineLength:PaymentSheet.kt$PaymentSheet.Address$*</ID>
     <ID>MaxLineLength:PaymentSheet.kt$PaymentSheet.BillingDetails$*</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -12,7 +12,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAvailable
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.requireValidOrThrow
+import com.stripe.android.paymentsheet.model.validate
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.paymentsheet.state.toInternal
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
@@ -60,7 +60,7 @@ internal class DefaultCustomerSheetLoader @Inject constructor(
                 mode = PaymentSheet.IntentConfiguration.Mode.Setup(),
             )
         )
-        return elementsSessionRepository.get(initializationMode).mapCatching { elementsSession ->
+        return elementsSessionRepository.get(initializationMode).onSuccess { elementsSession ->
             val billingDetailsCollectionConfig = configuration?.billingDetailsCollectionConfiguration.toInternal()
             val metadata = PaymentMethodMetadata(
                 stripeIntent = elementsSession.stripeIntent,
@@ -73,8 +73,6 @@ internal class DefaultCustomerSheetLoader @Inject constructor(
                 metadata = metadata,
                 serverLpmSpecs = elementsSession.paymentMethodSpecs,
             )
-
-            elementsSession.requireValidOrThrow()
         }
     }
 
@@ -154,6 +152,7 @@ internal class DefaultCustomerSheetLoader @Inject constructor(
                         } else {
                             CardBrandChoiceEligibility.Ineligible
                         },
+                        validationError = elementsSession?.stripeIntent?.validate(),
                     )
                 )
             },

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetState.kt
@@ -18,5 +18,6 @@ internal sealed interface CustomerSheetState {
         val isGooglePayReady: Boolean,
         val paymentSelection: PaymentSelection?,
         val cbcEligibility: CardBrandChoiceEligibility,
+        val validationError: Throwable?,
     ) : CustomerSheetState
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -271,18 +271,24 @@ internal class CustomerSheetViewModel @Inject constructor(
 
         result.fold(
             onSuccess = { state ->
-                supportedPaymentMethods.clear()
-                supportedPaymentMethods.addAll(state.supportedPaymentMethods)
+                if (state.validationError != null) {
+                    _result.update {
+                        InternalCustomerSheetResult.Error(state.validationError)
+                    }
+                } else {
+                    supportedPaymentMethods.clear()
+                    supportedPaymentMethods.addAll(state.supportedPaymentMethods)
 
-                originalPaymentSelection = state.paymentSelection
-                isGooglePayReadyAndEnabled = state.isGooglePayReady
-                stripeIntent = state.stripeIntent
+                    originalPaymentSelection = state.paymentSelection
+                    isGooglePayReadyAndEnabled = state.isGooglePayReady
+                    stripeIntent = state.stripeIntent
 
-                transitionToInitialScreen(
-                    paymentMethods = state.customerPaymentMethods,
-                    paymentSelection = state.paymentSelection,
-                    cbcEligibility = state.cbcEligibility,
-                )
+                    transitionToInitialScreen(
+                        paymentMethods = state.customerPaymentMethods,
+                        paymentSelection = state.paymentSelection,
+                        cbcEligibility = state.cbcEligibility,
+                    )
+                }
             },
             onFailure = { cause ->
                 _result.update {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
@@ -88,9 +88,13 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
 
         paymentSheetLoader.load(initializationMode, configuration).fold(
             onSuccess = { state ->
-                viewModel.previousConfigureRequest = configureRequest
-                onInitSuccess(state, configureRequest)
-                onConfigured()
+                if (state.validationError != null) {
+                    onConfigured(state.validationError)
+                } else {
+                    viewModel.previousConfigureRequest = configureRequest
+                    onInitSuccess(state, configureRequest)
+                    onConfigured()
+                }
             },
             onFailure = { error ->
                 onConfigured(error = error)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -25,7 +25,7 @@ import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.paymentsheet.model.getPMAddForm
 import com.stripe.android.paymentsheet.model.getPMsToAdd
 import com.stripe.android.paymentsheet.model.getSupportedSavedCustomerPMs
-import com.stripe.android.paymentsheet.model.requireValidOrThrow
+import com.stripe.android.paymentsheet.model.validate
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
@@ -173,6 +173,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
                 linkState = linkState.await(),
                 isEligibleForCardBrandChoice = elementsSession.isEligibleForCardBrandChoice,
                 paymentSelection = initialPaymentSelection.await(),
+                validationError = stripeIntent.validate(),
             )
         } else {
             val requested = stripeIntent.paymentMethodTypes.joinToString(separator = ", ")
@@ -212,7 +213,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         initializationMode: PaymentSheet.InitializationMode,
         configuration: PaymentSheet.Configuration,
     ): Result<ElementsSession> {
-        return elementsSessionRepository.get(initializationMode).mapCatching { elementsSession ->
+        return elementsSessionRepository.get(initializationMode).onSuccess { elementsSession ->
             val billingDetailsCollectionConfig =
                 configuration.billingDetailsCollectionConfiguration.toInternal()
 
@@ -230,8 +231,6 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             if (!didParseServerResponse) {
                 eventReporter.onLpmSpecFailure()
             }
-
-            elementsSession.requireValidOrThrow()
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoadingException.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoadingException.kt
@@ -2,20 +2,16 @@ package com.stripe.android.paymentsheet.state
 
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.model.PaymentIntent
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException.Unknown
 
 internal sealed class PaymentSheetLoadingException : Throwable() {
 
     abstract val type: String
-    abstract val usedPaymentMethod: PaymentMethod?
 
     data class InvalidConfirmationMethod(
         private val confirmationMethod: PaymentIntent.ConfirmationMethod,
     ) : PaymentSheetLoadingException() {
-
-        override val usedPaymentMethod: PaymentMethod? = null
 
         override val type: String = "invalidConfirmationMethod"
 
@@ -31,8 +27,6 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
         private val supported: String,
     ) : PaymentSheetLoadingException() {
 
-        override val usedPaymentMethod: PaymentMethod? = null
-
         override val type: String = "noPaymentMethodTypesAvailable"
 
         override val message: String
@@ -41,7 +35,6 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
     }
 
     data class PaymentIntentInTerminalState(
-        override val usedPaymentMethod: PaymentMethod?,
         private val status: StripeIntent.Status?,
     ) : PaymentSheetLoadingException() {
 
@@ -55,7 +48,6 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
     }
 
     data class SetupIntentInTerminalState(
-        override val usedPaymentMethod: PaymentMethod?,
         private val status: StripeIntent.Status?,
     ) : PaymentSheetLoadingException() {
 
@@ -69,7 +61,6 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
     }
 
     object MissingAmountOrCurrency : PaymentSheetLoadingException() {
-        override val usedPaymentMethod: PaymentMethod? = null
         override val type: String = "missingAmountOrCurrency"
         override val message: String = "PaymentIntent must contain amount and currency."
     }
@@ -82,8 +73,6 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
             get() = StripeException.create(cause).analyticsValue()
 
         override val message: String? = cause.message
-
-        override val usedPaymentMethod: PaymentMethod? = null
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetState.kt
@@ -21,6 +21,7 @@ internal sealed interface PaymentSheetState : Parcelable {
         val linkState: LinkState?,
         val isEligibleForCardBrandChoice: Boolean,
         val paymentSelection: PaymentSelection?,
+        val validationError: PaymentSheetLoadingException?,
     ) : PaymentSheetState {
 
         val showSavedPaymentMethods: Boolean

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -140,6 +140,7 @@ class DefaultCustomerSheetLoaderTest {
                     paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 ),
                 cbcEligibility = CardBrandChoiceEligibility.Ineligible,
+                validationError = null,
             )
         )
 
@@ -196,6 +197,7 @@ class DefaultCustomerSheetLoaderTest {
                 isGooglePayReady = false,
                 paymentSelection = null,
                 cbcEligibility = CardBrandChoiceEligibility.Ineligible,
+                validationError = null,
             )
         )
     }
@@ -238,6 +240,7 @@ class DefaultCustomerSheetLoaderTest {
                     PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_3")
                 ),
                 cbcEligibility = CardBrandChoiceEligibility.Ineligible,
+                validationError = null,
             )
         )
     }
@@ -276,6 +279,7 @@ class DefaultCustomerSheetLoaderTest {
                 isGooglePayReady = false,
                 paymentSelection = null,
                 cbcEligibility = CardBrandChoiceEligibility.Ineligible,
+                validationError = null,
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
@@ -43,6 +43,7 @@ internal class FakeCustomerSheetLoader(
                     isGooglePayReady = isGooglePayAvailable,
                     paymentSelection = paymentSelection,
                     cbcEligibility = cbcEligibility,
+                    validationError = null,
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -738,6 +738,7 @@ internal class PaymentOptionsViewModelTest {
                 paymentSelection = null,
                 linkState = null,
                 isEligibleForCardBrandChoice = false,
+                validationError = null,
             ),
             statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR,
             enableLogging = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -111,6 +111,7 @@ internal object PaymentSheetFixtures {
             paymentSelection = null,
             linkState = null,
             isEligibleForCardBrandChoice = false,
+            validationError = null,
         ),
         statusBarColor = STATUS_BAR_COLOR,
         enableLogging = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/TestViewModelFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/TestViewModelFactory.kt
@@ -9,13 +9,13 @@ import org.mockito.kotlin.mock
 internal object TestViewModelFactory {
     fun <T : BaseSheetViewModel> create(
         linkConfigurationCoordinator: LinkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+        savedStateHandle: SavedStateHandle = SavedStateHandle(),
         viewModelFactory: (
             linkHandler: LinkHandler,
             linkConfigurationCoordinator: LinkConfigurationCoordinator,
             savedStateHandle: SavedStateHandle,
         ) -> T
     ): T {
-        val savedStateHandle = SavedStateHandle()
         val linkHandler = LinkHandler(
             linkLauncher = mock(),
             linkConfigurationCoordinator = linkConfigurationCoordinator,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -416,6 +416,7 @@ internal class DefaultFlowControllerTest {
                 paymentSelection = null,
                 linkState = null,
                 isEligibleForCardBrandChoice = false,
+                validationError = null,
             ),
             statusBarColor = STATUS_BAR_COLOR,
             enableLogging = ENABLE_LOGGING,
@@ -590,6 +591,7 @@ internal class DefaultFlowControllerTest {
                 linkState = null,
                 paymentSelection = initialSelection,
                 isEligibleForCardBrandChoice = false,
+                validationError = null,
             )
         )
 
@@ -628,6 +630,7 @@ internal class DefaultFlowControllerTest {
                 linkState = null,
                 paymentSelection = initialSelection,
                 isEligibleForCardBrandChoice = false,
+                validationError = null,
             )
         )
 
@@ -669,6 +672,7 @@ internal class DefaultFlowControllerTest {
                 linkState = null,
                 paymentSelection = initialSelection,
                 isEligibleForCardBrandChoice = false,
+                validationError = null,
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
@@ -261,6 +261,7 @@ class PaymentSelectionUpdaterTest {
             linkState = null,
             paymentSelection = paymentSelection,
             isEligibleForCardBrandChoice = false,
+            validationError = null,
         )
     }
 
@@ -282,6 +283,7 @@ class PaymentSelectionUpdaterTest {
             linkState = null,
             paymentSelection = paymentSelection,
             isEligibleForCardBrandChoice = false,
+            validationError = null,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -129,6 +129,7 @@ internal class DefaultPaymentSheetLoaderTest {
                 ),
                 linkState = null,
                 isEligibleForCardBrandChoice = false,
+                validationError = null,
             )
         )
     }
@@ -163,6 +164,7 @@ internal class DefaultPaymentSheetLoaderTest {
                 ),
                 linkState = null,
                 isEligibleForCardBrandChoice = false,
+                validationError = null,
             )
         )
     }
@@ -402,7 +404,7 @@ internal class DefaultPaymentSheetLoaderTest {
             PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
         ).exceptionOrNull()
 
-        assertThat(result).isEqualTo(PaymentIntentInTerminalState(paymentMethod, Succeeded))
+        assertThat(result).isEqualTo(PaymentIntentInTerminalState(Succeeded))
     }
 
     @Test
@@ -746,7 +748,7 @@ internal class DefaultPaymentSheetLoaderTest {
 
     @Test
     fun `Emits correct events when loading fails for deferred intent`() = runTest {
-        val error = PaymentIntentInTerminalState(usedPaymentMethod = null, status = Canceled)
+        val error = PaymentIntentInTerminalState(Canceled)
         val loader = createPaymentSheetLoader(error = error)
 
         loader.load(

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
@@ -7,6 +7,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
+import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import kotlinx.coroutines.delay
 import kotlin.time.Duration
@@ -19,6 +20,7 @@ internal class FakePaymentSheetLoader(
     private val isGooglePayAvailable: Boolean = false,
     private val delay: Duration = Duration.ZERO,
     private val linkState: LinkState? = null,
+    private val validationError: PaymentSheetLoadingException? = null,
 ) : PaymentSheetLoader {
 
     fun updatePaymentMethods(paymentMethods: List<PaymentMethod>) {
@@ -45,6 +47,7 @@ internal class FakePaymentSheetLoader(
                     linkState = linkState,
                     paymentSelection = paymentSelection,
                     isEligibleForCardBrandChoice = false,
+                    validationError = validationError,
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/RelayingPaymentSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/RelayingPaymentSheetLoader.kt
@@ -3,6 +3,7 @@ package com.stripe.android.utils
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
+import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.testing.PaymentIntentFactory
 import kotlinx.coroutines.channels.Channel
@@ -13,6 +14,7 @@ internal class RelayingPaymentSheetLoader : PaymentSheetLoader {
 
     fun enqueueSuccess(
         stripeIntent: StripeIntent = PaymentIntentFactory.create(),
+        validationError: PaymentSheetLoadingException? = null,
     ) {
         enqueue(
             Result.success(
@@ -24,6 +26,7 @@ internal class RelayingPaymentSheetLoader : PaymentSheetLoader {
                     paymentSelection = null,
                     linkState = null,
                     isEligibleForCardBrandChoice = false,
+                    validationError = validationError,
                 ),
             )
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where an unserializable `Throwable` in `PaymentSheetResult.Failed` caused a crash. The cause turned out to be the `Address` in the `PaymentMethod` object.

Now, we no longer include the entire `PaymentMethod` in the exception, but rather keep this information in the `PaymentSheetViewModel`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
