### PR TITLE
Add `TimeZoneRule` for screenshot tests

### DIFF
--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/screenshottests/FinancialConnectionsShotShowkaseScreenshotTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/screenshottests/FinancialConnectionsShotShowkaseScreenshotTest.kt
@@ -12,6 +12,7 @@ import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.stripe.android.financialconnections.getMetadata
+import com.stripe.android.financialconnections.utils.TimeZoneRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -33,6 +34,9 @@ class PaparazziSampleScreenshotTest {
         NEXUS_5(DeviceConfig.NEXUS_5),
         PIXEL_C(DeviceConfig.PIXEL_C),
     }
+
+    @get:Rule
+    val timeZoneRule = TimeZoneRule()
 
     @get:Rule
     val paparazzi = Paparazzi(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/utils/TimeZoneRule.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/utils/TimeZoneRule.kt
@@ -1,0 +1,22 @@
+package com.stripe.android.financialconnections.utils
+
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import java.util.TimeZone
+
+class TimeZoneRule(
+    private val timeZone: TimeZone = TimeZone.getTimeZone("America/Los_Angeles"),
+) : TestWatcher() {
+
+    private val original: TimeZone = TimeZone.getDefault()
+
+    override fun starting(description: Description) {
+        super.starting(description)
+        TimeZone.setDefault(timeZone)
+    }
+
+    override fun finished(description: Description) {
+        TimeZone.setDefault(original)
+        super.finished(description)
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This helps us generate the same screenshots even though we’re 3 hours apart.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
