### PR TITLE
Don't limit phone number length when phone number format is missing

### DIFF
--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
@@ -55,11 +55,14 @@ internal sealed class PhoneNumberFormatter {
         override val placeholder = metadata.pattern.replace('#', '5')
         override val countryCode = metadata.regionCode
 
-        private val maxSubscriberDigits = metadata.pattern.count { it == '#' }
-
         override fun userInputFilter(input: String) =
             input.filter { VALID_INPUT_RANGE.contains(it) }.run {
-                substring(0, min(length, maxSubscriberDigits))
+                if (metadata.pattern.isEmpty()) {
+                    this
+                } else {
+                    val maxSubscriberDigits = metadata.pattern.count { it == '#' }
+                    substring(0, min(length, maxSubscriberDigits))
+                }
             }
 
         override fun toE164Format(input: String) = "${prefix}${userInputFilter(input)}"
@@ -150,7 +153,7 @@ internal sealed class PhoneNumberFormatter {
     }
 
     /**
-     * Phone number formatter for an ubknown region.
+     * Phone number formatter for an unknown region.
      */
     class UnknownRegion(override val countryCode: String) : PhoneNumberFormatter() {
         override val prefix = ""

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
@@ -55,11 +55,14 @@ internal sealed class PhoneNumberFormatter {
         override val placeholder = metadata.pattern.replace('#', '5')
         override val countryCode = metadata.regionCode
 
-        private val maxSubscriberDigits = metadata.pattern.count { it == '#' }
-
         override fun userInputFilter(input: String) =
             input.filter { VALID_INPUT_RANGE.contains(it) }.run {
-                substring(0, min(length, maxSubscriberDigits))
+                if (metadata.pattern.isEmpty()) {
+                    this
+                } else {
+                    val maxSubscriberDigits = metadata.pattern.count { it == '#' }
+                    substring(0, min(length, maxSubscriberDigits))
+                }
             }
 
         override fun toE164Format(input: String) = "${prefix}${userInputFilter(input)}"

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
@@ -55,14 +55,11 @@ internal sealed class PhoneNumberFormatter {
         override val placeholder = metadata.pattern.replace('#', '5')
         override val countryCode = metadata.regionCode
 
+        private val maxSubscriberDigits = metadata.pattern.count { it == '#' }
+
         override fun userInputFilter(input: String) =
             input.filter { VALID_INPUT_RANGE.contains(it) }.run {
-                if (metadata.pattern.isEmpty()) {
-                    this
-                } else {
-                    val maxSubscriberDigits = metadata.pattern.count { it == '#' }
-                    substring(0, min(length, maxSubscriberDigits))
-                }
+                substring(0, min(length, maxSubscriberDigits))
             }
 
         override fun toE164Format(input: String) = "${prefix}${userInputFilter(input)}"
@@ -153,7 +150,7 @@ internal sealed class PhoneNumberFormatter {
     }
 
     /**
-     * Phone number formatter for an unknown region.
+     * Phone number formatter for an ubknown region.
      */
     class UnknownRegion(override val countryCode: String) : PhoneNumberFormatter() {
         override val prefix = ""

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
@@ -61,6 +61,39 @@ internal class PhoneNumberFormatterTest {
         assertThat(formatter.format("123456789012456")).isEqualTo("(123)-456+78901!2")
     }
 
+    @Test
+    fun `WithRegion doesn't format when pattern is missing`() {
+        val pattern = ""
+        val formatter = PhoneNumberFormatter.WithRegion(
+            PhoneNumberFormatter.Metadata(
+                "prefix",
+                "regionCode",
+                pattern
+            )
+        )
+
+        // visualTransformation appends a space to the beginning of the filtered string
+        assertThat(formatter.format("123")).isEqualTo(" 123")
+        assertThat(formatter.format("1234567")).isEqualTo(" 1234567")
+        assertThat(formatter.format("123456789012")).isEqualTo(" 123456789012")
+        assertThat(formatter.format("123456789012456")).isEqualTo(" 123456789012456")
+    }
+
+    @Test
+    fun `WithRegion removes chars when pattern is missing`() {
+        val pattern = ""
+        val formatter = PhoneNumberFormatter.WithRegion(
+            PhoneNumberFormatter.Metadata(
+                "prefix",
+                "regionCode",
+                pattern
+            )
+        )
+
+        // visualTransformation appends a space to the beginning of the filtered string
+        assertThat(formatter.format("123ABC")).isEqualTo(" 123")
+    }
+
     private fun PhoneNumberFormatter.format(input: String) =
         visualTransformation.filter(AnnotatedString(userInputFilter(input))).text.text
 }

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
@@ -61,39 +61,6 @@ internal class PhoneNumberFormatterTest {
         assertThat(formatter.format("123456789012456")).isEqualTo("(123)-456+78901!2")
     }
 
-    @Test
-    fun `WithRegion doesn't format when pattern is missing`() {
-        val pattern = ""
-        val formatter = PhoneNumberFormatter.WithRegion(
-            PhoneNumberFormatter.Metadata(
-                "prefix",
-                "regionCode",
-                pattern
-            )
-        )
-
-        // visualTransformation appends a space to the beginning of the filter string
-        assertThat(formatter.format("123")).isEqualTo(" 123")
-        assertThat(formatter.format("1234567")).isEqualTo(" 1234567")
-        assertThat(formatter.format("123456789012")).isEqualTo(" 123456789012")
-        assertThat(formatter.format("123456789012456")).isEqualTo(" 123456789012456")
-    }
-
-    @Test
-    fun `WithRegion removes chars when pattern is missing`() {
-        val pattern = ""
-        val formatter = PhoneNumberFormatter.WithRegion(
-            PhoneNumberFormatter.Metadata(
-                "prefix",
-                "regionCode",
-                pattern
-            )
-        )
-
-        // visualTransformation appends a space to the beginning of the filter string
-        assertThat(formatter.format("123ABC")).isEqualTo(" 123")
-    }
-
     private fun PhoneNumberFormatter.format(input: String) =
         visualTransformation.filter(AnnotatedString(userInputFilter(input))).text.text
 }

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
@@ -61,6 +61,39 @@ internal class PhoneNumberFormatterTest {
         assertThat(formatter.format("123456789012456")).isEqualTo("(123)-456+78901!2")
     }
 
+    @Test
+    fun `WithRegion doesn't limit phone number length when pattern is missing`() {
+        val pattern = ""
+        val formatter = PhoneNumberFormatter.WithRegion(
+            PhoneNumberFormatter.Metadata(
+                "prefix",
+                "regionCode",
+                pattern
+            )
+        )
+
+        // visualTransformation appends a space to the beginning of the output.
+        assertThat(formatter.format("123")).isEqualTo(" 123")
+        assertThat(formatter.format("1234567")).isEqualTo(" 1234567")
+        assertThat(formatter.format("123456789012")).isEqualTo(" 123456789012")
+        assertThat(formatter.format("123456789012456")).isEqualTo(" 123456789012456")
+    }
+
+    @Test
+    fun `WithRegion filters out chars when pattern is missing`() {
+        val pattern = ""
+        val formatter = PhoneNumberFormatter.WithRegion(
+            PhoneNumberFormatter.Metadata(
+                "prefix",
+                "regionCode",
+                pattern
+            )
+        )
+
+        // visualTransformation appends a space to the beginning of the output.
+        assertThat(formatter.format("123ABC")).isEqualTo(" 123")
+    }
+
     private fun PhoneNumberFormatter.format(input: String) =
         visualTransformation.filter(AnnotatedString(userInputFilter(input))).text.text
 }


### PR DESCRIPTION
# Summary
Don't limit phone number length when the phone number region's metadata is missing a pattern.

# Motivation
The current behavior makes it impossible to type a phone number for some regions.

We currently restrict the length of a phone number to the length of its pattern. When the pattern is empty, we are limiting the length of the phone number to 0, which prevents users from typing in any phone number.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| [before fix.webm](https://github.com/stripe/stripe-android/assets/160939932/7405b521-5656-4c90-9fa6-21544ce48227) | [no pattern no format.webm](https://github.com/stripe/stripe-android/assets/160939932/0a6fefb5-1b50-4604-bdc7-917d6ddfdb36) |

# Changelog
    - [Fixed] inability to type phone number in 10+ regions
