### PR TITLE
Correctly handle missing phone number patterns

### DIFF
--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
@@ -71,6 +71,8 @@ internal sealed class PhoneNumberFormatter {
                     AnnotatedString(formatted),
                     object : OffsetMapping {
                         override fun originalToTransformed(offset: Int): Int {
+                            if (metadata.pattern.isEmpty()) return offset
+
                             metadata.pattern.let {
                                 if (offset == 0) return 0
 
@@ -95,7 +97,9 @@ internal sealed class PhoneNumberFormatter {
                         }
 
                         override fun transformedToOriginal(offset: Int): Int {
-                            return if (offset == 0) {
+                            return if (metadata.pattern.isEmpty()) {
+                                offset
+                            } else if (offset == 0) {
                                 0
                             } else {
                                 metadata.pattern.let {
@@ -121,6 +125,10 @@ internal sealed class PhoneNumberFormatter {
          * for invalid characters and the numbers of characters limited based on E.164 spec.
          */
         fun formatNumberNational(filteredInput: String): String {
+            if (metadata.pattern.isEmpty()) {
+                // If there's no pattern to format on, return early.
+                return filteredInput
+            }
             var inputIndex = 0
             val formatted = StringBuilder()
             metadata.pattern.forEach {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
@@ -52,7 +52,7 @@ internal sealed class PhoneNumberFormatter {
      */
     class WithRegion constructor(private val metadata: Metadata) : PhoneNumberFormatter() {
         override val prefix = metadata.prefix
-        override val placeholder = metadata.pattern.replace('#', '5')
+        override val placeholder = metadata.pattern?.replace('#', '5') ?: ""
         override val countryCode = metadata.regionCode
 
         override fun userInputFilter(input: String) =
@@ -71,7 +71,7 @@ internal sealed class PhoneNumberFormatter {
                     AnnotatedString(formatted),
                     object : OffsetMapping {
                         override fun originalToTransformed(offset: Int): Int {
-                            if (metadata.pattern.isEmpty()) return offset
+                            if (metadata.pattern == null) return offset
 
                             metadata.pattern.let {
                                 if (offset == 0) return 0
@@ -97,7 +97,7 @@ internal sealed class PhoneNumberFormatter {
                         }
 
                         override fun transformedToOriginal(offset: Int): Int {
-                            return if (metadata.pattern.isEmpty()) {
+                            return if (metadata.pattern == null) {
                                 offset
                             } else if (offset == 0) {
                                 0
@@ -125,7 +125,7 @@ internal sealed class PhoneNumberFormatter {
          * for invalid characters and the numbers of characters limited based on E.164 spec.
          */
         fun formatNumberNational(filteredInput: String): String {
-            if (metadata.pattern.isEmpty()) {
+            if (metadata.pattern == null) {
                 // If there's no pattern to format on, return early.
                 return filteredInput
             }
@@ -187,8 +187,13 @@ internal sealed class PhoneNumberFormatter {
     data class Metadata(
         val prefix: String,
         val regionCode: String,
-        val pattern: String
-    )
+        val pattern: String? = null
+    ) {
+        init {
+            require(pattern == null || pattern.isNotEmpty())
+            { "Pattern should not be empty. Set it to null if it's missing." }
+        }
+    }
 
     companion object {
         private const val E164_MAX_DIGITS = 15
@@ -306,7 +311,7 @@ internal sealed class PhoneNumberFormatter {
             "AO" to Metadata(prefix = "+244", regionCode = "AO", pattern = "### ### ###"),
             "GW" to Metadata(prefix = "+245", regionCode = "GW", pattern = "### ####"),
             "IO" to Metadata(prefix = "+246", regionCode = "IO", pattern = "### ####"),
-            "AC" to Metadata(prefix = "+247", regionCode = "AC", pattern = ""),
+            "AC" to Metadata(prefix = "+247", regionCode = "AC"),
             "SC" to Metadata(prefix = "+248", regionCode = "SC", pattern = "# ### ###"),
             "RW" to Metadata(prefix = "+250", regionCode = "RW", pattern = "### ### ###"),
             "ET" to Metadata(prefix = "+251", regionCode = "ET", pattern = "## ### ####"),
@@ -319,8 +324,8 @@ internal sealed class PhoneNumberFormatter {
             "MZ" to Metadata(prefix = "+258", regionCode = "MZ", pattern = "## ### ####"),
             "ZM" to Metadata(prefix = "+260", regionCode = "ZM", pattern = "## #######"),
             "MG" to Metadata(prefix = "+261", regionCode = "MG", pattern = "## ## ### ##"),
-            "RE" to Metadata(prefix = "+262", regionCode = "RE", pattern = ""),
-            "TF" to Metadata(prefix = "+262", regionCode = "TF", pattern = ""),
+            "RE" to Metadata(prefix = "+262", regionCode = "RE"),
+            "TF" to Metadata(prefix = "+262", regionCode = "TF"),
             "YT" to Metadata(prefix = "+262", regionCode = "YT", pattern = "### ## ## ##"),
             "ZW" to Metadata(prefix = "+263", regionCode = "ZW", pattern = "## ### ####"),
             "NA" to Metadata(prefix = "+264", regionCode = "NA", pattern = "## ### ####"),
@@ -330,8 +335,8 @@ internal sealed class PhoneNumberFormatter {
             "SZ" to Metadata(prefix = "+268", regionCode = "SZ", pattern = "#### ####"),
             "KM" to Metadata(prefix = "+269", regionCode = "KM", pattern = "### ## ##"),
             "ZA" to Metadata(prefix = "+27", regionCode = "ZA", pattern = "## ### ####"),
-            "SH" to Metadata(prefix = "+290", regionCode = "SH", pattern = ""),
-            "TA" to Metadata(prefix = "+290", regionCode = "TA", pattern = ""),
+            "SH" to Metadata(prefix = "+290", regionCode = "SH"),
+            "TA" to Metadata(prefix = "+290", regionCode = "TA"),
             "ER" to Metadata(prefix = "+291", regionCode = "ER", pattern = "# ### ###"),
             "AW" to Metadata(prefix = "+297", regionCode = "AW", pattern = "### ####"),
             "FO" to Metadata(prefix = "+298", regionCode = "FO", pattern = "######"),
@@ -350,7 +355,7 @@ internal sealed class PhoneNumberFormatter {
             "MT" to Metadata(prefix = "+356", regionCode = "MT", pattern = "#### ####"),
             "CY" to Metadata(prefix = "+357", regionCode = "CY", pattern = "## ######"),
             "FI" to Metadata(prefix = "+358", regionCode = "FI", pattern = "## ### ## ##"),
-            "AX" to Metadata(prefix = "+358", regionCode = "AX", pattern = ""),
+            "AX" to Metadata(prefix = "+358", regionCode = "AX"),
             "BG" to Metadata(prefix = "+359", regionCode = "BG", pattern = "### ### ##"),
             "HU" to Metadata(prefix = "+36", regionCode = "HU", pattern = "## ### ####"),
             "LT" to Metadata(prefix = "+370", regionCode = "LT", pattern = "### #####"),
@@ -362,7 +367,7 @@ internal sealed class PhoneNumberFormatter {
             "AD" to Metadata(prefix = "+376", regionCode = "AD", pattern = "### ###"),
             "MC" to Metadata(prefix = "+377", regionCode = "MC", pattern = "# ## ## ## ##"),
             "SM" to Metadata(prefix = "+378", regionCode = "SM", pattern = "## ## ## ##"),
-            "VA" to Metadata(prefix = "+379", regionCode = "VA", pattern = ""),
+            "VA" to Metadata(prefix = "+379", regionCode = "VA"),
             "UA" to Metadata(prefix = "+380", regionCode = "UA", pattern = "## ### ####"),
             "RS" to Metadata(prefix = "+381", regionCode = "RS", pattern = "## #######"),
             "ME" to Metadata(prefix = "+382", regionCode = "ME", pattern = "## ### ###"),
@@ -385,12 +390,12 @@ internal sealed class PhoneNumberFormatter {
             "DK" to Metadata(prefix = "+45", regionCode = "DK", pattern = "## ## ## ##"),
             "SE" to Metadata(prefix = "+46", regionCode = "SE", pattern = "##-### ## ##"),
             "NO" to Metadata(prefix = "+47", regionCode = "NO", pattern = "### ## ###"),
-            "BV" to Metadata(prefix = "+47", regionCode = "BV", pattern = ""),
+            "BV" to Metadata(prefix = "+47", regionCode = "BV"),
             "SJ" to Metadata(prefix = "+47", regionCode = "SJ", pattern = "## ## ## ##"),
             "PL" to Metadata(prefix = "+48", regionCode = "PL", pattern = "## ### ## ##"),
             "DE" to Metadata(prefix = "+49", regionCode = "DE", pattern = "### #######"),
-            "FK" to Metadata(prefix = "+500", regionCode = "FK", pattern = ""),
-            "GS" to Metadata(prefix = "+500", regionCode = "GS", pattern = ""),
+            "FK" to Metadata(prefix = "+500", regionCode = "FK"),
+            "GS" to Metadata(prefix = "+500", regionCode = "GS"),
             "BZ" to Metadata(prefix = "+501", regionCode = "BZ", pattern = "###-####"),
             "GT" to Metadata(prefix = "+502", regionCode = "GT", pattern = "#### ####"),
             "SV" to Metadata(prefix = "+503", regionCode = "SV", pattern = "#### ####"),
@@ -402,14 +407,14 @@ internal sealed class PhoneNumberFormatter {
             "HT" to Metadata(prefix = "+509", regionCode = "HT", pattern = "## ## ####"),
             "PE" to Metadata(prefix = "+51", regionCode = "PE", pattern = "### ### ###"),
             "MX" to Metadata(prefix = "+52", regionCode = "MX", pattern = "### ### ####"),
-            "CY" to Metadata(prefix = "+537", regionCode = "CY", pattern = ""),
+            "CY" to Metadata(prefix = "+537", regionCode = "CY"),
             "AR" to Metadata(prefix = "+54", regionCode = "AR", pattern = "## ##-####-####"),
             "BR" to Metadata(prefix = "+55", regionCode = "BR", pattern = "## #####-####"),
             "CL" to Metadata(prefix = "+56", regionCode = "CL", pattern = "# #### ####"),
             "CO" to Metadata(prefix = "+57", regionCode = "CO", pattern = "### #######"),
             "VE" to Metadata(prefix = "+58", regionCode = "VE", pattern = "###-#######"),
             "BL" to Metadata(prefix = "+590", regionCode = "BL", pattern = "### ## ## ##"),
-            "MF" to Metadata(prefix = "+590", regionCode = "MF", pattern = ""),
+            "MF" to Metadata(prefix = "+590", regionCode = "MF"),
             "GP" to Metadata(prefix = "+590", regionCode = "GP", pattern = "### ## ## ##"),
             "BO" to Metadata(prefix = "+591", regionCode = "BO", pattern = "########"),
             "GY" to Metadata(prefix = "+592", regionCode = "GY", pattern = "### ####"),
@@ -439,15 +444,15 @@ internal sealed class PhoneNumberFormatter {
             "FJ" to Metadata(prefix = "+679", regionCode = "FJ", pattern = "### ####"),
             "WF" to Metadata(prefix = "+681", regionCode = "WF", pattern = "## ## ##"),
             "CK" to Metadata(prefix = "+682", regionCode = "CK", pattern = "## ###"),
-            "NU" to Metadata(prefix = "+683", regionCode = "NU", pattern = ""),
-            "WS" to Metadata(prefix = "+685", regionCode = "WS", pattern = ""),
-            "KI" to Metadata(prefix = "+686", regionCode = "KI", pattern = ""),
+            "NU" to Metadata(prefix = "+683", regionCode = "NU"),
+            "WS" to Metadata(prefix = "+685", regionCode = "WS"),
+            "KI" to Metadata(prefix = "+686", regionCode = "KI"),
             "NC" to Metadata(prefix = "+687", regionCode = "NC", pattern = "########"),
-            "TV" to Metadata(prefix = "+688", regionCode = "TV", pattern = ""),
+            "TV" to Metadata(prefix = "+688", regionCode = "TV"),
             "PF" to Metadata(prefix = "+689", regionCode = "PF", pattern = "## ## ##"),
-            "TK" to Metadata(prefix = "+690", regionCode = "TK", pattern = ""),
+            "TK" to Metadata(prefix = "+690", regionCode = "TK"),
             "RU" to Metadata(prefix = "+7", regionCode = "RU", pattern = "### ###-##-##"),
-            "KZ" to Metadata(prefix = "+7", regionCode = "KZ", pattern = ""),
+            "KZ" to Metadata(prefix = "+7", regionCode = "KZ"),
             "JP" to Metadata(prefix = "+81", regionCode = "JP", pattern = "##-####-####"),
             "KR" to Metadata(prefix = "+82", regionCode = "KR", pattern = "##-####-####"),
             "VN" to Metadata(prefix = "+84", regionCode = "VN", pattern = "## ### ## ##"),
@@ -456,7 +461,7 @@ internal sealed class PhoneNumberFormatter {
             "KH" to Metadata(prefix = "+855", regionCode = "KH", pattern = "## ### ###"),
             "LA" to Metadata(prefix = "+856", regionCode = "LA", pattern = "## ## ### ###"),
             "CN" to Metadata(prefix = "+86", regionCode = "CN", pattern = "### #### ####"),
-            "PN" to Metadata(prefix = "+872", regionCode = "PN", pattern = ""),
+            "PN" to Metadata(prefix = "+872", regionCode = "PN"),
             "BD" to Metadata(prefix = "+880", regionCode = "BD", pattern = "####-######"),
             "TW" to Metadata(prefix = "+886", regionCode = "TW", pattern = "### ### ###"),
             "TR" to Metadata(prefix = "+90", regionCode = "TR", pattern = "### ### ####"),

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
@@ -190,7 +190,9 @@ internal sealed class PhoneNumberFormatter {
         val pattern: String? = null
     ) {
         init {
-            require(pattern == null || pattern.isNotEmpty()) { "Pattern should not be empty. Set it to null if it's missing." }
+            require(pattern == null || pattern.isNotEmpty()) {
+                "Pattern should not be empty. Set it to null if it's missing."
+            }
         }
     }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
@@ -190,8 +190,7 @@ internal sealed class PhoneNumberFormatter {
         val pattern: String? = null
     ) {
         init {
-            require(pattern == null || pattern.isNotEmpty())
-            { "Pattern should not be empty. Set it to null if it's missing." }
+            require(pattern == null || pattern.isNotEmpty()) { "Pattern should not be empty. Set it to null if it's missing." }
         }
     }
 

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
@@ -104,6 +104,24 @@ internal class PhoneNumberFormatterTest {
         assertThat(formatter.toE164Format("0137111222")).isEqualTo("+44137111222")
     }
 
+    @Test
+    fun `When pattern is empty, there is no formatting`() {
+        val pattern = ""
+        val formatter = PhoneNumberFormatter.WithRegion(
+            PhoneNumberFormatter.Metadata(
+                "prefix",
+                "regionCode",
+                pattern
+            )
+        )
+
+        // visualTransformation prepends a space to the output string
+        assertThat(formatter.format("123")).isEqualTo(" 123")
+        assertThat(formatter.format("1234567")).isEqualTo(" 1234567")
+        assertThat(formatter.format("123456789012")).isEqualTo(" 123456789012")
+        assertThat(formatter.format("123456789012456")).isEqualTo(" 123456789012456")
+    }
+
     private fun PhoneNumberFormatter.format(input: String) =
         visualTransformation.filter(AnnotatedString(userInputFilter(input))).text.text
 }

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
@@ -108,9 +108,9 @@ internal class PhoneNumberFormatterTest {
     fun `When pattern is missing, there is no formatting`() {
         val formatter = PhoneNumberFormatter.WithRegion(
             PhoneNumberFormatter.Metadata(
-                "prefix",
-                "regionCode",
-                // no pattern specified
+                prefix = "prefix",
+                regionCode = "regionCode",
+                pattern = null
             )
         )
 

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
@@ -105,13 +105,12 @@ internal class PhoneNumberFormatterTest {
     }
 
     @Test
-    fun `When pattern is empty, there is no formatting`() {
-        val pattern = ""
+    fun `When pattern is missing, there is no formatting`() {
         val formatter = PhoneNumberFormatter.WithRegion(
             PhoneNumberFormatter.Metadata(
                 "prefix",
                 "regionCode",
-                pattern
+                // no pattern specified
             )
         )
 

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
@@ -115,11 +115,10 @@ internal class PhoneNumberFormatterTest {
             )
         )
 
-        // visualTransformation prepends a space to the output string
-        assertThat(formatter.format("123")).isEqualTo(" 123")
-        assertThat(formatter.format("1234567")).isEqualTo(" 1234567")
-        assertThat(formatter.format("123456789012")).isEqualTo(" 123456789012")
-        assertThat(formatter.format("123456789012456")).isEqualTo(" 123456789012456")
+        assertThat(formatter.format("123")).isEqualTo("123")
+        assertThat(formatter.format("1234567")).isEqualTo("1234567")
+        assertThat(formatter.format("123456789012")).isEqualTo("123456789012")
+        assertThat(formatter.format("123456789012456")).isEqualTo("123456789012456")
     }
 
     private fun PhoneNumberFormatter.format(input: String) =


### PR DESCRIPTION
# Summary
Correctly handle missing phone number patterns. 

- Represent them as null rather than empty string to ensure we always handle the case where the pattern is missing.
- Don't add a leading space to them.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified