### PR TITLE
Add configuration defaults to make all defaults consistent.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/configuration/ConfigurationDefaults.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/configuration/ConfigurationDefaults.kt
@@ -1,0 +1,25 @@
+package com.stripe.android.common.configuration
+
+import android.content.res.ColorStateList
+import com.stripe.android.model.CardBrand
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
+
+internal object ConfigurationDefaults {
+    const val allowsDelayedPaymentMethods: Boolean = false
+    const val allowsPaymentMethodsRequiringShippingAddress: Boolean = false
+    const val allowsRemovalOfLastSavedPaymentMethod: Boolean = true
+    val appearance: PaymentSheet.Appearance = PaymentSheet.Appearance()
+    val billingDetails: PaymentSheet.BillingDetails = PaymentSheet.BillingDetails()
+    val billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration =
+        PaymentSheet.BillingDetailsCollectionConfiguration()
+    val customer: PaymentSheet.CustomerConfiguration? = null
+    val googlePay: PaymentSheet.GooglePayConfiguration? = null
+    const val googlePayEnabled: Boolean = false
+    val headerTextForSelectionScreen: String? = null
+    val paymentMethodOrder: List<String> = emptyList()
+    val preferredNetworks: List<CardBrand> = emptyList()
+    val primaryButtonColor: ColorStateList? = null
+    val primaryButtonLabel: String? = null
+    val shippingDetails: AddressDetails? = null
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
+import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.customersheet.util.CustomerSheetHacks
 import com.stripe.android.model.CardBrand
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -136,17 +137,17 @@ class CustomerSheet @Inject internal constructor(
         /**
          * Describes the appearance of [CustomerSheet].
          */
-        val appearance: PaymentSheet.Appearance = PaymentSheet.Appearance(),
+        val appearance: PaymentSheet.Appearance = ConfigurationDefaults.appearance,
 
         /**
          * Whether [CustomerSheet] displays Google Pay as a payment option.
          */
-        val googlePayEnabled: Boolean = false,
+        val googlePayEnabled: Boolean = ConfigurationDefaults.googlePayEnabled,
 
         /**
          * The text to display at the top of the presented bottom sheet.
          */
-        val headerTextForSelectionScreen: String? = null,
+        val headerTextForSelectionScreen: String? = ConfigurationDefaults.headerTextForSelectionScreen,
 
         /**
          * [CustomerSheet] pre-populates fields with the values provided. If
@@ -154,7 +155,7 @@ class CustomerSheet @Inject internal constructor(
          * is true, these values will be attached to the payment method even if they are not
          * collected by the [CustomerSheet] UI.
          */
-        val defaultBillingDetails: PaymentSheet.BillingDetails = PaymentSheet.BillingDetails(),
+        val defaultBillingDetails: PaymentSheet.BillingDetails = ConfigurationDefaults.billingDetails,
 
         /**
          * Describes how billing details should be collected. All values default to
@@ -164,7 +165,7 @@ class CustomerSheet @Inject internal constructor(
          * you must provide an appropriate value as part of [defaultBillingDetails].
          */
         val billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration =
-            PaymentSheet.BillingDetailsCollectionConfiguration(),
+            ConfigurationDefaults.billingDetailsCollectionConfiguration,
 
         /**
          * Your customer-facing business name. The default value is the name of your app.
@@ -178,22 +179,23 @@ class CustomerSheet @Inject internal constructor(
          * The first preferred network that matches an available network will be used. If no preferred network is
          * applicable, Stripe will select the network.
          */
-        val preferredNetworks: List<CardBrand> = emptyList(),
+        val preferredNetworks: List<CardBrand> = ConfigurationDefaults.preferredNetworks,
 
-        internal val allowsRemovalOfLastSavedPaymentMethod: Boolean = true,
+        internal val allowsRemovalOfLastSavedPaymentMethod: Boolean =
+            ConfigurationDefaults.allowsRemovalOfLastSavedPaymentMethod,
 
-        internal val paymentMethodOrder: List<String> = emptyList(),
+        internal val paymentMethodOrder: List<String> = ConfigurationDefaults.paymentMethodOrder,
     ) : Parcelable {
 
         // Hide no-argument constructor init
         internal constructor(merchantDisplayName: String) : this(
-            appearance = PaymentSheet.Appearance(),
-            googlePayEnabled = false,
-            headerTextForSelectionScreen = null,
-            defaultBillingDetails = PaymentSheet.BillingDetails(),
-            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
+            appearance = ConfigurationDefaults.appearance,
+            googlePayEnabled = ConfigurationDefaults.googlePayEnabled,
+            headerTextForSelectionScreen = ConfigurationDefaults.headerTextForSelectionScreen,
+            defaultBillingDetails = ConfigurationDefaults.billingDetails,
+            billingDetailsCollectionConfiguration = ConfigurationDefaults.billingDetailsCollectionConfiguration,
             merchantDisplayName = merchantDisplayName,
-            allowsRemovalOfLastSavedPaymentMethod = true,
+            allowsRemovalOfLastSavedPaymentMethod = ConfigurationDefaults.allowsRemovalOfLastSavedPaymentMethod,
         )
 
         fun newBuilder(): Builder {
@@ -210,16 +212,16 @@ class CustomerSheet @Inject internal constructor(
 
         @ExperimentalCustomerSheetApi
         class Builder internal constructor(private val merchantDisplayName: String) {
-            private var appearance: PaymentSheet.Appearance = PaymentSheet.Appearance()
-            private var googlePayEnabled: Boolean = false
-            private var headerTextForSelectionScreen: String? = null
-            private var defaultBillingDetails: PaymentSheet.BillingDetails = PaymentSheet.BillingDetails()
-            private var billingDetailsCollectionConfiguration:
-                PaymentSheet.BillingDetailsCollectionConfiguration =
-                    PaymentSheet.BillingDetailsCollectionConfiguration()
-            private var preferredNetworks: List<CardBrand> = emptyList()
-            private var allowsRemovalOfLastSavedPaymentMethod: Boolean = true
-            private var paymentMethodOrder: List<String> = emptyList()
+            private var appearance: PaymentSheet.Appearance = ConfigurationDefaults.appearance
+            private var googlePayEnabled: Boolean = ConfigurationDefaults.googlePayEnabled
+            private var headerTextForSelectionScreen: String? = ConfigurationDefaults.headerTextForSelectionScreen
+            private var defaultBillingDetails: PaymentSheet.BillingDetails = ConfigurationDefaults.billingDetails
+            private var billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration =
+                ConfigurationDefaults.billingDetailsCollectionConfiguration
+            private var preferredNetworks: List<CardBrand> = ConfigurationDefaults.preferredNetworks
+            private var allowsRemovalOfLastSavedPaymentMethod: Boolean =
+                ConfigurationDefaults.allowsRemovalOfLastSavedPaymentMethod
+            private var paymentMethodOrder: List<String> = ConfigurationDefaults.paymentMethodOrder
 
             fun appearance(appearance: PaymentSheet.Appearance) = apply {
                 this.appearance = appearance

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.fragment.app.Fragment
 import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
+import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.link.account.LinkStore
 import com.stripe.android.model.CardBrand
@@ -336,14 +337,14 @@ class PaymentSheet internal constructor(
         /**
          * If set, the customer can select a previously saved payment method within PaymentSheet.
          */
-        val customer: CustomerConfiguration? = null,
+        val customer: CustomerConfiguration? = ConfigurationDefaults.customer,
 
         /**
          * Configuration related to the Stripe Customer making a payment.
          *
          * If set, PaymentSheet displays Google Pay as a payment option.
          */
-        val googlePay: GooglePayConfiguration? = null,
+        val googlePay: GooglePayConfiguration? = ConfigurationDefaults.googlePay,
 
         /**
          * The color of the Pay or Add button. Keep in mind the text color is white.
@@ -357,7 +358,7 @@ class PaymentSheet internal constructor(
                     "or PrimaryButton.colorsLight/colorsDark.background"
             )
         )
-        val primaryButtonColor: ColorStateList? = null,
+        val primaryButtonColor: ColorStateList? = ConfigurationDefaults.primaryButtonColor,
 
         /**
          * The billing information for the customer.
@@ -367,7 +368,7 @@ class PaymentSheet internal constructor(
          * these values will be attached to the payment method even if they are not collected by
          * the PaymentSheet UI.
          */
-        val defaultBillingDetails: BillingDetails? = null,
+        val defaultBillingDetails: BillingDetails? = ConfigurationDefaults.billingDetails,
 
         /**
          * The shipping information for the customer.
@@ -375,7 +376,7 @@ class PaymentSheet internal constructor(
          * This is used to display a "Billing address is same as shipping" checkbox if `defaultBillingDetails` is not provided.
          * If `name` and `line1` are populated, it's also [attached to the PaymentIntent](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-shipping) during payment.
          */
-        val shippingDetails: AddressDetails? = null,
+        val shippingDetails: AddressDetails? = ConfigurationDefaults.shippingDetails,
 
         /**
          * If true, allows payment methods that do not move money at the end of the checkout.
@@ -389,7 +390,7 @@ class PaymentSheet internal constructor(
          *
          * See [payment-notification](https://stripe.com/docs/payments/payment-methods#payment-notification).
          */
-        val allowsDelayedPaymentMethods: Boolean = false,
+        val allowsDelayedPaymentMethods: Boolean = ConfigurationDefaults.allowsDelayedPaymentMethods,
 
         /**
          * If `true`, allows payment methods that require a shipping address, like Afterpay and
@@ -401,12 +402,13 @@ class PaymentSheet internal constructor(
          * **Note**: PaymentSheet considers this property `true` if `shipping` details are present
          * on the PaymentIntent when PaymentSheet loads.
          */
-        val allowsPaymentMethodsRequiringShippingAddress: Boolean = false,
+        val allowsPaymentMethodsRequiringShippingAddress: Boolean =
+            ConfigurationDefaults.allowsPaymentMethodsRequiringShippingAddress,
 
         /**
          * Describes the appearance of Payment Sheet.
          */
-        val appearance: Appearance = Appearance(),
+        val appearance: Appearance = ConfigurationDefaults.appearance,
 
         /**
          * The label to use for the primary button.
@@ -414,7 +416,7 @@ class PaymentSheet internal constructor(
          * If not set, Payment Sheet will display suitable default labels for payment and setup
          * intents.
          */
-        val primaryButtonLabel: String? = null,
+        val primaryButtonLabel: String? = ConfigurationDefaults.primaryButtonLabel,
 
         /**
          * Describes how billing details should be collected.
@@ -423,7 +425,7 @@ class PaymentSheet internal constructor(
          * you **must** provide an appropriate value as part of [defaultBillingDetails].
          */
         val billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
-            BillingDetailsCollectionConfiguration(),
+            ConfigurationDefaults.billingDetailsCollectionConfiguration,
 
         /**
          * A list of preferred networks that should be used to process payments
@@ -434,11 +436,12 @@ class PaymentSheet internal constructor(
          * be used. If no preferred network is applicable, Stripe will select
          * the network.
          */
-        val preferredNetworks: List<CardBrand> = emptyList(),
+        val preferredNetworks: List<CardBrand> = ConfigurationDefaults.preferredNetworks,
 
-        internal val allowsRemovalOfLastSavedPaymentMethod: Boolean = true,
+        internal val allowsRemovalOfLastSavedPaymentMethod: Boolean =
+            ConfigurationDefaults.allowsRemovalOfLastSavedPaymentMethod,
 
-        internal val paymentMethodOrder: List<String> = emptyList(),
+        internal val paymentMethodOrder: List<String> = ConfigurationDefaults.paymentMethodOrder,
     ) : Parcelable {
 
         @JvmOverloads
@@ -453,21 +456,21 @@ class PaymentSheet internal constructor(
             /**
              * If set, the customer can select a previously saved payment method within PaymentSheet.
              */
-            customer: CustomerConfiguration? = null,
+            customer: CustomerConfiguration? = ConfigurationDefaults.customer,
 
             /**
              * Configuration related to the Stripe Customer making a payment.
              *
              * If set, PaymentSheet displays Google Pay as a payment option.
              */
-            googlePay: GooglePayConfiguration? = null,
+            googlePay: GooglePayConfiguration? = ConfigurationDefaults.googlePay,
 
             /**
              * The color of the Pay or Add button. Keep in mind the text color is white.
              *
              * If set, PaymentSheet displays the button with this color.
              */
-            primaryButtonColor: ColorStateList? = null,
+            primaryButtonColor: ColorStateList? = ConfigurationDefaults.primaryButtonColor,
 
             /**
              * The billing information for the customer.
@@ -477,7 +480,7 @@ class PaymentSheet internal constructor(
              * these values will be attached to the payment method even if they are not collected by
              * the PaymentSheet UI.
              */
-            defaultBillingDetails: BillingDetails? = null,
+            defaultBillingDetails: BillingDetails? = ConfigurationDefaults.billingDetails,
 
             /**
              * The shipping information for the customer.
@@ -485,7 +488,7 @@ class PaymentSheet internal constructor(
              * This is used to display a "Billing address is same as shipping" checkbox if `defaultBillingDetails` is not provided.
              * If `name` and `line1` are populated, it's also [attached to the PaymentIntent](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-shipping) during payment.
              */
-            shippingDetails: AddressDetails? = null,
+            shippingDetails: AddressDetails? = ConfigurationDefaults.shippingDetails,
 
             /**
              * If true, allows payment methods that do not move money at the end of the checkout.
@@ -499,7 +502,7 @@ class PaymentSheet internal constructor(
              *
              * See [payment-notification](https://stripe.com/docs/payments/payment-methods#payment-notification).
              */
-            allowsDelayedPaymentMethods: Boolean = false,
+            allowsDelayedPaymentMethods: Boolean = ConfigurationDefaults.allowsDelayedPaymentMethods,
 
             /**
              * If `true`, allows payment methods that require a shipping address, like Afterpay and
@@ -511,12 +514,13 @@ class PaymentSheet internal constructor(
              * **Note**: PaymentSheet considers this property `true` if `shipping` details are present
              * on the PaymentIntent when PaymentSheet loads.
              */
-            allowsPaymentMethodsRequiringShippingAddress: Boolean = false,
+            allowsPaymentMethodsRequiringShippingAddress: Boolean =
+                ConfigurationDefaults.allowsPaymentMethodsRequiringShippingAddress,
 
             /**
              * Describes the appearance of Payment Sheet.
              */
-            appearance: Appearance = Appearance(),
+            appearance: Appearance = ConfigurationDefaults.appearance,
 
             /**
              * The label to use for the primary button.
@@ -524,7 +528,7 @@ class PaymentSheet internal constructor(
              * If not set, Payment Sheet will display suitable default labels for payment and setup
              * intents.
              */
-            primaryButtonLabel: String? = null,
+            primaryButtonLabel: String? = ConfigurationDefaults.primaryButtonLabel,
 
             /**
              * Describes how billing details should be collected.
@@ -533,7 +537,7 @@ class PaymentSheet internal constructor(
              * you **must** provide an appropriate value as part of [defaultBillingDetails].
              */
             billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
-                BillingDetailsCollectionConfiguration(),
+                ConfigurationDefaults.billingDetailsCollectionConfiguration,
 
             /**
              * A list of preferred networks that should be used to process payments
@@ -544,7 +548,7 @@ class PaymentSheet internal constructor(
              * be used. If no preferred network is applicable, Stripe will select
              * the network.
              */
-            preferredNetworks: List<CardBrand> = emptyList(),
+            preferredNetworks: List<CardBrand> = ConfigurationDefaults.preferredNetworks,
         ) : this(
             merchantDisplayName = merchantDisplayName,
             customer = customer,
@@ -558,7 +562,7 @@ class PaymentSheet internal constructor(
             primaryButtonLabel = primaryButtonLabel,
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
             preferredNetworks = preferredNetworks,
-            allowsRemovalOfLastSavedPaymentMethod = true,
+            allowsRemovalOfLastSavedPaymentMethod = ConfigurationDefaults.allowsRemovalOfLastSavedPaymentMethod,
         )
 
         /**
@@ -568,20 +572,22 @@ class PaymentSheet internal constructor(
         class Builder(
             private var merchantDisplayName: String
         ) {
-            private var customer: CustomerConfiguration? = null
-            private var googlePay: GooglePayConfiguration? = null
-            private var primaryButtonColor: ColorStateList? = null
-            private var defaultBillingDetails: BillingDetails? = null
-            private var shippingDetails: AddressDetails? = null
-            private var allowsDelayedPaymentMethods: Boolean = false
-            private var allowsPaymentMethodsRequiringShippingAddress: Boolean = false
-            private var appearance: Appearance = Appearance()
-            private var primaryButtonLabel: String? = null
+            private var customer: CustomerConfiguration? = ConfigurationDefaults.customer
+            private var googlePay: GooglePayConfiguration? = ConfigurationDefaults.googlePay
+            private var primaryButtonColor: ColorStateList? = ConfigurationDefaults.primaryButtonColor
+            private var defaultBillingDetails: BillingDetails? = ConfigurationDefaults.billingDetails
+            private var shippingDetails: AddressDetails? = ConfigurationDefaults.shippingDetails
+            private var allowsDelayedPaymentMethods: Boolean = ConfigurationDefaults.allowsDelayedPaymentMethods
+            private var allowsPaymentMethodsRequiringShippingAddress: Boolean =
+                ConfigurationDefaults.allowsPaymentMethodsRequiringShippingAddress
+            private var appearance: Appearance = ConfigurationDefaults.appearance
+            private var primaryButtonLabel: String? = ConfigurationDefaults.primaryButtonLabel
             private var billingDetailsCollectionConfiguration =
-                BillingDetailsCollectionConfiguration()
-            private var preferredNetworks: List<CardBrand> = listOf()
-            private var allowsRemovalOfLastSavedPaymentMethod: Boolean = true
-            private var paymentMethodOrder: List<String> = emptyList()
+                ConfigurationDefaults.billingDetailsCollectionConfiguration
+            private var preferredNetworks: List<CardBrand> = ConfigurationDefaults.preferredNetworks
+            private var allowsRemovalOfLastSavedPaymentMethod: Boolean =
+                ConfigurationDefaults.allowsRemovalOfLastSavedPaymentMethod
+            private var paymentMethodOrder: List<String> = ConfigurationDefaults.paymentMethodOrder
 
             fun merchantDisplayName(merchantDisplayName: String) =
                 apply { this.merchantDisplayName = merchantDisplayName }
@@ -1152,6 +1158,13 @@ class PaymentSheet internal constructor(
          */
         val phone: String? = null
     ) : Parcelable {
+        internal fun isFilledOut(): Boolean {
+            return address != null ||
+                email != null ||
+                name != null ||
+                phone != null
+        }
+
         /**
          * [BillingDetails] builder for cleaner object creation from Java.
          */

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -175,7 +175,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
                     FIELD_CUSTOMER to (configuration.customer != null),
                     FIELD_GOOGLE_PAY to (configuration.googlePay != null),
                     FIELD_PRIMARY_BUTTON_COLOR to (configuration.primaryButtonColor != null),
-                    FIELD_BILLING to (configuration.defaultBillingDetails != null),
+                    FIELD_BILLING to (configuration.defaultBillingDetails?.isFilledOut() == true),
                     FIELD_DELAYED_PMS to (configuration.allowsDelayedPaymentMethods),
                     FIELD_APPEARANCE to appearanceConfigMap,
                     FIELD_BILLING_DETAILS_COLLECTION_CONFIGURATION to

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetBillingDetailsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetBillingDetailsTest.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.paymentsheet
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+internal class PaymentSheetBillingDetailsTest {
+    @Test
+    fun `isFilledOut is false when all values are null`() {
+        assertThat(PaymentSheet.BillingDetails().isFilledOut()).isFalse()
+    }
+
+    @Test
+    fun `isFilledOut is true when any value is not null`() {
+        assertThat(PaymentSheet.BillingDetails(address = PaymentSheet.Address()).isFilledOut()).isTrue()
+        assertThat(PaymentSheet.BillingDetails(email = "example@test.com").isFilledOut()).isTrue()
+        assertThat(PaymentSheet.BillingDetails(name = "Jane Doe").isFilledOut()).isTrue()
+        assertThat(PaymentSheet.BillingDetails(phone = "1234567890").isFilledOut()).isTrue()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1416,7 +1416,7 @@ internal class PaymentSheetViewModelTest {
                 ),
                 showCheckbox = false,
                 showCheckboxControlledFields = true,
-                billingDetails = null,
+                billingDetails = PaymentSheet.BillingDetails(),
             )
         )
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Follow up to #8011 making defaults for PaymentSheet and CustomerSheet consistent between each other, their constructor, and their builders.
