### PR TITLE
Store CbcEligibility in PaymentMethodMetadata.

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/cbc/CardBrandChoiceEligibility.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/cbc/CardBrandChoiceEligibility.kt
@@ -14,4 +14,16 @@ sealed interface CardBrandChoiceEligibility : Parcelable {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     object Ineligible : CardBrandChoiceEligibility
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    companion object {
+        fun create(isEligible: Boolean, preferredNetworks: List<CardBrand>): CardBrandChoiceEligibility {
+            return when (isEligible) {
+                true -> Eligible(
+                    preferredNetworks = preferredNetworks
+                )
+                false -> Ineligible
+            }
+        }
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -99,12 +99,10 @@ internal class DefaultCustomerSheetLoader(
                 serverLpmSpecs = elementsSession.paymentMethodSpecs,
             ).sharedDataSpecs
 
-            val cbcEligibility = when (elementsSession.isEligibleForCardBrandChoice) {
-                true -> CardBrandChoiceEligibility.Eligible(
-                    preferredNetworks = configuration.preferredNetworks
-                )
-                false -> CardBrandChoiceEligibility.Ineligible
-            }
+            val cbcEligibility = CardBrandChoiceEligibility.create(
+                isEligible = elementsSession.isEligibleForCardBrandChoice,
+                preferredNetworks = configuration.preferredNetworks,
+            )
 
             val metadata = PaymentMethodMetadata(
                 stripeIntent = elementsSession.stripeIntent,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -98,12 +98,21 @@ internal class DefaultCustomerSheetLoader(
                 stripeIntent = elementsSession.stripeIntent,
                 serverLpmSpecs = elementsSession.paymentMethodSpecs,
             ).sharedDataSpecs
+
+            val cbcEligibility = when (elementsSession.isEligibleForCardBrandChoice) {
+                true -> CardBrandChoiceEligibility.Eligible(
+                    preferredNetworks = configuration.preferredNetworks
+                )
+                false -> CardBrandChoiceEligibility.Ineligible
+            }
+
             val metadata = PaymentMethodMetadata(
                 stripeIntent = elementsSession.stripeIntent,
                 billingDetailsCollectionConfiguration = billingDetailsCollectionConfig,
                 allowsDelayedPaymentMethods = true,
                 allowsPaymentMethodsRequiringShippingAddress = false,
                 paymentMethodOrder = configuration.paymentMethodOrder,
+                cbcEligibility = cbcEligibility,
                 sharedDataSpecs = sharedDataSpecs,
                 financialConnectionsAvailable = isFinancialConnectionsAvailable()
             )
@@ -173,8 +182,6 @@ internal class DefaultCustomerSheetLoader(
                     isFinancialConnectionsAvailable,
                 )
 
-                val isCbcEligible = elementsSession.isEligibleForCardBrandChoice
-
                 Result.success(
                     CustomerSheetState.Full(
                         config = configuration,
@@ -183,13 +190,6 @@ internal class DefaultCustomerSheetLoader(
                         customerPaymentMethods = paymentMethods,
                         isGooglePayReady = isGooglePayReadyAndEnabled,
                         paymentSelection = paymentSelection,
-                        cbcEligibility = if (isCbcEligible) {
-                            CardBrandChoiceEligibility.Eligible(
-                                preferredNetworks = configuration.preferredNetworks,
-                            )
-                        } else {
-                            CardBrandChoiceEligibility.Ineligible
-                        },
                         validationError = elementsSession.stripeIntent.validate(),
                     )
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetState.kt
@@ -4,7 +4,6 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 internal sealed interface CustomerSheetState {
@@ -17,7 +16,6 @@ internal sealed interface CustomerSheetState {
         val supportedPaymentMethods: List<SupportedPaymentMethod>,
         val isGooglePayReady: Boolean,
         val paymentSelection: PaymentSelection?,
-        val cbcEligibility: CardBrandChoiceEligibility,
         val validationError: Throwable?,
     ) : CustomerSheetState
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -333,7 +333,7 @@ internal class CustomerSheetViewModel(
                     transitionToInitialScreen(
                         paymentMethods = state.customerPaymentMethods,
                         paymentSelection = state.paymentSelection,
-                        cbcEligibility = state.cbcEligibility,
+                        cbcEligibility = state.paymentMethodMetadata.cbcEligibility,
                     )
                 }
             },

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -8,6 +8,7 @@ import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.financialconnections.DefaultIsFinancialConnectionsAvailable
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
+import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.SharedDataSpec
 import kotlinx.parcelize.Parcelize
 
@@ -22,6 +23,7 @@ internal data class PaymentMethodMetadata(
     val allowsDelayedPaymentMethods: Boolean,
     val allowsPaymentMethodsRequiringShippingAddress: Boolean,
     val paymentMethodOrder: List<String>,
+    val cbcEligibility: CardBrandChoiceEligibility,
     val sharedDataSpecs: List<SharedDataSpec>,
     val financialConnectionsAvailable: Boolean = DefaultIsFinancialConnectionsAvailable(),
 ) : Parcelable {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -31,7 +31,6 @@ import com.stripe.android.paymentsheet.ui.ModifiableEditPaymentMethodViewInterac
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.PrimaryButtonUiStateMapper
-import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.utils.requireApplication
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -174,13 +173,6 @@ internal class PaymentOptionsViewModel @Inject constructor(
         savedStateHandle[SAVE_PROCESSING] = false
 
         updateSelection(args.state.paymentSelection)
-
-        cbcEligibility = when (args.state.isEligibleForCardBrandChoice) {
-            true -> CardBrandChoiceEligibility.Eligible(
-                preferredNetworks = args.state.config.preferredNetworks
-            )
-            false -> CardBrandChoiceEligibility.Ineligible
-        }
 
         transitionToFirstScreen()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -64,7 +64,6 @@ import com.stripe.android.paymentsheet.utils.canSave
 import com.stripe.android.paymentsheet.utils.combineStateFlows
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.PrimaryButtonUiStateMapper
-import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.utils.requireApplication
 import dagger.Lazy
 import kotlinx.coroutines.CoroutineScope
@@ -382,13 +381,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     private suspend fun initializeWithState(state: PaymentSheetState.Full) {
-        cbcEligibility = when (state.isEligibleForCardBrandChoice) {
-            true -> CardBrandChoiceEligibility.Eligible(
-                preferredNetworks = state.config.preferredNetworks
-            )
-            false -> CardBrandChoiceEligibility.Ineligible
-        }
-
         savedStateHandle[SAVE_PAYMENT_METHODS] = state.customerPaymentMethods
         updateSelection(state.paymentSelection)
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
@@ -21,7 +21,6 @@ internal object FormArgumentsFactory {
         merchantName: String,
         amount: Amount? = null,
         newLpm: PaymentSelection.New?,
-        cbcEligibility: CardBrandChoiceEligibility,
     ): FormArguments {
         val setupFutureUsageFieldConfiguration =
             paymentMethod.paymentMethodDefinition().getSetupFutureUsageFieldConfiguration(
@@ -73,7 +72,7 @@ internal object FormArgumentsFactory {
             initialPaymentMethodCreateParams = initialParams,
             initialPaymentMethodExtraParams = initialExtraParams,
             billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
-            cbcEligibility = cbcEligibility,
+            cbcEligibility = metadata.cbcEligibility,
             requiresMandate = paymentMethod.requiresMandate,
             requiredFields = paymentMethod.placeholderOverrideList,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -79,12 +79,10 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             val billingDetailsCollectionConfig =
                 paymentSheetConfiguration.billingDetailsCollectionConfiguration.toInternal()
 
-            val cbcEligibility = when (elementsSession.isEligibleForCardBrandChoice) {
-                true -> CardBrandChoiceEligibility.Eligible(
-                    preferredNetworks = paymentSheetConfiguration.preferredNetworks
-                )
-                false -> CardBrandChoiceEligibility.Ineligible
-            }
+            val cbcEligibility = CardBrandChoiceEligibility.create(
+                isEligible = elementsSession.isEligibleForCardBrandChoice,
+                preferredNetworks = paymentSheetConfiguration.preferredNetworks,
+            )
 
             val sharedDataSpecsResult = lpmRepository.getSharedDataSpecs(
                 stripeIntent = elementsSession.stripeIntent,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -27,6 +27,7 @@ import com.stripe.android.paymentsheet.model.validate
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
+import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -78,6 +79,13 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             val billingDetailsCollectionConfig =
                 paymentSheetConfiguration.billingDetailsCollectionConfiguration.toInternal()
 
+            val cbcEligibility = when (elementsSession.isEligibleForCardBrandChoice) {
+                true -> CardBrandChoiceEligibility.Eligible(
+                    preferredNetworks = paymentSheetConfiguration.preferredNetworks
+                )
+                false -> CardBrandChoiceEligibility.Ineligible
+            }
+
             val sharedDataSpecsResult = lpmRepository.getSharedDataSpecs(
                 stripeIntent = elementsSession.stripeIntent,
                 serverLpmSpecs = elementsSession.paymentMethodSpecs,
@@ -89,6 +97,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
                 allowsPaymentMethodsRequiringShippingAddress = paymentSheetConfiguration
                     .allowsPaymentMethodsRequiringShippingAddress,
                 paymentMethodOrder = paymentSheetConfiguration.paymentMethodOrder,
+                cbcEligibility = cbcEligibility,
                 sharedDataSpecs = sharedDataSpecsResult.sharedDataSpecs,
             )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -94,7 +94,6 @@ internal abstract class BaseSheetViewModel(
     internal val merchantName = config.merchantDisplayName
 
     protected var mostRecentError: Throwable? = null
-    protected var cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible
 
     internal val googlePayState: StateFlow<GooglePayState> = savedStateHandle
         .getStateFlow(SAVE_GOOGLE_PAY_STATE, GooglePayState.Indeterminate)
@@ -219,7 +218,7 @@ internal abstract class BaseSheetViewModel(
             isLinkEnabled = linkHandler.isLinkEnabled,
             isNotPaymentFlow = this is PaymentOptionsViewModel,
             nameProvider = ::providePaymentMethodName,
-            isCbcEligible = { cbcEligibility is CardBrandChoiceEligibility.Eligible }
+            isCbcEligible = { paymentMethodMetadata.value?.cbcEligibility is CardBrandChoiceEligibility.Eligible }
         )
     }
 
@@ -682,7 +681,6 @@ internal abstract class BaseSheetViewModel(
         merchantName = merchantName,
         amount = amount.value,
         newLpm = newPaymentSelection,
-        cbcEligibility = cbcEligibility,
     )
 
     fun handleBackPressed() {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -134,6 +134,7 @@ class DefaultCustomerSheetLoaderTest {
         val state = loader.load(config).getOrThrow()
         assertThat(state.config).isEqualTo(config)
         assertThat(state.paymentMethodMetadata.stripeIntent).isEqualTo(STRIPE_INTENT)
+        assertThat(state.paymentMethodMetadata.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
         assertThat(state.customerPaymentMethods).containsExactly(
             PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             PaymentMethodFixtures.US_BANK_ACCOUNT,
@@ -145,7 +146,6 @@ class DefaultCustomerSheetLoaderTest {
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             )
         )
-        assertThat(state.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
         assertThat(state.validationError).isNull()
 
         val mode = elementsSessionRepository.lastGetParam as PaymentSheet.InitializationMode.DeferredIntent
@@ -197,7 +197,7 @@ class DefaultCustomerSheetLoaderTest {
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             )
         )
-        assertThat(state.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
+        assertThat(state.paymentMethodMetadata.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
         assertThat(state.validationError).isNull()
 
         val mode = elementsSessionRepository.lastGetParam as PaymentSheet.InitializationMode.DeferredIntent
@@ -229,7 +229,7 @@ class DefaultCustomerSheetLoaderTest {
         assertThat(state.supportedPaymentMethods).containsExactly(LpmRepositoryTestHelpers.card)
         assertThat(state.isGooglePayReady).isFalse()
         assertThat(state.paymentSelection).isNull()
-        assertThat(state.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
+        assertThat(state.paymentMethodMetadata.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
         assertThat(state.validationError).isNull()
     }
 
@@ -328,7 +328,7 @@ class DefaultCustomerSheetLoaderTest {
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_3"),
             )
         )
-        assertThat(state.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
+        assertThat(state.paymentMethodMetadata.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
         assertThat(state.validationError).isNull()
     }
 
@@ -360,7 +360,7 @@ class DefaultCustomerSheetLoaderTest {
         assertThat(state.supportedPaymentMethods).containsExactly(LpmRepositoryTestHelpers.card)
         assertThat(state.isGooglePayReady).isFalse()
         assertThat(state.paymentSelection).isNull()
-        assertThat(state.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
+        assertThat(state.paymentMethodMetadata.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
         assertThat(state.validationError).isNull()
     }
 
@@ -596,7 +596,8 @@ class DefaultCustomerSheetLoaderTest {
     fun `Loads correct CBC eligibility`() = runTest {
         val loader = createCustomerSheetLoader(isCbcEligible = true)
         val state = loader.load(CustomerSheet.Configuration(merchantDisplayName = "Example")).getOrThrow()
-        assertThat(state.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Eligible(emptyList()))
+        assertThat(state.paymentMethodMetadata.cbcEligibility)
+            .isEqualTo(CardBrandChoiceEligibility.Eligible(emptyList()))
     }
 
     @Test
@@ -610,9 +611,8 @@ class DefaultCustomerSheetLoaderTest {
             )
         ).getOrThrow()
 
-        assertThat(state.cbcEligibility).isEqualTo(
-            CardBrandChoiceEligibility.Eligible(preferredNetworks = listOf(CardBrand.CartesBancaires))
-        )
+        assertThat(state.paymentMethodMetadata.cbcEligibility)
+            .isEqualTo(CardBrandChoiceEligibility.Eligible(preferredNetworks = listOf(CardBrand.CartesBancaires)))
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
@@ -38,12 +38,14 @@ internal class FakeCustomerSheetLoader(
             Result.success(
                 CustomerSheetState.Full(
                     config = configuration,
-                    PaymentMethodMetadataFactory.create(stripeIntent = stripeIntent),
+                    PaymentMethodMetadataFactory.create(
+                        stripeIntent = stripeIntent,
+                        cbcEligibility = cbcEligibility,
+                    ),
                     supportedPaymentMethods = supportedPaymentMethods,
                     customerPaymentMethods = customerPaymentMethods,
                     isGooglePayReady = isGooglePayAvailable,
                     paymentSelection = paymentSelection,
-                    cbcEligibility = cbcEligibility,
                     validationError = null,
                 )
             )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
+import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.LpmSerializer
 import com.stripe.android.ui.core.elements.SharedDataSpec
 
@@ -17,6 +18,7 @@ internal object PaymentMethodMetadataFactory {
         allowsPaymentMethodsRequiringShippingAddress: Boolean = false,
         financialConnectionsAvailable: Boolean = true,
         paymentMethodOrder: List<String> = emptyList(),
+        cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
         sharedDataSpecs: List<SharedDataSpec> = createSharedDataSpecs(),
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
@@ -26,6 +28,7 @@ internal object PaymentMethodMetadataFactory {
             allowsPaymentMethodsRequiringShippingAddress = allowsPaymentMethodsRequiringShippingAddress,
             financialConnectionsAvailable = financialConnectionsAvailable,
             paymentMethodOrder = paymentMethodOrder,
+            cbcEligibility = cbcEligibility,
             sharedDataSpecs = sharedDataSpecs,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
@@ -15,7 +15,6 @@ import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.ui.core.Amount
-import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.SharedDataSpec
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -58,7 +57,6 @@ class FormArgumentsFactoryTest {
                 paymentMethodCreateParams = paymentMethodCreateParams,
                 customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
             ),
-            cbcEligibility = CardBrandChoiceEligibility.Ineligible
         )
 
         assertThat(actualArgs.initialPaymentMethodCreateParams).isEqualTo(paymentMethodCreateParams)
@@ -84,7 +82,6 @@ class FormArgumentsFactoryTest {
             merchantName = PaymentSheetFixtures.MERCHANT_DISPLAY_NAME,
             amount = null,
             newLpm = null,
-            cbcEligibility = CardBrandChoiceEligibility.Ineligible
         )
 
         assertThat(actualArgs.showCheckbox).isFalse()
@@ -161,7 +158,6 @@ class FormArgumentsFactoryTest {
                 brand = CardBrand.Visa,
                 customerRequestedSave = customerReuse
             ),
-            cbcEligibility = CardBrandChoiceEligibility.Ineligible
         )
 
         assertThat(actualArgs.initialPaymentMethodCreateParams).isEqualTo(paymentMethodCreateParams)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I'm attempting to move the transformation of specs to fields into PaymentMethodDefinitions, where we only have access to PaymentMethodMetadata.
