### PR TITLE
Replace unknown exceptions with GenericStripeException.

### DIFF
--- a/payments-core/src/test/java/com/stripe/android/payments/PaymentFlowResultTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/PaymentFlowResultTest.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.payments
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.core.exception.APIException
+import com.stripe.android.core.exception.GenericStripeException
 import com.stripe.android.core.exception.StripeException
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
@@ -21,7 +21,7 @@ class PaymentFlowResultTest {
 
     @Test
     fun `validate() should fail if exception is non-null`() {
-        val exception = assertFailsWith<APIException> {
+        val exception = assertFailsWith<GenericStripeException> {
             PaymentFlowResult.Unvalidated(
                 exception = StripeException.create(RuntimeException("failure"))
             ).validate()

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/GenericStripeException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/GenericStripeException.kt
@@ -1,0 +1,16 @@
+package com.stripe.android.core.exception
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class GenericStripeException(
+    cause: Throwable,
+    private val analyticsValue: String? = null,
+) : StripeException(
+    cause = cause,
+    message = cause.message,
+) {
+    override fun analyticsValue(): String {
+        return analyticsValue ?: "unknown"
+    }
+}

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/StripeException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/StripeException.kt
@@ -59,7 +59,7 @@ abstract class StripeException(
                     message = throwable.message,
                     cause = throwable
                 )
-                else -> APIException(throwable)
+                else -> GenericStripeException(throwable)
             }
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This is to ensure we send unknown for analytics events rather than apiError, when it wasn't an API erorr.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-1553
