### PR TITLE
Add additional passthrough mode failure tests & re-enable payment option assertion test.

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
@@ -313,7 +313,7 @@ internal class LinkTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
-            not(linkInformation())
+            not(bodyPart("payment_method", "pm_1234")),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -378,7 +378,7 @@ internal class LinkTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
-            not(linkInformation())
+            not(bodyPart("payment_method", "pm_1234")),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }


### PR DESCRIPTION
# Summary
Add additional passthrough mode failure tests & re-enable payment option assertion test.

# Motivation
Tests that payment continues after a sign up failure in `Link` passthrough mode. Also ensures the proper `PaymentOption` is returned from passthrough mode in `FlowController`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
