### PR TITLE
Use payment method metadata to create SupportedPaymentMethods in CustomerSheetLoader.

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -23,7 +23,7 @@
     <ID>LargeClass:USBankAccountFormViewModelTest.kt$USBankAccountFormViewModelTest</ID>
     <ID>LongMethod:AddPaymentMethod.kt$@Composable internal fun AddPaymentMethod( sheetViewModel: BaseSheetViewModel, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:AutocompleteScreen.kt$@Composable internal fun AutocompleteScreenUI(viewModel: AutocompleteViewModel)</ID>
-    <ID>LongMethod:CustomerSheetLoader.kt$DefaultCustomerSheetLoader$private suspend fun loadPaymentMethods( customerAdapter: CustomerAdapter, configuration: CustomerSheet.Configuration?, elementsSession: ElementsSession?, )</ID>
+    <ID>LongMethod:CustomerSheetLoader.kt$DefaultCustomerSheetLoader$private suspend fun loadPaymentMethods( customerAdapter: CustomerAdapter, configuration: CustomerSheet.Configuration?, elementsSessionWithMetadata: ElementsSessionWithMetadata?, )</ID>
     <ID>LongMethod:CustomerSheetScreen.kt$@Composable internal fun AddPaymentMethodWithPaymentElement( viewState: CustomerSheetViewState.AddPaymentMethod, viewActionHandler: (CustomerSheetViewAction) -> Unit, formViewModelSubComponentBuilderProvider: Provider&lt;FormViewModelSubcomponent.Builder>?, )</ID>
     <ID>LongMethod:CustomerSheetScreen.kt$@Composable internal fun SelectPaymentMethod( viewState: CustomerSheetViewState.SelectPaymentMethod, viewActionHandler: (CustomerSheetViewAction) -> Unit, paymentMethodNameProvider: (PaymentMethodCode?) -> String, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:CustomerSheetViewModel.kt$CustomerSheetViewModel$private fun transitionToAddPaymentMethod( isFirstPaymentMethod: Boolean, cbcEligibility: CardBrandChoiceEligibility = viewState.value.cbcEligibility, )</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -73,24 +73,24 @@ internal class DefaultCustomerSheetLoader(
             } else {
                 adapter to null
             }
-        }.map { (adapter, session) ->
+        }.map { (adapter, elementsSessionWithMetadata) ->
             loadPaymentMethods(
                 customerAdapter = adapter,
                 configuration = configuration,
-                elementsSession = session,
+                elementsSessionWithMetadata = elementsSessionWithMetadata,
             ).getOrThrow()
         }
     }
 
     private suspend fun retrieveElementsSession(
         configuration: CustomerSheet.Configuration?,
-    ): Result<ElementsSession> {
+    ): Result<ElementsSessionWithMetadata> {
         val initializationMode = PaymentSheet.InitializationMode.DeferredIntent(
             PaymentSheet.IntentConfiguration(
                 mode = PaymentSheet.IntentConfiguration.Mode.Setup(),
             )
         )
-        return elementsSessionRepository.get(initializationMode).onSuccess { elementsSession ->
+        return elementsSessionRepository.get(initializationMode).map { elementsSession ->
             val billingDetailsCollectionConfig = configuration?.billingDetailsCollectionConfiguration.toInternal()
             val sharedDataSpecs = lpmRepository.getSharedDataSpecs(
                 stripeIntent = elementsSession.stripeIntent,
@@ -99,7 +99,7 @@ internal class DefaultCustomerSheetLoader(
             val metadata = PaymentMethodMetadata(
                 stripeIntent = elementsSession.stripeIntent,
                 billingDetailsCollectionConfiguration = billingDetailsCollectionConfig,
-                allowsDelayedPaymentMethods = false,
+                allowsDelayedPaymentMethods = true,
                 allowsPaymentMethodsRequiringShippingAddress = false,
                 sharedDataSpecs = sharedDataSpecs,
                 financialConnectionsAvailable = isFinancialConnectionsAvailable()
@@ -109,13 +109,14 @@ internal class DefaultCustomerSheetLoader(
                 metadata = metadata,
                 specs = sharedDataSpecs,
             )
+            ElementsSessionWithMetadata(elementsSession = elementsSession, metadata = metadata)
         }
     }
 
     private suspend fun loadPaymentMethods(
         customerAdapter: CustomerAdapter,
         configuration: CustomerSheet.Configuration?,
-        elementsSession: ElementsSession?,
+        elementsSessionWithMetadata: ElementsSessionWithMetadata?,
     ) = coroutineScope {
         val paymentMethodsResult = async {
             customerAdapter.retrievePaymentMethods()
@@ -161,10 +162,14 @@ internal class DefaultCustomerSheetLoader(
 
                 val billingDetailsCollectionConfig = configuration?.billingDetailsCollectionConfiguration.toInternal()
 
+                val elementsSession = elementsSessionWithMetadata?.elementsSession
+                val metadata = elementsSessionWithMetadata?.metadata
+                val supportedPaymentMethodDefinitions = metadata?.supportedPaymentMethodDefinitions()
+
                 // By default, only cards are supported. If the elements session is not available, then US Bank account
                 // is not supported
-                val supportedPaymentMethods = elementsSession?.stripeIntent?.paymentMethodTypes?.mapNotNull {
-                    lpmRepository.fromCode(it)
+                val supportedPaymentMethods = supportedPaymentMethodDefinitions?.mapNotNull { paymentMethodDefinition ->
+                    metadata.supportedPaymentMethodForCode(paymentMethodDefinition.type.code)
                 } ?: listOf(CardDefinition.hardcodedCardSpec(billingDetailsCollectionConfig))
 
                 val validSupportedPaymentMethods = filterSupportedPaymentMethods(
@@ -214,6 +219,11 @@ internal class DefaultCustomerSheetLoader(
         }
     }
 }
+
+private data class ElementsSessionWithMetadata(
+    val elementsSession: ElementsSession,
+    val metadata: PaymentMethodMetadata,
+)
 
 private suspend fun <T> Deferred<T>.awaitAsResult(
     timeout: Duration,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -500,7 +500,14 @@ class DefaultCustomerSheetLoaderTest {
             elementsSessionRepository = FakeElementsSessionRepository(
                 stripeIntent = STRIPE_INTENT.copy(
                     clientSecret = null,
-                    paymentMethodTypes = listOf("card", "us_bank_account")
+                    paymentMethodTypes = listOf("card", "us_bank_account"),
+                    paymentMethodOptionsJsonString = """
+                        {
+                            "us_bank_account": {
+                                "verification_method": "automatic"
+                            }
+                        }
+                    """.trimIndent(),
                 ),
                 error = null,
                 linkSettings = null,
@@ -509,9 +516,8 @@ class DefaultCustomerSheetLoaderTest {
 
         val config = CustomerSheet.Configuration(merchantDisplayName = "Example")
 
-        assertThat(
-            loader.load(config).getOrThrow().supportedPaymentMethods
-        ).contains(LpmRepositoryTestHelpers.usBankAccount)
+        val supportedPaymentMethods = loader.load(config).getOrThrow().supportedPaymentMethods
+        assertThat(supportedPaymentMethods).contains(LpmRepositoryTestHelpers.usBankAccount)
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This is the last phase of getting CustomerSheet onto the new architecture.
