### PR TITLE
Fix small-screen issues in Networking signup screen

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
@@ -62,7 +62,7 @@ import com.stripe.android.financialconnections.ui.components.FinancialConnection
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsTopAppBar
 import com.stripe.android.financialconnections.ui.components.elevation
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
-import com.stripe.android.financialconnections.ui.theme.Layout
+import com.stripe.android.financialconnections.ui.theme.LazyLayout
 import com.stripe.android.financialconnections.ui.theme.Neutral900
 import kotlinx.coroutines.launch
 
@@ -218,7 +218,7 @@ private fun AccountPickerLoaded(
     onClickableTextClick: (String) -> Unit,
     onSubmit: () -> Unit
 ) {
-    Layout(
+    LazyLayout(
         lazyListState = lazyListState,
         verticalArrangement = Arrangement.spacedBy(16.dp),
         body = {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ErrorContent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ErrorContent.kt
@@ -32,7 +32,7 @@ import com.stripe.android.financialconnections.ui.components.FinancialConnection
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsScaffold
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsTopAppBar
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.typography
-import com.stripe.android.financialconnections.ui.theme.Layout
+import com.stripe.android.financialconnections.ui.theme.LazyLayout
 import java.text.SimpleDateFormat
 
 @Composable
@@ -269,7 +269,7 @@ internal fun ErrorContent(
             view.performHapticFeedback(REJECT)
         }
     }
-    Layout(
+    LazyLayout(
         verticalArrangement = Arrangement.spacedBy(16.dp),
         body = {
             iconContent?.let {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ModalBottomSheetContent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ModalBottomSheetContent.kt
@@ -27,7 +27,7 @@ import com.stripe.android.financialconnections.ui.sdui.fromHtml
 import com.stripe.android.financialconnections.ui.sdui.rememberHtml
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.colors
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.typography
-import com.stripe.android.financialconnections.ui.theme.Layout
+import com.stripe.android.financialconnections.ui.theme.LazyLayout
 
 @Composable
 internal fun DataAccessBottomSheetContent(
@@ -162,7 +162,7 @@ private fun ModalBottomSheetContent(
     onConfirmModalClick: () -> Unit,
     content: LazyListScope.() -> Unit,
 ) {
-    Layout(
+    LazyLayout(
         modifier = Modifier.padding(top = 32.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
         inModal = true,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/SharedPartnerAuth.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/SharedPartnerAuth.kt
@@ -68,7 +68,7 @@ import com.stripe.android.financialconnections.ui.components.FinancialConnection
 import com.stripe.android.financialconnections.ui.sdui.fromHtml
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.colors
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.typography
-import com.stripe.android.financialconnections.ui.theme.Layout
+import com.stripe.android.financialconnections.ui.theme.LazyLayout
 import com.stripe.android.uicore.image.StripeImage
 
 @Composable
@@ -294,7 +294,7 @@ private fun PrePaneContent(
     onCancelClick: () -> Unit,
     onClickableTextClick: (String) -> Unit,
 ) {
-    Layout(
+    LazyLayout(
         inModal = showInModal,
         // Overrides padding values to allow full-span prepane image background
         verticalArrangement = Arrangement.spacedBy(24.dp),

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
@@ -59,7 +59,7 @@ import com.stripe.android.financialconnections.ui.sdui.BulletUI
 import com.stripe.android.financialconnections.ui.sdui.fromHtml
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.colors
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.typography
-import com.stripe.android.financialconnections.ui.theme.Layout
+import com.stripe.android.financialconnections.ui.theme.LazyLayout
 import kotlinx.coroutines.launch
 
 @ExperimentalMaterialApi
@@ -167,7 +167,7 @@ private fun ConsentMainContent(
             )
         }
     ) {
-        Layout(
+        LazyLayout(
             lazyListState = scrollState,
             body = {
                 item {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerScreen.kt
@@ -74,7 +74,7 @@ import com.stripe.android.financialconnections.ui.components.clickableSingle
 import com.stripe.android.financialconnections.ui.components.elevation
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.colors
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.typography
-import com.stripe.android.financialconnections.ui.theme.Layout
+import com.stripe.android.financialconnections.ui.theme.LazyLayout
 import com.stripe.android.financialconnections.ui.theme.Neutral900
 import com.stripe.android.uicore.image.StripeImage
 import kotlinx.coroutines.launch
@@ -225,7 +225,7 @@ private fun LinkAccountPickerLoaded(
     onSelectAccountClick: () -> Unit,
     cta: String?
 ) {
-    Layout(
+    LazyLayout(
         verticalArrangement = Arrangement.spacedBy(16.dp),
         lazyListState = scrollState,
         body = {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationScreen.kt
@@ -48,7 +48,7 @@ import com.stripe.android.financialconnections.ui.components.StringAnnotation
 import com.stripe.android.financialconnections.ui.components.elevation
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.colors
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.typography
-import com.stripe.android.financialconnections.ui.theme.Layout
+import com.stripe.android.financialconnections.ui.theme.LazyLayout
 
 @Composable
 internal fun LinkStepUpVerificationScreen() {
@@ -125,7 +125,7 @@ private fun LinkStepUpVerificationLoaded(
             onCloseFromErrorClick = onCloseFromErrorClick
         )
     } else {
-        Layout(
+        LazyLayout(
             verticalArrangement = Arrangement.spacedBy(24.dp),
             lazyListState = lazyListState,
             body = {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupScreen.kt
@@ -41,7 +41,7 @@ import com.stripe.android.financialconnections.ui.components.FinancialConnection
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsButton.Type
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.colors
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.typography
-import com.stripe.android.financialconnections.ui.theme.Layout
+import com.stripe.android.financialconnections.ui.theme.LazyLayout
 import com.stripe.android.financialconnections.ui.theme.LinkColors
 
 @Composable
@@ -62,7 +62,7 @@ private fun NetworkingLinkLoginWarmupContent(
     onSkipClicked: () -> Unit,
 ) {
     val lazyListState = rememberLazyListState()
-    Layout(
+    LazyLayout(
         modifier = Modifier
             .fillMaxWidth()
             .background(color = colors.backgroundSurface)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupScreen.kt
@@ -67,7 +67,7 @@ import com.stripe.android.financialconnections.ui.sdui.BulletUI
 import com.stripe.android.financialconnections.ui.sdui.fromHtml
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.colors
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.typography
-import com.stripe.android.financialconnections.ui.theme.Layout
+import com.stripe.android.financialconnections.ui.theme.LazyLayout
 import com.stripe.android.financialconnections.ui.theme.StripeThemeForConnections
 import com.stripe.android.model.ConsumerSessionLookup
 import com.stripe.android.uicore.elements.DropDown
@@ -198,7 +198,7 @@ private fun NetworkingLinkSignupLoaded(
     onSaveToLink: () -> Unit,
     onSkipClick: () -> Unit
 ) {
-    Layout(
+    LazyLayout(
         lazyListState = lazyListState,
         body = {
             item {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupScreen.kt
@@ -1,16 +1,18 @@
 package com.stripe.android.financialconnections.features.networkinglinksignup
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ModalBottomSheetState
@@ -28,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.testTag
@@ -67,14 +70,18 @@ import com.stripe.android.financialconnections.ui.sdui.BulletUI
 import com.stripe.android.financialconnections.ui.sdui.fromHtml
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.colors
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.typography
-import com.stripe.android.financialconnections.ui.theme.LazyLayout
+import com.stripe.android.financialconnections.ui.theme.Layout
 import com.stripe.android.financialconnections.ui.theme.StripeThemeForConnections
 import com.stripe.android.model.ConsumerSessionLookup
 import com.stripe.android.uicore.elements.DropDown
 import com.stripe.android.uicore.elements.PhoneNumberCollectionSection
 import com.stripe.android.uicore.elements.TextFieldController
 import com.stripe.android.uicore.elements.TextFieldSection
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
+
+private val ScrollToPhoneNumberFieldDelay = 300.milliseconds
 
 @Composable
 internal fun NetworkingLinkSignupScreen() {
@@ -154,11 +161,11 @@ private fun NetworkingLinkSignupMainContent(
     onSkipClick: () -> Unit,
     onCloseFromErrorClick: (Throwable) -> Unit
 ) {
-    val lazyListState = rememberLazyListState()
+    val scrollState = rememberScrollState()
     FinancialConnectionsScaffold(
         topBar = {
             FinancialConnectionsTopAppBar(
-                elevation = lazyListState.elevation,
+                elevation = scrollState.elevation,
                 showBack = false,
                 onCloseClick = onCloseClick,
             )
@@ -167,7 +174,7 @@ private fun NetworkingLinkSignupMainContent(
         when (val payload = state.payload) {
             Uninitialized, is Loading -> FullScreenGenericLoading()
             is Success -> NetworkingLinkSignupLoaded(
-                lazyListState = lazyListState,
+                scrollState = scrollState,
                 validForm = state.valid(),
                 payload = payload(),
                 lookupAccountSync = state.lookupAccount,
@@ -188,7 +195,7 @@ private fun NetworkingLinkSignupMainContent(
 
 @Composable
 private fun NetworkingLinkSignupLoaded(
-    lazyListState: LazyListState,
+    scrollState: ScrollState,
     validForm: Boolean,
     payload: Payload,
     saveAccountToLinkSync: Async<FinancialConnectionsSessionManifest>,
@@ -198,31 +205,42 @@ private fun NetworkingLinkSignupLoaded(
     onSaveToLink: () -> Unit,
     onSkipClick: () -> Unit
 ) {
-    LazyLayout(
-        lazyListState = lazyListState,
+    val phoneNumberFocusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(showFullForm) {
+        if (showFullForm) {
+            delay(ScrollToPhoneNumberFieldDelay)
+            scrollState.animateScrollBy(Float.MAX_VALUE, animationSpec = tween())
+            phoneNumberFocusRequester.requestFocus()
+        }
+    }
+
+    Layout(
+        scrollState = scrollState,
         body = {
-            item {
-                Title(payload.content.title)
-                Spacer(modifier = Modifier.size(24.dp))
-            }
-            items(payload.content.body.bullets) {
+            Title(payload.content.title)
+            Spacer(modifier = Modifier.size(24.dp))
+
+            for (bullet in payload.content.body.bullets) {
                 ListItem(
-                    bullet = BulletUI.from(it),
+                    bullet = BulletUI.from(bullet),
                     onClickableTextClick = onClickableTextClick
                 )
                 Spacer(modifier = Modifier.size(16.dp))
             }
-            item {
-                EmailSection(
-                    showFullForm = showFullForm,
-                    loading = lookupAccountSync is Loading,
-                    emailController = payload.emailController,
-                    enabled = true,
-                )
-            }
 
-            if (showFullForm) {
-                item { PhoneNumberSection(payload = payload) }
+            EmailSection(
+                showFullForm = showFullForm,
+                loading = lookupAccountSync is Loading,
+                emailController = payload.emailController,
+                enabled = true,
+            )
+
+            AnimatedVisibility(showFullForm) {
+                PhoneNumberSection(
+                    payload = payload,
+                    focusRequester = phoneNumberFocusRequester,
+                )
             }
         },
         footer = {
@@ -283,7 +301,8 @@ private fun NetworkingLinkSignupFooter(
 
 @Composable
 private fun PhoneNumberSection(
-    payload: Payload
+    payload: Payload,
+    focusRequester: FocusRequester,
 ) {
     var focused by remember { mutableStateOf(false) }
     Column {
@@ -303,9 +322,9 @@ private fun PhoneNumberSection(
                     )
                 },
                 isSelected = focused,
-                requestFocusWhenShown = payload.phoneController.initialPhoneNumber.isEmpty(),
                 phoneNumberController = payload.phoneController,
                 imeAction = ImeAction.Default,
+                focusRequester = focusRequester,
                 enabled = true,
             )
         }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupScreen.kt
@@ -2,6 +2,7 @@ package com.stripe.android.financialconnections.features.networkinglinksignup
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
@@ -77,11 +78,7 @@ import com.stripe.android.uicore.elements.DropDown
 import com.stripe.android.uicore.elements.PhoneNumberCollectionSection
 import com.stripe.android.uicore.elements.TextFieldController
 import com.stripe.android.uicore.elements.TextFieldSection
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlin.time.Duration.Companion.milliseconds
-
-private val ScrollToPhoneNumberFieldDelay = 300.milliseconds
 
 @Composable
 internal fun NetworkingLinkSignupScreen() {
@@ -209,8 +206,7 @@ private fun NetworkingLinkSignupLoaded(
 
     LaunchedEffect(showFullForm) {
         if (showFullForm) {
-            delay(ScrollToPhoneNumberFieldDelay)
-            scrollState.animateScrollBy(Float.MAX_VALUE, animationSpec = tween())
+            scrollState.animateScrollToBottom()
             phoneNumberFocusRequester.requestFocus()
         }
     }
@@ -378,6 +374,12 @@ internal fun EmailSection(
             }
         }
     }
+}
+
+private suspend fun ScrollState.animateScrollToBottom(
+    animationSpec: AnimationSpec<Float> = tween(),
+) {
+    animateScrollBy(Float.MAX_VALUE, animationSpec)
 }
 
 @Composable

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationScreen.kt
@@ -41,7 +41,7 @@ import com.stripe.android.financialconnections.ui.FinancialConnectionsPreview
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsScaffold
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsTopAppBar
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
-import com.stripe.android.financialconnections.ui.theme.Layout
+import com.stripe.android.financialconnections.ui.theme.LazyLayout
 
 @Composable
 internal fun NetworkingLinkVerificationScreen() {
@@ -107,7 +107,7 @@ private fun NetworkingLinkVerificationLoaded(
             onCloseFromErrorClick = onCloseFromErrorClick
         )
     } else {
-        Layout(
+        LazyLayout(
             verticalArrangement = Arrangement.spacedBy(24.dp),
             body = {
                 item { Header(payload) }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationScreen.kt
@@ -45,7 +45,7 @@ import com.stripe.android.financialconnections.ui.components.FinancialConnection
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsTopAppBar
 import com.stripe.android.financialconnections.ui.components.elevation
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
-import com.stripe.android.financialconnections.ui.theme.Layout
+import com.stripe.android.financialconnections.ui.theme.LazyLayout
 
 @Composable
 internal fun NetworkingSaveToLinkVerificationScreen() {
@@ -120,7 +120,7 @@ private fun NetworkingSaveToLinkVerificationLoaded(
             onCloseFromErrorClick = onCloseFromErrorClick
         )
     } else {
-        Layout(
+        LazyLayout(
             lazyListState = lazyListState,
             verticalArrangement = Arrangement.spacedBy(24.dp),
             body = {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Layout.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Layout.kt
@@ -41,7 +41,7 @@ import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsThem
  * @param lazyListState the [LazyListState] to use for the scrollable body.
  */
 @Composable
-internal fun Layout(
+internal fun LazyLayout(
     modifier: Modifier = Modifier,
     body: LazyListScope.() -> Unit,
     footer: (@Composable () -> Unit)? = null,
@@ -124,7 +124,7 @@ internal fun LayoutPreview() {
                 )
             },
             content = {
-                Layout(
+                LazyLayout(
                     lazyListState = state,
                     body = {
                         item {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Layout.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Layout.kt
@@ -1,10 +1,13 @@
 package com.stripe.android.financialconnections.ui.theme
 
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -15,6 +18,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -38,6 +43,49 @@ import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsThem
  * @param inModal whether the layout is being used in a modal or not. If true, the [body] won't expand to fill the
  * available content.
  * @param showFooterShadowWhenScrollable whether to show a shadow at the top of the footer when the body is scrollable.
+ * @param scrollState the [ScrollState] to use for the scrollable body.
+ */
+@Composable
+internal fun Layout(
+    modifier: Modifier = Modifier,
+    body: @Composable ColumnScope.() -> Unit,
+    footer: (@Composable () -> Unit)? = null,
+    bodyPadding: PaddingValues = PaddingValues(horizontal = 24.dp),
+    inModal: Boolean = false,
+    verticalArrangement: Arrangement.Vertical = Arrangement.Top,
+    showFooterShadowWhenScrollable: Boolean = true,
+    scrollState: ScrollState = rememberScrollState(),
+) {
+    LayoutScaffold(
+        canScrollForward = scrollState.canScrollForward,
+        inModal = inModal,
+        showFooterShadowWhenScrollable = showFooterShadowWhenScrollable,
+        modifier = modifier,
+        footer = footer,
+    ) {
+        Column(
+            modifier = Modifier
+                .verticalScroll(scrollState)
+                .animateContentSize(),
+            verticalArrangement = verticalArrangement,
+        ) {
+            // Nested columns to achieve proper content padding
+            Column(modifier = Modifier.padding(bodyPadding)) {
+                body()
+            }
+        }
+    }
+}
+
+/**
+ * A layout that contains a body, and an optional, bottom fixed footer.
+ *
+ * @param modifier the modifier to apply to the layout.
+ * @param body the content of the layout.
+ * @param footer the content of the footer.
+ * @param inModal whether the layout is being used in a modal or not. If true, the [body] won't expand to fill the
+ * available content.
+ * @param showFooterShadowWhenScrollable whether to show a shadow at the top of the footer when the body is scrollable.
  * @param lazyListState the [LazyListState] to use for the scrollable body.
  */
 @Composable
@@ -51,6 +99,32 @@ internal fun LazyLayout(
     showFooterShadowWhenScrollable: Boolean = true,
     lazyListState: LazyListState = rememberLazyListState()
 ) {
+    LayoutScaffold(
+        canScrollForward = lazyListState.canScrollForward,
+        inModal = inModal,
+        showFooterShadowWhenScrollable = showFooterShadowWhenScrollable,
+        modifier = modifier,
+        footer = footer,
+    ) {
+        LazyColumn(
+            state = lazyListState,
+            verticalArrangement = verticalArrangement,
+            contentPadding = bodyPadding,
+        ) {
+            body()
+        }
+    }
+}
+
+@Composable
+private fun LayoutScaffold(
+    canScrollForward: Boolean,
+    inModal: Boolean,
+    showFooterShadowWhenScrollable: Boolean,
+    modifier: Modifier = Modifier,
+    footer: (@Composable () -> Unit)?,
+    body: @Composable () -> Unit,
+) {
     Column(
         modifier
             .also { if (inModal.not()) it.fillMaxSize() }
@@ -62,17 +136,11 @@ internal fun LazyLayout(
                 .weight(1f, fill = inModal.not())
         ) {
             // Footer shadow (top aligned)
-            if (showFooterShadowWhenScrollable && lazyListState.canScrollForward) {
+            if (showFooterShadowWhenScrollable && canScrollForward) {
                 FooterTopShadow()
             }
             // Body content
-            LazyColumn(
-                state = lazyListState,
-                verticalArrangement = verticalArrangement,
-                contentPadding = bodyPadding,
-            ) {
-                body()
-            }
+            body()
         }
         // Footer content (bottom aligned)
         footer?.let {
@@ -133,9 +201,9 @@ internal fun LayoutPreview() {
                                 style = typography.headingXLarge
                             )
                         }
-                        for (it in 1..50) {
+                        for (index in 1..50) {
                             item {
-                                Text("Body item $it")
+                                Text("Body item $index")
                             }
                         }
                     },


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue on the Networking signup screen that occurred on small-screen devices.

Given that `Layout` uses a `LazyColumn` internally, UI elements are rendered on a lazy basis. Therefore, moving the focus from the email field to the phone number field didn’t work. As you see in the video, it took a scroll to force the move.

To fix this issue, this pull request renames `Layout` to `LazyLayout` and adds a separate `Layout` scaffold that uses a standard `Column`. It moves `NetworkingLinkSignupScreen` to using the latter, but I’m also open to transition more screens.

The _After_ video shows that moving the focus now works as expected. The jumping at the end is caused by the keyboard’s top bar disappearing without an animation.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

V3 polish.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screen recordings

<details><summary>Before</summary>
<p>

https://github.com/stripe/stripe-android/assets/110940675/bf5b2210-a127-4b8d-bd09-6e92a4b25345

</p>
</details> 

<details><summary>After</summary>
<p>

https://github.com/stripe/stripe-android/assets/110940675/31f94730-1c27-43bc-b5df-4d1d850366ab

</p>
</details> 

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
