### PR TITLE
Continue processing payment even if `Link` signup fails.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
@@ -152,9 +152,7 @@ internal class LinkHandler @Inject constructor(
                                 )
                             },
                             onFailure = {
-                                _processingState.emit(ProcessingState.Error(it.localizedMessage))
-                                savedStateHandle[SAVE_PROCESSING] = false
-                                _processingState.emit(ProcessingState.Ready)
+                                _processingState.emit(ProcessingState.CompleteWithoutLink)
                             }
                         )
                     } ?: run {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/LinkHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/LinkHandlerTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.link.analytics.LinkAnalyticsHelper
 import com.stripe.android.link.injection.LinkAnalyticsComponent
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.LinkSignupMode
+import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
@@ -323,7 +324,7 @@ class LinkHandlerTest {
     }
 
     @Test
-    fun `payWithLinkInline fails for signedOut user`() = runLinkInlineTest {
+    fun `if lookup fails, payWithLinkInline emits event to pay without Link`() = runLinkInlineTest {
         val userInput = UserInput.SignIn(email = "example@example.com")
 
         handler.setupLink(
@@ -342,8 +343,45 @@ class LinkHandlerTest {
                 handler.payWithLinkInline(userInput, cardSelection(), shouldCompleteLinkFlow)
             }
             assertThat(awaitItem()).isEqualTo(LinkHandler.ProcessingState.Started)
-            assertThat(awaitItem()).isEqualTo(LinkHandler.ProcessingState.Error("Whoops"))
-            assertThat(awaitItem()).isEqualTo(LinkHandler.ProcessingState.Ready)
+            assertThat(awaitItem()).isEqualTo(LinkHandler.ProcessingState.CompleteWithoutLink)
+            verify(linkLauncher, never()).present(eq(configuration))
+        }
+
+        handler.accountStatus.test {
+            assertThat(awaitItem()).isEqualTo(AccountStatus.SignedOut)
+        }
+
+        processingStateTurbine.cancelAndIgnoreRemainingEvents() // Validated above.
+        accountStatusTurbine.cancelAndIgnoreRemainingEvents() // Validated above.
+    }
+
+    @Test
+    fun `if sign up fails, payWithLinkInline emits event to pay without Link`() = runLinkInlineTest {
+        val userInput = UserInput.SignUp(
+            name = "John Doe",
+            email = "example@example.com",
+            phone = "+11234567890",
+            country = "US",
+            consentAction = SignUpConsentAction.Checkbox,
+        )
+
+        handler.setupLink(
+            state = LinkState(
+                loginState = LinkState.LoginState.LoggedOut,
+                configuration = configuration,
+            )
+        )
+
+        handler.processingState.test {
+            accountStatusFlow.emit(AccountStatus.SignedOut)
+            ensureAllEventsConsumed() // Begin with no events.
+            whenever(linkConfigurationCoordinator.signInWithUserInput(any(), any()))
+                .thenReturn(Result.failure(IllegalStateException("Whoops")))
+            testScope.launch {
+                handler.payWithLinkInline(userInput, cardSelection(), shouldCompleteLinkFlow)
+            }
+            assertThat(awaitItem()).isEqualTo(LinkHandler.ProcessingState.Started)
+            assertThat(awaitItem()).isEqualTo(LinkHandler.ProcessingState.CompleteWithoutLink)
             verify(linkLauncher, never()).present(eq(configuration))
         }
 


### PR DESCRIPTION
# Summary
Continue processing payment even if `Link` signup fails.

**Note**: I have an additional test in https://github.com/stripe/stripe-android/pull/7966 for further testing this behavior. I'll enable it when this PR is merged.

# Motivation
`iOS` silently fails `Link` signup and continues payment to not impede on potentially successful payment flows irregardless of Link status. The failure is reported for further investigation .

Resolves [MOBILESDK-1782](https://jira.corp.stripe.com/browse/MOBILESDK-1782)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
