### PR TITLE
Make FC playground scrollable

### DIFF
--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
@@ -5,7 +5,6 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -144,10 +143,10 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
             },
             content = {
                 PlaygroundContent(
-                    padding = it,
                     state = state,
                     onSettingsChanged = onSettingsChanged,
-                    onButtonClick = onButtonClick
+                    onButtonClick = onButtonClick,
+                    modifier = Modifier.padding(it),
                 )
             }
         )
@@ -157,56 +156,71 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
     @Composable
     @Suppress("LongMethod")
     private fun PlaygroundContent(
-        padding: PaddingValues,
         state: FinancialConnectionsPlaygroundState,
         onSettingsChanged: (PlaygroundSettings) -> Unit,
-        onButtonClick: () -> Unit
+        onButtonClick: () -> Unit,
+        modifier: Modifier = Modifier,
     ) {
-        Column(
-            modifier = Modifier
-                .padding(padding)
-                .padding(16.dp)
+        LazyColumn(
+            contentPadding = PaddingValues(16.dp),
+            modifier = modifier,
         ) {
-            SettingsUi(
-                playgroundSettings = state.settings,
-                onSettingsChanged = onSettingsChanged
-            )
-            if (state.loading) {
-                LinearProgressIndicator(
-                    modifier = Modifier.fillMaxWidth(),
+            item {
+                SettingsUi(
+                    playgroundSettings = state.settings,
+                    onSettingsChanged = onSettingsChanged
                 )
             }
-            Divider(Modifier.padding(vertical = 8.dp))
-            Text(
-                text = "backend: ${state.backendUrl}",
-                color = MaterialTheme.colors.secondaryVariant
-            )
-            Text(
-                text = "env: ${BuildConfig.TEST_ENVIRONMENT}",
-                color = MaterialTheme.colors.secondaryVariant
-            )
-            Button(
-                modifier = Modifier
-                    .semantics { testTagsAsResourceId = true }
-                    .testTag("connect_accounts"),
-                onClick = onButtonClick,
-            ) {
-                Text("Connect Accounts")
+
+            if (state.loading) {
+                item {
+                    LinearProgressIndicator(
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
             }
-            LazyColumn {
-                items(state.status) { item ->
-                    Row(Modifier.padding(4.dp), verticalAlignment = Alignment.Top) {
-                        val primary = MaterialTheme.colors.primary
-                        Canvas(
-                            modifier = Modifier
-                                .padding(end = 8.dp, top = 6.dp)
-                                .size(6.dp)
-                        ) {
-                            drawCircle(primary)
-                        }
-                        SelectionContainer {
-                            Text(text = item, fontSize = 12.sp)
-                        }
+
+            item {
+                Divider(Modifier.padding(vertical = 8.dp))
+            }
+
+            item {
+                Text(
+                    text = "backend: ${state.backendUrl}",
+                    color = MaterialTheme.colors.secondaryVariant
+                )
+            }
+
+            item {
+                Text(
+                    text = "env: ${BuildConfig.TEST_ENVIRONMENT}",
+                    color = MaterialTheme.colors.secondaryVariant
+                )
+            }
+
+            item {
+                Button(
+                    modifier = Modifier
+                        .semantics { testTagsAsResourceId = true }
+                        .testTag("connect_accounts"),
+                    onClick = onButtonClick,
+                ) {
+                    Text("Connect Accounts")
+                }
+            }
+
+            items(state.status) { item ->
+                Row(Modifier.padding(4.dp), verticalAlignment = Alignment.Top) {
+                    val primary = MaterialTheme.colors.primary
+                    Canvas(
+                        modifier = Modifier
+                            .padding(end = 8.dp, top = 6.dp)
+                            .size(6.dp)
+                    ) {
+                        drawCircle(primary)
+                    }
+                    SelectionContainer {
+                        Text(text = item, fontSize = 12.sp)
                     }
                 }
             }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request makes the FC playground scrollable. Before, one wasn’t able to press the `Connect accounts` button on smaller test device like my own.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
