### PR TITLE
PaymentMethodMetadata should filter unactivated payment methods.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -35,6 +35,9 @@ internal data class PaymentMethodMetadata(
             PaymentMethodRegistry.definitionsByCode[it]
         }.filter {
             it.isSupported(this)
+        }.filterNot {
+            stripeIntent.isLiveMode &&
+                stripeIntent.unactivatedPaymentMethods.contains(it.type.code)
         }.filter { paymentMethodDefinition ->
             sharedDataSpecs.firstOrNull { it.type == paymentMethodDefinition.type.code } != null
         }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -39,4 +39,35 @@ internal class PaymentMethodMetadataTest {
         assertThat(supportedPaymentMethods[0].type.code).isEqualTo("card")
         assertThat(supportedPaymentMethods[1].type.code).isEqualTo("klarna")
     }
+
+    @Test
+    fun `filterSupportedPaymentMethods filters unactivated payment methods in live mode`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "klarna"),
+                unactivatedPaymentMethods = listOf("klarna"),
+                isLiveMode = true,
+            ),
+            sharedDataSpecs = listOf(SharedDataSpec("card"), SharedDataSpec("klarna")),
+        )
+        val supportedPaymentMethods = metadata.supportedPaymentMethodDefinitions()
+        assertThat(supportedPaymentMethods).hasSize(1)
+        assertThat(supportedPaymentMethods[0].type.code).isEqualTo("card")
+    }
+
+    @Test
+    fun `filterSupportedPaymentMethods does not filter unactivated payment methods in test mode`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "klarna"),
+                unactivatedPaymentMethods = listOf("klarna"),
+                isLiveMode = false,
+            ),
+            sharedDataSpecs = listOf(SharedDataSpec("card"), SharedDataSpec("klarna")),
+        )
+        val supportedPaymentMethods = metadata.supportedPaymentMethodDefinitions()
+        assertThat(supportedPaymentMethods).hasSize(2)
+        assertThat(supportedPaymentMethods[0].type.code).isEqualTo("card")
+        assertThat(supportedPaymentMethods[1].type.code).isEqualTo("klarna")
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I missed this when porting the original implementation. 
