### PR TITLE
Expose underlying `StripeException` instead of `FinancialConnectionsError`

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/FinancialConnectionsError.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/FinancialConnectionsError.kt
@@ -8,7 +8,7 @@ import com.stripe.android.core.exception.StripeException
  */
 internal abstract class FinancialConnectionsError(
     val name: String,
-    stripeException: StripeException,
+    val stripeException: StripeException,
 ) : StripeException(
     stripeException.stripeError,
     stripeException.requestId,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -30,6 +30,7 @@ import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Complete.EarlyTerminationCause
 import com.stripe.android.financialconnections.exception.CustomManualEntryRequiredError
+import com.stripe.android.financialconnections.exception.FinancialConnectionsError
 import com.stripe.android.financialconnections.features.manualentry.isCustomManualEntryError
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityResult
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityResult.Canceled
@@ -198,9 +199,12 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
         closeAuthFlow(closeAuthFlowError = null)
     }
 
-    fun onCloseFromErrorClick(error: Throwable) = closeAuthFlow(
-        closeAuthFlowError = error
-    )
+    fun onCloseFromErrorClick(error: Throwable) {
+        // FinancialConnectionsError subclasses aren't public, so we just return their
+        // backing StripeException.
+        val exposedError = (error as? FinancialConnectionsError)?.stripeException ?: error
+        closeAuthFlow(closeAuthFlowError = exposedError)
+    }
 
     /**
      * [NavHost] handles back presses except for when backstack is empty, where it delegates

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
@@ -1,0 +1,24 @@
+appId: com.stripe.android.financialconnections.example
+tags:
+  - all
+  - edge
+  - testmode-payments
+---
+- startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-networking-' + new Date().getTime()}
+- clearState
+- openLink: stripeconnectionsexample://playground?flow=PaymentIntent&financial_connections_override_native=native&merchant=testmode&permissions=payment_method
+- tapOn:
+    id: "connect_accounts"
+# Wait until the consent button is visible
+- extendedWaitUntil:
+    visible:
+      id: "consent_cta"
+    timeout: 30000
+- tapOn:
+    id: "consent_cta"
+# SELECT INSTITUTION WITH DOWNTIME
+- tapOn: "Down Bank (unscheduled)"
+# CLOSE FLOW FROM ERROR PAGE
+- tapOn: "Close icon"
+- assertVisible: "Failed! Request-id: .*"
+- stopRecording


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request remedies a crash we’re seeing in the unreleased V3 flow: When trying to return an `InstitutionUnplannedDowntimeError` from Financial Connections, the parcel process throws a `NotSerializableException`.

This is likely because the `Error` is a `Throwable`, which can’t be parcelized and instead needs to be serialized. However, several of its properties aren’t serializable.

Since `InstitutionUnplannedDowntimeError` isn’t exposed in the public API, including it in `CollectBankAccountResult.Failed` doesn’t provide any benefit to merchants. We can therefore safely make a behavior change and instead return the underlying `StripeException`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Bugfix.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
