### PR TITLE
Replace StripeIntent with PaymentMethodMetadata in PaymentSheetState.

### DIFF
--- a/example/detekt-baseline.xml
+++ b/example/detekt-baseline.xml
@@ -18,7 +18,6 @@
     <ID>MagicNumber:SourcesAdapter.kt$SourcesAdapter.ViewHolder$6</ID>
     <ID>MagicNumber:UpiWaitingActivity.kt$UpiWaitingActivity$5000</ID>
     <ID>MaxLineLength:CreateCardSourceActivity.kt$CreateCardSourceActivity$viewBinding.cardWidget</ID>
-    <ID>SpreadOperator:SimpleConfirmationActivity.kt$SimpleConfirmationActivity.DropdownItemAdapter$(*DropdownItem.values())</ID>
     <ID>ThrowingExceptionsWithoutMessageOrCause:PaymentSessionActivity.kt$PaymentSessionActivity.ActivityViewModel.&lt;no name provided>$RuntimeException()</ID>
     <ID>VariableNaming:StripeImageActivity.kt$StripeImageActivity$private val LocalStripeImageLoader = staticCompositionLocalOf&lt;StripeImageLoader> { error("No ImageLoader provided") }</ID>
   </CurrentIssues>

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -30,10 +30,9 @@
     <ID>LongMethod:EditPaymentMethod.kt$@Composable internal fun EditPaymentMethodUi( viewState: EditPaymentMethodViewState, viewActionHandler: (action: EditPaymentMethodViewAction) -> Unit, modifier: Modifier = Modifier )</ID>
     <ID>LongMethod:FormViewModelTest.kt$FormViewModelTest$@Test fun `Verify params are set when element address fields are complete`()</ID>
     <ID>LongMethod:FormViewModelTest.kt$FormViewModelTest$@Test fun `Verify params are set when required address fields are complete`()</ID>
-    <ID>LongMethod:PaymentElement.kt$@Composable internal fun PaymentElement( formViewModelSubComponentBuilderProvider: Provider&lt;FormViewModelSubcomponent.Builder>, enabled: Boolean, supportedPaymentMethods: List&lt;SupportedPaymentMethod>, selectedItem: SupportedPaymentMethod, linkSignupMode: LinkSignupMode?, linkConfigurationCoordinator: LinkConfigurationCoordinator?, showCheckboxFlow: Flow&lt;Boolean>, onItemSelectedListener: (SupportedPaymentMethod) -> Unit, onLinkSignupStateChanged: (LinkConfiguration, InlineSignupViewState) -> Unit, formArguments: FormArguments, usBankAccountFormArguments: USBankAccountFormArguments, onFormFieldValuesChanged: (FormFieldValues?) -> Unit, )</ID>
     <ID>LongMethod:PaymentOptionFactory.kt$PaymentOptionFactory$fun create(selection: PaymentSelection): PaymentOption</ID>
     <ID>LongMethod:PaymentSheetConfigurationKtx.kt$internal fun PaymentSheet.Appearance.parseAppearance()</ID>
-    <ID>LongMethod:PaymentSheetLoader.kt$DefaultPaymentSheetLoader$private suspend fun create( elementsSession: ElementsSession, config: PaymentSheet.Configuration, ): PaymentSheetState.Full</ID>
+    <ID>LongMethod:PaymentSheetLoader.kt$DefaultPaymentSheetLoader$private suspend fun create( elementsSession: ElementsSession, config: PaymentSheet.Configuration, metadata: PaymentMethodMetadata, ): PaymentSheetState.Full</ID>
     <ID>LongMethod:PaymentSheetScreen.kt$@Composable internal fun PaymentSheetScreenContent( viewModel: BaseSheetViewModel, type: PaymentSheetFlowType, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:PlaceholderHelperTest.kt$PlaceholderHelperTest$@Test fun `Test correct placeholder is removed for placeholder spec`()</ID>
     <ID>LongMethod:USBankAccountEmitters.kt$@Composable internal fun USBankAccountEmitters( viewModel: USBankAccountFormViewModel, usBankAccountFormArgs: USBankAccountFormArguments, )</ID>
@@ -80,9 +79,6 @@
     <ID>MaxLineLength:PrimaryButtonTest.kt$PrimaryButtonTest$primaryButton.setAppearanceConfiguration(StripeThemeDefaults.primaryButtonStyle, ColorStateList.valueOf(Color.BLACK))</ID>
     <ID>MaxLineLength:SupportedPaymentMethod.kt$SupportedPaymentMethod$/** This describes the image in the LPM selector. These can be found internally [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0) */</ID>
     <ID>MaxLineLength:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest$* This will generate payment intent scenarios for all combinations of customers, lpm types in the intent, shipping, and SFU states</ID>
-    <ID>MaxLineLength:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest$val formDescriptor = lpm.getSpecWithFullfilledRequirements(testInput.getIntent(lpm), testInput.getConfig())</ID>
-    <ID>MaxLineLength:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest.PaymentIntentTestInput$fun toCsv()</ID>
-    <ID>MaxLineLength:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest.PaymentIntentTestInput.Companion$fun toCsvHeader()</ID>
     <ID>MaxLineLength:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest.TestOutput.Companion$formShowsSaveCheckbox == false &amp;&amp; formShowsCheckboxControlledFields == true -> "merchantRequiredSave"</ID>
     <ID>MaxLineLength:USBankAccountFormViewModelTest.kt$USBankAccountFormViewModelTest$viewModel.handlePrimaryButtonClick(currentScreenState as USBankAccountFormScreenState.VerifyWithMicrodeposits)</ID>
     <ID>NestedBlockDepth:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest$private fun generatePaymentIntentScenarios(): List&lt;PaymentIntentTestInput></ID>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetState.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.state
 
 import android.os.Parcelable
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -15,16 +16,19 @@ internal sealed interface PaymentSheetState : Parcelable {
     @Parcelize
     data class Full(
         val config: PaymentSheet.Configuration,
-        val stripeIntent: StripeIntent,
         val customerPaymentMethods: List<PaymentMethod>,
         val isGooglePayReady: Boolean,
         val linkState: LinkState?,
         val isEligibleForCardBrandChoice: Boolean,
         val paymentSelection: PaymentSelection?,
         val validationError: PaymentSheetLoadingException?,
+        val paymentMethodMetadata: PaymentMethodMetadata,
     ) : PaymentSheetState {
 
         val showSavedPaymentMethods: Boolean
             get() = customerPaymentMethods.isNotEmpty() || isGooglePayReady
+
+        val stripeIntent: StripeIntent
+            get() = paymentMethodMetadata.stripeIntent
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.lpmfoundations.luxe.update
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
@@ -523,7 +524,11 @@ internal class PaymentOptionsViewModelTest {
     @Test
     fun `Sends dismiss event when the user cancels the flow with deferred intent`() = runTest {
         val deferredIntentArgs = PAYMENT_OPTION_CONTRACT_ARGS.copy(
-            state = PAYMENT_OPTION_CONTRACT_ARGS.state.copy(stripeIntent = DEFERRED_PAYMENT_INTENT),
+            state = PAYMENT_OPTION_CONTRACT_ARGS.state.copy(
+                paymentMethodMetadata = PAYMENT_OPTION_CONTRACT_ARGS.state.paymentMethodMetadata.copy(
+                    stripeIntent = DEFERRED_PAYMENT_INTENT,
+                )
+            ),
         )
 
         val viewModel = createViewModel(args = deferredIntentArgs)
@@ -540,11 +545,13 @@ internal class PaymentOptionsViewModelTest {
                 ),
                 isGooglePayReady = false,
                 customerPaymentMethods = emptyList(),
-                stripeIntent = PAYMENT_INTENT.copy(
-                    paymentMethodTypes = listOf(
-                        PaymentMethod.Type.Card.code,
-                        PaymentMethod.Type.AuBecsDebit.code,
-                    ),
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                    stripeIntent = PAYMENT_INTENT.copy(
+                        paymentMethodTypes = listOf(
+                            PaymentMethod.Type.Card.code,
+                            PaymentMethod.Type.AuBecsDebit.code,
+                        ),
+                    )
                 )
             ),
         )
@@ -735,7 +742,6 @@ internal class PaymentOptionsViewModelTest {
         )
         private val PAYMENT_OPTION_CONTRACT_ARGS = PaymentOptionContract.Args(
             state = PaymentSheetState.Full(
-                stripeIntent = PAYMENT_INTENT,
                 customerPaymentMethods = emptyList(),
                 config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
                 isGooglePayReady = true,
@@ -743,6 +749,7 @@ internal class PaymentOptionsViewModelTest {
                 linkState = null,
                 isEligibleForCardBrandChoice = false,
                 validationError = null,
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(stripeIntent = PAYMENT_INTENT),
             ),
             statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR,
             enableLogging = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -3,7 +3,7 @@ package com.stripe.android.paymentsheet
 import android.content.res.ColorStateList
 import android.graphics.Color
 import androidx.core.graphics.toColorInt
-import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
@@ -104,7 +104,6 @@ internal object PaymentSheetFixtures {
 
     internal val PAYMENT_OPTIONS_CONTRACT_ARGS = PaymentOptionContract.Args(
         state = PaymentSheetState.Full(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
             customerPaymentMethods = emptyList(),
             config = CONFIG_GOOGLEPAY,
             isGooglePayReady = false,
@@ -112,6 +111,7 @@ internal object PaymentSheetFixtures {
             linkState = null,
             isEligibleForCardBrandChoice = false,
             validationError = null,
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         ),
         statusBarColor = STATUS_BAR_COLOR,
         enableLogging = false,
@@ -130,10 +130,10 @@ internal object PaymentSheetFixtures {
             state = state.copy(
                 customerPaymentMethods = paymentMethods,
                 isGooglePayReady = isGooglePayReady,
-                stripeIntent = stripeIntent,
                 config = config,
                 paymentSelection = paymentSelection,
                 linkState = linkState,
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(stripeIntent = stripeIntent)
             ),
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -23,6 +23,7 @@ import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
@@ -410,7 +411,6 @@ internal class DefaultFlowControllerTest {
 
         val expectedArgs = PaymentOptionContract.Args(
             state = PaymentSheetState.Full(
-                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 customerPaymentMethods = emptyList(),
                 config = PaymentSheet.Configuration("com.stripe.android.paymentsheet.test"),
                 isGooglePayReady = false,
@@ -418,6 +418,7 @@ internal class DefaultFlowControllerTest {
                 linkState = null,
                 isEligibleForCardBrandChoice = false,
                 validationError = null,
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
             ),
             statusBarColor = STATUS_BAR_COLOR,
             enableLogging = ENABLE_LOGGING,
@@ -586,13 +587,13 @@ internal class DefaultFlowControllerTest {
             NEW_CARD_PAYMENT_SELECTION,
             PaymentSheetState.Full(
                 PaymentSheetFixtures.CONFIG_CUSTOMER,
-                PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 customerPaymentMethods = PAYMENT_METHODS,
                 isGooglePayReady = false,
                 linkState = null,
                 paymentSelection = initialSelection,
                 isEligibleForCardBrandChoice = false,
                 validationError = null,
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
             )
         )
 
@@ -625,13 +626,13 @@ internal class DefaultFlowControllerTest {
             GENERIC_PAYMENT_SELECTION,
             PaymentSheetState.Full(
                 PaymentSheetFixtures.CONFIG_CUSTOMER,
-                PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 customerPaymentMethods = PAYMENT_METHODS,
                 isGooglePayReady = false,
                 linkState = null,
                 paymentSelection = initialSelection,
                 isEligibleForCardBrandChoice = false,
                 validationError = null,
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
             )
         )
 
@@ -667,13 +668,13 @@ internal class DefaultFlowControllerTest {
             paymentSelection,
             PaymentSheetState.Full(
                 PaymentSheetFixtures.CONFIG_CUSTOMER,
-                PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 customerPaymentMethods = PAYMENT_METHODS,
                 isGooglePayReady = false,
                 linkState = null,
                 paymentSelection = initialSelection,
                 isEligibleForCardBrandChoice = false,
                 validationError = null,
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.lpmfoundations.luxe.update
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
@@ -253,15 +254,17 @@ class PaymentSelectionUpdaterTest {
 
         return PaymentSheetState.Full(
             config = config,
-            stripeIntent = intent.copy(
-                paymentMethodTypes = paymentMethodTypes ?: intent.paymentMethodTypes,
-            ),
             customerPaymentMethods = customerPaymentMethods,
             isGooglePayReady = true,
             linkState = null,
             paymentSelection = paymentSelection,
             isEligibleForCardBrandChoice = false,
             validationError = null,
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = intent.copy(
+                    paymentMethodTypes = paymentMethodTypes ?: intent.paymentMethodTypes,
+                )
+            ),
         )
     }
 
@@ -275,15 +278,17 @@ class PaymentSelectionUpdaterTest {
 
         return PaymentSheetState.Full(
             config = config,
-            stripeIntent = intent.copy(
-                paymentMethodTypes = paymentMethodTypes ?: intent.paymentMethodTypes,
-            ),
             customerPaymentMethods = customerPaymentMethods,
             isGooglePayReady = true,
             linkState = null,
             paymentSelection = paymentSelection,
             isEligibleForCardBrandChoice = false,
             validationError = null,
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = intent.copy(
+                    paymentMethodTypes = paymentMethodTypes ?: intent.paymentMethodTypes,
+                )
+            ),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.link.ui.inline.LinkSignupMode.AlongsideSaveForFutureUs
 import com.stripe.android.link.ui.inline.LinkSignupMode.InsteadOfSaveForFutureUse
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.lpmfoundations.luxe.update
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentIntent.ConfirmationMethod.Manual
 import com.stripe.android.model.PaymentIntentFixtures
@@ -121,7 +122,6 @@ internal class DefaultPaymentSheetLoaderTest {
         ).isEqualTo(
             PaymentSheetState.Full(
                 config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
-                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
                 customerPaymentMethods = PAYMENT_METHODS,
                 isGooglePayReady = true,
                 paymentSelection = PaymentSelection.Saved(
@@ -130,6 +130,10 @@ internal class DefaultPaymentSheetLoaderTest {
                 linkState = null,
                 isEligibleForCardBrandChoice = false,
                 validationError = null,
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                    stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
+                    allowsDelayedPaymentMethods = false,
+                ),
             )
         )
     }
@@ -156,7 +160,6 @@ internal class DefaultPaymentSheetLoaderTest {
         ).isEqualTo(
             PaymentSheetState.Full(
                 config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
-                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
                 customerPaymentMethods = PAYMENT_METHODS,
                 isGooglePayReady = false,
                 paymentSelection = PaymentSelection.Saved(
@@ -165,6 +168,10 @@ internal class DefaultPaymentSheetLoaderTest {
                 linkState = null,
                 isEligibleForCardBrandChoice = false,
                 validationError = null,
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                    stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
+                    allowsDelayedPaymentMethods = false,
+                ),
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.utils
 
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
@@ -42,13 +43,13 @@ internal class FakePaymentSheetLoader(
             Result.success(
                 PaymentSheetState.Full(
                     config = paymentSheetConfiguration,
-                    stripeIntent = stripeIntent,
                     customerPaymentMethods = customerPaymentMethods,
                     isGooglePayReady = isGooglePayAvailable,
                     linkState = linkState,
                     paymentSelection = paymentSelection,
                     isEligibleForCardBrandChoice = false,
                     validationError = validationError,
+                    paymentMethodMetadata = PaymentMethodMetadataFactory.create(stripeIntent = stripeIntent),
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/RelayingPaymentSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/RelayingPaymentSheetLoader.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.utils
 
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
@@ -19,7 +20,6 @@ internal class RelayingPaymentSheetLoader : PaymentSheetLoader {
         enqueue(
             Result.success(
                 PaymentSheetState.Full(
-                    stripeIntent = stripeIntent,
                     customerPaymentMethods = emptyList(),
                     config = PaymentSheet.Configuration("Example"),
                     isGooglePayReady = false,
@@ -27,6 +27,7 @@ internal class RelayingPaymentSheetLoader : PaymentSheetLoader {
                     linkState = null,
                     isEligibleForCardBrandChoice = false,
                     validationError = validationError,
+                    paymentMethodMetadata = PaymentMethodMetadataFactory.create(stripeIntent = stripeIntent),
                 ),
             )
         )

--- a/stripe-core/detekt-baseline.xml
+++ b/stripe-core/detekt-baseline.xml
@@ -7,7 +7,6 @@
     <ID>MagicNumber:NetworkTypeDetector.kt$NetworkTypeDetector$19</ID>
     <ID>MagicNumber:StripeJsonUtils.kt$StripeJsonUtils$3</ID>
     <ID>MaxLineLength:QueryStringFactoryTest.kt$QueryStringFactoryTest$"colors[]=blue&amp;colors[]=green&amp;empty_list=&amp;person[age]=45&amp;person[city]=San Francisco&amp;person[wishes]=&amp;person[friends][]=Alice&amp;person[friends][]=Bob"</ID>
-    <ID>MaxLineLength:RequestHeadersFactoriesTest.kt$RequestHeadersFactoriesTest$.</ID>
     <ID>MaxLineLength:StripeErrorJsonParserTest.kt$StripeErrorJsonParserTest$message = "The Stripe API is only accessible over HTTPS. Please see &lt;https://stripe.com/docs> for more information."</ID>
     <ID>SerialVersionUIDInSerializableClass:StripeError.kt$StripeError : StripeModelSerializable</ID>
     <ID>SwallowedException:StripeJsonUtils.kt$StripeJsonUtils$classCastException: ClassCastException</ID>


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I don't want the same data to exist twice, otherwise it'll cause confusion. But I need `PaymentMethodMetadata` to handle the new filtering logic. Updating the loaders and the viewmodels to consume PaymentMethodMetadata will come in a follow up.
