### PR TITLE
Add `intentMode` & `setupFutureUsage` to `PopupPayload`

### DIFF
--- a/link/src/test/java/com/stripe/android/link/serialization/PopupPayloadTest.kt
+++ b/link/src/test/java/com/stripe/android/link/serialization/PopupPayloadTest.kt
@@ -7,7 +7,9 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.ui.inline.LinkSignupMode
+import com.stripe.android.model.StripeIntent
 import com.stripe.android.testing.PaymentIntentFactory
+import com.stripe.android.testing.SetupIntentFactory
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -25,14 +27,14 @@ internal class PopupPayloadTest {
             value = createPayload(),
         )
 
-        assertThat(json).isEqualTo("""{"publishableKey":"pk_test_abc","stripeAccount":"123","merchantInfo":{"businessName":"Jay's Taco Stand","country":"US"},"customerInfo":{"email":"jaystacostandfake@gmail.com","country":"US"},"paymentInfo":{"currency":"USD","amount":5555},"appId":"example.stripe.unittest","locale":"US","paymentUserAgent":"test","paymentObject":"link_payment_method","flags":{"link_authenticated_change_event_enabled":false,"link_bank_incentives_enabled":false,"link_bank_onboarding_enabled":false,"link_email_verification_login_enabled":false,"link_financial_incentives_experiment_enabled":false,"link_local_storage_login_enabled":true,"link_only_for_payment_method_types_enabled":false,"link_passthrough_mode_enabled":true},"path":"mobile_pay","integrationType":"mobile","loggerMetadata":{"mobile_session_id":"$currentSessionId"},"experiments":{}}""")
+        assertThat(json).isEqualTo("""{"publishableKey":"pk_test_abc","stripeAccount":"123","merchantInfo":{"businessName":"Jay's Taco Stand","country":"US"},"customerInfo":{"email":"jaystacostandfake@gmail.com","country":"US"},"paymentInfo":{"currency":"USD","amount":5555},"appId":"example.stripe.unittest","locale":"US","paymentUserAgent":"test","paymentObject":"link_payment_method","intentMode":"payment","setupFutureUsage":true,"flags":{"link_authenticated_change_event_enabled":false,"link_bank_incentives_enabled":false,"link_bank_onboarding_enabled":false,"link_email_verification_login_enabled":false,"link_financial_incentives_experiment_enabled":false,"link_local_storage_login_enabled":true,"link_only_for_payment_method_types_enabled":false,"link_passthrough_mode_enabled":true},"path":"mobile_pay","integrationType":"mobile","loggerMetadata":{"mobile_session_id":"$currentSessionId"},"experiments":{}}""")
     }
 
     @Test
     fun testToUrl() {
         AnalyticsRequestFactory.setSessionId(UUID.fromString("537a88ff-a54f-42cc-ba52-c7c5623730b6"))
 
-        assertThat(createPayload().toUrl()).isEqualTo("https://checkout.link.com/#eyJwdWJsaXNoYWJsZUtleSI6InBrX3Rlc3RfYWJjIiwic3RyaXBlQWNjb3VudCI6IjEyMyIsIm1lcmNoYW50SW5mbyI6eyJidXNpbmVzc05hbWUiOiJKYXkncyBUYWNvIFN0YW5kIiwiY291bnRyeSI6IlVTIn0sImN1c3RvbWVySW5mbyI6eyJlbWFpbCI6ImpheXN0YWNvc3RhbmRmYWtlQGdtYWlsLmNvbSIsImNvdW50cnkiOiJVUyJ9LCJwYXltZW50SW5mbyI6eyJjdXJyZW5jeSI6IlVTRCIsImFtb3VudCI6NTU1NX0sImFwcElkIjoiZXhhbXBsZS5zdHJpcGUudW5pdHRlc3QiLCJsb2NhbGUiOiJVUyIsInBheW1lbnRVc2VyQWdlbnQiOiJ0ZXN0IiwicGF5bWVudE9iamVjdCI6ImxpbmtfcGF5bWVudF9tZXRob2QiLCJmbGFncyI6eyJsaW5rX2F1dGhlbnRpY2F0ZWRfY2hhbmdlX2V2ZW50X2VuYWJsZWQiOmZhbHNlLCJsaW5rX2JhbmtfaW5jZW50aXZlc19lbmFibGVkIjpmYWxzZSwibGlua19iYW5rX29uYm9hcmRpbmdfZW5hYmxlZCI6ZmFsc2UsImxpbmtfZW1haWxfdmVyaWZpY2F0aW9uX2xvZ2luX2VuYWJsZWQiOmZhbHNlLCJsaW5rX2ZpbmFuY2lhbF9pbmNlbnRpdmVzX2V4cGVyaW1lbnRfZW5hYmxlZCI6ZmFsc2UsImxpbmtfbG9jYWxfc3RvcmFnZV9sb2dpbl9lbmFibGVkIjp0cnVlLCJsaW5rX29ubHlfZm9yX3BheW1lbnRfbWV0aG9kX3R5cGVzX2VuYWJsZWQiOmZhbHNlLCJsaW5rX3Bhc3N0aHJvdWdoX21vZGVfZW5hYmxlZCI6dHJ1ZX0sInBhdGgiOiJtb2JpbGVfcGF5IiwiaW50ZWdyYXRpb25UeXBlIjoibW9iaWxlIiwibG9nZ2VyTWV0YWRhdGEiOnsibW9iaWxlX3Nlc3Npb25faWQiOiI1MzdhODhmZi1hNTRmLTQyY2MtYmE1Mi1jN2M1NjIzNzMwYjYifSwiZXhwZXJpbWVudHMiOnt9fQ==")
+        assertThat(createPayload().toUrl()).isEqualTo("https://checkout.link.com/#eyJwdWJsaXNoYWJsZUtleSI6InBrX3Rlc3RfYWJjIiwic3RyaXBlQWNjb3VudCI6IjEyMyIsIm1lcmNoYW50SW5mbyI6eyJidXNpbmVzc05hbWUiOiJKYXkncyBUYWNvIFN0YW5kIiwiY291bnRyeSI6IlVTIn0sImN1c3RvbWVySW5mbyI6eyJlbWFpbCI6ImpheXN0YWNvc3RhbmRmYWtlQGdtYWlsLmNvbSIsImNvdW50cnkiOiJVUyJ9LCJwYXltZW50SW5mbyI6eyJjdXJyZW5jeSI6IlVTRCIsImFtb3VudCI6NTU1NX0sImFwcElkIjoiZXhhbXBsZS5zdHJpcGUudW5pdHRlc3QiLCJsb2NhbGUiOiJVUyIsInBheW1lbnRVc2VyQWdlbnQiOiJ0ZXN0IiwicGF5bWVudE9iamVjdCI6ImxpbmtfcGF5bWVudF9tZXRob2QiLCJpbnRlbnRNb2RlIjoicGF5bWVudCIsInNldHVwRnV0dXJlVXNhZ2UiOnRydWUsImZsYWdzIjp7ImxpbmtfYXV0aGVudGljYXRlZF9jaGFuZ2VfZXZlbnRfZW5hYmxlZCI6ZmFsc2UsImxpbmtfYmFua19pbmNlbnRpdmVzX2VuYWJsZWQiOmZhbHNlLCJsaW5rX2Jhbmtfb25ib2FyZGluZ19lbmFibGVkIjpmYWxzZSwibGlua19lbWFpbF92ZXJpZmljYXRpb25fbG9naW5fZW5hYmxlZCI6ZmFsc2UsImxpbmtfZmluYW5jaWFsX2luY2VudGl2ZXNfZXhwZXJpbWVudF9lbmFibGVkIjpmYWxzZSwibGlua19sb2NhbF9zdG9yYWdlX2xvZ2luX2VuYWJsZWQiOnRydWUsImxpbmtfb25seV9mb3JfcGF5bWVudF9tZXRob2RfdHlwZXNfZW5hYmxlZCI6ZmFsc2UsImxpbmtfcGFzc3Rocm91Z2hfbW9kZV9lbmFibGVkIjp0cnVlfSwicGF0aCI6Im1vYmlsZV9wYXkiLCJpbnRlZ3JhdGlvblR5cGUiOiJtb2JpbGUiLCJsb2dnZXJNZXRhZGF0YSI6eyJtb2JpbGVfc2Vzc2lvbl9pZCI6IjUzN2E4OGZmLWE1NGYtNDJjYy1iYTUyLWM3YzU2MjM3MzBiNiJ9LCJleHBlcmltZW50cyI6e319")
     }
 
     @Test
@@ -61,8 +63,129 @@ internal class PopupPayloadTest {
         assertThat(payload.customerInfo.country).isEqualTo("CA")
     }
 
+    @Test
+    fun `on 'create' with payment intent, intent mode should be Payment`() {
+        val payload = PopupPayload.create(
+            configuration = createLinkConfiguration(
+                customerCountryCode = null,
+                intent = PaymentIntentFactory.create()
+            ),
+            context = getContext(Locale.CANADA),
+            paymentUserAgent = "Android",
+            publishableKey = "pk_123",
+            stripeAccount = "str_123"
+        )
+
+        assertThat(payload.intentMode).isEqualTo(PopupPayload.IntentMode.Payment.type)
+    }
+
+    @Test
+    fun `on 'create' with setup intent, intent mode should be Setup`() {
+        val payload = PopupPayload.create(
+            configuration = createLinkConfiguration(
+                customerCountryCode = null,
+                intent = SetupIntentFactory.create()
+            ),
+            context = getContext(Locale.CANADA),
+            paymentUserAgent = "Android",
+            publishableKey = "pk_123",
+            stripeAccount = "str_123"
+        )
+
+        assertThat(payload.intentMode).isEqualTo(PopupPayload.IntentMode.Setup.type)
+    }
+
+    @Test
+    fun `on 'create' with setup intent, 'setupForFutureUsage' should be true`() {
+        val payload = PopupPayload.create(
+            configuration = createLinkConfiguration(
+                customerCountryCode = null,
+                intent = SetupIntentFactory.create()
+            ),
+            context = getContext(Locale.CANADA),
+            paymentUserAgent = "Android",
+            publishableKey = "pk_123",
+            stripeAccount = "str_123"
+        )
+
+        assertThat(payload.setupFutureUsage).isTrue()
+    }
+
+    @Test
+    fun `on 'create' with payment intent with no usage, 'setupForFutureUsage' should be false`() {
+        val payload = PopupPayload.create(
+            configuration = createLinkConfiguration(
+                customerCountryCode = null,
+                intent = PaymentIntentFactory.create(
+                    setupFutureUsage = null
+                )
+            ),
+            context = getContext(Locale.CANADA),
+            paymentUserAgent = "Android",
+            publishableKey = "pk_123",
+            stripeAccount = "str_123"
+        )
+
+        assertThat(payload.setupFutureUsage).isFalse()
+    }
+
+    @Test
+    fun `on 'create' with payment intent with one time usage, 'setupForFutureUsage' should be false`() {
+        val payload = PopupPayload.create(
+            configuration = createLinkConfiguration(
+                customerCountryCode = null,
+                intent = PaymentIntentFactory.create(
+                    setupFutureUsage = StripeIntent.Usage.OneTime
+                )
+            ),
+            context = getContext(Locale.CANADA),
+            paymentUserAgent = "Android",
+            publishableKey = "pk_123",
+            stripeAccount = "str_123"
+        )
+
+        assertThat(payload.setupFutureUsage).isFalse()
+    }
+
+    @Test
+    fun `on 'create' with payment intent with off session usage, 'setupForFutureUsage' should be true`() {
+        val payload = PopupPayload.create(
+            configuration = createLinkConfiguration(
+                customerCountryCode = null,
+                intent = PaymentIntentFactory.create(
+                    setupFutureUsage = StripeIntent.Usage.OffSession
+                )
+            ),
+            context = getContext(Locale.CANADA),
+            paymentUserAgent = "Android",
+            publishableKey = "pk_123",
+            stripeAccount = "str_123"
+        )
+
+        assertThat(payload.setupFutureUsage).isTrue()
+    }
+
+    @Test
+    fun `on 'create' with payment intent with on session usage, 'setupForFutureUsage' should be true`() {
+        val payload = PopupPayload.create(
+            configuration = createLinkConfiguration(
+                customerCountryCode = null,
+                intent = PaymentIntentFactory.create(
+                    setupFutureUsage = StripeIntent.Usage.OnSession
+                )
+            ),
+            context = getContext(Locale.CANADA),
+            paymentUserAgent = "Android",
+            publishableKey = "pk_123",
+            stripeAccount = "str_123"
+        )
+
+        assertThat(payload.setupFutureUsage).isTrue()
+    }
+
     private fun createLinkConfiguration(
-        customerCountryCode: String?
+        customerCountryCode: String?,
+        intent: StripeIntent = PaymentIntentFactory.create()
     ): LinkConfiguration {
         return LinkConfiguration(
             merchantName = "Jay's Taco Stand",
@@ -77,7 +200,7 @@ internal class PopupPayloadTest {
             passthroughModeEnabled = true,
             shippingValues = emptyMap(),
             signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
-            stripeIntent = PaymentIntentFactory.create()
+            stripeIntent = intent
         )
     }
 
@@ -100,6 +223,8 @@ internal class PopupPayloadTest {
         locale = "US",
         paymentUserAgent = "test",
         paymentObject = "link_payment_method",
+        intentMode = "payment",
+        setupFutureUsage = true,
         flags = mapOf(
             "link_authenticated_change_event_enabled" to false,
             "link_bank_incentives_enabled" to false,

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/SetupIntentFactory.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/SetupIntentFactory.kt
@@ -1,0 +1,48 @@
+package com.stripe.android.testing
+
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.StripeIntent
+
+object SetupIntentFactory {
+    fun create(
+        paymentMethod: PaymentMethod? = createCardPaymentMethod(),
+        paymentMethodTypes: List<String> = listOf("card"),
+        status: StripeIntent.Status = StripeIntent.Status.RequiresConfirmation,
+        paymentMethodOptionsJsonString: String? = null,
+        linkFundingSources: List<String> = emptyList(),
+        countryCode: String? = null,
+        cancellationReason: SetupIntent.CancellationReason? = null,
+        usage: StripeIntent.Usage? = null,
+    ): SetupIntent = SetupIntent(
+        created = 500L,
+        clientSecret = "secret",
+        paymentMethod = paymentMethod,
+        isLiveMode = false,
+        id = "pi_12345",
+        countryCode = countryCode,
+        paymentMethodTypes = paymentMethodTypes,
+        status = status,
+        unactivatedPaymentMethods = emptyList(),
+        paymentMethodOptionsJsonString = paymentMethodOptionsJsonString,
+        linkFundingSources = linkFundingSources,
+        cancellationReason = cancellationReason,
+        description = null,
+        nextActionData = null,
+        paymentMethodId = paymentMethod?.id,
+        usage = usage,
+    )
+
+    private fun createCardPaymentMethod(): PaymentMethod = PaymentMethod(
+        id = "12",
+        created = 123456789L,
+        liveMode = false,
+        type = PaymentMethod.Type.Card,
+        card = PaymentMethod.Card(
+            brand = CardBrand.Visa,
+            last4 = "4242"
+        ),
+        code = "card"
+    )
+}

--- a/payments-core/src/main/java/com/stripe/android/model/SetupIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/SetupIntent.kt
@@ -16,7 +16,9 @@ import java.util.regex.Pattern
  * - [SetupIntents API Reference](https://stripe.com/docs/api/setup_intents)
  */
 @Parcelize
-data class SetupIntent internal constructor(
+data class SetupIntent
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+constructor(
     /**
      * Unique identifier for the object.
      */


### PR DESCRIPTION
# Summary
Add `intentMode` to `PopupPayload`.

`Link` does not know the intent type sending payment details for. This results in `Link` showing `Pay` instead of `Continue` which we expect with `SetupIntent` types.

This PR adds a `intentMode` field & `setupForFutureUsage` field to send in the popup URL in order to tell `Link` to update its primary button to use `Continue` when saving the payment method and `Pay` with one time payments.

# Motivation
Resolves [MOBILESDK-1845](https://jira.corp.stripe.com/browse/MOBILESDK-1845)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Video
| Before | After |
| ------ | ------ |
| <video src="https://github.com/stripe/stripe-android/assets/141707240/038a4040-bb2e-41e1-a2a7-92fe7fd8ae68" /> | <video src="https://github.com/stripe/stripe-android/assets/141707240/da298a81-0571-493e-892b-d724889ae4fa" /> |