### PR TITLE
Move from builders to factories

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeComponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeComponent.kt
@@ -46,25 +46,25 @@ internal interface FinancialConnectionsSheetNativeComponent {
 
     val viewModel: FinancialConnectionsSheetNativeViewModel
 
-    // Exposed subcomponent builders.
-    val consentBuilder: ConsentSubcomponent.Builder
-    val institutionPickerBuilder: InstitutionPickerSubcomponent.Builder
-    val accountPickerBuilder: AccountPickerSubcomponent.Builder
-    val manualEntryBuilder: ManualEntrySubcomponent.Builder
-    val manualEntrySuccessBuilder: ManualEntrySuccessSubcomponent.Builder
-    val partnerAuthSubcomponent: PartnerAuthSubcomponent.Builder
-    val bankAuthRepairSubcomponent: BankAuthRepairSubcomponent.Builder
-    val successSubcomponent: SuccessSubcomponent.Builder
-    val attachPaymentSubcomponent: AttachPaymentSubcomponent.Builder
-    val resetSubcomponent: ResetSubcomponent.Builder
+    // Exposed subcomponent factories.
+    val consentSubcomponent: ConsentSubcomponent.Factory
+    val institutionPickerSubcomponent: InstitutionPickerSubcomponent.Factory
+    val accountPickerSubcomponent: AccountPickerSubcomponent.Factory
+    val manualEntrySubcomponent: ManualEntrySubcomponent.Factory
+    val manualEntrySuccessSubcomponent: ManualEntrySuccessSubcomponent.Factory
+    val partnerAuthSubcomponent: PartnerAuthSubcomponent.Factory
+    val bankAuthRepairSubcomponent: BankAuthRepairSubcomponent.Factory
+    val successSubcomponent: SuccessSubcomponent.Factory
+    val attachPaymentSubcomponent: AttachPaymentSubcomponent.Factory
+    val resetSubcomponent: ResetSubcomponent.Factory
     val errorSubcomponent: ErrorSubcomponent.Factory
     val exitSubcomponent: ExitSubcomponent.Factory
-    val networkingLinkSignupSubcomponent: NetworkingLinkSignupSubcomponent.Builder
-    val networkingLinkLoginWarmupSubcomponent: NetworkingLinkLoginWarmupSubcomponent.Builder
-    val networkingLinkVerificationSubcomponent: NetworkingLinkVerificationSubcomponent.Builder
-    val networkingSaveToLinkVerificationSubcomponent: NetworkingSaveToLinkVerificationSubcomponent.Builder
-    val linkAccountPickerSubcomponent: LinkAccountPickerSubcomponent.Builder
-    val linkStepUpVerificationSubcomponent: LinkStepUpVerificationSubcomponent.Builder
+    val networkingLinkSignupSubcomponent: NetworkingLinkSignupSubcomponent.Factory
+    val networkingLinkLoginWarmupSubcomponent: NetworkingLinkLoginWarmupSubcomponent.Factory
+    val networkingLinkVerificationSubcomponent: NetworkingLinkVerificationSubcomponent.Factory
+    val networkingSaveToLinkVerificationSubcomponent: NetworkingSaveToLinkVerificationSubcomponent.Factory
+    val linkAccountPickerSubcomponent: LinkAccountPickerSubcomponent.Factory
+    val linkStepUpVerificationSubcomponent: LinkStepUpVerificationSubcomponent.Factory
 
     @Component.Builder
     interface Builder {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerSubcomponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerSubcomponent.kt
@@ -8,12 +8,8 @@ internal interface AccountPickerSubcomponent {
 
     val viewModel: AccountPickerViewModel
 
-    @Subcomponent.Builder
-    interface Builder {
-
-        @BindsInstance
-        fun initialState(initialState: AccountPickerState): Builder
-
-        fun build(): AccountPickerSubcomponent
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(@BindsInstance initialState: AccountPickerState): AccountPickerSubcomponent
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
@@ -325,9 +325,8 @@ internal class AccountPickerViewModel @Inject constructor(
             viewModelFactory {
                 initializer {
                     parentComponent
-                        .accountPickerBuilder
-                        .initialState(AccountPickerState())
-                        .build()
+                        .accountPickerSubcomponent
+                        .create(AccountPickerState())
                         .viewModel
                 }
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentSubcomponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentSubcomponent.kt
@@ -8,12 +8,8 @@ internal interface AttachPaymentSubcomponent {
 
     val viewModel: AttachPaymentViewModel
 
-    @Subcomponent.Builder
-    interface Builder {
-
-        @BindsInstance
-        fun initialState(initialState: AttachPaymentState): Builder
-
-        fun build(): AttachPaymentSubcomponent
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(@BindsInstance initialState: AttachPaymentState): AttachPaymentSubcomponent
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
@@ -120,8 +120,7 @@ internal class AttachPaymentViewModel @Inject constructor(
                 initializer {
                     parentComponent
                         .attachPaymentSubcomponent
-                        .initialState(AttachPaymentState())
-                        .build()
+                        .create(AttachPaymentState())
                         .viewModel
                 }
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/bankauthrepair/BankAuthRepairSubcomponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/bankauthrepair/BankAuthRepairSubcomponent.kt
@@ -9,12 +9,8 @@ internal interface BankAuthRepairSubcomponent {
 
     val viewModel: BankAuthRepairViewModel
 
-    @Subcomponent.Builder
-    interface Builder {
-
-        @BindsInstance
-        fun initialState(initialState: SharedPartnerAuthState): Builder
-
-        fun build(): BankAuthRepairSubcomponent
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(@BindsInstance initialState: SharedPartnerAuthState): BankAuthRepairSubcomponent
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/bankauthrepair/BankAuthRepairViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/bankauthrepair/BankAuthRepairViewModel.kt
@@ -34,8 +34,7 @@ internal class BankAuthRepairViewModel @Inject constructor(
                 initializer {
                     parentComponent
                         .bankAuthRepairSubcomponent
-                        .initialState(SharedPartnerAuthState(Args(PANE)))
-                        .build()
+                        .create(SharedPartnerAuthState(Args(PANE)))
                         .viewModel
                 }
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentSubcomponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentSubcomponent.kt
@@ -8,12 +8,8 @@ internal interface ConsentSubcomponent {
 
     val viewModel: ConsentViewModel
 
-    @Subcomponent.Builder
-    interface Builder {
-
-        @BindsInstance
-        fun initialState(state: ConsentState): Builder
-
-        fun build(): ConsentSubcomponent
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(@BindsInstance state: ConsentState): ConsentSubcomponent
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentViewModel.kt
@@ -137,9 +137,8 @@ internal class ConsentViewModel @Inject constructor(
             viewModelFactory {
                 initializer {
                     parentComponent
-                        .consentBuilder
-                        .initialState(ConsentState())
-                        .build()
+                        .consentSubcomponent
+                        .create(ConsentState())
                         .viewModel
                 }
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerSubcomponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerSubcomponent.kt
@@ -8,12 +8,8 @@ internal interface InstitutionPickerSubcomponent {
 
     val viewModel: InstitutionPickerViewModel
 
-    @Subcomponent.Builder
-    interface Builder {
-
-        @BindsInstance
-        fun initialState(initialState: InstitutionPickerState): Builder
-
-        fun build(): InstitutionPickerSubcomponent
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(@BindsInstance initialState: InstitutionPickerState): InstitutionPickerSubcomponent
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModel.kt
@@ -252,9 +252,8 @@ internal class InstitutionPickerViewModel @Inject constructor(
             viewModelFactory {
                 initializer {
                     parentComponent
-                        .institutionPickerBuilder
-                        .initialState(InstitutionPickerState())
-                        .build()
+                        .institutionPickerSubcomponent
+                        .create(InstitutionPickerState())
                         .viewModel
                 }
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerSubcomponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerSubcomponent.kt
@@ -8,12 +8,8 @@ internal interface LinkAccountPickerSubcomponent {
 
     val viewModel: LinkAccountPickerViewModel
 
-    @Subcomponent.Builder
-    interface Builder {
-
-        @BindsInstance
-        fun initialState(initialState: LinkAccountPickerState): Builder
-
-        fun build(): LinkAccountPickerSubcomponent
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(@BindsInstance initialState: LinkAccountPickerState): LinkAccountPickerSubcomponent
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
@@ -220,8 +220,7 @@ internal class LinkAccountPickerViewModel @Inject constructor(
                 initializer {
                     parentComponent
                         .linkAccountPickerSubcomponent
-                        .initialState(LinkAccountPickerState())
-                        .build()
+                        .create(LinkAccountPickerState())
                         .viewModel
                 }
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationSubcomponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationSubcomponent.kt
@@ -8,12 +8,10 @@ internal interface LinkStepUpVerificationSubcomponent {
 
     val viewModel: LinkStepUpVerificationViewModel
 
-    @Subcomponent.Builder
-    interface Builder {
-
-        @BindsInstance
-        fun initialState(initialState: LinkStepUpVerificationState): Builder
-
-        fun build(): LinkStepUpVerificationSubcomponent
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(
+            @BindsInstance initialState: LinkStepUpVerificationState,
+        ): LinkStepUpVerificationSubcomponent
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationViewModel.kt
@@ -221,8 +221,7 @@ internal class LinkStepUpVerificationViewModel @Inject constructor(
                 initializer {
                     parentComponent
                         .linkStepUpVerificationSubcomponent
-                        .initialState(LinkStepUpVerificationState())
-                        .build()
+                        .create(LinkStepUpVerificationState())
                         .viewModel
                 }
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntrySubcomponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntrySubcomponent.kt
@@ -8,12 +8,8 @@ internal interface ManualEntrySubcomponent {
 
     val viewModel: ManualEntryViewModel
 
-    @Subcomponent.Builder
-    interface Builder {
-
-        @BindsInstance
-        fun initialState(initialState: ManualEntryState): Builder
-
-        fun build(): ManualEntrySubcomponent
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(@BindsInstance initialState: ManualEntryState): ManualEntrySubcomponent
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
@@ -173,9 +173,8 @@ internal class ManualEntryViewModel @Inject constructor(
             viewModelFactory {
                 initializer {
                     parentComponent
-                        .manualEntryBuilder
-                        .initialState(ManualEntryState())
-                        .build()
+                        .manualEntrySubcomponent
+                        .create(ManualEntryState())
                         .viewModel
                 }
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessSubcomponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessSubcomponent.kt
@@ -8,12 +8,10 @@ internal interface ManualEntrySuccessSubcomponent {
 
     val viewModel: ManualEntrySuccessViewModel
 
-    @Subcomponent.Builder
-    interface Builder {
-
-        @BindsInstance
-        fun initialState(initialState: ManualEntrySuccessState): Builder
-
-        fun build(): ManualEntrySuccessSubcomponent
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(
+            @BindsInstance initialState: ManualEntrySuccessState,
+        ): ManualEntrySuccessSubcomponent
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessViewModel.kt
@@ -65,9 +65,8 @@ internal class ManualEntrySuccessViewModel @Inject constructor(
             viewModelFactory {
                 initializer {
                     parentComponent
-                        .manualEntrySuccessBuilder
-                        .initialState(ManualEntrySuccessState())
-                        .build()
+                        .manualEntrySuccessSubcomponent
+                        .create(ManualEntrySuccessState())
                         .viewModel
                 }
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupSubcomponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupSubcomponent.kt
@@ -8,12 +8,10 @@ internal interface NetworkingLinkLoginWarmupSubcomponent {
 
     val viewModel: NetworkingLinkLoginWarmupViewModel
 
-    @Subcomponent.Builder
-    interface Builder {
-
-        @BindsInstance
-        fun initialState(initialState: NetworkingLinkLoginWarmupState): Builder
-
-        fun build(): NetworkingLinkLoginWarmupSubcomponent
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(
+            @BindsInstance initialState: NetworkingLinkLoginWarmupState,
+        ): NetworkingLinkLoginWarmupSubcomponent
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModel.kt
@@ -123,8 +123,7 @@ internal class NetworkingLinkLoginWarmupViewModel @Inject constructor(
                 initializer {
                     parentComponent
                         .networkingLinkLoginWarmupSubcomponent
-                        .initialState(NetworkingLinkLoginWarmupState(arguments))
-                        .build()
+                        .create(NetworkingLinkLoginWarmupState(arguments))
                         .viewModel
                 }
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupSubcomponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupSubcomponent.kt
@@ -8,12 +8,10 @@ internal interface NetworkingLinkSignupSubcomponent {
 
     val viewModel: NetworkingLinkSignupViewModel
 
-    @Subcomponent.Builder
-    interface Builder {
-
-        @BindsInstance
-        fun initialState(initialState: NetworkingLinkSignupState): Builder
-
-        fun build(): NetworkingLinkSignupSubcomponent
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(
+            @BindsInstance initialState: NetworkingLinkSignupState,
+        ): NetworkingLinkSignupSubcomponent
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
@@ -274,8 +274,7 @@ internal class NetworkingLinkSignupViewModel @Inject constructor(
                 initializer {
                     parentComponent
                         .networkingLinkSignupSubcomponent
-                        .initialState(NetworkingLinkSignupState())
-                        .build()
+                        .create(NetworkingLinkSignupState())
                         .viewModel
                 }
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationSubcomponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationSubcomponent.kt
@@ -8,12 +8,10 @@ internal interface NetworkingLinkVerificationSubcomponent {
 
     val viewModel: NetworkingLinkVerificationViewModel
 
-    @Subcomponent.Builder
-    interface Builder {
-
-        @BindsInstance
-        fun initialState(initialState: NetworkingLinkVerificationState): Builder
-
-        fun build(): NetworkingLinkVerificationSubcomponent
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(
+            @BindsInstance initialState: NetworkingLinkVerificationState,
+        ): NetworkingLinkVerificationSubcomponent
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModel.kt
@@ -168,8 +168,7 @@ internal class NetworkingLinkVerificationViewModel @Inject constructor(
                 initializer {
                     parentComponent
                         .networkingLinkVerificationSubcomponent
-                        .initialState(NetworkingLinkVerificationState())
-                        .build()
+                        .create(NetworkingLinkVerificationState())
                         .viewModel
                 }
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationSubcomponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationSubcomponent.kt
@@ -8,12 +8,10 @@ internal interface NetworkingSaveToLinkVerificationSubcomponent {
 
     val viewModel: NetworkingSaveToLinkVerificationViewModel
 
-    @Subcomponent.Builder
-    interface Builder {
-
-        @BindsInstance
-        fun initialState(initialState: NetworkingSaveToLinkVerificationState): Builder
-
-        fun build(): NetworkingSaveToLinkVerificationSubcomponent
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(
+            @BindsInstance initialState: NetworkingSaveToLinkVerificationState,
+        ): NetworkingSaveToLinkVerificationSubcomponent
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModel.kt
@@ -156,8 +156,7 @@ internal class NetworkingSaveToLinkVerificationViewModel @Inject constructor(
                 initializer {
                     parentComponent
                         .networkingSaveToLinkVerificationSubcomponent
-                        .initialState(NetworkingSaveToLinkVerificationState())
-                        .build()
+                        .create(NetworkingSaveToLinkVerificationState())
                         .viewModel
                 }
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthSubcomponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthSubcomponent.kt
@@ -8,12 +8,8 @@ internal interface PartnerAuthSubcomponent {
 
     val viewModel: PartnerAuthViewModel
 
-    @Subcomponent.Builder
-    interface Builder {
-
-        @BindsInstance
-        fun initialState(initialState: SharedPartnerAuthState): Builder
-
-        fun build(): PartnerAuthSubcomponent
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(@BindsInstance initialState: SharedPartnerAuthState): PartnerAuthSubcomponent
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
@@ -463,8 +463,7 @@ internal class PartnerAuthViewModel @Inject constructor(
                 initializer {
                     parentComponent
                         .partnerAuthSubcomponent
-                        .initialState(SharedPartnerAuthState(args))
-                        .build()
+                        .create(SharedPartnerAuthState(args))
                         .viewModel
                 }
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/reset/ResetSubcomponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/reset/ResetSubcomponent.kt
@@ -8,12 +8,8 @@ internal interface ResetSubcomponent {
 
     val viewModel: ResetViewModel
 
-    @Subcomponent.Builder
-    interface Builder {
-
-        @BindsInstance
-        fun initialState(initialState: ResetState): Builder
-
-        fun build(): ResetSubcomponent
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(@BindsInstance initialState: ResetState): ResetSubcomponent
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/reset/ResetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/reset/ResetViewModel.kt
@@ -69,8 +69,7 @@ internal class ResetViewModel @Inject constructor(
                 initializer {
                     parentComponent
                         .resetSubcomponent
-                        .initialState(ResetState())
-                        .build()
+                        .create(ResetState())
                         .viewModel
                 }
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessSubcomponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessSubcomponent.kt
@@ -8,12 +8,8 @@ internal interface SuccessSubcomponent {
 
     val viewModel: SuccessViewModel
 
-    @Subcomponent.Builder
-    interface Builder {
-
-        @BindsInstance
-        fun initialState(initialState: SuccessState): Builder
-
-        fun build(): SuccessSubcomponent
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(@BindsInstance initialState: SuccessState): SuccessSubcomponent
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessViewModel.kt
@@ -94,8 +94,7 @@ internal class SuccessViewModel @Inject constructor(
                 initializer {
                     parentComponent
                         .successSubcomponent
-                        .initialState(SuccessState())
-                        .build()
+                        .create(SuccessState())
                         .viewModel
                 }
             }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request converts all subcomponent builders to factories, given that we only ever need to inject a single property into the graph.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
