### PR TITLE
Move warning suppressions to baseline file in FC

### DIFF
--- a/financial-connections/detekt-baseline.xml
+++ b/financial-connections/detekt-baseline.xml
@@ -1,5 +1,46 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <SmellBaseline>
   <ManuallySuppressedIssues/>
-  <CurrentIssues/>
+  <CurrentIssues>
+    <ID>ConstructorParameterNaming:FinancialConnectionsAuthorizationSession.kt$FinancialConnectionsAuthorizationSession$@SerialName(value = "is_oauth") private val _isOAuth: Boolean? = false</ID>
+    <ID>ConstructorParameterNaming:PartnerAccountsList.kt$PartnerAccount$@SerialName(value = "allow_selection") private val _allowSelection: Boolean? = null</ID>
+    <ID>LongMethod:AccountItem.kt$@Composable @Preview internal fun AccountItemPreview()</ID>
+    <ID>LongMethod:ConsentPreviewParameterProvider.kt$ConsentPreviewParameterProvider$private fun sampleConsent(): ConsentPane</ID>
+    <ID>LongMethod:InstitutionPickerScreen.kt$private fun LazyListScope.searchResults( isInputEmpty: Boolean, payload: Payload, selectedInstitutionId: String?, onInstitutionSelected: (FinancialConnectionsInstitution, Boolean) -> Unit, institutions: Async&lt;InstitutionResponse>, onManualEntryClick: () -> Unit, onSearchMoreClick: () -> Unit )</ID>
+    <ID>LongMethod:LinkAccountPickerPreviewParameterProvider.kt$LinkAccountPickerPreviewParameterProvider$private fun partnerAccountList()</ID>
+    <ID>LongMethod:ManualEntryScreen.kt$@Composable private fun ManualEntryLoaded( scrollState: ScrollState, payload: Payload, linkPaymentAccountStatus: Async&lt;LinkAccountSessionPaymentAccount>, routing: Pair&lt;String?, Int?>, onRoutingEntered: (String) -> Unit, account: Pair&lt;String?, Int?>, onAccountEntered: (String) -> Unit, accountConfirm: Pair&lt;String?, Int?>, onAccountConfirmEntered: (String) -> Unit, isValidForm: Boolean, onSubmit: () -> Unit )</ID>
+    <ID>MagicNumber:AccountPickerScreen.kt$3</ID>
+    <ID>MagicNumber:ConsentLogoHeader.kt$3</ID>
+    <ID>MagicNumber:ConsentLogoHeader.kt$4</ID>
+    <ID>MagicNumber:ConsentLogoHeader.kt$5</ID>
+    <ID>MagicNumber:ConsumerSessionExtensions.kt$10</ID>
+    <ID>MagicNumber:ConsumerSessionExtensions.kt$5</ID>
+    <ID>MagicNumber:ConsumerSessionExtensions.kt$7</ID>
+    <ID>MagicNumber:InstitutionPickerScreen.kt$0.5f</ID>
+    <ID>MagicNumber:InstitutionPickerScreen.kt$0.75f</ID>
+    <ID>MagicNumber:InstitutionPickerScreen.kt$10</ID>
+    <ID>MagicNumber:Layout.kt$4</ID>
+    <ID>MagicNumber:Layout.kt$50</ID>
+    <ID>MagicNumber:LinkAccountPickerScreen.kt$3</ID>
+    <ID>MagicNumber:ManualEntryInputValidator.kt$ManualEntryInputValidator$10</ID>
+    <ID>MagicNumber:ManualEntryInputValidator.kt$ManualEntryInputValidator$3</ID>
+    <ID>MagicNumber:ManualEntryInputValidator.kt$ManualEntryInputValidator$7</ID>
+    <ID>MagicNumber:ManualEntryViewModel.kt$ManualEntryViewModel$4</ID>
+    <ID>MagicNumber:SharedPartnerAuth.kt$.50f</ID>
+    <ID>MatchingDeclarationName:ServerDrivenUi.kt$BulletUI</ID>
+    <ID>MatchingDeclarationName:Type.kt$FinancialConnectionsTypography</ID>
+    <ID>MaxLineLength:FinancialConnectionsUrls.kt$FinancialConnectionsUrls.DataPolicy$const val merchant = "https://support.stripe.com/user/questions/what-data-does-stripe-access-from-my-linked-financial-account"</ID>
+    <ID>MaxLineLength:FinancialConnectionsUrls.kt$FinancialConnectionsUrls.Disconnect$const val link = "https://support.link.co/questions/connecting-your-bank-account#how-do-i-disconnect-my-connected-bank-account"</ID>
+    <ID>MaxLineLength:FinancialConnectionsUrls.kt$FinancialConnectionsUrls.PartnerNotice$const val merchant = "https://support.stripe.com/user/questions/what-is-the-relationship-between-stripe-and-stripes-service-providers"</ID>
+    <ID>MaximumLineLength:com.stripe.android.financialconnections.presentation.FinancialConnectionsUrls.kt:41</ID>
+    <ID>MaximumLineLength:com.stripe.android.financialconnections.presentation.FinancialConnectionsUrls.kt:46</ID>
+    <ID>MaximumLineLength:com.stripe.android.financialconnections.presentation.FinancialConnectionsUrls.kt:9</ID>
+    <ID>NestedBlockDepth:InstitutionPickerScreen.kt$private fun LazyListScope.searchResults( isInputEmpty: Boolean, payload: Payload, selectedInstitutionId: String?, onInstitutionSelected: (FinancialConnectionsInstitution, Boolean) -> Unit, institutions: Async&lt;InstitutionResponse>, onManualEntryClick: () -> Unit, onSearchMoreClick: () -> Unit )</ID>
+    <ID>SwallowedException:PollAttachPaymentAccount.kt$PollAttachPaymentAccount$e: StripeException</ID>
+    <ID>SwallowedException:PollAuthorizationSessionAccounts.kt$PollAuthorizationSessionAccounts$e: StripeException</ID>
+    <ID>SwallowedException:PostAuthorizationSession.kt$PostAuthorizationSession$e: StripeException</ID>
+    <ID>TooManyFunctions:FinancialConnectionsManifestRepository.kt$FinancialConnectionsManifestRepository</ID>
+    <ID>TooManyFunctions:FinancialConnectionsManifestRepository.kt$FinancialConnectionsManifestRepositoryImpl : FinancialConnectionsManifestRepository</ID>
+    <ID>TooManyFunctions:FinancialConnectionsSheetNativeViewModel.kt$FinancialConnectionsSheetNativeViewModel : MavericksViewModel</ID>
+  </CurrentIssues>
 </SmellBaseline>

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -48,7 +48,6 @@ import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Named
 
-@Suppress("LongParameterList", "TooManyFunctions")
 internal class FinancialConnectionsSheetViewModel @Inject constructor(
     @Named(APPLICATION_ID) private val applicationId: String,
     private val synchronizeFinancialConnectionsSession: SynchronizeFinancialConnectionsSession,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowRouter.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowRouter.kt
@@ -25,7 +25,6 @@ internal class NativeAuthFlowRouter @Inject constructor(
         return killSwitchEnabled.not() && nativeExperimentEnabled
     }
 
-    @Suppress("ComplexCondition")
     suspend fun logExposure(manifest: FinancialConnectionsSessionManifest) {
         debugConfiguration.overriddenNative?.let { return }
         if (nativeKillSwitchActive(manifest).not()) {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAttachPaymentAccount.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAttachPaymentAccount.kt
@@ -40,9 +40,7 @@ internal class PollAttachPaymentAccount @Inject constructor(
                     paymentAccount = params,
                     consumerSessionClientSecret = consumerSessionClientSecret
                 )
-            } catch (
-                @Suppress("SwallowedException") e: StripeException
-            ) {
+            } catch (e: StripeException) {
                 throw e.toDomainException(
                     activeInstitution,
                     sync.showManualEntryInErrors()

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts.kt
@@ -56,7 +56,7 @@ internal class PollAuthorizationSessionAccounts @Inject constructor(
                 accounts
             }
         }
-    } catch (@Suppress("SwallowedException") e: StripeException) {
+    } catch (e: StripeException) {
         throw e.toDomainException(
             institution = sync.manifest.activeInstitution,
             businessName = sync.manifest.getBusinessName(),

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PostAuthorizationSession.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PostAuthorizationSession.kt
@@ -39,9 +39,7 @@ internal class PostAuthorizationSession @Inject constructor(
                 institution = institution,
                 applicationId = applicationId
             )
-        } catch (
-            @Suppress("SwallowedException") e: StripeException
-        ) {
+        } catch (e: StripeException) {
             throw e.toDomainException(
                 showManualEntry = sync.showManualEntryInErrors(),
                 institution = institution

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerPreviewParameterProvider.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerPreviewParameterProvider.kt
@@ -1,5 +1,3 @@
-@file:Suppress("LongMethod")
-
 package com.stripe.android.financialconnections.features.accountpicker
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions", "LongMethod")
-
 package com.stripe.android.financialconnections.features.accountpicker
 
 import androidx.activity.compose.BackHandler
@@ -279,7 +277,6 @@ private fun LazyListScope.loadedContent(
     }
 }
 
-@Suppress("MagicNumber")
 private fun LazyListScope.loadingContent() {
     item {
         Text(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
@@ -40,7 +40,6 @@ import kotlinx.coroutines.launch
 import java.util.Date
 import javax.inject.Inject
 
-@Suppress("LongParameterList", "TooManyFunctions")
 internal class AccountPickerViewModel @Inject constructor(
     initialState: AccountPickerState,
     private val eventTracker: FinancialConnectionsAnalyticsTracker,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
@@ -26,7 +26,6 @@ import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativ
 import com.stripe.android.financialconnections.utils.measureTimeMillis
 import javax.inject.Inject
 
-@Suppress("LongParameterList")
 internal class AttachPaymentViewModel @Inject constructor(
     initialState: AttachPaymentState,
     private val saveToLinkWithStripeSucceeded: SaveToLinkWithStripeSucceededRepository,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/bankauthrepair/BankAuthRepairScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/bankauthrepair/BankAuthRepairScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("LongMethod")
-
 package com.stripe.android.financialconnections.features.bankauthrepair
 
 import androidx.compose.runtime.Composable

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/AccountItem.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/AccountItem.kt
@@ -55,7 +55,6 @@ import java.util.Locale
  * @param networkedAccount For networked accounts, extra info to display
  */
 @Composable
-@Suppress("LongMethod")
 internal fun AccountItem(
     selected: Boolean,
     showInstitutionIcon: Boolean = true,
@@ -181,7 +180,6 @@ private fun PartnerAccount.getFormattedBalance(): String? {
     }
 }
 
-@Suppress("LongMethod")
 @Composable
 @Preview
 internal fun AccountItemPreview() {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ConsumerSessionExtensions.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ConsumerSessionExtensions.kt
@@ -3,7 +3,6 @@ import com.stripe.android.model.ConsumerSession
 /**
  * Mask the phone number to show only the last 4 digits.
  */
-@Suppress("MagicNumber")
 internal fun ConsumerSession.getRedactedPhoneNumber(): String {
     val number = redactedPhoneNumber.replace("*", "•")
     val formattedPhoneNumber = buildString {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ErrorContent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ErrorContent.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.stripe.android.financialconnections.features.common
 
 import android.os.Build

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/MerchantDataAccessText.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/MerchantDataAccessText.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions", "LongMethod")
-
 package com.stripe.android.financialconnections.features.common
 
 import androidx.compose.foundation.layout.Arrangement

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ModalBottomSheetContent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ModalBottomSheetContent.kt
@@ -1,5 +1,3 @@
-@file:Suppress("LongMethod")
-
 package com.stripe.android.financialconnections.features.common
 
 import androidx.compose.foundation.layout.Column

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/SharedPartnerAuth.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/SharedPartnerAuth.kt
@@ -136,7 +136,6 @@ private fun SharedPartnerAuthContent(
 }
 
 @Composable
-@Suppress("MagicNumber")
 private fun SharedPartnerLoading(inModal: Boolean) {
     LoadingShimmerEffect { shimmerBrush ->
         Column(
@@ -287,7 +286,6 @@ private fun LoadedContent(
 }
 
 @Composable
-@Suppress("LongMethod")
 private fun PrePaneContent(
     showInModal: Boolean,
     content: OauthPrepane,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentPreviewParameterProvider.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentPreviewParameterProvider.kt
@@ -98,7 +98,6 @@ internal class ConsentPreviewParameterProvider :
         )
     )
 
-    @Suppress("LongMethod")
     private fun sampleConsent(): ConsentPane = ConsentPane(
         title = "Goldilocks uses Stripe to link your accounts",
         body = ConsentPaneBody(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
@@ -1,9 +1,3 @@
-@file:OptIn(
-    ExperimentalMaterialApi::class,
-    ExperimentalComposeUiApi::class
-)
-@file:Suppress("LongMethod", "TooManyFunctions")
-
 package com.stripe.android.financialconnections.features.consent
 
 import androidx.activity.compose.BackHandler

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ui/ConsentLogoHeader.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ui/ConsentLogoHeader.kt
@@ -47,7 +47,6 @@ import androidx.compose.ui.unit.dp
 import com.stripe.android.financialconnections.ui.LocalImageLoader
 
 @Composable
-@Suppress("MagicNumber")
 internal fun ConsentLogoHeader(
     modifier: Modifier = Modifier,
     logos: List<String>
@@ -221,7 +220,6 @@ private fun Logo(imageBitmap: ImageBitmap) {
  *
  * @param startSide whether the quarter is the start or end of the bitmap
  */
-@Suppress("MagicNumber")
 private fun getPrevalentColorCloseToDots(bitmap: Bitmap, startSide: Boolean): Color {
     val colorMap = HashMap<Int, Int>()
     val width = bitmap.width

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/error/ErrorPreviewParameterProvider.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/error/ErrorPreviewParameterProvider.kt
@@ -1,5 +1,3 @@
-@file:Suppress("LongMethod")
-
 package com.stripe.android.financialconnections.features.error
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions", "LongMethod")
-
 package com.stripe.android.financialconnections.features.institutionpicker
 
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -211,7 +209,6 @@ private fun LoadedContent(
     }
 }
 
-@Suppress("MagicNumber", "NestedBlockDepth")
 private fun LazyListScope.searchResults(
     isInputEmpty: Boolean,
     payload: Payload,
@@ -536,7 +533,6 @@ private fun InstitutionResultTile(
 }
 
 @Composable
-@Suppress("MagicNumber")
 private fun InstitutionResultShimmer(modifier: Modifier) {
     LoadingShimmerEffect { shimmer ->
         Row(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModel.kt
@@ -42,7 +42,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@Suppress("LongParameterList")
 internal class InstitutionPickerViewModel @Inject constructor(
     private val configuration: FinancialConnectionsSheet.Configuration,
     private val postAuthorizationSession: PostAuthorizationSession,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerPreviewParameterProvider.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerPreviewParameterProvider.kt
@@ -1,5 +1,3 @@
-@file:Suppress("LongMethod")
-
 package com.stripe.android.financialconnections.features.linkaccountpicker
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerScreen.kt
@@ -296,7 +296,6 @@ private fun LazyListScope.loadedContent(
     }
 }
 
-@Suppress("MagicNumber")
 private fun LazyListScope.loadingContent() {
     item {
         Text(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationPreviewParameterProvider.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationPreviewParameterProvider.kt
@@ -1,5 +1,3 @@
-@file:Suppress("LongMethod")
-
 package com.stripe.android.financialconnections.features.linkstepupverification
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryInputValidator.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryInputValidator.kt
@@ -26,7 +26,6 @@ internal object ManualEntryInputValidator {
         else -> null
     }
 
-    @Suppress("MagicNumber")
     private fun String.isUSRoutingNumber(): Boolean {
         val usRoutingFactor: (Int) -> Int = {
             when (it % 3) {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.stripe.android.financialconnections.features.manualentry
 
 import androidx.compose.foundation.ScrollState
@@ -125,7 +123,6 @@ private fun ManualEntryContent(
 }
 
 @Composable
-@Suppress("LongMethod")
 private fun ManualEntryLoaded(
     scrollState: ScrollState,
     payload: Payload,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
@@ -24,7 +24,6 @@ import com.stripe.android.financialconnections.navigation.NavigationManager
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
 import javax.inject.Inject
 
-@Suppress("LongParameterList")
 internal class ManualEntryViewModel @Inject constructor(
     initialState: ManualEntryState,
     private val nativeAuthFlowCoordinator: NativeAuthFlowCoordinator,
@@ -124,7 +123,6 @@ internal class ManualEntryViewModel @Inject constructor(
         }
     }
 
-    @Suppress("MagicNumber")
     fun onSubmit() {
         suspend {
             val state = awaitState()

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions", "LongMethod")
-
 package com.stripe.android.financialconnections.features.manualentrysuccess
 
 import androidx.activity.compose.BackHandler

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessViewModel.kt
@@ -23,7 +23,6 @@ import com.stripe.android.financialconnections.ui.TextResource.StringId
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@Suppress("LongParameterList")
 internal class ManualEntrySuccessViewModel @Inject constructor(
     initialState: ManualEntrySuccessState,
     private val getManifest: GetManifest,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationPreviewParameterProvider.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationPreviewParameterProvider.kt
@@ -1,5 +1,3 @@
-@file:Suppress("LongMethod")
-
 package com.stripe.android.financialconnections.features.networkinglinkverification
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationScreen.kt
@@ -97,7 +97,7 @@ private fun NetworkingLinkVerificationLoaded(
     LaunchedEffect(confirmVerificationAsync) {
         if (confirmVerificationAsync is Loading) {
             focusManager.clearFocus(true)
-            @Suppress()
+            @Suppress("DEPRECATION")
             textInputService?.hideSoftwareKeyboard()
         }
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationPreviewParameterProvider.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationPreviewParameterProvider.kt
@@ -1,5 +1,3 @@
-@file:Suppress("LongMethod")
-
 package com.stripe.android.financialconnections.features.networkingsavetolinkverification
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthPreviewParameterProvider.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthPreviewParameterProvider.kt
@@ -1,5 +1,3 @@
-@file:Suppress("LongMethod")
-
 package com.stripe.android.financialconnections.features.partnerauth
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("LongMethod")
-
 package com.stripe.android.financialconnections.features.partnerauth
 
 import androidx.compose.runtime.Composable

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
@@ -56,7 +56,6 @@ import javax.inject.Inject
 import javax.inject.Named
 import com.stripe.android.financialconnections.features.partnerauth.SharedPartnerAuthState.AuthenticationStatus as Status
 
-@Suppress("LongParameterList")
 internal class PartnerAuthViewModel @Inject constructor(
     private val completeAuthorizationSession: CompleteAuthorizationSession,
     private val createAuthorizationSession: PostAuthorizationSession,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessContent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessContent.kt
@@ -255,7 +255,6 @@ private fun SuccessFooter(
     group = "Success",
     name = "Loading"
 )
-@Suppress("LongMethod")
 @Composable
 internal fun SuccessScreenPreview(
     @PreviewParameter(SuccessPreviewParameterProvider::class) state: SuccessState
@@ -275,7 +274,6 @@ internal fun SuccessScreenPreview(
     group = "Success",
     name = "Animation completed"
 )
-@Suppress("LongMethod")
 @Composable
 internal fun SuccessScreenAnimationCompletedPreview(
     @PreviewParameter(SuccessPreviewParameterProvider::class) state: SuccessState

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessPreviewParameterProvider.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessPreviewParameterProvider.kt
@@ -1,5 +1,3 @@
-@file:Suppress("LongMethod")
-
 package com.stripe.android.financialconnections.features.success
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessViewModel.kt
@@ -25,7 +25,6 @@ import com.stripe.android.financialconnections.ui.TextResource
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@Suppress("LongParameterList")
 internal class SuccessViewModel @Inject constructor(
     initialState: SuccessState,
     getCachedAccounts: GetCachedAccounts,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsAuthorizationSession.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsAuthorizationSession.kt
@@ -20,7 +20,6 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 @Parcelize
-@Suppress("ConstructorParameterNaming")
 internal data class FinancialConnectionsAuthorizationSession(
 
     @SerialName(value = "id")

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsSessionManifest.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsSessionManifest.kt
@@ -47,7 +47,6 @@ import kotlinx.serialization.Serializable
  * @param paymentMethodType
  * @param successUrl
  */
-@Suppress("MaxLineLength")
 @Serializable
 @Parcelize
 internal data class FinancialConnectionsSessionManifest(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/PartnerAccountsList.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/PartnerAccountsList.kt
@@ -43,7 +43,6 @@ internal data class PartnerAccountsList(
  */
 @Serializable
 @Parcelize
-@Suppress("ConstructorParameterNaming")
 internal data class PartnerAccount(
 
     @SerialName(value = "authorization") @Required val authorization: String,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -54,7 +54,6 @@ import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 import javax.inject.Named
 
-@Suppress("LongParameterList", "TooManyFunctions")
 internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
     /**
      * Exposes parent dagger component (activity viewModel scoped so that it survives config changes)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsUrls.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsUrls.kt
@@ -1,5 +1,3 @@
-@file:Suppress("MaxLineLength", "MaximumLineLength")
-
 package com.stripe.android.financialconnections.presentation
 
 internal object FinancialConnectionsUrls {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepository.kt
@@ -23,7 +23,6 @@ import java.util.Locale
  * Repository to centralize reads and writes to the [FinancialConnectionsSessionManifest]
  * of the current flow.
  */
-@Suppress("TooManyFunctions")
 internal interface FinancialConnectionsManifestRepository {
 
     /**
@@ -199,7 +198,6 @@ internal interface FinancialConnectionsManifestRepository {
     }
 }
 
-@Suppress("TooManyFunctions")
 private class FinancialConnectionsManifestRepositoryImpl(
     val requestExecutor: FinancialConnectionsRequestExecutor,
     val apiRequestFactory: ApiRequest.Factory,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -114,7 +114,6 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
         }
     }
 
-    @Suppress("LongMethod")
     @Composable
     fun NavHost(
         initialPane: Pane,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Button.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Button.kt
@@ -1,5 +1,3 @@
-@file:Suppress("ktlint:filename")
-
 package com.stripe.android.financialconnections.ui.components
 
 import android.os.Build.VERSION.SDK_INT

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Scaffold.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Scaffold.kt
@@ -1,5 +1,3 @@
-@file:Suppress("ktlint:filename")
-
 package com.stripe.android.financialconnections.ui.components
 
 import androidx.compose.foundation.layout.PaddingValues

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Text.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Text.kt
@@ -1,5 +1,3 @@
-@file:Suppress("MatchingDeclarationName")
-
 package com.stripe.android.financialconnections.ui.components
 
 import android.graphics.Typeface

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TextField.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TextField.kt
@@ -1,6 +1,3 @@
-@file:OptIn(ExperimentalMaterialApi::class)
-@file:Suppress("ktlint:filename")
-
 package com.stripe.android.financialconnections.ui.components
 
 import androidx.compose.foundation.layout.Arrangement
@@ -9,7 +6,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ExposedDropdownMenuDefaults.outlinedTextFieldColors
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.runtime.Composable

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
@@ -1,5 +1,3 @@
-@file:Suppress("ktlint:filename")
-
 package com.stripe.android.financialconnections.ui.components
 
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/sdui/ServerDrivenUi.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/sdui/ServerDrivenUi.kt
@@ -1,5 +1,3 @@
-@file:Suppress("MatchingDeclarationName")
-
 package com.stripe.android.financialconnections.ui.sdui
 
 import android.os.Build

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Color.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Color.kt
@@ -1,5 +1,3 @@
-@file:Suppress("MagicNumber")
-
 package com.stripe.android.financialconnections.ui.theme
 
 import androidx.compose.foundation.background

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Layout.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Layout.kt
@@ -90,7 +90,6 @@ internal fun Layout(
 }
 
 @Composable
-@Suppress("MagicNumber")
 private fun BoxScope.FooterTopShadow() {
     val shadowSize = 4
     Box(
@@ -112,7 +111,6 @@ private fun BoxScope.FooterTopShadow() {
 }
 
 @Preview(showBackground = true)
-@Suppress("MagicNumber")
 @Composable
 internal fun LayoutPreview() {
     FinancialConnectionsTheme {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Type.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Type.kt
@@ -1,5 +1,3 @@
-@file:Suppress("MatchingDeclarationName", "ktlint:filename")
-
 package com.stripe.android.financialconnections.ui.theme
 
 import androidx.compose.foundation.background


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request moves the warning suppressions out of the code and into a baseline file.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
