### PR TITLE
Remove usage of LpmRepository when crafting the exception.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -206,9 +206,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             )
         } else {
             val requested = stripeIntent.paymentMethodTypes.joinToString(separator = ", ")
-            val supported = lpmRepository.values().joinToString(separator = ", ") { it.code }
-
-            throw PaymentSheetLoadingException.NoPaymentMethodTypesAvailable(requested, supported)
+            throw PaymentSheetLoadingException.NoPaymentMethodTypesAvailable(requested)
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoadingException.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoadingException.kt
@@ -23,15 +23,14 @@ internal sealed class PaymentSheetLoadingException : Throwable() {
     }
 
     data class NoPaymentMethodTypesAvailable(
-        private val requested: String,
-        private val supported: String,
+        private val requested: String
     ) : PaymentSheetLoadingException() {
 
         override val type: String = "noPaymentMethodTypesAvailable"
 
         override val message: String
             get() = "None of the requested payment methods ($requested) " +
-                "match the supported payment types ($supported)."
+                "are supported."
     }
 
     data class PaymentIntentInTerminalState(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -12,7 +12,6 @@ import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.LinkSignupMode.AlongsideSaveForFutureUse
 import com.stripe.android.link.ui.inline.LinkSignupMode.InsteadOfSaveForFutureUse
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
-import com.stripe.android.lpmfoundations.luxe.update
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentIntent.ConfirmationMethod.Manual
@@ -31,7 +30,6 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException.PaymentIntentInTerminalState
-import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.FakeElementsSessionRepository
@@ -64,18 +62,7 @@ internal class DefaultPaymentSheetLoaderTest {
             resources = ApplicationProvider.getApplicationContext<Application>().resources,
         ),
         lpmInitialFormData = LpmRepository.LpmInitialFormData(),
-    ).apply {
-        this.update(
-            PaymentIntentFactory.create(
-                paymentMethodTypes = listOf(
-                    PaymentMethod.Type.Card.code,
-                    PaymentMethod.Type.USBankAccount.code,
-                    PaymentMethod.Type.CashAppPay.code,
-                ),
-            ),
-            null
-        )
-    }
+    )
 
     private val prefsRepository = FakePrefsRepository()
 
@@ -701,7 +688,6 @@ internal class DefaultPaymentSheetLoaderTest {
         assertThat(result).isEqualTo(
             PaymentSheetLoadingException.NoPaymentMethodTypesAvailable(
                 requested = "gold, silver, bronze",
-                supported = "card, cashapp",
             )
         )
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This was always empty in practice, and we don't have a good way to determine this. 