### PR TITLE
[FC] Playground: Remove focus on email field when launching 

### DIFF
--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
@@ -161,6 +162,7 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
         onButtonClick: () -> Unit,
         modifier: Modifier = Modifier,
     ) {
+        val focusManager = LocalFocusManager.current
         LazyColumn(
             contentPadding = PaddingValues(16.dp),
             modifier = modifier,
@@ -203,7 +205,10 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
                     modifier = Modifier
                         .semantics { testTagsAsResourceId = true }
                         .testTag("connect_accounts"),
-                    onClick = onButtonClick,
+                    onClick = {
+                        focusManager.clearFocus()
+                        onButtonClick()
+                    },
                 ) {
                     Text("Connect Accounts")
                 }


### PR DESCRIPTION
# Summary
- Prevents keyboard from relaunching when returning from auth flow due to email field being focused. It breaks Maestro tests by hiding the result text.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
