### PR TITLE
Fix issue where autofilled Canadian postal code was cut off

### DIFF
--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
@@ -101,6 +101,6 @@ class PostalCodeConfigTest {
     }
 
     private fun PostalCodeConfig.determineStateForInput(input: String): TextFieldState {
-        return determineState(filter(convertFromRaw(input)))
+        return determineState(filter(input))
     }
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PostalCodeConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PostalCodeConfig.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 import com.stripe.android.uicore.R
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlin.math.max
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class PostalCodeConfig(
@@ -69,7 +68,7 @@ class PostalCodeConfig(
             CountryPostalFormat.US -> userTyped.filter { it.isDigit() }
             CountryPostalFormat.CA -> userTyped.filter { it.isLetterOrDigit() }.uppercase()
             CountryPostalFormat.Other -> userTyped
-        }.dropLast(max(0, userTyped.length - format.maximumLength))
+        }.take(format.maximumLength)
     }
 
     override fun convertToRaw(displayName: String) = displayName


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where auto-filling Canadian postal codes could result in the code being cut-off.

The reason:
- Canadian postal codes have the format `A1B 2C3`.
- We define a maximum length of 6, not accounting for the whitespace (which is fine).
- The logic used with `dropLast()` will drop the last character, since `input length (7) – max length (6) = 1`. This leads to us auto-filling `A1B 2C`.
- Now, we simply `take(format.maximumLength)`.

I’m also changing the test to **not** call `convertFromRaw()`, as this isn’t called in production code.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
