### PR TITLE
Show `Link` wallet cards as saved payment methods

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
@@ -96,7 +96,6 @@ internal class CustomerApiRepository @Inject constructor(
                         Wallet.Type.ApplePay,
                         Wallet.Type.GooglePay,
                         Wallet.Type.SamsungPay,
-                        Wallet.Type.Link,
                     )
                     paymentMethods.addAll(
                         customerPaymentMethods.filter { paymentMethod ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
@@ -172,6 +172,66 @@ internal class CustomerRepositoryTest {
         }
 
     @Test
+    fun `getPaymentsMeth() should keep cards from Link wallet`() = runTest {
+        givenGetPaymentMethodsReturns(
+            Result.success(emptyList())
+        )
+
+        val initialCard = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+
+        val mockedReturnPaymentMethods = listOf(
+            initialCard.copy("pm_1"),
+            initialCard.copy(
+                id = "pm_2",
+                card = initialCard.card?.copy(
+                    wallet = Wallet.GooglePayWallet("3000")
+                )
+            ),
+            initialCard.copy(
+                id = "pm_3",
+                card = initialCard.card?.copy(
+                    wallet = Wallet.LinkWallet("4000")
+                )
+            ),
+            initialCard.copy(
+                id = "pm_4",
+                card = initialCard.card?.copy(
+                    wallet = Wallet.LinkWallet("5000")
+                )
+            ),
+        )
+
+        stripeRepository.stub {
+            onBlocking {
+                getPaymentMethods(
+                    listPaymentMethodsParams = eq(
+                        ListPaymentMethodsParams(
+                            customerId = "customer_id",
+                            paymentMethodType = PaymentMethod.Type.Card
+                        )
+                    ),
+                    productUsageTokens = any(),
+                    requestOptions = any()
+                )
+            }.thenReturn(Result.success(mockedReturnPaymentMethods))
+        }
+
+        val result = repository.getPaymentMethods(
+            PaymentSheet.CustomerConfiguration(
+                "customer_id",
+                "ephemeral_key"
+            ),
+            listOf(PaymentMethod.Type.Card),
+            true,
+        ).getOrThrow()
+
+        assertThat(result).hasSize(3)
+        assertThat(result[0].id).isEqualTo("pm_1")
+        assertThat(result[1].id).isEqualTo("pm_3")
+        assertThat(result[2].id).isEqualTo("pm_4")
+    }
+
+    @Test
     fun `getPaymentMethods() should return empty list on failure when silent failures`() =
         runTest {
             givenGetPaymentMethodsReturns(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
@@ -172,7 +172,7 @@ internal class CustomerRepositoryTest {
         }
 
     @Test
-    fun `getPaymentsMeth() should keep cards from Link wallet`() = runTest {
+    fun `getPaymentsMethods() should keep cards from Link wallet`() = runTest {
         givenGetPaymentMethodsReturns(
             Result.success(emptyList())
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
@@ -172,7 +172,7 @@ internal class CustomerRepositoryTest {
         }
 
     @Test
-    fun `getPaymentsMethods() should keep cards from Link wallet`() = runTest {
+    fun `getPaymentsMethods() should keep cards from Link wallet and dedupe them`() = runTest {
         givenGetPaymentMethodsReturns(
             Result.success(emptyList())
         )
@@ -196,7 +196,7 @@ internal class CustomerRepositoryTest {
             initialCard.copy(
                 id = "pm_4",
                 card = initialCard.card?.copy(
-                    wallet = Wallet.LinkWallet("5000")
+                    wallet = Wallet.LinkWallet("4000")
                 )
             ),
         )
@@ -225,10 +225,9 @@ internal class CustomerRepositoryTest {
             true,
         ).getOrThrow()
 
-        assertThat(result).hasSize(3)
-        assertThat(result[0].id).isEqualTo("pm_1")
-        assertThat(result[1].id).isEqualTo("pm_3")
-        assertThat(result[2].id).isEqualTo("pm_4")
+        assertThat(result).hasSize(2)
+        assertThat(result[0].id).isEqualTo("pm_3")
+        assertThat(result[1].id).isEqualTo("pm_1")
     }
 
     @Test


### PR DESCRIPTION
# Summary
Show `Link` wallet cards as saved payment methods.

# Motivation
Part of #ir-perturb-silences, we will now show `Link` card payment methods as regular payment methods irregardless of if they are duplicate cards.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified