### PR TITLE
Remove single `NoArgumentsDestination` subclass in `Destination`

### DIFF
--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/utils/TestNavigationManager.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/utils/TestNavigationManager.kt
@@ -43,11 +43,10 @@ internal class TestNavigationManager : NavigationManager {
         destination: Destination,
         pane: Pane,
         popUpTo: PopUpToBehavior? = null,
-        args: Map<String, String?> = emptyMap()
     ) {
         val last: NavigationIntent = emittedIntents.last()
         assertIs<NavigationIntent.NavigateTo>(last)
-        assertThat(last.route).isEqualTo(destination(pane, args))
+        assertThat(last.route).isEqualTo(destination(pane))
         assertThat(last.popUpTo).isEqualTo(popUpTo)
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull requests removes the `NoArgumentsDestination` subclass of `Destination`, which became unnecessary with https://github.com/stripe/stripe-android/pull/8070.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
