### PR TITLE
Add error message to confirmation analytics on failure.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsRequestFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsRequestFactory.kt
@@ -176,21 +176,25 @@ class PaymentAnalyticsRequestFactory @VisibleForTesting internal constructor(
 
     @JvmSynthetic
     internal fun createPaymentIntentConfirmation(
-        paymentMethodType: String? = null
+        paymentMethodType: String? = null,
+        errorMessage: String?,
     ): AnalyticsRequest {
         return createRequest(
             PaymentAnalyticsEvent.PaymentIntentConfirm,
-            sourceType = paymentMethodType
+            sourceType = paymentMethodType,
+            errorMessage = errorMessage,
         )
     }
 
     @JvmSynthetic
     internal fun createSetupIntentConfirmation(
-        paymentMethodType: String?
+        paymentMethodType: String?,
+        errorMessage: String?,
     ): AnalyticsRequest {
         return createRequest(
             PaymentAnalyticsEvent.SetupIntentConfirm,
-            sourceType = paymentMethodType
+            sourceType = paymentMethodType,
+            errorMessage = errorMessage,
         )
     }
 
@@ -200,7 +204,8 @@ class PaymentAnalyticsRequestFactory @VisibleForTesting internal constructor(
         productUsageTokens: Set<String> = emptySet(),
         @Source.SourceType sourceType: String? = null,
         tokenType: Token.Type? = null,
-        threeDS2UiType: ThreeDS2UiType? = null
+        threeDS2UiType: ThreeDS2UiType? = null,
+        errorMessage: String? = null
     ): AnalyticsRequest {
         return createRequest(
             event,
@@ -208,7 +213,8 @@ class PaymentAnalyticsRequestFactory @VisibleForTesting internal constructor(
                 productUsageTokens = productUsageTokens,
                 sourceType = sourceType,
                 tokenType = tokenType,
-                threeDS2UiType = threeDS2UiType
+                threeDS2UiType = threeDS2UiType,
+                errorMessage = errorMessage,
             )
         )
     }
@@ -217,7 +223,8 @@ class PaymentAnalyticsRequestFactory @VisibleForTesting internal constructor(
         productUsageTokens: Set<String> = emptySet(),
         @Source.SourceType sourceType: String? = null,
         tokenType: Token.Type? = null,
-        threeDS2UiType: ThreeDS2UiType? = null
+        threeDS2UiType: ThreeDS2UiType? = null,
+        errorMessage: String?,
     ): Map<String, Any> {
         return defaultProductUsageTokens
             .plus(productUsageTokens)
@@ -226,6 +233,7 @@ class PaymentAnalyticsRequestFactory @VisibleForTesting internal constructor(
             .plus(sourceType?.let { mapOf(FIELD_SOURCE_TYPE to it) }.orEmpty())
             .plus(createTokenTypeParam(sourceType, tokenType))
             .plus(threeDS2UiType?.let { mapOf(FIELD_3DS2_UI_TYPE to it.toString()) }.orEmpty())
+            .plus(errorMessage?.let { mapOf(FIELD_ERROR_MESSAGE to it) }.orEmpty())
     }
 
     private fun createTokenTypeParam(
@@ -271,5 +279,6 @@ class PaymentAnalyticsRequestFactory @VisibleForTesting internal constructor(
         internal const val FIELD_PRODUCT_USAGE = "product_usage"
         internal const val FIELD_SOURCE_TYPE = "source_type"
         internal const val FIELD_3DS2_UI_TYPE = "3ds2_ui_type"
+        internal const val FIELD_ERROR_MESSAGE = "error_message"
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -22,6 +22,7 @@ import com.stripe.android.core.exception.InvalidRequestException
 import com.stripe.android.core.exception.PermissionException
 import com.stripe.android.core.exception.RateLimitException
 import com.stripe.android.core.exception.StripeException
+import com.stripe.android.core.exception.safeAnalyticsMessage
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.model.StripeFile
@@ -250,13 +251,16 @@ class StripeApiRepository @JvmOverloads internal constructor(
                 params = params,
             ),
             jsonParser = PaymentIntentJsonParser(),
-        ) {
+        ) { result ->
             val paymentMethodType =
                 confirmPaymentIntentParams.paymentMethodCreateParams?.typeCode
                     ?: confirmPaymentIntentParams.sourceParams?.type
+            val errorMessage = result.exceptionOrNull()?.safeAnalyticsMessage
+
             fireAnalyticsRequest(
                 paymentAnalyticsRequestFactory.createPaymentIntentConfirmation(
-                    paymentMethodType
+                    paymentMethodType = paymentMethodType,
+                    errorMessage = errorMessage,
                 )
             )
         }
@@ -393,10 +397,13 @@ class StripeApiRepository @JvmOverloads internal constructor(
                 )
             ),
             SetupIntentJsonParser()
-        ) {
+        ) { result ->
+            val errorMessage = result.exceptionOrNull()?.safeAnalyticsMessage
+
             fireAnalyticsRequest(
                 paymentAnalyticsRequestFactory.createSetupIntentConfirmation(
-                    confirmSetupIntentParams.paymentMethodCreateParams?.typeCode
+                    paymentMethodType = confirmSetupIntentParams.paymentMethodCreateParams?.typeCode,
+                    errorMessage = errorMessage,
                 )
             )
         }
@@ -1530,7 +1537,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
     private suspend fun <ModelType : StripeModel> fetchStripeModelResult(
         apiRequest: ApiRequest,
         jsonParser: ModelJsonParser<ModelType>,
-        onResponse: () -> Unit = {},
+        onResponse: (result: Result<*>) -> Unit = {},
     ): Result<ModelType> {
         return runCatching {
             val response = makeApiRequest(apiRequest, onResponse).responseJson()
@@ -1550,14 +1557,14 @@ class StripeApiRepository @JvmOverloads internal constructor(
     )
     internal suspend fun makeApiRequest(
         apiRequest: ApiRequest,
-        onResponse: () -> Unit
+        onResponse: (result: Result<*>) -> Unit
     ): StripeResponse<String> {
         val dnsCacheData = disableDnsCache()
 
         val response = runCatching {
             stripeNetworkClient.executeRequest(apiRequest)
         }.also {
-            onResponse()
+            onResponse(it)
         }.getOrElse {
             throw when (it) {
                 is IOException -> APIConnectionException.create(it, apiRequest.baseUrl)

--- a/payments-core/src/test/java/com/stripe/android/PaymentAnalyticsRequestFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentAnalyticsRequestFactoryTest.kt
@@ -45,9 +45,9 @@ class PaymentAnalyticsRequestFactoryTest {
             Token.Type.Pii
         ).params
 
-        // Size is SIZE-1 because tokens don't have a source_type field
+        // Size is SIZE-2 because tokens don't have a token_type, or error_message fields
         assertThat(params)
-            .hasSize(VALID_PARAM_FIELDS.size - 1)
+            .hasSize(VALID_PARAM_FIELDS.size - 2)
 
         assertThat(params[AnalyticsFields.EVENT])
             .isEqualTo(expectedEvent)
@@ -65,9 +65,9 @@ class PaymentAnalyticsRequestFactoryTest {
             Token.Type.CvcUpdate
         ).params
 
-        // Size is SIZE-1 because tokens don't have a source_type field
+        // Size is SIZE-2 because tokens don't have a token_type, or error_message fields
         assertThat(params)
-            .hasSize(VALID_PARAM_FIELDS.size - 1)
+            .hasSize(VALID_PARAM_FIELDS.size - 2)
         assertEquals(expectedEventName, params[AnalyticsFields.EVENT])
         assertEquals(Token.Type.CvcUpdate.code, params[PaymentAnalyticsRequestFactory.FIELD_TOKEN_TYPE])
     }
@@ -79,9 +79,9 @@ class PaymentAnalyticsRequestFactoryTest {
             ATTRIBUTION
         ).params
 
-        // Size is SIZE-1 because tokens don't have a token_type field
+        // Size is SIZE-2 because tokens don't have a token_type, or error_message fields
         assertThat(loggingParams)
-            .hasSize(VALID_PARAM_FIELDS.size - 1)
+            .hasSize(VALID_PARAM_FIELDS.size - 2)
 
         assertEquals(
             Source.SourceType.SEPA_DEBIT,
@@ -162,7 +162,28 @@ class PaymentAnalyticsRequestFactoryTest {
     fun createPaymentIntentConfirmationParams_withValidInput_createsCorrectMap() {
         val loggingParams =
             analyticsRequestFactory.createPaymentIntentConfirmation(
-                PaymentMethod.Type.Card.code
+                paymentMethodType = PaymentMethod.Type.Card.code,
+                errorMessage = null,
+            ).params
+
+        assertThat(loggingParams)
+            .hasSize(VALID_PARAM_FIELDS.size - 3)
+        assertThat(loggingParams[AnalyticsFields.PUBLISHABLE_KEY])
+            .isEqualTo(API_KEY)
+        assertThat(loggingParams[AnalyticsFields.EVENT])
+            .isEqualTo(PaymentAnalyticsEvent.PaymentIntentConfirm.toString())
+        assertThat(loggingParams[AnalyticsFields.ANALYTICS_UA])
+            .isEqualTo(AnalyticsRequestFactory.ANALYTICS_UA)
+        assertThat(loggingParams[PaymentAnalyticsRequestFactory.FIELD_ERROR_MESSAGE])
+            .isNull()
+    }
+
+    @Test
+    fun createPaymentIntentConfirmationParams_withErrorMessage_createsCorrectMap() {
+        val loggingParams =
+            analyticsRequestFactory.createPaymentIntentConfirmation(
+                paymentMethodType = PaymentMethod.Type.Card.code,
+                errorMessage = "connectionError",
             ).params
 
         assertThat(loggingParams)
@@ -173,6 +194,8 @@ class PaymentAnalyticsRequestFactoryTest {
             .isEqualTo(PaymentAnalyticsEvent.PaymentIntentConfirm.toString())
         assertThat(loggingParams[AnalyticsFields.ANALYTICS_UA])
             .isEqualTo(AnalyticsRequestFactory.ANALYTICS_UA)
+        assertThat(loggingParams[PaymentAnalyticsRequestFactory.FIELD_ERROR_MESSAGE])
+            .isEqualTo("connectionError")
     }
 
     @Test
@@ -182,7 +205,7 @@ class PaymentAnalyticsRequestFactoryTest {
         ).params
 
         assertThat(loggingParams)
-            .hasSize(VALID_PARAM_FIELDS.size - 2)
+            .hasSize(VALID_PARAM_FIELDS.size - 3)
         assertEquals(API_KEY, loggingParams[AnalyticsFields.PUBLISHABLE_KEY])
         assertEquals(
             PaymentAnalyticsEvent.PaymentIntentRetrieve.toString(),
@@ -197,11 +220,27 @@ class PaymentAnalyticsRequestFactoryTest {
     @Test
     fun getSetupIntentConfirmationParams_withValidInput_createsCorrectMap() {
         val params = analyticsRequestFactory.createSetupIntentConfirmation(
-            PaymentMethod.Type.Card.code
+            paymentMethodType = PaymentMethod.Type.Card.code,
+            errorMessage = null,
         ).params
 
         assertThat(params[PaymentAnalyticsRequestFactory.FIELD_SOURCE_TYPE])
             .isEqualTo("card")
+        assertThat(params[PaymentAnalyticsRequestFactory.FIELD_ERROR_MESSAGE])
+            .isNull()
+    }
+
+    @Test
+    fun getSetupIntentConfirmationParams_withErrorMessage_createsCorrectMap() {
+        val params = analyticsRequestFactory.createSetupIntentConfirmation(
+            paymentMethodType = PaymentMethod.Type.Card.code,
+            errorMessage = "connectionError",
+        ).params
+
+        assertThat(params[PaymentAnalyticsRequestFactory.FIELD_SOURCE_TYPE])
+            .isEqualTo("card")
+        assertThat(params[PaymentAnalyticsRequestFactory.FIELD_ERROR_MESSAGE])
+            .isEqualTo("connectionError")
     }
 
     @Test
@@ -230,7 +269,7 @@ class PaymentAnalyticsRequestFactoryTest {
         ).params
 
         assertThat(params)
-            .hasSize(VALID_PARAM_FIELDS.size - 1)
+            .hasSize(VALID_PARAM_FIELDS.size - 2)
         assertEquals(API_KEY, params[AnalyticsFields.PUBLISHABLE_KEY])
         assertEquals(ATTRIBUTION.toList(), params[PaymentAnalyticsRequestFactory.FIELD_PRODUCT_USAGE])
         assertEquals(Token.Type.Card.code, params[PaymentAnalyticsRequestFactory.FIELD_TOKEN_TYPE])
@@ -262,7 +301,7 @@ class PaymentAnalyticsRequestFactoryTest {
         ).params
 
         assertThat(params)
-            .hasSize(VALID_PARAM_FIELDS.size - 2)
+            .hasSize(VALID_PARAM_FIELDS.size - 3)
         assertEquals(API_KEY, params[AnalyticsFields.PUBLISHABLE_KEY])
         assertEquals(
             Source.SourceType.SEPA_DEBIT,
@@ -409,6 +448,7 @@ class PaymentAnalyticsRequestFactoryTest {
             PaymentAnalyticsRequestFactory.FIELD_PRODUCT_USAGE,
             PaymentAnalyticsRequestFactory.FIELD_SOURCE_TYPE,
             PaymentAnalyticsRequestFactory.FIELD_TOKEN_TYPE,
+            PaymentAnalyticsRequestFactory.FIELD_ERROR_MESSAGE,
             AnalyticsFields.NETWORK_TYPE,
             AnalyticsFields.LOCALE,
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This change adds error_message to analytics requests for payment intent and setup intent confirmations.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-1563
