### PR TITLE
Fix disabled `Save to Link` button issue

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupScreen.kt
@@ -172,7 +172,7 @@ private fun NetworkingLinkSignupMainContent(
             Uninitialized, is Loading -> FullScreenGenericLoading()
             is Success -> NetworkingLinkSignupLoaded(
                 scrollState = scrollState,
-                validForm = state.valid(),
+                validForm = state.valid,
                 payload = payload(),
                 lookupAccountSync = state.lookupAccount,
                 saveAccountToLinkSync = state.saveAccountToLink,

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.features.networkinglinksignup
 
+import app.cash.turbine.test
 import com.airbnb.mvrx.test.MavericksTestRule
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
@@ -11,11 +12,14 @@ import com.stripe.android.financialconnections.domain.GetManifest
 import com.stripe.android.financialconnections.domain.LookupAccount
 import com.stripe.android.financialconnections.domain.SaveAccountToLink
 import com.stripe.android.financialconnections.domain.SynchronizeFinancialConnectionsSession
+import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane.NETWORKING_LINK_SIGNUP_PANE
 import com.stripe.android.financialconnections.model.NetworkingLinkSignupBody
 import com.stripe.android.financialconnections.model.NetworkingLinkSignupPane
 import com.stripe.android.financialconnections.model.TextUpdate
+import com.stripe.android.financialconnections.navigation.Destination.NetworkingSaveToLinkVerification
+import com.stripe.android.financialconnections.navigation.NavigationIntent
+import com.stripe.android.financialconnections.navigation.NavigationManagerImpl
 import com.stripe.android.financialconnections.repository.SaveToLinkWithStripeSucceededRepository
-import com.stripe.android.financialconnections.utils.TestNavigationManager
 import com.stripe.android.financialconnections.utils.UriUtils
 import com.stripe.android.model.ConsumerSessionLookup
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -26,6 +30,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -39,7 +45,7 @@ class NetworkingLinkSignupViewModelTest {
     private val getManifest = mock<GetManifest>()
     private val eventTracker = TestFinancialConnectionsAnalyticsTracker()
     private val getAuthorizationSessionAccounts = mock<GetCachedAccounts>()
-    private val navigationManager = TestNavigationManager()
+    private val navigationManager = NavigationManagerImpl()
     private val lookupAccount = mock<LookupAccount>()
     private val saveAccountToLink = mock<SaveAccountToLink>()
     private val sync = mock<SynchronizeFinancialConnectionsSession>()
@@ -83,6 +89,86 @@ class NetworkingLinkSignupViewModelTest {
         val state = viewModel.awaitState()
         val payload = requireNotNull(state.payload())
         assertThat(payload.emailController.fieldValue.first()).isEqualTo("test@test.com")
+    }
+
+    @Test
+    fun `Redirects to verification screen if entering returning user email`() = runTest {
+        val manifest = ApiKeyFixtures.sessionManifest()
+
+        whenever(sync()).thenReturn(
+            syncResponse().copy(
+                text = TextUpdate(
+                    consent = null,
+                    networkingLinkSignupPane = networkingLinkSignupPane()
+                )
+            )
+        )
+        whenever(getManifest()).thenReturn(manifest)
+        whenever(lookupAccount(any())).thenReturn(ConsumerSessionLookup(exists = true))
+
+        val viewModel = buildViewModel(NetworkingLinkSignupState())
+
+        navigationManager.navigationFlow.test {
+            val state = viewModel.awaitState()
+            val payload = requireNotNull(state.payload())
+            payload.emailController.onValueChange("email@email.com")
+
+            assertThat(awaitItem()).isEqualTo(
+                NavigationIntent.NavigateTo(
+                    route = NetworkingSaveToLinkVerification(referrer = NETWORKING_LINK_SIGNUP_PANE),
+                    popUpToCurrent = false,
+                    inclusive = false,
+                    isSingleTop = true,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `Enables Save To Link button if we encounter a returning user`() = runTest {
+        val manifest = ApiKeyFixtures.sessionManifest()
+
+        whenever(sync()).thenReturn(
+            syncResponse().copy(
+                text = TextUpdate(
+                    consent = null,
+                    networkingLinkSignupPane = networkingLinkSignupPane()
+                )
+            )
+        )
+        whenever(getManifest()).thenReturn(manifest)
+        whenever(lookupAccount(any())).thenReturn(ConsumerSessionLookup(exists = true))
+
+        val viewModel = buildViewModel(NetworkingLinkSignupState())
+
+        navigationManager.navigationFlow.test {
+            val state = viewModel.awaitState()
+            val payload = requireNotNull(state.payload())
+            payload.emailController.onValueChange("email@email.com")
+
+            assertThat(awaitItem()).isEqualTo(
+                NavigationIntent.NavigateTo(
+                    route = NetworkingSaveToLinkVerification(referrer = NETWORKING_LINK_SIGNUP_PANE),
+                    popUpToCurrent = false,
+                    inclusive = false,
+                    isSingleTop = true,
+                )
+            )
+
+            // Simulate the user pressing Save To Link after returning from the OTP screen
+            viewModel.onSaveAccount()
+
+            verify(saveAccountToLink, never()).new(any(), any(), any(), any())
+
+            assertThat(awaitItem()).isEqualTo(
+                NavigationIntent.NavigateTo(
+                    route = NetworkingSaveToLinkVerification(referrer = NETWORKING_LINK_SIGNUP_PANE),
+                    popUpToCurrent = false,
+                    inclusive = false,
+                    isSingleTop = true,
+                )
+            )
+        }
     }
 
     private fun networkingLinkSignupPane() = NetworkingLinkSignupPane(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue happening for returning Link consumers: If they were auto-forwarded to the SMS OTP screen and then pressed the back button, they weren’t able to press `Save To Link`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

V3 polish: [BANKCON-9396](https://jira.corp.stripe.com/browse/BANKCON-9396)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
