### PR TITLE
Fix `TextField` selection issues.

### DIFF
--- a/stripe-ui-core/build.gradle
+++ b/stripe-ui-core/build.gradle
@@ -55,6 +55,8 @@ dependencies {
     testImplementation testLibs.androidx.archCore
     testImplementation testLibs.androidx.core
     testImplementation testLibs.androidx.junitKtx
+    testImplementation testLibs.androidx.composeUi
+    testImplementation testLibs.hamcrest
     testImplementation testLibs.junit
     testImplementation testLibs.kotlin.annotations
     testImplementation testLibs.kotlin.coroutines

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
@@ -175,21 +175,20 @@ fun TextField(
         ),
         loading = loading,
         onValueChange = { newValue ->
-            when (val newTextValue = newValue.text) {
-                value -> {
+            val newTextValue = newValue.text
+
+            if (newTextValue == value) {
+                selection = newValue.selection
+            } else {
+                val acceptInput = fieldState.canAcceptInput(value, newTextValue)
+
+                if (acceptInput) {
                     selection = newValue.selection
-                }
-                else -> {
-                    val acceptInput = fieldState.canAcceptInput(value, newTextValue)
 
-                    if (acceptInput) {
-                        selection = newValue.selection
+                    val newTextState = textFieldController.onValueChange(newTextValue)
 
-                        val newTextState = textFieldController.onValueChange(newTextValue)
-
-                        if (newTextState != null) {
-                            onTextStateChanged(newTextState)
-                        }
+                    if (newTextState != null) {
+                        onTextStateChanged(newTextState)
                     }
                 }
             }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
@@ -53,9 +53,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.editableText
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
@@ -128,8 +126,8 @@ fun TextFieldSection(
  * attribute of [textFieldController] is also taken into account to decide if the UI should be
  * enabled.
  */
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
+@Suppress("LongMethod")
 fun TextField(
     textFieldController: TextFieldController,
     enabled: Boolean,
@@ -176,20 +174,17 @@ fun TextField(
         loading = loading,
         onValueChange = { newValue ->
             val newTextValue = newValue.text
+            val acceptInput = fieldState.canAcceptInput(value, newTextValue)
 
-            if (newTextValue == value) {
+            if (newTextValue == value || acceptInput) {
                 selection = newValue.selection
-            } else {
-                val acceptInput = fieldState.canAcceptInput(value, newTextValue)
+            }
 
-                if (acceptInput) {
-                    selection = newValue.selection
+            if (acceptInput) {
+                val newTextState = textFieldController.onValueChange(newTextValue)
 
-                    val newTextState = textFieldController.onValueChange(newTextValue)
-
-                    if (newTextState != null) {
-                        onTextStateChanged(newTextState)
-                    }
+                if (newTextState != null) {
+                    onTextStateChanged(newTextState)
                 }
             }
         },
@@ -211,7 +206,6 @@ fun TextField(
             .focusRequester(focusRequester)
             .semantics {
                 this.contentDescription = contentDescription
-                this.editableText = AnnotatedString("")
             },
         enabled = enabled && textFieldController.enabled,
         label = label?.let {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/compat/CompatTextField.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/compat/CompatTextField.kt
@@ -130,8 +130,8 @@ import androidx.compose.ui.R as ComposeUiR
  */
 @Composable
 internal fun CompatTextField(
-    value: String,
-    onValueChange: (String) -> Unit,
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     readOnly: Boolean = false,
@@ -184,7 +184,7 @@ internal fun CompatTextField(
         decorationBox = @Composable { innerTextField ->
             // places leading icon, text field with label and placeholder, trailing icon
             CommonDecorationBox(
-                value = value,
+                value = value.text,
                 visualTransformation = visualTransformation,
                 innerTextField = innerTextField,
                 placeholder = placeholder,

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/TextFieldTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/TextFieldTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.hasInsertTextAtCursorAction
 import androidx.compose.ui.test.hasRequestFocusAction
 import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isEnabled
 import androidx.compose.ui.test.isFocused
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -36,7 +37,7 @@ class TextFieldTest {
     val composeTestRule = createComposeRule()
 
     @Test
-    fun `On initial value passed, selection should be at the start of the field`() {
+    fun `On initial value passed, selection should be at the end of the field`() {
         composeTestRule.setContent {
             TestTextField(initialValue = "A1B")
         }
@@ -58,6 +59,7 @@ class TextFieldTest {
         textField.performTextInput("C")
 
         textField.assert(hasTextSelection(TextRange(5)))
+        textField.assert(hasText("A1B2C"))
     }
 
     @Test
@@ -74,6 +76,7 @@ class TextFieldTest {
         textField.performTextInput("C")
 
         textField.assert(hasTextSelection(TextRange(3)))
+        textField.assert(hasText("A2C1B"))
     }
 
     @Test
@@ -85,6 +88,7 @@ class TextFieldTest {
         val textField = composeTestRule.onNodeWithTag(TEST_TAG)
 
         textField.performTextInput("A1B2C3")
+        textField.assert(hasText("A1B2C3"))
 
         textField.performTextInputSelection(TextRange(4))
         textField.assert(hasTextSelection(TextRange(4)))
@@ -99,7 +103,10 @@ class TextFieldTest {
     @Test
     fun `On text complete and attempted input, selection should not change`() {
         composeTestRule.setContent {
-            TestTextField(initialValue = null)
+            TestTextField(
+                initialValue = null,
+                maxInputLength = 6
+            )
         }
 
         val textField = composeTestRule.onNodeWithTag(TEST_TAG)
@@ -108,12 +115,15 @@ class TextFieldTest {
         textField.performTextInput("D4E")
 
         textField.assert(hasTextSelection(TextRange(6)))
+        textField.assert(hasText("A1B2C3"))
     }
 
     @Test
     fun `On text complete and attempted input from middle of text, selection should not change`() {
         composeTestRule.setContent {
-            TestTextField(initialValue = null)
+            TestTextField(
+                initialValue = null,
+            )
         }
 
         val textField = composeTestRule.onNodeWithTag(TEST_TAG)
@@ -123,15 +133,19 @@ class TextFieldTest {
         textField.performTextInput("D4E")
 
         textField.assert(hasTextSelection(TextRange(3)))
+        textField.assert(hasText("A1B2C3"))
     }
 
     @Composable
-    private fun TestTextField(initialValue: String?) {
+    private fun TestTextField(
+        initialValue: String?,
+        maxInputLength: Int = 6,
+    ) {
         TextField(
             modifier = Modifier.testTag(TEST_TAG),
             textFieldController = SimpleTextFieldController(
                 textFieldConfig = TestTextFieldConfig(
-                    maxInputLength = MAX_INPUT_LENGTH
+                    maxInputLength = maxInputLength
                 ),
                 initialValue = initialValue
             ),
@@ -198,6 +212,5 @@ class TextFieldTest {
     companion object {
         private const val TEST_TAG = "CORE_TEXT_FIELD"
         private const val ERROR_ON_FAIL = "Failed to perform text selection."
-        private const val MAX_INPUT_LENGTH = 6
     }
 }

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/TextFieldTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/TextFieldTest.kt
@@ -1,0 +1,203 @@
+package com.stripe.android.uicore.elements
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.R
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties.TextSelectionRange
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.hasInsertTextAtCursorAction
+import androidx.compose.ui.test.hasRequestFocusAction
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.isEnabled
+import androidx.compose.ui.test.isFocused
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TextFieldTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `On initial value passed, selection should be at the start of the field`() {
+        composeTestRule.setContent {
+            TestTextField(initialValue = "A1B")
+        }
+
+        composeTestRule
+            .onNodeWithTag(TEST_TAG)
+            .assert(hasTextSelection(TextRange(3)))
+    }
+
+    @Test
+    fun `On input, selection should move with input`() {
+        composeTestRule.setContent {
+            TestTextField(initialValue = "A1B")
+        }
+
+        val textField = composeTestRule.onNodeWithTag(TEST_TAG)
+
+        textField.performTextInput("2")
+        textField.performTextInput("C")
+
+        textField.assert(hasTextSelection(TextRange(5)))
+    }
+
+    @Test
+    fun `On input in middle of text, selection should move with input`() {
+        composeTestRule.setContent {
+            TestTextField(initialValue = "A1B")
+        }
+
+        val textField = composeTestRule.onNodeWithTag(TEST_TAG)
+
+        textField.performTextInputSelection(TextRange(1))
+
+        textField.performTextInput("2")
+        textField.performTextInput("C")
+
+        textField.assert(hasTextSelection(TextRange(3)))
+    }
+
+    @Test
+    fun `On text complete, should be able to change selection without changing text`() {
+        composeTestRule.setContent {
+            TestTextField(initialValue = null)
+        }
+
+        val textField = composeTestRule.onNodeWithTag(TEST_TAG)
+
+        textField.performTextInput("A1B2C3")
+
+        textField.performTextInputSelection(TextRange(4))
+        textField.assert(hasTextSelection(TextRange(4)))
+
+        textField.performTextInputSelection(TextRange(2))
+        textField.assert(hasTextSelection(TextRange(2)))
+
+        textField.performTextInputSelection(TextRange(1, 4))
+        textField.assert(hasTextSelection(TextRange(1, 4)))
+    }
+
+    @Test
+    fun `On text complete and attempted input, selection should not change`() {
+        composeTestRule.setContent {
+            TestTextField(initialValue = null)
+        }
+
+        val textField = composeTestRule.onNodeWithTag(TEST_TAG)
+
+        textField.performTextInput("A1B2C3")
+        textField.performTextInput("D4E")
+
+        textField.assert(hasTextSelection(TextRange(6)))
+    }
+
+    @Test
+    fun `On text complete and attempted input from middle of text, selection should not change`() {
+        composeTestRule.setContent {
+            TestTextField(initialValue = null)
+        }
+
+        val textField = composeTestRule.onNodeWithTag(TEST_TAG)
+
+        textField.performTextInput("A1B2C3")
+        textField.performTextInputSelection(TextRange(3))
+        textField.performTextInput("D4E")
+
+        textField.assert(hasTextSelection(TextRange(3)))
+    }
+
+    @Composable
+    private fun TestTextField(initialValue: String?) {
+        TextField(
+            modifier = Modifier.testTag(TEST_TAG),
+            textFieldController = SimpleTextFieldController(
+                textFieldConfig = TestTextFieldConfig(
+                    maxInputLength = MAX_INPUT_LENGTH
+                ),
+                initialValue = initialValue
+            ),
+            enabled = true,
+            imeAction = ImeAction.Next,
+        )
+    }
+
+    private class TestTextFieldConfig(
+        private val maxInputLength: Int
+    ) : TextFieldConfig {
+        override val capitalization: KeyboardCapitalization = KeyboardCapitalization.Characters
+        override val debugLabel: String = TEST_TAG
+        override val label: Int? = null
+        override val keyboard: KeyboardType = KeyboardType.Text
+        override val visualTransformation: VisualTransformation? = null
+        override val trailingIcon: StateFlow<TextFieldIcon?> = MutableStateFlow(null)
+        override val loading: StateFlow<Boolean> = MutableStateFlow(false)
+
+        override fun determineState(input: String): TextFieldState {
+            return if (input.length == maxInputLength) {
+                TextFieldStateConstants.Valid.Full
+            } else if (input.length > maxInputLength) {
+                TextFieldStateConstants.Error.Invalid(
+                    R.string.default_error_message
+                )
+            } else {
+                TextFieldStateConstants.Error.Incomplete(
+                    R.string.default_error_message
+                )
+            }
+        }
+
+        override fun filter(userTyped: String) = userTyped
+
+        override fun convertToRaw(displayName: String) = displayName
+
+        override fun convertFromRaw(rawValue: String) = rawValue
+    }
+
+    private fun hasTextSelection(range: TextRange): SemanticsMatcher {
+        return SemanticsMatcher.expectValue(TextSelectionRange, range)
+    }
+
+    private fun SemanticsNodeInteraction.performTextInputSelection(
+        selection: TextRange
+    ) {
+        val node = fetchSemanticsNode(ERROR_ON_FAIL)
+
+        assert(isEnabled()) { ERROR_ON_FAIL }
+        assert(hasSetTextAction()) { ERROR_ON_FAIL }
+        assert(hasRequestFocusAction()) { ERROR_ON_FAIL }
+        assert(hasInsertTextAtCursorAction()) { ERROR_ON_FAIL }
+
+        if (!isFocused().matches(node)) {
+            performSemanticsAction(SemanticsActions.RequestFocus)
+        }
+
+        performSemanticsAction(SemanticsActions.SetSelection) {
+            it(selection.min, selection.max, true)
+        }
+    }
+
+    companion object {
+        private const val TEST_TAG = "CORE_TEXT_FIELD"
+        private const val ERROR_ON_FAIL = "Failed to perform text selection."
+        private const val MAX_INPUT_LENGTH = 6
+    }
+}

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/TextFieldUiScreenshotTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/TextFieldUiScreenshotTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.uicore.elements
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.R
@@ -28,7 +29,7 @@ class TextFieldUiScreenshotTest {
         paparazziRule.snapshot {
             TextFieldUi(
                 label = "Search",
-                value = "John Doe",
+                value = TextFieldValue("John Doe"),
                 enabled = true,
                 loading = false,
                 placeholder = null,
@@ -44,7 +45,7 @@ class TextFieldUiScreenshotTest {
         paparazziRule.snapshot {
             TextFieldUi(
                 label = "Search",
-                value = "John Doe",
+                value = TextFieldValue("John Doe"),
                 enabled = false,
                 loading = false,
                 placeholder = null,
@@ -60,7 +61,7 @@ class TextFieldUiScreenshotTest {
         paparazziRule.snapshot {
             TextFieldUi(
                 label = "Search",
-                value = "John Doe",
+                value = TextFieldValue("John Doe"),
                 enabled = true,
                 loading = false,
                 placeholder = null,
@@ -76,7 +77,7 @@ class TextFieldUiScreenshotTest {
         paparazziRule.snapshot {
             TextFieldUi(
                 label = "Search",
-                value = "John Doe",
+                value = TextFieldValue("John Doe"),
                 enabled = true,
                 loading = false,
                 placeholder = null,
@@ -92,7 +93,7 @@ class TextFieldUiScreenshotTest {
         paparazziRule.snapshot {
             TextFieldUi(
                 label = "Search",
-                value = "John Doe",
+                value = TextFieldValue("John Doe"),
                 enabled = true,
                 loading = false,
                 placeholder = null,
@@ -111,7 +112,7 @@ class TextFieldUiScreenshotTest {
         paparazziRule.snapshot {
             TextFieldUi(
                 label = "Search",
-                value = "John Doe",
+                value = TextFieldValue("John Doe"),
                 enabled = true,
                 loading = false,
                 placeholder = null,
@@ -142,7 +143,7 @@ class TextFieldUiScreenshotTest {
         paparazziRule.snapshot {
             TextFieldUi(
                 label = "Card number",
-                value = "4000 0025 0000 1001",
+                value = TextFieldValue("4000 0025 0000 1001"),
                 enabled = true,
                 loading = false,
                 placeholder = null,
@@ -173,7 +174,7 @@ class TextFieldUiScreenshotTest {
         paparazziRule.snapshot {
             TextFieldUi(
                 label = "Search",
-                value = "",
+                value = TextFieldValue(""),
                 enabled = true,
                 loading = false,
                 placeholder = null,
@@ -189,7 +190,7 @@ class TextFieldUiScreenshotTest {
         paparazziRule.snapshot {
             TextFieldUi(
                 label = "Search",
-                value = "John Doe",
+                value = TextFieldValue("John Doe"),
                 enabled = false,
                 loading = false,
                 placeholder = null,
@@ -205,7 +206,7 @@ class TextFieldUiScreenshotTest {
         paparazziRule.snapshot {
             TextFieldUi(
                 label = "Search",
-                value = "",
+                value = TextFieldValue(""),
                 enabled = true,
                 loading = false,
                 placeholder = "Search for someone...",
@@ -221,7 +222,7 @@ class TextFieldUiScreenshotTest {
         paparazziRule.snapshot {
             TextFieldUi(
                 label = "Search",
-                value = "",
+                value = TextFieldValue(""),
                 enabled = false,
                 loading = false,
                 placeholder = "Search for someone...",


### PR DESCRIPTION
# Summary
Jetpack Compose keeps `BasicTextField` fairly stateless in comparison to `EditText`.  This PR fixes several issues with `TextField` selection (cursor position and text selection):
- `TextField` selection not initially starting at the end of the text.
- Cursor moving while text was not changed.

The behavior for selections in `TextField` are changed as follows:
- If a user focuses on a field on the first time, the cursor position will be placed at the end of text.
- If a user makes a selection without changing the text, the selection will changed.
- If a user tries to enter input for `TextField` after it is complete (reached max characters for use case), the cursor position will no longer change and stay where it currently is.

**Note**
After a user makes a selection, that selection is maintained both while in and out of focus until the user manually changes it. 

If the user makes a selection change in one `TextField` then goes back to a previous `TextField` and makes change which causes the `TextField` to be complete and push focus back to the next `TextField`, its selection change is maintained. You can see an example of what this looks like at the end of the video below.

There isn't a good solution for this as updating the selection when the field is focused would conflict with users manually focusing on the field by pressing it which could also change the selection. On top of that, we don't have a way of checking if the focus change came from the user or was requested by the system.

# Motivation
Resolves [RUN_MOBILESDK-3019](https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3019)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Video
https://github.com/stripe/stripe-android/assets/141707240/e8084ada-045a-4db4-a4c1-7333544a5e6c


