### PR TITLE
Move defaultBillingDetails and shippingDetails to PaymentMethodMetadata.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -111,6 +111,8 @@ internal class DefaultCustomerSheetLoader(
                 paymentMethodOrder = configuration.paymentMethodOrder,
                 cbcEligibility = cbcEligibility,
                 merchantName = configuration.merchantDisplayName,
+                defaultBillingDetails = configuration.defaultBillingDetails,
+                shippingDetails = null,
                 sharedDataSpecs = sharedDataSpecs,
                 financialConnectionsAvailable = isFinancialConnectionsAvailable()
             )

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -8,6 +8,7 @@ import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.financialconnections.DefaultIsFinancialConnectionsAvailable
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -26,6 +27,8 @@ internal data class PaymentMethodMetadata(
     val paymentMethodOrder: List<String>,
     val cbcEligibility: CardBrandChoiceEligibility,
     val merchantName: String,
+    val defaultBillingDetails: PaymentSheet.BillingDetails?,
+    val shippingDetails: AddressDetails?,
     val sharedDataSpecs: List<SharedDataSpec>,
     val financialConnectionsAvailable: Boolean = DefaultIsFinancialConnectionsAvailable(),
 ) : Parcelable {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
@@ -17,13 +17,13 @@ internal object FormArgumentsFactory {
     fun create(
         paymentMethod: SupportedPaymentMethod,
         metadata: PaymentMethodMetadata,
-        config: PaymentSheet.Configuration,
+        customerConfig: PaymentSheet.CustomerConfiguration?,
         newLpm: PaymentSelection.New?,
     ): FormArguments {
         val setupFutureUsageFieldConfiguration =
             paymentMethod.paymentMethodDefinition().getSetupFutureUsageFieldConfiguration(
                 metadata = metadata,
-                customerConfiguration = config.customer,
+                customerConfiguration = customerConfig,
             )
 
         val initialParams = when (newLpm) {
@@ -65,8 +65,8 @@ internal object FormArgumentsFactory {
             saveForFutureUseInitialValue = saveForFutureUseInitialValue,
             merchantName = metadata.merchantName,
             amount = metadata.amount(),
-            billingDetails = config.defaultBillingDetails,
-            shippingDetails = config.shippingDetails,
+            billingDetails = metadata.defaultBillingDetails,
+            shippingDetails = metadata.shippingDetails,
             initialPaymentMethodCreateParams = initialParams,
             initialPaymentMethodExtraParams = initialExtraParams,
             billingDetailsCollectionConfiguration = metadata.billingDetailsCollectionConfiguration,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -96,6 +96,8 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
                 paymentMethodOrder = paymentSheetConfiguration.paymentMethodOrder,
                 cbcEligibility = cbcEligibility,
                 merchantName = paymentSheetConfiguration.merchantDisplayName,
+                defaultBillingDetails = paymentSheetConfiguration.defaultBillingDetails,
+                shippingDetails = paymentSheetConfiguration.shippingDetails,
                 sharedDataSpecs = sharedDataSpecsResult.sharedDataSpecs,
             )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -666,7 +666,7 @@ internal abstract class BaseSheetViewModel(
         return FormArgumentsFactory.create(
             paymentMethod = selectedItem,
             metadata = metadata,
-            config = config,
+            customerConfig = config.customer,
             newLpm = newPaymentSelection,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -31,6 +31,8 @@ internal object PaymentMethodMetadataFactory {
             paymentMethodOrder = paymentMethodOrder,
             cbcEligibility = cbcEligibility,
             merchantName = PaymentSheetFixtures.MERCHANT_DISPLAY_NAME,
+            defaultBillingDetails = PaymentSheet.BillingDetails(),
+            shippingDetails = null,
             sharedDataSpecs = sharedDataSpecs,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
@@ -45,7 +45,7 @@ class FormArgumentsFactoryTest {
         val actualArgs = FormArgumentsFactory.create(
             paymentMethod = metadata.supportedPaymentMethodForCode("bancontact")!!,
             metadata = metadata,
-            config = PaymentSheetFixtures.CONFIG_MINIMUM,
+            customerConfig = null,
             newLpm = PaymentSelection.New.GenericPaymentMethod(
                 labelResource = resources.getString(StripeUiCoreR.string.stripe_paymentsheet_payment_method_bancontact),
                 iconResource = StripeUiCoreR.drawable.stripe_ic_paymentsheet_pm_bancontact,
@@ -75,7 +75,7 @@ class FormArgumentsFactoryTest {
         val actualArgs = FormArgumentsFactory.create(
             paymentMethod = supportedPaymentMethod,
             metadata = metadata,
-            config = PaymentSheetFixtures.CONFIG_MINIMUM,
+            customerConfig = null,
             newLpm = null,
         )
 
@@ -147,7 +147,7 @@ class FormArgumentsFactoryTest {
             metadata = PaymentMethodMetadataFactory.create(
                 billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
             ),
-            config = config,
+            customerConfig = config.customer,
             newLpm = PaymentSelection.New.Card(
                 paymentMethodCreateParams = paymentMethodCreateParams,
                 brand = CardBrand.Visa,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I'm gradually moving everything over so I can eventually run `TransformSpecToElements` with just a `PaymentMethodMetadata`.
