### PR TITLE
Strip leading zeros in `PhoneNumberFormatter` when converting to E164 format.

### DIFF
--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
@@ -62,7 +62,7 @@ internal sealed class PhoneNumberFormatter {
                 substring(0, min(length, maxSubscriberDigits))
             }
 
-        override fun toE164Format(input: String) = "${prefix}${userInputFilter(input)}"
+        override fun toE164Format(input: String) = "${prefix}${userInputFilter(input).trimStart('0')}"
 
         override val visualTransformation = object : VisualTransformation {
             override fun filter(text: AnnotatedString): TransformedText {
@@ -161,7 +161,7 @@ internal sealed class PhoneNumberFormatter {
                 substring(0, min(length, E164_MAX_DIGITS))
             }
 
-        override fun toE164Format(input: String) = "+${userInputFilter(input)}"
+        override fun toE164Format(input: String) = "+${userInputFilter(input).trimStart('0')}"
 
         override val visualTransformation =
             VisualTransformation { text ->

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
@@ -61,6 +61,15 @@ internal class PhoneNumberFormatterTest {
         assertThat(formatter.format("123456789012456")).isEqualTo("(123)-456+78901!2")
     }
 
+    @Test
+    fun `Leading zeros should be stripped in E164 format`() {
+        val formatter = PhoneNumberFormatter.forCountry("GB")
+
+        assertThat(formatter.toE164Format("01371112")).isEqualTo("+441371112")
+        assertThat(formatter.toE164Format("013711122")).isEqualTo("+4413711122")
+        assertThat(formatter.toE164Format("0137111222")).isEqualTo("+44137111222")
+    }
+
     private fun PhoneNumberFormatter.format(input: String) =
         visualTransformation.filter(AnnotatedString(userInputFilter(input))).text.text
 }


### PR DESCRIPTION
# Summary
Strip leading zeros in `PhoneNumberFormatter` when converting to E164 format.

# Motivation
E.164 format expects leading zeros to be removed.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
