### PR TITLE
Update compose pay button to version 0.1.4

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -54,7 +54,7 @@ ext.versions = [
         okio                        : '3.7.0',
         paparazzi                   : '1.2.0',
         poko                        : '0.15.2',
-        payButtonCompose            : '0.1.3',
+        payButtonCompose            : '0.1.4',
         places                      : '3.3.0',
         playServicesCoroutines      : '1.7.3',
         playServicesTfLite          : '16.0.1',

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationForm.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.paymentdatacollection.bacs
 
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -28,7 +29,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.google.android.gms.common.util.VisibleForTesting
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.utils.PaymentSheetContentPadding
@@ -201,6 +201,7 @@ internal fun BacsMandateItem(
                 color = MaterialTheme.colors.primary
             )
         )
+
         false -> Text(
             modifier = modifier,
             text = text,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Just a small update of the compose pay button dependency.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Background is that we are using stripe (so this library 😁 ) together with [licensee](https://github.com/cashapp/licensee).
Unfortunately up to version 0.1.3 compose pay button didn't provide a valid `<license>` tag in their POM.
This prevents us to update stripe as the transitive dependency compose pay button will report as "invalid license" (for us).
This is now fixed, since compose pay button has the default Apache 2 license 🙂 

See also the following related issue and PR:
https://github.com/google-pay/compose-pay-button/issues/17
https://github.com/google-pay/compose-pay-button/pull/18

Seems this is the full changelog/diff of the update:
https://github.com/google-pay/compose-pay-button/compare/fc3aacfd0bb632bdda40ba915f616a4a0cd0f87f..3418fd1ffd9dc9d9c88e368e721649f8ad0c62df

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
