### PR TITLE
Update our analytics param names to use snake case

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/RealErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/RealErrorReporter.kt
@@ -16,9 +16,9 @@ class RealErrorReporter @Inject constructor(
 ) : ErrorReporter {
     override fun report(errorEvent: ErrorReporter.ErrorEvent, stripeException: StripeException) {
         val additionalParams = mapOf(
-            "analyticsValue" to stripeException.analyticsValue(),
-            "statusCode" to stripeException.statusCode.toString(),
-            "requestId" to stripeException.requestId,
+            "analytics_value" to stripeException.analyticsValue(),
+            "status_code" to stripeException.statusCode.toString(),
+            "request_id" to stripeException.requestId,
         ).filterNotNullValues()
         analyticsRequestExecutor.executeAsync(
             analyticsRequestFactory.createRequest(errorEvent, additionalParams)

--- a/payments-core/src/test/java/com/stripe/android/payments/core/analytics/RealErrorReporterTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/analytics/RealErrorReporterTest.kt
@@ -44,9 +44,9 @@ class RealErrorReporterTest {
         val executedAnalyticsRequests = analyticsRequestExecutor.getExecutedRequests()
         assertThat(executedAnalyticsRequests.size).isEqualTo(1)
         val analyticsRequestParams = executedAnalyticsRequests.get(0).params
-        assertThat(analyticsRequestParams.get("analyticsValue")).isEqualTo(expectedAnalyticsValue)
-        assertThat(analyticsRequestParams.get("statusCode")).isEqualTo(expectedStatusCode)
-        assertThat(analyticsRequestParams.get("requestId")).isNull()
+        assertThat(analyticsRequestParams.get("analytics_value")).isEqualTo(expectedAnalyticsValue)
+        assertThat(analyticsRequestParams.get("status_code")).isEqualTo(expectedStatusCode)
+        assertThat(analyticsRequestParams.get("request_id")).isNull()
     }
 
     @Test
@@ -61,8 +61,8 @@ class RealErrorReporterTest {
         val executedAnalyticsRequests = analyticsRequestExecutor.getExecutedRequests()
         assertThat(executedAnalyticsRequests.size).isEqualTo(1)
         val analyticsRequestParams = executedAnalyticsRequests.get(0).params
-        assertThat(analyticsRequestParams.get("analyticsValue")).isEqualTo(expectedAnalyticsValue)
-        assertThat(analyticsRequestParams.get("statusCode")).isEqualTo(expectedStatusCode)
-        assertThat(analyticsRequestParams.get("requestId")).isEqualTo(expectedRequestId)
+        assertThat(analyticsRequestParams.get("analytics_value")).isEqualTo(expectedAnalyticsValue)
+        assertThat(analyticsRequestParams.get("status_code")).isEqualTo(expectedStatusCode)
+        assertThat(analyticsRequestParams.get("request_id")).isEqualTo(expectedRequestId)
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Change analytics params from RealErrorReporter to snake_case

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This is more consistent with other analytics params, e.g. see the params in [AnalyticsFields](https://github.com/stripe/stripe-android/blob/faa76a99ca3b77cbb8076afe99520aeecafd6b59/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsFields.kt#L11)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

# Screenshots
No UI change

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
Not user facing
