### PR TITLE
Attempt to stabilize flaky tests.

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet
 
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.espresso.Espresso.closeSoftKeyboard
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
@@ -31,11 +31,10 @@ internal class LinkTest {
     @get:Rule
     val composeTestRule = createAndroidComposeRule<MainActivity>()
 
-    @get:Rule
-    val networkRule = NetworkRule()
+    private val activityScenarioRule = composeTestRule.activityRule
 
     @get:Rule
-    val activityScenarioRule = ActivityScenarioRule(MainActivity::class.java)
+    val networkRule = NetworkRule()
 
     private val page: PaymentSheetPage = PaymentSheetPage(composeTestRule)
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet
 
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
@@ -29,15 +28,14 @@ internal class PaymentSheetAnalyticsTest {
     @get:Rule
     val composeTestRule = createAndroidComposeRule<MainActivity>()
 
+    private val activityScenarioRule = composeTestRule.activityRule
+
     private val page: PaymentSheetPage = PaymentSheetPage(composeTestRule)
 
     @get:Rule
     val networkRule = NetworkRule(
         hostsToTrack = listOf(ApiRequest.API_HOST, AnalyticsRequest.HOST),
     )
-
-    @get:Rule
-    val activityScenarioRule = ActivityScenarioRule(MainActivity::class.java)
 
     @TestParameter(valuesProvider = IntegrationTypeProvider::class)
     lateinit var integrationType: IntegrationType

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet
 
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.stripe.android.networktesting.NetworkRule
@@ -27,11 +26,10 @@ internal class PaymentSheetTest {
     @get:Rule
     val composeTestRule = createAndroidComposeRule<MainActivity>()
 
-    @get:Rule
-    val networkRule = NetworkRule()
+    private val activityScenarioRule = composeTestRule.activityRule
 
     @get:Rule
-    val activityScenarioRule = ActivityScenarioRule(MainActivity::class.java)
+    val networkRule = NetworkRule()
 
     private val page: PaymentSheetPage = PaymentSheetPage(composeTestRule)
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ActivityLaunchObserver.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ActivityLaunchObserver.kt
@@ -50,7 +50,7 @@ internal class ActivityLaunchObserver(
     fun awaitLaunch() {
         try {
             if (!launchedCountDownLatch.await(5, TimeUnit.SECONDS)) {
-                println("Failed to launch.")
+                throw IllegalStateException("Failed to launch.")
             }
         } finally {
             unregisterer()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ActivityLaunchObserver.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ActivityLaunchObserver.kt
@@ -39,7 +39,6 @@ internal class ActivityLaunchObserver(
 
             override fun onActivityDestroyed(activity: Activity) {
             }
-
         }
         val application = host.applicationContext as Application
         application.registerActivityLifecycleCallbacks(activityLifecycleCallbacks)

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ActivityLaunchObserver.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ActivityLaunchObserver.kt
@@ -1,0 +1,61 @@
+package com.stripe.android.paymentsheet.utils
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+internal class ActivityLaunchObserver(
+    private val expectedActivityType: Class<out Activity>
+) {
+    @Volatile
+    private var unregisterer: (() -> Unit) = { }
+
+    private val launchedCountDownLatch = CountDownLatch(1)
+
+    fun prepareForLaunch(host: Activity) {
+        val activityLifecycleCallbacks = object : Application.ActivityLifecycleCallbacks {
+            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+            }
+
+            override fun onActivityStarted(activity: Activity) {
+            }
+
+            override fun onActivityResumed(activity: Activity) {
+                if (expectedActivityType.isInstance(activity)) {
+                    launchedCountDownLatch.countDown()
+                }
+            }
+
+            override fun onActivityPaused(activity: Activity) {
+            }
+
+            override fun onActivityStopped(activity: Activity) {
+            }
+
+            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
+            }
+
+            override fun onActivityDestroyed(activity: Activity) {
+            }
+
+        }
+        val application = host.applicationContext as Application
+        application.registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
+        unregisterer = {
+            application.unregisterActivityLifecycleCallbacks(activityLifecycleCallbacks)
+        }
+    }
+
+    fun awaitLaunch() {
+        try {
+            if (!launchedCountDownLatch.await(5, TimeUnit.SECONDS)) {
+                println("Failed to launch.")
+            }
+        } finally {
+            unregisterer()
+            unregisterer = { }
+        }
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestRunner.kt
@@ -12,6 +12,7 @@ import com.stripe.android.link.account.LinkStore
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.MainActivity
 import com.stripe.android.paymentsheet.PaymentOptionCallback
+import com.stripe.android.paymentsheet.PaymentOptionsActivity
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
 import java.util.concurrent.CountDownLatch
@@ -25,9 +26,12 @@ internal class FlowControllerTestRunnerContext(
     fun configureFlowController(
         block: PaymentSheet.FlowController.() -> Unit,
     ) {
+        val activityLaunchObserver = ActivityLaunchObserver(PaymentOptionsActivity::class.java)
         scenario.onActivity {
+            activityLaunchObserver.prepareForLaunch(it)
             flowController.block()
         }
+        activityLaunchObserver.awaitLaunch()
     }
 }
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetTestRunner.kt
@@ -1,15 +1,20 @@
 package com.stripe.android.paymentsheet.utils
 
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.runner.lifecycle.ActivityLifecycleCallback
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.link.account.LinkStore
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.MainActivity
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheetActivity
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -23,8 +28,49 @@ internal class PaymentSheetTestRunnerContext(
     fun presentPaymentSheet(
         block: PaymentSheet.() -> Unit,
     ) {
+        var unregisterer: (() -> Unit) = { }
+        val paymentSheetLaunchedCountDownLatch = CountDownLatch(1)
+
         scenario.onActivity {
+            val activityLifecycleCallbacks = object : Application.ActivityLifecycleCallbacks {
+                override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+                }
+
+                override fun onActivityStarted(activity: Activity) {
+                }
+
+                override fun onActivityResumed(activity: Activity) {
+                    if (activity is PaymentSheetActivity) {
+                        paymentSheetLaunchedCountDownLatch.countDown()
+                    }
+                }
+
+                override fun onActivityPaused(activity: Activity) {
+                }
+
+                override fun onActivityStopped(activity: Activity) {
+                }
+
+                override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
+                }
+
+                override fun onActivityDestroyed(activity: Activity) {
+                }
+
+            }
+            val application = it.applicationContext as Application
+            application.registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
+            unregisterer = {
+                application.unregisterActivityLifecycleCallbacks(activityLifecycleCallbacks)
+            }
             paymentSheet.block()
+        }
+        try {
+            if (!paymentSheetLaunchedCountDownLatch.await(5, TimeUnit.SECONDS)) {
+                println("PaymentSheet failed to launch.")
+            }
+        } finally {
+            unregisterer()
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This moves to a single activityRule, and ensures the target activity (PaymentSheetActivity/PaymentOptionsActivity) is launched before attempting any compose actions/assertions.