### PR TITLE
Allow passing multiple IDs to `SelectNetworkedAccounts`

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SelectNetworkedAccounts.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SelectNetworkedAccounts.kt
@@ -5,19 +5,19 @@ import com.stripe.android.financialconnections.model.InstitutionResponse
 import com.stripe.android.financialconnections.repository.FinancialConnectionsAccountsRepository
 import javax.inject.Inject
 
-internal class SelectNetworkedAccount @Inject constructor(
+internal class SelectNetworkedAccounts @Inject constructor(
     private val configuration: FinancialConnectionsSheet.Configuration,
     private val repository: FinancialConnectionsAccountsRepository
 ) {
 
     suspend operator fun invoke(
         consumerSessionClientSecret: String,
-        selectedAccountId: String,
+        selectedAccountIds: Set<String>,
     ): InstitutionResponse {
-        return repository.postShareNetworkedAccount(
+        return repository.postShareNetworkedAccounts(
             clientSecret = configuration.financialConnectionsSessionClientSecret,
             consumerSessionClientSecret = consumerSessionClientSecret,
-            selectedAccountId = selectedAccountId
+            selectedAccountIds = selectedAccountIds,
         )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
@@ -18,7 +18,7 @@ import com.stripe.android.financialconnections.domain.FetchNetworkedAccounts
 import com.stripe.android.financialconnections.domain.GetCachedConsumerSession
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
-import com.stripe.android.financialconnections.domain.SelectNetworkedAccount
+import com.stripe.android.financialconnections.domain.SelectNetworkedAccounts
 import com.stripe.android.financialconnections.domain.UpdateCachedAccounts
 import com.stripe.android.financialconnections.domain.UpdateLocalManifest
 import com.stripe.android.financialconnections.features.common.MerchantDataAccessModel
@@ -50,7 +50,7 @@ internal class LinkAccountPickerViewModel @Inject constructor(
     private val getCachedConsumerSession: GetCachedConsumerSession,
     private val handleClickableUrl: HandleClickableUrl,
     private val fetchNetworkedAccounts: FetchNetworkedAccounts,
-    private val selectNetworkedAccount: SelectNetworkedAccount,
+    private val selectNetworkedAccounts: SelectNetworkedAccounts,
     private val updateLocalManifest: UpdateLocalManifest,
     private val updateCachedAccounts: UpdateCachedAccounts,
     private val coreAuthorizationPendingNetworkingRepair: CoreAuthorizationPendingNetworkingRepairRepository,
@@ -173,9 +173,9 @@ internal class LinkAccountPickerViewModel @Inject constructor(
         )
         when (nextPane) {
             Pane.SUCCESS -> {
-                val activeInstitution = selectNetworkedAccount(
+                val activeInstitution = selectNetworkedAccounts(
                     consumerSessionClientSecret = payload.consumerSessionClientSecret,
-                    selectedAccountId = account.id
+                    selectedAccountIds = setOf(account.id),
                 )
                 // Updates manifest active institution after account networked.
                 updateLocalManifest { it.copy(activeInstitution = activeInstitution.data.firstOrNull()) }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationViewModel.kt
@@ -20,7 +20,7 @@ import com.stripe.android.financialconnections.domain.GetManifest
 import com.stripe.android.financialconnections.domain.LookupConsumerAndStartVerification
 import com.stripe.android.financialconnections.domain.MarkLinkStepUpVerified
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
-import com.stripe.android.financialconnections.domain.SelectNetworkedAccount
+import com.stripe.android.financialconnections.domain.SelectNetworkedAccounts
 import com.stripe.android.financialconnections.domain.UpdateCachedAccounts
 import com.stripe.android.financialconnections.domain.UpdateLocalManifest
 import com.stripe.android.financialconnections.features.linkstepupverification.LinkStepUpVerificationState.Payload
@@ -52,7 +52,7 @@ internal class LinkStepUpVerificationViewModel @Inject constructor(
     private val getManifest: GetManifest,
     private val lookupConsumerAndStartVerification: LookupConsumerAndStartVerification,
     private val confirmVerification: ConfirmVerification,
-    private val selectNetworkedAccount: SelectNetworkedAccount,
+    private val selectNetworkedAccounts: SelectNetworkedAccounts,
     private val getCachedAccounts: GetCachedAccounts,
     private val updateLocalManifest: UpdateLocalManifest,
     private val markLinkStepUpVerified: MarkLinkStepUpVerified,
@@ -168,9 +168,9 @@ internal class LinkStepUpVerificationViewModel @Inject constructor(
             .getOrThrow()
 
         // Mark networked account as selected.
-        val activeInstitution = selectNetworkedAccount(
+        val activeInstitution = selectNetworkedAccounts(
             consumerSessionClientSecret = payload.consumerSessionClientSecret,
-            selectedAccountId = selectedAccount.id
+            selectedAccountIds = setOf(selectedAccount.id),
         )
 
         // Updates manifest active institution after account networked.

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsAccountsRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsAccountsRepository.kt
@@ -56,10 +56,10 @@ internal interface FinancialConnectionsAccountsRepository {
         updateLocalCache: Boolean
     ): PartnerAccountsList
 
-    suspend fun postShareNetworkedAccount(
+    suspend fun postShareNetworkedAccounts(
         clientSecret: String,
         consumerSessionClientSecret: String,
-        selectedAccountId: String
+        selectedAccountIds: Set<String>,
     ): InstitutionResponse
 
     companion object {
@@ -140,10 +140,10 @@ private class FinancialConnectionsAccountsRepositoryImpl(
         }
     }
 
-    override suspend fun postShareNetworkedAccount(
+    override suspend fun postShareNetworkedAccounts(
         clientSecret: String,
         consumerSessionClientSecret: String,
-        selectedAccountId: String
+        selectedAccountIds: Set<String>
     ): InstitutionResponse {
         val request = apiRequestFactory.createPost(
             url = shareNetworkedAccountsUrl,
@@ -151,8 +151,9 @@ private class FinancialConnectionsAccountsRepositoryImpl(
             params = mapOf(
                 PARAMS_CLIENT_SECRET to clientSecret,
                 PARAMS_CONSUMER_CLIENT_SECRET to consumerSessionClientSecret,
-                "$PARAM_SELECTED_ACCOUNTS[0]" to selectedAccountId,
-            )
+            ) + selectedAccountIds.mapIndexed { index, selectedAccountId ->
+                "$PARAM_SELECTED_ACCOUNTS[$index]" to selectedAccountId
+            },
         )
         return requestExecutor.execute(
             request,

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModelTest.kt
@@ -12,7 +12,7 @@ import com.stripe.android.financialconnections.domain.FetchNetworkedAccounts
 import com.stripe.android.financialconnections.domain.GetCachedConsumerSession
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
-import com.stripe.android.financialconnections.domain.SelectNetworkedAccount
+import com.stripe.android.financialconnections.domain.SelectNetworkedAccounts
 import com.stripe.android.financialconnections.domain.UpdateCachedAccounts
 import com.stripe.android.financialconnections.domain.UpdateLocalManifest
 import com.stripe.android.financialconnections.model.AddNewAccount
@@ -51,7 +51,7 @@ class LinkAccountPickerViewModelTest {
     private val fetchNetworkedAccounts = mock<FetchNetworkedAccounts>()
     private val updateLocalManifest = mock<UpdateLocalManifest>()
     private val updateCachedAccounts = mock<UpdateCachedAccounts>()
-    private val selectNetworkedAccount = mock<SelectNetworkedAccount>()
+    private val selectNetworkedAccounts = mock<SelectNetworkedAccounts>()
     private val eventTracker = TestFinancialConnectionsAnalyticsTracker()
     private val nativeAuthFlowCoordinator = NativeAuthFlowCoordinator()
 
@@ -64,7 +64,7 @@ class LinkAccountPickerViewModelTest {
         eventTracker = eventTracker,
         getCachedConsumerSession = getCachedConsumerSession,
         fetchNetworkedAccounts = fetchNetworkedAccounts,
-        selectNetworkedAccount = selectNetworkedAccount,
+        selectNetworkedAccounts = selectNetworkedAccounts,
         updateLocalManifest = updateLocalManifest,
         updateCachedAccounts = updateCachedAccounts,
         initialState = state,
@@ -148,9 +148,9 @@ class LinkAccountPickerViewModelTest {
         whenever(getCachedConsumerSession()).thenReturn(consumerSession())
         whenever(fetchNetworkedAccounts(any())).thenReturn(accounts)
         whenever(
-            selectNetworkedAccount(
+            selectNetworkedAccounts(
                 consumerSessionClientSecret = any(),
-                selectedAccountId = any()
+                selectedAccountIds = any(),
             )
         ).thenReturn(InstitutionResponse(showManualEntry = false, listOf(institution())))
 
@@ -191,9 +191,9 @@ class LinkAccountPickerViewModelTest {
             whenever(getCachedConsumerSession()).thenReturn(consumerSession())
             whenever(fetchNetworkedAccounts(any())).thenReturn(accounts)
             whenever(
-                selectNetworkedAccount(
+                selectNetworkedAccounts(
                     consumerSessionClientSecret = any(),
-                    selectedAccountId = any()
+                    selectedAccountIds = any(),
                 )
             ).thenReturn(InstitutionResponse(showManualEntry = false, listOf(institution())))
 
@@ -207,7 +207,7 @@ class LinkAccountPickerViewModelTest {
                 assertThat(firstValue(null)).isEqualTo(listOf(selectedAccount))
             }
             verifyNoInteractions(updateLocalManifest)
-            verifyNoInteractions(selectNetworkedAccount)
+            verifyNoInteractions(selectNetworkedAccounts)
             navigationManager.assertNavigatedTo(LinkStepUpVerification, Pane.LINK_ACCOUNT_PICKER)
         }
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationViewModelTest.kt
@@ -14,7 +14,7 @@ import com.stripe.android.financialconnections.domain.GetManifest
 import com.stripe.android.financialconnections.domain.LookupConsumerAndStartVerification
 import com.stripe.android.financialconnections.domain.MarkLinkStepUpVerified
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
-import com.stripe.android.financialconnections.domain.SelectNetworkedAccount
+import com.stripe.android.financialconnections.domain.SelectNetworkedAccounts
 import com.stripe.android.financialconnections.domain.UpdateCachedAccounts
 import com.stripe.android.financialconnections.domain.UpdateLocalManifest
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
@@ -46,7 +46,7 @@ class LinkStepUpVerificationViewModelTest {
     private val confirmVerification = mock<ConfirmVerification>()
     private val getCachedAccounts = mock<GetCachedAccounts>()
     private val lookupConsumerAndStartVerification = mock<LookupConsumerAndStartVerification>()
-    private val selectNetworkedAccount = mock<SelectNetworkedAccount>()
+    private val selectNetworkedAccounts = mock<SelectNetworkedAccounts>()
     private val markLinkVerified = mock<MarkLinkStepUpVerified>()
     private val updateLocalManifest = mock<UpdateLocalManifest>()
     private val updateCachedAccounts = mock<UpdateCachedAccounts>()
@@ -62,7 +62,7 @@ class LinkStepUpVerificationViewModelTest {
         confirmVerification = confirmVerification,
         markLinkStepUpVerified = markLinkVerified,
         getCachedAccounts = getCachedAccounts,
-        selectNetworkedAccount = selectNetworkedAccount,
+        selectNetworkedAccounts = selectNetworkedAccounts,
         updateCachedAccounts = updateCachedAccounts,
         updateLocalManifest = updateLocalManifest,
         lookupConsumerAndStartVerification = lookupConsumerAndStartVerification,
@@ -188,9 +188,9 @@ class LinkStepUpVerificationViewModelTest {
 
             verify(confirmVerification).email(any(), eq("111111"))
             verify(markLinkVerified).invoke()
-            verify(selectNetworkedAccount).invoke(
+            verify(selectNetworkedAccounts).invoke(
                 consumerSession.clientSecret,
-                selectedAccount.id
+                setOf(selectedAccount.id)
             )
             navigationManager.assertNavigatedTo(
                 Destination.Success,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request renames `SelectNetworkedAccount` to `SelectNetworkedAccounts` and allows it to update multiple accounts at the same time, which will be added with https://github.com/stripe/stripe-android/pull/8171.

(cc @kgaidis-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Preparation for multi-account selection in the data flow.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
