### PR TITLE
Keyboard keeps showing up after browser


### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
@@ -515,6 +515,7 @@ private fun InstitutionResultTile(
     index: Int,
     onInstitutionSelected: (FinancialConnectionsInstitution) -> Unit
 ) {
+    val focusManager = LocalFocusManager.current
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
@@ -525,7 +526,10 @@ private fun InstitutionResultTile(
                 enabled = enabled && loading.not(),
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null,
-            ) { onInstitutionSelected(institution) }
+            ) {
+                focusManager.clearFocus()
+                onInstitutionSelected(institution)
+            }
             .alpha(if (enabled) 1f else DISABLED_DEPTH_ALPHA)
     ) {
         InstitutionIcon(institution.icon?.default)


### PR DESCRIPTION
# Summary
- Issue: When returning from the browser, the search field being focused triggers the keyboard open right before navigating to account picker.
- Solution: Remove focus when institution selected.

https://github.com/stripe/stripe-android/assets/99293320/21a917a0-817d-4a09-88e4-24b7a88ea45a

# Motivation
:notebook_with_decorative_cover: &nbsp;**Keyboard keeps showing up after browser**
:globe_with_meridians: &nbsp;[BANKCON-9801](https://jira.corp.stripe.com/browse/BANKCON-9801)

> If I choose an institution and the keyboard is open, it’ll pop up briefly before we navigate to the account picker screen
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->