### PR TITLE
Add `form_shown`, `form_interacted`, and `card_number_completed` events to `PaymentSheet`

### DIFF
--- a/payments-ui-core/build.gradle
+++ b/payments-ui-core/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     testImplementation testLibs.androidx.core
     testImplementation testLibs.androidx.fragment
     testImplementation testLibs.androidx.truth
+    testImplementation testLibs.androidx.composeUi
+    testImplementation testLibs.hamcrest
     testImplementation testLibs.junit
     testImplementation testLibs.json
     testImplementation testLibs.kotlin.annotations

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -2,8 +2,14 @@ package com.stripe.android.ui.core.elements
 
 import android.content.Context
 import androidx.annotation.VisibleForTesting
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.autofill.AutofillType
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import com.stripe.android.cards.CardAccountRangeRepository
@@ -17,18 +23,25 @@ import com.stripe.android.model.AccountRange
 import com.stripe.android.model.CardBrand
 import com.stripe.android.stripecardscan.cardscan.CardScanSheetResult
 import com.stripe.android.ui.core.asIndividualDigits
+import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventReporter
 import com.stripe.android.uicore.elements.FieldError
+import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.SectionFieldElement
 import com.stripe.android.uicore.elements.SectionFieldErrorController
 import com.stripe.android.uicore.elements.TextFieldController
 import com.stripe.android.uicore.elements.TextFieldIcon
 import com.stripe.android.uicore.elements.TextFieldState
+import com.stripe.android.uicore.elements.TextFieldStateConstants
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.shareIn
 import kotlin.coroutines.CoroutineContext
 import com.stripe.android.R as PaymentsCoreR
 
@@ -306,6 +319,44 @@ internal class DefaultCardNumberController(
 
     override fun onDropdownItemClicked(item: TextFieldIcon.Dropdown.Item) {
         mostRecentUserSelectedBrand.value = CardBrand.fromCode(item.id)
+    }
+
+    @Composable
+    override fun ComposeUI(
+        enabled: Boolean,
+        field: SectionFieldElement,
+        modifier: Modifier,
+        hiddenIdentifiers: Set<IdentifierSpec>,
+        lastTextFieldIdentifier: IdentifierSpec?,
+        nextFocusDirection: FocusDirection,
+        previousFocusDirection: FocusDirection
+    ) {
+        val scope = rememberCoroutineScope()
+
+        val sharedFieldStateFlow = remember(scope) {
+            fieldState.shareIn(scope, started = SharingStarted.WhileSubscribed())
+        }
+
+        val reporter = LocalCardNumberCompletedEventReporter.current
+
+        LaunchedEffect(sharedFieldStateFlow) {
+            sharedFieldStateFlow.collectLatest { state ->
+                when (state) {
+                    is TextFieldStateConstants.Valid.Full -> reporter.onCardNumberCompleted()
+                    else -> Unit
+                }
+            }
+        }
+
+        super.ComposeUI(
+            enabled,
+            field,
+            modifier,
+            hiddenIdentifiers,
+            lastTextFieldIdentifier,
+            nextFocusDirection,
+            previousFocusDirection
+        )
     }
 
     private companion object {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/events/CardNumberCompletedEventReporter.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/events/CardNumberCompletedEventReporter.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.ui.core.elements.events
+
+import androidx.annotation.RestrictTo
+import androidx.compose.runtime.staticCompositionLocalOf
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun interface CardNumberCompletedEventReporter {
+    fun onCardNumberCompleted(): Unit
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+val LocalCardNumberCompletedEventReporter = staticCompositionLocalOf<CardNumberCompletedEventReporter> {
+    EmptyCardEventReporter
+}
+
+private object EmptyCardEventReporter : CardNumberCompletedEventReporter {
+    override fun onCardNumberCompleted() {
+        // No-op
+    }
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/events/CardNumberCompletedEventReporter.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/events/CardNumberCompletedEventReporter.kt
@@ -2,6 +2,7 @@ package com.stripe.android.ui.core.elements.events
 
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.staticCompositionLocalOf
+import com.stripe.android.uicore.BuildConfig
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun interface CardNumberCompletedEventReporter {
@@ -15,6 +16,8 @@ val LocalCardNumberCompletedEventReporter = staticCompositionLocalOf<CardNumberC
 
 private object EmptyCardEventReporter : CardNumberCompletedEventReporter {
     override fun onCardNumberCompleted() {
-        // No-op
+        if (BuildConfig.DEBUG) {
+            error("CardNumberCompletedEventReporter.onCardNumberCompleted() was not reported")
+        }
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
@@ -59,6 +59,7 @@ internal class PaymentSheetAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_load_started")
         validateAnalyticsRequest(eventName = "mc_load_succeeded")
         validateAnalyticsRequest(eventName = "mc_complete_sheet_newpm_show")
+        validateAnalyticsRequest(eventName = "mc_form_shown")
 
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
@@ -68,6 +69,8 @@ internal class PaymentSheetAnalyticsTest {
         }
 
         validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
+        validateAnalyticsRequest(eventName = "mc_form_interacted")
+        validateAnalyticsRequest(eventName = "mc_card_number_completed")
 
         page.fillOutCardDetails()
 
@@ -107,6 +110,7 @@ internal class PaymentSheetAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_load_started")
         validateAnalyticsRequest(eventName = "mc_load_succeeded")
         validateAnalyticsRequest(eventName = "mc_custom_sheet_newpm_show")
+        validateAnalyticsRequest(eventName = "mc_form_shown")
 
         testContext.configureFlowController {
             configureWithPaymentIntent(
@@ -122,6 +126,8 @@ internal class PaymentSheetAnalyticsTest {
 
         validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
         validateAnalyticsRequest(eventName = "mc_custom_paymentoption_newpm_select")
+        validateAnalyticsRequest(eventName = "mc_form_interacted")
+        validateAnalyticsRequest(eventName = "mc_card_number_completed")
 
         page.fillOutCardDetails()
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -47,7 +47,6 @@ internal class DefaultEventReporter @Inject internal constructor(
 
     override fun onLoadStarted() {
         durationProvider.start(DurationProvider.Key.Loading)
-        durationProvider.start(DurationProvider.Key.ConfirmButtonClicked) // TODO(samer-stripe) move to formShown.
         fireEvent(PaymentSheetEvent.LoadStarted(isDeferred, linkEnabled))
     }
 
@@ -138,6 +137,37 @@ internal class DefaultEventReporter @Inject internal constructor(
                 code = code,
                 isDeferred = isDeferred,
                 currency = currency,
+                linkEnabled = linkEnabled,
+            )
+        )
+    }
+
+    override fun onPaymentMethodFormShown(code: PaymentMethodCode) {
+        durationProvider.start(DurationProvider.Key.ConfirmButtonClicked)
+
+        fireEvent(
+            PaymentSheetEvent.ShowPaymentOptionForm(
+                code = code,
+                isDeferred = isDeferred,
+                linkEnabled = linkEnabled,
+            )
+        )
+    }
+
+    override fun onPaymentMethodFormInteraction(code: PaymentMethodCode) {
+        fireEvent(
+            PaymentSheetEvent.PaymentOptionFormInteraction(
+                code = code,
+                isDeferred = isDeferred,
+                linkEnabled = linkEnabled,
+            )
+        )
+    }
+
+    override fun onCardNumberCompleted() {
+        fireEvent(
+            PaymentSheetEvent.CardNumberCompleted(
+                isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
             )
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -66,6 +66,25 @@ internal interface EventReporter {
     )
 
     /**
+     * The form shown in PaymentSheet after a user or system initiated change.
+     */
+    fun onPaymentMethodFormShown(
+        code: PaymentMethodCode,
+    )
+
+    /**
+     * The customer has interacted with the form of an available payment method.
+     */
+    fun onPaymentMethodFormInteraction(
+        code: PaymentMethodCode,
+    )
+
+    /**
+     * The customer has filled in the card number field in the card payment method form.
+     */
+    fun onCardNumberCompleted()
+
+    /**
      * The customer has selected one of their existing payment methods.
      */
     fun onSelectPaymentOption(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -241,6 +241,36 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         )
     }
 
+    class ShowPaymentOptionForm(
+        code: String,
+        override val isDeferred: Boolean,
+        override val linkEnabled: Boolean,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = "mc_form_shown"
+        override val additionalParams: Map<String, Any?> = mapOf(
+            FIELD_SELECTED_LPM to code
+        )
+    }
+
+    class PaymentOptionFormInteraction(
+        code: String,
+        override val isDeferred: Boolean,
+        override val linkEnabled: Boolean,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = "mc_form_interacted"
+        override val additionalParams: Map<String, Any?> = mapOf(
+            FIELD_SELECTED_LPM to code
+        )
+    }
+
+    class CardNumberCompleted(
+        override val isDeferred: Boolean,
+        override val linkEnabled: Boolean,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = "mc_card_number_completed"
+        override val additionalParams: Map<String, Any?> = mapOf()
+    }
+
     class PressConfirmButton(
         currency: String?,
         duration: Duration?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -93,7 +93,7 @@ internal fun AddPaymentMethod(
     Column(modifier = modifier.fillMaxWidth()) {
         CompositionLocalProvider(
             LocalAutofillEventReporter provides sheetViewModel::reportAutofillEvent,
-            LocalCardNumberCompletedEventReporter provides sheetViewModel::reportCardNumberCompleted
+            LocalCardNumberCompletedEventReporter provides sheetViewModel::reportCardNumberCompleted,
         ) {
             val initializationMode = (sheetViewModel as? PaymentSheetViewModel)
                 ?.args

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -19,7 +19,6 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
@@ -30,6 +29,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.FieldValuesToParamsMapConverter
+import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventReporter
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.LocalAutofillEventReporter
 import com.stripe.android.uicore.elements.ParameterDestination
@@ -92,7 +92,8 @@ internal fun AddPaymentMethod(
 
     Column(modifier = modifier.fillMaxWidth()) {
         CompositionLocalProvider(
-            LocalAutofillEventReporter provides sheetViewModel::reportAutofillEvent
+            LocalAutofillEventReporter provides sheetViewModel::reportAutofillEvent,
+            LocalCardNumberCompletedEventReporter provides sheetViewModel::reportCardNumberCompleted
         ) {
             val initializationMode = (sheetViewModel as? PaymentSheetViewModel)
                 ?.args
@@ -140,20 +141,14 @@ internal fun AddPaymentMethod(
                         paymentMethod = selectedItem,
                     )
                     sheetViewModel.updateSelection(newSelection)
+                },
+                onInteractionEvent = {
+                    sheetViewModel.reportFieldInteraction(selectedPaymentMethodCode)
                 }
             )
         }
     }
 }
-
-private val BaseSheetViewModel.initiallySelectedPaymentMethodType: PaymentMethodCode
-    get() = when (val selection = newPaymentSelection) {
-        is PaymentSelection.New.LinkInline -> PaymentMethod.Type.Card.code
-        is PaymentSelection.New.Card,
-        is PaymentSelection.New.USBankAccount,
-        is PaymentSelection.New.GenericPaymentMethod -> selection.paymentMethodCreateParams.typeCode
-        else -> supportedPaymentMethods.first().code
-    }
 
 internal fun FormFieldValues.transformToPaymentMethodCreateParams(
     paymentMethod: SupportedPaymentMethod

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -92,11 +92,13 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.runner.RunWith
+import org.mockito.Mockito.atMostOnce
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.atMost
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
@@ -105,7 +107,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoMoreInteractions
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.io.IOException
@@ -1337,22 +1338,6 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `Sends no event when navigating to AddAnotherPaymentMethod screen`() = runTest {
-        val viewModel = createViewModel(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-            customerPaymentMethods = PaymentMethodFixtures.createCards(1),
-        )
-
-        verify(eventReporter).onInit(configuration = anyOrNull(), isDeferred = any())
-
-        verify(eventReporter).onShowExistingPaymentOptions()
-
-        viewModel.transitionToAddPaymentScreen()
-
-        verifyNoMoreInteractions(eventReporter)
-    }
-
-    @Test
     fun `Sends correct event when navigating to EditPaymentMethod screen`() = runTest {
         val cards = listOf(CARD_WITH_NETWORKS_PAYMENT_METHOD)
 
@@ -2188,6 +2173,117 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `Returns payment success after process death if state is loaded before result is returned`() = runTest {
         testProcessDeathRestorationAfterPaymentSuccess(loadStateBeforePaymentResult = true)
+    }
+
+    @Test
+    fun `on initial navigation to AddPaymentMethod screen, should report form shown event`() = runTest {
+        createViewModel(
+            args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP,
+            isGooglePayReady = true,
+            stripeIntent = SETUP_INTENT,
+            customerPaymentMethods = listOf()
+        )
+
+        verify(eventReporter).onPaymentMethodFormShown("card")
+    }
+
+    @Test
+    fun `on navigate to AddPaymentMethod screen, should report form shown event`() = runTest {
+        val viewModel = createViewModel(
+            args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP,
+            isGooglePayReady = true,
+            stripeIntent = SETUP_INTENT,
+        )
+
+        viewModel.transitionToAddPaymentScreen()
+
+        verify(eventReporter).onPaymentMethodFormShown("card")
+    }
+
+    @Test
+    fun `on payment form changed, should report form shown event`() = runTest {
+        val viewModel = createViewModel(
+            args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP,
+            isGooglePayReady = true,
+            stripeIntent = SETUP_INTENT,
+            customerPaymentMethods = listOf()
+        )
+
+        viewModel.reportPaymentMethodTypeSelected("us_bank_account")
+
+        verify(eventReporter).onPaymentMethodFormShown("us_bank_account")
+    }
+
+    @Test
+    fun `on form changed to same value, should report form shown event only once`() = runTest {
+        val viewModel = createViewModel(
+            args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP,
+            isGooglePayReady = true,
+            stripeIntent = SETUP_INTENT,
+            customerPaymentMethods = listOf()
+        )
+
+        viewModel.reportPaymentMethodTypeSelected("us_bank_account")
+        viewModel.reportPaymentMethodTypeSelected("us_bank_account")
+        viewModel.reportPaymentMethodTypeSelected("us_bank_account")
+
+        verify(eventReporter, atMostOnce()).onPaymentMethodFormShown("us_bank_account")
+    }
+
+    @Test
+    fun `on leaving form and returning, should report form shown event on each navigation event`() = runTest {
+        val viewModel = createViewModel(
+            args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP,
+            isGooglePayReady = true,
+            stripeIntent = SETUP_INTENT,
+        )
+
+        viewModel.transitionToAddPaymentScreen()
+        viewModel.handleBackPressed()
+        viewModel.transitionToAddPaymentScreen()
+
+        verify(eventReporter, atMost(2)).onPaymentMethodFormShown("card")
+    }
+
+    @Test
+    fun `on field interaction, should report event`() = runTest {
+        val viewModel = createViewModel(
+            args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP,
+            isGooglePayReady = true,
+            stripeIntent = SETUP_INTENT,
+        )
+
+        viewModel.reportFieldInteraction("card")
+
+        verify(eventReporter).onPaymentMethodFormInteraction("card")
+    }
+
+    @Test
+    fun `on multiple field interactions with same payment form, should report event only once`() = runTest {
+        val viewModel = createViewModel(
+            args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP,
+            isGooglePayReady = true,
+            stripeIntent = SETUP_INTENT,
+        )
+
+        viewModel.reportFieldInteraction("card")
+        viewModel.reportFieldInteraction("card")
+        viewModel.reportFieldInteraction("card")
+
+        verify(eventReporter, atMostOnce()).onPaymentMethodFormInteraction("card")
+    }
+
+    @Test
+    fun `on card number completed event, should report event`() = runTest {
+        val viewModel = createViewModel(
+            args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP,
+            isGooglePayReady = true,
+            stripeIntent = SETUP_INTENT,
+        )
+
+        viewModel.reportCardNumberCompleted()
+
+        verify(eventReporter).onCardNumberCompleted()
     }
 
     private suspend fun testProcessDeathRestorationAfterPaymentSuccess(loadStateBeforePaymentResult: Boolean) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -238,6 +238,57 @@ class DefaultEventReporterTest {
     }
 
     @Test
+    fun `onPaymentMethodFormShown() should fire analytics request with expected event value`() {
+        val customEventReporter = createEventReporter(EventReporter.Mode.Custom) {
+            simulateSuccessfulSetup()
+        }
+
+        customEventReporter.onPaymentMethodFormShown(
+            code = "card",
+        )
+
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == "mc_form_shown" &&
+                    req.params["selected_lpm"] == "card"
+            }
+        )
+    }
+
+    @Test
+    fun `onPaymentMethodFormInteraction() should fire analytics request with expected event value`() {
+        val customEventReporter = createEventReporter(EventReporter.Mode.Custom) {
+            simulateSuccessfulSetup()
+        }
+
+        customEventReporter.onPaymentMethodFormInteraction(
+            code = "card",
+        )
+
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == "mc_form_interacted" &&
+                    req.params["selected_lpm"] == "card"
+            }
+        )
+    }
+
+    @Test
+    fun `onCardNumberCompleted() should fire analytics request with expected event value`() {
+        val customEventReporter = createEventReporter(EventReporter.Mode.Custom) {
+            simulateSuccessfulSetup()
+        }
+
+        customEventReporter.onCardNumberCompleted()
+
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == "mc_card_number_completed"
+            }
+        )
+    }
+
+    @Test
     fun `onShowEditablePaymentOption() should fire analytics request with expected event value`() {
         val customEventReporter = createEventReporter(EventReporter.Mode.Custom) {
             simulateSuccessfulSetup()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -600,6 +600,73 @@ class PaymentSheetEventTest {
     }
 
     @Test
+    fun `ShowPaymentOptionForm event should return expected toString()`() {
+        val event = PaymentSheetEvent.ShowPaymentOptionForm(
+            code = "card",
+            isDeferred = false,
+            linkEnabled = false,
+        )
+        assertThat(
+            event.eventName
+        ).isEqualTo(
+            "mc_form_shown"
+        )
+        assertThat(
+            event.params
+        ).isEqualTo(
+            mapOf(
+                "selected_lpm" to "card",
+                "is_decoupled" to false,
+                "link_enabled" to false,
+            )
+        )
+    }
+
+    @Test
+    fun `PaymentOptionFormInteraction event should return expected toString()`() {
+        val event = PaymentSheetEvent.PaymentOptionFormInteraction(
+            code = "card",
+            isDeferred = false,
+            linkEnabled = false,
+        )
+        assertThat(
+            event.eventName
+        ).isEqualTo(
+            "mc_form_interacted"
+        )
+        assertThat(
+            event.params
+        ).isEqualTo(
+            mapOf(
+                "selected_lpm" to "card",
+                "is_decoupled" to false,
+                "link_enabled" to false,
+            )
+        )
+    }
+
+    @Test
+    fun `CardNumberCompleted event should return expected toString()`() {
+        val event = PaymentSheetEvent.CardNumberCompleted(
+            isDeferred = false,
+            linkEnabled = false,
+        )
+        assertThat(
+            event.eventName
+        ).isEqualTo(
+            "mc_card_number_completed"
+        )
+        assertThat(
+            event.params
+        ).isEqualTo(
+            mapOf(
+                "is_decoupled" to false,
+                "link_enabled" to false,
+            )
+        )
+    }
+
+    @Test
     fun `ShowEditablePaymentOption event should return expected toString()`() {
         val event = PaymentSheetEvent.ShowEditablePaymentOption(
             isDeferred = false,


### PR DESCRIPTION
# Summary
Add `form_shown`, `form_interacted`, and `card_number_completed` events to `PaymentSheet`

# Motivation
Adds new events for form interactions and card number completions (card numbers being completely filled) to `PaymentSheet`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
