### PR TITLE
Refactor ErrorReporter to allow a nullable exception, and additionalNonPiiParams.

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/FakeErrorReporter.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/FakeErrorReporter.kt
@@ -9,7 +9,11 @@ class FakeErrorReporter : ErrorReporter {
 
     private val loggedErrors: MutableList<String> = mutableListOf()
 
-    override fun report(errorEvent: ErrorReporter.ErrorEvent, stripeException: StripeException) {
+    override fun report(
+        errorEvent: ErrorReporter.ErrorEvent,
+        stripeException: StripeException?,
+        additionalNonPiiParams: Map<String, String>,
+    ) {
         loggedErrors.add(errorEvent.eventName)
     }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -59,7 +59,10 @@ interface ErrorReporter {
         ),
         MISSING_CARDSCAN_DEPENDENCY(
             eventName = "unexpected.cardscan.missing_dependency"
-        )
+        ),
+        MISSING_HOSTED_VOUCHER_URL(
+            eventName = "unexpected.payments.missing_hosted_voucher_url"
+        ),
     }
 }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -26,7 +26,11 @@ import kotlin.coroutines.CoroutineContext
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface ErrorReporter {
 
-    fun report(errorEvent: ErrorEvent, stripeException: StripeException)
+    fun report(
+        errorEvent: ErrorEvent,
+        stripeException: StripeException? = null,
+        additionalNonPiiParams: Map<String, String> = emptyMap(),
+    )
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/RealErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/RealErrorReporter.kt
@@ -14,14 +14,18 @@ class RealErrorReporter @Inject constructor(
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val analyticsRequestFactory: AnalyticsRequestFactory
 ) : ErrorReporter {
-    override fun report(errorEvent: ErrorReporter.ErrorEvent, stripeException: StripeException) {
+    override fun report(
+        errorEvent: ErrorReporter.ErrorEvent,
+        stripeException: StripeException?,
+        additionalNonPiiParams: Map<String, String>,
+    ) {
         val additionalParams = mapOf(
-            "analytics_value" to stripeException.analyticsValue(),
-            "status_code" to stripeException.statusCode.toString(),
-            "request_id" to stripeException.requestId,
-            "error_type" to stripeException.stripeError?.type,
-            "error_code" to stripeException.stripeError?.code,
-        ).filterNotNullValues()
+            "analytics_value" to stripeException?.analyticsValue(),
+            "status_code" to stripeException?.statusCode?.toString(),
+            "request_id" to stripeException?.requestId,
+            "error_type" to stripeException?.stripeError?.type,
+            "error_code" to stripeException?.stripeError?.code,
+        ).plus(additionalNonPiiParams).filterNotNullValues()
         analyticsRequestExecutor.executeAsync(
             analyticsRequestFactory.createRequest(errorEvent, additionalParams)
         )

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/BoletoAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/BoletoAuthenticator.kt
@@ -1,8 +1,10 @@
 package com.stripe.android.payments.core.authentication
 
+import android.content.Context
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.StripeIntent.NextActionData
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.view.AuthActivityStarterHost
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -15,7 +17,8 @@ import javax.inject.Singleton
 @Singleton
 internal class BoletoAuthenticator @Inject constructor(
     private val webIntentAuthenticator: WebIntentAuthenticator,
-    private val noOpIntentAuthenticator: NoOpIntentAuthenticator
+    private val noOpIntentAuthenticator: NoOpIntentAuthenticator,
+    private val context: Context,
 ) : PaymentAuthenticator<StripeIntent>() {
     override suspend fun performAuthentication(
         host: AuthActivityStarterHost,
@@ -24,6 +27,10 @@ internal class BoletoAuthenticator @Inject constructor(
     ) {
         val detailsData = authenticatable.nextActionData as NextActionData.DisplayBoletoDetails
         if (detailsData.hostedVoucherUrl == null) {
+            ErrorReporter.createFallbackInstance(context, emptySet()).report(
+                ErrorReporter.ErrorEvent.MISSING_HOSTED_VOUCHER_URL,
+                additionalNonPiiParams = mapOf("lpm" to "boleto")
+            )
             noOpIntentAuthenticator.authenticate(
                 host,
                 authenticatable,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/KonbiniAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/KonbiniAuthenticator.kt
@@ -1,8 +1,10 @@
 package com.stripe.android.payments.core.authentication
 
+import android.content.Context
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.StripeIntent.NextActionData
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.view.AuthActivityStarterHost
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -15,7 +17,8 @@ import javax.inject.Singleton
 @Singleton
 internal class KonbiniAuthenticator @Inject constructor(
     private val webIntentAuthenticator: WebIntentAuthenticator,
-    private val noOpIntentAuthenticator: NoOpIntentAuthenticator
+    private val noOpIntentAuthenticator: NoOpIntentAuthenticator,
+    private val context: Context,
 ) : PaymentAuthenticator<StripeIntent>() {
     override suspend fun performAuthentication(
         host: AuthActivityStarterHost,
@@ -24,6 +27,10 @@ internal class KonbiniAuthenticator @Inject constructor(
     ) {
         val detailsData = authenticatable.nextActionData as NextActionData.DisplayKonbiniDetails
         if (detailsData.hostedVoucherUrl == null) {
+            ErrorReporter.createFallbackInstance(context, emptySet()).report(
+                ErrorReporter.ErrorEvent.MISSING_HOSTED_VOUCHER_URL,
+                additionalNonPiiParams = mapOf("lpm" to "konbini")
+            )
             noOpIntentAuthenticator.authenticate(
                 host,
                 authenticatable,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/OxxoAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/OxxoAuthenticator.kt
@@ -1,8 +1,10 @@
 package com.stripe.android.payments.core.authentication
 
+import android.content.Context
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.StripeIntent.NextActionData
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.view.AuthActivityStarterHost
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -15,7 +17,8 @@ import javax.inject.Singleton
 @Singleton
 internal class OxxoAuthenticator @Inject constructor(
     private val webIntentAuthenticator: WebIntentAuthenticator,
-    private val noOpIntentAuthenticator: NoOpIntentAuthenticator
+    private val noOpIntentAuthenticator: NoOpIntentAuthenticator,
+    private val context: Context,
 ) : PaymentAuthenticator<StripeIntent>() {
     override suspend fun performAuthentication(
         host: AuthActivityStarterHost,
@@ -24,6 +27,10 @@ internal class OxxoAuthenticator @Inject constructor(
     ) {
         val oxxoDetailsData = authenticatable.nextActionData as NextActionData.DisplayOxxoDetails
         if (oxxoDetailsData.hostedVoucherUrl == null) {
+            ErrorReporter.createFallbackInstance(context, emptySet()).report(
+                ErrorReporter.ErrorEvent.MISSING_HOSTED_VOUCHER_URL,
+                additionalNonPiiParams = mapOf("lpm" to "oxxo")
+            )
             noOpIntentAuthenticator.authenticate(
                 host,
                 authenticatable,

--- a/payments-core/src/test/java/com/stripe/android/payments/core/analytics/RealErrorReporterTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/analytics/RealErrorReporterTest.kt
@@ -85,4 +85,39 @@ class RealErrorReporterTest {
         assertThat(analyticsRequestParams.get("error_type")).isEqualTo(expectedErrorType)
         assertThat(analyticsRequestParams.get("request_id")).isEqualTo(expectedRequestId)
     }
+
+    @Test
+    fun `RealErrorReporter logs additionalNonPiiParams via analyticsRequestExecutor`() {
+        val exception = StripeException.create(IllegalArgumentException("this arg isn't legal"))
+        val expectedAnalyticsValue = exception.analyticsValue()
+        val expectedStatusCode = exception.statusCode.toString()
+
+        realErrorReporter.report(
+            errorEvent = ErrorReporter.ErrorEvent.GET_SAVED_PAYMENT_METHODS_FAILURE,
+            stripeException = exception,
+            additionalNonPiiParams = mapOf("foo" to "bar")
+        )
+
+        val executedAnalyticsRequests = analyticsRequestExecutor.getExecutedRequests()
+        assertThat(executedAnalyticsRequests.size).isEqualTo(1)
+        val analyticsRequestParams = executedAnalyticsRequests.get(0).params
+        assertThat(analyticsRequestParams.get("analytics_value")).isEqualTo(expectedAnalyticsValue)
+        assertThat(analyticsRequestParams.get("status_code")).isEqualTo(expectedStatusCode)
+        assertThat(analyticsRequestParams.get("request_id")).isNull()
+        assertThat(analyticsRequestParams.get("foo")).isEqualTo("bar")
+    }
+
+    @Test
+    fun `RealErrorReporter logs skips exception params when exception is null via analyticsRequestExecutor`() {
+        realErrorReporter.report(
+            errorEvent = ErrorReporter.ErrorEvent.GET_SAVED_PAYMENT_METHODS_FAILURE,
+        )
+
+        val executedAnalyticsRequests = analyticsRequestExecutor.getExecutedRequests()
+        assertThat(executedAnalyticsRequests.size).isEqualTo(1)
+        val analyticsRequestParams = executedAnalyticsRequests.get(0).params
+        assertThat(analyticsRequestParams.get("analytics_value")).isNull()
+        assertThat(analyticsRequestParams.get("status_code")).isNull()
+        assertThat(analyticsRequestParams.get("request_id")).isNull()
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This updates ErrorReporter to be a little bit more flexible. Not always requiring an exception.
It also add the ability to include more data for shared errors (as demonstrated by these authenticators).
