### PR TITLE
support running IDDetector and MBDetector together

### DIFF
--- a/identity/detekt-baseline.xml
+++ b/identity/detekt-baseline.xml
@@ -6,6 +6,7 @@
     <ID>CyclomaticComplexMethod:MBDetector.kt$MBDetector$private fun FrameAnalysisStatus.toCaptureFeedback(): CaptureFeedback</ID>
     <ID>CyclomaticComplexMethod:OTPScreen.kt$@Composable internal fun OTPScreen( navController: NavController, identityViewModel: IdentityViewModel, otpViewModelFactory: ViewModelProvider.Factory = OTPViewModel.Factory( identityRepository = identityViewModel.identityRepository, verificationArgs = identityViewModel.verificationArgs ) )</ID>
     <ID>CyclomaticComplexMethod:UploadScreen.kt$@Composable internal fun UploadScreen( navController: NavController, identityViewModel: IdentityViewModel, )</ID>
+    <ID>LargeClass:IDDetectorTransitionerTest.kt$IDDetectorTransitionerTest</ID>
     <ID>LargeClass:IdentityViewModel.kt$IdentityViewModel : AndroidViewModel</ID>
     <ID>LargeClass:IdentityViewModelTest.kt$IdentityViewModelTest</ID>
     <ID>LongMethod:AddressSection.kt$@Composable internal fun AddressSection( enabled: Boolean, identityViewModel: IdentityViewModel, addressCountries: List&lt;Country>, addressNotListedText: String, navController: NavController, onAddressCollected: (Resource&lt;RequiredInternationalAddress>) -> Unit )</ID>

--- a/identity/src/main/java/com/stripe/android/identity/analytics/IdentityAnalyticsRequestFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/analytics/IdentityAnalyticsRequestFactory.kt
@@ -325,6 +325,15 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         )
     )
 
+    fun mbCaptureStatus(
+        capturedByMb: Boolean
+    ) = maybeLogExperimentAndSendLog(
+        eventName = EVENT_MB_CAPTURE_STATUS,
+        additionalParamWithEventMetadata(
+            PARAM_CAPTURED_BY_MB to capturedByMb
+        )
+    )
+
     private fun IdentityScanState.ScanType.toParam(): String =
         when (this) {
             IdentityScanState.ScanType.DOC_FRONT -> DOC_FRONT
@@ -370,6 +379,7 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         const val EVENT_GENERIC_ERROR = "generic_error"
         const val EVENT_MB_STATUS = "mb_status"
         const val EVENT_MB_ERROR = "mb_error"
+        const val EVENT_MB_CAPTURE_STATUS = "mb_capture_status"
         const val EVENT_EXPERIMENT_EXPOSURE = "preloaded_experiment_retrieved"
 
         const val PARAM_EVENT_META_DATA = "event_metadata"
@@ -414,6 +424,7 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         const val PARAM_INIT_FAILED_REASON = "init_failed_reason"
         const val PARAM_EXPERIMENT_RETRIEVED = "experiment_retrieved"
         const val PARAM_ARB_ID = "arb_id"
+        const val PARAM_CAPTURED_BY_MB = "captured_by_mb"
 
         const val SCREEN_NAME_CONSENT = "consent"
         const val SCREEN_NAME_DOC_WARMUP = "document_warmup"

--- a/identity/src/main/java/com/stripe/android/identity/ml/IDDetectorAnalyzer.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ml/IDDetectorAnalyzer.kt
@@ -131,10 +131,12 @@ internal class IDDetectorAnalyzer(
                     )
                 } else {
                     // MB executed successfully, return Modern result
-                    IDDetectorOutput.Modern(
+                    buildModernOutput(
+                        bestBoundingBox,
                         bestCategory,
                         bestScore,
                         categoriesMapping,
+                        croppedImage,
                         mbOutput
                     )
                 }
@@ -188,6 +190,28 @@ internal class IDDetectorAnalyzer(
             categoriesMapping,
             laplacianBlurDetector.calculateBlurOutput(croppedImage)
         )
+
+    private fun buildModernOutput(
+        bestBoundingBox: FloatArray,
+        bestCategory: Category,
+        bestScore: Float,
+        categoriesMapping: List<Float>,
+        croppedImage: Bitmap,
+        mbOutput: MBDetector.DetectorResult
+    ) = IDDetectorOutput.Modern(
+        // Return Legacy output if mbDetector is not available
+        BoundingBox(
+            bestBoundingBox[0],
+            bestBoundingBox[1],
+            bestBoundingBox[2],
+            bestBoundingBox[3]
+        ),
+        bestCategory,
+        bestScore,
+        categoriesMapping,
+        laplacianBlurDetector.calculateBlurOutput(croppedImage),
+        mbOutput
+    )
 
     internal class Factory(
         private val context: Context,

--- a/identity/src/main/java/com/stripe/android/identity/ml/ModelIO.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ml/ModelIO.kt
@@ -37,24 +37,28 @@ internal sealed interface AnalyzerOutput
  * Output of IDDetector
  */
 internal sealed class IDDetectorOutput(
+    open val boundingBox: BoundingBox,
     open val category: Category,
     open val resultScore: Float,
     open val allScores: List<Float>,
+    open val blurScore: Float
 ) : AnalyzerOutput {
     data class Legacy(
-        val boundingBox: BoundingBox,
+        override val boundingBox: BoundingBox,
         override val category: Category,
         override val resultScore: Float,
         override val allScores: List<Float>,
-        val blurScore: Float
-    ) : IDDetectorOutput(category, resultScore, allScores)
+        override val blurScore: Float
+    ) : IDDetectorOutput(boundingBox, category, resultScore, allScores, blurScore)
 
     data class Modern(
+        override val boundingBox: BoundingBox,
         override val category: Category,
         override val resultScore: Float,
         override val allScores: List<Float>,
+        override val blurScore: Float,
         val mbOutput: MBDetector.DetectorResult
-    ) : IDDetectorOutput(category, resultScore, allScores)
+    ) : IDDetectorOutput(boundingBox, category, resultScore, allScores, blurScore)
 
     fun blurScore(): Float? =
         when (this) {

--- a/identity/src/main/java/com/stripe/android/identity/states/MBDetector.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/MBDetector.kt
@@ -151,7 +151,7 @@ internal class MBDetector private constructor(settings: MBSettings) {
     }
 
     companion object {
-        suspend fun maybeCreateMBInstance(
+        fun maybeCreateMBInstance(
             context: Context,
             settings: MBSettings?,
             identityAnalyticsRequestFactory: IdentityAnalyticsRequestFactory

--- a/identity/src/test/java/com/stripe/android/identity/viewmodel/IdentityViewModelTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/viewmodel/IdentityViewModelTest.kt
@@ -1250,9 +1250,11 @@ internal class IdentityViewModelTest {
                 mock()
             ),
             result = IDDetectorOutput.Modern(
+                boundingBox = BOUNDING_BOX,
                 category = Category.ID_FRONT,
                 resultScore = 0.8f,
                 allScores = ALL_SCORES,
+                blurScore = 1.0f,
                 mbOutput = MBDetector.DetectorResult.Captured(
                     INPUT_BITMAP,
                     EXTRACTED_BITMAP,
@@ -1270,9 +1272,11 @@ internal class IdentityViewModelTest {
                 mock()
             ),
             result = IDDetectorOutput.Modern(
+                boundingBox = BOUNDING_BOX,
                 category = Category.ID_BACK,
                 resultScore = 0.8f,
                 allScores = ALL_SCORES,
+                blurScore = 1.0f,
                 mbOutput = MBDetector.DetectorResult.Captured(
                     INPUT_BITMAP,
                     EXTRACTED_BITMAP,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Analyze the result of IDDetector and MBDetector and return whenever either returns positive result

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Better user capture experience - when MB doesn't support a certain type, use IDDetector instead.
See [this](https://docs.google.com/document/d/1LyVYV4mLaozxjJu-wkMojDdAkV8NajQ_E8NVNAQAGK4/edit#bookmark=id.w07dal7n2i8v) internal doc for more details

Related iOS - https://github.com/stripe/stripe-ios/pull/3463
# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
