### PR TITLE
Always call elements sessions in CustomerSheetLoader.

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -21,7 +21,7 @@
     <ID>LargeClass:USBankAccountFormViewModelTest.kt$USBankAccountFormViewModelTest</ID>
     <ID>LongMethod:AddPaymentMethod.kt$@Composable internal fun AddPaymentMethod( sheetViewModel: BaseSheetViewModel, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:AutocompleteScreen.kt$@Composable internal fun AutocompleteScreenUI(viewModel: AutocompleteViewModel)</ID>
-    <ID>LongMethod:CustomerSheetLoader.kt$DefaultCustomerSheetLoader$private suspend fun loadPaymentMethods( customerAdapter: CustomerAdapter, configuration: CustomerSheet.Configuration?, elementsSessionWithMetadata: ElementsSessionWithMetadata?, )</ID>
+    <ID>LongMethod:CustomerSheetLoader.kt$DefaultCustomerSheetLoader$private suspend fun loadPaymentMethods( customerAdapter: CustomerAdapter, configuration: CustomerSheet.Configuration, elementsSessionWithMetadata: ElementsSessionWithMetadata, )</ID>
     <ID>LongMethod:CustomerSheetScreen.kt$@Composable internal fun AddPaymentMethodWithPaymentElement( viewState: CustomerSheetViewState.AddPaymentMethod, viewActionHandler: (CustomerSheetViewAction) -> Unit, formViewModelSubComponentBuilderProvider: Provider&lt;FormViewModelSubcomponent.Builder>?, )</ID>
     <ID>LongMethod:CustomerSheetScreen.kt$@Composable internal fun SelectPaymentMethod( viewState: CustomerSheetViewState.SelectPaymentMethod, viewActionHandler: (CustomerSheetViewAction) -> Unit, paymentMethodNameProvider: (PaymentMethodCode?) -> String, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:CustomerSheetViewModel.kt$CustomerSheetViewModel$private fun transitionToAddPaymentMethod( isFirstPaymentMethod: Boolean, cbcEligibility: CardBrandChoiceEligibility = viewState.value.cbcEligibility, )</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetState.kt
@@ -11,8 +11,8 @@ internal sealed interface CustomerSheetState {
     object Loading : CustomerSheetState
 
     data class Full(
-        val config: CustomerSheet.Configuration?,
-        val paymentMethodMetadata: PaymentMethodMetadata?,
+        val config: CustomerSheet.Configuration,
+        val paymentMethodMetadata: PaymentMethodMetadata,
         val customerPaymentMethods: List<PaymentMethod>,
         val supportedPaymentMethods: List<SupportedPaymentMethod>,
         val isGooglePayReady: Boolean,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
@@ -30,7 +30,7 @@ internal class FakeCustomerSheetLoader(
     private val cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
 ) : CustomerSheetLoader {
 
-    override suspend fun load(configuration: CustomerSheet.Configuration?): Result<CustomerSheetState.Full> {
+    override suspend fun load(configuration: CustomerSheet.Configuration): Result<CustomerSheetState.Full> {
         delay(delay)
         return if (shouldFail) {
             Result.failure(IllegalStateException("failed to load"))


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We rely on the information coming from elements session (before a recent refactor we were relying on the side effects of this call). But we never made it in the case of `customerAdapter.canCreateSetupIntents`, which caused CustomerSheet to not work.

I also included a few cleanups that were made obvious from this change (nullability in state).
