### PR TITLE
Simplify FormViewModel by removing an unnecessary flow.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PlaceholderHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PlaceholderHelper.kt
@@ -20,11 +20,7 @@ import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.PhoneNumberElement
 import com.stripe.android.uicore.elements.SectionElement
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.flatMapConcat
-import kotlinx.coroutines.flow.map
 
 internal object PlaceholderHelper {
     /**
@@ -173,47 +169,36 @@ internal object PlaceholderHelper {
         else -> null
     }
 
-    internal suspend fun connectBillingDetailsFields(elementsFlow: Flow<List<FormElement>>) {
-        var phoneNumberElement: PhoneNumberElement? = null
+    internal suspend fun connectBillingDetailsFields(elements: List<FormElement>) {
+        val phoneNumberElement: PhoneNumberElement? = elements
+            .filterIsInstance<SectionElement>()
+            .flatMap { it.fields }
+            .filterIsInstance<PhoneNumberElement>()
+            .firstOrNull()
 
-        elementsFlow.map { elementsList ->
-            elementsList
+        // Look for a standalone CountryElement.
+        // Note that this should be done first, because AddressElement always has a
+        // CountryElement, but it might be hidden.
+        var countryElement = elements
+            .filterIsInstance<SectionElement>()
+            .flatMap { it.fields }
+            .filterIsInstance<CountryElement>()
+            .firstOrNull()
+
+        // If not found, look for one inside an AddressElement.
+        if (countryElement == null) {
+            countryElement = elements
                 .filterIsInstance<SectionElement>()
                 .flatMap { it.fields }
-                .filterIsInstance<PhoneNumberElement>()
+                .filterIsInstance<AddressElement>()
                 .firstOrNull()
-        }.collect {
-            phoneNumberElement = it
+                ?.countryElement
         }
 
-        elementsFlow
-            .flatMapConcat { elementsList ->
-                // Look for a standalone CountryElement.
-                // Note that this should be done first, because AddressElement always has a
-                // CountryElement, but it might be hidden.
-                var countryElement = elementsList
-                    .filterIsInstance<SectionElement>()
-                    .flatMap { it.fields }
-                    .filterIsInstance<CountryElement>()
-                    .firstOrNull()
-
-                // If not found, look for one inside an AddressElement.
-                if (countryElement == null) {
-                    countryElement = elementsList
-                        .filterIsInstance<SectionElement>()
-                        .flatMap { it.fields }
-                        .filterIsInstance<AddressElement>()
-                        .firstOrNull()
-                        ?.countryElement
-                }
-
-                countryElement?.controller?.rawFieldValue ?: emptyFlow()
+        countryElement?.controller?.rawFieldValue?.filterNotNull()?.collect {
+            if (phoneNumberElement?.controller?.getLocalNumber().isNullOrBlank()) {
+                phoneNumberElement?.controller?.countryDropdownController?.onRawValueChange(it)
             }
-            .filterNotNull()
-            .collect {
-                if (phoneNumberElement?.controller?.getLocalNumber().isNullOrBlank()) {
-                    phoneNumberElement?.controller?.countryDropdownController?.onRawValueChange(it)
-                }
-            }
+        }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
@@ -36,8 +36,8 @@ internal fun PaymentMethodForm(
         )
     )
 
+    val elements = formViewModel.elements
     val hiddenIdentifiers by formViewModel.hiddenIdentifiers.collectAsState(emptySet())
-    val elements by formViewModel.elementsFlow.collectAsState(emptyList())
     val lastTextFieldIdentifier by formViewModel.lastTextFieldIdentifier.collectAsState(null)
 
     PaymentMethodForm(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -45,7 +45,6 @@ import com.stripe.android.uicore.elements.TextFieldController
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -65,9 +64,8 @@ internal class FormViewModelTest {
         ApplicationProvider.getApplicationContext(),
         StripeR.style.StripeDefaultTheme
     )
-    val lpmRepository = LpmRepository(LpmRepository.LpmRepositoryArguments(context.resources))
 
-    val showCheckboxFlow = MutableStateFlow(false)
+    private val showCheckboxFlow = MutableStateFlow(false)
 
     private fun createLpmRepositorySupportedPaymentMethod(
         paymentMethodType: PaymentMethod.Type,
@@ -662,7 +660,7 @@ internal class FormViewModelTest {
                 LayoutSpec(specs),
             )
         )
-        val formElement = formViewModel.elementsFlow.first()
+        val formElement = formViewModel.elements
 
         val nameSection = formElement[0] as SectionElement
         val nameElement = nameSection.fields[0] as SimpleTextElement
@@ -711,7 +709,7 @@ internal class FormViewModelTest {
                 ),
             )
         )
-        val formElement = formViewModel.elementsFlow.first()
+        val formElement = formViewModel.elements
 
         val addressSection = formElement.first() as SectionElement
         val addressElement = addressSection.fields[0] as AddressElement
@@ -752,7 +750,7 @@ internal class FormViewModelTest {
                 ),
             )
 
-            val elements = formViewModel.elementsFlow.first()
+            val elements = formViewModel.elements
             val countryElement = elements
                 .filterIsInstance<SectionElement>()
                 .flatMap { it.fields }
@@ -809,7 +807,7 @@ internal class FormViewModelTest {
                 ),
             )
 
-            val elements = formViewModel.elementsFlow.first()
+            val elements = formViewModel.elements
             val countryElement = elements
                 .filterIsInstance<SectionElement>()
                 .flatMap { it.fields }
@@ -869,7 +867,7 @@ internal class FormViewModelTest {
         formViewModel: FormViewModel,
         @StringRes label: Int
     ) =
-        formViewModel.elementsFlow.first()
+        formViewModel.elements
             .filterIsInstance<SectionElement>()
             .flatMap { it.fields }
             .filterIsInstance<SectionSingleFieldElement>()
@@ -914,7 +912,7 @@ internal class FormViewModelTest {
             formViewModel: FormViewModel,
             @StringRes label: Int
         ): TextFieldController? {
-            val addressElementFields = formViewModel.elementsFlow.first()
+            val addressElementFields = formViewModel.elements
                 .filterIsInstance<SectionElement>()
                 .flatMap { it.fields }
                 .filterIsInstance<AddressElement>()
@@ -935,7 +933,7 @@ internal class FormViewModelTest {
         }
     }
 
-    fun createViewModel(
+    private fun createViewModel(
         arguments: FormArguments,
         lpmRepository: LpmRepository
     ) = FormViewModel(
@@ -947,11 +945,10 @@ internal class FormViewModelTest {
     )
 }
 
-internal suspend fun FormViewModel.setSaveForFutureUse(value: Boolean) {
-    elementsFlow
-        .firstOrNull()
-        ?.filterIsInstance<SaveForFutureUseElement>()
-        ?.firstOrNull()?.controller?.onValueChange(value)
+private fun FormViewModel.setSaveForFutureUse(value: Boolean) {
+    elements
+        .filterIsInstance<SaveForFutureUseElement>()
+        .firstOrNull()?.controller?.onValueChange(value)
 }
 
 private fun createAddressRepository(): AddressRepository {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I'd like to be able to pass the `elements` in here in the future. And we don't have any use for the flow today, so removing it.
