### PR TITLE
Update CustomerSheetViewModel to store paymentMethodMetadata rather than stripeIntent.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -183,7 +183,7 @@ internal class DefaultCustomerSheetLoader(
                 Result.success(
                     CustomerSheetState.Full(
                         config = configuration,
-                        stripeIntent = elementsSession?.stripeIntent,
+                        paymentMethodMetadata = metadata,
                         supportedPaymentMethods = validSupportedPaymentMethods,
                         customerPaymentMethods = paymentMethods,
                         isGooglePayReady = isGooglePayReadyAndEnabled,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetState.kt
@@ -1,8 +1,8 @@
 package com.stripe.android.customersheet
 
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 
@@ -12,7 +12,7 @@ internal sealed interface CustomerSheetState {
 
     data class Full(
         val config: CustomerSheet.Configuration?,
-        val stripeIntent: StripeIntent?,
+        val paymentMethodMetadata: PaymentMethodMetadata?,
         val customerPaymentMethods: List<PaymentMethod>,
         val supportedPaymentMethods: List<SupportedPaymentMethod>,
         val isGooglePayReady: Boolean,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -23,6 +23,7 @@ import com.stripe.android.customersheet.util.CustomerSheetHacks
 import com.stripe.android.customersheet.util.isUnverifiedUSBankAccount
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.CardDefinition
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmSetupIntentParams
@@ -156,7 +157,7 @@ internal class CustomerSheetViewModel(
 
     private var previouslySelectedPaymentMethod: SupportedPaymentMethod? = null
     private var unconfirmedPaymentMethod: PaymentMethod? = null
-    private var stripeIntent: StripeIntent? = null
+    private var paymentMethodMetadata: PaymentMethodMetadata? = null
     private var supportedPaymentMethods = mutableListOf<SupportedPaymentMethod>()
 
     private val card = CardDefinition.hardcodedCardSpec(
@@ -330,7 +331,7 @@ internal class CustomerSheetViewModel(
 
                     originalPaymentSelection = state.paymentSelection
                     isGooglePayReadyAndEnabled = state.isGooglePayReady
-                    stripeIntent = state.stripeIntent
+                    paymentMethodMetadata = state.paymentMethodMetadata
 
                     transitionToInitialScreen(
                         paymentMethods = state.customerPaymentMethods,
@@ -784,6 +785,8 @@ internal class CustomerSheetViewModel(
 
         val selectedPaymentMethod = previouslySelectedPaymentMethod
             ?: requireNotNull(lpmRepository.fromCode(paymentMethodCode))
+
+        val stripeIntent = paymentMethodMetadata?.stripeIntent
 
         transition(
             to = CustomerSheetViewState.AddPaymentMethod(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -18,7 +18,6 @@ import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
 import com.stripe.android.lpmfoundations.luxe.update
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntent
@@ -131,27 +130,22 @@ class DefaultCustomerSheetLoaderTest {
             googlePayEnabled = true
         )
 
-        assertThat(
-            loader.load(config).getOrThrow()
-        ).isEqualTo(
-            CustomerSheetState.Full(
-                config = config,
-                paymentMethodMetadata = PaymentMethodMetadataFactory.create(stripeIntent = STRIPE_INTENT),
-                customerPaymentMethods = listOf(
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                    PaymentMethodFixtures.US_BANK_ACCOUNT,
-                ),
-                supportedPaymentMethods = listOf(
-                    LpmRepositoryTestHelpers.card,
-                ),
-                isGooglePayReady = true,
-                paymentSelection = PaymentSelection.Saved(
-                    paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                ),
-                cbcEligibility = CardBrandChoiceEligibility.Ineligible,
-                validationError = null,
+        val state = loader.load(config).getOrThrow()
+        assertThat(state.config).isEqualTo(config)
+        assertThat(state.paymentMethodMetadata?.stripeIntent).isEqualTo(STRIPE_INTENT)
+        assertThat(state.customerPaymentMethods).containsExactly(
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            PaymentMethodFixtures.US_BANK_ACCOUNT,
+        )
+        assertThat(state.supportedPaymentMethods).containsExactly(LpmRepositoryTestHelpers.card)
+        assertThat(state.isGooglePayReady).isTrue()
+        assertThat(state.paymentSelection).isEqualTo(
+            PaymentSelection.Saved(
+                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             )
         )
+        assertThat(state.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
+        assertThat(state.validationError).isNull()
 
         val mode = elementsSessionRepository.lastGetParam as PaymentSheet.InitializationMode.DeferredIntent
         assertThat(mode.intentConfiguration.paymentMethodTypes)
@@ -188,27 +182,22 @@ class DefaultCustomerSheetLoaderTest {
             googlePayEnabled = true
         )
 
-        assertThat(
-            loader.load(config).getOrThrow()
-        ).isEqualTo(
-            CustomerSheetState.Full(
-                config = config,
-                paymentMethodMetadata = PaymentMethodMetadataFactory.create(stripeIntent = STRIPE_INTENT),
-                customerPaymentMethods = listOf(
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                    PaymentMethodFixtures.US_BANK_ACCOUNT,
-                ),
-                supportedPaymentMethods = listOf(
-                    LpmRepositoryTestHelpers.card,
-                ),
-                isGooglePayReady = true,
-                paymentSelection = PaymentSelection.Saved(
-                    paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                ),
-                cbcEligibility = CardBrandChoiceEligibility.Ineligible,
-                validationError = null,
+        val state = loader.load(config).getOrThrow()
+        assertThat(state.config).isEqualTo(config)
+        assertThat(state.paymentMethodMetadata?.stripeIntent).isEqualTo(STRIPE_INTENT)
+        assertThat(state.customerPaymentMethods).containsExactly(
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            PaymentMethodFixtures.US_BANK_ACCOUNT,
+        )
+        assertThat(state.supportedPaymentMethods).containsExactly(LpmRepositoryTestHelpers.card)
+        assertThat(state.isGooglePayReady).isTrue()
+        assertThat(state.paymentSelection).isEqualTo(
+            PaymentSelection.Saved(
+                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             )
         )
+        assertThat(state.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
+        assertThat(state.validationError).isNull()
 
         val mode = elementsSessionRepository.lastGetParam as PaymentSheet.InitializationMode.DeferredIntent
         assertThat(mode.intentConfiguration.paymentMethodTypes)
@@ -287,28 +276,23 @@ class DefaultCustomerSheetLoaderTest {
 
         val config = CustomerSheet.Configuration(merchantDisplayName = "Example")
 
-        assertThat(
-            loader.load(config).getOrThrow()
-        ).isEqualTo(
-            CustomerSheetState.Full(
-                config = config,
-                paymentMethodMetadata = PaymentMethodMetadataFactory.create(stripeIntent = STRIPE_INTENT),
-                customerPaymentMethods = listOf(
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_3"),
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_1"),
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_2"),
-                ),
-                supportedPaymentMethods = listOf(
-                    LpmRepositoryTestHelpers.card,
-                ),
-                isGooglePayReady = false,
-                paymentSelection = PaymentSelection.Saved(
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_3")
-                ),
-                cbcEligibility = CardBrandChoiceEligibility.Ineligible,
-                validationError = null,
+        val state = loader.load(config).getOrThrow()
+        assertThat(state.config).isEqualTo(config)
+        assertThat(state.paymentMethodMetadata?.stripeIntent).isEqualTo(STRIPE_INTENT)
+        assertThat(state.customerPaymentMethods).containsExactly(
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_3"),
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_1"),
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_2"),
+        )
+        assertThat(state.supportedPaymentMethods).containsExactly(LpmRepositoryTestHelpers.card)
+        assertThat(state.isGooglePayReady).isFalse()
+        assertThat(state.paymentSelection).isEqualTo(
+            PaymentSelection.Saved(
+                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_3"),
             )
         )
+        assertThat(state.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
+        assertThat(state.validationError).isNull()
     }
 
     @Test
@@ -328,26 +312,19 @@ class DefaultCustomerSheetLoaderTest {
 
         val config = CustomerSheet.Configuration(merchantDisplayName = "Example")
 
-        assertThat(
-            loader.load(config).getOrThrow()
-        ).isEqualTo(
-            CustomerSheetState.Full(
-                config = config,
-                paymentMethodMetadata = PaymentMethodMetadataFactory.create(stripeIntent = STRIPE_INTENT),
-                customerPaymentMethods = listOf(
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_1"),
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_2"),
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_3"),
-                ),
-                supportedPaymentMethods = listOf(
-                    LpmRepositoryTestHelpers.card,
-                ),
-                isGooglePayReady = false,
-                paymentSelection = null,
-                cbcEligibility = CardBrandChoiceEligibility.Ineligible,
-                validationError = null,
-            )
+        val state = loader.load(config).getOrThrow()
+        assertThat(state.config).isEqualTo(config)
+        assertThat(state.paymentMethodMetadata?.stripeIntent).isEqualTo(STRIPE_INTENT)
+        assertThat(state.customerPaymentMethods).containsExactly(
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_1"),
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_2"),
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_3"),
         )
+        assertThat(state.supportedPaymentMethods).containsExactly(LpmRepositoryTestHelpers.card)
+        assertThat(state.isGooglePayReady).isFalse()
+        assertThat(state.paymentSelection).isNull()
+        assertThat(state.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
+        assertThat(state.validationError).isNull()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -18,6 +18,7 @@ import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
 import com.stripe.android.lpmfoundations.luxe.update
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntent
@@ -135,7 +136,7 @@ class DefaultCustomerSheetLoaderTest {
         ).isEqualTo(
             CustomerSheetState.Full(
                 config = config,
-                stripeIntent = STRIPE_INTENT,
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(stripeIntent = STRIPE_INTENT),
                 customerPaymentMethods = listOf(
                     PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                     PaymentMethodFixtures.US_BANK_ACCOUNT,
@@ -192,7 +193,7 @@ class DefaultCustomerSheetLoaderTest {
         ).isEqualTo(
             CustomerSheetState.Full(
                 config = config,
-                stripeIntent = STRIPE_INTENT,
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(stripeIntent = STRIPE_INTENT),
                 customerPaymentMethods = listOf(
                     PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                     PaymentMethodFixtures.US_BANK_ACCOUNT,
@@ -230,7 +231,7 @@ class DefaultCustomerSheetLoaderTest {
         val config = CustomerSheet.Configuration(merchantDisplayName = "Example")
 
         assertThat(
-            loader.load(config).getOrThrow().stripeIntent
+            loader.load(config).getOrThrow().paymentMethodMetadata
         ).isNull()
     }
 
@@ -254,7 +255,7 @@ class DefaultCustomerSheetLoaderTest {
         ).isEqualTo(
             CustomerSheetState.Full(
                 config = config,
-                stripeIntent = null,
+                paymentMethodMetadata = null,
                 customerPaymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
                 supportedPaymentMethods = listOf(
                     LpmRepositoryTestHelpers.card,
@@ -291,7 +292,7 @@ class DefaultCustomerSheetLoaderTest {
         ).isEqualTo(
             CustomerSheetState.Full(
                 config = config,
-                stripeIntent = STRIPE_INTENT,
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(stripeIntent = STRIPE_INTENT),
                 customerPaymentMethods = listOf(
                     PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_3"),
                     PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_1"),
@@ -332,7 +333,7 @@ class DefaultCustomerSheetLoaderTest {
         ).isEqualTo(
             CustomerSheetState.Full(
                 config = config,
-                stripeIntent = STRIPE_INTENT,
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(stripeIntent = STRIPE_INTENT),
                 customerPaymentMethods = listOf(
                     PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_1"),
                     PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_2"),

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
@@ -6,6 +6,7 @@ import com.stripe.android.customersheet.CustomerSheetState
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
@@ -37,7 +38,7 @@ internal class FakeCustomerSheetLoader(
             Result.success(
                 CustomerSheetState.Full(
                     config = configuration,
-                    stripeIntent = stripeIntent,
+                    PaymentMethodMetadataFactory.create(stripeIntent = stripeIntent),
                     supportedPaymentMethods = supportedPaymentMethods,
                     customerPaymentMethods = customerPaymentMethods,
                     isGooglePayReady = isGooglePayAvailable,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We will need PaymentMethodMetadata to do more to remove the dependence on lpmRepository, which will be done as a follow up.

This is a pure refactor, no behavior changes.