### PR TITLE
[V3] customSuccessMessage on Success pane.

### DIFF
--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -1597,6 +1597,14 @@ public final class com/stripe/android/financialconnections/model/ServerLink$Crea
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/financialconnections/model/SuccessPane$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/model/SuccessPane;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/financialconnections/model/SuccessPane;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/financialconnections/model/SynchronizeSessionResponse$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/model/SynchronizeSessionResponse;

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
@@ -29,6 +29,7 @@ import com.stripe.android.financialconnections.repository.FinancialConnectionsEr
 import com.stripe.android.financialconnections.repository.FinancialConnectionsInstitutionsRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
 import com.stripe.android.financialconnections.repository.SuccessContentRepository
+import com.stripe.android.financialconnections.repository.SuccessContentRepositoryImpl
 import com.stripe.android.financialconnections.repository.api.FinancialConnectionsConsumersApiService
 import com.stripe.android.repository.ConsumersApiService
 import com.stripe.android.repository.ConsumersApiServiceImpl
@@ -154,7 +155,7 @@ internal interface FinancialConnectionsSheetNativeModule {
         @Provides
         fun providesSaveToLinkWithStripeSucceededRepository(
             @IOContext workContext: CoroutineContext
-        ) = SuccessContentRepository(
+        ): SuccessContentRepository = SuccessContentRepositoryImpl(
             CoroutineScope(SupervisorJob() + workContext)
         )
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
@@ -28,7 +28,7 @@ import com.stripe.android.financialconnections.repository.FinancialConnectionsCo
 import com.stripe.android.financialconnections.repository.FinancialConnectionsErrorRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsInstitutionsRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
-import com.stripe.android.financialconnections.repository.SaveToLinkWithStripeSucceededRepository
+import com.stripe.android.financialconnections.repository.SuccessContentRepository
 import com.stripe.android.financialconnections.repository.api.FinancialConnectionsConsumersApiService
 import com.stripe.android.repository.ConsumersApiService
 import com.stripe.android.repository.ConsumersApiServiceImpl
@@ -154,7 +154,7 @@ internal interface FinancialConnectionsSheetNativeModule {
         @Provides
         fun providesSaveToLinkWithStripeSucceededRepository(
             @IOContext workContext: CoroutineContext
-        ) = SaveToLinkWithStripeSucceededRepository(
+        ) = SuccessContentRepository(
             CoroutineScope(SupervisorJob() + workContext)
         )
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
@@ -7,6 +7,7 @@ import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.ViewModelContext
 import com.stripe.android.core.Logger
+import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.PollAttachPaymentsSucceeded
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
 import com.stripe.android.financialconnections.analytics.logError
@@ -21,14 +22,15 @@ import com.stripe.android.financialconnections.navigation.Destination.ManualEntr
 import com.stripe.android.financialconnections.navigation.Destination.Reset
 import com.stripe.android.financialconnections.navigation.NavigationManager
 import com.stripe.android.financialconnections.navigation.destination
-import com.stripe.android.financialconnections.repository.SaveToLinkWithStripeSucceededRepository
+import com.stripe.android.financialconnections.repository.SuccessContentRepository
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
+import com.stripe.android.financialconnections.ui.TextResource.PluralId
 import com.stripe.android.financialconnections.utils.measureTimeMillis
 import javax.inject.Inject
 
 internal class AttachPaymentViewModel @Inject constructor(
     initialState: AttachPaymentState,
-    private val saveToLinkWithStripeSucceeded: SaveToLinkWithStripeSucceededRepository,
+    private val successContentRepository: SuccessContentRepository,
     private val pollAttachPaymentAccount: PollAttachPaymentAccount,
     private val eventTracker: FinancialConnectionsAnalyticsTracker,
     private val getCachedAccounts: GetCachedAccounts,
@@ -58,7 +60,16 @@ internal class AttachPaymentViewModel @Inject constructor(
                 )
             }
             if (manifest.isNetworkingUserFlow == true && manifest.accountholderIsLinkConsumer == true) {
-                result.networkingSuccessful?.let { saveToLinkWithStripeSucceeded.set(it) }
+                result.networkingSuccessful?.let {
+                    successContentRepository.update {
+                        copy(
+                            customSuccessMessage = PluralId(
+                                value = R.plurals.stripe_success_pane_desc_link_success,
+                                count = accounts.size
+                            )
+                        )
+                    }
+                }
             }
             eventTracker.track(
                 PollAttachPaymentsSucceeded(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
@@ -28,11 +28,11 @@ import com.stripe.android.financialconnections.navigation.Destination
 import com.stripe.android.financialconnections.navigation.NavigationManager
 import com.stripe.android.financialconnections.repository.SuccessContentRepository
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
+import com.stripe.android.financialconnections.ui.TextResource
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
-import com.stripe.android.financialconnections.ui.TextResource
 import javax.inject.Inject
 
 internal class ManualEntryViewModel @Inject constructor(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
@@ -7,6 +7,7 @@ import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.ViewModelContext
 import com.stripe.android.core.Logger
+import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.PaneLoaded
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
 import com.stripe.android.financialconnections.analytics.logError
@@ -19,15 +20,18 @@ import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.financialconnections.model.LinkAccountSessionPaymentAccount
 import com.stripe.android.financialconnections.model.ManualEntryMode
 import com.stripe.android.financialconnections.model.PaymentAccountParams
-import com.stripe.android.financialconnections.navigation.Destination.ManualEntrySuccess
+import com.stripe.android.financialconnections.navigation.Destination
 import com.stripe.android.financialconnections.navigation.NavigationManager
+import com.stripe.android.financialconnections.repository.SuccessContentRepository
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
+import com.stripe.android.financialconnections.ui.TextResource
 import javax.inject.Inject
 
 internal class ManualEntryViewModel @Inject constructor(
     initialState: ManualEntryState,
     private val nativeAuthFlowCoordinator: NativeAuthFlowCoordinator,
     private val pollAttachPaymentAccount: PollAttachPaymentAccount,
+    private val successContentRepository: SuccessContentRepository,
     private val eventTracker: FinancialConnectionsAnalyticsTracker,
     private val getOrFetchSync: GetOrFetchSync,
     private val navigationManager: NavigationManager,
@@ -117,18 +121,16 @@ internal class ManualEntryViewModel @Inject constructor(
                 )
             ).also {
                 if (sync.manifest.manualEntryUsesMicrodeposits) {
-                    navigationManager.tryNavigateTo(
-                        ManualEntrySuccess(
-                            referrer = PANE,
-                            args = ManualEntrySuccess.argMap(
-                                microdepositVerificationMethod = it.microdepositVerificationMethod,
-                                last4 = state.account.takeLast(4)
+                    successContentRepository.update {
+                        copy(
+                            customSuccessMessage = TextResource.StringId(
+                                R.string.stripe_success_pane_desc_microdeposits,
+                                listOf(state.account.takeLast(4))
                             )
                         )
-                    )
-                } else {
-                    nativeAuthFlowCoordinator().emit(Complete())
+                    }
                 }
+                navigationManager.tryNavigateTo(Destination.ManualEntrySuccess(referrer = PANE))
             }
         }.execute { copy(linkPaymentAccount = it) }
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessScreen.kt
@@ -3,7 +3,6 @@ package com.stripe.android.financialconnections.features.manualentrysuccess
 import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.navigation.NavBackStackEntry
 import com.airbnb.mvrx.compose.collectAsState
 import com.airbnb.mvrx.compose.mavericksViewModel
 import com.stripe.android.financialconnections.features.success.SuccessContent
@@ -11,11 +10,9 @@ import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.financialconnections.presentation.parentViewModel
 
 @Composable
-internal fun ManualEntrySuccessScreen(
-    backStackEntry: NavBackStackEntry,
-) {
+internal fun ManualEntrySuccessScreen() {
     val parentViewModel = parentViewModel()
-    val viewModel: ManualEntrySuccessViewModel = mavericksViewModel(argsFactory = { backStackEntry.arguments })
+    val viewModel: ManualEntrySuccessViewModel = mavericksViewModel()
     val state by viewModel.collectAsState()
     BackHandler(true) {}
     SuccessContent(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessViewModel.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.financialconnections.features.manualentrysuccess
 
-import android.os.Bundle
 import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.MavericksState
@@ -8,7 +7,6 @@ import com.airbnb.mvrx.MavericksViewModel
 import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.ViewModelContext
-import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.ClickDone
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.PaneLoaded
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
@@ -17,15 +15,15 @@ import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.features.success.SuccessState
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
-import com.stripe.android.financialconnections.navigation.Destination
+import com.stripe.android.financialconnections.repository.SuccessContentRepository
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
-import com.stripe.android.financialconnections.ui.TextResource.StringId
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 internal class ManualEntrySuccessViewModel @Inject constructor(
     initialState: ManualEntrySuccessState,
     private val getManifest: GetManifest,
+    private val successContentRepository: SuccessContentRepository,
     private val eventTracker: FinancialConnectionsAnalyticsTracker,
     private val nativeAuthFlowCoordinator: NativeAuthFlowCoordinator,
 ) : MavericksViewModel<ManualEntrySuccessState>(initialState) {
@@ -35,10 +33,7 @@ internal class ManualEntrySuccessViewModel @Inject constructor(
             val manifest = getManifest()
             SuccessState.Payload(
                 businessName = manifest.businessName,
-                customSuccessMessage = when (val last4 = initialState.last4) {
-                    null -> StringId(R.string.stripe_success_pane_desc_microdeposits_no_account)
-                    else -> StringId(R.string.stripe_success_pane_desc_microdeposits, listOf(last4))
-                },
+                customSuccessMessage = successContentRepository.get().customSuccessMessage,
                 accountsCount = 1, // on manual entry just one account is connected,
                 skipSuccessPane = false
             ).also {
@@ -74,15 +69,6 @@ internal class ManualEntrySuccessViewModel @Inject constructor(
 }
 
 internal data class ManualEntrySuccessState(
-    val last4: String?,
-    val payload: Async<SuccessState.Payload>,
-    val completeSession: Async<FinancialConnectionsSession>
-) : MavericksState {
-
-    @Suppress("unused") // used by mavericks to create initial state.
-    constructor(args: Bundle?) : this(
-        last4 = Destination.ManualEntrySuccess.last4(args),
-        payload = Uninitialized,
-        completeSession = Uninitialized
-    )
-}
+    val payload: Async<SuccessState.Payload> = Uninitialized,
+    val completeSession: Async<FinancialConnectionsSession> = Uninitialized
+) : MavericksState

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
@@ -29,7 +29,6 @@ import com.stripe.android.financialconnections.model.NetworkingLinkSignupPane
 import com.stripe.android.financialconnections.navigation.Destination.NetworkingSaveToLinkVerification
 import com.stripe.android.financialconnections.navigation.Destination.Success
 import com.stripe.android.financialconnections.navigation.NavigationManager
-import com.stripe.android.financialconnections.repository.SaveToLinkWithStripeSucceededRepository
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
 import com.stripe.android.financialconnections.utils.ConflatedJob
 import com.stripe.android.financialconnections.utils.UriUtils
@@ -50,7 +49,6 @@ import javax.inject.Inject
 
 internal class NetworkingLinkSignupViewModel @Inject constructor(
     initialState: NetworkingLinkSignupState,
-    private val saveToLinkWithStripeSucceeded: SaveToLinkWithStripeSucceededRepository,
     private val saveAccountToLink: SaveAccountToLink,
     private val lookupAccount: LookupAccount,
     private val uriUtils: UriUtils,
@@ -116,11 +114,9 @@ internal class NetworkingLinkSignupViewModel @Inject constructor(
         onAsync(
             NetworkingLinkSignupState::saveAccountToLink,
             onSuccess = {
-                saveToLinkWithStripeSucceeded.set(true)
                 navigationManager.tryNavigateTo(Success(referrer = PANE))
             },
             onFail = { error ->
-                saveToLinkWithStripeSucceeded.set(false)
                 eventTracker.logError(
                     extraMessage = "Error saving account to Link",
                     error = error,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModel.kt
@@ -24,7 +24,6 @@ import com.stripe.android.financialconnections.domain.StartVerification
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.navigation.Destination.Success
 import com.stripe.android.financialconnections.navigation.NavigationManager
-import com.stripe.android.financialconnections.repository.SaveToLinkWithStripeSucceededRepository
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.OTPController
@@ -38,7 +37,6 @@ internal class NetworkingSaveToLinkVerificationViewModel @Inject constructor(
     initialState: NetworkingSaveToLinkVerificationState,
     private val eventTracker: FinancialConnectionsAnalyticsTracker,
     private val getCachedConsumerSession: GetCachedConsumerSession,
-    private val saveToLinkWithStripeSucceeded: SaveToLinkWithStripeSucceededRepository,
     private val startVerification: StartVerification,
     private val confirmVerification: ConfirmVerification,
     private val markLinkVerified: MarkLinkVerified,
@@ -90,7 +88,6 @@ internal class NetworkingSaveToLinkVerificationViewModel @Inject constructor(
         onAsync(
             NetworkingSaveToLinkVerificationState::confirmVerification,
             onSuccess = {
-                saveToLinkWithStripeSucceeded.set(true)
                 navigationManager.tryNavigateTo(Success(referrer = PANE))
             },
             onFail = { error ->
@@ -101,7 +98,6 @@ internal class NetworkingSaveToLinkVerificationViewModel @Inject constructor(
                     pane = PANE
                 )
                 if (error !is OTPError) {
-                    saveToLinkWithStripeSucceeded.set(false)
                     navigationManager.tryNavigateTo(Success(referrer = PANE))
                 }
             },

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessViewModel.kt
@@ -8,7 +8,6 @@ import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.ViewModelContext
 import com.stripe.android.core.Logger
-import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.ClickDone
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.PaneLoaded
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
@@ -19,7 +18,7 @@ import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.
 import com.stripe.android.financialconnections.features.common.useContinueWithMerchantText
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
-import com.stripe.android.financialconnections.repository.SaveToLinkWithStripeSucceededRepository
+import com.stripe.android.financialconnections.repository.SuccessContentRepository
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
 import com.stripe.android.financialconnections.ui.TextResource
 import kotlinx.coroutines.launch
@@ -29,7 +28,7 @@ internal class SuccessViewModel @Inject constructor(
     initialState: SuccessState,
     getCachedAccounts: GetCachedAccounts,
     getManifest: GetManifest,
-    private val saveToLinkWithStripeSucceeded: SaveToLinkWithStripeSucceededRepository,
+    private val successContentRepository: SuccessContentRepository,
     private val eventTracker: FinancialConnectionsAnalyticsTracker,
     private val logger: Logger,
     private val nativeAuthFlowCoordinator: NativeAuthFlowCoordinator
@@ -40,25 +39,17 @@ internal class SuccessViewModel @Inject constructor(
         suspend {
             val manifest = getManifest()
             val accounts = getCachedAccounts()
-            val saveToLinkWithStripeSucceeded: Boolean? = saveToLinkWithStripeSucceeded.get()
+            val successContent: SuccessContentRepository.State = successContentRepository.get()
             SuccessState.Payload(
                 skipSuccessPane = manifest.skipSuccessPane ?: false,
                 accountsCount = accounts.size,
-                customSuccessMessage = saveToLinkWithStripeSucceeded?.let { buildCustomMessage(it, accounts.size) },
+                customSuccessMessage = successContent.customSuccessMessage,
                 // We just want to use the business name in the CTA if the feature is enabled in the manifest.
                 businessName = manifest.businessName?.takeIf { manifest.useContinueWithMerchantText() },
             )
         }.execute {
             copy(payload = it)
         }
-    }
-
-    private fun buildCustomMessage(
-        saveToLinkWithStripeSucceeded: Boolean,
-        accountsCount: Int
-    ): TextResource = when (saveToLinkWithStripeSucceeded) {
-        true -> TextResource.PluralId(R.plurals.stripe_success_pane_desc_link_success, accountsCount)
-        false -> TextResource.PluralId(R.plurals.stripe_success_pane_desc_link_error, accountsCount)
     }
 
     private fun observeAsyncs() {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsSessionManifest.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsSessionManifest.kt
@@ -138,6 +138,9 @@ internal data class FinancialConnectionsSessionManifest(
     @SerialName(value = "experiment_assignments")
     val experimentAssignments: Map<String, String>? = null,
 
+    @SerialName(value = "display_text")
+    val displayText: TextUpdate? = null,
+
     @SerialName(value = "features")
     val features: Map<String, Boolean>? = null,
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/TextUpdate.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/TextUpdate.kt
@@ -17,7 +17,20 @@ internal data class TextUpdate(
     @SerialName("oauth_prepane")
     val oauthPrepane: OauthPrepane? = null,
     @SerialName("returning_networking_user_account_picker")
-    val returningNetworkingUserAccountPicker: ReturningNetworkingUserAccountPicker? = null
+    val returningNetworkingUserAccountPicker: ReturningNetworkingUserAccountPicker? = null,
+    @SerialName("success_pane")
+    val successPane: SuccessPane? = null,
+) : Parcelable
+
+@Serializable
+@Parcelize
+internal data class SuccessPane(
+    @SerialName("caption")
+    @Serializable(with = MarkdownToHtmlSerializer::class)
+    val caption: String,
+    @SerialName("sub_caption")
+    @Serializable(with = MarkdownToHtmlSerializer::class)
+    val subCaption: String,
 ) : Parcelable
 
 @Serializable

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/Destination.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/Destination.kt
@@ -31,7 +31,6 @@ import com.stripe.android.financialconnections.features.partnerauth.PartnerAuthS
 import com.stripe.android.financialconnections.features.reset.ResetScreen
 import com.stripe.android.financialconnections.features.success.SuccessScreen
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
-import com.stripe.android.financialconnections.model.LinkAccountSessionPaymentAccount.MicrodepositVerificationMethod
 import com.stripe.android.financialconnections.navigation.bottomsheet.bottomSheet
 import com.stripe.android.financialconnections.presentation.parentViewModel
 
@@ -183,31 +182,10 @@ internal sealed class Destination(
         composable = { BankAuthRepairScreen() }
     )
 
-    data object ManualEntrySuccess : Destination(
+    data object ManualEntrySuccess : NoArgumentsDestination(
         route = Pane.MANUAL_ENTRY_SUCCESS.value,
-        paramKeys = listOf(KEY_REFERRER, KEY_MICRODEPOSITS, KEY_LAST4),
-        screenBuilder = { ManualEntrySuccessScreen(it) }
-    ) {
-
-        fun argMap(
-            microdepositVerificationMethod: MicrodepositVerificationMethod,
-            last4: String?
-        ): Map<String, String?> = mapOf(
-            KEY_MICRODEPOSITS to microdepositVerificationMethod.value,
-            KEY_LAST4 to last4
-        )
-
-        fun last4(args: Bundle?): String? = args?.getString(KEY_LAST4)
-
-        override fun invoke(
-            referrer: Pane?,
-            args: Map<String, String?>
-        ): String = route.appendParamValues(
-            KEY_REFERRER to referrer?.value,
-            KEY_MICRODEPOSITS to args[KEY_MICRODEPOSITS],
-            KEY_LAST4 to args[KEY_LAST4]
-        )
-    }
+        composable = { ManualEntrySuccessScreen() }
+    )
 
     companion object {
         internal fun referrer(args: Bundle?): Pane? = args
@@ -215,8 +193,6 @@ internal sealed class Destination(
             ?.let { value -> Pane.entries.firstOrNull { it.value == value } }
 
         const val KEY_REFERRER = "referrer"
-        const val KEY_MICRODEPOSITS = "microdeposits"
-        const val KEY_LAST4 = "last4"
     }
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/SuccessContentRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/SuccessContentRepository.kt
@@ -3,10 +3,11 @@ package com.stripe.android.financialconnections.repository
 import com.airbnb.mvrx.MavericksRepository
 import com.airbnb.mvrx.MavericksState
 import com.stripe.android.financialconnections.BuildConfig
-import com.stripe.android.financialconnections.repository.SaveToLinkWithStripeSucceededRepository.State
+import com.stripe.android.financialconnections.repository.SuccessContentRepository.State
+import com.stripe.android.financialconnections.ui.TextResource
 import kotlinx.coroutines.CoroutineScope
 
-internal class SaveToLinkWithStripeSucceededRepository(
+internal class SuccessContentRepository(
     coroutineScope: CoroutineScope
 ) : MavericksRepository<State>(
     initialState = State(),
@@ -14,15 +15,13 @@ internal class SaveToLinkWithStripeSucceededRepository(
     performCorrectnessValidations = BuildConfig.DEBUG,
 ) {
 
-    suspend fun get() = awaitState().saveToLinkWithStripeSucceeded
+    suspend fun get() = awaitState()
 
-    fun set(saveToLinkWithStripeSucceeded: Boolean) {
-        setState {
-            copy(saveToLinkWithStripeSucceeded = saveToLinkWithStripeSucceeded)
-        }
+    fun update(reducer: State.() -> State) {
+        setState(reducer)
     }
 
     data class State(
-        val saveToLinkWithStripeSucceeded: Boolean? = null
+        val customSuccessMessage: TextResource? = null
     ) : MavericksState
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/SuccessContentRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/SuccessContentRepository.kt
@@ -1,27 +1,35 @@
 package com.stripe.android.financialconnections.repository
 
+import com.airbnb.mvrx.ExperimentalMavericksApi
 import com.airbnb.mvrx.MavericksRepository
 import com.airbnb.mvrx.MavericksState
 import com.stripe.android.financialconnections.BuildConfig
 import com.stripe.android.financialconnections.repository.SuccessContentRepository.State
 import com.stripe.android.financialconnections.ui.TextResource
 import kotlinx.coroutines.CoroutineScope
+import javax.inject.Inject
 
-internal class SuccessContentRepository(
+internal interface SuccessContentRepository {
+    suspend fun get(): State
+    fun update(reducer: State.() -> State)
+
+    data class State(
+        val customSuccessMessage: TextResource? = null
+    ) : MavericksState
+}
+
+@OptIn(ExperimentalMavericksApi::class)
+internal class SuccessContentRepositoryImpl @Inject constructor(
     coroutineScope: CoroutineScope
-) : MavericksRepository<State>(
+) : SuccessContentRepository, MavericksRepository<State>(
     initialState = State(),
     coroutineScope = coroutineScope,
     performCorrectnessValidations = BuildConfig.DEBUG,
 ) {
 
-    suspend fun get() = awaitState()
+    override suspend fun get() = awaitState()
 
-    fun update(reducer: State.() -> State) {
+    override fun update(reducer: State.() -> State) {
         setState(reducer)
     }
-
-    data class State(
-        val customSuccessMessage: TextResource? = null
-    ) : MavericksState
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModelTest.kt
@@ -15,9 +15,9 @@ import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Complete.EarlyTerminationCause.USER_INITIATED_WITH_CUSTOM_MANUAL_ENTRY
 import com.stripe.android.financialconnections.domain.PollAttachPaymentAccount
 import com.stripe.android.financialconnections.features.manualentry.ManualEntryState.Payload
+import com.stripe.android.financialconnections.mock.TestSuccessContentRepository
 import com.stripe.android.financialconnections.model.ManualEntryMode
 import com.stripe.android.financialconnections.utils.TestNavigationManager
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -26,7 +26,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class ManualEntryViewModelTest {
     @get:Rule
     val mavericksTestRule = MavericksTestRule()
@@ -44,6 +43,7 @@ class ManualEntryViewModelTest {
         eventTracker = eventTracker,
         initialState = ManualEntryState(),
         pollAttachPaymentAccount = pollAttachPaymentAccount,
+        successContentRepository = TestSuccessContentRepository(),
         nativeAuthFlowCoordinator = nativeAuthFlowCoordinator,
     )
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
@@ -19,7 +19,6 @@ import com.stripe.android.financialconnections.model.TextUpdate
 import com.stripe.android.financialconnections.navigation.Destination.NetworkingSaveToLinkVerification
 import com.stripe.android.financialconnections.navigation.NavigationIntent
 import com.stripe.android.financialconnections.navigation.NavigationManagerImpl
-import com.stripe.android.financialconnections.repository.SuccessContentRepository
 import com.stripe.android.financialconnections.utils.UriUtils
 import com.stripe.android.model.ConsumerSessionLookup
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -49,7 +48,6 @@ class NetworkingLinkSignupViewModelTest {
     private val lookupAccount = mock<LookupAccount>()
     private val saveAccountToLink = mock<SaveAccountToLink>()
     private val sync = mock<SynchronizeFinancialConnectionsSession>()
-    private val saveToLinkWithStripeSucceeded = mock<SuccessContentRepository>()
 
     private fun buildViewModel(
         state: NetworkingLinkSignupState
@@ -63,7 +61,6 @@ class NetworkingLinkSignupViewModelTest {
         lookupAccount = lookupAccount,
         uriUtils = UriUtils(Logger.noop(), eventTracker),
         sync = sync,
-        saveToLinkWithStripeSucceeded = saveToLinkWithStripeSucceeded,
         saveAccountToLink = saveAccountToLink
     )
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
@@ -19,7 +19,7 @@ import com.stripe.android.financialconnections.model.TextUpdate
 import com.stripe.android.financialconnections.navigation.Destination.NetworkingSaveToLinkVerification
 import com.stripe.android.financialconnections.navigation.NavigationIntent
 import com.stripe.android.financialconnections.navigation.NavigationManagerImpl
-import com.stripe.android.financialconnections.repository.SaveToLinkWithStripeSucceededRepository
+import com.stripe.android.financialconnections.repository.SuccessContentRepository
 import com.stripe.android.financialconnections.utils.UriUtils
 import com.stripe.android.model.ConsumerSessionLookup
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -49,7 +49,7 @@ class NetworkingLinkSignupViewModelTest {
     private val lookupAccount = mock<LookupAccount>()
     private val saveAccountToLink = mock<SaveAccountToLink>()
     private val sync = mock<SynchronizeFinancialConnectionsSession>()
-    private val saveToLinkWithStripeSucceeded = mock<SaveToLinkWithStripeSucceededRepository>()
+    private val saveToLinkWithStripeSucceeded = mock<SuccessContentRepository>()
 
     private fun buildViewModel(
         state: NetworkingLinkSignupState

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModelTest.kt
@@ -16,7 +16,6 @@ import com.stripe.android.financialconnections.domain.StartVerification
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane.INSTITUTION_PICKER
 import com.stripe.android.financialconnections.navigation.Destination
-import com.stripe.android.financialconnections.repository.SuccessContentRepository
 import com.stripe.android.financialconnections.utils.TestNavigationManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -39,7 +38,6 @@ class NetworkingSaveToLinkVerificationViewModelTest {
     private val confirmVerification = mock<ConfirmVerification>()
     private val startVerification = mock<StartVerification>()
     private val markLinkVerified = mock<MarkLinkVerified>()
-    private val saveToLinkWithStripeSucceeded = mock<SuccessContentRepository>()
     private val getCachedAccounts = mock<GetCachedAccounts>()
     private val getCachedConsumerSession = mock<GetCachedConsumerSession>()
     private val saveAccountToLink = mock<SaveAccountToLink>()
@@ -56,7 +54,6 @@ class NetworkingSaveToLinkVerificationViewModelTest {
         getCachedAccounts = getCachedAccounts,
         saveAccountToLink = saveAccountToLink,
         getCachedConsumerSession = getCachedConsumerSession,
-        saveToLinkWithStripeSucceeded = saveToLinkWithStripeSucceeded,
         logger = Logger.noop(),
         initialState = state
     )

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModelTest.kt
@@ -16,7 +16,7 @@ import com.stripe.android.financialconnections.domain.StartVerification
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane.INSTITUTION_PICKER
 import com.stripe.android.financialconnections.navigation.Destination
-import com.stripe.android.financialconnections.repository.SaveToLinkWithStripeSucceededRepository
+import com.stripe.android.financialconnections.repository.SuccessContentRepository
 import com.stripe.android.financialconnections.utils.TestNavigationManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -39,7 +39,7 @@ class NetworkingSaveToLinkVerificationViewModelTest {
     private val confirmVerification = mock<ConfirmVerification>()
     private val startVerification = mock<StartVerification>()
     private val markLinkVerified = mock<MarkLinkVerified>()
-    private val saveToLinkWithStripeSucceeded = mock<SaveToLinkWithStripeSucceededRepository>()
+    private val saveToLinkWithStripeSucceeded = mock<SuccessContentRepository>()
     private val getCachedAccounts = mock<GetCachedAccounts>()
     private val getCachedConsumerSession = mock<GetCachedConsumerSession>()
     private val saveAccountToLink = mock<SaveAccountToLink>()

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/success/SuccessViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/success/SuccessViewModelTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.financialconnections.domain.GetCachedAccounts
 import com.stripe.android.financialconnections.domain.GetManifest
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Complete
+import com.stripe.android.financialconnections.mock.TestSuccessContentRepository
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -44,7 +45,7 @@ internal class SuccessViewModelTest {
         eventTracker = eventTracker,
         initialState = state,
         nativeAuthFlowCoordinator = nativeAuthFlowCoordinator,
-        saveToLinkWithStripeSucceeded = mock(),
+        successContentRepository = TestSuccessContentRepository(),
         getCachedAccounts = getCachedAccounts,
     )
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/mock/TestSuccessContentRepository.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/mock/TestSuccessContentRepository.kt
@@ -1,0 +1,15 @@
+package com.stripe.android.financialconnections.mock
+
+import com.stripe.android.financialconnections.repository.SuccessContentRepository
+
+internal class TestSuccessContentRepository() : SuccessContentRepository {
+
+    var state = SuccessContentRepository.State()
+    override suspend fun get(): SuccessContentRepository.State {
+        return state
+    }
+
+    override fun update(reducer: SuccessContentRepository.State.() -> SuccessContentRepository.State) {
+        state = state.reducer()
+    }
+}

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/mock/TestSuccessContentRepository.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/mock/TestSuccessContentRepository.kt
@@ -2,7 +2,7 @@ package com.stripe.android.financialconnections.mock
 
 import com.stripe.android.financialconnections.repository.SuccessContentRepository
 
-internal class TestSuccessContentRepository() : SuccessContentRepository {
+internal class TestSuccessContentRepository : SuccessContentRepository {
 
     var state = SuccessContentRepository.State()
     override suspend fun get(): SuccessContentRepository.State {


### PR DESCRIPTION
# Summary

We used to set some flags + pass parameters via bundle to determine the success screen messaging. This PR brings us closer to what web and iOS do, store the success message before navigating to the success screen, based on different criteria (backend responses + what happens on the flow).

Also makes sure we display the success message after manual entry (we used to skip it in v2 some times).

**non-networking messaging**
- If manual entry + microdeposits: We locally set `customSuccessMessage` (expect deposits to arrive in your bank account...)
- else (regular flow, manual entry with other verification method): no custom message.

default message when no custom message is set: "your account(s) were connected"

**networking messaging:**
- on the `save_accounts_to_link` api call:
  - **succeeds**: we rely on `manifest.display.success.sub_caption`, we set it as `customSuccessMessage`). If it doesn't come in the response, build the message locally (your accounts were linked **and saved to Link**)
  - **fails**: we set the customSuccessMessage locally (your accounts were connected, but couldn't be saved...)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests: Maestro tests will test the displayed success message (WIP) 
- [ ] Modified tests
- [X] Manually verified

