### PR TITLE
Fix leap year test

### DIFF
--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/payment/card/PaymentCardTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/payment/card/PaymentCardTest.kt
@@ -4,6 +4,7 @@ import androidx.test.filters.SmallTest
 import org.junit.Before
 import org.junit.Test
 import java.util.Calendar
+import java.util.GregorianCalendar
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -150,7 +151,7 @@ class PaymentCardTest {
     fun isValidExpiry() {
         val expDay = "01"
         val expMonth = "02"
-        val expYear = "2025"
+        val expYear = nextYear().toString()
 
         assertTrue { isValidExpiry(expDay, expMonth, expYear) }
         assertTrue { isValidExpiry(null, expMonth, expYear) }
@@ -161,7 +162,7 @@ class PaymentCardTest {
     fun isValidExpiry_leapYear() {
         val expDay = "29"
         val expMonth = "2"
-        val expYear = "2024"
+        val expYear = nextLeapYear().toString()
 
         assertTrue { isValidExpiry(expDay, expMonth, expYear) }
     }
@@ -265,5 +266,20 @@ class PaymentCardTest {
         assertEquals("01/02/03", formatExpiry("1", "2", "3"))
         assertEquals("01/02/03", formatExpiry("1", "2", "2003"))
         assertEquals("02/03", formatExpiry(null, "02", "03"))
+    }
+
+    private fun nextYear(): Int {
+        return Calendar.getInstance().get(Calendar.YEAR) + 1
+    }
+
+    private fun nextLeapYear(): Int {
+        val calendar = GregorianCalendar()
+        var year = Calendar.getInstance().get(Calendar.YEAR) + 1
+
+        while (!calendar.isLeapYear(year)) {
+            year += 1
+        }
+
+        return year
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes a test that used 29 February 2024 to test expiry date validation logic.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
