### PR TITLE
Dismiss software keyboard on navigation

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -44,7 +44,9 @@ import com.stripe.android.financialconnections.presentation.FinancialConnections
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewModel
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsModalBottomSheetLayout
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
+import com.stripe.android.financialconnections.utils.KeyboardController
 import com.stripe.android.financialconnections.utils.argsOrNull
+import com.stripe.android.financialconnections.utils.rememberKeyboardController
 import com.stripe.android.financialconnections.utils.viewModelLazy
 import com.stripe.android.uicore.image.StripeImageLoader
 import kotlinx.coroutines.flow.SharedFlow
@@ -126,10 +128,13 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
             ModalBottomSheetValue.Hidden,
             skipHalfExpanded = true
         )
+
         val bottomSheetNavigator = remember { BottomSheetNavigator(sheetState) }
         val navController = rememberNavController(bottomSheetNavigator)
+        val keyboardController = rememberKeyboardController()
+
         PaneBackgroundEffects(navController)
-        NavigationEffects(viewModel.navigationFlow, navController)
+        NavigationEffects(viewModel.navigationFlow, navController, keyboardController)
 
         CompositionLocalProvider(
             LocalReducedBranding provides reducedBranding,
@@ -208,7 +213,8 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
     @Composable
     fun NavigationEffects(
         navigationChannel: SharedFlow<NavigationIntent>,
-        navHostController: NavHostController
+        navHostController: NavHostController,
+        keyboardController: KeyboardController,
     ) {
         val activity = (LocalContext.current as? Activity)
         LaunchedEffect(activity, navHostController, navigationChannel) {
@@ -216,6 +222,9 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
                 if (activity?.isFinishing == true) {
                     return@onEach
                 }
+
+                keyboardController.dismiss()
+
                 when (intent) {
                     is NavigationIntent.NavigateTo -> {
                         val from: String? = navHostController.currentDestination?.route

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -29,6 +30,8 @@ import com.stripe.android.financialconnections.ui.FinancialConnectionsPreview
 import com.stripe.android.financialconnections.ui.LocalNavHostController
 import com.stripe.android.financialconnections.ui.LocalReducedBranding
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
+import com.stripe.android.financialconnections.utils.rememberKeyboardController
+import kotlinx.coroutines.launch
 
 @Composable
 internal fun FinancialConnectionsTopAppBar(
@@ -42,6 +45,9 @@ internal fun FinancialConnectionsTopAppBar(
 
     val navController = LocalNavHostController.current
     val canGoBack by navController.collectCanGoBackAsState()
+
+    val keyboardController = rememberKeyboardController()
+    val scope = rememberCoroutineScope()
 
     TopAppBar(
         title = if (hideStripeLogo) {
@@ -57,7 +63,14 @@ internal fun FinancialConnectionsTopAppBar(
         elevation = elevation,
         navigationIcon = if (canGoBack && showBack) {
             {
-                IconButton(onClick = { localBackPressed?.onBackPressed() }) {
+                IconButton(
+                    onClick = {
+                        scope.launch {
+                            keyboardController.dismiss()
+                            localBackPressed?.onBackPressed()
+                        }
+                    },
+                ) {
                     Icon(
                         imageVector = Icons.Filled.ArrowBack,
                         contentDescription = "Back icon",
@@ -69,7 +82,14 @@ internal fun FinancialConnectionsTopAppBar(
             null
         },
         actions = {
-            IconButton(onClick = onCloseClick) {
+            IconButton(
+                onClick = {
+                    scope.launch {
+                        keyboardController.dismiss()
+                        onCloseClick()
+                    }
+                }
+            ) {
                 Icon(
                     imageVector = Icons.Filled.Close,
                     contentDescription = "Close icon",

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/KeyboardController.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/KeyboardController.kt
@@ -37,6 +37,9 @@ internal fun rememberKeyboardController(): KeyboardController {
 
     return KeyboardController(
         dismissKeyboard = {
+            // We're using this method because LocalSoftwareKeyboardController is
+            // still experimental in Compose 1.5. We should switch over once we update
+            // to Compose 1.6, in which the experimental state has been removed.
             textInputService?.hideSoftwareKeyboard()
         },
         isKeyboardVisible = keyboardState,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/KeyboardController.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/KeyboardController.kt
@@ -1,0 +1,65 @@
+package com.stripe.android.financialconnections.utils
+
+import android.view.ViewTreeObserver
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.platform.LocalTextInputService
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import kotlinx.coroutines.flow.first
+
+internal class KeyboardController(
+    private val dismissKeyboard: () -> Unit,
+    private val isKeyboardVisible: State<Boolean>,
+) {
+
+    suspend fun dismiss() {
+        if (isKeyboardVisible.value) {
+            dismissKeyboard()
+            awaitKeyboardDismissed()
+        }
+    }
+
+    private suspend fun awaitKeyboardDismissed() {
+        snapshotFlow { isKeyboardVisible.value }.first { !it }
+    }
+}
+
+@Composable
+internal fun rememberKeyboardController(): KeyboardController {
+    val textInputService = LocalTextInputService.current
+    val keyboardState = isKeyboardVisibleAsState()
+
+    return KeyboardController(
+        dismissKeyboard = {
+            textInputService?.hideSoftwareKeyboard()
+        },
+        isKeyboardVisible = keyboardState,
+    )
+}
+
+@Composable
+private fun isKeyboardVisibleAsState(): State<Boolean> {
+    val view = LocalView.current
+    val state = remember { mutableStateOf(false) }
+
+    DisposableEffect(view) {
+        val onGlobalListener = ViewTreeObserver.OnGlobalLayoutListener {
+            val insets = ViewCompat.getRootWindowInsets(view)
+            val isKeyboardOpen = insets?.isVisible(WindowInsetsCompat.Type.ime()) ?: true
+            state.value = isKeyboardOpen
+        }
+
+        view.viewTreeObserver.addOnGlobalLayoutListener(onGlobalListener)
+        onDispose {
+            view.viewTreeObserver.removeOnGlobalLayoutListener(onGlobalListener)
+        }
+    }
+
+    return state
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds functionality to hide the software keyboard whenever we navigate to a new screen or open the exit modal.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screen recordings

<details><summary>Before</summary>
<p>

https://github.com/stripe/stripe-android/assets/110940675/33fdc11b-fc11-4aee-a0e5-8a3bdbdbc240

</p>
</details>

<details><summary>After</summary>
<p>

https://github.com/stripe/stripe-android/assets/110940675/09edd1c5-1fb2-48d6-bc7f-a55575883584

</p>
</details>

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
