### PR TITLE
Fix bug in `FlowController` for unknown cards from wallet.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
@@ -13,6 +13,7 @@ import com.stripe.android.link.injection.LinkAnalyticsComponent
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.link.ui.inline.UserInput
+import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethod.Type.Card
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -183,10 +184,18 @@ internal class LinkHandler @Inject constructor(
                     PaymentSelection.New.LinkInline(linkPaymentDetails)
                 }
                 is LinkPaymentDetails.Saved -> {
+                    val last4 = when (val paymentDetails = linkPaymentDetails.paymentDetails) {
+                        is ConsumerPaymentDetails.Card -> paymentDetails.last4
+                        is ConsumerPaymentDetails.Passthrough -> paymentDetails.last4
+                        is ConsumerPaymentDetails.BankAccount -> paymentDetails.last4
+                        else -> null
+                    }
+
                     PaymentSelection.Saved(
                         paymentMethod = PaymentMethod.Builder()
                             .setId(linkPaymentDetails.paymentDetails.id)
                             .setCode(paymentMethodCreateParams.typeCode)
+                            .setCard(PaymentMethod.Card(last4 = last4))
                             .setType(PaymentMethod.Type.Card)
                             .build(),
                         walletType = PaymentSelection.Saved.WalletType.Link,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
@@ -75,10 +75,10 @@ internal class PaymentOptionFactory @Inject constructor(
             }
             is PaymentSelection.Saved -> {
                 PaymentOption(
-                    drawableResourceId = selection.paymentMethod.getSavedPaymentMethodIcon(),
+                    drawableResourceId = getSavedIcon(selection),
                     lightThemeIconUrl = null,
                     darkThemeIconUrl = null,
-                    label = selection.paymentMethod.getLabel(resources).orEmpty(),
+                    label = getSavedLabel(selection).orEmpty(),
                     imageLoader = ::loadPaymentOption,
                 )
             }
@@ -122,6 +122,29 @@ internal class PaymentOptionFactory @Inject constructor(
                     imageLoader = ::loadPaymentOption,
                 )
             }
+        }
+    }
+
+    private fun getSavedLabel(selection: PaymentSelection.Saved): String? {
+        return selection.paymentMethod.getLabel(resources) ?: run {
+            when (selection.walletType) {
+                PaymentSelection.Saved.WalletType.Link -> resources.getString(StripeR.string.stripe_link)
+                PaymentSelection.Saved.WalletType.GooglePay -> resources.getString(StripeR.string.stripe_google_pay)
+                else -> null
+            }
+        }
+    }
+
+    private fun getSavedIcon(selection: PaymentSelection.Saved): Int {
+        return when (val resourceId = selection.paymentMethod.getSavedPaymentMethodIcon()) {
+            R.drawable.stripe_ic_paymentsheet_card_unknown -> {
+                when (selection.walletType) {
+                    PaymentSelection.Saved.WalletType.Link -> R.drawable.stripe_ic_paymentsheet_link
+                    PaymentSelection.Saved.WalletType.GooglePay -> R.drawable.stripe_google_pay_mark
+                    else -> resourceId
+                }
+            }
+            else -> resourceId
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtension.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtension.kt
@@ -35,7 +35,7 @@ internal fun CardBrand.getCardBrandIcon(): Int = when (this) {
 }
 
 internal fun PaymentMethod.getLabel(resources: Resources): String? = when (type) {
-    PaymentMethod.Type.Card -> createCardLabel(resources, card?.last4)
+    PaymentMethod.Type.Card -> createCardLabel(resources, card?.last4).takeIf { it.isNotEmpty() }
     PaymentMethod.Type.SepaDebit -> resources.getString(
         R.string.stripe_paymentsheet_payment_method_item_card_number,
         sepaDebit?.last4

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/LinkHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/LinkHandlerTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -315,7 +316,19 @@ class LinkHandlerTest {
             assertThat(accountStatusTurbine.awaitItem()).isEqualTo(AccountStatus.SignedOut)
 
             accountStatusFlow.emit(AccountStatus.Verified)
-            assertThat(awaitItem()).isInstanceOf(LinkHandler.ProcessingState.PaymentDetailsCollected::class.java)
+            assertThat(awaitItem()).isEqualTo(
+                LinkHandler.ProcessingState.PaymentDetailsCollected(
+                    paymentSelection = PaymentSelection.Saved(
+                        paymentMethod = PaymentMethod.Builder()
+                            .setId("pm_123")
+                            .setCode("card")
+                            .setCard(PaymentMethod.Card(last4 = "4242"))
+                            .setType(PaymentMethod.Type.Card)
+                            .build(),
+                        walletType = PaymentSelection.Saved.WalletType.Link,
+                    ),
+                )
+            )
             assertThat(accountStatusTurbine.awaitItem()).isEqualTo(AccountStatus.Verified)
             verify(linkLauncher, never()).present(eq(configuration))
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.R
@@ -65,5 +66,102 @@ class PaymentOptionFactoryTest {
                 "····4242"
             )
         )
+    }
+
+    @Test
+    fun `create() with saved card params with known brand from wallet should return expected object`() {
+        assertThat(
+            factory.create(
+                PaymentSelection.Saved(
+                    paymentMethod = card(CardBrand.Visa),
+                    walletType = PaymentSelection.Saved.WalletType.GooglePay
+                )
+            )
+        ).isEqualTo(
+            PaymentOption(
+                R.drawable.stripe_ic_paymentsheet_card_visa,
+                "····4242"
+            )
+        )
+    }
+
+    @Test
+    fun `create() with saved card params with unknown brand from Link wallet should return expected object`() {
+        assertThat(
+            factory.create(
+                PaymentSelection.Saved(
+                    paymentMethod = card(),
+                    walletType = PaymentSelection.Saved.WalletType.Link
+                )
+            )
+        ).isEqualTo(
+            PaymentOption(
+                R.drawable.stripe_ic_paymentsheet_link,
+                "····4242"
+            )
+        )
+    }
+
+    @Test
+    fun `create() with saved card params without last 4 digits from Link wallet should return expected object`() {
+        assertThat(
+            factory.create(
+                PaymentSelection.Saved(
+                    paymentMethod = card(last4 = null),
+                    walletType = PaymentSelection.Saved.WalletType.Link
+                )
+            )
+        ).isEqualTo(
+            PaymentOption(
+                R.drawable.stripe_ic_paymentsheet_link,
+                "Link"
+            )
+        )
+    }
+
+    @Test
+    fun `create() with saved card params with unknown brand from Google wallet should return expected object`() {
+        assertThat(
+            factory.create(
+                PaymentSelection.Saved(
+                    paymentMethod = card(),
+                    walletType = PaymentSelection.Saved.WalletType.GooglePay
+                )
+            )
+        ).isEqualTo(
+            PaymentOption(
+                R.drawable.stripe_google_pay_mark,
+                "····4242"
+            )
+        )
+    }
+
+    @Test
+    fun `create() with saved card params without last 4 digits from Google wallet should return expected object`() {
+        assertThat(
+            factory.create(
+                PaymentSelection.Saved(
+                    paymentMethod = card(last4 = null),
+                    walletType = PaymentSelection.Saved.WalletType.GooglePay
+                )
+            )
+        ).isEqualTo(
+            PaymentOption(
+                R.drawable.stripe_google_pay_mark,
+                "Google Pay"
+            )
+        )
+    }
+
+    private fun card(
+        brand: CardBrand = CardBrand.Unknown,
+        last4: String? = "4242"
+    ): PaymentMethod {
+        return PaymentMethod.Builder()
+            .setId("pm_1")
+            .setCode("card")
+            .setType(PaymentMethod.Type.Card)
+            .setCard(PaymentMethod.Card(last4 = last4, brand = brand, displayBrand = brand.code))
+            .build()
     }
 }


### PR DESCRIPTION
# Summary
Fix bug in `FlowController` for unknown cards from wallet.

# Motivation
Fixes issue where a saved card from Link passthrough mode does not show the last 4 digits of the payment method nor a logo for the wallet used.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
