### PR TITLE
Bottom sheet on Link signup screen doesn’t fully expand


### DIFF
--- a/financial-connections/detekt-baseline.xml
+++ b/financial-connections/detekt-baseline.xml
@@ -5,10 +5,8 @@
     <ID>ConstructorParameterNaming:FinancialConnectionsAuthorizationSession.kt$FinancialConnectionsAuthorizationSession$@SerialName(value = "is_oauth") private val _isOAuth: Boolean? = false</ID>
     <ID>ConstructorParameterNaming:PartnerAccountsList.kt$PartnerAccount$@SerialName(value = "allow_selection") private val _allowSelection: Boolean? = null</ID>
     <ID>LongMethod:AccountItem.kt$@Composable @Preview internal fun AccountItemPreview()</ID>
-    <ID>LongMethod:InstitutionPickerScreen.kt$@Composable private fun SearchRow( modifier: Modifier = Modifier, focusRequester: FocusRequester, query: TextFieldValue, onQueryChanged: (TextFieldValue) -> Unit, )</ID>
     <ID>LongMethod:InstitutionPickerScreen.kt$private fun LazyListScope.searchResults( isInputEmpty: Boolean, payload: Payload, selectedInstitutionId: String?, onInstitutionSelected: (FinancialConnectionsInstitution, Boolean) -> Unit, institutions: Async&lt;InstitutionResponse>, onManualEntryClick: () -> Unit, onSearchMoreClick: () -> Unit )</ID>
     <ID>LongMethod:LinkAccountPickerPreviewParameterProvider.kt$LinkAccountPickerPreviewParameterProvider$private fun partnerAccountList()</ID>
-    <ID>LongMethod:ManualEntryScreen.kt$@Composable private fun ManualEntryLoaded( scrollState: ScrollState, payload: Payload, linkPaymentAccountStatus: Async&lt;LinkAccountSessionPaymentAccount>, routing: Pair&lt;String?, Int?>, onRoutingEntered: (String) -> Unit, account: Pair&lt;String?, Int?>, onAccountEntered: (String) -> Unit, accountConfirm: Pair&lt;String?, Int?>, onAccountConfirmEntered: (String) -> Unit, isValidForm: Boolean, onSubmit: () -> Unit )</ID>
     <ID>MagicNumber:AccountPickerScreen.kt$3</ID>
     <ID>MagicNumber:ConsentLogoHeader.kt$3</ID>
     <ID>MagicNumber:ConsentLogoHeader.kt$4</ID>
@@ -22,9 +20,6 @@
     <ID>MagicNumber:Layout.kt$4</ID>
     <ID>MagicNumber:Layout.kt$50</ID>
     <ID>MagicNumber:LinkAccountPickerScreen.kt$3</ID>
-    <ID>MagicNumber:ManualEntryInputValidator.kt$ManualEntryInputValidator$10</ID>
-    <ID>MagicNumber:ManualEntryInputValidator.kt$ManualEntryInputValidator$3</ID>
-    <ID>MagicNumber:ManualEntryInputValidator.kt$ManualEntryInputValidator$7</ID>
     <ID>MagicNumber:ManualEntryViewModel.kt$ManualEntryViewModel$4</ID>
     <ID>MagicNumber:SharedPartnerAuth.kt$.50f</ID>
     <ID>MatchingDeclarationName:ServerDrivenUi.kt$BulletUI</ID>

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupScreen.kt
@@ -88,7 +88,8 @@ internal fun NetworkingLinkSignupScreen() {
     BackHandler(enabled = true) {}
     val uriHandler = LocalUriHandler.current
     val bottomSheetState: ModalBottomSheetState = rememberModalBottomSheetState(
-        initialValue = ModalBottomSheetValue.Hidden
+        initialValue = ModalBottomSheetValue.Hidden,
+        skipHalfExpanded = true
     )
 
     state.value.viewEffect?.let { viewEffect ->


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

# Motivation
:notebook_with_decorative_cover: &nbsp;**Bottom sheet on Link signup screen doesn’t fully expand**
:globe_with_meridians: &nbsp;[BANKCON-9802](https://jira.corp.stripe.com/browse/BANKCON-9802)
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->