### PR TITLE
Replace all usages of `LocalSoftwareKeyboardController ` with `TextInputService`

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationScreen.kt
@@ -19,11 +19,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalTextInputService
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -102,7 +101,6 @@ private fun LinkStepUpVerificationContent(
 }
 
 @Composable
-@OptIn(ExperimentalComposeUiApi::class)
 private fun LinkStepUpVerificationLoaded(
     confirmVerificationAsync: Async<Unit>,
     resendOtpAsync: Async<Unit>,
@@ -113,11 +111,12 @@ private fun LinkStepUpVerificationLoaded(
     val focusManager = LocalFocusManager.current
     val focusRequester: FocusRequester = remember { FocusRequester() }
     LaunchedEffect(Unit) { focusRequester.requestFocus() }
-    val keyboardController = LocalSoftwareKeyboardController.current
+    val textInputService = LocalTextInputService.current
     LaunchedEffect(confirmVerificationAsync) {
         if (confirmVerificationAsync is Loading) {
             focusManager.clearFocus(true)
-            keyboardController?.hide()
+            @Suppress("DEPRECATION")
+            textInputService?.hideSoftwareKeyboard()
         }
     }
     Column(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationScreen.kt
@@ -14,11 +14,10 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalTextInputService
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -92,7 +91,6 @@ private fun NetworkingLinkVerificationContent(
 }
 
 @Composable
-@OptIn(ExperimentalComposeUiApi::class)
 private fun NetworkingLinkVerificationLoaded(
     confirmVerificationAsync: Async<Unit>,
     scrollState: ScrollState,
@@ -101,11 +99,12 @@ private fun NetworkingLinkVerificationLoaded(
     val focusManager = LocalFocusManager.current
     val focusRequester: FocusRequester = remember { FocusRequester() }
     LaunchedEffect(Unit) { focusRequester.requestFocus() }
-    val keyboardController = LocalSoftwareKeyboardController.current
+    val textInputService = LocalTextInputService.current
     LaunchedEffect(confirmVerificationAsync) {
         if (confirmVerificationAsync is Loading) {
             focusManager.clearFocus(true)
-            keyboardController?.hide()
+            @Suppress()
+            textInputService?.hideSoftwareKeyboard()
         }
     }
     Column(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationScreen.kt
@@ -16,11 +16,10 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalTextInputService
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -97,7 +96,6 @@ private fun NetworkingSaveToLinkVerificationContent(
 }
 
 @Composable
-@OptIn(ExperimentalComposeUiApi::class)
 private fun NetworkingSaveToLinkVerificationLoaded(
     confirmVerificationAsync: Async<Unit>,
     scrollState: ScrollState,
@@ -106,11 +104,12 @@ private fun NetworkingSaveToLinkVerificationLoaded(
 ) {
     val focusManager = LocalFocusManager.current
     val focusRequester: FocusRequester = remember { FocusRequester() }
-    val keyboardController = LocalSoftwareKeyboardController.current
+    val textInputService = LocalTextInputService.current
     LaunchedEffect(confirmVerificationAsync) {
         if (confirmVerificationAsync is Loading) {
             focusManager.clearFocus(true)
-            keyboardController?.hide()
+            @Suppress("DEPRECATION")
+            textInputService?.hideSoftwareKeyboard()
         }
     }
     LaunchedEffect(Unit) { focusRequester.requestFocus() }

--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
@@ -24,13 +24,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalTextInputService
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -57,7 +56,6 @@ import com.stripe.android.uicore.stripeShapes
 
 internal const val ProgressIndicatorTestTag = "CircularProgressIndicator"
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun LinkInlineSignup(
     linkConfigurationCoordinator: LinkConfigurationCoordinator,
@@ -78,12 +76,13 @@ fun LinkInlineSignup(
         }
 
         val focusManager = LocalFocusManager.current
-        val keyboardController = LocalSoftwareKeyboardController.current
+        val textInputService = LocalTextInputService.current
 
         LaunchedEffect(viewState.signUpState) {
             if (viewState.signUpState == SignUpState.InputtingPrimaryField && viewState.userInput != null) {
                 focusManager.clearFocus(true)
-                keyboardController?.hide()
+                @Suppress("DEPRECATION")
+                textInputService?.hideSoftwareKeyboard()
             }
         }
 

--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkOptionalInlineSignup.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkOptionalInlineSignup.kt
@@ -23,12 +23,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalTextInputService
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
@@ -55,7 +54,6 @@ import com.stripe.android.uicore.elements.TextFieldController
 import com.stripe.android.uicore.stripeColors
 import kotlinx.coroutines.job
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun LinkOptionalInlineSignup(
     linkConfigurationCoordinator: LinkConfigurationCoordinator,
@@ -76,12 +74,13 @@ fun LinkOptionalInlineSignup(
         }
 
         val focusManager = LocalFocusManager.current
-        val keyboardController = LocalSoftwareKeyboardController.current
+        val textInputService = LocalTextInputService.current
 
         LaunchedEffect(viewState.signUpState) {
             if (viewState.signUpState == SignUpState.InputtingPrimaryField && viewState.userInput != null) {
                 focusManager.clearFocus(true)
-                keyboardController?.hide()
+                @Suppress("DEPRECATION")
+                textInputService?.hideSoftwareKeyboard()
             }
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheetKeyboardHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheetKeyboardHandler.kt
@@ -6,21 +6,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.platform.SoftwareKeyboardController
+import androidx.compose.ui.platform.LocalTextInputService
+import androidx.compose.ui.text.input.TextInputService
 import kotlinx.coroutines.flow.first
 
-@OptIn(ExperimentalComposeUiApi::class)
 internal class BottomSheetKeyboardHandler(
-    private val keyboardController: SoftwareKeyboardController?,
+    private val textInputService: TextInputService?,
     private val isKeyboardVisible: State<Boolean>,
 ) {
 
     suspend fun dismiss() {
         if (isKeyboardVisible.value) {
-            keyboardController?.hide()
+            @Suppress("DEPRECATION")
+            textInputService?.hideSoftwareKeyboard()
             awaitKeyboardDismissed()
         }
     }
@@ -30,11 +29,10 @@ internal class BottomSheetKeyboardHandler(
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal fun rememberBottomSheetKeyboardHandler(): BottomSheetKeyboardHandler {
     val imeHeight = WindowInsets.ime.getBottom(LocalDensity.current)
     val isImeVisibleState = rememberUpdatedState(newValue = imeHeight > 0)
-    val keyboardController = LocalSoftwareKeyboardController.current
-    return BottomSheetKeyboardHandler(keyboardController, isImeVisibleState)
+    val textInputService = LocalTextInputService.current
+    return BottomSheetKeyboardHandler(textInputService, isImeVisibleState)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -14,9 +14,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalTextInputService
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
@@ -64,14 +63,14 @@ internal fun PaymentSheetScreen(
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun DismissKeyboardOnProcessing(processing: Boolean) {
-    val keyboardController = LocalSoftwareKeyboardController.current
+    val keyboardController = LocalTextInputService.current
 
     if (processing) {
         LaunchedEffect(Unit) {
-            keyboardController?.hide()
+            @Suppress("DEPRECATION")
+            keyboardController?.hideSoftwareKeyboard()
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBar.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBar.kt
@@ -12,12 +12,11 @@ import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalTextInputService
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
@@ -53,7 +52,6 @@ internal fun PaymentSheetTopBar(
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal fun PaymentSheetTopBar(
     state: PaymentSheetTopBarState,
@@ -61,7 +59,7 @@ internal fun PaymentSheetTopBar(
     onNavigationIconPressed: () -> Unit,
     onEditIconPressed: () -> Unit,
 ) {
-    val keyboardController = LocalSoftwareKeyboardController.current
+    val keyboardController = LocalTextInputService.current
     val tintColor = MaterialTheme.stripeColors.appBarIcon
 
     TopAppBar(
@@ -74,7 +72,8 @@ internal fun PaymentSheetTopBar(
             IconButton(
                 enabled = state.isEnabled,
                 onClick = {
-                    keyboardController?.hide()
+                    @Suppress("DEPRECATION")
+                    keyboardController?.hideSoftwareKeyboard()
                     onNavigationIconPressed()
                 },
                 modifier = Modifier.testTag(SHEET_NAVIGATION_BUTTON_TAG)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarTest.kt
@@ -2,13 +2,12 @@ package com.stripe.android.paymentsheet.ui
 
 import android.os.Build
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.platform.SoftwareKeyboardController
+import androidx.compose.ui.platform.LocalTextInputService
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.text.input.TextInputService
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
@@ -30,15 +29,14 @@ class PaymentSheetTopBarTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
-    @OptIn(ExperimentalComposeUiApi::class)
     @Test
     fun `Handles navigation icon press correctly`() {
-        val mockKeyboardController = mock<SoftwareKeyboardController>()
+        val mockTextInputService = mock<TextInputService>()
         var didCallOnNavigationIconPressed = false
 
         composeTestRule.setContent {
             CompositionLocalProvider(
-                LocalSoftwareKeyboardController provides mockKeyboardController,
+                LocalTextInputService provides mockTextInputService,
             ) {
                 PaymentSheetTopBar(
                     state = mockState(isEnabled = true),
@@ -53,19 +51,19 @@ class PaymentSheetTopBarTest {
             .onNodeWithContentDescription("Back")
             .performClick()
 
-        verify(mockKeyboardController).hide()
+        @Suppress("DEPRECATION")
+        verify(mockTextInputService).hideSoftwareKeyboard()
         assertThat(didCallOnNavigationIconPressed).isTrue()
     }
 
-    @OptIn(ExperimentalComposeUiApi::class)
     @Test
     fun `Ignores navigation icon press if not enabled`() {
-        val mockKeyboardController = mock<SoftwareKeyboardController>()
+        val mockTextInputService = mock<TextInputService>()
         var didCallOnNavigationIconPressed = false
 
         composeTestRule.setContent {
             CompositionLocalProvider(
-                LocalSoftwareKeyboardController provides mockKeyboardController,
+                LocalTextInputService provides mockTextInputService,
             ) {
                 PaymentSheetTopBar(
                     state = mockState(isEnabled = false),
@@ -79,8 +77,8 @@ class PaymentSheetTopBarTest {
         composeTestRule
             .onNodeWithContentDescription("Back")
             .performClick()
-
-        verify(mockKeyboardController, never()).hide()
+        @Suppress("DEPRECATION")
+        verify(mockTextInputService, never()).hideSoftwareKeyboard()
         assertThat(didCallOnNavigationIconPressed).isFalse()
     }
 


### PR DESCRIPTION
# Summary
Replace all usages of `LocalSoftwareKeyboardController` with `TextInputService`.

**Note**: `TextInputService.hideSoftwareKeyboard` ids deprecated but stable. In fact, `LocalSoftwareKeyboardController` wraps this method by default.

# Motivation
Allows developers to upgrade to Compose 1.6.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified