### PR TITLE
Make event reporting non-blocking in FC

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -138,7 +138,7 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
     }
 
     private fun logNoBrowserAvailableAndFinish() {
-        viewModelScope.launch {
+        withState { state ->
             val error = AppInitializationError("No Web browser available to launch AuthFlow")
             analyticsTracker.logError(
                 "error Launching the Auth Flow",
@@ -147,7 +147,7 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
                 error = error
             )
             finishWithResult(
-                state = awaitState(),
+                state = state,
                 result = Failed(error)
             )
         }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/HandleError.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/HandleError.kt
@@ -10,7 +10,7 @@ import com.stripe.android.financialconnections.repository.FinancialConnectionsEr
 import javax.inject.Inject
 
 internal interface HandleError {
-    suspend operator fun invoke(
+    operator fun invoke(
         extraMessage: String,
         error: Throwable,
         pane: FinancialConnectionsSessionManifest.Pane,
@@ -38,7 +38,7 @@ internal class RealHandleError @Inject constructor(
      * @param displayErrorScreen whether to navigate to the error screen
      *
      */
-    override suspend operator fun invoke(
+    override operator fun invoke(
         extraMessage: String,
         error: Throwable,
         pane: FinancialConnectionsSessionManifest.Pane,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModel.kt
@@ -133,7 +133,7 @@ internal class NetworkingLinkVerificationViewModel @Inject constructor(
             )
     }.execute { copy(confirmVerification = it) }
 
-    private suspend fun onNetworkedAccountsFailed(
+    private fun onNetworkedAccountsFailed(
         error: Throwable,
         updatedManifest: FinancialConnectionsSessionManifest
     ) {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/CoreAuthorizationPendingNetworkingRepairRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/CoreAuthorizationPendingNetworkingRepairRepository.kt
@@ -35,7 +35,7 @@ internal class CoreAuthorizationPendingNetworkingRepairRepository(
         )
     }.getOrNull()
 
-    suspend fun set(coreAuthorization: String) = runCatching {
+    fun set(coreAuthorization: String) = runCatching {
         logger.debug("core authorization set to $coreAuthorization")
         setState { copy(coreAuthorization = coreAuthorization) }
     }.onFailure {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/UriUtils.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/UriUtils.kt
@@ -11,7 +11,7 @@ internal class UriUtils @Inject constructor(
     private val logger: Logger,
     private val tracker: FinancialConnectionsAnalyticsTracker,
 ) {
-    suspend fun compareSchemeAuthorityAndPath(
+    fun compareSchemeAuthorityAndPath(
         uriString1: String,
         uriString2: String
     ): Boolean {
@@ -28,7 +28,7 @@ internal class UriUtils @Inject constructor(
      *
      * stripe-auth://link-accounts/authentication_return?code=failure
      */
-    suspend fun getQueryParameter(uri: String, key: String): String? = kotlin.runCatching {
+    fun getQueryParameter(uri: String, key: String): String? = kotlin.runCatching {
         uri.toUriOrNull()?.getQueryParameter(key)
     }.onFailure { error ->
         tracker.logError(
@@ -66,7 +66,7 @@ internal class UriUtils @Inject constructor(
         )
     }.getOrNull()
 
-    private suspend fun String.toUriOrNull(): Uri? = kotlin.runCatching {
+    private fun String.toUriOrNull(): Uri? = kotlin.runCatching {
         return Uri.parse(this)
     }.onFailure { error ->
         tracker.logError(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/TestFinancialConnectionsAnalyticsTracker.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/TestFinancialConnectionsAnalyticsTracker.kt
@@ -8,9 +8,8 @@ internal class TestFinancialConnectionsAnalyticsTracker : FinancialConnectionsAn
 
     val sentEvents = mutableListOf<FinancialConnectionsAnalyticsEvent>()
 
-    override suspend fun track(event: FinancialConnectionsAnalyticsEvent): Result<Unit> {
+    override fun track(event: FinancialConnectionsAnalyticsEvent) {
         sentEvents += event
-        return Result.success(Unit)
     }
 
     /**

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/utils/TestHandleError.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/utils/TestHandleError.kt
@@ -5,9 +5,9 @@ import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 
 internal class TestHandleError : HandleError {
 
-    val invocations = mutableListOf<HandleErrorInvocation>()
+    private val invocations = mutableListOf<HandleErrorInvocation>()
 
-    override suspend fun invoke(
+    override fun invoke(
         extraMessage: String,
         error: Throwable,
         pane: FinancialConnectionsSessionManifest.Pane,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request ensures that event reporting in Financial Connections isn’t blocking. We use the `GlobalScope` to ensure that events are being sent even if the surrounding coroutine scope is canceled.

I’ll follow up with https://github.com/stripe/stripe-android/pull/7972 to make us use `WorkManager` if it’s pulled in by the host app.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
