### PR TITLE
Use `PaymentMethodMetadata` in `BaseSheetViewModel` to create supportedPaymentMethods.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -100,6 +100,7 @@ internal class DefaultCustomerSheetLoader(
                 stripeIntent = elementsSession.stripeIntent,
                 billingDetailsCollectionConfiguration = billingDetailsCollectionConfig,
                 allowsDelayedPaymentMethods = false,
+                allowsPaymentMethodsRequiringShippingAddress = false,
                 sharedDataSpecs = sharedDataSpecs,
                 financialConnectionsAvailable = isFinancialConnectionsAvailable()
             )

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirement.kt
@@ -19,6 +19,10 @@ internal enum class AddPaymentMethodRequirement {
     /** Indicates that a payment method requires shipping information. */
     ShippingAddress {
         override fun isMetBy(metadata: PaymentMethodMetadata): Boolean {
+            if (metadata.allowsPaymentMethodsRequiringShippingAddress) {
+                return true
+            }
+
             val shipping = (metadata.stripeIntent as? PaymentIntent)?.shipping
             return shipping?.name != null &&
                 shipping.address.line1 != null &&

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -31,7 +31,9 @@ internal data class PaymentMethodMetadata(
     }
 
     fun supportedPaymentMethodDefinitions(): List<PaymentMethodDefinition> {
-        return PaymentMethodRegistry.all.filter {
+        return stripeIntent.paymentMethodTypes.mapNotNull {
+            PaymentMethodRegistry.definitionsByCode[it]
+        }.filter {
             it.isSupported(this)
         }.filter { paymentMethodDefinition ->
             sharedDataSpecs.firstOrNull { it.type == paymentMethodDefinition.type.code } != null

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -19,6 +19,7 @@ internal data class PaymentMethodMetadata(
     val stripeIntent: StripeIntent,
     val billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration,
     val allowsDelayedPaymentMethods: Boolean,
+    val allowsPaymentMethodsRequiringShippingAddress: Boolean,
     val sharedDataSpecs: List<SharedDataSpec>,
     val financialConnectionsAvailable: Boolean = DefaultIsFinancialConnectionsAvailable(),
 ) : Parcelable {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -171,7 +171,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
         // calling setStripeIntent would require the repository be initialized, which
         // would not be the case.
         if (stripeIntent.value == null) {
-            setStripeIntent(args.state.stripeIntent)
+            setPaymentMethodMetadata(args.state.paymentMethodMetadata)
         }
         savedStateHandle[SAVE_PAYMENT_METHODS] = args.state.customerPaymentMethods
         savedStateHandle[SAVE_PROCESSING] = false

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -353,7 +353,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     private fun handlePaymentSheetStateLoadFailure(error: Throwable) {
-        setStripeIntent(null)
+        setPaymentMethodMetadata(null)
         onFatal(error)
     }
 
@@ -401,7 +401,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             GooglePayState.NotAvailable
         }
 
-        setStripeIntent(state.stripeIntent)
+        setPaymentMethodMetadata(state.paymentMethodMetadata)
 
         val linkState = state.linkState
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -87,6 +87,8 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
                 stripeIntent = elementsSession.stripeIntent,
                 billingDetailsCollectionConfiguration = billingDetailsCollectionConfig,
                 allowsDelayedPaymentMethods = paymentSheetConfiguration.allowsDelayedPaymentMethods,
+                allowsPaymentMethodsRequiringShippingAddress = paymentSheetConfiguration
+                    .allowsPaymentMethodsRequiringShippingAddress,
                 sharedDataSpecs = sharedDataSpecsResult.sharedDataSpecs,
             )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -12,6 +12,7 @@ import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
@@ -32,7 +33,6 @@ import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.MandateText
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSelection.CustomerRequestedSave.RequestReuse
-import com.stripe.android.paymentsheet.model.getPMsToAdd
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddAnotherPaymentMethod
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddFirstPaymentMethod
@@ -349,9 +349,12 @@ internal abstract class BaseSheetViewModel(
         eventReporter.onPressConfirmButton(selection.value)
     }
 
-    protected fun setStripeIntent(stripeIntent: StripeIntent?) {
+    protected fun setPaymentMethodMetadata(paymentMethodMetadata: PaymentMethodMetadata?) {
+        val stripeIntent = paymentMethodMetadata?.stripeIntent
         _stripeIntent.value = stripeIntent
-        supportedPaymentMethods = getPMsToAdd(stripeIntent, config, lpmRepository)
+        supportedPaymentMethods = paymentMethodMetadata?.supportedPaymentMethodDefinitions()?.mapNotNull {
+            paymentMethodMetadata.supportedPaymentMethodForCode(it.type.code)
+        } ?: emptyList()
 
         if (stripeIntent is PaymentIntent) {
             _amount.value = Amount(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirementTest.kt
@@ -57,6 +57,17 @@ internal class AddPaymentMethodRequirementTest {
     }
 
     @Test
+    fun testShippingAddressReturnsTrueWhenMetadataAllowsPaymentMethodsRequiringShippingAddress() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                shipping = null
+            ),
+            allowsPaymentMethodsRequiringShippingAddress = true,
+        )
+        assertThat(AddPaymentMethodRequirement.ShippingAddress.isMetBy(metadata)).isTrue()
+    }
+
+    @Test
     fun testShippingAddressReturnsFalseWithNullName() {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -1,8 +1,11 @@
 package com.stripe.android.lpmfoundations.paymentmethod
 
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
+import com.stripe.android.ui.core.elements.LpmSerializer
 import com.stripe.android.ui.core.elements.SharedDataSpec
 
 internal object PaymentMethodMetadataFactory {
@@ -11,15 +14,29 @@ internal object PaymentMethodMetadataFactory {
         billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
             BillingDetailsCollectionConfiguration(),
         allowsDelayedPaymentMethods: Boolean = true,
+        allowsPaymentMethodsRequiringShippingAddress: Boolean = false,
         financialConnectionsAvailable: Boolean = true,
-        sharedDataSpecs: List<SharedDataSpec> = listOf(SharedDataSpec(type = "card", fields = ArrayList())),
+        sharedDataSpecs: List<SharedDataSpec> = createSharedDataSpecs(),
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
             allowsDelayedPaymentMethods = allowsDelayedPaymentMethods,
+            allowsPaymentMethodsRequiringShippingAddress = allowsPaymentMethodsRequiringShippingAddress,
             financialConnectionsAvailable = financialConnectionsAvailable,
             sharedDataSpecs = sharedDataSpecs,
         )
+    }
+
+    private fun createSharedDataSpecs(): List<SharedDataSpec> = runCatching {
+        val resources = ApplicationProvider.getApplicationContext<Context>().resources
+        val specsString = resources.assets!!.open("lpms.json").bufferedReader().use { it.readText() }
+        LpmSerializer.deserializeList(specsString).getOrThrow()
+    }.getOrElse {
+        createSharedDataSpecsWithCardOnly()
+    }
+
+    fun createSharedDataSpecsWithCardOnly(): List<SharedDataSpec> {
+        return listOf(SharedDataSpec(type = "card", fields = ArrayList()))
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -551,7 +551,8 @@ internal class PaymentOptionsViewModelTest {
                             PaymentMethod.Type.Card.code,
                             PaymentMethod.Type.AuBecsDebit.code,
                         ),
-                    )
+                    ),
+                    allowsDelayedPaymentMethods = false,
                 )
             ),
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -418,7 +418,7 @@ internal class DefaultFlowControllerTest {
                 linkState = null,
                 isEligibleForCardBrandChoice = false,
                 validationError = null,
-                paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(allowsDelayedPaymentMethods = false),
             ),
             statusBarColor = STATUS_BAR_COLOR,
             enableLogging = ENABLE_LOGGING,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -133,6 +133,7 @@ internal class DefaultPaymentSheetLoaderTest {
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                     stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
                     allowsDelayedPaymentMethods = false,
+                    sharedDataSpecs = PaymentMethodMetadataFactory.createSharedDataSpecsWithCardOnly(),
                 ),
             )
         )
@@ -156,24 +157,8 @@ internal class DefaultPaymentSheetLoaderTest {
                     clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
                 ),
                 PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
-            ).getOrThrow()
-        ).isEqualTo(
-            PaymentSheetState.Full(
-                config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
-                customerPaymentMethods = PAYMENT_METHODS,
-                isGooglePayReady = false,
-                paymentSelection = PaymentSelection.Saved(
-                    paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                ),
-                linkState = null,
-                isEligibleForCardBrandChoice = false,
-                validationError = null,
-                paymentMethodMetadata = PaymentMethodMetadataFactory.create(
-                    stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
-                    allowsDelayedPaymentMethods = false,
-                ),
-            )
-        )
+            ).getOrThrow().isGooglePayReady
+        ).isFalse()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
@@ -10,6 +10,7 @@ import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException
 import com.stripe.android.paymentsheet.state.PaymentSheetState
+import com.stripe.android.paymentsheet.state.toInternal
 import kotlinx.coroutines.delay
 import kotlin.time.Duration
 
@@ -49,7 +50,14 @@ internal class FakePaymentSheetLoader(
                     paymentSelection = paymentSelection,
                     isEligibleForCardBrandChoice = false,
                     validationError = validationError,
-                    paymentMethodMetadata = PaymentMethodMetadataFactory.create(stripeIntent = stripeIntent),
+                    paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                        stripeIntent = stripeIntent,
+                        billingDetailsCollectionConfiguration = paymentSheetConfiguration
+                            .billingDetailsCollectionConfiguration.toInternal(),
+                        allowsDelayedPaymentMethods = paymentSheetConfiguration.allowsDelayedPaymentMethods,
+                        allowsPaymentMethodsRequiringShippingAddress = paymentSheetConfiguration
+                            .allowsPaymentMethodsRequiringShippingAddress,
+                    ),
                 )
             )
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This also identified a bug in the filtering logic for shipping address, which I also addressed.
