### PR TITLE
Add missing v3 analytics events


### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsAnalyticsEvent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsAnalyticsEvent.kt
@@ -196,6 +196,28 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
         ).filterNotNullValues()
     )
 
+    class AccountsSubmitted(
+        accountIds: Set<String>,
+        isSkipAccountSelection: Boolean
+    ) : FinancialConnectionsAnalyticsEvent(
+        name = "account_picker.accounts_submitted",
+        mapOf(
+            "account_ids" to accountIds.joinToString(","),
+            "is_skip_account_selection" to isSkipAccountSelection.toString(),
+        ).filterNotNullValues()
+    )
+
+    class AccountsAutoSelected(
+        accountIds: Set<String>,
+        isSingleAccount: Boolean
+    ) : FinancialConnectionsAnalyticsEvent(
+        name = "account_picker.accounts_auto_selected",
+        mapOf(
+            "account_ids" to accountIds.joinToString(","),
+            "is_single_account" to isSingleAccount.toString(),
+        ).filterNotNullValues()
+    )
+
     class PollAttachPaymentsSucceeded(
         authSessionId: String,
         duration: Long

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsAnalyticsEvent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsAnalyticsEvent.kt
@@ -202,7 +202,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
     ) : FinancialConnectionsAnalyticsEvent(
         name = "account_picker.accounts_submitted",
         mapOf(
-            "account_ids" to accountIds.joinToString(","),
+            "account_ids" to accountIds.joinToString(" "),
             "is_skip_account_selection" to isSkipAccountSelection.toString(),
         ).filterNotNullValues()
     )
@@ -213,7 +213,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
     ) : FinancialConnectionsAnalyticsEvent(
         name = "account_picker.accounts_auto_selected",
         mapOf(
-            "account_ids" to accountIds.joinToString(","),
+            "account_ids" to accountIds.joinToString(" "),
             "is_single_account" to isSingleAccount.toString(),
         ).filterNotNullValues()
     )

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModelTest.kt
@@ -185,7 +185,7 @@ internal class AccountPickerViewModelTest {
         eventTracker.assertContainsEvent(
             "linked_accounts.account_picker.accounts_auto_selected",
             mapOf(
-                "account_ids" to "selectable_1,selectable_2",
+                "account_ids" to "selectable_1 selectable_2",
                 "is_single_account" to "false",
             )
         )


### PR DESCRIPTION
# Summary

:notebook_with_decorative_cover: &nbsp;**Add missing v3 analytics events**
:globe_with_meridians: &nbsp;[BANKCON-9391](https://jira.corp.stripe.com/browse/BANKCON-9391)

> - \`account_picker.accounts_submitted\`
>
> - \`account_picker.accounts_auto_selected\`
>
> <https://git.corp.stripe.com/stripe-internal/stripe-js-v3/blob/master/src/linkedAccounts/inner/components/panes/v3/AccountPickerPane/containers/NewUser.tsx#L86-L98>
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

No UI changes.