### PR TITLE
Use PaymentSheet's billing address collection configuration in PaymentMethodMetadata.

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/BillingDetailsCollectionConfiguration.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/BillingDetailsCollectionConfiguration.kt
@@ -12,10 +12,6 @@ data class BillingDetailsCollectionConfiguration(
     val collectPhone: Boolean = false,
     val address: AddressCollectionMode = AddressCollectionMode.Automatic,
 ) : Parcelable {
-
-    val collectAddress: Boolean
-        get() = address != AddressCollectionMode.Never
-
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     enum class AddressCollectionMode {
         Automatic,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -15,7 +15,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.validate
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
-import com.stripe.android.paymentsheet.state.toInternal
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
@@ -93,7 +92,7 @@ internal class DefaultCustomerSheetLoader(
             )
         )
         return elementsSessionRepository.get(initializationMode).map { elementsSession ->
-            val billingDetailsCollectionConfig = configuration.billingDetailsCollectionConfiguration.toInternal()
+            val billingDetailsCollectionConfig = configuration.billingDetailsCollectionConfiguration
             val sharedDataSpecs = lpmRepository.getSharedDataSpecs(
                 stripeIntent = elementsSession.stripeIntent,
                 serverLpmSpecs = elementsSession.paymentMethodSpecs,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -7,8 +7,8 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.financialconnections.DefaultIsFinancialConnectionsAvailable
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.ui.core.elements.SharedDataSpec
 import kotlinx.parcelize.Parcelize
 
@@ -19,7 +19,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 internal data class PaymentMethodMetadata(
     val stripeIntent: StripeIntent,
-    val billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration,
+    val billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration,
     val allowsDelayedPaymentMethods: Boolean,
     val allowsPaymentMethodsRequiringShippingAddress: Boolean,
     val paymentMethodOrder: List<String>,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -7,8 +7,8 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.financialconnections.DefaultIsFinancialConnectionsAvailable
-import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.SharedDataSpec
 import kotlinx.parcelize.Parcelize
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -5,6 +5,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequireme
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.CardBillingSpec
@@ -31,21 +32,21 @@ internal object CardDefinition : PaymentMethodDefinition {
     }
 
     fun hardcodedCardSpec(
-        billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration
+        billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration
     ): SupportedPaymentMethod {
         val specs = listOfNotNull(
             ContactInformationSpec(
                 collectName = false,
-                collectEmail = billingDetailsCollectionConfiguration.collectEmail,
-                collectPhone = billingDetailsCollectionConfiguration.collectPhone,
+                collectEmail = billingDetailsCollectionConfiguration.collectsEmail,
+                collectPhone = billingDetailsCollectionConfiguration.collectsPhone,
             ),
             CardDetailsSectionSpec(
-                collectName = billingDetailsCollectionConfiguration.collectName,
+                collectName = billingDetailsCollectionConfiguration.collectsName,
             ),
             CardBillingSpec(
-                collectionMode = billingDetailsCollectionConfiguration.address,
+                collectionMode = billingDetailsCollectionConfiguration.address.toInternal(),
             ).takeIf {
-                billingDetailsCollectionConfiguration.collectAddress
+                billingDetailsCollectionConfiguration.collectsAddress
             },
             SaveForFutureUseSpec(),
         )
@@ -59,5 +60,25 @@ internal object CardDefinition : PaymentMethodDefinition {
             tintIconOnSelection = true,
             formSpec = LayoutSpec(specs),
         )
+    }
+}
+
+
+internal fun PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode?.toInternal(
+): BillingDetailsCollectionConfiguration.AddressCollectionMode {
+    return when (this) {
+        PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic -> {
+            BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
+        }
+
+        PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never -> {
+            BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
+        }
+
+        PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full -> {
+            BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
+        }
+
+        else -> BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -46,7 +46,8 @@ internal object CardDefinition : PaymentMethodDefinition {
             CardBillingSpec(
                 collectionMode = billingDetailsCollectionConfiguration.address.toInternal(),
             ).takeIf {
-                billingDetailsCollectionConfiguration.collectsAddress
+                billingDetailsCollectionConfiguration.address !=
+                    PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
             },
             SaveForFutureUseSpec(),
         )

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -63,9 +63,8 @@ internal object CardDefinition : PaymentMethodDefinition {
     }
 }
 
-
-internal fun PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode?.toInternal(
-): BillingDetailsCollectionConfiguration.AddressCollectionMode {
+internal fun PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode?
+.toInternal(): BillingDetailsCollectionConfiguration.AddressCollectionMode {
     return when (this) {
         PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic -> {
             BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -1229,9 +1229,6 @@ class PaymentSheet internal constructor(
         internal val collectsPhone: Boolean
             get() = phone == CollectionMode.Always
 
-        internal val collectsAddress: Boolean
-            get() = address == AddressCollectionMode.Full
-
         internal val collectsAnything: Boolean
             get() = name == CollectionMode.Always ||
                 phone == CollectionMode.Always ||

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -1220,8 +1220,17 @@ class PaymentSheet internal constructor(
         val attachDefaultsToPaymentMethod: Boolean = false,
     ) : Parcelable {
 
+        internal val collectsName: Boolean
+            get() = name == CollectionMode.Always
+
         internal val collectsEmail: Boolean
             get() = email == CollectionMode.Always
+
+        internal val collectsPhone: Boolean
+            get() = phone == CollectionMode.Always
+
+        internal val collectsAddress: Boolean
+            get() = address == AddressCollectionMode.Full
 
         internal val collectsAnything: Boolean
             get() = name == CollectionMode.Always ||

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
@@ -72,7 +72,7 @@ internal object FormArgumentsFactory {
             shippingDetails = config.shippingDetails,
             initialPaymentMethodCreateParams = initialParams,
             initialPaymentMethodExtraParams = initialExtraParams,
-            billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
+            billingDetailsCollectionConfiguration = metadata.billingDetailsCollectionConfiguration,
             cbcEligibility = metadata.cbcEligibility,
             requiresMandate = paymentMethod.requiresMandate,
             requiredFields = paymentMethod.placeholderOverrideList,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -26,7 +26,6 @@ import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.paymentsheet.model.validate
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
@@ -77,7 +76,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
 
         elementsSessionResult.mapCatching { elementsSession ->
             val billingDetailsCollectionConfig =
-                paymentSheetConfiguration.billingDetailsCollectionConfiguration.toInternal()
+                paymentSheetConfiguration.billingDetailsCollectionConfiguration
 
             val cbcEligibility = CardBrandChoiceEligibility.create(
                 isEligible = elementsSession.isEligibleForCardBrandChoice,
@@ -437,24 +436,4 @@ private fun List<PaymentMethod>.withLastUsedPaymentMethodFirst(
 
 private fun PaymentMethod.toPaymentSelection(): PaymentSelection.Saved {
     return PaymentSelection.Saved(this)
-}
-
-internal fun PaymentSheet.BillingDetailsCollectionConfiguration?.toInternal(): BillingDetailsCollectionConfiguration {
-    return BillingDetailsCollectionConfiguration(
-        collectName = this?.name == PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
-        collectEmail = this?.email == PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
-        collectPhone = this?.phone == PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
-        address = when (this?.address) {
-            PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic -> {
-                BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
-            }
-            PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never -> {
-                BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
-            }
-            PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full -> {
-                BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
-            }
-            else -> BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
-        },
-    )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/LpmRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/LpmRepositoryTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethod.Type.Card
 import com.stripe.android.model.PaymentMethod.Type.CashAppPay
 import com.stripe.android.model.PaymentMethod.Type.USBankAccount
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.R
@@ -438,11 +439,11 @@ class LpmRepositoryTest {
             }
          ]
             """.trimIndent(),
-            BillingDetailsCollectionConfiguration(
-                collectName = true,
-                collectEmail = true,
-                collectPhone = false,
-                address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+            PaymentSheet.BillingDetailsCollectionConfiguration(
+                name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+                address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/LpmRepositoryTestHelpers.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/LpmRepositoryTestHelpers.kt
@@ -3,12 +3,14 @@ package com.stripe.android.lpmfoundations.luxe
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.CardDefinition
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.LayoutSpec
 
 object LpmRepositoryTestHelpers {
-    val card: SupportedPaymentMethod = CardDefinition.hardcodedCardSpec(BillingDetailsCollectionConfiguration())
+    val card: SupportedPaymentMethod = CardDefinition.hardcodedCardSpec(
+        PaymentSheet.BillingDetailsCollectionConfiguration()
+    )
 
     val usBankAccount: SupportedPaymentMethod = SupportedPaymentMethod(
         code = "us_bank_account",
@@ -30,8 +32,8 @@ internal fun LpmRepository.updateFromDisk(stripeIntent: StripeIntent) {
 internal fun LpmRepository.update(
     stripeIntent: StripeIntent,
     serverLpmSpecs: String? = null,
-    billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
-        BillingDetailsCollectionConfiguration(),
+    billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration =
+        PaymentSheet.BillingDetailsCollectionConfiguration(),
     financialConnectionsAvailable: Boolean = true
 ) {
     val metadata = PaymentMethodMetadataFactory.create(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.LpmSerializer
 import com.stripe.android.ui.core.elements.SharedDataSpec
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -4,16 +4,16 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.ui.core.elements.LpmSerializer
 import com.stripe.android.ui.core.elements.SharedDataSpec
 
 internal object PaymentMethodMetadataFactory {
     fun create(
         stripeIntent: StripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-        billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
-            BillingDetailsCollectionConfiguration(),
+        billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration =
+            PaymentSheet.BillingDetailsCollectionConfiguration(),
         allowsDelayedPaymentMethods: Boolean = true,
         allowsPaymentMethodsRequiringShippingAddress: Boolean = false,
         financialConnectionsAvailable: Boolean = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
@@ -149,7 +149,9 @@ class FormArgumentsFactoryTest {
 
         val actualArgs = FormArgumentsFactory.create(
             paymentMethod = LpmRepositoryTestHelpers.card,
-            metadata = PaymentMethodMetadataFactory.create(),
+            metadata = PaymentMethodMetadataFactory.create(
+                billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
+            ),
             config = config,
             merchantName = PaymentSheetFixtures.MERCHANT_DISPLAY_NAME,
             amount = Amount(50, "USD"),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -16,7 +16,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.COMPOSE_FRAGMENT_ARGS
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.AddressSpec
 import com.stripe.android.ui.core.elements.CardDetailsSectionElement
@@ -729,13 +728,6 @@ internal class FormViewModelTest {
                 attachDefaultsToPaymentMethod = false,
             )
 
-            val internalBillingDetailsCollectionConfig = BillingDetailsCollectionConfiguration(
-                collectName = true,
-                collectEmail = true,
-                collectPhone = true,
-                address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
-            )
-
             val args = COMPOSE_FRAGMENT_ARGS.copy(
                 PaymentMethod.Type.Card.code,
                 billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
@@ -746,7 +738,7 @@ internal class FormViewModelTest {
                 args,
                 createLpmRepositorySupportedPaymentMethod(
                     PaymentMethod.Type.Card,
-                    CardDefinition.hardcodedCardSpec(internalBillingDetailsCollectionConfig).formSpec,
+                    CardDefinition.hardcodedCardSpec(billingDetailsCollectionConfiguration).formSpec,
                 ),
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
@@ -10,7 +10,6 @@ import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException
 import com.stripe.android.paymentsheet.state.PaymentSheetState
-import com.stripe.android.paymentsheet.state.toInternal
 import kotlinx.coroutines.delay
 import kotlin.time.Duration
 
@@ -53,7 +52,7 @@ internal class FakePaymentSheetLoader(
                     paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                         stripeIntent = stripeIntent,
                         billingDetailsCollectionConfiguration = paymentSheetConfiguration
-                            .billingDetailsCollectionConfiguration.toInternal(),
+                            .billingDetailsCollectionConfiguration,
                         allowsDelayedPaymentMethods = paymentSheetConfiguration.allowsDelayedPaymentMethods,
                         allowsPaymentMethodsRequiringShippingAddress = paymentSheetConfiguration
                             .allowsPaymentMethodsRequiringShippingAddress,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We use this when transforming specs to fields, and was only being used for cards before, so unifying.