### PR TITLE
Add gray placeholders for consent header logos


### DIFF
--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -387,6 +387,13 @@ public final class com/stripe/android/financialconnections/features/common/Compo
 	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 }
 
+public final class com/stripe/android/financialconnections/features/consent/ui/ComposableSingletons$ConsentLogoHeaderKt {
+	public static final field INSTANCE Lcom/stripe/android/financialconnections/features/consent/ui/ComposableSingletons$ConsentLogoHeaderKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public fun <init> ()V
+	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function3;
+}
+
 public final class com/stripe/android/financialconnections/features/error/ComposableSingletons$ErrorScreenKt {
 	public static final field INSTANCE Lcom/stripe/android/financialconnections/features/error/ComposableSingletons$ErrorScreenKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ui/ConsentLogoHeader.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ui/ConsentLogoHeader.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
@@ -63,14 +62,15 @@ internal fun ConsentLogoHeader(
     val stripeImageLoader = LocalImageLoader.current
     val placeholderBitmap = rememberPlaceholderBitmap(bitmapLoadSize, colors.border)
     val loadedImages: SnapshotStateList<ImageBitmap> = remember {
-        val elements = if (isPreview) {
-            // preview: initially fill with placeholders
-            debugPreviewBitmaps(logos, bitmapLoadSize)
-        } else {
-            // prod: initially fill with placeholders
-            Array(logos.size) { placeholderBitmap }
+        SnapshotStateList<ImageBitmap>().also {
+            if (isPreview) {
+                // preview: initially fill with placeholders
+                it.addAll(debugPreviewBitmaps(logos, bitmapLoadSize))
+            } else {
+                // prod: initially fill with placeholders
+                for (i in logos.indices) it.add(placeholderBitmap)
+            }
         }
-        mutableStateListOf(*elements)
     }
 
     logos.forEachIndexed { index, logo ->
@@ -136,19 +136,21 @@ private fun ForegroundRow(images: List<ImageBitmap>) {
 private fun debugPreviewBitmaps(
     size: List<String>,
     bitmapLoadSize: Int,
-): Array<ImageBitmap> {
+): List<ImageBitmap> {
     return listOf(Color.Red, Color.Blue, Color.Green).take(size.size).map {
         val androidBitmap = Bitmap.createBitmap(bitmapLoadSize, bitmapLoadSize, Bitmap.Config.ARGB_8888)
         val canvas = android.graphics.Canvas(androidBitmap)
         canvas.drawColor(it.toArgb())
         androidBitmap.asImageBitmap()
-    }.toTypedArray()
+    }
 }
 
 @Composable
 private fun rememberPlaceholderBitmap(bitmapLoadSize: Int, placeholderColor: Color): ImageBitmap = remember {
     val androidBitmap = Bitmap.createBitmap(
-        bitmapLoadSize, bitmapLoadSize, Bitmap.Config.ARGB_8888
+        bitmapLoadSize,
+        bitmapLoadSize,
+        Bitmap.Config.ARGB_8888
     )
     androidBitmap.eraseColor(placeholderColor.toArgb())
     androidBitmap.asImageBitmap()

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ui/ConsentLogoHeader.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ui/ConsentLogoHeader.kt
@@ -46,7 +46,6 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
 import com.stripe.android.financialconnections.ui.LocalImageLoader
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.colors
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 
@@ -67,26 +66,22 @@ internal fun ConsentLogoHeader(
     var bitmaps: List<ImageBitmap> by remember {
         mutableStateOf(
             if (isPreview) {
-                // preview: initially fill with placeholders
                 debugPreviewBitmaps(logos, bitmapLoadSize)
             } else {
-                // prod: initially fill with placeholders
                 List(logos.size) { placeholderBitmap }
             }
         )
     }
 
     LaunchedEffect(logos) {
-        val deferredList: List<Deferred<ImageBitmap>> = logos.map {
+        bitmaps = logos.map {
             async {
-                stripeImageLoader
-                    .load(it, bitmapLoadSize, bitmapLoadSize)
+                stripeImageLoader.load(it, bitmapLoadSize, bitmapLoadSize)
                     .getOrNull()
                     ?.asImageBitmap()
                     ?: placeholderBitmap
             }
-        }
-        bitmaps = deferredList.awaitAll()
+        }.awaitAll()
     }
 
     Box(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

# Motivation
:notebook_with_decorative_cover: &nbsp;**Add gray placeholders for consent header logos**
:globe_with_meridians: &nbsp;[BANKCON-9419](https://jira.corp.stripe.com/browse/BANKCON-9419)

> Design review feedback: “Missing grey placeholder state on merchant logo on consent screen, to soften the image loading into place after opening the flow”
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->