### PR TITLE
Increase afterpay information clickable area

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayElementUI.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.ui.core.elements
 
+import android.content.Intent
+import android.net.Uri
 import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
@@ -54,6 +56,10 @@ fun AfterpayClearpayElementUI(
         color = MaterialTheme.stripeColors.subtitle,
         style = MaterialTheme.typography.h6,
         urlSpanStyle = SpanStyle(),
-        imageAlign = PlaceholderVerticalAlign.Bottom
+        imageAlign = PlaceholderVerticalAlign.Bottom,
+        onClick = {
+            val openURL = Intent(Intent.ACTION_VIEW, Uri.parse(element.infoUrl))
+            context.startActivity(openURL)
+        }
     )
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement.kt
@@ -46,7 +46,7 @@ data class AfterpayClearpayHeaderElement(
             // The no break space will keep the afterpay logo and (i) on the same line.
             .replace(
                 "<img/>",
-                "<img/>$NO_BREAK_SPACE<a href=\"$infoUrl\"><b>ⓘ</b></a>"
+                "<img/>$NO_BREAK_SPACE<b>ⓘ</b>"
             )
     }
 

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElementTest.kt
@@ -25,8 +25,7 @@ class AfterpayClearpayHeaderElementTest {
             element.getLabel(ApplicationProvider.getApplicationContext<Application>().resources)
         ).isEqualTo(
             "Pay in 4 interest-free payments of $50.00 with <img/> " +
-                "<a href=\"https://static.afterpay.com/modal/en_US.html\">" +
-                "<b>ⓘ</b></a>"
+                "<b>ⓘ</b>"
         )
     }
 
@@ -41,8 +40,7 @@ class AfterpayClearpayHeaderElementTest {
             element.getLabel(ApplicationProvider.getApplicationContext<Application>().resources)
         ).isEqualTo(
             "Pay in 3 interest-free payments of €66.66 with <img/> " +
-                "<a href=\"https://static.afterpay.com/modal/en_US.html\">" +
-                "<b>ⓘ</b></a>"
+                "<b>ⓘ</b>"
         )
     }
 
@@ -58,8 +56,7 @@ class AfterpayClearpayHeaderElementTest {
             element.getLabel(ApplicationProvider.getApplicationContext<Application>().resources)
         ).isEqualTo(
             "Pay in 4 interest-free payments of US$50.00 with <img/> " +
-                "<a href=\"https://static.afterpay.com/modal/en_CA.html\">" +
-                "<b>ⓘ</b></a>"
+                "<b>ⓘ</b>"
         )
     }
 


### PR DESCRIPTION
# Summary
Increase clickable area for afterpay information webview listener

# Motivation
Clickable area was too small on just information symbol. Makes whole textview clickable to match iOS.
[Resolves](https://jira.corp.stripe.com/browse/MOBILESDK-1305)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified



# Screenshots
| Before  | After |
| ------------- | ------------- |
| [Before](https://github.com/stripe/stripe-android/assets/163896025/e929bdf0-b7c6-4b0b-b4fa-73e6203b9a5c)  | [After](https://github.com/stripe/stripe-android/assets/163896025/e038d788-561f-45e0-b7ae-903059bef30e) |


