### PR TITLE
[FC] Do not show exit confirmation on Account Picker failure screen

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
@@ -135,16 +135,16 @@ private fun AccountPickerContent(
         },
         content = {
             AccountPickerMainContent(
-                onCloseClick,
-                lazyListState,
-                state,
-                onSelectAnotherBank,
-                onEnterDetailsManually,
-                onLoadAccountsAgain,
-                onCloseFromErrorClick,
-                onAccountClicked,
-                onClickableTextClick,
-                onSubmit
+                onCloseClick = onCloseClick,
+                lazyListState = lazyListState,
+                state = state,
+                onSelectAnotherBank = onSelectAnotherBank,
+                onEnterDetailsManually = onEnterDetailsManually,
+                onLoadAccountsAgain = onLoadAccountsAgain,
+                onCloseFromErrorClick = onCloseFromErrorClick,
+                onAccountClicked = onAccountClicked,
+                onClickableTextClick = onClickableTextClick,
+                onSubmit = onSubmit
             )
         },
     )
@@ -167,7 +167,13 @@ private fun AccountPickerMainContent(
         topBar = {
             FinancialConnectionsTopAppBar(
                 allowBackNavigation = false,
-                onCloseClick = onCloseClick,
+                onCloseClick = {
+                    if (state.payload is Fail) {
+                        onCloseFromErrorClick(state.payload.error)
+                    } else {
+                        onCloseClick()
+                    }
+                },
                 elevation = lazyListState.elevation
             )
         }


### PR DESCRIPTION
# Summary
Correctly trigger `onCloseFromErrorClick` when Account Picker pane is in error state.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
Maestro tests should pass now, regardless of the merchant.
