### PR TITLE
Add paymentMethodOrder to PaymentSheet and CustomerSheet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## XX.XX.XX - 2023-XX-XX
 * [Changed][7999](https://github.com/stripe/stripe-android/pull/7999) In test mode, PaymentSheet now fails to load when getting saved payment methods fails.
-
-* [Added] Added support for `paymentMethodTypes` in `CustomerAdapter`, which filters payment methods to the provided list.
+* [Added][8015](https://github.com/stripe/stripe-android/pull/8015) Added support for `paymentMethodTypes` in `CustomerAdapter`, which filters payment methods to the provided list.
+* [Added][8011](https://github.com/stripe/stripe-android/pull/8011) Added support for `paymentMethodOrder` in `PaymentSheet` and `CustomerSheet`, which provides client side sorting of payment methods.
 
 ### PaymentSheet
 * [Added] Added support for `paymentMethodOrder` to PaymentSheet and CustomerSheet.π

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 * [Added] Added support for `paymentMethodTypes` in `CustomerAdapter`, which filters payment methods to the provided list.
 
+### PaymentSheet
+* [Added] Added support for `paymentMethodOrder` to PaymentSheet and CustomerSheet.π
+
 ## 20.38.0 - 2024-02-26
 
 ### PaymentSheet

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
@@ -4,13 +4,12 @@ import android.graphics.Color
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
-import com.stripe.android.lpmfoundations.paymentmethod.defaultSorter
-import com.stripe.android.lpmfoundations.paymentmethod.paymentMethodSorter
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.R
 import com.stripe.android.paymentsheet.example.playground.activity.AppearanceStore
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
+import com.stripe.android.paymentsheet.example.playground.settings.PaymentMethodOrderSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.PrimaryButtonLabelSettingsDefinition
 import com.stripe.android.test.core.TestParameters
 import org.junit.After
@@ -23,7 +22,9 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
 
     private val testParams = TestParameters.create(
         paymentMethodCode = "card",
-    ).copy(
+    ) { settings ->
+        settings[PaymentMethodOrderSettingsDefinition] = "card,klarna,p24,eps"
+    }.copy(
         saveForFutureUseCheckboxVisible = true,
         authorizationAction = null,
         snapshotReturningCustomer = true,
@@ -78,26 +79,6 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
     fun resetAppearanceStore() {
         AppearanceStore.reset()
         forceLightMode()
-    }
-
-    @Before
-    fun setSort() {
-        paymentMethodSorter = {
-            sortedBy {
-                when (it.code) {
-                    "card" -> 1
-                    "klarna" -> 2
-                    "p24" -> 3
-                    "eps" -> 4
-                    else -> 100
-                }
-            }
-        }
-    }
-
-    @After
-    fun resetSort() {
-        paymentMethodSorter = defaultSorter
     }
 
     @Test

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PaymentMethodOrderSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PaymentMethodOrderSettingsDefinition.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.playground.PlaygroundState
+
+internal object PaymentMethodOrderSettingsDefinition :
+    PlaygroundSettingDefinition<String>,
+    PlaygroundSettingDefinition.Saveable<String>,
+    PlaygroundSettingDefinition.Displayable<String> {
+    override val key: String = "paymentMethodOrder"
+    override val displayName: String = "Payment method order"
+    override val defaultValue: String = ""
+    override val options: List<PlaygroundSettingDefinition.Displayable.Option<String>> = emptyList()
+
+    override fun convertToString(value: String): String = value
+    override fun convertToValue(value: String): String = value
+
+    override fun configure(
+        value: String,
+        configurationBuilder: PaymentSheet.Configuration.Builder,
+        playgroundState: PlaygroundState,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData
+    ) {
+        if (value.isNotEmpty()) {
+            configurationBuilder.paymentMethodOrder(value.split(",").map { it.trim() })
+        }
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -203,6 +203,7 @@ internal class PlaygroundSettings private constructor(
             PaymentMethodConfigurationSettingsDefinition,
             PreferredNetworkSettingsDefinition,
             AllowsRemovalOfLastSavedPaymentMethodSettingsDefinition,
+            PaymentMethodOrderSettingsDefinition,
             IntegrationTypeSettingsDefinition,
         )
 

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -122,6 +122,7 @@ public final class com/stripe/android/customersheet/CustomerSheet$Configuration$
 	public final fun defaultBillingDetails (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;)Lcom/stripe/android/customersheet/CustomerSheet$Configuration$Builder;
 	public final fun googlePayEnabled (Z)Lcom/stripe/android/customersheet/CustomerSheet$Configuration$Builder;
 	public final fun headerTextForSelectionScreen (Ljava/lang/String;)Lcom/stripe/android/customersheet/CustomerSheet$Configuration$Builder;
+	public final fun paymentMethodOrder (Ljava/util/List;)Lcom/stripe/android/customersheet/CustomerSheet$Configuration$Builder;
 	public final fun preferredNetworks (Ljava/util/List;)Lcom/stripe/android/customersheet/CustomerSheet$Configuration$Builder;
 }
 
@@ -621,8 +622,8 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration : 
 	public final fun component7 ()Z
 	public final fun component8 ()Z
 	public final fun component9 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;
-	public final fun copy (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;Ljava/util/List;Z)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;Ljava/util/List;ZILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
+	public final fun copy (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;Ljava/util/List;ZLjava/util/List;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;Ljava/util/List;ZLjava/util/List;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowsDelayedPaymentMethods ()Z
@@ -655,6 +656,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration$Bu
 	public final fun defaultBillingDetails (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun googlePay (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun merchantDisplayName (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
+	public final fun paymentMethodOrder (Ljava/util/List;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun preferredNetworks (Ljava/util/List;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun primaryButtonColor (Landroid/content/res/ColorStateList;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun primaryButtonLabel (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -181,6 +181,8 @@ class CustomerSheet @Inject internal constructor(
         val preferredNetworks: List<CardBrand> = emptyList(),
 
         internal val allowsRemovalOfLastSavedPaymentMethod: Boolean = true,
+
+        internal val paymentMethodOrder: List<String> = emptyList(),
     ) : Parcelable {
 
         // Hide no-argument constructor init
@@ -203,6 +205,7 @@ class CustomerSheet @Inject internal constructor(
                 .defaultBillingDetails(defaultBillingDetails)
                 .billingDetailsCollectionConfiguration(billingDetailsCollectionConfiguration)
                 .allowsRemovalOfLastSavedPaymentMethod(allowsRemovalOfLastSavedPaymentMethod)
+                .paymentMethodOrder(paymentMethodOrder)
         }
 
         @ExperimentalCustomerSheetApi
@@ -216,6 +219,7 @@ class CustomerSheet @Inject internal constructor(
                     PaymentSheet.BillingDetailsCollectionConfiguration()
             private var preferredNetworks: List<CardBrand> = emptyList()
             private var allowsRemovalOfLastSavedPaymentMethod: Boolean = true
+            private var paymentMethodOrder: List<String> = emptyList()
 
             fun appearance(appearance: PaymentSheet.Appearance) = apply {
                 this.appearance = appearance
@@ -250,6 +254,17 @@ class CustomerSheet @Inject internal constructor(
                 this.allowsRemovalOfLastSavedPaymentMethod = allowsRemovalOfLastSavedPaymentMethod
             }
 
+            /**
+             * By default, PaymentSheet will use a dynamic ordering that optimizes payment method display for the customer.
+             * You can override the default order in which payment methods are displayed in PaymentSheet with a list of payment method types.
+             * See https://stripe.com/docs/api/payment_methods/object#payment_method_object-type for the list of valid types.
+             * - Example: listOf("card", "external_paypal", "klarna")
+             * - Note: If you omit payment methods from this list, they’ll be automatically ordered by Stripe after the ones you provide. Invalid payment methods are ignored.
+             */
+            fun paymentMethodOrder(paymentMethodOrder: List<String>): Builder = apply {
+                this.paymentMethodOrder = paymentMethodOrder
+            }
+
             fun build() = Configuration(
                 appearance = appearance,
                 googlePayEnabled = googlePayEnabled,
@@ -259,6 +274,7 @@ class CustomerSheet @Inject internal constructor(
                 merchantDisplayName = merchantDisplayName,
                 preferredNetworks = preferredNetworks,
                 allowsRemovalOfLastSavedPaymentMethod = allowsRemovalOfLastSavedPaymentMethod,
+                paymentMethodOrder = paymentMethodOrder,
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -255,11 +255,15 @@ class CustomerSheet @Inject internal constructor(
             }
 
             /**
-             * By default, PaymentSheet will use a dynamic ordering that optimizes payment method display for the customer.
-             * You can override the default order in which payment methods are displayed in PaymentSheet with a list of payment method types.
-             * See https://stripe.com/docs/api/payment_methods/object#payment_method_object-type for the list of valid types.
-             * - Example: listOf("card", "external_paypal", "klarna")
-             * - Note: If you omit payment methods from this list, they’ll be automatically ordered by Stripe after the ones you provide. Invalid payment methods are ignored.
+             * By default, PaymentSheet will use a dynamic ordering that optimizes payment method display for the
+             * customer. You can override the default order in which payment methods are displayed in PaymentSheet with
+             * a list of payment method types.
+             *
+             * See https://stripe.com/docs/api/payment_methods/object#payment_method_object-type for the list of valid
+             *  types.
+             * - Example: listOf("card", "klarna")
+             * - Note: If you omit payment methods from this list, they’ll be automatically ordered by Stripe after the
+             *  ones you provide. Invalid payment methods are ignored.
              */
             fun paymentMethodOrder(paymentMethodOrder: List<String>): Builder = apply {
                 this.paymentMethodOrder = paymentMethodOrder

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -255,13 +255,13 @@ class CustomerSheet @Inject internal constructor(
             }
 
             /**
-             * By default, PaymentSheet will use a dynamic ordering that optimizes payment method display for the
+             * By default, CustomerSheet will use a dynamic ordering that optimizes payment method display for the
              * customer. You can override the default order in which payment methods are displayed in PaymentSheet with
              * a list of payment method types.
              *
              * See https://stripe.com/docs/api/payment_methods/object#payment_method_object-type for the list of valid
              *  types.
-             * - Example: listOf("card", "klarna")
+             * - Example: listOf("card")
              * - Note: If you omit payment methods from this list, they’ll be automatically ordered by Stripe after the
              *  ones you provide. Invalid payment methods are ignored.
              */

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -103,6 +103,7 @@ internal class DefaultCustomerSheetLoader(
                 billingDetailsCollectionConfiguration = billingDetailsCollectionConfig,
                 allowsDelayedPaymentMethods = true,
                 allowsPaymentMethodsRequiringShippingAddress = false,
+                paymentMethodOrder = configuration?.paymentMethodOrder ?: emptyList(),
                 sharedDataSpecs = sharedDataSpecs,
                 financialConnectionsAvailable = isFinancialConnectionsAvailable()
             )

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -77,7 +77,7 @@ internal data class PaymentMethodMetadata(
         // 1. Add each PM in paymentMethodOrder first
         for (pm in paymentMethodOrder) {
             // Ignore the PM if it's not in originalOrderedTypes
-            if (originalOrderedTypes.contains(pm))  {
+            if (originalOrderedTypes.contains(pm)) {
                 result += pm
                 // 2. Remove each PM we add from originalOrderedTypes.
                 originalOrderedTypes.remove(pm)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -436,7 +436,9 @@ class PaymentSheet internal constructor(
          */
         val preferredNetworks: List<CardBrand> = emptyList(),
 
-        internal val allowsRemovalOfLastSavedPaymentMethod: Boolean = true
+        internal val allowsRemovalOfLastSavedPaymentMethod: Boolean = true,
+
+        internal val paymentMethodOrder: List<String> = emptyList(),
     ) : Parcelable {
 
         @JvmOverloads
@@ -579,6 +581,7 @@ class PaymentSheet internal constructor(
                 BillingDetailsCollectionConfiguration()
             private var preferredNetworks: List<CardBrand> = listOf()
             private var allowsRemovalOfLastSavedPaymentMethod: Boolean = true
+            private var paymentMethodOrder: List<String> = emptyList()
 
             fun merchantDisplayName(merchantDisplayName: String) =
                 apply { this.merchantDisplayName = merchantDisplayName }
@@ -638,6 +641,17 @@ class PaymentSheet internal constructor(
                 this.allowsRemovalOfLastSavedPaymentMethod = allowsRemovalOfLastSavedPaymentMethod
             }
 
+            /**
+             * By default, PaymentSheet will use a dynamic ordering that optimizes payment method display for the customer.
+             * You can override the default order in which payment methods are displayed in PaymentSheet with a list of payment method types.
+             * See https://stripe.com/docs/api/payment_methods/object#payment_method_object-type for the list of valid types.
+             * - Example: listOf("card", "external_paypal", "klarna")
+             * - Note: If you omit payment methods from this list, they’ll be automatically ordered by Stripe after the ones you provide. Invalid payment methods are ignored.
+             */
+            fun paymentMethodOrder(paymentMethodOrder: List<String>): Builder = apply {
+                this.paymentMethodOrder = paymentMethodOrder
+            }
+
             fun build() = Configuration(
                 merchantDisplayName = merchantDisplayName,
                 customer = customer,
@@ -652,6 +666,7 @@ class PaymentSheet internal constructor(
                 billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
                 preferredNetworks = preferredNetworks,
                 allowsRemovalOfLastSavedPaymentMethod = allowsRemovalOfLastSavedPaymentMethod,
+                paymentMethodOrder = paymentMethodOrder,
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -642,11 +642,15 @@ class PaymentSheet internal constructor(
             }
 
             /**
-             * By default, PaymentSheet will use a dynamic ordering that optimizes payment method display for the customer.
-             * You can override the default order in which payment methods are displayed in PaymentSheet with a list of payment method types.
-             * See https://stripe.com/docs/api/payment_methods/object#payment_method_object-type for the list of valid types.
-             * - Example: listOf("card", "external_paypal", "klarna")
-             * - Note: If you omit payment methods from this list, they’ll be automatically ordered by Stripe after the ones you provide. Invalid payment methods are ignored.
+             * By default, PaymentSheet will use a dynamic ordering that optimizes payment method display for the
+             * customer. You can override the default order in which payment methods are displayed in PaymentSheet with
+             * a list of payment method types.
+             *
+             * See https://stripe.com/docs/api/payment_methods/object#payment_method_object-type for the list of valid
+             *  types.
+             * - Example: listOf("card", "klarna")
+             * - Note: If you omit payment methods from this list, they’ll be automatically ordered by Stripe after the
+             *  ones you provide. Invalid payment methods are ignored.
              */
             fun paymentMethodOrder(paymentMethodOrder: List<String>): Builder = apply {
                 this.paymentMethodOrder = paymentMethodOrder

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -89,6 +89,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
                 allowsDelayedPaymentMethods = paymentSheetConfiguration.allowsDelayedPaymentMethods,
                 allowsPaymentMethodsRequiringShippingAddress = paymentSheetConfiguration
                     .allowsPaymentMethodsRequiringShippingAddress,
+                paymentMethodOrder = paymentSheetConfiguration.paymentMethodOrder,
                 sharedDataSpecs = sharedDataSpecsResult.sharedDataSpecs,
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetConfigurationTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetConfigurationTest.kt
@@ -83,6 +83,7 @@ class CustomerSheetConfigurationTest {
             "preferredNetworks",
             "build",
             "allowsRemovalOfLastSavedPaymentMethod",
+            "paymentMethodOrder",
         )
 
         // Programmatically check for any new method on the builder using reflection

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -16,6 +16,7 @@ internal object PaymentMethodMetadataFactory {
         allowsDelayedPaymentMethods: Boolean = true,
         allowsPaymentMethodsRequiringShippingAddress: Boolean = false,
         financialConnectionsAvailable: Boolean = true,
+        paymentMethodOrder: List<String> = emptyList(),
         sharedDataSpecs: List<SharedDataSpec> = createSharedDataSpecs(),
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
@@ -24,6 +25,7 @@ internal object PaymentMethodMetadataFactory {
             allowsDelayedPaymentMethods = allowsDelayedPaymentMethods,
             allowsPaymentMethodsRequiringShippingAddress = allowsPaymentMethodsRequiringShippingAddress,
             financialConnectionsAvailable = financialConnectionsAvailable,
+            paymentMethodOrder = paymentMethodOrder,
             sharedDataSpecs = sharedDataSpecs,
         )
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Added the ability to client side sort payment methods via a new property on PaymentSheet.Configuration and CustomerSheet.Configuration.

Closes #8003

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILE_APIREVIEW-71
