### PR TITLE
Make SharedDataSpec Parcelable, and pass it with PaymentMethodMetadata.

### DIFF
--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -66,7 +66,31 @@ public final class com/stripe/android/ui/core/elements/AddressSpec$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/AddressSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/AddressSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/AddressSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/ui/core/elements/AffirmTextSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/AffirmTextSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/AffirmTextSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement$Companion {
+}
+
+public final class com/stripe/android/ui/core/elements/AfterpayClearpayTextSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/AfterpayClearpayTextSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/AfterpayClearpayTextSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/ui/core/elements/AuBankAccountNumberSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -85,6 +109,22 @@ public final class com/stripe/android/ui/core/elements/AuBankAccountNumberSpec$C
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/AuBankAccountNumberSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/AuBankAccountNumberSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/AuBankAccountNumberSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/ui/core/elements/AuBecsDebitMandateTextSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/AuBecsDebitMandateTextSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/AuBecsDebitMandateTextSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/ui/core/elements/BacsDebitBankAccountSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/BacsDebitBankAccountSpec$$serializer;
@@ -95,6 +135,14 @@ public final class com/stripe/android/ui/core/elements/BacsDebitBankAccountSpec$
 	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/ui/core/elements/BacsDebitBankAccountSpec;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/BacsDebitBankAccountSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/BacsDebitBankAccountSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/BacsDebitBankAccountSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/ui/core/elements/BacsDebitConfirmSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -113,6 +161,14 @@ public final class com/stripe/android/ui/core/elements/BacsDebitConfirmSpec$Comp
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/BacsDebitConfirmSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/BacsDebitConfirmSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/BacsDebitConfirmSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/ui/core/elements/BlikSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/BlikSpec$$serializer;
@@ -127,6 +183,14 @@ public final class com/stripe/android/ui/core/elements/BlikSpec$$serializer : ko
 
 public final class com/stripe/android/ui/core/elements/BlikSpec$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/BlikSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/BlikSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/BlikSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/ui/core/elements/BoletoTaxIdSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -145,6 +209,14 @@ public final class com/stripe/android/ui/core/elements/BoletoTaxIdSpec$Companion
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/BoletoTaxIdSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/BoletoTaxIdSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/BoletoTaxIdSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/ui/core/elements/BsbSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/BsbSpec$$serializer;
@@ -159,6 +231,14 @@ public final class com/stripe/android/ui/core/elements/BsbSpec$$serializer : kot
 
 public final class com/stripe/android/ui/core/elements/BsbSpec$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/BsbSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/BsbSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/BsbSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/ui/core/elements/Capitalization : java/lang/Enum {
@@ -192,6 +272,14 @@ public final class com/stripe/android/ui/core/elements/CardBillingSpec$Companion
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/CardBillingSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/CardBillingSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/CardBillingSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/ui/core/elements/CardDetailsSectionSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/CardDetailsSectionSpec$$serializer;
@@ -206,6 +294,14 @@ public final class com/stripe/android/ui/core/elements/CardDetailsSectionSpec$$s
 
 public final class com/stripe/android/ui/core/elements/CardDetailsSectionSpec$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/CardDetailsSectionSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/CardDetailsSectionSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/CardDetailsSectionSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/ui/core/elements/CashAppPayMandateTextSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -224,15 +320,37 @@ public final class com/stripe/android/ui/core/elements/CashAppPayMandateTextSpec
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public abstract class com/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs {
+public final class com/stripe/android/ui/core/elements/CashAppPayMandateTextSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/CashAppPayMandateTextSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/CashAppPayMandateTextSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public abstract class com/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs : android/os/Parcelable {
 	public static final field $stable I
 	public static final field Companion Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$Companion;
 }
 
 public final class com/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$CanceledSpec : com/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs {
 	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$CanceledSpec;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$CanceledSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$CanceledSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$CanceledSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$Companion {
@@ -241,12 +359,27 @@ public final class com/stripe/android/ui/core/elements/ConfirmResponseStatusSpec
 
 public final class com/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$FinishedSpec : com/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs {
 	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$FinishedSpec;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$FinishedSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$FinishedSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$FinishedSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$RedirectNextActionSpec : com/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs {
 	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$RedirectNextActionSpec$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
@@ -255,11 +388,13 @@ public final class com/stripe/android/ui/core/elements/ConfirmResponseStatusSpec
 	public final fun component2 ()Ljava/lang/String;
 	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$RedirectNextActionSpec;
 	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$RedirectNextActionSpec;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$RedirectNextActionSpec;
+	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getReturnUrlPath ()Ljava/lang/String;
 	public final fun getUrlPath ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$RedirectNextActionSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -278,13 +413,22 @@ public final class com/stripe/android/ui/core/elements/ConfirmResponseStatusSpec
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$RedirectNextActionSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$RedirectNextActionSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$RedirectNextActionSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/ui/core/elements/ConfirmResponseStatusSpecsSerializer : kotlinx/serialization/json/JsonContentPolymorphicSerializer {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecsSerializer;
 }
 
-public final class com/stripe/android/ui/core/elements/ConfirmStatusSpecAssociation {
+public final class com/stripe/android/ui/core/elements/ConfirmStatusSpecAssociation : android/os/Parcelable {
 	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/ui/core/elements/ConfirmStatusSpecAssociation$Companion;
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;)V
@@ -297,6 +441,7 @@ public final class com/stripe/android/ui/core/elements/ConfirmStatusSpecAssociat
 	public final fun component6 ()Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;
 	public final fun copy (Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;)Lcom/stripe/android/ui/core/elements/ConfirmStatusSpecAssociation;
 	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/ConfirmStatusSpecAssociation;Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/ConfirmStatusSpecAssociation;
+	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCanceled ()Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;
 	public final fun getMap ()Ljava/util/Map;
@@ -307,6 +452,7 @@ public final class com/stripe/android/ui/core/elements/ConfirmStatusSpecAssociat
 	public final fun getSucceeded ()Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/stripe/android/ui/core/elements/ConfirmStatusSpecAssociation$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -325,6 +471,14 @@ public final class com/stripe/android/ui/core/elements/ConfirmStatusSpecAssociat
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/ConfirmStatusSpecAssociation$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/ConfirmStatusSpecAssociation;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/ConfirmStatusSpecAssociation;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/ui/core/elements/ContactInformationSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/ContactInformationSpec$$serializer;
@@ -341,6 +495,14 @@ public final class com/stripe/android/ui/core/elements/ContactInformationSpec$Co
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/ContactInformationSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/ContactInformationSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/ContactInformationSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/ui/core/elements/CountrySpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/CountrySpec$$serializer;
@@ -355,6 +517,14 @@ public final class com/stripe/android/ui/core/elements/CountrySpec$$serializer :
 
 public final class com/stripe/android/ui/core/elements/CountrySpec$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/CountrySpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/CountrySpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/CountrySpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/ui/core/elements/DisplayField : java/lang/Enum {
@@ -385,6 +555,14 @@ public final class com/stripe/android/ui/core/elements/DropdownItemSpec$Companio
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/DropdownItemSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/DropdownItemSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/DropdownItemSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/ui/core/elements/DropdownSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/DropdownSpec$$serializer;
@@ -401,6 +579,14 @@ public final class com/stripe/android/ui/core/elements/DropdownSpec$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/DropdownSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/DropdownSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/DropdownSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/ui/core/elements/EmailSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/EmailSpec$$serializer;
@@ -415,6 +601,22 @@ public final class com/stripe/android/ui/core/elements/EmailSpec$$serializer : k
 
 public final class com/stripe/android/ui/core/elements/EmailSpec$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/EmailSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/EmailSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/EmailSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/ui/core/elements/EmptyFormSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/EmptyFormSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/EmptyFormSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/ui/core/elements/FormItemSpec$Companion {
@@ -440,6 +642,14 @@ public final class com/stripe/android/ui/core/elements/IbanSpec$$serializer : ko
 
 public final class com/stripe/android/ui/core/elements/IbanSpec$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/IbanSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/IbanSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/IbanSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/ui/core/elements/KeyboardType : java/lang/Enum {
@@ -477,20 +687,28 @@ public final class com/stripe/android/ui/core/elements/KlarnaCountrySpec$Compani
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/stripe/android/ui/core/elements/KonbiniConfirmationNumberSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field $stable I
-	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/KonbiniConfirmationNumberSpec$$serializer;
-	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/ui/core/elements/KonbiniConfirmationNumberSpec;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/ui/core/elements/KonbiniConfirmationNumberSpec;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+public final class com/stripe/android/ui/core/elements/KlarnaCountrySpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/KlarnaCountrySpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/KlarnaCountrySpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/ui/core/elements/KonbiniConfirmationNumberSpec$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+public final class com/stripe/android/ui/core/elements/KlarnaHeaderStaticTextSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/KlarnaHeaderStaticTextSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/KlarnaHeaderStaticTextSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/ui/core/elements/KonbiniConfirmationNumberSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/KonbiniConfirmationNumberSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/KonbiniConfirmationNumberSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/ui/core/elements/LayoutSpec$Companion {
@@ -514,6 +732,14 @@ public final class com/stripe/android/ui/core/elements/MandateTextSpec$Companion
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/MandateTextSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/MandateTextSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/MandateTextSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/ui/core/elements/NameSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/NameSpec$$serializer;
@@ -530,8 +756,17 @@ public final class com/stripe/android/ui/core/elements/NameSpec$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/stripe/android/ui/core/elements/NextActionSpec {
+public final class com/stripe/android/ui/core/elements/NameSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/NameSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/NameSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/ui/core/elements/NextActionSpec : android/os/Parcelable {
 	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/ui/core/elements/NextActionSpec$Companion;
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/ui/core/elements/ConfirmStatusSpecAssociation;Lcom/stripe/android/ui/core/elements/PostConfirmStatusSpecAssociation;)V
@@ -540,11 +775,13 @@ public final class com/stripe/android/ui/core/elements/NextActionSpec {
 	public final fun component2 ()Lcom/stripe/android/ui/core/elements/PostConfirmStatusSpecAssociation;
 	public final fun copy (Lcom/stripe/android/ui/core/elements/ConfirmStatusSpecAssociation;Lcom/stripe/android/ui/core/elements/PostConfirmStatusSpecAssociation;)Lcom/stripe/android/ui/core/elements/NextActionSpec;
 	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/NextActionSpec;Lcom/stripe/android/ui/core/elements/ConfirmStatusSpecAssociation;Lcom/stripe/android/ui/core/elements/PostConfirmStatusSpecAssociation;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/NextActionSpec;
+	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConfirmResponseStatusSpecs ()Lcom/stripe/android/ui/core/elements/ConfirmStatusSpecAssociation;
 	public final fun getPostConfirmHandlingPiStatusSpecs ()Lcom/stripe/android/ui/core/elements/PostConfirmStatusSpecAssociation;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/stripe/android/ui/core/elements/NextActionSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -563,12 +800,28 @@ public final class com/stripe/android/ui/core/elements/NextActionSpec$Companion 
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/NextActionSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/NextActionSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/NextActionSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/ui/core/elements/NextActionSpecKt {
 	public static final fun filterNotNullValues (Ljava/util/Map;)Ljava/util/Map;
 	public static final fun getNextActionFromSpec (Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;)Lcom/stripe/android/model/LuxePostConfirmActionCreator;
 	public static final fun mapToOutcome (Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs;)Ljava/lang/Integer;
 	public static final fun mapToOutcome (Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;)Ljava/lang/Integer;
 	public static final fun transform (Lcom/stripe/android/ui/core/elements/NextActionSpec;)Lcom/stripe/android/model/LuxePostConfirmActionRepository$LuxeAction;
+}
+
+public final class com/stripe/android/ui/core/elements/OTPSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/OTPSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/OTPSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/ui/core/elements/PhoneSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -587,6 +840,14 @@ public final class com/stripe/android/ui/core/elements/PhoneSpec$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/PhoneSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/PhoneSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/PhoneSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/ui/core/elements/PlaceholderSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/PlaceholderSpec$$serializer;
@@ -603,19 +864,41 @@ public final class com/stripe/android/ui/core/elements/PlaceholderSpec$Companion
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/PlaceholderSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/PlaceholderSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/PlaceholderSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/ui/core/elements/PlaceholderSpec$PlaceholderField$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public abstract class com/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs {
+public abstract class com/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs : android/os/Parcelable {
 	public static final field $stable I
 	public static final field Companion Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs$Companion;
 }
 
 public final class com/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs$CanceledSpec : com/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs {
 	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs$CanceledSpec;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs$CanceledSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs$CanceledSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs$CanceledSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs$Companion {
@@ -624,8 +907,22 @@ public final class com/stripe/android/ui/core/elements/PostConfirmHandlingPiStat
 
 public final class com/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs$FinishedSpec : com/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs {
 	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs$FinishedSpec;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs$FinishedSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs$FinishedSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs$FinishedSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecsSerializer : kotlinx/serialization/json/JsonContentPolymorphicSerializer {
@@ -633,8 +930,9 @@ public final class com/stripe/android/ui/core/elements/PostConfirmHandlingPiStat
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecsSerializer;
 }
 
-public final class com/stripe/android/ui/core/elements/PostConfirmStatusSpecAssociation {
+public final class com/stripe/android/ui/core/elements/PostConfirmStatusSpecAssociation : android/os/Parcelable {
 	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/ui/core/elements/PostConfirmStatusSpecAssociation$Companion;
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;)V
@@ -647,6 +945,7 @@ public final class com/stripe/android/ui/core/elements/PostConfirmStatusSpecAsso
 	public final fun component6 ()Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;
 	public final fun copy (Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;)Lcom/stripe/android/ui/core/elements/PostConfirmStatusSpecAssociation;
 	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/PostConfirmStatusSpecAssociation;Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/PostConfirmStatusSpecAssociation;
+	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCanceled ()Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;
 	public final fun getMap ()Ljava/util/Map;
@@ -657,6 +956,7 @@ public final class com/stripe/android/ui/core/elements/PostConfirmStatusSpecAsso
 	public final fun getSucceeded ()Lcom/stripe/android/ui/core/elements/PostConfirmHandlingPiStatusSpecs;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/stripe/android/ui/core/elements/PostConfirmStatusSpecAssociation$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -673,6 +973,14 @@ public final class com/stripe/android/ui/core/elements/PostConfirmStatusSpecAsso
 
 public final class com/stripe/android/ui/core/elements/PostConfirmStatusSpecAssociation$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/PostConfirmStatusSpecAssociation$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/PostConfirmStatusSpecAssociation;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/PostConfirmStatusSpecAssociation;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/ui/core/elements/SaveForFutureUseElementUIKt {
@@ -695,6 +1003,14 @@ public final class com/stripe/android/ui/core/elements/SaveForFutureUseSpec$Comp
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/SaveForFutureUseSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/SaveForFutureUseSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/SaveForFutureUseSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/ui/core/elements/SelectorIcon$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/SelectorIcon$$serializer;
@@ -709,6 +1025,14 @@ public final class com/stripe/android/ui/core/elements/SelectorIcon$$serializer 
 
 public final class com/stripe/android/ui/core/elements/SelectorIcon$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/SelectorIcon$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/SelectorIcon;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/SelectorIcon;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/ui/core/elements/SepaMandateTextSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -727,6 +1051,14 @@ public final class com/stripe/android/ui/core/elements/SepaMandateTextSpec$Compa
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/SepaMandateTextSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/SepaMandateTextSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/SepaMandateTextSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/ui/core/elements/SharedDataSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/SharedDataSpec$$serializer;
@@ -743,6 +1075,14 @@ public final class com/stripe/android/ui/core/elements/SharedDataSpec$Companion 
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/SharedDataSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/SharedDataSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/SharedDataSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/ui/core/elements/SimpleTextSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/SimpleTextSpec$$serializer;
@@ -757,6 +1097,22 @@ public final class com/stripe/android/ui/core/elements/SimpleTextSpec$$serialize
 
 public final class com/stripe/android/ui/core/elements/SimpleTextSpec$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/SimpleTextSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/SimpleTextSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/SimpleTextSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/ui/core/elements/StaticTextSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/StaticTextSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/StaticTextSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/ui/core/elements/TranslationId$Companion {
@@ -777,6 +1133,14 @@ public final class com/stripe/android/ui/core/elements/UpiSpec$$serializer : kot
 
 public final class com/stripe/android/ui/core/elements/UpiSpec$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/UpiSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/UpiSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/UpiSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy$Companion {

--- a/payments-ui-core/detekt-baseline.xml
+++ b/payments-ui-core/detekt-baseline.xml
@@ -53,8 +53,6 @@
     <ID>MaxLineLength:CardNumberConfigTest.kt$CardNumberConfigTest$val state = cardNumberConfig.determineState(CardBrand.Visa, "4242424242424242", CardBrand.Visa.getMaxLengthForCardNumber("4242424242424242"))</ID>
     <ID>MaxLineLength:CardNumberConfigTest.kt$CardNumberConfigTest$val state = cardNumberConfig.determineState(CardBrand.Visa, "4242424242424243", CardBrand.Visa.getMaxLengthForCardNumber("4242424242424243"))</ID>
     <ID>MaxLineLength:CardNumberControllerTest.kt$CardNumberControllerTest$fun</ID>
-    <ID>MaxLineLength:NextActionSpec.kt$PostConfirmHandlingPiStatusSpecsSerializer$override</ID>
-    <ID>MaximumLineLength:com.stripe.android.ui.core.elements.NextActionSpec.kt:63</ID>
     <ID>SpreadOperator:BsbElementUI.kt$( it.errorMessage, *args )</ID>
     <ID>SpreadOperator:MandateTextUI.kt$(element.stringResId, *element.args.toTypedArray())</ID>
     <ID>TooGenericExceptionCaught:PlacesClientProxy.kt$DefaultPlacesClientProxy$e: Exception</ID>

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.ui.core.elements
 
+import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.ui.core.R
@@ -13,6 +14,7 @@ import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SameAsShippingController
 import com.stripe.android.uicore.elements.SameAsShippingElement
 import com.stripe.android.uicore.elements.SectionElement
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -25,6 +27,7 @@ enum class DisplayField {
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 @Serializable
+@Parcelize
 data class AddressSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("billing_details[address]"),
@@ -50,7 +53,7 @@ data class AddressSpec(
      */
     @Transient
     val hideCountry: Boolean = false,
-) : FormItemSpec() {
+) : FormItemSpec(), Parcelable {
     fun transform(
         initialValues: Map<IdentifierSpec, String?>,
         addressRepository: AddressRepository,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AffirmTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AffirmTextSpec.kt
@@ -2,6 +2,7 @@ package com.stripe.android.ui.core.elements
 
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -9,6 +10,7 @@ import kotlinx.serialization.Serializable
  * Header that displays promo information about Affirm
  */
 @Serializable
+@Parcelize
 internal data class AffirmTextSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("affirm_header")

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayTextSpec.kt
@@ -3,6 +3,7 @@ package com.stripe.android.ui.core.elements
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -10,6 +11,7 @@ import kotlinx.serialization.Serializable
  * Header that displays information about installments for Afterpay
  */
 @Serializable
+@Parcelize
 internal data class AfterpayClearpayTextSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("afterpay_text")

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBankAccountNumberSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBankAccountNumberSpec.kt
@@ -4,12 +4,14 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SimpleTextElement
 import com.stripe.android.uicore.elements.SimpleTextFieldController
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 @Serializable
-class AuBankAccountNumberSpec(
+@Parcelize
+data class AuBankAccountNumberSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic(
         "au_becs_debit[account_number]"

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateTextSpec.kt
@@ -2,10 +2,12 @@ package com.stripe.android.ui.core.elements
 
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@Parcelize
 internal data class AuBecsDebitMandateTextSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("au_becs_mandate")

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitBankAccountSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitBankAccountSpec.kt
@@ -15,6 +15,7 @@ import kotlinx.serialization.Serializable
 class BacsDebitBankAccountSpec : FormItemSpec() {
     @IgnoredOnParcel
     private val sortCodeIdentifier = IdentifierSpec.Generic(SORT_CODE_API_PATH)
+
     @IgnoredOnParcel
     private val accountNumberIdentifier = IdentifierSpec.Generic(ACCOUNT_NUMBER_API_PATH)
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitBankAccountSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitBankAccountSpec.kt
@@ -5,14 +5,20 @@ import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SimpleTextElement
 import com.stripe.android.uicore.elements.SimpleTextFieldController
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 @Serializable
+@Parcelize
 class BacsDebitBankAccountSpec : FormItemSpec() {
+    @IgnoredOnParcel
     private val sortCodeIdentifier = IdentifierSpec.Generic(SORT_CODE_API_PATH)
+    @IgnoredOnParcel
     private val accountNumberIdentifier = IdentifierSpec.Generic(ACCOUNT_NUMBER_API_PATH)
 
+    @IgnoredOnParcel
     override val apiPath: IdentifierSpec = IdentifierSpec()
 
     fun transform(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitConfirmSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitConfirmSpec.kt
@@ -5,11 +5,15 @@ import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.CheckboxFieldController
 import com.stripe.android.uicore.elements.CheckboxFieldElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 @Serializable
+@Parcelize
 class BacsDebitConfirmSpec : FormItemSpec() {
+    @IgnoredOnParcel
     override val apiPath: IdentifierSpec = IdentifierSpec.BacsDebitConfirmed
 
     fun transform(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BlikSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BlikSpec.kt
@@ -3,11 +3,13 @@ package com.stripe.android.ui.core.elements
 import androidx.annotation.RestrictTo
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionElement
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 @Serializable
+@Parcelize
 data class BlikSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Blik

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BoletoTaxIdSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BoletoTaxIdSpec.kt
@@ -4,16 +4,20 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
 @Serializable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+@Parcelize
 data class BoletoTaxIdSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("boleto[tax_id]")
 ) : FormItemSpec() {
+    @IgnoredOnParcel
     @Transient
     private val simpleTextSpec =
         SimpleTextSpec(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbSpec.kt
@@ -3,11 +3,13 @@ package com.stripe.android.ui.core.elements
 import androidx.annotation.RestrictTo
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.view.BecsDebitBanks
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 @Serializable
+@Parcelize
 data class BsbSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingSpec.kt
@@ -9,11 +9,13 @@ import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SameAsShippingController
 import com.stripe.android.uicore.elements.SameAsShippingElement
 import com.stripe.android.uicore.elements.SectionElement
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 @Serializable
+@Parcelize
 data class CardBillingSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("card_billing"),

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionSpec.kt
@@ -5,6 +5,7 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -13,6 +14,7 @@ import kotlinx.serialization.Serializable
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 @Serializable
+@Parcelize
 data class CardDetailsSectionSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("card_details"),

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CashAppPayMandateTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CashAppPayMandateTextSpec.kt
@@ -5,12 +5,15 @@ import androidx.annotation.StringRes
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Serializable
+@Parcelize
 data class CashAppPayMandateTextSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("cashapp_mandate"),
@@ -18,6 +21,7 @@ data class CashAppPayMandateTextSpec(
     val stringResId: Int = R.string.stripe_cash_app_pay_mandate,
 ) : FormItemSpec() {
 
+    @IgnoredOnParcel
     @Transient
     private val mandateTextSpec = MandateTextSpec(apiPath, stringResId)
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/ContactInformationSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/ContactInformationSpec.kt
@@ -11,11 +11,14 @@ import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextElement
 import com.stripe.android.uicore.elements.SimpleTextFieldConfig
 import com.stripe.android.uicore.elements.SimpleTextFieldController
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Serializable
+@Parcelize
 data class ContactInformationSpec(
     @SerialName("collect_name")
     val collectName: Boolean = true,
@@ -24,6 +27,7 @@ data class ContactInformationSpec(
     @SerialName("collect_phone")
     val collectPhone: Boolean = true,
 ) : FormItemSpec() {
+    @IgnoredOnParcel
     override val apiPath: IdentifierSpec = IdentifierSpec()
 
     fun transform(initialValues: Map<IdentifierSpec, String?>): SectionElement? {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CountrySpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CountrySpec.kt
@@ -6,6 +6,7 @@ import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -16,6 +17,7 @@ import kotlinx.serialization.Serializable
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Serializable
+@Parcelize
 data class CountrySpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Country,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownItemSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownItemSpec.kt
@@ -1,15 +1,18 @@
 package com.stripe.android.ui.core.elements
 
+import android.os.Parcelable
 import androidx.annotation.RestrictTo
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Parcelize
 data class DropdownItemSpec(
     @SerialName("api_value")
     val apiValue: String? = null,
 
     @SerialName("display_text")
     val displayText: String = "Other"
-)
+) : Parcelable

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownSpec.kt
@@ -3,11 +3,13 @@ package com.stripe.android.ui.core.elements
 import androidx.annotation.RestrictTo
 import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 @Serializable
+@Parcelize
 data class DropdownSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/EmailSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/EmailSpec.kt
@@ -2,11 +2,13 @@ package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Serializable
+@Parcelize
 data class EmailSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Email

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/EmptyFormSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/EmptyFormSpec.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.ui.core.elements
 
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -11,7 +13,9 @@ import kotlinx.serialization.Serializable
  * the form as complete. {@link LayoutSpec#create()} is the way to build a form with no elements.
  */
 @Serializable
+@Parcelize
 internal object EmptyFormSpec : FormItemSpec() {
+    @IgnoredOnParcel
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("empty")
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/FormItemSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/FormItemSpec.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.ui.core.elements
 
+import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionElement
@@ -17,7 +18,7 @@ import kotlinx.serialization.json.jsonPrimitive
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Serializable(with = FormItemSpecSerializer::class)
-sealed class FormItemSpec {
+sealed class FormItemSpec : Parcelable {
     @SerialName("api_path")
     abstract val apiPath: IdentifierSpec
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IbanSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IbanSpec.kt
@@ -3,11 +3,13 @@ package com.stripe.android.ui.core.elements
 import androidx.annotation.RestrictTo
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SimpleTextFieldController
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 @Serializable
+@Parcelize
 data class IbanSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("sepa_debit[iban]")

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/KlarnaCountrySpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/KlarnaCountrySpec.kt
@@ -5,6 +5,7 @@ import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -13,7 +14,8 @@ import kotlinx.serialization.Serializable
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 @Serializable
-class KlarnaCountrySpec(
+@Parcelize
+data class KlarnaCountrySpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Country
 ) : FormItemSpec() {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/KlarnaHeaderStaticTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/KlarnaHeaderStaticTextSpec.kt
@@ -2,6 +2,7 @@ package com.stripe.android.ui.core.elements
 
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -9,6 +10,7 @@ import kotlinx.serialization.Serializable
  * This is for the Klarna header
  */
 @Serializable
+@Parcelize
 internal data class KlarnaHeaderStaticTextSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("klarna_header_text")

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/KonbiniConfirmationNumberSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/KonbiniConfirmationNumberSpec.kt
@@ -4,14 +4,19 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
 @Serializable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
-class KonbiniConfirmationNumberSpec : FormItemSpec() {
+@Parcelize
+data object KonbiniConfirmationNumberSpec : FormItemSpec() {
+    @IgnoredOnParcel
     override val apiPath: IdentifierSpec = IdentifierSpec.KonbiniConfirmationNumber
 
+    @IgnoredOnParcel
     @Transient
     private val simpleTextSpec = SimpleTextSpec(
         apiPath,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextSpec.kt
@@ -4,6 +4,7 @@ import androidx.annotation.RestrictTo
 import androidx.annotation.StringRes
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,6 +13,7 @@ import kotlinx.serialization.Serializable
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Serializable
+@Parcelize
 data class MandateTextSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("mandate"),

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/NameSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/NameSpec.kt
@@ -2,12 +2,15 @@ package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Serializable
+@Parcelize
 data class NameSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Name,
@@ -15,6 +18,7 @@ data class NameSpec(
     @SerialName("translation_id")
     val labelTranslationId: TranslationId = TranslationId.AddressName
 ) : FormItemSpec() {
+    @IgnoredOnParcel
     @Transient
     private val simpleTextSpec =
         SimpleTextSpec(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/NextActionSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/NextActionSpec.kt
@@ -1,9 +1,11 @@
 package com.stripe.android.ui.core.elements
 
+import android.os.Parcelable
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.model.LuxePostConfirmActionCreator
 import com.stripe.android.model.LuxePostConfirmActionRepository
 import com.stripe.android.model.StripeIntent
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -13,9 +15,10 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 @Serializable(with = ConfirmResponseStatusSpecsSerializer::class)
-sealed class ConfirmResponseStatusSpecs {
+sealed class ConfirmResponseStatusSpecs : Parcelable {
     @Serializable
     @SerialName("redirect_to_url")
+    @Parcelize
     data class RedirectNextActionSpec(
         @SerialName("url_path")
         val urlPath: String = "next_action[redirect_to_url][url]",
@@ -25,11 +28,13 @@ sealed class ConfirmResponseStatusSpecs {
 
     @Serializable
     @SerialName("finished")
-    object FinishedSpec : ConfirmResponseStatusSpecs()
+    @Parcelize
+    data object FinishedSpec : ConfirmResponseStatusSpecs()
 
     @Serializable
     @SerialName("canceled")
-    object CanceledSpec : ConfirmResponseStatusSpecs()
+    @Parcelize
+    data object CanceledSpec : ConfirmResponseStatusSpecs()
 }
 
 object ConfirmResponseStatusSpecsSerializer :
@@ -45,15 +50,17 @@ object ConfirmResponseStatusSpecsSerializer :
 }
 
 @Serializable(with = PostConfirmHandlingPiStatusSpecsSerializer::class)
-sealed class PostConfirmHandlingPiStatusSpecs {
+sealed class PostConfirmHandlingPiStatusSpecs : Parcelable {
 
     @Serializable
     @SerialName("finished")
-    object FinishedSpec : PostConfirmHandlingPiStatusSpecs()
+    @Parcelize
+    data object FinishedSpec : PostConfirmHandlingPiStatusSpecs()
 
     @Serializable
     @SerialName("canceled")
-    object CanceledSpec : PostConfirmHandlingPiStatusSpecs()
+    @Parcelize
+    data object CanceledSpec : PostConfirmHandlingPiStatusSpecs()
 }
 
 object PostConfirmHandlingPiStatusSpecsSerializer :
@@ -73,6 +80,7 @@ fun <K, V> Map<K, V?>.filterNotNullValues(): Map<K, V> =
     mapNotNull { (key, value) -> value?.let { key to it } }.toMap()
 
 @Serializable
+@Parcelize
 data class ConfirmStatusSpecAssociation(
     @SerialName("requires_payment_method")
     val requiresPaymentMethod: ConfirmResponseStatusSpecs? = null,
@@ -86,7 +94,7 @@ data class ConfirmStatusSpecAssociation(
     val succeeded: ConfirmResponseStatusSpecs? = ConfirmResponseStatusSpecs.FinishedSpec,
     @SerialName("canceled")
     val canceled: ConfirmResponseStatusSpecs? = null
-) {
+) : Parcelable {
     fun getMap() =
         mapOf(
             StripeIntent.Status.RequiresPaymentMethod to requiresPaymentMethod,
@@ -99,6 +107,7 @@ data class ConfirmStatusSpecAssociation(
 }
 
 @Serializable
+@Parcelize
 data class PostConfirmStatusSpecAssociation(
     @SerialName("requires_payment_method")
     val requiresPaymentMethod: PostConfirmHandlingPiStatusSpecs? = null,
@@ -112,7 +121,7 @@ data class PostConfirmStatusSpecAssociation(
     val succeeded: PostConfirmHandlingPiStatusSpecs? = null,
     @SerialName("canceled")
     val canceled: PostConfirmHandlingPiStatusSpecs? = null
-) {
+) : Parcelable {
     fun getMap() = mapOf(
         StripeIntent.Status.RequiresPaymentMethod to requiresPaymentMethod,
         StripeIntent.Status.RequiresConfirmation to requiresConfirmation,
@@ -125,13 +134,14 @@ data class PostConfirmStatusSpecAssociation(
 
 @Serializable
 @SerialName("next_action_spec")
+@Parcelize
 data class NextActionSpec(
     @SerialName("confirm_response_status_specs")
     val confirmResponseStatusSpecs: ConfirmStatusSpecAssociation? = null,
 
     @SerialName("post_confirm_handling_pi_status_specs")
     val postConfirmHandlingPiStatusSpecs: PostConfirmStatusSpecAssociation? = null
-)
+) : Parcelable
 
 fun NextActionSpec?.transform() =
     if (this == null) {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/NextActionSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/NextActionSpec.kt
@@ -67,7 +67,9 @@ object PostConfirmHandlingPiStatusSpecsSerializer :
     JsonContentPolymorphicSerializer<PostConfirmHandlingPiStatusSpecs>(
         PostConfirmHandlingPiStatusSpecs::class
     ) {
-    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<out PostConfirmHandlingPiStatusSpecs> {
+    override fun selectDeserializer(
+        element: JsonElement
+    ): DeserializationStrategy<PostConfirmHandlingPiStatusSpecs> {
         return when (element.jsonObject["type"]?.jsonPrimitive?.content) {
             "finished" -> PostConfirmHandlingPiStatusSpecs.FinishedSpec.serializer()
             "canceled" -> PostConfirmHandlingPiStatusSpecs.CanceledSpec.serializer()

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPSpec.kt
@@ -4,11 +4,13 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.OTPController
 import com.stripe.android.uicore.elements.OTPElement
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Serializable
-object OTPSpec : FormItemSpec() {
+@Parcelize
+data object OTPSpec : FormItemSpec() {
     override val apiPath: IdentifierSpec
         get() = IdentifierSpec.Generic("otp")
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PhoneSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PhoneSpec.kt
@@ -4,11 +4,13 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.PhoneNumberController
 import com.stripe.android.uicore.elements.PhoneNumberElement
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Serializable
+@Parcelize
 data class PhoneSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Phone

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PlaceholderSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PlaceholderSpec.kt
@@ -2,11 +2,13 @@ package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Serializable
+@Parcelize
 data class PlaceholderSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("placeholder"),

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseSpec.kt
@@ -3,6 +3,7 @@ package com.stripe.android.ui.core.elements
 import androidx.annotation.RestrictTo
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,6 +13,7 @@ import kotlinx.serialization.Serializable
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Serializable
+@Parcelize
 data class SaveForFutureUseSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.SaveForFutureUse

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SelectorIcon.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SelectorIcon.kt
@@ -1,13 +1,16 @@
 package com.stripe.android.ui.core.elements
 
+import android.os.Parcelable
 import androidx.annotation.RestrictTo
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 @SerialName("next_action_spec")
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Parcelize
 data class SelectorIcon internal constructor(
     @SerialName("light_theme_png") val lightThemePng: String? = null,
     @SerialName("dark_theme_png") val darkThemePng: String? = null,
-)
+) : Parcelable

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SepaMandateTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SepaMandateTextSpec.kt
@@ -5,6 +5,8 @@ import androidx.annotation.StringRes
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -14,12 +16,14 @@ import kotlinx.serialization.Transient
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Serializable
+@Parcelize
 data class SepaMandateTextSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("sepa_mandate"),
     @StringRes
     val stringResId: Int = R.string.stripe_sepa_mandate
 ) : FormItemSpec() {
+    @IgnoredOnParcel
     @Transient
     private val mandateTextSpec = MandateTextSpec(apiPath, stringResId)
     fun transform(merchantName: String): FormElement = mandateTextSpec.transform(merchantName)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SharedDataSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SharedDataSpec.kt
@@ -1,11 +1,14 @@
 package com.stripe.android.ui.core.elements
 
+import android.os.Parcelable
 import androidx.annotation.RestrictTo
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Parcelize
 data class SharedDataSpec(
     @SerialName("type")
     val type: String,
@@ -24,4 +27,4 @@ data class SharedDataSpec(
 
     @SerialName("selector_icon")
     val selectorIcon: SelectorIcon? = null,
-)
+) : Parcelable

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SimpleTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SimpleTextSpec.kt
@@ -7,6 +7,7 @@ import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SimpleTextElement
 import com.stripe.android.uicore.elements.SimpleTextFieldConfig
 import com.stripe.android.uicore.elements.SimpleTextFieldController
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -54,6 +55,7 @@ enum class KeyboardType {
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Serializable
+@Parcelize
 data class SimpleTextSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/StaticTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/StaticTextSpec.kt
@@ -3,6 +3,7 @@ package com.stripe.android.ui.core.elements
 import androidx.annotation.StringRes
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -10,6 +11,7 @@ import kotlinx.serialization.Serializable
  * This is for elements that do not receive user input
  */
 @Serializable
+@Parcelize
 internal data class StaticTextSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("static_text"),

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/UpiSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/UpiSpec.kt
@@ -4,11 +4,13 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionElement
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 @Serializable
+@Parcelize
 data class UpiSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Upi

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/SharedDataSpecParcelerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/SharedDataSpecParcelerTest.kt
@@ -36,7 +36,6 @@ class SharedDataSpecParcelerTest {
     ) : Parcelable
 }
 
-
 private inline fun <reified R : Parcelable> R.testParcel(): R {
     val bytes = marshallParcelable(this)
     return unmarshallParcelable(bytes)

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/SharedDataSpecParcelerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/SharedDataSpecParcelerTest.kt
@@ -1,0 +1,73 @@
+package com.stripe.android.ui.core.elements
+
+import android.app.Application
+import android.os.Bundle
+import android.os.Parcel
+import android.os.Parcelable
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import kotlinx.parcelize.Parcelize
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SharedDataSpecParcelerTest {
+    @Test
+    fun `parceled specs result in the same specs`() {
+        val resources = ApplicationProvider.getApplicationContext<Application>().resources
+        val specsString = resources.assets!!.open("lpms.json").bufferedReader().use { it.readText() }
+        val originalSpecs = LpmSerializer.deserializeList(specsString).getOrThrow()
+        assertThat(originalSpecs).isNotEmpty()
+
+        val example = ExampleWithList(originalSpecs)
+        val parcelizedExample = example.testParcel()
+
+        assertThat(originalSpecs.size).isEqualTo(parcelizedExample.specs.size)
+        originalSpecs.indices.forEach { index ->
+            assertThat(originalSpecs[index]).isEqualTo(parcelizedExample.specs[index])
+        }
+        assertThat(originalSpecs).isEqualTo(parcelizedExample.specs)
+    }
+
+    @Parcelize
+    data class ExampleWithList(
+        val specs: List<SharedDataSpec>
+    ) : Parcelable
+}
+
+
+private inline fun <reified R : Parcelable> R.testParcel(): R {
+    val bytes = marshallParcelable(this)
+    return unmarshallParcelable(bytes)
+}
+
+private inline fun <reified R : Parcelable> marshallParcelable(parcelable: R): ByteArray {
+    val bundle = Bundle().apply { putParcelable(R::class.java.name, parcelable) }
+    return marshall(bundle)
+}
+
+private fun marshall(bundle: Bundle): ByteArray =
+    Parcel.obtain().use {
+        it.writeBundle(bundle)
+        it.marshall()
+    }
+
+private inline fun <reified R : Parcelable> unmarshallParcelable(bytes: ByteArray): R = unmarshall(bytes)
+    .readBundle()!!
+    .run {
+        classLoader = R::class.java.classLoader
+        getParcelable(R::class.java.name)!!
+    }
+
+private fun unmarshall(bytes: ByteArray): Parcel =
+    Parcel.obtain().apply {
+        unmarshall(bytes, 0, bytes.size)
+        setDataPosition(0)
+    }
+
+private fun <T> Parcel.use(block: (Parcel) -> T): T = try {
+    block(this)
+} finally {
+    this.recycle()
+}

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -32,8 +32,7 @@
     <ID>LongMethod:FormViewModelTest.kt$FormViewModelTest$@Test fun `Verify params are set when required address fields are complete`()</ID>
     <ID>LongMethod:PaymentOptionFactory.kt$PaymentOptionFactory$fun create(selection: PaymentSelection): PaymentOption</ID>
     <ID>LongMethod:PaymentSheetConfigurationKtx.kt$internal fun PaymentSheet.Appearance.parseAppearance()</ID>
-    <ID>LongMethod:PaymentSheetLoader.kt$DefaultPaymentSheetLoader$private suspend fun create( elementsSession: ElementsSession, config: PaymentSheet.Configuration, metadata: PaymentMethodMetadata, sharedDataSpecs: List&lt;SharedDataSpec>, ): PaymentSheetState.Full</ID>
-    <ID>LongMethod:PaymentSheetScreen.kt$@Composable internal fun PaymentSheetScreenContent( viewModel: BaseSheetViewModel, type: PaymentSheetFlowType, modifier: Modifier = Modifier, )</ID>
+    <ID>LongMethod:PaymentSheetLoader.kt$DefaultPaymentSheetLoader$private suspend fun create( elementsSession: ElementsSession, config: PaymentSheet.Configuration, metadata: PaymentMethodMetadata, ): PaymentSheetState.Full</ID>
     <ID>LongMethod:PlaceholderHelperTest.kt$PlaceholderHelperTest$@Test fun `Test correct placeholder is removed for placeholder spec`()</ID>
     <ID>LongMethod:USBankAccountEmitters.kt$@Composable internal fun USBankAccountEmitters( viewModel: USBankAccountFormViewModel, usBankAccountFormArgs: USBankAccountFormArguments, )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable internal fun BillingDetailsForm( formArgs: FormArguments, isProcessing: Boolean, isPaymentFlow: Boolean, nameController: TextFieldController, emailController: TextFieldController, phoneController: PhoneNumberController, addressController: AddressController, lastTextFieldIdentifier: IdentifierSpec?, sameAsShippingElement: SameAsShippingElement?, )</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -92,16 +92,21 @@ internal class DefaultCustomerSheetLoader(
         )
         return elementsSessionRepository.get(initializationMode).onSuccess { elementsSession ->
             val billingDetailsCollectionConfig = configuration?.billingDetailsCollectionConfiguration.toInternal()
+            val sharedDataSpecs = lpmRepository.getSharedDataSpecs(
+                stripeIntent = elementsSession.stripeIntent,
+                serverLpmSpecs = elementsSession.paymentMethodSpecs,
+            ).sharedDataSpecs
             val metadata = PaymentMethodMetadata(
                 stripeIntent = elementsSession.stripeIntent,
                 billingDetailsCollectionConfiguration = billingDetailsCollectionConfig,
                 allowsDelayedPaymentMethods = false,
+                sharedDataSpecs = sharedDataSpecs,
                 financialConnectionsAvailable = isFinancialConnectionsAvailable()
             )
 
             lpmRepository.update(
                 metadata = metadata,
-                serverLpmSpecs = elementsSession.paymentMethodSpecs,
+                specs = sharedDataSpecs,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/LpmRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/LpmRepository.kt
@@ -57,7 +57,7 @@ internal class LpmRepository(
         metadata: PaymentMethodMetadata,
         serverLpmSpecs: String?,
     ): Boolean {
-        val sharedDataSpecsResult: Result = getSharedDataSpecs(metadata, serverLpmSpecs)
+        val sharedDataSpecsResult: Result = getSharedDataSpecs(metadata.stripeIntent, serverLpmSpecs)
 
         update(
             metadata = metadata,
@@ -68,10 +68,10 @@ internal class LpmRepository(
     }
 
     fun getSharedDataSpecs(
-        metadata: PaymentMethodMetadata,
+        stripeIntent: StripeIntent,
         serverLpmSpecs: String?,
     ): Result {
-        val expectedLpms = metadata.stripeIntent.paymentMethodTypes
+        val expectedLpms = stripeIntent.paymentMethodTypes
         var failedToParseServerResponse = false
 
         val sharedDataSpecs: MutableList<SharedDataSpec> = mutableListOf()

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodRegistry.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodRegistry.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.lpmfoundations.paymentmethod
 
-import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.AffirmDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.AfterpayClearpayDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.AlipayDefinition
@@ -33,7 +32,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.definitions.UpiDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.UsBankAccountDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.WeChatPayDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.ZipDefinition
-import com.stripe.android.ui.core.elements.SharedDataSpec
 
 internal object PaymentMethodRegistry {
 
@@ -74,21 +72,5 @@ internal object PaymentMethodRegistry {
 
     val definitionsByCode: Map<String, PaymentMethodDefinition> by lazy {
         all.associateBy { it.type.code }
-    }
-
-    fun filterSupportedPaymentMethods(
-        metadata: PaymentMethodMetadata,
-        sharedDataSpecs: List<SharedDataSpec>,
-    ): List<SupportedPaymentMethod> {
-        return all.filter {
-            it.isSupported(metadata)
-        }.mapNotNull { paymentMethodDefinition ->
-            val sharedDataSpec = sharedDataSpecs.firstOrNull { it.type == paymentMethodDefinition.type.code }
-            if (sharedDataSpec != null) {
-                paymentMethodDefinition.supportedPaymentMethod(metadata, sharedDataSpec)
-            } else {
-                null
-            }
-        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/LpmRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/LpmRepositoryTest.kt
@@ -3,7 +3,6 @@ package com.stripe.android.lpmfoundations.luxe
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
@@ -540,12 +539,10 @@ class LpmRepositoryTest {
                 }
             ]
         """.trimIndent()
-        val metadata = PaymentMethodMetadataFactory.create(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                paymentMethodTypes = listOf("card", "cashapp")
-            )
+        val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+            paymentMethodTypes = listOf("card", "cashapp")
         )
-        val result = lpmRepository.getSharedDataSpecs(metadata, serverSpecs)
+        val result = lpmRepository.getSharedDataSpecs(paymentIntent, serverSpecs)
         assertThat(result.failedToParseServerResponse).isFalse()
         val sharedDataSpecs = result.sharedDataSpecs
         assertThat(sharedDataSpecs).hasSize(2)
@@ -572,12 +569,10 @@ class LpmRepositoryTest {
                 }
             ]
         """.trimIndent()
-        val metadata = PaymentMethodMetadataFactory.create(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                paymentMethodTypes = listOf("card", "cashapp")
-            )
+        val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+            paymentMethodTypes = listOf("card", "cashapp")
         )
-        val result = lpmRepository.getSharedDataSpecs(metadata, serverSpecs)
+        val result = lpmRepository.getSharedDataSpecs(paymentIntent, serverSpecs)
         assertThat(result.failedToParseServerResponse).isFalse()
         val sharedDataSpecs = result.sharedDataSpecs
         assertThat(sharedDataSpecs).hasSize(2)
@@ -593,12 +588,10 @@ class LpmRepositoryTest {
             ),
         )
 
-        val metadata = PaymentMethodMetadataFactory.create(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                paymentMethodTypes = listOf("card", "cashapp")
-            )
+        val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+            paymentMethodTypes = listOf("card", "cashapp")
         )
-        val result = lpmRepository.getSharedDataSpecs(metadata, null)
+        val result = lpmRepository.getSharedDataSpecs(paymentIntent, null)
         assertThat(result.failedToParseServerResponse).isFalse()
         val sharedDataSpecs = result.sharedDataSpecs
         assertThat(sharedDataSpecs).hasSize(2)
@@ -614,12 +607,10 @@ class LpmRepositoryTest {
             ),
         )
 
-        val metadata = PaymentMethodMetadataFactory.create(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                paymentMethodTypes = listOf("card", "cashapp")
-            )
+        val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+            paymentMethodTypes = listOf("card", "cashapp")
         )
-        val result = lpmRepository.getSharedDataSpecs(metadata, "{[]}")
+        val result = lpmRepository.getSharedDataSpecs(paymentIntent, "{[]}")
         assertThat(result.failedToParseServerResponse).isTrue()
         val sharedDataSpecs = result.sharedDataSpecs
         assertThat(sharedDataSpecs).hasSize(2)

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -3,6 +3,7 @@ package com.stripe.android.lpmfoundations.paymentmethod
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
+import com.stripe.android.ui.core.elements.SharedDataSpec
 
 internal object PaymentMethodMetadataFactory {
     fun create(
@@ -11,12 +12,14 @@ internal object PaymentMethodMetadataFactory {
             BillingDetailsCollectionConfiguration(),
         allowsDelayedPaymentMethods: Boolean = true,
         financialConnectionsAvailable: Boolean = true,
+        sharedDataSpecs: List<SharedDataSpec> = listOf(SharedDataSpec(type = "card", fields = ArrayList())),
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
             allowsDelayedPaymentMethods = allowsDelayedPaymentMethods,
             financialConnectionsAvailable = financialConnectionsAvailable,
+            sharedDataSpecs = sharedDataSpecs,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -5,15 +5,13 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.ui.core.elements.SharedDataSpec
 import org.junit.Test
 
-internal class PaymentMethodRegistryTest {
-    private val cardSharedDataSpecs = listOf(SharedDataSpec("card"))
-
+internal class PaymentMethodMetadataTest {
     @Test
     fun `filterSupportedPaymentMethods removes unsupported paymentMethodTypes`() {
         val metadata = PaymentMethodMetadataFactory.create()
-        val supportedPaymentMethods = PaymentMethodRegistry.filterSupportedPaymentMethods(metadata, cardSharedDataSpecs)
+        val supportedPaymentMethods = metadata.supportedPaymentMethodDefinitions()
         assertThat(supportedPaymentMethods).hasSize(1)
-        assertThat(supportedPaymentMethods.first().code).isEqualTo("card")
+        assertThat(supportedPaymentMethods.first().type.code).isEqualTo("card")
     }
 
     @Test
@@ -23,9 +21,9 @@ internal class PaymentMethodRegistryTest {
                 paymentMethodTypes = listOf("card", "klarna")
             )
         )
-        val supportedPaymentMethods = PaymentMethodRegistry.filterSupportedPaymentMethods(metadata, cardSharedDataSpecs)
+        val supportedPaymentMethods = metadata.supportedPaymentMethodDefinitions()
         assertThat(supportedPaymentMethods).hasSize(1)
-        assertThat(supportedPaymentMethods.first().code).isEqualTo("card")
+        assertThat(supportedPaymentMethods.first().type.code).isEqualTo("card")
     }
 
     @Test
@@ -33,12 +31,12 @@ internal class PaymentMethodRegistryTest {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
                 paymentMethodTypes = listOf("card", "klarna")
-            )
+            ),
+            sharedDataSpecs = listOf(SharedDataSpec("card"), SharedDataSpec("klarna")),
         )
-        val sharedDataSpecs = listOf(SharedDataSpec("card"), SharedDataSpec("klarna"))
-        val supportedPaymentMethods = PaymentMethodRegistry.filterSupportedPaymentMethods(metadata, sharedDataSpecs)
+        val supportedPaymentMethods = metadata.supportedPaymentMethodDefinitions()
         assertThat(supportedPaymentMethods).hasSize(2)
-        assertThat(supportedPaymentMethods[0].code).isEqualTo("card")
-        assertThat(supportedPaymentMethods[1].code).isEqualTo("klarna")
+        assertThat(supportedPaymentMethods[0].type.code).isEqualTo("card")
+        assertThat(supportedPaymentMethods[1].type.code).isEqualTo("klarna")
     }
 }

--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -65,6 +65,30 @@ public final class com/stripe/android/uicore/address/StateSchema$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/uicore/elements/AddressType$Normal$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/uicore/elements/AddressType$Normal;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/uicore/elements/AddressType$Normal;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/uicore/elements/AddressType$ShippingCondensed$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/uicore/elements/AddressType$ShippingCondensed;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/uicore/elements/AddressType$ShippingCondensed;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/uicore/elements/AddressType$ShippingExpanded$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/uicore/elements/AddressType$ShippingExpanded;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/uicore/elements/AddressType$ShippingExpanded;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/uicore/elements/ComposableSingletons$OTPElementUIKt {
 	public static final field INSTANCE Lcom/stripe/android/uicore/elements/ComposableSingletons$OTPElementUIKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressType.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressType.kt
@@ -1,13 +1,16 @@
 package com.stripe.android.uicore.elements
 
+import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.stripe.android.uicore.address.AutocompleteCapableAddressType
+import kotlinx.parcelize.Parcelize
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
-sealed class AddressType {
+sealed class AddressType : Parcelable {
     abstract val phoneNumberState: PhoneNumberState
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+    @Parcelize
     data class ShippingCondensed(
         override val googleApiKey: String?,
         override val autocompleteCountries: Set<String>?,
@@ -16,7 +19,8 @@ sealed class AddressType {
     ) : AddressType(), AutocompleteCapableAddressType
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
-    data class ShippingExpanded constructor(
+    @Parcelize
+    data class ShippingExpanded(
         override val googleApiKey: String?,
         override val autocompleteCountries: Set<String>?,
         override val phoneNumberState: PhoneNumberState,
@@ -24,6 +28,7 @@ sealed class AddressType {
     ) : AddressType(), AutocompleteCapableAddressType
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+    @Parcelize
     data class Normal(
         override val phoneNumberState: PhoneNumberState =
             PhoneNumberState.HIDDEN


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We need SharedDataSpecs passed around with the metadata in order to construct SupportedPaymentMethods. Updating it to be supported!
