### PR TITLE
Add filter capability to PaymentMethodRegistry.

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -728,12 +728,7 @@ style:
   RedundantVisibilityModifierRule:
     active: false
   ReturnCount:
-    active: true
-    max: 2
-    excludedFunctions: 'equals'
-    excludeLabeled: false
-    excludeReturnFromLambda: true
-    excludeGuardClauses: false
+    active: false
   SafeCast:
     active: true
   SerialVersionUIDInSerializableClass:

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodDefinition.kt
@@ -24,6 +24,9 @@ internal interface PaymentMethodDefinition {
 }
 
 internal fun PaymentMethodDefinition.isSupported(metadata: PaymentMethodMetadata): Boolean {
+    if (type.code !in metadata.stripeIntent.paymentMethodTypes) {
+        return false
+    }
     val requirements = addRequirement(metadata.hasIntentToSetup())
     for (requirement in requirements) {
         if (!requirement.meetsRequirements(metadata)) {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodRegistry.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodRegistry.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.lpmfoundations.paymentmethod
 
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.AffirmDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.AfterpayClearpayDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.AlipayDefinition
@@ -31,6 +32,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.definitions.UpiDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.UsBankAccountDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.WeChatPayDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.ZipDefinition
+import com.stripe.android.ui.core.elements.SharedDataSpec
 
 internal object PaymentMethodRegistry {
 
@@ -70,5 +72,21 @@ internal object PaymentMethodRegistry {
 
     val definitionsByCode: Map<String, PaymentMethodDefinition> by lazy {
         all.associateBy { it.type.code }
+    }
+
+    fun filterSupportedPaymentMethods(
+        metadata: PaymentMethodMetadata,
+        sharedDataSpecs: List<SharedDataSpec>,
+    ): List<SupportedPaymentMethod> {
+        return all.filter {
+            it.isSupported(metadata)
+        }.mapNotNull { paymentMethodDefinition ->
+            val sharedDataSpec = sharedDataSpecs.firstOrNull { it.type == paymentMethodDefinition.type.code }
+            if (sharedDataSpec != null) {
+                paymentMethodDefinition.supportedPaymentMethod(metadata, sharedDataSpec)
+            } else {
+                null
+            }
+        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodDefinitionTest.kt
@@ -1,0 +1,29 @@
+package com.stripe.android.lpmfoundations.paymentmethod
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.definitions.CardDefinition
+import com.stripe.android.lpmfoundations.paymentmethod.definitions.KlarnaDefinition
+import com.stripe.android.model.SetupIntentFixtures
+import org.junit.Test
+
+internal class PaymentMethodDefinitionTest {
+    @Test
+    fun `isSupported returns false for PaymentMethodDefinitions that are not in stripeIntent#paymentMethodTypes`() {
+        assertThat(KlarnaDefinition.isSupported(PaymentMethodMetadataFactory.create())).isFalse()
+    }
+
+    @Test
+    fun `isSupported returns false for PaymentMethodDefinitions that do not meet add requirements`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "klarna")
+            )
+        )
+        assertThat(KlarnaDefinition.isSupported(metadata)).isFalse()
+    }
+
+    @Test
+    fun `isSupported returns true for supported PaymentMethodDefinitions`() {
+        assertThat(CardDefinition.isSupported(PaymentMethodMetadataFactory.create())).isTrue()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodRegistryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodRegistryTest.kt
@@ -1,0 +1,44 @@
+package com.stripe.android.lpmfoundations.paymentmethod
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.ui.core.elements.SharedDataSpec
+import org.junit.Test
+
+internal class PaymentMethodRegistryTest {
+    private val cardSharedDataSpecs = listOf(SharedDataSpec("card"))
+
+    @Test
+    fun `filterSupportedPaymentMethods removes unsupported paymentMethodTypes`() {
+        val metadata = PaymentMethodMetadataFactory.create()
+        val supportedPaymentMethods = PaymentMethodRegistry.filterSupportedPaymentMethods(metadata, cardSharedDataSpecs)
+        assertThat(supportedPaymentMethods).hasSize(1)
+        assertThat(supportedPaymentMethods.first().code).isEqualTo("card")
+    }
+
+    @Test
+    fun `filterSupportedPaymentMethods filters payment methods without shared data specs`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "klarna")
+            )
+        )
+        val supportedPaymentMethods = PaymentMethodRegistry.filterSupportedPaymentMethods(metadata, cardSharedDataSpecs)
+        assertThat(supportedPaymentMethods).hasSize(1)
+        assertThat(supportedPaymentMethods.first().code).isEqualTo("card")
+    }
+
+    @Test
+    fun `filterSupportedPaymentMethods returns expected items`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "klarna")
+            )
+        )
+        val sharedDataSpecs = listOf(SharedDataSpec("card"), SharedDataSpec("klarna"))
+        val supportedPaymentMethods = PaymentMethodRegistry.filterSupportedPaymentMethods(metadata, sharedDataSpecs)
+        assertThat(supportedPaymentMethods).hasSize(2)
+        assertThat(supportedPaymentMethods[0].code).isEqualTo("card")
+        assertThat(supportedPaymentMethods[1].code).isEqualTo("klarna")
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This adds functionality and tests for getting the SupportedPaymentMethods from metadata.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This will be used in the view model to return the supported payment methods in a follow up.
