### PR TITLE
Use content padding in account picker screen

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Layout.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Layout.kt
@@ -69,7 +69,7 @@ internal fun Layout(
             LazyColumn(
                 state = lazyListState,
                 verticalArrangement = verticalArrangement,
-                modifier = Modifier.padding(bodyPadding)
+                contentPadding = bodyPadding,
             ) {
                 body()
             }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request switches to using `contentPadding` over `Modifier.padding()` in the account picker screen. This results in the desired overscroll indicator behavior.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
