### PR TITLE
Add `setup_future_usage` for saved `Link` payment methods from PM and passthrough mode.

### DIFF
--- a/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
@@ -117,6 +117,44 @@ class ConfirmPaymentIntentParamsFactoryTest {
         assertThat(result.shipping).isEqualTo(shippingDetails)
     }
 
+    @Test
+    fun `create() with saved card and does not require save on confirmation`() {
+        val factoryWithConfig = ConfirmPaymentIntentParamsFactory(
+            clientSecret = CLIENT_SECRET,
+            shipping = null,
+        )
+
+        val result = factoryWithConfig.create(
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            requiresSaveOnConfirmation = false
+        )
+
+        assertThat(result.paymentMethodOptions).isEqualTo(
+            PaymentMethodOptionsParams.Card(
+                setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.Blank
+            )
+        )
+    }
+
+    @Test
+    fun `create() with saved card and requires save on confirmation`() {
+        val factoryWithConfig = ConfirmPaymentIntentParamsFactory(
+            clientSecret = CLIENT_SECRET,
+            shipping = null,
+        )
+
+        val result = factoryWithConfig.create(
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            requiresSaveOnConfirmation = true
+        )
+
+        assertThat(result.paymentMethodOptions).isEqualTo(
+            PaymentMethodOptionsParams.Card(
+                setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+            )
+        )
+    }
+
     private companion object {
         private const val CLIENT_SECRET = "client_secret"
     }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
@@ -20,7 +20,6 @@ import com.stripe.android.paymentsheet.utils.LinkIntegrationType
 import com.stripe.android.paymentsheet.utils.LinkIntegrationTypeProvider
 import com.stripe.android.paymentsheet.utils.assertCompleted
 import com.stripe.android.paymentsheet.utils.runLinkTest
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -423,7 +422,6 @@ internal class LinkTest {
     }
 
     @Test
-    @Ignore("test")
     fun testSuccessfulCardPaymentWithLinkSignUpAndLinkPassthroughModeAndSaveForFutureUsage() =
         activityScenarioRule.runLinkTest(
             integrationType = integrationType,

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
@@ -41,6 +41,14 @@ internal class PaymentSheetPage(
         clickViewWithText("Save your info for secure 1-click checkout with Link")
     }
 
+    fun clickOnSaveForFutureUsage(merchantName: String) {
+        Espresso.onIdle()
+        composeTestRule.waitForIdle()
+
+        waitForText("Save for future $merchantName payments", true)
+        clickViewWithText("Save for future $merchantName payments")
+    }
+
     fun clickOnLinkCheckbox() {
         Espresso.onIdle()
         composeTestRule.waitForIdle()
@@ -72,8 +80,8 @@ internal class PaymentSheetPage(
         Espresso.onIdle()
         composeTestRule.waitForIdle()
 
-        waitForText("Phone number")
-        replaceText("Phone number", phoneNumber)
+        waitForText("Phone number", true)
+        replaceText("Phone number", phoneNumber, true)
     }
 
     fun fillOutLinkName() {
@@ -147,8 +155,8 @@ internal class PaymentSheetPage(
             .performClick()
     }
 
-    fun replaceText(label: String, text: String) {
-        composeTestRule.onNode(hasText(label))
+    fun replaceText(label: String, text: String, isLabelSubstring: Boolean = false) {
+        composeTestRule.onNode(hasText(label, substring = isLabelSubstring))
             .performScrollTo()
             .performTextReplacement(text)
     }

--- a/paymentsheet/src/androidTest/resources/customer-get-success.json
+++ b/paymentsheet/src/androidTest/resources/customer-get-success.json
@@ -1,0 +1,58 @@
+{
+  "id": "cus_1",
+  "object": "customer",
+  "created": 1607372586,
+  "default_source": "src_1",
+  "description": null,
+  "email": "email@stripe.com",
+  "livemode": false,
+  "shipping": null,
+  "sources": {
+    "object": "list",
+    "data": [{
+      "id": "src_1",
+      "object": "source",
+      "ach_credit_transfer": {
+        "account_number": "test_1",
+        "bank_name": "TEST BANK",
+        "fingerprint": "12345678",
+        "refund_account_holder_name": null,
+        "refund_account_holder_type": null,
+        "refund_routing_number": null,
+        "routing_number": "110000000",
+        "swift_code": "TSTEZ122"
+      },
+      "amount": null,
+      "client_secret": "src_client_secret_1",
+      "created": 1643133663,
+      "currency": "usd",
+      "flow": "receiver",
+      "livemode": false,
+      "owner": {
+        "address": null,
+        "email": "amount_0@stripe.com",
+        "name": null,
+        "phone": null,
+        "verified_address": null,
+        "verified_email": null,
+        "verified_name": null,
+        "verified_phone": null
+      },
+      "receiver": {
+        "address": "110000000-test_1",
+        "amount_charged": 0,
+        "amount_received": 0,
+        "amount_returned": 0,
+        "refund_attributes_method": "email",
+        "refund_attributes_status": "missing"
+      },
+      "statement_descriptor": null,
+      "status": "pending",
+      "type": "ach_credit_transfer",
+      "usage": "reusable"
+    }],
+    "has_more": false,
+    "total_count": 1,
+    "url": "/v1/customers/cus_1/sources"
+  }
+}

--- a/paymentsheet/src/androidTest/resources/payment-methods-get-success-empty.json
+++ b/paymentsheet/src/androidTest/resources/payment-methods-get-success-empty.json
@@ -1,0 +1,6 @@
+{
+  "object": "list",
+  "data": [],
+  "has_more": false,
+  "url": "/v1/payment_methods"
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -954,7 +954,7 @@ internal class CustomerSheetViewModel(
             ),
             paymentMethod = paymentMethod,
             shippingValues = null,
-            customerRequestedSave = true,
+            requiresSaveOnConfirmation = true,
         )
 
         unconfirmedPaymentMethod = paymentMethod

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
@@ -24,7 +24,7 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
                 initializationMode = initializationMode,
                 paymentMethod = paymentSelection.paymentMethod,
                 shippingValues = shippingValues,
-                customerRequestedSave = false,
+                requiresSaveOnConfirmation = paymentSelection.requiresSaveOnConfirmation,
             )
         }
         else -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
@@ -133,7 +133,7 @@ internal class LinkHandler @Inject constructor(
                     completeLinkInlinePayment(
                         configuration,
                         params,
-                        paymentSelection.customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse,
+                        paymentSelection.customerRequestedSave,
                         userInput is UserInput.SignIn && shouldCompleteLinkInlineFlow
                     )
                 }
@@ -170,7 +170,7 @@ internal class LinkHandler @Inject constructor(
     private suspend fun completeLinkInlinePayment(
         configuration: LinkConfiguration,
         paymentMethodCreateParams: PaymentMethodCreateParams,
-        customerRequestedSave: Boolean,
+        customerRequestedSave: PaymentSelection.CustomerRequestedSave,
         shouldCompleteLinkInlineFlow: Boolean
     ) {
         if (shouldCompleteLinkInlineFlow) {
@@ -184,7 +184,7 @@ internal class LinkHandler @Inject constructor(
 
             val paymentSelection = when (linkPaymentDetails) {
                 is LinkPaymentDetails.New -> {
-                    PaymentSelection.New.LinkInline(linkPaymentDetails)
+                    PaymentSelection.New.LinkInline(linkPaymentDetails, customerRequestedSave)
                 }
                 is LinkPaymentDetails.Saved -> {
                     val last4 = when (val paymentDetails = linkPaymentDetails.paymentDetails) {
@@ -207,7 +207,8 @@ internal class LinkHandler @Inject constructor(
                             .setType(PaymentMethod.Type.Card)
                             .build(),
                         walletType = PaymentSelection.Saved.WalletType.Link,
-                        requiresSaveOnConfirmation = customerRequestedSave
+                        requiresSaveOnConfirmation = customerRequestedSave ==
+                            PaymentSelection.CustomerRequestedSave.RequestReuse,
                     )
                 }
                 null -> null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -190,7 +190,9 @@ internal sealed class PaymentSelection : Parcelable {
             override val paymentMethodCreateParams = linkPaymentDetails.paymentMethodCreateParams
 
             @IgnoredOnParcel
-            override val paymentMethodOptionsParams = null
+            override val paymentMethodOptionsParams = PaymentMethodOptionsParams.Card(
+                setupFutureUsage = customerRequestedSave.setupFutureUsage
+            )
 
             @IgnoredOnParcel
             override val paymentMethodExtraParams = null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -69,6 +69,7 @@ internal sealed class PaymentSelection : Parcelable {
     data class Saved(
         val paymentMethod: PaymentMethod,
         val walletType: WalletType? = null,
+        val requiresSaveOnConfirmation: Boolean = false,
     ) : PaymentSelection() {
 
         enum class WalletType(val paymentSelection: PaymentSelection) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -179,10 +179,10 @@ internal sealed class PaymentSelection : Parcelable {
         }
 
         @Parcelize
-        data class LinkInline(val linkPaymentDetails: LinkPaymentDetails) : New() {
-            @IgnoredOnParcel
-            override val customerRequestedSave = CustomerRequestedSave.NoRequest
-
+        data class LinkInline(
+            val linkPaymentDetails: LinkPaymentDetails,
+            override val customerRequestedSave: CustomerRequestedSave,
+        ) : New() {
             @IgnoredOnParcel
             private val paymentDetails = linkPaymentDetails.paymentDetails
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
@@ -91,15 +91,9 @@ class DefaultIntentConfirmationInterceptorTest {
     }
 
     @Test
-    fun `Returns confirm params with setup future usage set to off session when requires save on confirmation`() =
+    fun `Returns confirm params with 'setup_future_usage' set to 'off_session' when requires save on confirmation`() =
         runTest {
-            val interceptor = DefaultIntentConfirmationInterceptor(
-                context = context,
-                stripeRepository = object : AbsFakeStripeRepository() {},
-                publishableKeyProvider = { "pk" },
-                stripeAccountIdProvider = { null },
-                isFlowController = false,
-            )
+            val interceptor = createIntentConfirmationInterceptor()
 
             val nextStep = interceptor.intercept(
                 initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),
@@ -554,6 +548,16 @@ class DefaultIntentConfirmationInterceptorTest {
                 displayMessage = message
             )
         }
+    }
+
+    private fun createIntentConfirmationInterceptor(): DefaultIntentConfirmationInterceptor {
+        return DefaultIntentConfirmationInterceptor(
+            context = context,
+            stripeRepository = object : AbsFakeStripeRepository() {},
+            publishableKeyProvider = { "pk" },
+            stripeAccountIdProvider = { null },
+            isFlowController = false,
+        )
     }
 
     private class TestException(message: String? = null) : Exception(message) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/LinkHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/LinkHandlerTest.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.test
-import app.cash.turbine.testIn
 import app.cash.turbine.turbineScope
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.LinkActivityResult
@@ -22,6 +21,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.LinkState
@@ -322,10 +322,16 @@ class LinkHandlerTest {
                         paymentMethod = PaymentMethod.Builder()
                             .setId("pm_123")
                             .setCode("card")
-                            .setCard(PaymentMethod.Card(last4 = "4242"))
+                            .setCard(
+                                PaymentMethod.Card(
+                                    last4 = "4242",
+                                    wallet = Wallet.LinkWallet("4242")
+                                )
+                            )
                             .setType(PaymentMethod.Type.Card)
                             .build(),
                         walletType = PaymentSelection.Saved.WalletType.Link,
+                        requiresSaveOnConfirmation = true,
                     ),
                 )
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -394,7 +394,8 @@ class PaymentSheetEventTest {
                     PaymentDetailsFixtures.CONSUMER_SINGLE_PAYMENT_DETAILS.paymentDetails.first(),
                     mock(),
                     mock()
-                )
+                ),
+                PaymentSelection.CustomerRequestedSave.NoRequest,
             ),
             duration = 1.milliseconds,
             result = PaymentSheetEvent.Payment.Result.Success,
@@ -575,7 +576,8 @@ class PaymentSheetEventTest {
                     PaymentDetailsFixtures.CONSUMER_SINGLE_PAYMENT_DETAILS.paymentDetails.first(),
                     mock(),
                     mock()
-                )
+                ),
+                PaymentSelection.CustomerRequestedSave.NoRequest,
             ),
             duration = 1.milliseconds,
             result = PaymentSheetEvent.Payment.Result.Failure(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -721,7 +721,8 @@ internal class DefaultFlowControllerTest {
                 PaymentDetailsFixtures.CONSUMER_SINGLE_PAYMENT_DETAILS.paymentDetails.first(),
                 mock(),
                 PaymentMethodCreateParamsFixtures.DEFAULT_CARD
-            )
+            ),
+            PaymentSelection.CustomerRequestedSave.NoRequest,
         )
 
         flowController.onPaymentOptionResult(
@@ -760,7 +761,8 @@ internal class DefaultFlowControllerTest {
                 PaymentDetailsFixtures.CONSUMER_SINGLE_PAYMENT_DETAILS.paymentDetails.first(),
                 mock(),
                 PaymentMethodCreateParamsFixtures.DEFAULT_CARD
-            )
+            ),
+            PaymentSelection.CustomerRequestedSave.NoRequest,
         )
 
         flowController.onPaymentOptionResult(
@@ -810,7 +812,8 @@ internal class DefaultFlowControllerTest {
                 PaymentDetailsFixtures.CONSUMER_SINGLE_PAYMENT_DETAILS.paymentDetails.first(),
                 mock(),
                 PaymentMethodCreateParamsFixtures.DEFAULT_CARD
-            )
+            ),
+            PaymentSelection.CustomerRequestedSave.NoRequest,
         )
 
         flowController.onPaymentOptionResult(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -1,0 +1,45 @@
+package com.stripe.android.paymentsheet.utils
+
+import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.LinkPaymentDetails
+import com.stripe.android.link.ui.inline.LinkSignupMode
+import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.PaymentMethod
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+object LinkTestUtils {
+    val LINK_SAVED_PAYMENT_DETAILS = LinkPaymentDetails.Saved(
+        paymentDetails = ConsumerPaymentDetails.Card(
+            id = "pm_123",
+            last4 = "4242",
+        ),
+        paymentMethodCreateParams = mock(),
+    )
+
+    val LINK_NEW_PAYMENT_DETAILS = LinkPaymentDetails.New(
+        paymentDetails = ConsumerPaymentDetails.Card(
+            id = "pm_123",
+            last4 = "4242",
+        ),
+        paymentMethodCreateParams = mock(),
+        originalParams = mock()
+    )
+
+    fun createLinkConfiguration(): LinkConfiguration {
+        return LinkConfiguration(
+            stripeIntent = mock {
+                on { linkFundingSources } doReturn listOf(
+                    PaymentMethod.Type.Card.code
+                )
+            },
+            signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
+            customerInfo = LinkConfiguration.CustomerInfo(null, null, null, null),
+            flags = mapOf(),
+            merchantName = "Test merchant inc.",
+            merchantCountryCode = "US",
+            passthroughModeEnabled = false,
+            shippingValues = mapOf(),
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
@@ -57,7 +57,7 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
         initializationMode: PaymentSheet.InitializationMode,
         paymentMethod: PaymentMethod,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
-        customerRequestedSave: Boolean,
+        requiresSaveOnConfirmation: Boolean,
     ): IntentConfirmationInterceptor.NextStep {
         return channel.receive()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeLinkConfigurationCoordinator.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeLinkConfigurationCoordinator.kt
@@ -13,7 +13,19 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import org.mockito.kotlin.mock
 
-class FakeLinkConfigurationCoordinator : LinkConfigurationCoordinator {
+class FakeLinkConfigurationCoordinator(
+    private val attachNewCardToAccountResult: Result<LinkPaymentDetails> = Result.success(
+        LinkPaymentDetails.New(
+            paymentDetails = ConsumerPaymentDetails.Card(
+                id = "pm_123",
+                last4 = "4242",
+            ),
+            paymentMethodCreateParams = mock(),
+            originalParams = mock(),
+        )
+    ),
+    private val accountStatus: AccountStatus = AccountStatus.SignedOut,
+) : LinkConfigurationCoordinator {
 
     override val component: LinkComponent?
         get() = mock()
@@ -22,7 +34,7 @@ class FakeLinkConfigurationCoordinator : LinkConfigurationCoordinator {
         get() = flowOf(null)
 
     override fun getAccountStatusFlow(configuration: LinkConfiguration): Flow<AccountStatus> {
-        return flowOf(AccountStatus.SignedOut)
+        return flowOf(accountStatus)
     }
 
     override suspend fun signInWithUserInput(configuration: LinkConfiguration, userInput: UserInput): Result<Boolean> {
@@ -33,16 +45,7 @@ class FakeLinkConfigurationCoordinator : LinkConfigurationCoordinator {
         configuration: LinkConfiguration,
         paymentMethodCreateParams: PaymentMethodCreateParams
     ): Result<LinkPaymentDetails> {
-        return Result.success(
-            LinkPaymentDetails.New(
-                paymentDetails = ConsumerPaymentDetails.Card(
-                    id = "pm_123",
-                    last4 = "4242",
-                ),
-                paymentMethodCreateParams = mock(),
-                originalParams = mock(),
-            )
-        )
+        return attachNewCardToAccountResult
     }
 
     override suspend fun logOut(configuration: LinkConfiguration): Result<ConsumerSession> {


### PR DESCRIPTION
# Summary
Add `setup_future_usage` for saved payment methods from PM and passthrough mode.

Currently, we assume that paying with saved payment methods (using `PaymentMethod` objects) meant that the payment method was already attached to the customer. We recently found out that Link was not saving payment methods to the customer account due to a limitation from the Mobile SDK's continued usage of ephemeral keys over customer sessions.

This PR adds behavior for [allowing payment methods saved on Link to also be saved on the customer's account](https://github.com/stripe/stripe-android/pull/8117/files#diff-2a78fdb89b3d58b2ca857a9827f8bdd6186e94d0d19616b9980ef03618c0f795R212) so that they can be reused by the customer through Elements UI interfaces as well as expected when the customer asks to save a payment method through `PaymentSheet`.

When we move to `CustomerSession`, Link will automatically save the payment method on both Link and their Stripe customer's account rather than need to implement a solution on the client side.

# Motivation
Fixes an issue in passthrough mode where a payment method saved through Link signup is not saved in as a customer payment method.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified