### PR TITLE
Add compose compatibility table.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ dependencies {
 }
 ```
 
+### Compose versions
+
+`stripe-android` uses compose internally, and expects consumers to use a compatible compose version. Compatible versions listed below:
+
+<table>
+ <tr>
+  <td>20.22.0-20.31.0</td><td>Compose UI 1.4.x</td>
+  <td>20.32.0-20.37.3</td><td>Compose UI 1.5.x</td>
+  <td>20.37.4-Current</td><td>Compose UI 1.5.x or Compose UI 1.6.x</td>
+ </tr>
+</table>
+
 ## Getting Started
 
 ### Integration

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ dependencies {
 }
 ```
 
-### Compose versions
+### Compatibility with Jetpack Compose
 
-`stripe-android` uses compose internally, and expects consumers to use a compatible compose version. Compatible versions listed below:
+`stripe-android` uses Jetpack Compose internally and expects consumers to use a compatible version:
 
 <table>
  <tr>

--- a/README.md
+++ b/README.md
@@ -75,7 +75,11 @@ dependencies {
 <table>
  <tr>
   <td>20.22.0-20.31.0</td><td>Compose UI 1.4.x</td>
+ </tr>
+ <tr>
   <td>20.32.0-20.37.3</td><td>Compose UI 1.5.x</td>
+ </tr>
+ <tr>
   <td>20.37.4-Current</td><td>Compose UI 1.5.x or Compose UI 1.6.x</td>
  </tr>
 </table>


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We've seen confusion around which compose versions are compatible with our SDK. This table adds clarity.
