### PR TITLE
Relax maximum length requirement for `PhoneNumberFormatter`

### DIFF
--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
@@ -55,11 +55,9 @@ internal sealed class PhoneNumberFormatter {
         override val placeholder = metadata.pattern.replace('#', '5')
         override val countryCode = metadata.regionCode
 
-        private val maxSubscriberDigits = metadata.pattern.count { it == '#' }
-
         override fun userInputFilter(input: String) =
             input.filter { VALID_INPUT_RANGE.contains(it) }.run {
-                substring(0, min(length, maxSubscriberDigits))
+                substring(0, min(length, E164_MAX_DIGITS))
             }
 
         override fun toE164Format(input: String) = "${prefix}${userInputFilter(input).trimStart('0')}"


### PR DESCRIPTION
# Summary
Relax maximum length requirement for `PhoneNumberFormatter`.

# Motivation
The length requirement in `PhoneNumberController` is coded to have the minimum and maximum length the same. This is not accurate for all countries which can have different minimum and maximum lengths. Disabling this to allow all phone number lengths. We should re-enable this with a better solution in the future.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
