### PR TITLE
Add more details to confirm button pressed analytics.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -47,6 +47,7 @@ internal class DefaultEventReporter @Inject internal constructor(
 
     override fun onLoadStarted() {
         durationProvider.start(DurationProvider.Key.Loading)
+        durationProvider.start(DurationProvider.Key.ConfirmButtonClicked) // TODO(samer-stripe) move to formShown.
         fireEvent(PaymentSheetEvent.LoadStarted(isDeferred, linkEnabled))
     }
 
@@ -156,10 +157,14 @@ internal class DefaultEventReporter @Inject internal constructor(
         )
     }
 
-    override fun onPressConfirmButton() {
+    override fun onPressConfirmButton(paymentSelection: PaymentSelection?,) {
+        val duration = durationProvider.end(DurationProvider.Key.ConfirmButtonClicked)
+
         fireEvent(
             PaymentSheetEvent.PressConfirmButton(
                 currency = currency,
+                duration = duration,
+                selectedLpm = paymentSelection.code(),
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -75,7 +75,9 @@ internal interface EventReporter {
     /**
      * The customer has pressed the confirm button.
      */
-    fun onPressConfirmButton()
+    fun onPressConfirmButton(
+        paymentSelection: PaymentSelection?,
+    )
 
     /**
      * Payment or setup have succeeded.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -308,7 +308,7 @@ internal abstract class BaseSheetViewModel(
     }
 
     protected fun reportConfirmButtonPressed() {
-        eventReporter.onPressConfirmButton()
+        eventReporter.onPressConfirmButton(selection.value)
     }
 
     protected fun setStripeIntent(stripeIntent: StripeIntent?) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -933,7 +933,7 @@ internal class PaymentSheetActivityTest {
             composeTestRule.waitForIdle()
         }
 
-        verify(eventReporter).onPressConfirmButton()
+        verify(eventReporter).onPressConfirmButton(any())
     }
 
     private fun activityScenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1808,7 +1808,7 @@ internal class PaymentSheetViewModelTest {
 
         viewModel.handleConfirmUSBankAccount(newPaymentSelection)
 
-        verify(eventReporter).onPressConfirmButton()
+        verify(eventReporter).onPressConfirmButton(newPaymentSelection)
     }
 
     @Test
@@ -1847,7 +1847,7 @@ internal class PaymentSheetViewModelTest {
 
         viewModel.checkout()
 
-        verify(eventReporter, never()).onPressConfirmButton()
+        verify(eventReporter, never()).onPressConfirmButton(any())
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -340,6 +341,32 @@ class DefaultEventReporterTest {
                 req.params["event"] == "mc_update_card_failed" &&
                     req.params["selected_card_brand"] == "cartes_bancaires" &&
                     req.params["error_message"] == "No network available!"
+            }
+        )
+    }
+
+    @Test
+    fun `onPressConfirmButton() should fire analytics request with expected event value`() {
+        val customEventReporter = createEventReporter(EventReporter.Mode.Custom) {
+            simulateSuccessfulSetup()
+        }
+
+        customEventReporter.onPressConfirmButton(
+            PaymentSelection.New.GenericPaymentMethod(
+                labelResource = "Cash App Pay",
+                iconResource = 0,
+                lightThemeIconUrl = null,
+                darkThemeIconUrl = null,
+                paymentMethodCreateParams = PaymentMethodCreateParams.createCashAppPay(),
+                customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
+            )
+        )
+
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == "mc_confirm_button_tapped" &&
+                    req.params["selected_lpm"] == "cashapp" &&
+                    req.params["currency"] == "usd"
             }
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -892,4 +892,55 @@ class PaymentSheetEventTest {
             )
         )
     }
+
+    @Test
+    fun `PressConfirmButton event should return expected toString()`() {
+        val event = PaymentSheetEvent.PressConfirmButton(
+            selectedLpm = "card",
+            currency = "USD",
+            duration = 60.seconds,
+            isDeferred = false,
+            linkEnabled = false,
+        )
+        assertThat(
+            event.eventName
+        ).isEqualTo(
+            "mc_confirm_button_tapped"
+        )
+        assertThat(
+            event.params
+        ).isEqualTo(
+            mapOf(
+                "selected_lpm" to "card",
+                "is_decoupled" to false,
+                "link_enabled" to false,
+                "duration" to 60f,
+                "currency" to "USD",
+            )
+        )
+    }
+
+    @Test
+    fun `PressConfirmButton event should return expected toString() with null values`() {
+        val event = PaymentSheetEvent.PressConfirmButton(
+            selectedLpm = null,
+            currency = null,
+            duration = null,
+            isDeferred = false,
+            linkEnabled = false,
+        )
+        assertThat(
+            event.eventName
+        ).isEqualTo(
+            "mc_confirm_button_tapped"
+        )
+        assertThat(
+            event.params
+        ).isEqualTo(
+            mapOf(
+                "is_decoupled" to false,
+                "link_enabled" to false,
+            )
+        )
+    }
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
@@ -15,6 +15,7 @@ interface DurationProvider {
         Loading,
         Checkout,
         LinkSignup,
+        ConfirmButtonClicked,
     }
 }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
https://docs.google.com/document/d/1nv8z6k_fIKPOAbOuj4EgiYu9to92e-Sln-f5xN9z0Dg/edit

Adds new fields for duration and selected_lpm for confirm button clicked analytics events.
