### PR TITLE
Fix broken ripple effect on `Add bank account` button

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerScreen.kt
@@ -351,8 +351,8 @@ private fun SelectNewAccount(
                 color = colors.border,
                 shape = shape
             )
-            .padding(16.dp)
             .clickableSingle { onClick() }
+            .padding(16.dp)
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes the broken ripple effect on the `Add bank account` button in the Link account picker.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Polish.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
