### PR TITLE
Add a UiDefinitionFactory abstraction.

### DIFF
--- a/payments-ui-core/src/main/assets/lpms.json
+++ b/payments-ui-core/src/main/assets/lpms.json
@@ -911,11 +911,6 @@
     ]
   },
   {
-    "type": "us_bank_account",
-    "async": true,
-    "fields": []
-  },
-  {
     "type": "grabpay",
     "async": false,
     "fields": [],

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodDefinition.kt
@@ -1,14 +1,10 @@
 package com.stripe.android.lpmfoundations.paymentmethod
 
 import com.stripe.android.lpmfoundations.luxe.SetupFutureUsageFieldConfiguration
-import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
-import com.stripe.android.lpmfoundations.luxe.TransformSpecToElements
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.ui.core.elements.SharedDataSpec
-import com.stripe.android.uicore.elements.FormElement
 
 internal interface PaymentMethodDefinition {
     /**
@@ -28,19 +24,7 @@ internal interface PaymentMethodDefinition {
      */
     fun requirementsToBeUsedAsNewPaymentMethod(hasIntentToSetup: Boolean): Set<AddPaymentMethodRequirement>
 
-    fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod
-
-    fun createFormElements(
-        metadata: PaymentMethodMetadata,
-        sharedDataSpec: SharedDataSpec,
-        transformSpecToElements: TransformSpecToElements,
-    ): List<FormElement> {
-        return transformSpecToElements.transform(
-            specs = sharedDataSpec.fields,
-        )
-    }
+    fun uiDefinitionFactory(): UiDefinitionFactory
 }
 
 internal fun PaymentMethodDefinition.isSupported(metadata: PaymentMethodMetadata): Boolean {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
@@ -1,0 +1,80 @@
+package com.stripe.android.lpmfoundations.paymentmethod
+
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.luxe.TransformSpecToElements
+import com.stripe.android.ui.core.elements.SharedDataSpec
+import com.stripe.android.uicore.elements.FormElement
+
+internal sealed interface UiDefinitionFactory {
+    interface RequiresSharedDataSpec : UiDefinitionFactory {
+        fun createSupportedPaymentMethod(
+            sharedDataSpec: SharedDataSpec,
+        ): SupportedPaymentMethod
+
+        fun createFormElements(
+            metadata: PaymentMethodMetadata,
+            sharedDataSpec: SharedDataSpec,
+            transformSpecToElements: TransformSpecToElements,
+        ): List<FormElement> {
+            return transformSpecToElements.transform(
+                specs = sharedDataSpec.fields,
+            )
+        }
+    }
+
+    interface Simple : UiDefinitionFactory {
+        fun createSupportedPaymentMethod(): SupportedPaymentMethod
+        fun createFormElements(metadata: PaymentMethodMetadata): List<FormElement>
+    }
+
+    fun canBeDisplayedInUi(
+        definition: PaymentMethodDefinition,
+        sharedDataSpecs: List<SharedDataSpec>,
+    ): Boolean = when (this) {
+        is Simple -> {
+            true
+        }
+
+        is RequiresSharedDataSpec -> {
+            sharedDataSpecs.firstOrNull { it.type == definition.type.code } != null
+        }
+    }
+
+    fun supportedPaymentMethod(
+        definition: PaymentMethodDefinition,
+        sharedDataSpecs: List<SharedDataSpec>,
+    ): SupportedPaymentMethod? = when (this) {
+        is Simple -> {
+            createSupportedPaymentMethod()
+        }
+
+        is RequiresSharedDataSpec -> {
+            val sharedDataSpec = sharedDataSpecs.firstOrNull { it.type == definition.type.code }
+            if (sharedDataSpec != null) {
+                createSupportedPaymentMethod(sharedDataSpec)
+            } else {
+                null
+            }
+        }
+    }
+
+    fun formElements(
+        definition: PaymentMethodDefinition,
+        metadata: PaymentMethodMetadata,
+        sharedDataSpecs: List<SharedDataSpec>,
+        transformSpecToElements: TransformSpecToElements,
+    ): List<FormElement>? = when (this) {
+        is Simple -> {
+            createFormElements(metadata)
+        }
+
+        is RequiresSharedDataSpec -> {
+            val sharedDataSpec = sharedDataSpecs.firstOrNull { it.type == definition.type.code }
+            if (sharedDataSpec != null) {
+                createFormElements(metadata, sharedDataSpec, transformSpecToElements)
+            } else {
+                null
+            }
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AffirmDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AffirmDefinition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -22,14 +23,14 @@ internal object AffirmDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_affirm,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_affirm,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = AffirmUiDefinitionFactory
+}
+
+private object AffirmUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = AffirmDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_affirm,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_affirm,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AfterpayClearpayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AfterpayClearpayDefinition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.AfterpayClearpayHeaderElement
@@ -23,18 +24,18 @@ internal object AfterpayClearpayDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = if (AfterpayClearpayHeaderElement.isClearpay()) {
-                R.string.stripe_paymentsheet_payment_method_clearpay
-            } else {
-                R.string.stripe_paymentsheet_payment_method_afterpay
-            },
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_afterpay_clearpay,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = AfterpayClearpayUiDefinitionFactory
+}
+
+private object AfterpayClearpayUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = AfterpayClearpayDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = if (AfterpayClearpayHeaderElement.isClearpay()) {
+            R.string.stripe_paymentsheet_payment_method_clearpay
+        } else {
+            R.string.stripe_paymentsheet_payment_method_afterpay
+        },
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_afterpay_clearpay,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlipayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlipayDefinition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -21,14 +22,14 @@ internal object AlipayDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_alipay,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_alipay,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = AlipayUiDefinitionFactory
+}
+
+private object AlipayUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = AlipayDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_alipay,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_alipay,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlmaDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlmaDefinition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -21,14 +22,14 @@ internal object AlmaDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_alma,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_alma,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = AlmaUiDefinitionFactory
+}
+
+private object AlmaUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = AlmaDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_alma,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_alma,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AmazonPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AmazonPayDefinition.kt
@@ -5,6 +5,7 @@ import com.stripe.android.lpmfoundations.luxe.TransformSpecToElements
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.FormItemSpec
@@ -23,23 +24,23 @@ internal object AmazonPayDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup()
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_amazon_pay,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_amazon_pay,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = AmazonPayUiDefinitionFactory
+}
+
+private object AmazonPayUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = AmazonPayDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_amazon_pay,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_amazon_pay,
+    )
 
     override fun createFormElements(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
         transformSpecToElements: TransformSpecToElements
     ): List<FormElement> {
-        val localLayoutSpecs: List<FormItemSpec> = if (requiresMandate(metadata)) {
+        val localLayoutSpecs: List<FormItemSpec> = if (AmazonPayDefinition.requiresMandate(metadata)) {
             listOf(MandateTextSpec(stringResId = R.string.stripe_amazon_pay_mandate))
         } else {
             emptyList()

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AuBecsDebitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AuBecsDebitDefinition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -21,15 +22,15 @@ internal object AuBecsDebitDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = true
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_au_becs_debit,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_bank,
-            tintIconOnSelection = true,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = AuBecsDebitUiDefinitionFactory
+}
+
+private object AuBecsDebitUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = AuBecsDebitDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_au_becs_debit,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_bank,
+        tintIconOnSelection = true,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BacsDebitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BacsDebitDefinition.kt
@@ -5,6 +5,7 @@ import com.stripe.android.lpmfoundations.luxe.TransformSpecToElements
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.BacsDebitBankAccountSpec
@@ -28,17 +29,17 @@ internal object BacsDebitDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = true
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_bacs_debit,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_bank,
-            tintIconOnSelection = true,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = BacsDebitUiDefinitionFactory
+}
+
+private object BacsDebitUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = BacsDebitDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_bacs_debit,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_bank,
+        tintIconOnSelection = true,
+    )
 
     override fun createFormElements(
         metadata: PaymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BancontactDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BancontactDefinition.kt
@@ -5,6 +5,7 @@ import com.stripe.android.lpmfoundations.luxe.TransformSpecToElements
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -24,16 +25,16 @@ internal object BancontactDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup()
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_bancontact,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_bancontact,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = BancontactUiDefinitionFactory
+}
+
+private object BancontactUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = BancontactDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_bancontact,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_bancontact,
+    )
 
     override fun createFormElements(
         metadata: PaymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikDefinition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -21,14 +22,14 @@ internal object BlikDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_blik,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_blik,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = BlikUiDefinitionFactory
+}
+
+private object BlikUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = BlikDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_blik,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_blik,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoDefinition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -21,14 +22,14 @@ internal object BoletoDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_boleto,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_boleto,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = BoletoUiDefinitionFactory
+}
+
+private object BoletoUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = BoletoDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_boleto,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_boleto,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -5,6 +5,7 @@ import com.stripe.android.lpmfoundations.luxe.TransformSpecToElements
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
@@ -27,17 +28,17 @@ internal object CardDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_card,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_card,
-            tintIconOnSelection = true,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = CardUiDefinitionFactory
+}
+
+private object CardUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = CardDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_card,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_card,
+        tintIconOnSelection = true,
+    )
 
     override fun createFormElements(
         metadata: PaymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CashAppPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CashAppPayDefinition.kt
@@ -5,6 +5,7 @@ import com.stripe.android.lpmfoundations.luxe.TransformSpecToElements
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.CashAppPayMandateTextSpec
@@ -22,25 +23,23 @@ internal object CashAppPayDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup()
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            code = "cashapp",
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_cashapp,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_cash_app_pay,
-            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
-            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
-            tintIconOnSelection = false,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = CashAppPayUiDefinitionFactory
+}
+
+private object CashAppPayUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = CashAppPayDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_cashapp,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_cash_app_pay,
+    )
 
     override fun createFormElements(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
         transformSpecToElements: TransformSpecToElements
     ): List<FormElement> {
-        val localLayoutSpecs = if (requiresMandate(metadata)) {
+        val localLayoutSpecs = if (CashAppPayDefinition.requiresMandate(metadata)) {
             listOf(CashAppPayMandateTextSpec())
         } else {
             emptyList()

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/EpsDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/EpsDefinition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -21,14 +22,14 @@ internal object EpsDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = true
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_eps,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_eps,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = EpsUiDefinitionFactory
+}
+
+private object EpsUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = EpsDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_eps,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_eps,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/FpxDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/FpxDefinition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -21,15 +22,15 @@ internal object FpxDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_fpx,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_fpx,
-            tintIconOnSelection = false,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = FpxUiDefinitionFactory
+}
+
+private object FpxUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = FpxDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_fpx,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_fpx,
+        tintIconOnSelection = false,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/GiroPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/GiroPayDefinition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -21,14 +22,14 @@ internal object GiroPayDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_giropay,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_giropay,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = GiroPayUiDefinitionFactory
+}
+
+private object GiroPayUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = GiroPayDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_giropay,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_giropay,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/GrabPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/GrabPayDefinition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -21,14 +22,14 @@ internal object GrabPayDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_grabpay,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_grabpay,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = GrabPayUiDefinitionFactory
+}
+
+private object GrabPayUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = GrabPayDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_grabpay,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_grabpay,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/IdealDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/IdealDefinition.kt
@@ -5,6 +5,7 @@ import com.stripe.android.lpmfoundations.luxe.TransformSpecToElements
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -24,16 +25,16 @@ internal object IdealDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup()
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_ideal,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_ideal,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = IdealUiDefinitionFactory
+}
+
+private object IdealUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = IdealDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_ideal,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_ideal,
+    )
 
     override fun createFormElements(
         metadata: PaymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
@@ -5,6 +5,7 @@ import com.stripe.android.lpmfoundations.luxe.TransformSpecToElements
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.KlarnaMandateTextSpec
@@ -22,23 +23,23 @@ internal object KlarnaDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup()
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_klarna,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_klarna,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = KlarnaUiDefinitionFactory
+}
+
+private object KlarnaUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = KlarnaDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_klarna,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_klarna,
+    )
 
     override fun createFormElements(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
         transformSpecToElements: TransformSpecToElements
     ): List<FormElement> {
-        val localLayoutSpecs = if (requiresMandate(metadata)) {
+        val localLayoutSpecs = if (KlarnaDefinition.requiresMandate(metadata)) {
             listOf(KlarnaMandateTextSpec())
         } else {
             emptyList()

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KonbiniDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KonbiniDefinition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -22,14 +23,14 @@ internal object KonbiniDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_konbini,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_konbini,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = KonbiniUiDefinitionFactory
+}
+
+private object KonbiniUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = KonbiniDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_konbini,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_konbini,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/MobilePayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/MobilePayDefinition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -21,14 +22,14 @@ internal object MobilePayDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_mobile_pay,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_mobile_pay,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = MobilePayUiDefinitionFactory
+}
+
+private object MobilePayUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = MobilePayDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_mobile_pay,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_mobile_pay,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/OxxoDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/OxxoDefinition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -22,16 +23,16 @@ internal object OxxoDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            code = type.code,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_oxxo,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_oxxo,
-            lightThemeIconUrl = null,
-            darkThemeIconUrl = null,
-            tintIconOnSelection = false,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = OxxoUiDefinitionFactory
+}
+
+private object OxxoUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        code = OxxoDefinition.type.code,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_oxxo,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_oxxo,
+        lightThemeIconUrl = null,
+        darkThemeIconUrl = null,
+        tintIconOnSelection = false,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/P24Definition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/P24Definition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -21,14 +22,14 @@ internal object P24Definition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_p24,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_p24,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = P24UiDefinitionFactory
+}
+
+private object P24UiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = P24Definition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_p24,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_p24,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPalDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPalDefinition.kt
@@ -5,6 +5,7 @@ import com.stripe.android.lpmfoundations.luxe.TransformSpecToElements
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.FormItemSpec
@@ -23,16 +24,16 @@ internal object PayPalDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup()
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_paypal,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_paypal,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = PayPalUiDefinitionFactory
+}
+
+private object PayPalUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = PayPalDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_paypal,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_paypal,
+    )
 
     override fun createFormElements(
         metadata: PaymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/RevolutPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/RevolutPayDefinition.kt
@@ -5,6 +5,7 @@ import com.stripe.android.lpmfoundations.luxe.TransformSpecToElements
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.FormItemSpec
@@ -23,23 +24,23 @@ internal object RevolutPayDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup()
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_revolut_pay,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_revolut_pay,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = RevolutPayUiDefinitionFactory
+}
+
+private object RevolutPayUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = RevolutPayDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_revolut_pay,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_revolut_pay,
+    )
 
     override fun createFormElements(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
         transformSpecToElements: TransformSpecToElements
     ): List<FormElement> {
-        val localLayoutSpecs: List<FormItemSpec> = if (requiresMandate(metadata)) {
+        val localLayoutSpecs: List<FormItemSpec> = if (RevolutPayDefinition.requiresMandate(metadata)) {
             listOf(MandateTextSpec(stringResId = R.string.stripe_revolut_mandate))
         } else {
             emptyList()

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitDefinition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -21,14 +22,14 @@ internal object SepaDebitDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = true
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_sepa_debit,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_sepa_debit,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = SepaDebitUiDefinitionFactory
+}
+
+private object SepaDebitUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = SepaDebitDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_sepa_debit,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_sepa_debit,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SofortDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SofortDefinition.kt
@@ -5,6 +5,7 @@ import com.stripe.android.lpmfoundations.luxe.TransformSpecToElements
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -24,16 +25,16 @@ internal object SofortDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup()
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_sofort,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_klarna,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = SofortUiDefinitionFactory
+}
+
+private object SofortUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = SofortDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_sofort,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_klarna,
+    )
 
     override fun createFormElements(
         metadata: PaymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SwishDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SwishDefinition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -21,14 +22,14 @@ internal object SwishDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_swish,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_swish,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = SwishUiDefinitionFactory
+}
+
+private object SwishUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = SwishDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_swish,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_swish,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/TwintDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/TwintDefinition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -21,14 +22,14 @@ internal object TwintDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_twint,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_twint,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = TwintUiDefinitionFactory
+}
+
+private object TwintUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = TwintDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_twint,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_twint,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UpiDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UpiDefinition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -21,14 +22,14 @@ internal object UpiDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_upi,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_upi,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = UpiUiDefinitionFactory
+}
+
+private object UpiUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = UpiDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_upi,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_upi,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UsBankAccountDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UsBankAccountDefinition.kt
@@ -4,9 +4,10 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
-import com.stripe.android.ui.core.elements.SharedDataSpec
+import com.stripe.android.uicore.elements.FormElement
 
 internal object UsBankAccountDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.USBankAccount
@@ -23,15 +24,19 @@ internal object UsBankAccountDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = true
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_us_bank_account,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_bank,
-            tintIconOnSelection = true,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = UsBankAccountUiDefinitionFactory
+}
+
+private object UsBankAccountUiDefinitionFactory : UiDefinitionFactory.Simple {
+    override fun createSupportedPaymentMethod(): SupportedPaymentMethod = SupportedPaymentMethod(
+        code = UsBankAccountDefinition.type.code,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_us_bank_account,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_bank,
+        tintIconOnSelection = true,
+        lightThemeIconUrl = null,
+        darkThemeIconUrl = null,
+    )
+
+    // US Bank Account uses it's own mechanism, not these form elements.
+    override fun createFormElements(metadata: PaymentMethodMetadata): List<FormElement> = emptyList()
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeChatPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeChatPayDefinition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -21,14 +22,14 @@ internal object WeChatPayDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_wechat,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_wechat_pay,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = WeChatPayUiDefinitionFactory
+}
+
+private object WeChatPayUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = WeChatPayDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_wechat,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_wechat_pay,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/ZipDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/ZipDefinition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.SharedDataSpec
@@ -21,14 +22,14 @@ internal object ZipDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun supportedPaymentMethod(
-        sharedDataSpec: SharedDataSpec,
-    ): SupportedPaymentMethod {
-        return SupportedPaymentMethod(
-            paymentMethodDefinition = this,
-            sharedDataSpec = sharedDataSpec,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_zip,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_zip,
-        )
-    }
+    override fun uiDefinitionFactory(): UiDefinitionFactory = ZipUiDefinitionFactory
+}
+
+private object ZipUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createSupportedPaymentMethod(sharedDataSpec: SharedDataSpec) = SupportedPaymentMethod(
+        paymentMethodDefinition = ZipDefinition,
+        sharedDataSpec = sharedDataSpec,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_zip,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_zip,
+    )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -236,6 +236,23 @@ internal class PaymentMethodMetadataTest {
     }
 
     @Test
+    fun `sortedSupportedPaymentMethods keeps us_bank_account without a sharedDataSpec`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "us_bank_account"),
+                paymentMethodOptionsJsonString = """{"us_bank_account":{"verification_method":"automatic"}}""",
+            ),
+            sharedDataSpecs = listOf(
+                SharedDataSpec("card"),
+            ),
+        )
+        val sortedSupportedPaymentMethods = metadata.sortedSupportedPaymentMethods()
+        assertThat(sortedSupportedPaymentMethods).hasSize(2)
+        assertThat(sortedSupportedPaymentMethods[0].code).isEqualTo("card")
+        assertThat(sortedSupportedPaymentMethods[1].code).isEqualTo("us_bank_account")
+    }
+
+    @Test
     fun `sortedSupportedPaymentMethods sorts on custom sort`() {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This is ALMOST a pure refactor. I did change the behavior of us_bank_account to test the new UiDefinitionFactory.Simple. This also removes the need for a "fake LUXE spec" for us_bank_account 🎉 !!!!

The long term goal with this is to move non LUXE LPMs off of the "fake" (android only) LUXE specs!