### PR TITLE
Check `WalletType` when saving payment method in `FlowController`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+### PaymentSheet
+* [FIXED][7917](https://github.com/stripe/stripe-android/pull/7917) Fixed an issue where `Google Pay` & `Link` were not saved as default payment methods in `FlowController`.
+
 ### Identity
 * [FIXED][7903](https://github.com/stripe/stripe-android/pull/7903) Fixed an issue where camera fails to start on some devices.
-
 
 ## 20.37.2 - 2024-02-05
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -599,6 +599,13 @@ internal class DefaultFlowController @Inject internal constructor(
                     }?.let { method ->
                         PaymentSelection.Saved(method)
                     }
+                    is PaymentSelection.Saved -> {
+                        when (currentSelection.walletType) {
+                            PaymentSelection.Saved.WalletType.GooglePay -> PaymentSelection.GooglePay
+                            PaymentSelection.Saved.WalletType.Link -> PaymentSelection.Link
+                            else -> currentSelection
+                        }
+                    }
                     else -> currentSelection
                 }?.let {
                     prefsRepositoryFactory(viewModel.state?.config?.customer).savePaymentSelection(it)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -35,6 +35,7 @@ import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.PaymentResult
@@ -1663,6 +1664,70 @@ internal class DefaultFlowControllerTest {
                 )
             ) { _, _ -> }
         }
+    }
+
+    @Test
+    fun `On google pay intent result, should save payment selection as google_pay`() = runTest {
+        val paymentIntent = PaymentIntentFixtures.PI_WITH_PAYMENT_METHOD!!
+        val flowController = createFlowController()
+
+        flowController.configureWithPaymentIntent(
+            paymentIntentClientSecret = "pi_12345"
+        ) { _, _ -> }
+
+        flowController.onGooglePayResult(
+            GooglePayPaymentMethodLauncher.Result.Completed(
+                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
+                    card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.card?.copy(
+                        wallet = Wallet.GooglePayWallet(
+                            dynamicLast4 = "1234"
+                        )
+                    )
+                )
+            )
+        )
+        flowController.onInternalPaymentResult(InternalPaymentResult.Completed(paymentIntent))
+
+        assertThat(
+            prefsRepository.getSavedSelection(
+                isGooglePayAvailable = true,
+                isLinkAvailable = true
+            )
+        ).isEqualTo(
+            SavedSelection.GooglePay
+        )
+    }
+
+    @Test
+    fun `On link intent result, should save payment selection as link`() = runTest {
+        val paymentIntent = PaymentIntentFixtures.PI_WITH_PAYMENT_METHOD!!
+        val flowController = createFlowController()
+
+        flowController.configureWithPaymentIntent(
+            paymentIntentClientSecret = "pi_12345"
+        ) { _, _ -> }
+
+        flowController.onLinkActivityResult(
+            LinkActivityResult.Completed(
+                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
+                    card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.card?.copy(
+                        wallet = Wallet.LinkWallet(
+                            dynamicLast4 = "1234"
+                        )
+                    )
+                )
+            )
+        )
+        flowController.onInternalPaymentResult(InternalPaymentResult.Completed(paymentIntent))
+
+        assertThat(
+            prefsRepository.getSavedSelection(
+                isGooglePayAvailable = true,
+                isLinkAvailable = true
+            )
+        ).isEqualTo(
+            SavedSelection.Link
+        )
     }
 
     @Test


### PR DESCRIPTION
# Summary
Check `WalletType` when saving payment method in `FlowController`.

# Motivation
Allows `GooglePay` & `Link` to saved as default payment methods in `FlowController`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
