### PR TITLE
Remove LPM from tests where it isn't needed.

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -27,9 +27,7 @@ import com.stripe.android.link.ui.inline.InlineSignupViewState
 import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.inline.UserInput
-import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
-import com.stripe.android.lpmfoundations.luxe.update
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.CardDefinition
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
@@ -139,32 +137,6 @@ internal class PaymentSheetViewModelTest {
 
     private val eventReporter = mock<EventReporter>()
     private val application = ApplicationProvider.getApplicationContext<Application>()
-
-    private val lpmRepository = LpmRepository(
-        arguments = LpmRepository.LpmRepositoryArguments(application.resources),
-    ).apply {
-        this.update(
-            PaymentIntentFactory.create(
-                paymentMethodTypes = listOf(
-                    PaymentMethod.Type.Card.code,
-                    PaymentMethod.Type.USBankAccount.code,
-                    PaymentMethod.Type.CashAppPay.code,
-                    PaymentMethod.Type.Ideal.code,
-                    PaymentMethod.Type.SepaDebit.code,
-                    PaymentMethod.Type.Sofort.code,
-                    PaymentMethod.Type.Affirm.code,
-                    PaymentMethod.Type.AfterpayClearpay.code,
-                ),
-            ).copy(
-                shipping = PaymentIntent.Shipping(
-                    name = "Example buyer",
-                    address = Address(line1 = "123 Main st.", country = "US", postalCode = "12345"),
-                ),
-                clientSecret = null,
-            ),
-            null
-        )
-    }
 
     private val prefsRepository = FakePrefsRepository()
 
@@ -1028,8 +1000,7 @@ internal class PaymentSheetViewModelTest {
             ),
         )
 
-        val expectedPaymentMethod = lpmRepository.fromCode("afterpay_clearpay")
-        assertThat(viewModel.supportedPaymentMethods).containsExactly(expectedPaymentMethod)
+        assertThat(viewModel.supportedPaymentMethods.map { it.code }).containsExactly("afterpay_clearpay")
     }
 
     @Test
@@ -1045,8 +1016,7 @@ internal class PaymentSheetViewModelTest {
             ),
         )
 
-        val expectedPaymentMethod = lpmRepository.fromCode("afterpay_clearpay")
-        assertThat(viewModel.supportedPaymentMethods).containsExactly(expectedPaymentMethod)
+        assertThat(viewModel.supportedPaymentMethods.map { it.code }).containsExactly("afterpay_clearpay")
     }
 
     @Test
@@ -1147,11 +1117,8 @@ internal class PaymentSheetViewModelTest {
         )
 
         assertThat(
-            viewModel.supportedPaymentMethods
-        ).containsExactly(
-            lpmRepository.fromCode("card")!!,
-            lpmRepository.fromCode("ideal")!!
-        )
+            viewModel.supportedPaymentMethods.map { it.code }
+        ).containsExactly("card", "ideal")
     }
 
     @Test
@@ -1174,13 +1141,8 @@ internal class PaymentSheetViewModelTest {
         )
 
         assertThat(
-            viewModel.supportedPaymentMethods
-        ).containsExactly(
-            lpmRepository.fromCode("card")!!,
-            lpmRepository.fromCode("ideal")!!,
-            lpmRepository.fromCode("sepa_debit")!!,
-            lpmRepository.fromCode("sofort")!!
-        )
+            viewModel.supportedPaymentMethods.map { it.code }
+        ).containsExactly("card", "ideal", "sepa_debit", "sofort")
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
@@ -3,20 +3,17 @@ package com.stripe.android.paymentsheet.forms
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
-import com.stripe.android.lpmfoundations.luxe.update
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.BancontactDefinition
 import com.stripe.android.model.CardBrand
-import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
-import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -30,23 +27,6 @@ class FormArgumentsFactoryTest {
 
     private val resources = ApplicationProvider.getApplicationContext<Application>().resources
 
-    private val lpmRepository = LpmRepository(
-        LpmRepository.LpmRepositoryArguments(resources)
-    ).apply {
-        this.update(
-            PaymentIntentFactory.create(
-                paymentMethodTypes =
-                listOf(
-                    PaymentMethod.Type.Card.code,
-                    PaymentMethod.Type.USBankAccount.code,
-                    PaymentMethod.Type.SepaDebit.code,
-                    PaymentMethod.Type.Bancontact.code
-                )
-            ),
-            null
-        )
-    }
-
     @Test
     fun `Create correct FormArguments for new generic payment method with customer requested save`() {
         val paymentMethodCreateParams = PaymentMethodCreateParams.createWithOverride(
@@ -59,9 +39,14 @@ class FormArgumentsFactoryTest {
             productUsage = emptySet(),
         )
 
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "bancontact")
+            )
+        )
         val actualArgs = FormArgumentsFactory.create(
-            paymentMethod = lpmRepository.fromCode("bancontact")!!,
-            metadata = PaymentMethodMetadataFactory.create(),
+            paymentMethod = metadata.supportedPaymentMethodForCode("bancontact")!!,
+            metadata = metadata,
             config = PaymentSheetFixtures.CONFIG_MINIMUM,
             merchantName = PaymentSheetFixtures.MERCHANT_DISPLAY_NAME,
             amount = Amount(50, "USD"),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
These tests where using the mutability aspect of LpmRepository, and I refactored them to no longer rely on that functionality (which I'm hoping to remove in a follow up).
