### PR TITLE
Fix various lint warnings across Financial Connections

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator.kt
@@ -23,7 +23,7 @@ internal class NativeAuthFlowCoordinator @Inject constructor() {
         /**
          * Ensures partner web auth status gets cleared after the current session is finished.
          */
-        object ClearPartnerWebAuth : Message
+        data object ClearPartnerWebAuth : Message
 
         /**
          * Triggers a termination of the AuthFlow, completing the session in the current state.

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
@@ -149,7 +148,6 @@ private fun AccountPickerLoading() {
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun AccountPickerLoaded(
     submitEnabled: Boolean,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentScreen.kt
@@ -2,7 +2,6 @@ package com.stripe.android.financialconnections.features.attachpayment
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.airbnb.mvrx.Async
@@ -41,7 +40,6 @@ internal fun AttachPaymentScreen() {
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun AttachPaymentContent(
     payload: Async<AttachPaymentState.Payload>,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/bankauthrepair/BankAuthRepairScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/bankauthrepair/BankAuthRepairScreen.kt
@@ -1,9 +1,7 @@
-@file:OptIn(ExperimentalMaterialApi::class)
 @file:Suppress("LongMethod")
 
 package com.stripe.android.financialconnections.features.bankauthrepair
 
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import com.airbnb.mvrx.compose.collectAsState

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerScreen.kt
@@ -249,11 +249,11 @@ private fun SelectNewAccount(
         ) {
             SelectNewAccountIcon(
                 icon = text.icon?.default,
-                contentDescription = text.body ?: "",
+                contentDescription = text.body,
             )
             Spacer(modifier = Modifier.size(16.dp))
             Text(
-                text = text.body ?: "",
+                text = text.body,
                 style = FinancialConnectionsTheme.typography.body,
                 color = FinancialConnectionsTheme.colors.textBrand
             )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupPreviewParameterProvider.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupPreviewParameterProvider.kt
@@ -37,7 +37,7 @@ internal class NetworkingLinkSignupPreviewParameterProvider :
         )
     }
 
-    internal fun emailEntered(): NetworkingLinkSignupState {
+    private fun emailEntered(): NetworkingLinkSignupState {
         return NetworkingLinkSignupState(
             payload = Success(
                 NetworkingLinkSignupState.Payload(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthScreen.kt
@@ -1,9 +1,7 @@
-@file:OptIn(ExperimentalMaterialApi::class)
 @file:Suppress("LongMethod")
 
 package com.stripe.android.financialconnections.features.partnerauth
 
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import com.airbnb.mvrx.compose.collectAsState

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetActivityResult.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetActivityResult.kt
@@ -31,7 +31,7 @@ internal sealed class FinancialConnectionsSheetActivityResult : Parcelable {
      * The customer canceled the connections session attempt.
      */
     @Parcelize
-    object Canceled : FinancialConnectionsSheetActivityResult()
+    data object Canceled : FinancialConnectionsSheetActivityResult()
 
     /**
      * The connections session attempt failed.

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetLinkResult.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetLinkResult.kt
@@ -24,7 +24,7 @@ sealed class FinancialConnectionsSheetLinkResult : Parcelable {
      */
     @Parcelize
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    object Canceled : FinancialConnectionsSheetLinkResult()
+    data object Canceled : FinancialConnectionsSheetLinkResult()
 
     /**
      * The connections session attempt failed.

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsAccount.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsAccount.kt
@@ -35,77 +35,102 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 @Parcelize
-@Suppress("unused")
 data class FinancialConnectionsAccount(
 
     @SerialName("category")
     val category: Category = Category.UNKNOWN,
 
-    /* Time at which the object was created. Measured in seconds since the Unix epoch. */
+    /**
+     * Time at which the object was created. Measured in seconds since the Unix epoch.
+     */
     @SerialName("created")
     val created: Int,
 
-    /* Unique identifier for the object. */
+    /**
+     * Unique identifier for the object.
+     */
     @SerialName("id")
     val id: String,
 
-    /* The name of the institution that holds this account. */
+    /**
+     * The name of the institution that holds this account.
+     */
     @SerialName("institution_name")
     val institutionName: String,
 
-    /* Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+    /**
+     * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+     */
     @SerialName("livemode")
     val livemode: Boolean,
 
-    /* The status of the link to the account. */
+    /**
+     * The status of the link to the account.
+     */
     @SerialName("status")
     val status: Status = Status.UNKNOWN,
 
-    /* If `category` is `cash`, one of:   - `checking`  - `savings`  - `other`
-       If `category` is `credit`, one of:   - `mortgage`  - `line_of_credit`  - `credit_card`  - `other`
-       If `category` is `investment` or `other`, this will be `other`.
-    */
+    /**
+     * If `category` is `cash`, one of:   - `checking`  - `savings`  - `other`
+     * If `category` is `credit`, one of:   - `mortgage`  - `line_of_credit`  - `credit_card`  - `other`
+     * If `category` is `investment` or `other`, this will be `other`.
+     */
     @SerialName("subcategory")
     val subcategory: Subcategory = Subcategory.UNKNOWN,
 
-    /* The [PaymentMethod type](https://stripe.com/docs/api/payment_methods/object#payment_method_object-type)(s)
-     that can be created from this FinancialConnectionsAccount. */
+    /**
+     * The [PaymentMethod type](https://stripe.com/docs/api/payment_methods/object#payment_method_object-type)(s)
+     * that can be created from this FinancialConnectionsAccount.
+     */
     @SerialName("supported_payment_method_types")
     val supportedPaymentMethodTypes: List<SupportedPaymentMethodTypes>,
 
-    /* The most recent information about the account's balance. */
+    /**
+     * The most recent information about the account's balance.
+     */
     @SerialName("balance")
     val balance: Balance? = null,
 
-    /* The state of the most recent attempt to refresh the account balance. */
+    /**
+     * The state of the most recent attempt to refresh the account balance.
+     */
     @SerialName("balance_refresh")
     val balanceRefresh: BalanceRefresh? = null,
 
-    /* A human-readable name that has been assigned to this account,
-    either by the account holder or by the institution. */
+    /**
+     * A human-readable name that has been assigned to this account, either by the account holder or by the institution.
+     */
     @SerialName("display_name")
     val displayName: String? = null,
 
-    /* The last 4 digits of the account number. If present, this will be 4 numeric characters. */
+    /**
+     * The last 4 digits of the account number. If present, this will be 4 numeric characters.
+     */
     @SerialName("last4")
     val last4: String? = null,
 
-    /* The most recent information about the account's owners. */
+    /**
+     * The most recent information about the account's owners.
+     */
     @SerialName("ownership")
     val ownership: String? = null,
 
-    /* The state of the most recent attempt to refresh the account owners. */
+    /**
+     * The state of the most recent attempt to refresh the account owners.
+     */
     @SerialName("ownership_refresh")
     val ownershipRefresh: OwnershipRefresh? = null,
 
-    /* The list of permissions granted by this account. */
+    /**
+     * The list of permissions granted by this account.
+     */
     @SerialName("permissions")
     val permissions: List<Permissions>? = null
 
 ) : StripeModel, Parcelable, PaymentAccount() {
 
     /**
-     *
+     * The category of the account.
      *
      * Values: cash,credit,investment,other
      */

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsAccount.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsAccount.kt
@@ -15,8 +15,8 @@ import kotlinx.serialization.Serializable
  * @param created Time at which the object was created. Measured in seconds since the Unix epoch.
  * @param id Unique identifier for the object.
  * @param institutionName The name of the institution that holds this account.
- * @param livemode Has the value `true` if the object exists in live mode or the value `false` if
- * the object exists in test mode.
+ * @param livemode Has the value `true` if the object exists in live mode or the value `false` if the object
+ * exists in test mode.
  * @param status The status of the link to the account.
  * @param subcategory If `category` is `cash`, one of:   - `checking`  - `savings`  - `other`
  * If `category` is `credit`, one of:   - `mortgage`  - `line_of_credit`  - `credit_card`  - `other`
@@ -36,97 +36,36 @@ import kotlinx.serialization.Serializable
 @Serializable
 @Parcelize
 data class FinancialConnectionsAccount(
-
     @SerialName("category")
     val category: Category = Category.UNKNOWN,
-
-    /**
-     * Time at which the object was created. Measured in seconds since the Unix epoch.
-     */
     @SerialName("created")
     val created: Int,
-
-    /**
-     * Unique identifier for the object.
-     */
     @SerialName("id")
     val id: String,
-
-    /**
-     * The name of the institution that holds this account.
-     */
     @SerialName("institution_name")
     val institutionName: String,
-
-    /**
-     * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
-     */
     @SerialName("livemode")
     val livemode: Boolean,
-
-    /**
-     * The status of the link to the account.
-     */
     @SerialName("status")
     val status: Status = Status.UNKNOWN,
-
-    /**
-     * If `category` is `cash`, one of:   - `checking`  - `savings`  - `other`
-     * If `category` is `credit`, one of:   - `mortgage`  - `line_of_credit`  - `credit_card`  - `other`
-     * If `category` is `investment` or `other`, this will be `other`.
-     */
     @SerialName("subcategory")
     val subcategory: Subcategory = Subcategory.UNKNOWN,
-
-    /**
-     * The [PaymentMethod type](https://stripe.com/docs/api/payment_methods/object#payment_method_object-type)(s)
-     * that can be created from this FinancialConnectionsAccount.
-     */
     @SerialName("supported_payment_method_types")
     val supportedPaymentMethodTypes: List<SupportedPaymentMethodTypes>,
-
-    /**
-     * The most recent information about the account's balance.
-     */
     @SerialName("balance")
     val balance: Balance? = null,
-
-    /**
-     * The state of the most recent attempt to refresh the account balance.
-     */
     @SerialName("balance_refresh")
     val balanceRefresh: BalanceRefresh? = null,
-
-    /**
-     * A human-readable name that has been assigned to this account, either by the account holder or by the institution.
-     */
     @SerialName("display_name")
     val displayName: String? = null,
-
-    /**
-     * The last 4 digits of the account number. If present, this will be 4 numeric characters.
-     */
     @SerialName("last4")
     val last4: String? = null,
-
-    /**
-     * The most recent information about the account's owners.
-     */
     @SerialName("ownership")
     val ownership: String? = null,
-
-    /**
-     * The state of the most recent attempt to refresh the account owners.
-     */
     @SerialName("ownership_refresh")
     val ownershipRefresh: OwnershipRefresh? = null,
-
-    /**
-     * The list of permissions granted by this account.
-     */
     @SerialName("permissions")
-    val permissions: List<Permissions>? = null
-
+    val permissions: List<Permissions>? = null,
 ) : StripeModel, Parcelable, PaymentAccount() {
 
     /**

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsSessionManifest.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsSessionManifest.kt
@@ -261,7 +261,6 @@ internal data class FinancialConnectionsSessionManifest(
      * OPAL,PAYMENT_FLOWS,RESERVE_APPEALS,STANDARD_ONBOARDING,STRIPE_CARD,SUPPORT_SITE
      */
     @Serializable(with = Product.Serializer::class)
-    @Suppress("unused")
     enum class Product(val value: String) {
         @SerialName(value = "billpay")
         BILLPAY("billpay"),

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/Destination.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/Destination.kt
@@ -87,84 +87,84 @@ internal sealed class Destination(
         )
     }
 
-    object InstitutionPicker : NoArgumentsDestination(
+    data object InstitutionPicker : NoArgumentsDestination(
         Pane.INSTITUTION_PICKER.value,
         composable = { InstitutionPickerScreen() }
     )
 
-    object Consent : NoArgumentsDestination(
+    data object Consent : NoArgumentsDestination(
         route = Pane.CONSENT.value,
         composable = { ConsentScreen() }
     )
 
-    object PartnerAuth : NoArgumentsDestination(
+    data object PartnerAuth : NoArgumentsDestination(
         route = Pane.PARTNER_AUTH.value,
         composable = { PartnerAuthScreen() }
     )
 
-    object AccountPicker : NoArgumentsDestination(
+    data object AccountPicker : NoArgumentsDestination(
         route = Pane.ACCOUNT_PICKER.value,
         composable = { AccountPickerScreen() }
     )
 
-    object Success : NoArgumentsDestination(
+    data object Success : NoArgumentsDestination(
         route = Pane.SUCCESS.value,
         composable = { SuccessScreen() }
     )
 
-    object ManualEntry : NoArgumentsDestination(
+    data object ManualEntry : NoArgumentsDestination(
         route = Pane.MANUAL_ENTRY.value,
         composable = { ManualEntryScreen() }
     )
 
-    object AttachLinkedPaymentAccount : NoArgumentsDestination(
+    data object AttachLinkedPaymentAccount : NoArgumentsDestination(
         route = Pane.ATTACH_LINKED_PAYMENT_ACCOUNT.value,
         composable = { AttachPaymentScreen() }
     )
 
-    object NetworkingLinkSignup : NoArgumentsDestination(
+    data object NetworkingLinkSignup : NoArgumentsDestination(
         route = Pane.NETWORKING_LINK_SIGNUP_PANE.value,
         composable = { NetworkingLinkSignupScreen() }
     )
 
-    object NetworkingLinkLoginWarmup : NoArgumentsDestination(
+    data object NetworkingLinkLoginWarmup : NoArgumentsDestination(
         route = Pane.NETWORKING_LINK_LOGIN_WARMUP.value,
         composable = { NetworkingLinkLoginWarmupScreen() }
     )
 
-    object NetworkingLinkVerification : NoArgumentsDestination(
+    data object NetworkingLinkVerification : NoArgumentsDestination(
         route = Pane.NETWORKING_LINK_VERIFICATION.value,
         composable = { NetworkingLinkVerificationScreen() }
     )
 
-    object NetworkingSaveToLinkVerification : NoArgumentsDestination(
+    data object NetworkingSaveToLinkVerification : NoArgumentsDestination(
         route = Pane.NETWORKING_SAVE_TO_LINK_VERIFICATION.value,
         composable = { NetworkingSaveToLinkVerificationScreen() }
     )
 
-    object LinkAccountPicker : NoArgumentsDestination(
+    data object LinkAccountPicker : NoArgumentsDestination(
         route = Pane.LINK_ACCOUNT_PICKER.value,
         composable = {
             LinkAccountPickerScreen()
         },
     )
 
-    object LinkStepUpVerification : NoArgumentsDestination(
+    data object LinkStepUpVerification : NoArgumentsDestination(
         route = Pane.LINK_STEP_UP_VERIFICATION.value,
         composable = { LinkStepUpVerificationScreen() }
     )
 
-    object Reset : NoArgumentsDestination(
+    data object Reset : NoArgumentsDestination(
         route = Pane.RESET.value,
         composable = { ResetScreen() }
     )
 
-    object BankAuthRepair : NoArgumentsDestination(
+    data object BankAuthRepair : NoArgumentsDestination(
         route = Pane.BANK_AUTH_REPAIR.value,
         composable = { BankAuthRepairScreen() }
     )
 
-    object ManualEntrySuccess : Destination(
+    data object ManualEntrySuccess : Destination(
         route = Pane.MANUAL_ENTRY_SUCCESS.value,
         paramKeys = listOf(KEY_REFERRER, KEY_MICRODEPOSITS, KEY_LAST4),
         screenBuilder = { ManualEntrySuccessScreen(it) }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -415,13 +415,13 @@ internal sealed class WebAuthFlowState : Parcelable {
      * The web browser has not been opened yet.
      */
     @Parcelize
-    object Uninitialized : WebAuthFlowState()
+    data object Uninitialized : WebAuthFlowState()
 
     /**
      * The web browser has been opened and the authentication flow is in progress.
      */
     @Parcelize
-    object InProgress : WebAuthFlowState()
+    data object InProgress : WebAuthFlowState()
 
     /**
      * The web browser has been closed and triggered a deeplink with a success result.

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -10,7 +10,6 @@ import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -125,7 +125,6 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
         }
     }
 
-    @OptIn(ExperimentalMaterialApi::class)
     @Suppress("LongMethod")
     @Composable
     fun NavHost(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Button.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Button.kt
@@ -117,7 +117,7 @@ internal object FinancialConnectionsButton {
         abstract fun buttonColors(): ButtonColors
         abstract fun rippleColor(): Color
 
-        object Primary : Type() {
+        data object Primary : Type() {
             @Composable
             override fun buttonColors(): ButtonColors {
                 return buttonColors(
@@ -131,7 +131,7 @@ internal object FinancialConnectionsButton {
             override fun rippleColor(): Color = Brand400
         }
 
-        object Secondary : Type() {
+        data object Secondary : Type() {
             @Composable
             override fun buttonColors(): ButtonColors {
                 return buttonColors(
@@ -145,7 +145,7 @@ internal object FinancialConnectionsButton {
             override fun rippleColor(): Color = Neutral50
         }
 
-        object Critical : Type() {
+        data object Critical : Type() {
             @Composable
             override fun buttonColors(): ButtonColors {
                 return buttonColors(
@@ -166,7 +166,7 @@ internal object FinancialConnectionsButton {
         abstract fun paddingValues(): PaddingValues
         abstract val radius: Dp
 
-        object Pill : Size() {
+        data object Pill : Size() {
             override val radius: Dp = 4.dp
 
             @Composable
@@ -178,7 +178,7 @@ internal object FinancialConnectionsButton {
             )
         }
 
-        object Regular : Size() {
+        data object Regular : Size() {
             override val radius: Dp = 12.dp
 
             @Composable

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/MultipleEventsCutter.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/MultipleEventsCutter.kt
@@ -50,8 +50,7 @@ internal fun Modifier.clickableSingle(
     onClickLabel: String? = null,
     role: Role? = null,
     onClick: () -> Unit
-
-) = composed(
+) = this.composed(
     inspectorInfo = debugInspectorInfo {
         name = "clickable"
         properties["enabled"] = enabled
@@ -59,7 +58,6 @@ internal fun Modifier.clickableSingle(
         properties["role"] = role
         properties["onClick"] = onClick
     },
-
     factory = {
         val multipleEventsCutter = remember { MultipleEventsCutter.get() }
         Modifier.clickable(
@@ -84,8 +82,7 @@ internal fun Modifier.clickableSingle(
     onClickLabel: String? = null,
     role: Role? = null,
     onClick: () -> Unit
-
-) = composed(
+) = this.composed(
     inspectorInfo = debugInspectorInfo {
         name = "clickable"
         properties["enabled"] = enabled
@@ -93,7 +90,6 @@ internal fun Modifier.clickableSingle(
         properties["role"] = role
         properties["onClick"] = onClick
     },
-
     factory = {
         val multipleEventsCutter = remember { MultipleEventsCutter.get() }
         Modifier.clickable(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Text.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Text.kt
@@ -132,7 +132,9 @@ private fun annotatedStringResource(
                     start = spanStart,
                     end = spanEnd
                 )
-                spanStyleForAnnotation(it)?.let { resultBuilder.addStyle(it, spanStart, spanEnd) }
+                spanStyleForAnnotation(it)?.let { style ->
+                    resultBuilder.addStyle(style, spanStart, spanEnd)
+                }
             }
         }
     return resultBuilder.toAnnotatedString()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes some lint warnings across the Financial Connections module and removes some outdated opt-ins.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
