### PR TITLE
Remove CustomerSheet `ACHv2` flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+### CustomerSheet
+* [Added][8176](https://github.com/stripe/stripe-android/pull/8176) Enabled ACH Direct Debit in CustomerSheet
+
 ### Financial Connections
 * [CHANGED][8157](https://github.com/stripe/stripe-android/pull/8157) Financial Connections no longer depends on the Mavericks library.
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/playground/CustomerSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/playground/CustomerSheetPlaygroundActivity.kt
@@ -288,10 +288,6 @@ class CustomerSheetPlaygroundActivity : AppCompatActivity() {
                 configurationState = configurationState,
                 viewActionHandler = viewActionHandler,
             )
-            AchEnabledSwitch(
-                configurationState = configurationState,
-                viewActionHandler = viewActionHandler,
-            )
             BillingDetailsConfiguration(
                 configurationState = configurationState,
                 viewActionHandler = viewActionHandler,
@@ -376,29 +372,6 @@ class CustomerSheetPlaygroundActivity : AppCompatActivity() {
                 modifier = Modifier
                     .semantics { testTagsAsResourceId = true }
                     .testTag("CUSTOMER_SHEET_PLAYGROUND_EXISTING_CUSTOMER")
-            )
-        }
-    }
-
-    @Composable
-    private fun AchEnabledSwitch(
-        configurationState: CustomerSheetPlaygroundConfigurationState,
-        viewActionHandler: (CustomerSheetPlaygroundViewAction) -> Unit,
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text(
-                text = "US Bank Accounts",
-                color = MaterialTheme.colors.onBackground,
-            )
-            Switch(
-                checked = configurationState.achEnabled,
-                onCheckedChange = {
-                    viewActionHandler(CustomerSheetPlaygroundViewAction.ToggleAchEnabled)
-                },
             )
         }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/playground/CustomerSheetPlaygroundViewAction.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/playground/CustomerSheetPlaygroundViewAction.kt
@@ -6,7 +6,6 @@ sealed class CustomerSheetPlaygroundViewAction {
     object ToggleExistingCustomer : CustomerSheetPlaygroundViewAction()
     object ToggleUseDefaultBillingAddress : CustomerSheetPlaygroundViewAction()
     object ToggleAttachDefaultBillingAddress : CustomerSheetPlaygroundViewAction()
-    object ToggleAchEnabled : CustomerSheetPlaygroundViewAction()
     object ToggleAllowsRemovalOfLastSavedPaymentMethod : CustomerSheetPlaygroundViewAction()
     data class UpdateBillingNameCollection(val value: String) : CustomerSheetPlaygroundViewAction()
     data class UpdateBillingEmailCollection(val value: String) : CustomerSheetPlaygroundViewAction()

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/playground/CustomerSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/playground/CustomerSheetPlaygroundViewModel.kt
@@ -15,7 +15,6 @@ import com.github.kittinunf.fuel.core.requests.suspendable
 import com.github.kittinunf.result.Result
 import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.core.utils.FeatureFlags.customerSheetACHv2
 import com.stripe.android.core.utils.requireApplication
 import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.CustomerEphemeralKey
@@ -230,8 +229,6 @@ class CustomerSheetPlaygroundViewModel(
                 toggleSetupIntentEnabled()
             is CustomerSheetPlaygroundViewAction.ToggleExistingCustomer ->
                 toggleExistingCustomer()
-            is CustomerSheetPlaygroundViewAction.ToggleAchEnabled ->
-                toggleAchEnabled()
             is CustomerSheetPlaygroundViewAction.ToggleUseDefaultBillingAddress ->
                 toggleUseDefaultBillingAddress()
             is CustomerSheetPlaygroundViewAction.ToggleAttachDefaultBillingAddress ->
@@ -312,15 +309,6 @@ class CustomerSheetPlaygroundViewModel(
 
         viewModelScope.launch(Dispatchers.IO) {
             fetchClientSecret()
-        }
-    }
-
-    private fun toggleAchEnabled() {
-        updateConfiguration {
-            customerSheetACHv2.setEnabled(!it.achEnabled)
-            it.copy(
-                achEnabled = !it.achEnabled,
-            )
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.customersheet
 
 import com.stripe.android.core.injection.IS_LIVE_MODE
-import com.stripe.android.core.utils.FeatureFlags.customerSheetACHv2
 import com.stripe.android.customersheet.util.CustomerSheetHacks
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayRepository
@@ -203,7 +202,7 @@ internal class DefaultCustomerSheetLoader(
         val supported = setOfNotNull(
             PaymentMethod.Type.Card.code,
             PaymentMethod.Type.USBankAccount.code.takeIf {
-                customerSheetACHv2.isEnabled && isFinancialConnectionsAvailable()
+                isFinancialConnectionsAvailable()
             }
         )
         return supportedPaymentMethods.filter {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -172,10 +172,7 @@ internal class DefaultCustomerSheetLoader(
 
                 val supportedPaymentMethods = metadata.sortedSupportedPaymentMethods()
 
-                val validSupportedPaymentMethods = filterSupportedPaymentMethods(
-                    supportedPaymentMethods,
-                    isFinancialConnectionsAvailable,
-                )
+                val validSupportedPaymentMethods = filterSupportedPaymentMethods(supportedPaymentMethods)
 
                 Result.success(
                     CustomerSheetState.Full(
@@ -197,13 +194,10 @@ internal class DefaultCustomerSheetLoader(
 
     private fun filterSupportedPaymentMethods(
         supportedPaymentMethods: List<SupportedPaymentMethod>,
-        isFinancialConnectionsAvailable: IsFinancialConnectionsAvailable,
     ): List<SupportedPaymentMethod> {
         val supported = setOfNotNull(
             PaymentMethod.Type.Card.code,
-            PaymentMethod.Type.USBankAccount.code.takeIf {
-                isFinancialConnectionsAvailable()
-            }
+            PaymentMethod.Type.USBankAccount.code
         )
         return supportedPaymentMethods.filter {
             supported.contains(it.code)

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -7,7 +7,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.customersheet.StripeCustomerAdapter.Companion.CACHED_CUSTOMER_MAX_AGE_MILLIS
 import com.stripe.android.customersheet.util.CustomerSheetHacks
@@ -20,13 +19,11 @@ import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
-import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.utils.FakeCustomerRepository
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
@@ -44,12 +41,6 @@ class CustomerAdapterTest {
 
     private val application = ApplicationProvider.getApplicationContext<Application>()
     private val testDispatcher = UnconfinedTestDispatcher()
-
-    @get:Rule
-    val featureFlagTestRule = FeatureFlagTestRule(
-        featureFlag = FeatureFlags.customerSheetACHv2,
-        isEnabled = true,
-    )
 
     @Before
     fun setup() {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
@@ -214,21 +214,12 @@ internal class CustomerSheetActivityTest {
     }
 
     @Test
-    fun `When customer ACHv2 is enabled, should display form elements`() {
+    fun `When add payment method screen is shown, should display form elements`() {
         val eventReporter: CustomerSheetEventReporter = mock()
 
         runActivityScenario(
             viewState = createAddPaymentMethodViewState(),
             eventReporter = eventReporter,
-        ) {
-            page.waitForText("Card number")
-        }
-    }
-
-    @Test
-    fun `When customer ACHv2 is disabled, should display form elements`() {
-        runActivityScenario(
-            viewState = createAddPaymentMethodViewState(),
         ) {
             page.waitForText("Card number")
         }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
@@ -11,7 +11,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.utils.CustomerSheetTestHelper.createViewModel
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
@@ -22,7 +21,6 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
-import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils.viewModelFactoryFor
@@ -42,12 +40,6 @@ import java.util.Stack
 internal class CustomerSheetActivityTest {
     @get:Rule
     val rule = InstantTaskExecutorRule()
-
-    @get:Rule
-    val featureFlagTestRule = FeatureFlagTestRule(
-        FeatureFlags.customerSheetACHv2,
-        isEnabled = true
-    )
 
     @get:Rule
     val composeTestRule = createEmptyComposeRule()
@@ -235,8 +227,6 @@ internal class CustomerSheetActivityTest {
 
     @Test
     fun `When customer ACHv2 is disabled, should display form elements`() {
-        featureFlagTestRule.setEnabled(false)
-
         runActivityScenario(
             viewState = createAddPaymentMethodViewState(),
         ) {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.customersheet.ui.CustomerSheetScreen
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
 import com.stripe.android.model.CardBrand
@@ -17,7 +16,6 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
 import com.stripe.android.paymentsheet.ui.DefaultEditPaymentMethodViewInteractor
-import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.utils.screenshots.FontSize
@@ -36,12 +34,6 @@ internal class CustomerSheetScreenshotTest {
         boxModifier = Modifier
             .padding(0.dp)
             .fillMaxWidth(),
-    )
-
-    @get:Rule
-    val featureFlagTestRule = FeatureFlagTestRule(
-        featureFlag = FeatureFlags.customerSheetACHv2,
-        isEnabled = false,
     )
 
     private val usBankAccountFormArguments = USBankAccountFormArguments(
@@ -230,7 +222,6 @@ internal class CustomerSheetScreenshotTest {
 
     @Test
     fun testMandateAbovePrimaryButton() {
-        featureFlagTestRule.setEnabled(true)
         paparazzi.snapshot {
             CustomerSheetScreen(
                 viewState = addPaymentMethodViewState.copy(
@@ -249,7 +240,6 @@ internal class CustomerSheetScreenshotTest {
 
     @Test
     fun testMandateBelowPrimaryButton() {
-        featureFlagTestRule.setEnabled(true)
         paparazzi.snapshot {
             CustomerSheetScreen(
                 viewState = addPaymentMethodViewState.copy(
@@ -268,7 +258,6 @@ internal class CustomerSheetScreenshotTest {
 
     @Test
     fun testConfirmCloseDialog() {
-        featureFlagTestRule.setEnabled(true)
         paparazzi.snapshot {
             CustomerSheetScreen(
                 viewState = addPaymentMethodViewState.copy(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -8,7 +8,6 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.customersheet.CustomerSheetViewState.AddPaymentMethod
 import com.stripe.android.customersheet.CustomerSheetViewState.SelectPaymentMethod
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
@@ -44,7 +43,6 @@ import com.stripe.android.paymentsheet.ui.EditPaymentMethodViewAction.OnUpdatePr
 import com.stripe.android.paymentsheet.ui.EditPaymentMethodViewState
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.testing.CoroutineTestRule
-import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.ui.core.elements.CardBillingAddressElement
 import com.stripe.android.ui.core.elements.CardDetailsSectionElement
@@ -74,12 +72,6 @@ import com.stripe.android.ui.core.R as UiCoreR
 class CustomerSheetViewModelTest {
 
     private val testDispatcher = UnconfinedTestDispatcher(TestCoroutineScheduler())
-
-    @get:Rule
-    val featureFlagTestRule = FeatureFlagTestRule(
-        featureFlag = FeatureFlags.customerSheetACHv2,
-        isEnabled = false,
-    )
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule(testDispatcher)
@@ -472,8 +464,6 @@ class CustomerSheetViewModelTest {
 
     @Test
     fun `When CustomerViewAction#OnAddCardPressed & ACHv2 disabled, view state is updated to CustomerViewAction#AddPaymentMethod and fields are shwon`() = runTest(testDispatcher) {
-        featureFlagTestRule.setEnabled(false)
-
         val viewModel = createViewModel(
             workContext = testDispatcher
         )
@@ -1704,8 +1694,6 @@ class CustomerSheetViewModelTest {
 
     @Test
     fun `Payment method form changes on user selection`() = runTest(testDispatcher) {
-        featureFlagTestRule.setEnabled(true)
-
         val viewModel = createViewModel(
             workContext = testDispatcher,
             initialBackStack = listOf(
@@ -1732,8 +1720,6 @@ class CustomerSheetViewModelTest {
 
     @Test
     fun `Payment method user selection saved after returning to add screen`() = runTest(testDispatcher) {
-        featureFlagTestRule.setEnabled(true)
-
         val viewModel = createViewModel(
             workContext = testDispatcher,
             initialBackStack = listOf(
@@ -1773,8 +1759,6 @@ class CustomerSheetViewModelTest {
 
     @Test
     fun `When the payment method form is us bank account, the primary button label is continue`() = runTest(testDispatcher) {
-        featureFlagTestRule.setEnabled(true)
-
         val viewModel = createViewModel(
             workContext = testDispatcher,
             initialBackStack = listOf(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetLoader
@@ -23,7 +22,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.paymentsheet.repositories.toElementsSessionParams
-import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.utils.FakeElementsSessionRepository
 import kotlinx.coroutines.CompletableDeferred
@@ -32,7 +30,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.MockitoAnnotations
@@ -44,12 +41,6 @@ import kotlin.time.Duration.Companion.milliseconds
 @OptIn(ExperimentalCustomerSheetApi::class)
 @RunWith(RobolectricTestRunner::class)
 class DefaultCustomerSheetLoaderTest {
-    @get:Rule
-    val achFeatureFlagTestRule = FeatureFlagTestRule(
-        featureFlag = FeatureFlags.customerSheetACHv2,
-        isEnabled = false,
-    )
-
     private val lpmRepository = LpmRepository(
         arguments = LpmRepository.LpmRepositoryArguments(
             resources = ApplicationProvider.getApplicationContext<Application>().resources,
@@ -342,8 +333,6 @@ class DefaultCustomerSheetLoaderTest {
 
     @Test
     fun `When the FC unavailable, flag disabled, us bank not in intent, then us bank account is not available`() = runTest {
-        achFeatureFlagTestRule.setEnabled(false)
-
         val loader = createCustomerSheetLoader(
             customerAdapter = FakeCustomerAdapter(
                 canCreateSetupIntents = true,
@@ -367,8 +356,6 @@ class DefaultCustomerSheetLoaderTest {
 
     @Test
     fun `When the FC unavailable, flag disabled, us bank in intent, then us bank account is not available`() = runTest {
-        achFeatureFlagTestRule.setEnabled(false)
-
         val loader = createCustomerSheetLoader(
             customerAdapter = FakeCustomerAdapter(
                 canCreateSetupIntents = true,
@@ -392,8 +379,6 @@ class DefaultCustomerSheetLoaderTest {
 
     @Test
     fun `When the FC unavailable, flag enabled, us bank not in intent, then us bank account is not available`() = runTest {
-        achFeatureFlagTestRule.setEnabled(true)
-
         val loader = createCustomerSheetLoader(
             customerAdapter = FakeCustomerAdapter(
                 canCreateSetupIntents = true,
@@ -417,8 +402,6 @@ class DefaultCustomerSheetLoaderTest {
 
     @Test
     fun `When the FC unavailable, flag enabled, us bank in intent, then us bank account is not available`() = runTest {
-        achFeatureFlagTestRule.setEnabled(true)
-
         val loader = createCustomerSheetLoader(
             customerAdapter = FakeCustomerAdapter(
                 canCreateSetupIntents = true,
@@ -442,8 +425,6 @@ class DefaultCustomerSheetLoaderTest {
 
     @Test
     fun `When the FC available, flag disabled, us bank not in intent, then us bank account is not available`() = runTest {
-        achFeatureFlagTestRule.setEnabled(false)
-
         val loader = createCustomerSheetLoader(
             customerAdapter = FakeCustomerAdapter(
                 canCreateSetupIntents = true,
@@ -467,8 +448,6 @@ class DefaultCustomerSheetLoaderTest {
 
     @Test
     fun `When the FC available, flag disabled, us bank in intent, then us bank account is not available`() = runTest {
-        achFeatureFlagTestRule.setEnabled(false)
-
         val loader = createCustomerSheetLoader(
             customerAdapter = FakeCustomerAdapter(
                 canCreateSetupIntents = true,
@@ -492,8 +471,6 @@ class DefaultCustomerSheetLoaderTest {
 
     @Test
     fun `When the FC available, flag enabled, us bank not in intent, then us bank account is not available`() = runTest {
-        achFeatureFlagTestRule.setEnabled(true)
-
         val loader = createCustomerSheetLoader(
             customerAdapter = FakeCustomerAdapter(
                 canCreateSetupIntents = true,
@@ -517,8 +494,6 @@ class DefaultCustomerSheetLoaderTest {
 
     @Test
     fun `When the FC available, flag enabled, us bank in intent, then us bank account is available`() = runTest {
-        achFeatureFlagTestRule.setEnabled(true)
-
         val loader = createCustomerSheetLoader(
             customerAdapter = FakeCustomerAdapter(
                 canCreateSetupIntents = true,

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
@@ -4,9 +4,7 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.core.BuildConfig
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-object FeatureFlags {
-    val customerSheetACHv2 = FeatureFlag()
-}
+object FeatureFlags
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class FeatureFlag {


### PR DESCRIPTION
# Summary
Removes the CustomerSheet `ACHv2` flag.

# Motivation
No longer needed since we are now showing GAing ACHv2 with `CustomerSheet`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified