### PR TITLE
Move requiresMandate to PaymentMethodDefinition.

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -4,7 +4,7 @@
   <CurrentIssues>
     <ID>CyclomaticComplexMethod:CustomerSheetViewModel.kt$CustomerSheetViewModel$fun handleViewAction(viewAction: CustomerSheetViewAction)</ID>
     <ID>CyclomaticComplexMethod:PlaceholderHelper.kt$PlaceholderHelper$@VisibleForTesting internal fun specForPlaceholderField( field: PlaceholderField, placeholderOverrideList: List&lt;IdentifierSpec>, requiresMandate: Boolean, configuration: PaymentSheet.BillingDetailsCollectionConfiguration, )</ID>
-    <ID>CyclomaticComplexMethod:TransformSpecToElements.kt$TransformSpecToElements$fun transform( specs: List&lt;FormItemSpec>, requiresMandate: Boolean, placeholderOverrideList: List&lt;IdentifierSpec> = emptyList(), replacePlaceholders: Boolean = true, ): List&lt;FormElement></ID>
+    <ID>CyclomaticComplexMethod:TransformSpecToElements.kt$TransformSpecToElements$fun transform( specs: List&lt;FormItemSpec>, placeholderOverrideList: List&lt;IdentifierSpec> = emptyList(), replacePlaceholders: Boolean = true, ): List&lt;FormElement></ID>
     <ID>EmptyFunctionBlock:PrimaryButtonAnimator.kt$PrimaryButtonAnimator.&lt;no name provided>${ }</ID>
     <ID>ForbiddenComment:PaymentOptionFactory.kt$PaymentOptionFactory$// TODO: Should use labelResource paymentMethodCreateParams or extension function</ID>
     <ID>FunctionNaming:PaymentSheetTopBar.kt$@Preview @Composable internal fun PaymentSheetTopBar_Preview()</ID>
@@ -32,7 +32,7 @@
     <ID>LongMethod:PaymentSheetConfigurationKtx.kt$internal fun PaymentSheet.Appearance.parseAppearance()</ID>
     <ID>LongMethod:PaymentSheetLoader.kt$DefaultPaymentSheetLoader$private suspend fun create( elementsSession: ElementsSession, config: PaymentSheet.Configuration, metadata: PaymentMethodMetadata, ): PaymentSheetState.Full</ID>
     <ID>LongMethod:PlaceholderHelperTest.kt$PlaceholderHelperTest$@Test fun `Test correct placeholder is removed for placeholder spec`()</ID>
-    <ID>LongMethod:TransformSpecToElements.kt$TransformSpecToElements$fun transform( specs: List&lt;FormItemSpec>, requiresMandate: Boolean, placeholderOverrideList: List&lt;IdentifierSpec> = emptyList(), replacePlaceholders: Boolean = true, ): List&lt;FormElement></ID>
+    <ID>LongMethod:TransformSpecToElements.kt$TransformSpecToElements$fun transform( specs: List&lt;FormItemSpec>, placeholderOverrideList: List&lt;IdentifierSpec> = emptyList(), replacePlaceholders: Boolean = true, ): List&lt;FormElement></ID>
     <ID>LongMethod:USBankAccountEmitters.kt$@Composable internal fun USBankAccountEmitters( viewModel: USBankAccountFormViewModel, usBankAccountFormArgs: USBankAccountFormArguments, )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable internal fun BillingDetailsForm( formArgs: FormArguments, isProcessing: Boolean, isPaymentFlow: Boolean, nameController: TextFieldController, emailController: TextFieldController, phoneController: PhoneNumberController, addressController: AddressController, lastTextFieldIdentifier: IdentifierSpec?, sameAsShippingElement: SameAsShippingElement?, )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable internal fun USBankAccountForm( formArgs: FormArguments, usBankAccountFormArgs: USBankAccountFormArguments, modifier: Modifier = Modifier, )</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -441,17 +441,20 @@ internal class CustomerSheetViewModel(
     }
 
     private fun onFormFieldValuesCompleted(formFieldValues: FormFieldValues?) {
-        updateViewState<CustomerSheetViewState.AddPaymentMethod> {
-            it.copy(
-                formViewData = it.formViewData.copy(
-                    completeFormValues = formFieldValues,
-                ),
-                primaryButtonEnabled = formFieldValues != null && !it.isProcessing,
-                draftPaymentSelection = formFieldValues?.transformToPaymentSelection(
-                    resources = resources,
-                    paymentMethod = it.selectedPaymentMethod,
+        paymentMethodMetadata?.let { paymentMethodMetadata ->
+            updateViewState<CustomerSheetViewState.AddPaymentMethod> {
+                it.copy(
+                    formViewData = it.formViewData.copy(
+                        completeFormValues = formFieldValues,
+                    ),
+                    primaryButtonEnabled = formFieldValues != null && !it.isProcessing,
+                    draftPaymentSelection = formFieldValues?.transformToPaymentSelection(
+                        resources = resources,
+                        paymentMethod = it.selectedPaymentMethod,
+                        paymentMethodMetadata = paymentMethodMetadata
+                    )
                 )
-            )
+            }
         }
     }
 
@@ -692,7 +695,10 @@ internal class CustomerSheetViewModel(
                     val formData = currentViewState.formViewData
                     if (formData.completeFormValues == null) error("completeFormValues cannot be null")
                     val params = formData.completeFormValues
-                        .transformToPaymentMethodCreateParams(paymentMethodSpec)
+                        .transformToPaymentMethodCreateParams(
+                            paymentMethod = paymentMethodSpec,
+                            paymentMethodMetadata = requireNotNull(paymentMethodMetadata)
+                        )
                     createAndAttach(params)
                 } ?: error("${currentViewState.paymentMethodCode} is not supported")
             }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SupportedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SupportedPaymentMethod.kt
@@ -16,9 +16,6 @@ data class SupportedPaymentMethod(
      */
     val code: PaymentMethodCode,
 
-    /** This describes if the LPM requires a mandate see [ConfirmPaymentIntentParams.mandateDataParams]. */
-    val requiresMandate: Boolean,
-
     /** This describes the name that appears under the selector. */
     @StringRes val displayNameResource: Int,
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElements.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElements.kt
@@ -62,10 +62,10 @@ class TransformSpecToElements(
     private val context: Context,
     private val cbcEligibility: CardBrandChoiceEligibility,
     private val billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration,
+    private val requiresMandate: Boolean,
 ) {
     fun transform(
         specs: List<FormItemSpec>,
-        requiresMandate: Boolean,
         placeholderOverrideList: List<IdentifierSpec> = emptyList(),
         replacePlaceholders: Boolean = true,
     ): List<FormElement> {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodDefinition.kt
@@ -17,6 +17,8 @@ internal interface PaymentMethodDefinition {
 
     val supportedAsSavedPaymentMethod: Boolean
 
+    fun requiresMandate(metadata: PaymentMethodMetadata): Boolean
+
     /**
      * The requirements that need to be met in order for this Payment Method to be available for selection by the buyer.
      * For example emptySet() if no requirements exist.

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -55,6 +55,10 @@ internal data class PaymentMethodMetadata(
         }
     }
 
+    fun requiresMandate(paymentMethodCode: String): Boolean {
+        return PaymentMethodRegistry.definitionsByCode[paymentMethodCode]?.requiresMandate(this) ?: false
+    }
+
     fun supportedPaymentMethodDefinitions(): List<PaymentMethodDefinition> {
         return stripeIntent.paymentMethodTypes.mapNotNull {
             PaymentMethodRegistry.definitionsByCode[it]
@@ -99,6 +103,7 @@ internal data class PaymentMethodMetadata(
             sharedDataSpec = sharedDataSpec,
             transformSpecToElements = transformSpecToElements(
                 context = context,
+                requiresMandate = definition.requiresMandate(this),
                 paymentMethodCreateParams = paymentMethodCreateParams,
                 paymentMethodExtraParams = paymentMethodExtraParams,
             ),
@@ -116,7 +121,10 @@ internal data class PaymentMethodMetadata(
                 paymentMethodDefinition.supportedPaymentMethod(
                     metadata = this,
                     sharedDataSpec = sharedDataSpec,
-                    transformSpecToElements = transformSpecToElements(context),
+                    transformSpecToElements = transformSpecToElements(
+                        context = context,
+                        requiresMandate = paymentMethodDefinition.requiresMandate(this),
+                    ),
                 )
             }
         }
@@ -157,6 +165,7 @@ internal data class PaymentMethodMetadata(
 
     private fun transformSpecToElements(
         context: Context,
+        requiresMandate: Boolean,
         paymentMethodCreateParams: PaymentMethodCreateParams? = null,
         paymentMethodExtraParams: PaymentMethodExtraParams? = null,
     ): TransformSpecToElements {
@@ -184,6 +193,7 @@ internal data class PaymentMethodMetadata(
             context = context.applicationContext,
             addressRepository = requireNotNull(addressRepository),
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
+            requiresMandate = requiresMandate,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AffirmDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AffirmDefinition.kt
@@ -21,6 +21,8 @@ internal object AffirmDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -28,7 +30,6 @@ internal object AffirmDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "affirm",
-            requiresMandate = false,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_affirm,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_affirm,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -36,7 +37,6 @@ internal object AffirmDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = false,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AfterpayClearpayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AfterpayClearpayDefinition.kt
@@ -22,6 +22,8 @@ internal object AfterpayClearpayDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -29,7 +31,6 @@ internal object AfterpayClearpayDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "afterpay_clearpay",
-            requiresMandate = false,
             displayNameResource = if (AfterpayClearpayHeaderElement.isClearpay()) {
                 R.string.stripe_paymentsheet_payment_method_clearpay
             } else {
@@ -41,7 +42,6 @@ internal object AfterpayClearpayDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = false,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlipayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlipayDefinition.kt
@@ -20,6 +20,8 @@ internal object AlipayDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -27,7 +29,6 @@ internal object AlipayDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "alipay",
-            requiresMandate = false,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_alipay,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_alipay,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -35,7 +36,6 @@ internal object AlipayDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = false,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlmaDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlmaDefinition.kt
@@ -20,6 +20,8 @@ internal object AlmaDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -27,7 +29,6 @@ internal object AlmaDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "alma",
-            requiresMandate = false,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_alma,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_alma,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -35,7 +36,6 @@ internal object AlmaDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = false,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AmazonPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AmazonPayDefinition.kt
@@ -20,14 +20,14 @@ internal object AmazonPayDefinition : PaymentMethodDefinition {
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf()
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup()
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
         transformSpecToElements: TransformSpecToElements,
     ): SupportedPaymentMethod {
-        val requiresMandate = metadata.hasIntentToSetup()
-
-        val localLayoutSpecs: List<FormItemSpec> = if (requiresMandate) {
+        val localLayoutSpecs: List<FormItemSpec> = if (requiresMandate(metadata)) {
             listOf(MandateTextSpec(stringResId = R.string.stripe_amazon_pay_mandate))
         } else {
             emptyList()
@@ -35,7 +35,6 @@ internal object AmazonPayDefinition : PaymentMethodDefinition {
 
         return SupportedPaymentMethod(
             code = "amazon_pay",
-            requiresMandate = requiresMandate,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_amazon_pay,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_amazon_pay,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -43,7 +42,6 @@ internal object AmazonPayDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields + localLayoutSpecs,
-                requiresMandate = requiresMandate,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AuBecsDebitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AuBecsDebitDefinition.kt
@@ -20,6 +20,8 @@ internal object AuBecsDebitDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.MerchantSupportsDelayedPaymentMethods,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = true
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -27,7 +29,6 @@ internal object AuBecsDebitDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "au_becs_debit",
-            requiresMandate = true,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_au_becs_debit,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_bank,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -35,7 +36,6 @@ internal object AuBecsDebitDefinition : PaymentMethodDefinition {
             tintIconOnSelection = true,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = true,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BacsDebitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BacsDebitDefinition.kt
@@ -25,6 +25,8 @@ internal object BacsDebitDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = true
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -53,7 +55,6 @@ internal object BacsDebitDefinition : PaymentMethodDefinition {
 
         return SupportedPaymentMethod(
             code = "bacs_debit",
-            requiresMandate = true,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_bacs_debit,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_bank,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -61,7 +62,6 @@ internal object BacsDebitDefinition : PaymentMethodDefinition {
             tintIconOnSelection = true,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields + localFields,
-                requiresMandate = true,
                 placeholderOverrideList = listOf(
                     IdentifierSpec.Name,
                     IdentifierSpec.Email,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BancontactDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BancontactDefinition.kt
@@ -21,6 +21,8 @@ internal object BancontactDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.MerchantSupportsDelayedPaymentMethods.takeIf { hasIntentToSetup },
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup()
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -28,7 +30,6 @@ internal object BancontactDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "bancontact",
-            requiresMandate = metadata.hasIntentToSetup(),
             displayNameResource = R.string.stripe_paymentsheet_payment_method_bancontact,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_bancontact,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -36,7 +37,6 @@ internal object BancontactDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = metadata.hasIntentToSetup(),
                 placeholderOverrideList = if (metadata.hasIntentToSetup()) {
                     listOf(IdentifierSpec.Name, IdentifierSpec.Email)
                 } else {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikDefinition.kt
@@ -20,6 +20,8 @@ internal object BlikDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -27,7 +29,6 @@ internal object BlikDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "blik",
-            requiresMandate = false,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_blik,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_blik,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -35,7 +36,6 @@ internal object BlikDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = false,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoDefinition.kt
@@ -20,6 +20,8 @@ internal object BoletoDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.MerchantSupportsDelayedPaymentMethods,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -27,7 +29,6 @@ internal object BoletoDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "boleto",
-            requiresMandate = false,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_boleto,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_boleto,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -35,7 +36,6 @@ internal object BoletoDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = false,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -24,6 +24,8 @@ internal object CardDefinition : PaymentMethodDefinition {
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf()
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -46,7 +48,6 @@ internal object CardDefinition : PaymentMethodDefinition {
         )
         return SupportedPaymentMethod(
             code = "card",
-            requiresMandate = false,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_card,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_card,
             lightThemeIconUrl = null,
@@ -54,7 +55,6 @@ internal object CardDefinition : PaymentMethodDefinition {
             tintIconOnSelection = true,
             formElements = transformSpecToElements.transform(
                 specs = specs,
-                requiresMandate = false,
                 replacePlaceholders = false,
             ),
         )

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CashAppPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CashAppPayDefinition.kt
@@ -19,14 +19,14 @@ internal object CashAppPayDefinition : PaymentMethodDefinition {
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf()
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup()
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
         transformSpecToElements: TransformSpecToElements,
     ): SupportedPaymentMethod {
-        val requiresMandate = metadata.hasIntentToSetup()
-
-        val localLayoutSpecs = if (requiresMandate) {
+        val localLayoutSpecs = if (requiresMandate(metadata)) {
             listOf(CashAppPayMandateTextSpec())
         } else {
             emptyList()
@@ -34,15 +34,13 @@ internal object CashAppPayDefinition : PaymentMethodDefinition {
 
         return SupportedPaymentMethod(
             code = "cashapp",
-            requiresMandate = requiresMandate,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_cashapp,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_cash_app_pay,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
             darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
-                specs = sharedDataSpec.fields + localLayoutSpecs,
-                requiresMandate = requiresMandate
+                specs = sharedDataSpec.fields + localLayoutSpecs
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/EpsDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/EpsDefinition.kt
@@ -20,6 +20,8 @@ internal object EpsDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = true
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -27,7 +29,6 @@ internal object EpsDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "eps",
-            requiresMandate = true,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_eps,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_eps,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -35,7 +36,6 @@ internal object EpsDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = true,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/FpxDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/FpxDefinition.kt
@@ -20,6 +20,8 @@ internal object FpxDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -27,7 +29,6 @@ internal object FpxDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "fpx",
-            requiresMandate = false,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_fpx,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_fpx,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -35,7 +36,6 @@ internal object FpxDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = false,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/GiroPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/GiroPayDefinition.kt
@@ -20,6 +20,8 @@ internal object GiroPayDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -27,7 +29,6 @@ internal object GiroPayDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "giropay",
-            requiresMandate = false,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_giropay,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_giropay,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -35,7 +36,6 @@ internal object GiroPayDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = false,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/GrabPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/GrabPayDefinition.kt
@@ -20,6 +20,8 @@ internal object GrabPayDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -27,7 +29,6 @@ internal object GrabPayDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "grabpay",
-            requiresMandate = false,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_grabpay,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_grabpay,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -35,7 +36,6 @@ internal object GrabPayDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = false,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/IdealDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/IdealDefinition.kt
@@ -21,6 +21,8 @@ internal object IdealDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.MerchantSupportsDelayedPaymentMethods.takeIf { hasIntentToSetup },
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup()
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -28,7 +30,6 @@ internal object IdealDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "ideal",
-            requiresMandate = metadata.hasIntentToSetup(),
             displayNameResource = R.string.stripe_paymentsheet_payment_method_ideal,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_ideal,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -36,7 +37,6 @@ internal object IdealDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = metadata.hasIntentToSetup(),
                 placeholderOverrideList = if (metadata.hasIntentToSetup()) {
                     listOf(IdentifierSpec.Name, IdentifierSpec.Email)
                 } else {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
@@ -20,6 +20,8 @@ internal object KlarnaDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -27,7 +29,6 @@ internal object KlarnaDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "klarna",
-            requiresMandate = false,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_klarna,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_klarna,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -35,7 +36,6 @@ internal object KlarnaDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = false,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KonbiniDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KonbiniDefinition.kt
@@ -21,6 +21,8 @@ internal object KonbiniDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -28,7 +30,6 @@ internal object KonbiniDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "konbini",
-            requiresMandate = false,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_konbini,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_konbini,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -36,7 +37,6 @@ internal object KonbiniDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = false,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/MobilePayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/MobilePayDefinition.kt
@@ -20,6 +20,8 @@ internal object MobilePayDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -27,7 +29,6 @@ internal object MobilePayDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "mobilepay",
-            requiresMandate = false,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_mobile_pay,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_mobile_pay,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -35,7 +36,6 @@ internal object MobilePayDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = false,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/OxxoDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/OxxoDefinition.kt
@@ -21,6 +21,8 @@ internal object OxxoDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -28,7 +30,6 @@ internal object OxxoDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "oxxo",
-            requiresMandate = false,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_oxxo,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_oxxo,
             lightThemeIconUrl = null,
@@ -36,7 +37,6 @@ internal object OxxoDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = false,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/P24Definition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/P24Definition.kt
@@ -20,6 +20,8 @@ internal object P24Definition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -27,7 +29,6 @@ internal object P24Definition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "p24",
-            requiresMandate = false,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_p24,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_p24,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -35,7 +36,6 @@ internal object P24Definition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = false,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPalDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPalDefinition.kt
@@ -20,6 +20,8 @@ internal object PayPalDefinition : PaymentMethodDefinition {
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf()
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup()
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -33,7 +35,6 @@ internal object PayPalDefinition : PaymentMethodDefinition {
 
         return SupportedPaymentMethod(
             code = "paypal",
-            requiresMandate = metadata.hasIntentToSetup(),
             displayNameResource = R.string.stripe_paymentsheet_payment_method_paypal,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_paypal,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -41,7 +42,6 @@ internal object PayPalDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields + localLayoutSpecs,
-                requiresMandate = metadata.hasIntentToSetup()
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/RevolutPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/RevolutPayDefinition.kt
@@ -20,14 +20,14 @@ internal object RevolutPayDefinition : PaymentMethodDefinition {
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf()
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup()
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
         transformSpecToElements: TransformSpecToElements,
     ): SupportedPaymentMethod {
-        val requiresMandate = metadata.hasIntentToSetup()
-
-        val localLayoutSpecs: List<FormItemSpec> = if (requiresMandate) {
+        val localLayoutSpecs: List<FormItemSpec> = if (requiresMandate(metadata)) {
             listOf(MandateTextSpec(stringResId = R.string.stripe_revolut_mandate))
         } else {
             emptyList()
@@ -35,7 +35,6 @@ internal object RevolutPayDefinition : PaymentMethodDefinition {
 
         return SupportedPaymentMethod(
             code = "revolut_pay",
-            requiresMandate = requiresMandate,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_revolut_pay,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_revolut_pay,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -43,7 +42,6 @@ internal object RevolutPayDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields + localLayoutSpecs,
-                requiresMandate = requiresMandate,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitDefinition.kt
@@ -20,6 +20,8 @@ internal object SepaDebitDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.MerchantSupportsDelayedPaymentMethods,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = true
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -27,7 +29,6 @@ internal object SepaDebitDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "sepa_debit",
-            requiresMandate = true,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_sepa_debit,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_sepa_debit,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -35,7 +36,6 @@ internal object SepaDebitDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = true,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SofortDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SofortDefinition.kt
@@ -21,6 +21,8 @@ internal object SofortDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.MerchantSupportsDelayedPaymentMethods,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup()
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -28,7 +30,6 @@ internal object SofortDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "sofort",
-            requiresMandate = metadata.hasIntentToSetup(),
             displayNameResource = R.string.stripe_paymentsheet_payment_method_sofort,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_klarna,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -36,7 +37,6 @@ internal object SofortDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = metadata.hasIntentToSetup(),
                 placeholderOverrideList = if (metadata.hasIntentToSetup()) {
                     listOf(IdentifierSpec.Name, IdentifierSpec.Email)
                 } else {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SwishDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SwishDefinition.kt
@@ -20,6 +20,8 @@ internal object SwishDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -27,7 +29,6 @@ internal object SwishDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "swish",
-            requiresMandate = false,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_swish,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_swish,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -35,7 +36,6 @@ internal object SwishDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = false,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/TwintDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/TwintDefinition.kt
@@ -20,6 +20,8 @@ internal object TwintDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -27,7 +29,6 @@ internal object TwintDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "twint",
-            requiresMandate = false,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_twint,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_twint,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -35,7 +36,6 @@ internal object TwintDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = false,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UpiDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UpiDefinition.kt
@@ -20,6 +20,8 @@ internal object UpiDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -27,7 +29,6 @@ internal object UpiDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "upi",
-            requiresMandate = false,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_upi,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_upi,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -35,7 +36,6 @@ internal object UpiDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = false,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UsBankAccountDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UsBankAccountDefinition.kt
@@ -22,6 +22,8 @@ internal object UsBankAccountDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.MerchantSupportsDelayedPaymentMethods,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = true
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -29,7 +31,6 @@ internal object UsBankAccountDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "us_bank_account",
-            requiresMandate = true,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_us_bank_account,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_bank,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -37,7 +38,6 @@ internal object UsBankAccountDefinition : PaymentMethodDefinition {
             tintIconOnSelection = true,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = true,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeChatPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeChatPayDefinition.kt
@@ -20,6 +20,8 @@ internal object WeChatPayDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -27,7 +29,6 @@ internal object WeChatPayDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "wechat_pay",
-            requiresMandate = false,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_wechat,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_wechat_pay,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -35,7 +36,6 @@ internal object WeChatPayDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = false,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/ZipDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/ZipDefinition.kt
@@ -20,6 +20,8 @@ internal object ZipDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
+
     override fun supportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
@@ -27,7 +29,6 @@ internal object ZipDefinition : PaymentMethodDefinition {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = "zip",
-            requiresMandate = false,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_zip,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_zip,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -35,7 +36,6 @@ internal object ZipDefinition : PaymentMethodDefinition {
             tintIconOnSelection = false,
             formElements = transformSpecToElements.transform(
                 specs = sharedDataSpec.fields,
-                requiresMandate = false,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/FormController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/FormController.kt
@@ -27,7 +27,7 @@ class FormController @Inject constructor(
     transformSpecToElement: TransformSpecToElements,
 ) {
     val elements: StateFlow<List<FormElement>> =
-        MutableStateFlow(transformSpecToElement.transform(formSpec.items, requiresMandate = false))
+        MutableStateFlow(transformSpecToElement.transform(formSpec.items))
 
     private val cardBillingElement = elements.map { elementsList ->
         elementsList

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/FormControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/FormControllerModule.kt
@@ -44,5 +44,6 @@ object FormControllerModule {
         context = context,
         cbcEligibility = CardBrandChoiceEligibility.Ineligible,
         billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
+        requiresMandate = false,
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.flowcontroller
 
-import android.content.Context
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.containsVolatileDifferences
@@ -16,9 +15,7 @@ internal fun interface PaymentSelectionUpdater {
     ): PaymentSelection?
 }
 
-internal class DefaultPaymentSelectionUpdater @Inject constructor(
-    private val context: Context
-) : PaymentSelectionUpdater {
+internal class DefaultPaymentSelectionUpdater @Inject constructor() : PaymentSelectionUpdater {
 
     override operator fun invoke(
         currentSelection: PaymentSelection?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
@@ -68,10 +68,7 @@ internal class DefaultPaymentSelectionUpdater @Inject constructor(
     ): Boolean {
         val code = currentSelection.paymentMethodCreateParams.typeCode
 
-        val paymentMethodRequiresMandate = metadata.supportedPaymentMethodForCode(
-            code = code,
-            context = context
-        )?.requiresMandate ?: false
+        val paymentMethodRequiresMandate = metadata.requiresMandate(code)
 
         return if (paymentMethodRequiresMandate) {
             !currentSelection.customerAcknowledgedMandate

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/LpmRepositoryTestHelpers.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/LpmRepositoryTestHelpers.kt
@@ -7,7 +7,6 @@ import com.stripe.android.ui.core.R
 object LpmRepositoryTestHelpers {
     val card: SupportedPaymentMethod = cardFromPaymentMethodMetadata() ?: SupportedPaymentMethod(
         code = "card",
-        requiresMandate = false,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_card,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_card,
         lightThemeIconUrl = null,
@@ -18,7 +17,6 @@ object LpmRepositoryTestHelpers {
 
     val usBankAccount: SupportedPaymentMethod = SupportedPaymentMethod(
         code = "us_bank_account",
-        requiresMandate = true,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_us_bank_account,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_bank,
         lightThemeIconUrl = null,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementTest.kt
@@ -70,6 +70,7 @@ internal class TransformSpecToElementTest {
                 shippingValues = null,
                 cbcEligibility = CardBrandChoiceEligibility.Ineligible,
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
+                requiresMandate = false,
             )
     }
 
@@ -79,7 +80,6 @@ internal class TransformSpecToElementTest {
             val countrySection = CountrySpec(allowedCountryCodes = setOf("AT"))
             val formElement = transformSpecToElements.transform(
                 listOf(countrySection),
-                requiresMandate = false,
             )
 
             val countrySectionElement = formElement.first() as SectionElement
@@ -102,7 +102,6 @@ internal class TransformSpecToElementTest {
             val idealSection = IDEAL_BANK_CONFIG
             val formElement = transformSpecToElements.transform(
                 listOf(idealSection),
-                requiresMandate = false,
             )
 
             val idealSectionElement = formElement.first() as SectionElement
@@ -120,7 +119,6 @@ internal class TransformSpecToElementTest {
     fun `Add a name section spec sets up the name element correctly`() = runBlocking {
         val formElement = transformSpecToElements.transform(
             listOf(nameSection),
-            requiresMandate = false,
         )
 
         val nameElement = (formElement.first() as SectionElement)
@@ -150,7 +148,6 @@ internal class TransformSpecToElementTest {
                     capitalization = Capitalization.Words
                 )
             ),
-            requiresMandate = false,
         )
 
         val nameElement = (formElement.first() as SectionElement).fields[0]
@@ -166,7 +163,6 @@ internal class TransformSpecToElementTest {
     fun `Add a email section spec sets up the email element correctly`() = runBlocking {
         val formElement = transformSpecToElements.transform(
             listOf(emailSection),
-            requiresMandate = false,
         )
 
         val emailSectionElement = formElement.first() as SectionElement
@@ -185,7 +181,6 @@ internal class TransformSpecToElementTest {
         )
         val formElement = transformSpecToElements.transform(
             listOf(staticText),
-            requiresMandate = false,
         )
 
         val staticTextElement = formElement.first() as StaticTextElement
@@ -199,7 +194,6 @@ internal class TransformSpecToElementTest {
     fun `Empty spec is transformed to single EmptyFormElement`() {
         val formElement = transformSpecToElements.transform(
             emptyList(),
-            requiresMandate = false,
         )
 
         assertThat(formElement).containsExactly(EmptyFormElement())
@@ -208,7 +202,7 @@ internal class TransformSpecToElementTest {
     @Test
     fun `UPI spec is transformed into UPI element wrapped in section`() {
         val upiSpec = UpiSpec()
-        val formElement = transformSpecToElements.transform(listOf(upiSpec), requiresMandate = false)
+        val formElement = transformSpecToElements.transform(listOf(upiSpec))
 
         val sectionElement = formElement.first() as SectionElement
         val upiElement = sectionElement.fields.first() as UpiElement
@@ -221,7 +215,6 @@ internal class TransformSpecToElementTest {
         val phoneSpec = PhoneSpec()
         val formElement = transformSpecToElements.transform(
             listOf(phoneSpec),
-            requiresMandate = false,
         )
 
         val phoneSectionElement = formElement.first() as SectionElement
@@ -240,7 +233,6 @@ internal class TransformSpecToElementTest {
         )
         val formElement = transformSpecToElements.transform(
             listOf(contactInfoSpec),
-            requiresMandate = false,
         )
 
         val sectionElement = formElement.first() as SectionElement

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FormControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FormControllerTest.kt
@@ -45,6 +45,7 @@ class FormControllerTest {
         shippingValues = null,
         cbcEligibility = CardBrandChoiceEligibility.Ineligible,
         billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
+        requiresMandate = false,
     )
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet.flowcontroller
 
 import android.content.res.ColorStateList
 import android.graphics.Color
-import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
@@ -346,6 +345,6 @@ class PaymentSelectionUpdaterTest {
     }
 
     private fun createUpdater(): PaymentSelectionUpdater {
-        return DefaultPaymentSelectionUpdater(ApplicationProvider.getApplicationContext())
+        return DefaultPaymentSelectionUpdater()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/MockPaymentMethodsFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/MockPaymentMethodsFactory.kt
@@ -39,7 +39,6 @@ internal object MockPaymentMethodsFactory {
     ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = code,
-            requiresMandate = false,
             displayNameResource = displayNameResource,
             iconResource = iconResource,
             lightThemeIconUrl = null,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
As suggested [here](https://github.com/stripe/stripe-android/pull/8115#discussion_r1529202084) we now have a single source of truth for requiresMandate.