### PR TITLE
Add a default error reporter.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -75,19 +75,19 @@ internal interface DefaultErrorReporterComponent {
 }
 
 @Module
-internal abstract class DefaultErrorReporterModule {
+internal interface DefaultErrorReporterModule {
     @Binds
-    abstract fun bindRealErrorReporter(
+    fun bindRealErrorReporter(
         errorReporter: RealErrorReporter
     ): ErrorReporter
 
     @Binds
-    abstract fun providesAnalyticsRequestExecutor(
+    fun providesAnalyticsRequestExecutor(
         executor: DefaultAnalyticsRequestExecutor
     ): AnalyticsRequestExecutor
 
     @Binds
-    abstract fun providePaymentAnalyticsRequestFactory(
+    fun providePaymentAnalyticsRequestFactory(
         requestFactory: PaymentAnalyticsRequestFactory
     ): AnalyticsRequestFactory
 

--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -28,6 +28,7 @@ interface ErrorReporter {
 
     fun report(errorEvent: ErrorEvent, stripeException: StripeException)
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
         /**
          * Prefer using an injected version of [ErrorReporter].

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanActivity.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.stripecardscan.cardscan.CardScanSheetResult
 import com.stripe.android.ui.core.StripeCardScanProxy
 import com.stripe.android.ui.core.databinding.StripeActivityCardScanBinding
@@ -22,7 +23,8 @@ internal class CardScanActivity : AppCompatActivity() {
         stripeCardScanProxy = StripeCardScanProxy.create(
             this,
             PaymentConfiguration.getInstance(this).publishableKey,
-            this::onScanFinished
+            this::onScanFinished,
+            ErrorReporter.createFallbackInstance(applicationContext, setOf("CardScan"))
         )
         stripeCardScanProxy.present()
     }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/StripeCardScanProxyTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/StripeCardScanProxyTest.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.stripecardscan.cardscan.CardScanSheet
 import com.stripe.android.stripecardscan.cardscan.CardScanSheetResult
+import com.stripe.android.testing.FakeErrorReporter
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -45,7 +46,8 @@ class StripeCardScanProxyTest {
                 fragment = mockFragment,
                 stripePublishableKey = "test",
                 onFinished = {},
-                isStripeCardScanAvailable = mockIsStripeCardScanAvailable
+                isStripeCardScanAvailable = mockIsStripeCardScanAvailable,
+                errorReporter = FakeErrorReporter(),
             ) is UnsupportedStripeCardScanProxy
         )
         assertTrue(
@@ -53,7 +55,8 @@ class StripeCardScanProxyTest {
                 activity = mockActivity,
                 stripePublishableKey = "test",
                 onFinished = {},
-                isStripeCardScanAvailable = mockIsStripeCardScanAvailable
+                isStripeCardScanAvailable = mockIsStripeCardScanAvailable,
+                errorReporter = FakeErrorReporter(),
             ) is UnsupportedStripeCardScanProxy
         )
     }
@@ -68,7 +71,8 @@ class StripeCardScanProxyTest {
                 stripePublishableKey = "test",
                 onFinished = {},
                 isStripeCardScanAvailable = mockIsStripeCardScanAvailable,
-                provider = { FakeProxy() }
+                provider = { FakeProxy() },
+                errorReporter = FakeErrorReporter(),
             ) is FakeProxy
         )
         assertTrue(
@@ -77,7 +81,8 @@ class StripeCardScanProxyTest {
                 stripePublishableKey = "test",
                 onFinished = {},
                 isStripeCardScanAvailable = mockIsStripeCardScanAvailable,
-                provider = { FakeProxy() }
+                provider = { FakeProxy() },
+                errorReporter = FakeErrorReporter(),
             ) is FakeProxy
         )
     }
@@ -89,7 +94,8 @@ class StripeCardScanProxyTest {
                 fragment = mockFragment,
                 stripePublishableKey = "",
                 onFinished = {},
-                isStripeCardScanAvailable = mockIsStripeCardScanAvailable
+                isStripeCardScanAvailable = mockIsStripeCardScanAvailable,
+                errorReporter = FakeErrorReporter(),
             ).present()
         }
         assertFailsWith<IllegalStateException> {
@@ -97,7 +103,8 @@ class StripeCardScanProxyTest {
                 activity = mockActivity,
                 stripePublishableKey = "",
                 onFinished = {},
-                isStripeCardScanAvailable = mockIsStripeCardScanAvailable
+                isStripeCardScanAvailable = mockIsStripeCardScanAvailable,
+                errorReporter = FakeErrorReporter(),
             ).present()
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Some places don't have access to a dagger component, so we need to create an error reporter out of thin air.
