### PR TITLE
Populate `FormViewModel.ViewData` with form elements & remove redundant check for `customerACHv2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### PaymentSheet
 * [Added] Support for Klarna with SetupIntents and PaymentIntents with `setup_future_usage`.
+* [FIXED][8142](https://github.com/stripe/stripe-android/pull/8142) Fixed an issue with `CustomerSheet` where the form fields were not displayed when adding a payment method.
 
 ## 20.40.0 - 2024-03-18
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -776,8 +776,9 @@ internal class CustomerSheetViewModel(
             to = CustomerSheetViewState.AddPaymentMethod(
                 paymentMethodCode = paymentMethodCode,
                 supportedPaymentMethods = supportedPaymentMethods,
-                formElements = formElements,
-                formViewData = FormViewModel.ViewData(),
+                formViewData = FormViewModel.ViewData(
+                    elements = formElements
+                ),
                 formArguments = formArguments,
                 usBankAccountFormArguments = USBankAccountFormArguments(
                     onBehalfOf = null,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
@@ -17,7 +17,6 @@ import com.stripe.android.paymentsheet.ui.PaymentSheetTopBarState
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBarStateFactory
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
-import com.stripe.android.uicore.elements.FormElement
 
 internal sealed class CustomerSheetViewState(
     open val savedPaymentMethods: List<PaymentMethod>,
@@ -112,7 +111,6 @@ internal sealed class CustomerSheetViewState(
     data class AddPaymentMethod(
         val paymentMethodCode: PaymentMethodCode,
         val supportedPaymentMethods: List<SupportedPaymentMethod>,
-        val formElements: List<FormElement>,
         val formViewData: FormViewModel.ViewData,
         val formArguments: FormArguments,
         val usBankAccountFormArguments: USBankAccountFormArguments,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.stripe.android.common.ui.BottomSheetLoadingIndicator
 import com.stripe.android.common.ui.PrimaryButton
-import com.stripe.android.core.utils.FeatureFlags.customerSheetACHv2
 import com.stripe.android.customersheet.CustomerSheetViewAction
 import com.stripe.android.customersheet.CustomerSheetViewState
 import com.stripe.android.model.PaymentMethodCode
@@ -28,7 +27,6 @@ import com.stripe.android.paymentsheet.ui.PaymentOptions
 import com.stripe.android.paymentsheet.ui.PaymentSheetScaffold
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBar
 import com.stripe.android.paymentsheet.utils.PaymentSheetContentPadding
-import com.stripe.android.ui.core.FormUI
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.H4Text
 import com.stripe.android.ui.core.elements.SimpleDialogElementUI
@@ -75,18 +73,11 @@ internal fun CustomerSheetScreen(
                         PaymentSheetContentPadding()
                     }
                     is CustomerSheetViewState.AddPaymentMethod -> {
-                        if (customerSheetACHv2.isEnabled) {
-                            AddPaymentMethodWithPaymentElement(
-                                viewState = viewState,
-                                viewActionHandler = viewActionHandler,
-                                displayForm = displayAddForm,
-                            )
-                        } else {
-                            AddPaymentMethod(
-                                viewState = viewState,
-                                viewActionHandler = viewActionHandler,
-                            )
-                        }
+                        AddPaymentMethodWithPaymentElement(
+                            viewState = viewState,
+                            viewActionHandler = viewActionHandler,
+                            displayForm = displayAddForm,
+                        )
                         PaymentSheetContentPadding()
                     }
                     is CustomerSheetViewState.EditPaymentMethod -> {
@@ -181,49 +172,6 @@ internal fun SelectPaymentMethod(
 }
 
 @Composable
-internal fun AddPaymentMethod(
-    viewState: CustomerSheetViewState.AddPaymentMethod,
-    viewActionHandler: (CustomerSheetViewAction) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val horizontalPadding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
-
-    Column(
-        modifier = modifier.padding(horizontal = horizontalPadding),
-    ) {
-        H4Text(
-            text = stringResource(id = R.string.stripe_paymentsheet_save_a_new_payment_method),
-            modifier = Modifier
-                .padding(bottom = 20.dp)
-        )
-
-        FormUI(
-            hiddenIdentifiers = viewState.formViewData.hiddenIdentifiers,
-            enabled = viewState.enabled,
-            elements = viewState.formViewData.elements,
-            lastTextFieldIdentifier = viewState.formViewData.lastTextFieldIdentifier,
-            modifier = Modifier.padding(bottom = 8.dp),
-        )
-
-        AnimatedVisibility(visible = viewState.errorMessage != null) {
-            viewState.errorMessage?.let { error ->
-                ErrorMessage(error = error)
-            }
-        }
-
-        PrimaryButton(
-            label = stringResource(id = R.string.stripe_paymentsheet_save),
-            isEnabled = viewState.primaryButtonEnabled,
-            isLoading = viewState.isProcessing,
-            onButtonClick = {
-                viewActionHandler(CustomerSheetViewAction.OnPrimaryButtonPressed)
-            },
-            modifier = Modifier.padding(top = 10.dp),
-        )
-    }
-}
-
-@Composable
 internal fun AddPaymentMethodWithPaymentElement(
     viewState: CustomerSheetViewState.AddPaymentMethod,
     viewActionHandler: (CustomerSheetViewAction) -> Unit,
@@ -268,7 +216,7 @@ internal fun AddPaymentMethodWithPaymentElement(
                     enabled = viewState.enabled,
                     supportedPaymentMethods = viewState.supportedPaymentMethods,
                     selectedItem = viewState.selectedPaymentMethod,
-                    formElements = viewState.formElements,
+                    formElements = viewState.formViewData.elements,
                     linkSignupMode = null,
                     linkConfigurationCoordinator = null,
                     showCheckboxFlow = flowOf(false),

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -73,7 +73,7 @@ internal fun CustomerSheetScreen(
                         PaymentSheetContentPadding()
                     }
                     is CustomerSheetViewState.AddPaymentMethod -> {
-                        AddPaymentMethodWithPaymentElement(
+                        AddPaymentMethod(
                             viewState = viewState,
                             viewActionHandler = viewActionHandler,
                             displayForm = displayAddForm,
@@ -172,7 +172,8 @@ internal fun SelectPaymentMethod(
 }
 
 @Composable
-internal fun AddPaymentMethodWithPaymentElement(
+@Suppress("LongMethod")
+internal fun AddPaymentMethod(
     viewState: CustomerSheetViewState.AddPaymentMethod,
     viewActionHandler: (CustomerSheetViewAction) -> Unit,
     displayForm: Boolean,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
@@ -11,6 +11,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.utils.CustomerSheetTestHelper.createViewModel
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
@@ -21,6 +22,7 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
+import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils.viewModelFactoryFor
@@ -40,6 +42,12 @@ import java.util.Stack
 internal class CustomerSheetActivityTest {
     @get:Rule
     val rule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val featureFlagTestRule = FeatureFlagTestRule(
+        FeatureFlags.customerSheetACHv2,
+        isEnabled = true
+    )
 
     @get:Rule
     val composeTestRule = createEmptyComposeRule()
@@ -214,6 +222,29 @@ internal class CustomerSheetActivityTest {
     }
 
     @Test
+    fun `When customer ACHv2 is enabled, should display form elements`() {
+        val eventReporter: CustomerSheetEventReporter = mock()
+
+        runActivityScenario(
+            viewState = createAddPaymentMethodViewState(),
+            eventReporter = eventReporter,
+        ) {
+            page.waitForText("Card number")
+        }
+    }
+
+    @Test
+    fun `When customer ACHv2 is disabled, should display form elements`() {
+        featureFlagTestRule.setEnabled(false)
+
+        runActivityScenario(
+            viewState = createAddPaymentMethodViewState(),
+        ) {
+            page.waitForText("Card number")
+        }
+    }
+
+    @Test
     fun `When card number is completed, should execute event`() {
         val eventReporter: CustomerSheetEventReporter = mock()
 
@@ -305,7 +336,6 @@ internal class CustomerSheetActivityTest {
     private fun createAddPaymentMethodViewState(
         paymentMethodCode: PaymentMethodCode = PaymentMethod.Type.Card.code,
         isLiveMode: Boolean = false,
-        formViewData: FormViewModel.ViewData = FormViewModel.ViewData(),
         enabled: Boolean = true,
         isProcessing: Boolean = false,
     ): CustomerSheetViewState.AddPaymentMethod {
@@ -319,8 +349,9 @@ internal class CustomerSheetActivityTest {
         return CustomerSheetViewState.AddPaymentMethod(
             paymentMethodCode = paymentMethodCode,
             supportedPaymentMethods = listOf(card),
-            formElements = cardFormElements,
-            formViewData = formViewData,
+            formViewData = FormViewModel.ViewData(
+                elements = cardFormElements,
+            ),
             formArguments = FormArguments(
                 paymentMethodCode = PaymentMethod.Type.Card.code,
                 showCheckbox = false,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -96,7 +96,6 @@ internal class CustomerSheetScreenshotTest {
             LpmRepositoryTestHelpers.usBankAccount,
         ),
         selectedPaymentMethod = LpmRepositoryTestHelpers.card,
-        formElements = emptyList(),
         enabled = true,
         isLiveMode = false,
         isProcessing = false,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -20,8 +20,6 @@ import com.stripe.android.paymentsheet.ui.DefaultEditPaymentMethodViewInteractor
 import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
-import com.stripe.android.uicore.elements.IdentifierSpec
-import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.utils.screenshots.FontSize
 import com.stripe.android.utils.screenshots.PaparazziRule
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
@@ -224,80 +222,6 @@ internal class CustomerSheetScreenshotTest {
                     primaryButtonLabel = "Continue",
                     primaryButtonVisible = true,
                     mandateText = "Some mandate text."
-                ),
-                paymentMethodNameProvider = { it!! },
-            )
-        }
-    }
-
-    @Test
-    fun testAddPaymentMethodDisabled() {
-        paparazzi.snapshot {
-            CustomerSheetScreen(
-                viewState = addPaymentMethodViewState.copy(
-                    paymentMethodCode = PaymentMethod.Type.Card.code,
-                    formViewData = FormViewModel.ViewData(),
-                    errorMessage = "This is an error message.",
-                ),
-                paymentMethodNameProvider = { it!! },
-            )
-        }
-    }
-
-    @Test
-    fun testAddPaymentMethodEnabled() {
-        paparazzi.snapshot {
-            CustomerSheetScreen(
-                viewState = addPaymentMethodViewState.copy(
-                    paymentMethodCode = PaymentMethod.Type.Card.code,
-                    formViewData = FormViewModel.ViewData(
-                        completeFormValues = FormFieldValues(
-                            fieldValuePairs = mapOf(
-                                IdentifierSpec.Generic("test") to FormFieldEntry("test", true)
-                            ),
-                            showsMandate = true,
-                            userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestNoReuse
-                        )
-                    ),
-                    primaryButtonEnabled = true,
-                ),
-                paymentMethodNameProvider = { it!! },
-            )
-        }
-    }
-
-    @Test
-    fun testAddFirstPaymentMethodDisabled() {
-        paparazzi.snapshot {
-            CustomerSheetScreen(
-                viewState = addPaymentMethodViewState.copy(
-                    paymentMethodCode = PaymentMethod.Type.Card.code,
-                    formViewData = FormViewModel.ViewData(),
-                    errorMessage = "This is an error message.",
-                    isFirstPaymentMethod = true
-                ),
-                paymentMethodNameProvider = { it!! },
-            )
-        }
-    }
-
-    @Test
-    fun testAddFirstPaymentMethodEnabled() {
-        paparazzi.snapshot {
-            CustomerSheetScreen(
-                viewState = addPaymentMethodViewState.copy(
-                    paymentMethodCode = PaymentMethod.Type.Card.code,
-                    formViewData = FormViewModel.ViewData(
-                        completeFormValues = FormFieldValues(
-                            fieldValuePairs = mapOf(
-                                IdentifierSpec.Generic("test") to FormFieldEntry("test", true)
-                            ),
-                            showsMandate = true,
-                            userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestNoReuse
-                        )
-                    ),
-                    isFirstPaymentMethod = true,
-                    primaryButtonEnabled = true,
                 ),
                 paymentMethodNameProvider = { it!! },
             )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -49,6 +49,7 @@ import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.ui.core.elements.CardBillingAddressElement
 import com.stripe.android.ui.core.elements.CardDetailsSectionElement
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
+import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.forms.FormFieldEntry
@@ -459,11 +460,11 @@ class CustomerSheetViewModelTest {
             val item = awaitItem()
             assertThat(item).isInstanceOf(AddPaymentMethod::class.java)
 
-            val formElements = (item as AddPaymentMethod).formViewData.elements
+            val formElements = item.asAddState().formViewData.elements
 
             assertThat(formElements[0]).isInstanceOf(CardDetailsSectionElement::class.java)
             assertThat(formElements[1]).isInstanceOf(SectionElement::class.java)
-            assertThat((formElements[1] as SectionElement).fields[0])
+            assertThat(formElements[1].asSectionElement().fields[0])
                 .isInstanceOf(CardBillingAddressElement::class.java)
             assertThat(formElements[2]).isInstanceOf(SaveForFutureUseElement::class.java)
         }
@@ -485,11 +486,11 @@ class CustomerSheetViewModelTest {
             val item = awaitItem()
             assertThat(item).isInstanceOf(AddPaymentMethod::class.java)
 
-            val formElements = (item as AddPaymentMethod).formViewData.elements
+            val formElements = item.asAddState().formViewData.elements
 
             assertThat(formElements[0]).isInstanceOf(CardDetailsSectionElement::class.java)
             assertThat(formElements[1]).isInstanceOf(SectionElement::class.java)
-            assertThat((formElements[1] as SectionElement).fields[0])
+            assertThat(formElements[1].asSectionElement().fields[0])
                 .isInstanceOf(CardBillingAddressElement::class.java)
             assertThat(formElements[2]).isInstanceOf(SaveForFutureUseElement::class.java)
         }
@@ -2938,6 +2939,14 @@ class CustomerSheetViewModelTest {
         return CollectBankAccountResultInternal.Completed(
             response = bankAccountResponse,
         )
+    }
+
+    private fun CustomerSheetViewState.asAddState(): AddPaymentMethod {
+        return this as AddPaymentMethod
+    }
+
+    private fun FormElement.asSectionElement(): SectionElement {
+        return this as SectionElement
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -442,7 +442,7 @@ class CustomerSheetViewModelTest {
     }
 
     @Test
-    fun `When CustomerViewAction#OnAddCardPressed, view state is updated to CustomerViewAction#AddPaymentMethod`() = runTest(testDispatcher) {
+    fun `When CustomerViewAction#OnAddCardPressed, view state is updated to CustomerViewAction#AddPaymentMethod and fields are shwon`() = runTest(testDispatcher) {
         val viewModel = createViewModel(
             workContext = testDispatcher
         )
@@ -451,8 +451,29 @@ class CustomerSheetViewModelTest {
             assertThat(awaitItem())
                 .isInstanceOf(SelectPaymentMethod::class.java)
             viewModel.handleViewAction(CustomerSheetViewAction.OnAddCardPressed)
+
+            val item = awaitItem()
+            assertThat(item).isInstanceOf(AddPaymentMethod::class.java)
+            assertThat((item as AddPaymentMethod).formViewData.elements).isNotEmpty()
+        }
+    }
+
+    @Test
+    fun `When CustomerViewAction#OnAddCardPressed & ACHv2 disabled, view state is updated to CustomerViewAction#AddPaymentMethod and fields are shwon`() = runTest(testDispatcher) {
+        featureFlagTestRule.setEnabled(false)
+
+        val viewModel = createViewModel(
+            workContext = testDispatcher
+        )
+
+        viewModel.viewState.test {
             assertThat(awaitItem())
-                .isInstanceOf(AddPaymentMethod::class.java)
+                .isInstanceOf(SelectPaymentMethod::class.java)
+            viewModel.handleViewAction(CustomerSheetViewAction.OnAddCardPressed)
+
+            val item = awaitItem()
+            assertThat(item).isInstanceOf(AddPaymentMethod::class.java)
+            assertThat((item as AddPaymentMethod).formViewData.elements).isNotEmpty()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -46,7 +46,11 @@ import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentMethodFactory
+import com.stripe.android.ui.core.elements.CardBillingAddressElement
+import com.stripe.android.ui.core.elements.CardDetailsSectionElement
+import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor
 import kotlinx.coroutines.test.TestCoroutineScheduler
@@ -454,7 +458,14 @@ class CustomerSheetViewModelTest {
 
             val item = awaitItem()
             assertThat(item).isInstanceOf(AddPaymentMethod::class.java)
-            assertThat((item as AddPaymentMethod).formViewData.elements).isNotEmpty()
+
+            val formElements = (item as AddPaymentMethod).formViewData.elements
+
+            assertThat(formElements[0]).isInstanceOf(CardDetailsSectionElement::class.java)
+            assertThat(formElements[1]).isInstanceOf(SectionElement::class.java)
+            assertThat((formElements[1] as SectionElement).fields[0])
+                .isInstanceOf(CardBillingAddressElement::class.java)
+            assertThat(formElements[2]).isInstanceOf(SaveForFutureUseElement::class.java)
         }
     }
 
@@ -473,7 +484,14 @@ class CustomerSheetViewModelTest {
 
             val item = awaitItem()
             assertThat(item).isInstanceOf(AddPaymentMethod::class.java)
-            assertThat((item as AddPaymentMethod).formViewData.elements).isNotEmpty()
+
+            val formElements = (item as AddPaymentMethod).formViewData.elements
+
+            assertThat(formElements[0]).isInstanceOf(CardDetailsSectionElement::class.java)
+            assertThat(formElements[1]).isInstanceOf(SectionElement::class.java)
+            assertThat((formElements[1] as SectionElement).fields[0])
+                .isInstanceOf(CardBillingAddressElement::class.java)
+            assertThat(formElements[2]).isInstanceOf(SaveForFutureUseElement::class.java)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -101,7 +101,6 @@ internal object CustomerSheetTestHelper {
             LpmRepositoryTestHelpers.usBankAccount,
         ),
         selectedPaymentMethod = LpmRepositoryTestHelpers.card,
-        formElements = emptyList(),
         enabled = true,
         isLiveMode = false,
         isProcessing = false,


### PR DESCRIPTION
# Summary
Populate `FormViewModel.ViewData` with form elements & remove redundant check for `customerACHv2`.

We initialize `FormViewModel.ViewData` with empty form elements. While this isn't an issue when the local `customerACHv2` feature flag is enabled, it is an issue when it is.

We have two different paths for showing the form in `CustomerSheetScreen`:
- When enabled, show `AddPaymentMethodWithPaymentElement`.
- When disabled, show `AddPaymentMethod`

This was likely done because `CustomerSheet` originally had allowed adding a card payment method but had later added US Bank account support. The check is redundant because we filter out US bank account inside of `CustomerSheetLoader` already if `customerACHv2` is disabled. `AddPaymentMethod` relied on form elements to be provided from `FormViewModel.ViewData` which is always being populated as empty while `AddPaymentMethodWithPaymentElement`.

This PR:
- Removes the redundant check
- Removes the additional `formElements` field.
- Populates `FormViewModel.ViewData` with the form elements.
- Updates `AddPaymentMethodWithPaymentElement` to use `FormViewModel.ViewData`.

# Motivation
Fix for #ir-bashful-pedal

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
