### PR TITLE
Wait for FC before continuing US Bank Account Tests.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -806,6 +806,10 @@ internal class PlaygroundTestDriver(
     }
 
     private fun doUSBankAccountAuthorization() {
+        while (currentActivity[0]?.javaClass?.name != FINANCIAL_CONNECTIONS_ACTIVITY) {
+            TimeUnit.MILLISECONDS.sleep(250)
+        }
+
         Espresso.onIdle()
         composeTestRule.waitForIdle()
 
@@ -872,5 +876,7 @@ internal class PlaygroundTestDriver(
 
     private companion object {
         const val ADD_PAYMENT_METHOD_NODE_TAG = "${PAYMENT_OPTION_CARD_TEST_TAG}_+ Add"
+        const val FINANCIAL_CONNECTIONS_ACTIVITY =
+            "com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity"
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
These tests were flakey because sometimes we'd click back before showing the financial connections sheet. This will make that not happen!

