### PR TITLE
Manually sort LPMs for screenshot tests.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
@@ -10,6 +10,8 @@ import com.stripe.android.paymentsheet.example.playground.activity.AppearanceSto
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
 import com.stripe.android.paymentsheet.example.playground.settings.PrimaryButtonLabelSettingsDefinition
+import com.stripe.android.paymentsheet.model.defaultSorter
+import com.stripe.android.paymentsheet.model.paymentMethodSorter
 import com.stripe.android.test.core.TestParameters
 import org.junit.After
 import org.junit.Before
@@ -76,6 +78,26 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
     fun resetAppearanceStore() {
         AppearanceStore.reset()
         forceLightMode()
+    }
+
+    @Before
+    fun setSort() {
+        paymentMethodSorter = {
+            sortedBy {
+                when (it.code) {
+                    "card" -> 1
+                    "klarna" -> 2
+                    "p24" -> 3
+                    "eps" -> 4
+                    else -> 100
+                }
+            }
+        }
+    }
+
+    @After
+    fun resetSort() {
+        paymentMethodSorter = defaultSorter
     }
 
     @Test

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodKtx.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.model
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.lpmfoundations.luxe.Delayed
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.lpmfoundations.luxe.PIRequirement
@@ -217,4 +218,11 @@ internal fun getPMsToAdd(
 }?.filterNot { supportedPaymentMethod ->
     !isFinancialConnectionsAvailable() &&
         supportedPaymentMethod.code == PaymentMethod.Type.USBankAccount.code
-} ?: emptyList()
+}?.paymentMethodSorter() ?: emptyList()
+
+// Default to no sort. The server should be doing the sorting! But sometimes we need this for tests.
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+val defaultSorter: List<SupportedPaymentMethod>.() -> List<SupportedPaymentMethod> = { this }
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+var paymentMethodSorter: List<SupportedPaymentMethod>.() -> List<SupportedPaymentMethod> = defaultSorter


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
The backend is doing some ML experiments on PM sorting, causing our screenshot tests to fail. This makes the sorting happen on the client, only for those tests.
