### PR TITLE
Log out of Link on successful transaction

### DIFF
--- a/link/src/main/java/com/stripe/android/link/LinkConfigurationCoordinator.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkConfigurationCoordinator.kt
@@ -4,6 +4,7 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.link.injection.LinkComponent
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.UserInput
+import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.PaymentMethodCreateParams
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,14 +22,20 @@ interface LinkConfigurationCoordinator {
     val emailFlow: Flow<String?>
 
     fun getAccountStatusFlow(configuration: LinkConfiguration): Flow<AccountStatus>
+
     suspend fun signInWithUserInput(
         configuration: LinkConfiguration,
         userInput: UserInput
     ): Result<Boolean>
+
     suspend fun attachNewCardToAccount(
         configuration: LinkConfiguration,
         paymentMethodCreateParams: PaymentMethodCreateParams
     ): Result<LinkPaymentDetails>
+
+    suspend fun logOut(
+        configuration: LinkConfiguration,
+    ): Result<ConsumerSession>
 }
 
 @Singleton
@@ -82,6 +89,14 @@ class RealLinkConfigurationCoordinator @Inject internal constructor(
         getLinkPaymentLauncherComponent(configuration)
             .linkAccountManager
             .createCardPaymentDetails(paymentMethodCreateParams)
+
+    override suspend fun logOut(
+        configuration: LinkConfiguration,
+    ): Result<ConsumerSession> {
+        return getLinkPaymentLauncherComponent(configuration)
+            .linkAccountManager
+            .logOut()
+    }
 
     /**
      * Create or get the existing [LinkComponent], responsible for injecting all

--- a/link/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/link/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.link.account
 
 import androidx.annotation.VisibleForTesting
+import com.stripe.android.core.Logger
+import com.stripe.android.link.BuildConfig
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.analytics.LinkEventsReporter
@@ -89,6 +91,21 @@ internal class LinkAccountManager @Inject constructor(
                 consentAction = userInput.consentAction,
             )
         }
+
+    suspend fun logOut(): Result<ConsumerSession> {
+        return runCatching {
+            requireNotNull(linkAccount.value)
+        }.mapCatching { account ->
+            linkRepository.logOut(
+                consumerSessionClientSecret = account.clientSecret,
+                consumerAccountPublishableKey = consumerPublishableKey,
+            ).getOrThrow()
+        }.onSuccess {
+            Logger.getInstance(BuildConfig.DEBUG).debug("Logged out of Link successfully")
+        }.onFailure { error ->
+            Logger.getInstance(BuildConfig.DEBUG).warning("Failed to log out of Link: $error")
+        }
+    }
 
     /**
      * Attempts sign up if session is in valid state for sign up

--- a/link/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/link/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -50,4 +50,9 @@ internal interface LinkRepository {
         last4: String,
         consumerSessionClientSecret: String,
     ): Result<LinkPaymentDetails>
+
+    suspend fun logOut(
+        consumerSessionClientSecret: String,
+        consumerAccountPublishableKey: String?,
+    ): Result<ConsumerSession>
 }

--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
@@ -68,7 +68,7 @@ internal class NetworkDispatcher : Dispatcher() {
         // rest of the test will continue, even if a request was missed.
         // Killing the process will ensure the test fails for a missing request even if the
         // exception is silently ignored.
-        android.os.Process.killProcess(android.os.Process.myPid())
+//        android.os.Process.killProcess(android.os.Process.myPid())
 
         throw exception
     }

--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
@@ -68,7 +68,7 @@ internal class NetworkDispatcher : Dispatcher() {
         // rest of the test will continue, even if a request was missed.
         // Killing the process will ensure the test fails for a missing request even if the
         // exception is silently ignored.
-//        android.os.Process.killProcess(android.os.Process.myPid())
+        android.os.Process.killProcess(android.os.Process.myPid())
 
         throw exception
     }

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -318,6 +318,14 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         TODO("Not yet implemented")
     }
 
+    override suspend fun logOut(
+        consumerSessionClientSecret: String,
+        consumerAccountPublishableKey: String?,
+        requestOptions: ApiRequest.Options
+    ): Result<ConsumerSession> {
+        TODO("Not yet implemented")
+    }
+
     override suspend fun attachFinancialConnectionsSessionToPaymentIntent(
         clientSecret: String,
         paymentIntentId: String,

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1121,6 +1121,26 @@ class StripeApiRepository @JvmOverloads internal constructor(
         ).map { it.id }
     }
 
+    override suspend fun logOut(
+        consumerSessionClientSecret: String,
+        consumerAccountPublishableKey: String?,
+        requestOptions: ApiRequest.Options
+    ): Result<ConsumerSession> {
+        return fetchStripeModelResult(
+            apiRequest = apiRequestFactory.createPost(
+                url = logoutConsumerUrl,
+                options = requestOptions,
+                params = mapOf(
+                    "request_surface" to "android_payment_element",
+                    "credentials" to mapOf(
+                        "consumer_session_client_secret" to consumerSessionClientSecret
+                    ),
+                ),
+            ),
+            jsonParser = ConsumerSessionJsonParser(),
+        )
+    }
+
     override suspend fun createFinancialConnectionsSessionForDeferredPayments(
         params: CreateFinancialConnectionsSessionForDeferredPaymentParams,
         requestOptions: ApiRequest.Options

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -291,6 +291,13 @@ interface StripeRepository {
         requestOptions: ApiRequest.Options
     ): Result<String>
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun logOut(
+        consumerSessionClientSecret: String,
+        consumerAccountPublishableKey: String?,
+        requestOptions: ApiRequest.Options,
+    ): Result<ConsumerSession>
+
     // ACHv2 endpoints
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -2,11 +2,13 @@ package com.stripe.android.paymentsheet
 
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.lifecycle.Lifecycle
+import androidx.test.espresso.Espresso
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.RequestMatchers
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.not
@@ -21,6 +23,7 @@ import com.stripe.android.paymentsheet.utils.runFlowControllerTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.UUID
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -545,6 +548,96 @@ internal class FlowControllerTest {
             path("/v1/payment_intents/pi_example"),
         ) { response ->
             response.testBodyFromFile("payment-intent-get-requires_payment_method.json")
+        }
+
+        page.clickPrimaryButton()
+    }
+
+    @Test
+    fun testLogoutAfterLinkTransaction(
+        @TestParameter integrationType: IntegrationType,
+    ) = composeTestRule.activityRule.runFlowControllerTest(
+        integrationType = integrationType,
+        paymentOptionCallback = { paymentOption ->
+            assertThat(paymentOption?.label).endsWith("4242")
+        },
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
+        networkRule.enqueue(
+            RequestMatchers.host("api.stripe.com"),
+            method("GET"),
+            path("/v1/elements/sessions"),
+        ) { response ->
+            response.testBodyFromFile("elements-sessions-requires_payment_method.json")
+        }
+
+        repeat(3) {
+            networkRule.enqueue(
+                method("POST"),
+                path("/v1/consumers/sessions/lookup"),
+            ) { response ->
+                response.testBodyFromFile("consumer-session-lookup-success.json")
+            }
+        }
+
+        testContext.configureFlowController {
+            configureWithPaymentIntent(
+                paymentIntentClientSecret = "pi_example_secret_example",
+                configuration = PaymentSheet.Configuration(
+                    merchantDisplayName = "Merchant, Inc.",
+                    defaultBillingDetails = PaymentSheet.BillingDetails(
+                        email = "test-${UUID.randomUUID()}@email.com",
+                        phone = "+15555555555",
+                    )
+                ),
+                callback = { success, error ->
+                    assertThat(success).isTrue()
+                    assertThat(error).isNull()
+                    presentPaymentOptions()
+                },
+            )
+        }
+
+        page.fillOutCardDetails()
+        page.fillOutLink()
+
+        Espresso.closeSoftKeyboard()
+
+        repeat(2) {
+            networkRule.enqueue(
+                method("POST"),
+                path("/v1/consumers/sessions/lookup"),
+            ) { response ->
+                response.testBodyFromFile("consumer-session-lookup-success.json")
+            }
+        }
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/consumers/accounts/sign_up"),
+        ) { response ->
+            response.testBodyFromFile("consumer-accounts-signup-success.json")
+        }
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/consumers/payment_details"),
+        ) { response ->
+            response.testBodyFromFile("consumer-payment-details-success.json")
+        }
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/payment_intents/pi_example/confirm"),
+        ) { response ->
+            response.testBodyFromFile("payment-intent-confirm.json")
+        }
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/consumers/sessions/log_out"),
+        ) { response ->
+            response.testBodyFromFile("consumer-session-logout-success.json")
         }
 
         page.clickPrimaryButton()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
@@ -32,6 +32,14 @@ internal class PaymentSheetPage(
         }
     }
 
+    fun fillOutLink() {
+        Espresso.onIdle()
+        composeTestRule.waitForIdle()
+
+        waitForText("Save your info for secure 1-click checkout with Link")
+        clickViewWithText("Save your info for secure 1-click checkout with Link")
+    }
+
     fun fillOutCardDetailsWithCardBrandChoice(fillOutZipCode: Boolean = true) {
         Espresso.onIdle()
         composeTestRule.waitForIdle()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet
 
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
@@ -21,6 +22,7 @@ import okhttp3.mockwebserver.SocketPolicy
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.UUID
 
 @RunWith(TestParameterInjector::class)
 internal class PaymentSheetTest {
@@ -413,5 +415,85 @@ internal class PaymentSheetTest {
                 configuration = null,
             )
         }
+    }
+
+    @Test
+    fun testLogoutAfterLinkTransaction() = activityScenarioRule.runPaymentSheetTest(
+        integrationType = integrationType,
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("GET"),
+            path("/v1/elements/sessions"),
+        ) { response ->
+            response.testBodyFromFile("elements-sessions-requires_payment_method.json")
+        }
+
+        repeat(3) {
+            networkRule.enqueue(
+                method("POST"),
+                path("/v1/consumers/sessions/lookup"),
+            ) { response ->
+                response.testBodyFromFile("consumer-session-lookup-success.json")
+            }
+        }
+
+        testContext.presentPaymentSheet {
+            presentWithPaymentIntent(
+                paymentIntentClientSecret = "pi_example_secret_example",
+                configuration = PaymentSheet.Configuration(
+                    merchantDisplayName = "Merchant, Inc.",
+                    defaultBillingDetails = PaymentSheet.BillingDetails(
+                        email = "test-${UUID.randomUUID()}@email.com",
+                        phone = "+15555555555",
+                    )
+                ),
+            )
+        }
+
+        page.fillOutCardDetails()
+        page.fillOutLink()
+
+        Espresso.closeSoftKeyboard()
+
+        repeat(2) {
+            networkRule.enqueue(
+                method("POST"),
+                path("/v1/consumers/sessions/lookup"),
+            ) { response ->
+                response.testBodyFromFile("consumer-session-lookup-success.json")
+            }
+        }
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/consumers/accounts/sign_up"),
+        ) { response ->
+            response.testBodyFromFile("consumer-accounts-signup-success.json")
+        }
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/consumers/payment_details"),
+        ) { response ->
+            response.testBodyFromFile("consumer-payment-details-success.json")
+        }
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/payment_intents/pi_example/confirm"),
+        ) { response ->
+            response.testBodyFromFile("payment-intent-confirm.json")
+        }
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/consumers/sessions/log_out"),
+        ) { response ->
+            response.testBodyFromFile("consumer-session-logout-success.json")
+        }
+
+        page.clickPrimaryButton()
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestRunner.kt
@@ -8,6 +8,7 @@ import androidx.test.espresso.IdlingResource
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.link.account.LinkStore
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.MainActivity
 import com.stripe.android.paymentsheet.PaymentOptionCallback
@@ -65,6 +66,7 @@ private fun ActivityScenarioRule<MainActivity>.runFlowControllerTest(
 
     scenario.onActivity {
         PaymentConfiguration.init(it, "pk_test_123")
+        LinkStore(it.applicationContext).clear()
     }
 
     lateinit var flowController: PaymentSheet.FlowController

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetTestRunner.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.link.account.LinkStore
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.MainActivity
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -69,6 +70,7 @@ private fun ActivityScenarioRule<MainActivity>.runPaymentSheetTestInternal(
     scenario.moveToState(Lifecycle.State.CREATED)
     scenario.onActivity {
         PaymentConfiguration.init(it, "pk_test_123")
+        LinkStore(it.applicationContext).clear()
     }
 
     lateinit var paymentSheet: PaymentSheet

--- a/paymentsheet/src/androidTest/resources/consumer-accounts-signup-success.json
+++ b/paymentsheet/src/androidTest/resources/consumer-accounts-signup-success.json
@@ -1,0 +1,17 @@
+{
+  "auth_session_client_secret": null,
+  "consumer_session": {
+    "client_secret": "12oBEhVjc21yKkFYNnhMVTlXbXdBQUFJRmEaJDUzNTFkNjNhLTZkNGMtND",
+    "email_address": "test@stripe.com",
+    "redacted_phone_number": "+1********56",
+    "support_payment_details_types": [
+      "CARD"
+    ],
+    "verification_sessions": [
+      {
+        "state": "VERIFIED",
+        "type": "SMS"
+      }
+    ]
+  }
+}

--- a/paymentsheet/src/androidTest/resources/consumer-payment-details-success.json
+++ b/paymentsheet/src/androidTest/resources/consumer-payment-details-success.json
@@ -23,7 +23,7 @@
       },
       "exp_month": 12,
       "exp_year": 2029,
-      "last4": "4444"
+      "last4": "4242"
     },
     "is_default": true,
     "type": "CARD"

--- a/paymentsheet/src/androidTest/resources/consumer-payment-details-success.json
+++ b/paymentsheet/src/androidTest/resources/consumer-payment-details-success.json
@@ -1,0 +1,31 @@
+{
+  "redacted_payment_details": {
+    "id": "QAAAKJ6",
+    "bank_account_details": null,
+    "billing_address": {
+      "administrative_area": null,
+      "country_code": "US",
+      "dependent_locality": null,
+      "line_1": null,
+      "line_2": null,
+      "locality": null,
+      "name": null,
+      "postal_code": "12312",
+      "sorting_code": null
+    },
+    "billing_email_address": "",
+    "card_details": {
+      "brand": "MASTERCARD",
+      "checks": {
+        "address_line1_check": "STATE_INVALID",
+        "address_postal_code_check": "PASS",
+        "cvc_check": "PASS"
+      },
+      "exp_month": 12,
+      "exp_year": 2029,
+      "last4": "4444"
+    },
+    "is_default": true,
+    "type": "CARD"
+  }
+}

--- a/paymentsheet/src/androidTest/resources/consumer-session-logout-success.json
+++ b/paymentsheet/src/androidTest/resources/consumer-session-logout-success.json
@@ -1,0 +1,9 @@
+{
+  "auth_session_client_secret": null,
+  "consumer_session": {
+    "client_secret": "TA3ZTctNDJhYi1iODI3LWY0NTVlZTdkM2Q2MzIIQWJCWlFibkk",
+    "email_address": "test@stripe.com",
+    "redacted_phone_number": "+1********23",
+    "verification_sessions": []
+  }
+}

--- a/paymentsheet/src/androidTest/resources/consumer-session-lookup-success.json
+++ b/paymentsheet/src/androidTest/resources/consumer-session-lookup-success.json
@@ -1,0 +1,3 @@
+{
+  "exists": "false"
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
@@ -20,6 +20,8 @@ import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.SAVE_PROCESSING
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -30,6 +32,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 internal class LinkHandler @Inject constructor(
@@ -40,25 +43,25 @@ internal class LinkHandler @Inject constructor(
     linkAnalyticsComponentBuilder: LinkAnalyticsComponent.Builder,
 ) {
     sealed class ProcessingState {
-        object Ready : ProcessingState()
+        data object Ready : ProcessingState()
 
-        object Launched : ProcessingState()
+        data object Launched : ProcessingState()
 
-        object Started : ProcessingState()
+        data object Started : ProcessingState()
 
-        class PaymentDetailsCollected(
+        data class PaymentDetailsCollected(
             val paymentSelection: PaymentSelection?
         ) : ProcessingState()
 
         data class Error(val message: String?) : ProcessingState()
 
-        object Cancelled : ProcessingState()
+        data object Cancelled : ProcessingState()
 
         data class PaymentMethodCollected(val paymentMethod: PaymentMethod) : ProcessingState()
 
-        class CompletedWithPaymentResult(val result: PaymentResult) : ProcessingState()
+        data class CompletedWithPaymentResult(val result: PaymentResult) : ProcessingState()
 
-        object CompleteWithoutLink : ProcessingState()
+        data object CompleteWithoutLink : ProcessingState()
     }
 
     private val _processingState =
@@ -231,6 +234,16 @@ internal class LinkHandler @Inject constructor(
             val paymentResult = result.convertToPaymentResult()
             _processingState.tryEmit(ProcessingState.CompletedWithPaymentResult(paymentResult))
             linkStore.markLinkAsUsed()
+        }
+    }
+
+    @OptIn(DelicateCoroutinesApi::class)
+    fun logOut() {
+        val configuration = linkConfiguration.value ?: return
+
+        GlobalScope.launch {
+            // This usage is intentional. We want the request to be sent without regard for the UI lifecycle.
+            linkConfigurationCoordinator.logOut(configuration = configuration)
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -155,6 +155,9 @@ internal class PaymentOptionsViewModel @Inject constructor(
             }
         }
 
+        // This is bad, but I don't think there's a better option
+        PaymentSheet.FlowController.linkHandler = linkHandler
+
         linkHandler.linkInlineSelection.value = args.state.paymentSelection as? PaymentSelection.New.LinkInline
         linkHandler.setupLink(linkState)
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -1304,6 +1304,8 @@ class PaymentSheet internal constructor(
 
         companion object {
 
+            internal var linkHandler: LinkHandler? = null
+
             /**
              * Create a [FlowController] that you configure with a client secret by calling
              * [configureWithPaymentIntent] or [configureWithSetupIntent].

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -190,6 +190,7 @@ internal class DefaultFlowController @Inject internal constructor(
                     activityResultLaunchers.forEach { it.unregister() }
                     paymentLauncher = null
                     linkLauncher.unregister()
+                    PaymentSheet.FlowController.linkHandler = null
                 }
             }
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -224,3 +224,12 @@ internal sealed class PaymentSelection : Parcelable {
         ) : New()
     }
 }
+
+internal val PaymentSelection.isLink: Boolean
+    get() = when (this) {
+        is PaymentSelection.GooglePay -> false
+        is PaymentSelection.Link -> true
+        is PaymentSelection.New.LinkInline -> true
+        is PaymentSelection.New -> false
+        is PaymentSelection.Saved -> walletType == PaymentSelection.Saved.WalletType.Link
+    }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeLinkConfigurationCoordinator.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeLinkConfigurationCoordinator.kt
@@ -8,6 +8,7 @@ import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.CvcCheck
 import com.stripe.android.model.PaymentMethodCreateParams
 import kotlinx.coroutines.flow.Flow
@@ -46,6 +47,15 @@ class FakeLinkConfigurationCoordinator : LinkConfigurationCoordinator {
                 ),
                 paymentMethodCreateParams = mock(),
                 originalParams = mock(),
+            )
+        )
+    }
+
+    override suspend fun logOut(configuration: LinkConfiguration): Result<ConsumerSession> {
+        return Result.success(
+            ConsumerSession(
+                emailAddress = "email@email.com",
+                redactedPhoneNumber = "+15555555555",
             )
         )
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds an additional API call upon transaction completion that logs out users of newly-created Link accounts. This is so that the token can’t be used for unauthorized actions.

It also switches us to using the consumer publishable key for API requests (unless it’s `/share`) instead of the merchant publishable key.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[MOBILESDK-1551](https://jira.corp.stripe.com/browse/MOBILESDK-1551) and [MOBILESDK-1622](https://jira.corp.stripe.com/browse/MOBILESDK-1622)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
