### PR TITLE
Fix supportedAsSavedPaymentMethod issue.

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -61,6 +61,7 @@
     <ID>MaxLineLength:DefaultFlowControllerTest.kt$DefaultFlowControllerTest$fun</ID>
     <ID>MaxLineLength:DefaultPaymentSheetLoaderTest.kt$DefaultPaymentSheetLoaderTest$fun</ID>
     <ID>MaxLineLength:FlowControllerConfigurationHandlerTest.kt$FlowControllerConfigurationHandlerTest$.</ID>
+    <ID>MaxLineLength:FormArgumentsFactoryTest.kt$FormArgumentsFactoryTest$fun</ID>
     <ID>MaxLineLength:InjectableActivityScenario.kt$InjectableActivityScenario$delegate ?: throw IllegalStateException("Cannot move to state $newState since the activity hasn't been launched.")</ID>
     <ID>MaxLineLength:InjectableActivityScenario.kt$InjectableActivityScenario$val d = delegate ?: throw IllegalStateException("Cannot run onActivity since the activity hasn't been launched.")</ID>
     <ID>MaxLineLength:LpmRepositoryTest.kt$LpmRepositoryTest$fun</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AuBecsDebitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AuBecsDebitDefinition.kt
@@ -12,7 +12,7 @@ import com.stripe.android.ui.core.elements.SharedDataSpec
 internal object AuBecsDebitDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.AuBecsDebit
 
-    override val supportedAsSavedPaymentMethod: Boolean = true
+    override val supportedAsSavedPaymentMethod: Boolean = false
 
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BancontactDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BancontactDefinition.kt
@@ -13,7 +13,7 @@ import com.stripe.android.uicore.elements.IdentifierSpec
 internal object BancontactDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.Bancontact
 
-    override val supportedAsSavedPaymentMethod: Boolean = true
+    override val supportedAsSavedPaymentMethod: Boolean = false
 
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoDefinition.kt
@@ -12,7 +12,7 @@ import com.stripe.android.ui.core.elements.SharedDataSpec
 internal object BoletoDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.Boleto
 
-    override val supportedAsSavedPaymentMethod: Boolean = true
+    override val supportedAsSavedPaymentMethod: Boolean = false
 
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CashAppPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CashAppPayDefinition.kt
@@ -13,7 +13,7 @@ import com.stripe.android.ui.core.elements.SharedDataSpec
 internal object CashAppPayDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.CashAppPay
 
-    override val supportedAsSavedPaymentMethod: Boolean = true
+    override val supportedAsSavedPaymentMethod: Boolean = false
 
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/IdealDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/IdealDefinition.kt
@@ -13,7 +13,7 @@ import com.stripe.android.uicore.elements.IdentifierSpec
 internal object IdealDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.Ideal
 
-    override val supportedAsSavedPaymentMethod: Boolean = true
+    override val supportedAsSavedPaymentMethod: Boolean = false
 
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPalDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPalDefinition.kt
@@ -14,7 +14,7 @@ import com.stripe.android.ui.core.elements.SharedDataSpec
 internal object PayPalDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.PayPal
 
-    override val supportedAsSavedPaymentMethod: Boolean = true
+    override val supportedAsSavedPaymentMethod: Boolean = false
 
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/RevolutPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/RevolutPayDefinition.kt
@@ -14,7 +14,7 @@ import com.stripe.android.ui.core.elements.SharedDataSpec
 internal object RevolutPayDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.RevolutPay
 
-    override val supportedAsSavedPaymentMethod: Boolean = true
+    override val supportedAsSavedPaymentMethod: Boolean = false
 
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SofortDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SofortDefinition.kt
@@ -13,7 +13,7 @@ import com.stripe.android.uicore.elements.IdentifierSpec
 internal object SofortDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.Sofort
 
-    override val supportedAsSavedPaymentMethod: Boolean = true
+    override val supportedAsSavedPaymentMethod: Boolean = false
 
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
@@ -23,12 +23,11 @@ internal object FormArgumentsFactory {
         newLpm: PaymentSelection.New?,
         cbcEligibility: CardBrandChoiceEligibility,
     ): FormArguments {
-        val setupFutureUsageFieldConfiguration = requireNotNull(
+        val setupFutureUsageFieldConfiguration =
             paymentMethod.paymentMethodDefinition().getSetupFutureUsageFieldConfiguration(
                 metadata = metadata,
                 customerConfiguration = config.customer,
             )
-        )
 
         val initialParams = when (newLpm) {
             is PaymentSelection.New.LinkInline -> {
@@ -60,12 +59,12 @@ internal object FormArgumentsFactory {
         val saveForFutureUseInitialValue = if (newLpm != null) {
             newLpm.customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse
         } else {
-            setupFutureUsageFieldConfiguration.saveForFutureUseInitialValue
+            setupFutureUsageFieldConfiguration?.saveForFutureUseInitialValue == true
         }
 
         return FormArguments(
             paymentMethodCode = paymentMethod.code,
-            showCheckbox = setupFutureUsageFieldConfiguration.isSaveForFutureUseValueChangeable,
+            showCheckbox = setupFutureUsageFieldConfiguration?.isSaveForFutureUseValueChangeable == true,
             saveForFutureUseInitialValue = saveForFutureUseInitialValue,
             merchantName = merchantName,
             amount = amount,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
@@ -7,9 +7,11 @@ import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
 import com.stripe.android.lpmfoundations.luxe.update
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.definitions.BancontactDefinition
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -17,6 +19,7 @@ import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import com.stripe.android.ui.core.elements.SharedDataSpec
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -74,6 +77,30 @@ class FormArgumentsFactoryTest {
         )
 
         assertThat(actualArgs.initialPaymentMethodCreateParams).isEqualTo(paymentMethodCreateParams)
+        assertThat(actualArgs.showCheckbox).isFalse()
+        assertThat(actualArgs.saveForFutureUseInitialValue).isFalse()
+    }
+
+    @Test
+    fun `Create correct FormArguments for null new payment method with setup intent`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+        )
+        val supportedPaymentMethod = BancontactDefinition.supportedPaymentMethod(
+            metadata = metadata,
+            sharedDataSpec = SharedDataSpec("bancontact"),
+        )
+
+        val actualArgs = FormArgumentsFactory.create(
+            paymentMethod = supportedPaymentMethod,
+            metadata = metadata,
+            config = PaymentSheetFixtures.CONFIG_MINIMUM,
+            merchantName = PaymentSheetFixtures.MERCHANT_DISPLAY_NAME,
+            amount = null,
+            newLpm = null,
+            cbcEligibility = CardBrandChoiceEligibility.Ineligible
+        )
+
         assertThat(actualArgs.showCheckbox).isFalse()
         assertThat(actualArgs.saveForFutureUseInitialValue).isFalse()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
@@ -82,10 +82,11 @@ class FormArgumentsFactoryTest {
     }
 
     @Test
-    fun `Create correct FormArguments for null new payment method with setup intent`() {
+    fun `Create correct FormArguments for null newLpm with setup intent and paymentMethod not supportedAsSavedPaymentMethod`() {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
         )
+        assertThat(BancontactDefinition.supportedAsSavedPaymentMethod).isFalse()
         val supportedPaymentMethod = BancontactDefinition.supportedPaymentMethod(
             metadata = metadata,
             sharedDataSpec = SharedDataSpec("bancontact"),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
These weren't actually supported, so turned them to false. But this cause a change in expectations, so updated the code and wrote a test.

This came in multiple waves, but the latest wave was the one that really started reading this param, and where the issue was created. #8044