### PR TITLE
Move institution picker to `LazyLayout`

### DIFF
--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -1780,14 +1780,14 @@ public final class com/stripe/android/financialconnections/ui/theme/ComposableSi
 	public static final field INSTANCE Lcom/stripe/android/financialconnections/ui/theme/ComposableSingletons$LayoutKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function3;
 	public static field lambda-2 Lkotlin/jvm/functions/Function3;
-	public static field lambda-3 Lkotlin/jvm/functions/Function3;
-	public static field lambda-4 Lkotlin/jvm/functions/Function2;
+	public static field lambda-3 Lkotlin/jvm/functions/Function2;
+	public static field lambda-4 Lkotlin/jvm/functions/Function3;
 	public static field lambda-5 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-4$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-4$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-5$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -15,7 +16,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
@@ -36,6 +36,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -85,6 +86,7 @@ import com.stripe.android.financialconnections.ui.components.StringAnnotation
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsColors
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.colors
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.typography
+import com.stripe.android.financialconnections.ui.theme.LazyLayout
 import kotlinx.coroutines.launch
 
 @Composable
@@ -162,7 +164,7 @@ private fun LoadedContent(
     onManualEntryClick: () -> Unit,
     onScrollChanged: () -> Unit,
 ) {
-    var input by remember { mutableStateOf(previewText ?: "") }
+    var input by rememberSaveable { mutableStateOf(previewText ?: "") }
     var shouldEmitScrollEvent by remember { mutableStateOf(true) }
     val searchInputFocusRequester = remember { FocusRequester() }
     val coroutineScope = rememberCoroutineScope()
@@ -184,39 +186,38 @@ private fun LoadedContent(
         // Disable overscroll as it does not play well with sticky headers.
         LocalOverscrollConfiguration provides null
     ) {
-        LazyColumn(
-            Modifier.padding(horizontal = 16.dp),
-            state = listState,
-            content = {
-                item { SearchTitle(modifier = Modifier.padding(horizontal = 8.dp)) }
-                item { Spacer(modifier = Modifier.height(24.dp)) }
-                stickyHeader(key = "searchRow") {
-                    SearchRow(
-                        focusRequester = searchInputFocusRequester,
-                        query = input,
-                        onQueryChanged = {
-                            input = it
-                            onQueryChanged(input)
-                        },
-                    )
-                }
-                item { Spacer(modifier = Modifier.height(8.dp)) }
-
-                searchResults(
-                    isInputEmpty = input.isBlank(),
-                    payload = payload,
-                    selectedInstitutionId = selectedInstitutionId,
-                    onInstitutionSelected = onInstitutionSelected,
-                    institutions = institutions,
-                    onManualEntryClick = onManualEntryClick,
-                    onSearchMoreClick = {
-                        // Scroll to the top of the list and focus on the search input
-                        coroutineScope.launch { listState.animateScrollToItem(index = 1) }
-                        searchInputFocusRequester.requestFocus()
-                    }
+        LazyLayout(
+            lazyListState = listState,
+            bodyPadding = PaddingValues(horizontal = 16.dp),
+        ) {
+            item { SearchTitle(modifier = Modifier.padding(horizontal = 8.dp)) }
+            item { Spacer(modifier = Modifier.height(24.dp)) }
+            stickyHeader(key = "searchRow") {
+                SearchRow(
+                    focusRequester = searchInputFocusRequester,
+                    query = input,
+                    onQueryChanged = {
+                        input = it
+                        onQueryChanged(input)
+                    },
                 )
             }
-        )
+            item { Spacer(modifier = Modifier.height(8.dp)) }
+
+            searchResults(
+                isInputEmpty = input.isBlank(),
+                payload = payload,
+                selectedInstitutionId = selectedInstitutionId,
+                onInstitutionSelected = onInstitutionSelected,
+                institutions = institutions,
+                onManualEntryClick = onManualEntryClick,
+                onSearchMoreClick = {
+                    // Scroll to the top of the list and focus on the search input
+                    coroutineScope.launch { listState.animateScrollToItem(index = 1) }
+                    searchInputFocusRequester.requestFocus()
+                }
+            )
+        }
     }
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/Destination.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/Destination.kt
@@ -130,9 +130,7 @@ internal sealed class Destination(
 
     data object LinkAccountPicker : Destination(
         route = Pane.LINK_ACCOUNT_PICKER.value,
-        composable = {
-            LinkAccountPickerScreen()
-        },
+        composable = { LinkAccountPickerScreen() },
     )
 
     data object LinkStepUpVerification : Destination(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Layout.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Layout.kt
@@ -92,13 +92,13 @@ internal fun Layout(
 @Composable
 internal fun LazyLayout(
     modifier: Modifier = Modifier,
-    body: LazyListScope.() -> Unit,
-    footer: (@Composable () -> Unit)? = null,
     bodyPadding: PaddingValues = PaddingValues(horizontal = 24.dp),
     inModal: Boolean = false,
     verticalArrangement: Arrangement.Vertical = Arrangement.Top,
     showFooterShadowWhenScrollable: Boolean = true,
-    lazyListState: LazyListState = rememberLazyListState()
+    lazyListState: LazyListState = rememberLazyListState(),
+    footer: (@Composable () -> Unit)? = null,
+    body: LazyListScope.() -> Unit,
 ) {
     LayoutScaffold(
         canScrollForward = lazyListState.canScrollForward,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request makes the institution picker use `LazyLayout` internally. This is the first step towards the navigation bar changes that we’ve been talking about.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
