### PR TITLE
Support setting up Amazon Pay

### DIFF
--- a/payments-ui-core/res/values/strings.xml
+++ b/payments-ui-core/res/values/strings.xml
@@ -79,6 +79,8 @@
   <string name="stripe_paypal_mandate">By confirming your payment with PayPal, you allow %s to charge your PayPal account for future payments in accordance with their terms.</string>
   <!-- Revolut mandate text -->
   <string name="stripe_revolut_mandate">By confirming your payment with RevolutPay, you allow %s to charge your RevolutPay account for future payments in accordance with their terms.</string>
+  <!-- Amazon Pay mandate text -->
+  <string name="stripe_amazon_pay_mandate">By confirming your payment with Amazon Pay, you allow %s to charge your Amazon Pay account for future payments in accordance with their terms.</string>
   <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
   <string name="stripe_save_for_future_payments_with_merchant_name">Save for future %s payments</string>
   <!-- Button title to open camera to scan credit/debit card -->

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AmazonPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AmazonPayDefinition.kt
@@ -6,7 +6,9 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
+import com.stripe.android.ui.core.elements.FormItemSpec
 import com.stripe.android.ui.core.elements.LayoutSpec
+import com.stripe.android.ui.core.elements.MandateTextSpec
 import com.stripe.android.ui.core.elements.SharedDataSpec
 
 internal object AmazonPayDefinition : PaymentMethodDefinition {
@@ -16,23 +18,29 @@ internal object AmazonPayDefinition : PaymentMethodDefinition {
 
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
-    ): Set<AddPaymentMethodRequirement> = setOf(
-        AddPaymentMethodRequirement.UnsupportedForSetup,
-    )
+    ): Set<AddPaymentMethodRequirement> = setOf()
 
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec
     ): SupportedPaymentMethod {
+        val requiresMandate = metadata.hasIntentToSetup()
+
+        val localLayoutSpecs: List<FormItemSpec> = if (requiresMandate) {
+            listOf(MandateTextSpec(stringResId = R.string.stripe_amazon_pay_mandate))
+        } else {
+            emptyList()
+        }
+
         return SupportedPaymentMethod(
             code = "amazon_pay",
-            requiresMandate = false,
+            requiresMandate = requiresMandate,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_amazon_pay,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_amazon_pay,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
             darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
             tintIconOnSelection = false,
-            formSpec = LayoutSpec(sharedDataSpec.fields),
+            formSpec = LayoutSpec(sharedDataSpec.fields + localLayoutSpecs),
         )
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Allow Amazon Pay to be used with set up intents.

Also include a mandate text if Amazon Pay is being setup, per this [slack thread](https://stripe.slack.com/archives/C046NEQ9E01/p1709938214688729)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Amazon Pay GA

Amazon Pay doesn't yet support set up intents, but in an effort to have the SDK ready when they do, I'm sending out this change.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

Can't test yet because Amazon Pay doesn't support setup intents yet

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

N/A private beta for now (trying to be consistent with iOS here, see the [iOS PR](https://github.com/stripe/stripe-ios/pull/3390)
