### PR TITLE
[FC] Crash launching Reset pane due to missing binding instance 

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/reset/ResetSubcomponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/reset/ResetSubcomponent.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.financialconnections.features.reset
 
-import com.stripe.android.financialconnections.navigation.topappbar.TopAppBarHost
 import dagger.BindsInstance
 import dagger.Subcomponent
 
@@ -14,9 +13,6 @@ internal interface ResetSubcomponent {
 
         @BindsInstance
         fun initialState(initialState: ResetState): Builder
-
-        @BindsInstance
-        fun topAppBarHost(topAppBarHost: TopAppBarHost): Builder
 
         fun build(): ResetSubcomponent
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/reset/ResetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/reset/ResetViewModel.kt
@@ -43,13 +43,10 @@ internal class ResetViewModel @Inject constructor(
         }.execute { copy(payload = it) }
     }
 
-    override fun updateTopAppBar(state: ResetState): TopAppBarStateUpdate {
-        // TODO(tillh-stripe) This preserves behavior, but it should probably not allow back navigation, right?
-        return TopAppBarStateUpdate(
-            pane = PANE,
-            allowBackNavigation = true,
-        )
-    }
+    override fun updateTopAppBar(state: ResetState): TopAppBarStateUpdate = TopAppBarStateUpdate(
+        pane = PANE,
+        allowBackNavigation = false,
+    )
 
     private fun logErrors() {
         onAsync(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsViewModel.kt
@@ -3,6 +3,7 @@ package com.stripe.android.financialconnections.presentation
 import com.airbnb.mvrx.MavericksState
 import com.airbnb.mvrx.MavericksViewModel
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
+import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.UpdateTopAppBar
 import com.stripe.android.financialconnections.navigation.topappbar.TopAppBarStateUpdate
 import kotlinx.coroutines.launch
 
@@ -24,7 +25,7 @@ internal abstract class FinancialConnectionsViewModel<S : MavericksState>(
     private fun updateHostWithTopAppBarState(state: S) {
         viewModelScope.launch {
             val update = updateTopAppBar(state) ?: return@launch
-            nativeAuthFlowCoordinator().emit(NativeAuthFlowCoordinator.Message.UpdateTopAppBar(update))
+            nativeAuthFlowCoordinator().emit(UpdateTopAppBar(update))
         }
     }
 }

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
@@ -16,9 +16,13 @@ tags:
     timeout: 30000
 - tapOn:
     id: "consent_cta"
-# SELECT INSTITUTION WITH DOWNTIME
+# Select Down institution
 - tapOn: "Down Bank (unscheduled)"
-# CLOSE FLOW FROM ERROR PAGE
+# Selecting another bank resets the flow
+- tapOn: "Select another bank"
+# Assert flow correctly returns to institution picker
+- tapOn: "Down Bank (unscheduled)"
+# Close flow from error page
 - tapOn: "Close icon"
 - assertVisible: "Failed! Request-id: .*"
 - stopRecording


### PR DESCRIPTION
# Summary
- Issue: subcomponent builder was requiring an unneeded and unprovided instance (TopAppBarHost)
- Solution: Remove it and add tests that go over the reset pane.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
