### PR TITLE
Fix issue with `PersistentRepository`

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/error/ErrorViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/error/ErrorViewModel.kt
@@ -41,7 +41,7 @@ internal class ErrorViewModel @Inject constructor(
             // pane after an error, they will be able to start over.
             coordinator().emit(Message.ClearPartnerWebAuth)
             ErrorState.Payload(
-                error = errorRepository.await().error,
+                error = requireNotNull(errorRepository.get()?.error),
                 disableLinkMoreAccounts = getManifest().disableLinkMoreAccounts,
                 allowManualEntry = getManifest().allowManualEntry
             )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessViewModel.kt
@@ -36,7 +36,7 @@ internal class ManualEntrySuccessViewModel @Inject constructor(
             val manifest = getManifest()
             SuccessState.Payload(
                 businessName = manifest.businessName,
-                customSuccessMessage = successContentRepository.await().customSuccessMessage,
+                customSuccessMessage = successContentRepository.get()?.customSuccessMessage,
                 accountsCount = 1, // on manual entry just one account is connected,
                 skipSuccessPane = false
             ).also {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/notice/NoticeSheet.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/notice/NoticeSheet.kt
@@ -35,7 +35,7 @@ internal fun NoticeSheet(
         }
     }
 
-    state.content()?.let { content ->
+    state.content?.let { content ->
         StaticBottomSheetContent(
             content = content,
             onClickableTextClick = viewModel::handleClickableTextClick,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessViewModel.kt
@@ -42,11 +42,11 @@ internal class SuccessViewModel @Inject constructor(
         suspend {
             val manifest = getManifest()
             val accounts = getCachedAccounts()
-            val successContent: SuccessContentRepository.State = successContentRepository.await()
+            val successContent = successContentRepository.get()
             SuccessState.Payload(
                 skipSuccessPane = manifest.skipSuccessPane ?: false,
                 accountsCount = accounts.size,
-                customSuccessMessage = successContent.customSuccessMessage,
+                customSuccessMessage = successContent?.customSuccessMessage,
                 // We just want to use the business name in the CTA if the feature is enabled in the manifest.
                 businessName = manifest.businessName?.takeIf { manifest.useContinueWithMerchantText() },
             )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/PersistingRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/PersistingRepository.kt
@@ -2,11 +2,6 @@ package com.stripe.android.financialconnections.repository
 
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.withTimeout
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 
 internal abstract class PersistingRepository<S : Parcelable>(
     private val savedStateHandle: SavedStateHandle,
@@ -14,12 +9,8 @@ internal abstract class PersistingRepository<S : Parcelable>(
 
     private val key = makeKey()
 
-    suspend fun await(
-        timeout: Duration = 5.seconds,
-    ): S {
-        return withTimeout(timeout) {
-            savedStateHandle.getStateFlow<S?>(key, null).filterNotNull().first()
-        }
+    fun get(): S? {
+        return savedStateHandle[key]
     }
 
     fun set(state: S) {

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/success/SuccessViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/success/SuccessViewModelTest.kt
@@ -14,7 +14,6 @@ import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Complete
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.repository.SuccessContentRepository
-import com.stripe.android.financialconnections.ui.TextResource
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.test.runTest
@@ -43,7 +42,7 @@ internal class SuccessViewModelTest {
         eventTracker = eventTracker,
         initialState = state,
         nativeAuthFlowCoordinator = nativeAuthFlowCoordinator,
-        successContentRepository = fakeSuccessContentRepository(),
+        successContentRepository = SuccessContentRepository(SavedStateHandle()),
         getCachedAccounts = getCachedAccounts,
     )
 
@@ -94,18 +93,5 @@ internal class SuccessViewModelTest {
             buildViewModel(SuccessState()).onDoneClick()
             assertThat(awaitItem()).isEqualTo(Complete())
         }
-    }
-
-    private fun fakeSuccessContentRepository(
-        initialState: SuccessContentRepository.State = SuccessContentRepository.State(
-            customSuccessMessage = TextResource.Text("Yay!"),
-        ),
-    ): SuccessContentRepository {
-        val key = "PersistedState_${SuccessContentRepository::class.java.name}"
-        return SuccessContentRepository(
-            savedStateHandle = SavedStateHandle(
-                initialState = mapOf(key to initialState)
-            ),
-        )
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue with `PersistentRepository` that caused an infinite spinner on the success screen.

Instead of attempting to hide away all nullability in the repository’s `await()` method, we now expose a simple `get(): S?` and let the consumer decide what to do in the case of `null`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
