### PR TITLE
Don't count bottom sheets towards the back stack

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
@@ -166,7 +166,7 @@ private fun AccountPickerMainContent(
     FinancialConnectionsScaffold(
         topBar = {
             FinancialConnectionsTopAppBar(
-                showBack = false,
+                allowBackNavigation = false,
                 onCloseClick = onCloseClick,
                 elevation = lazyListState.elevation
             )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentScreen.kt
@@ -47,7 +47,7 @@ private fun AttachPaymentContent(
     FinancialConnectionsScaffold(
         topBar = {
             FinancialConnectionsTopAppBar(
-                showBack = false,
+                allowBackNavigation = false,
                 onCloseClick = onCloseClick
             )
         }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/SharedPartnerAuth.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/SharedPartnerAuth.kt
@@ -245,7 +245,7 @@ private fun SharedPartnerAuthContentWrapper(
         FinancialConnectionsScaffold(
             topBar = {
                 FinancialConnectionsTopAppBar(
-                    showBack = canNavigateBack,
+                    allowBackNavigation = canNavigateBack,
                     onCloseClick = onCloseClick
                 )
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/error/ErrorScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/error/ErrorScreen.kt
@@ -135,7 +135,7 @@ private fun FullScreenError(
     FinancialConnectionsScaffold(
         topBar = {
             FinancialConnectionsTopAppBar(
-                showBack = showBack,
+                allowBackNavigation = showBack,
                 onCloseClick = onCloseClick
             )
         }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerScreen.kt
@@ -184,7 +184,7 @@ private fun LinkAccountPickerMainContent(
     FinancialConnectionsScaffold(
         topBar = {
             FinancialConnectionsTopAppBar(
-                showBack = false,
+                allowBackNavigation = false,
                 elevation = scrollState.elevation,
                 onCloseClick = onCloseClick
             )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationScreen.kt
@@ -75,7 +75,7 @@ private fun LinkStepUpVerificationContent(
     FinancialConnectionsScaffold(
         topBar = {
             FinancialConnectionsTopAppBar(
-                showBack = false,
+                allowBackNavigation = false,
                 elevation = lazyListState.elevation,
                 onCloseClick = onCloseClick
             )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupScreen.kt
@@ -163,7 +163,7 @@ private fun NetworkingLinkSignupMainContent(
         topBar = {
             FinancialConnectionsTopAppBar(
                 elevation = scrollState.elevation,
-                showBack = false,
+                allowBackNavigation = false,
                 onCloseClick = onCloseClick,
             )
         }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationScreen.kt
@@ -71,7 +71,6 @@ private fun NetworkingSaveToLinkVerificationContent(
     FinancialConnectionsScaffold(
         topBar = {
             FinancialConnectionsTopAppBar(
-                showBack = true,
                 onCloseClick = onCloseClick,
                 elevation = rememberLazyListState().elevation
             )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessContent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessContent.kt
@@ -96,7 +96,7 @@ private fun SuccessContentInternal(
     FinancialConnectionsScaffold(
         topBar = {
             FinancialConnectionsTopAppBar(
-                showBack = false,
+                allowBackNavigation = false,
                 onCloseClick = onCloseClick,
                 elevation = scrollState.elevation
             )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
@@ -24,10 +24,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -100,6 +104,7 @@ internal fun FinancialConnectionsTopAppBar(
     )
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun BackButton(
     scope: CoroutineScope,
@@ -117,7 +122,10 @@ private fun BackButton(
         Icon(
             imageVector = Icons.Filled.ArrowBack,
             contentDescription = "Back icon",
-            tint = FinancialConnectionsTheme.colors.iconDefault
+            tint = FinancialConnectionsTheme.colors.iconDefault,
+            modifier = Modifier
+                .testTag("top-app-bar-back-button")
+                .semantics { testTagsAsResourceId = true }
         )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
@@ -61,14 +61,14 @@ internal fun FinancialConnectionsTopAppBar(
     hideStripeLogo: Boolean = LocalReducedBranding.current,
     testMode: Boolean = LocalTestMode.current,
     elevation: Dp = 0.dp,
-    showBack: Boolean = true,
+    allowBackNavigation: Boolean = true,
     onCloseClick: () -> Unit
 ) {
     val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current
     val localBackPressed = onBackPressedDispatcher?.onBackPressedDispatcher
 
     val navController = LocalNavHostController.current
-    val canGoBack by navController.collectCanGoBackAsState()
+    val canShowBackIcon by navController.collectCanShowBackIconAsState()
 
     val keyboardController = rememberKeyboardController()
     val scope = rememberCoroutineScope()
@@ -81,7 +81,7 @@ internal fun FinancialConnectionsTopAppBar(
             )
         },
         elevation = elevation,
-        navigationIcon = if (canGoBack && showBack) {
+        navigationIcon = if (canShowBackIcon && allowBackNavigation) {
             {
                 BackButton(
                     scope = scope,
@@ -204,14 +204,14 @@ internal val LazyListState.elevation: Dp
     }
 
 @Composable
-private fun NavHostController.collectCanGoBackAsState(): State<Boolean> {
-    val canGoBack = remember { mutableStateOf(false) }
+private fun NavHostController.collectCanShowBackIconAsState(): State<Boolean> {
+    val canShowBackIcon = remember { mutableStateOf(false) }
     DisposableEffect(Unit) {
         val listener = NavController.OnDestinationChangedListener { controller, destination, _ ->
             if (destination.navigatorName == BottomSheetNavigator::class.java.simpleName) {
                 // We're looking at a bottom sheet, so don't change the back button
             } else {
-                canGoBack.value = controller.previousBackStackEntry != null
+                canShowBackIcon.value = controller.previousBackStackEntry != null
             }
         }
         addOnDestinationChangedListener(listener)
@@ -219,7 +219,7 @@ private fun NavHostController.collectCanGoBackAsState(): State<Boolean> {
             removeOnDestinationChangedListener(listener)
         }
     }
-    return canGoBack
+    return canShowBackIcon
 }
 
 @Preview(group = "Components", name = "TopAppBar")

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import com.stripe.android.financialconnections.R
+import com.stripe.android.financialconnections.navigation.bottomsheet.BottomSheetNavigator
 import com.stripe.android.financialconnections.ui.FinancialConnectionsPreview
 import com.stripe.android.financialconnections.ui.LocalNavHostController
 import com.stripe.android.financialconnections.ui.LocalReducedBranding
@@ -198,8 +199,12 @@ internal val LazyListState.elevation: Dp
 private fun NavHostController.collectCanGoBackAsState(): State<Boolean> {
     val canGoBack = remember { mutableStateOf(false) }
     DisposableEffect(Unit) {
-        val listener = NavController.OnDestinationChangedListener { controller, _, _ ->
-            canGoBack.value = controller.previousBackStackEntry != null
+        val listener = NavController.OnDestinationChangedListener { controller, destination, _ ->
+            if (destination.navigatorName == BottomSheetNavigator::class.java.simpleName) {
+                // We're looking at a bottom sheet, so don't change the back button
+            } else {
+                canGoBack.value = controller.previousBackStackEntry != null
+            }
         }
         addOnDestinationChangedListener(listener)
         onDispose {

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking-ReturningUser.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking-ReturningUser.yaml
@@ -1,0 +1,51 @@
+appId: com.stripe.android.financialconnections.example
+tags:
+  - all
+  - edge
+  - testmode-payments
+---
+- startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-networking-returning-user-' + new Date().getTime()}
+- clearState
+- openLink: stripeconnectionsexample://playground?flow=PaymentIntent&financial_connections_override_native=native&merchant=networking_testmode&permissions=transactions,payment_method
+- tapOn:
+    id: "Customer email setting"
+- inputText: "email@email.com"
+- hideKeyboard
+- tapOn:
+    id: "connect_accounts"
+# Wait until the consent button is visible
+- extendedWaitUntil:
+    visible:
+      id: "consent_cta"
+    timeout: 30000
+- tapOn:
+    id: "consent_cta"
+# LINK WARMUP PANE
+- extendedWaitUntil:
+    visible:
+      id: "existing_email-button"
+    timeout: 5000
+- assertNotVisible:
+    id: "top-app-bar-back-button"
+- tapOn:
+    id: "existing_email-button"
+# OTP SCREEN
+- extendedWaitUntil:
+    visible: "Save your account to Link"
+    timeout: 5000
+- assertVisible:
+    id: "top-app-bar-back-button"
+- inputText: "000000"
+# SELECT ACCOUNT
+- extendedWaitUntil:
+    visible: "Select account"
+    timeout: 5000
+- tapOn: "Account Closed"
+- tapOn: "Connect account"
+# EMAIL OTP SCREEN
+- waitForAnimationToEnd
+- inputText: "000000"
+# CONFIRM AND COMPLETE
+- waitForAnimationToEnd
+- assertVisible: "Success"
+- stopRecording


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes when we display the back button. We now only show it if the second screen is not a bottom sheet.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

V3 polish.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
