### PR TITLE
Move merchant name to PaymentMethodMetadata.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -110,6 +110,7 @@ internal class DefaultCustomerSheetLoader(
                 allowsPaymentMethodsRequiringShippingAddress = false,
                 paymentMethodOrder = configuration.paymentMethodOrder,
                 cbcEligibility = cbcEligibility,
+                merchantName = configuration.merchantDisplayName,
                 sharedDataSpecs = sharedDataSpecs,
                 financialConnectionsAvailable = isFinancialConnectionsAvailable()
             )

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -24,6 +24,7 @@ internal data class PaymentMethodMetadata(
     val allowsPaymentMethodsRequiringShippingAddress: Boolean,
     val paymentMethodOrder: List<String>,
     val cbcEligibility: CardBrandChoiceEligibility,
+    val merchantName: String,
     val sharedDataSpecs: List<SharedDataSpec>,
     val financialConnectionsAvailable: Boolean = DefaultIsFinancialConnectionsAvailable(),
 ) : Parcelable {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
@@ -19,7 +19,6 @@ internal object FormArgumentsFactory {
         paymentMethod: SupportedPaymentMethod,
         metadata: PaymentMethodMetadata,
         config: PaymentSheet.Configuration,
-        merchantName: String,
         amount: Amount? = null,
         newLpm: PaymentSelection.New?,
     ): FormArguments {
@@ -66,7 +65,7 @@ internal object FormArgumentsFactory {
             paymentMethodCode = paymentMethod.code,
             showCheckbox = setupFutureUsageFieldConfiguration?.isSaveForFutureUseValueChangeable == true,
             saveForFutureUseInitialValue = saveForFutureUseInitialValue,
-            merchantName = merchantName,
+            merchantName = metadata.merchantName,
             amount = amount,
             billingDetails = config.defaultBillingDetails,
             shippingDetails = config.shippingDetails,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -95,6 +95,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
                     .allowsPaymentMethodsRequiringShippingAddress,
                 paymentMethodOrder = paymentSheetConfiguration.paymentMethodOrder,
                 cbcEligibility = cbcEligibility,
+                merchantName = paymentSheetConfiguration.merchantDisplayName,
                 sharedDataSpecs = sharedDataSpecsResult.sharedDataSpecs,
             )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -678,7 +678,6 @@ internal abstract class BaseSheetViewModel(
         paymentMethod = selectedItem,
         metadata = requireNotNull(paymentMethodMetadata.value),
         config = config,
-        merchantName = merchantName,
         amount = amount.value,
         newLpm = newPaymentSelection,
     )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.LpmSerializer
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -29,6 +30,7 @@ internal object PaymentMethodMetadataFactory {
             financialConnectionsAvailable = financialConnectionsAvailable,
             paymentMethodOrder = paymentMethodOrder,
             cbcEligibility = cbcEligibility,
+            merchantName = PaymentSheetFixtures.MERCHANT_DISPLAY_NAME,
             sharedDataSpecs = sharedDataSpecs,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
@@ -47,7 +47,6 @@ class FormArgumentsFactoryTest {
             paymentMethod = metadata.supportedPaymentMethodForCode("bancontact")!!,
             metadata = metadata,
             config = PaymentSheetFixtures.CONFIG_MINIMUM,
-            merchantName = PaymentSheetFixtures.MERCHANT_DISPLAY_NAME,
             amount = Amount(50, "USD"),
             newLpm = PaymentSelection.New.GenericPaymentMethod(
                 labelResource = resources.getString(StripeUiCoreR.string.stripe_paymentsheet_payment_method_bancontact),
@@ -79,7 +78,6 @@ class FormArgumentsFactoryTest {
             paymentMethod = supportedPaymentMethod,
             metadata = metadata,
             config = PaymentSheetFixtures.CONFIG_MINIMUM,
-            merchantName = PaymentSheetFixtures.MERCHANT_DISPLAY_NAME,
             amount = null,
             newLpm = null,
         )
@@ -153,7 +151,6 @@ class FormArgumentsFactoryTest {
                 billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
             ),
             config = config,
-            merchantName = PaymentSheetFixtures.MERCHANT_DISPLAY_NAME,
             amount = Amount(50, "USD"),
             newLpm = PaymentSelection.New.Card(
                 paymentMethodCreateParams = paymentMethodCreateParams,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I'm gradually moving everything over so I can eventually run `TransformSpecToElements` with just a `PaymentMethodMetadata`.
