### PR TITLE
Refactor `GooglePayRepository`

### DIFF
--- a/example/dependencies/dependencies.txt
+++ b/example/dependencies/dependencies.txt
@@ -702,6 +702,15 @@
 |    |    +--- com.google.dagger:dagger:2.50 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
+|    |    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1
+|    |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0
+|    |    |    |         +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    |         +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
+|    |    |    |         \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    |    +--- com.google.android.material:material:1.11.0 (*)
 |    |    +--- com.google.android.gms:play-services-wallet:19.2.1
 |    |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
@@ -709,12 +718,8 @@
 |    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
 |    |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
 |    |    |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    |    +--- com.google.android.gms:play-services-basement:18.0.0
-|    |    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
-|    |    |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
-|    |    |    |    |    \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1
-|    |    |    |         \--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    |    +--- com.google.android.gms:play-services-identity:18.0.1
 |    |    |    |    +--- com.google.android.gms:play-services-base:18.0.1 (*)
@@ -790,11 +795,7 @@
 |    |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
 |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
-|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3
-|    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
-|    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
-|    |    |    |    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1 (*)
-|    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 (*)
 |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2 (*)
 |    |    |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 |    |    |    +--- project :stripe-ui-core (*)

--- a/financial-connections-example/dependencies/dependencies.txt
+++ b/financial-connections-example/dependencies/dependencies.txt
@@ -40,7 +40,8 @@
 |    |    |    |    |    |    |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3
 |    |    |    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (c)
 |    |    |    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.3 (c)
-|    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (c)
+|    |    |    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (c)
+|    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 (c)
 |    |    |    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22
 |    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
 |    |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10
@@ -811,6 +812,15 @@
 |    +--- com.google.dagger:dagger:2.50 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
+|    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1
+|    |    |    \--- com.google.android.gms:play-services-basement:18.0.0
+|    |    |         +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |         +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
+|    |    |         \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    +--- com.google.android.material:material:1.11.0 (*)
 |    +--- com.google.android.gms:play-services-wallet:19.2.1
 |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
@@ -818,12 +828,8 @@
 |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
 |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
 |    |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    +--- com.google.android.gms:play-services-basement:18.0.0
-|    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
-|    |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
-|    |    |    |    \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1
-|    |    |         \--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    +--- com.google.android.gms:play-services-identity:18.0.1
 |    |    |    +--- com.google.android.gms:play-services-base:18.0.1 (*)

--- a/link/dependencies/dependencies.txt
+++ b/link/dependencies/dependencies.txt
@@ -693,6 +693,15 @@
 |    +--- com.google.dagger:dagger:2.50 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
+|    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1
+|    |    |    \--- com.google.android.gms:play-services-basement:18.0.0
+|    |    |         +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |         +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
+|    |    |         \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    +--- com.google.android.material:material:1.11.0 (*)
 |    +--- com.google.android.gms:play-services-wallet:19.2.1
 |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
@@ -700,12 +709,8 @@
 |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
 |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
 |    |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    +--- com.google.android.gms:play-services-basement:18.0.0
-|    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
-|    |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
-|    |    |    |    \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1
-|    |    |         \--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    +--- com.google.android.gms:play-services-identity:18.0.1
 |    |    |    +--- com.google.android.gms:play-services-base:18.0.1 (*)
@@ -774,11 +779,7 @@
 |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
-|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
-|    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 +--- project :stripe-ui-core (*)

--- a/network-testing/dependencies/dependencies.txt
+++ b/network-testing/dependencies/dependencies.txt
@@ -54,7 +54,8 @@
 |    |    |    |    |    |    |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3
 |    |    |    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (c)
 |    |    |    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.3 (c)
-|    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (c)
+|    |    |    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (c)
+|    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 (c)
 |    |    |    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22 (*)
 |    |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
@@ -679,6 +680,15 @@
 |    +--- com.google.dagger:dagger:2.50 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
+|    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1
+|    |    |    \--- com.google.android.gms:play-services-basement:18.0.0
+|    |    |         +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |         +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
+|    |    |         \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    +--- com.google.android.material:material:1.11.0 (*)
 |    +--- com.google.android.gms:play-services-wallet:19.2.1
 |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
@@ -686,12 +696,8 @@
 |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
 |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
 |    |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    +--- com.google.android.gms:play-services-basement:18.0.0
-|    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
-|    |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
-|    |    |    |    \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1
-|    |    |         \--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    +--- com.google.android.gms:play-services-identity:18.0.1
 |    |    |    +--- com.google.android.gms:play-services-base:18.0.1 (*)

--- a/payment-method-messaging/dependencies/dependencies.txt
+++ b/payment-method-messaging/dependencies/dependencies.txt
@@ -692,6 +692,15 @@
 |    +--- com.google.dagger:dagger:2.50 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
+|    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1
+|    |    |    \--- com.google.android.gms:play-services-basement:18.0.0
+|    |    |         +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |         +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
+|    |    |         \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    +--- com.google.android.material:material:1.11.0 (*)
 |    +--- com.google.android.gms:play-services-wallet:19.2.1
 |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
@@ -699,12 +708,8 @@
 |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
 |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
 |    |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    +--- com.google.android.gms:play-services-basement:18.0.0
-|    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
-|    |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
-|    |    |    |    \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1
-|    |    |         \--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    +--- com.google.android.gms:play-services-identity:18.0.1
 |    |    |    +--- com.google.android.gms:play-services-base:18.0.1 (*)
@@ -772,11 +777,7 @@
 |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
-|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
-|    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 +--- project :stripe-ui-core (*)

--- a/payments-core-testing/dependencies/dependencies.txt
+++ b/payments-core-testing/dependencies/dependencies.txt
@@ -41,6 +41,7 @@
 |    |    |    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (c)
 |    |    |    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.3 (c)
 |    |    |    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (c)
+|    |    |    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 (c)
 |    |    |    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm:1.7.3 (c)
 |    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3 (c)
 |    |    |    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22
@@ -671,6 +672,15 @@
 |    +--- com.google.dagger:dagger:2.50 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
+|    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1
+|    |    |    \--- com.google.android.gms:play-services-basement:18.0.0
+|    |    |         +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |         +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
+|    |    |         \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    +--- com.google.android.material:material:1.11.0 (*)
 |    +--- com.google.android.gms:play-services-wallet:19.2.1
 |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
@@ -678,12 +688,8 @@
 |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
 |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
 |    |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    +--- com.google.android.gms:play-services-basement:18.0.0
-|    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
-|    |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
-|    |    |    |    \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1
-|    |    |         \--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    +--- com.google.android.gms:play-services-identity:18.0.1
 |    |    |    +--- com.google.android.gms:play-services-base:18.0.1 (*)

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation libs.dagger
     implementation libs.kotlin.coroutines
     implementation libs.kotlin.coroutinesAndroid
+    implementation libs.kotlin.coroutinesPlayServices
     implementation libs.material
     implementation libs.playServicesWallet
     implementation libs.instantApps

--- a/payments-core/dependencies/dependencies.txt
+++ b/payments-core/dependencies/dependencies.txt
@@ -38,7 +38,8 @@
 |    |    |    |    |    |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3
 |    |    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (c)
 |    |    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.3 (c)
-|    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (c)
+|    |    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (c)
+|    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 (c)
 |    |    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22
 |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
 |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10
@@ -667,6 +668,15 @@
 +--- com.google.dagger:dagger:2.50 (*)
 +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
+|    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1
+|    |    \--- com.google.android.gms:play-services-basement:18.0.0
+|    |         +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |         +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
+|    |         \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 +--- com.google.android.material:material:1.11.0 (*)
 +--- com.google.android.gms:play-services-wallet:19.2.1
 |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
@@ -674,12 +684,8 @@
 |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
 |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
 |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    +--- com.google.android.gms:play-services-basement:18.0.0
-|    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
-|    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
-|    |    |    \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    \--- com.google.android.gms:play-services-tasks:18.0.1
-|    |         \--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    +--- com.google.android.gms:play-services-identity:18.0.1
 |    |    +--- com.google.android.gms:play-services-base:18.0.1 (*)

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
@@ -271,7 +271,7 @@ internal class GooglePayLauncherViewModel(
             )
 
             return GooglePayLauncherViewModel(
-                PaymentsClientFactory(application).create(googlePayEnvironment),
+                DefaultPaymentsClientFactory(application).create(googlePayEnvironment),
                 ApiRequest.Options(
                     publishableKey,
                     stripeAccountId

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/PaymentsClientFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/PaymentsClientFactory.kt
@@ -5,10 +5,16 @@ import com.google.android.gms.wallet.PaymentsClient
 import com.google.android.gms.wallet.Wallet
 import javax.inject.Inject
 
-internal class PaymentsClientFactory @Inject constructor(
-    private val context: Context
-) {
+internal fun interface PaymentsClientFactory {
     fun create(
+        environment: GooglePayEnvironment
+    ): PaymentsClient
+}
+
+internal class DefaultPaymentsClientFactory @Inject constructor(
+    private val context: Context
+) : PaymentsClientFactory {
+    override fun create(
         environment: GooglePayEnvironment
     ): PaymentsClient {
         val options = Wallet.WalletOptions.Builder()

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.googlepaylauncher.injection
 
 import com.stripe.android.googlepaylauncher.DefaultGooglePayRepository
+import com.stripe.android.googlepaylauncher.DefaultPaymentsClientFactory
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.googlepaylauncher.PaymentsClientFactory
@@ -19,6 +20,12 @@ internal abstract class GooglePayPaymentMethodLauncherModule {
     abstract fun bindsGooglePayRepository(
         defaultGooglePayRepository: DefaultGooglePayRepository
     ): GooglePayRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindsPaymentsClientFactory(
+        defaultPaymentsClientFactory: DefaultPaymentsClientFactory
+    ): PaymentsClientFactory
 
     companion object {
         @Provides

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayRepositoryTest.kt
@@ -1,0 +1,93 @@
+package com.stripe.android.googlepaylauncher
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.google.android.gms.common.api.ApiException
+import com.google.android.gms.common.api.Status
+import com.google.android.gms.tasks.Tasks
+import com.google.android.gms.wallet.PaymentsClient
+import com.stripe.android.GooglePayJsonFactory
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.Logger
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class GooglePayRepositoryTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun setup() {
+        PaymentConfiguration.init(context, "pk_123")
+    }
+
+    @Test
+    fun `when google pay is ready, 'isReady' should return true`() = runTest {
+        val paymentsClient = mock<PaymentsClient>()
+
+        whenever(paymentsClient.isReadyToPay(any())) doReturn Tasks.forResult(true)
+
+        val repository = createGooglePayRepository(paymentsClient)
+
+        repository.isReady().test {
+            assertEquals(true, awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when google pay is ready, 'isReady' should return false`() = runTest {
+        val paymentsClient = mock<PaymentsClient>()
+
+        whenever(paymentsClient.isReadyToPay(any())) doReturn Tasks.forResult(false)
+
+        val repository = createGooglePayRepository(paymentsClient)
+
+        repository.isReady().test {
+            assertEquals(false, awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when google pay is ready request fails, 'isReady' should return false`() = runTest {
+        val paymentsClient = mock<PaymentsClient>()
+
+        whenever(paymentsClient.isReadyToPay(any())) doReturn Tasks.forException(
+            ApiException(Status.RESULT_INTERNAL_ERROR)
+        )
+
+        val repository = createGooglePayRepository(paymentsClient)
+
+        repository.isReady().test {
+            assertEquals(false, awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private fun createGooglePayRepository(
+        paymentsClient: PaymentsClient,
+    ): DefaultGooglePayRepository {
+        return DefaultGooglePayRepository(
+            context = context,
+            environment = GooglePayEnvironment.Test,
+            billingAddressParameters = GooglePayJsonFactory.BillingAddressParameters(),
+            existingPaymentMethodRequired = true,
+            allowCreditCards = true,
+            paymentsClientFactory = { paymentsClient },
+            logger = Logger.noop(),
+        )
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayRepositoryTest.kt
@@ -46,7 +46,7 @@ class GooglePayRepositoryTest {
     }
 
     @Test
-    fun `when google pay is ready, 'isReady' should return false`() = runTest {
+    fun `when google pay is not ready, 'isReady' should return false`() = runTest {
         val paymentsClient = mock<PaymentsClient>()
 
         whenever(paymentsClient.isReadyToPay(any())) doReturn Tasks.forResult(false)

--- a/payments-ui-core/dependencies/dependencies.txt
+++ b/payments-ui-core/dependencies/dependencies.txt
@@ -672,6 +672,15 @@
 |    +--- com.google.dagger:dagger:2.50 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
+|    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1
+|    |    |    \--- com.google.android.gms:play-services-basement:18.0.0
+|    |    |         +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |         +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
+|    |    |         \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    +--- com.google.android.material:material:1.11.0 (*)
 |    +--- com.google.android.gms:play-services-wallet:19.2.1
 |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
@@ -679,12 +688,8 @@
 |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
 |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
 |    |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    +--- com.google.android.gms:play-services-basement:18.0.0
-|    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
-|    |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
-|    |    |    |    \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1
-|    |    |         \--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    +--- com.google.android.gms:play-services-identity:18.0.1
 |    |    |    +--- com.google.android.gms:play-services-base:18.0.1 (*)
@@ -745,10 +750,6 @@
 +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
 +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
-+--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3
-|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
-|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
-|    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1 (*)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 (*)
 +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2 (*)
 \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)

--- a/payments/dependencies/dependencies.txt
+++ b/payments/dependencies/dependencies.txt
@@ -699,6 +699,15 @@
 |    +--- com.google.dagger:dagger:2.50 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
+|    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1
+|    |    |    \--- com.google.android.gms:play-services-basement:18.0.0
+|    |    |         +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |         +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
+|    |    |         \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    +--- com.google.android.material:material:1.11.0 (*)
 |    +--- com.google.android.gms:play-services-wallet:19.2.1
 |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
@@ -706,12 +715,8 @@
 |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
 |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
 |    |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    +--- com.google.android.gms:play-services-basement:18.0.0
-|    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
-|    |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
-|    |    |    |    \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1
-|    |    |         \--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    +--- com.google.android.gms:play-services-identity:18.0.1
 |    |    |    +--- com.google.android.gms:play-services-base:18.0.1 (*)
@@ -787,11 +792,7 @@
 |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
-|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3
-|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
-|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
-|    |    |    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1 (*)
-|    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 (*)
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2 (*)
 |    |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 |    |    +--- project :stripe-ui-core (*)

--- a/paymentsheet-example/dependencies/dependencies.txt
+++ b/paymentsheet-example/dependencies/dependencies.txt
@@ -719,6 +719,15 @@
 |    |    +--- com.google.dagger:dagger:2.50 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
+|    |    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1
+|    |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0
+|    |    |    |         +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    |         +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
+|    |    |    |         \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    |    +--- com.google.android.material:material:1.11.0 (*)
 |    |    +--- com.google.android.gms:play-services-wallet:19.2.1
 |    |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
@@ -726,12 +735,8 @@
 |    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
 |    |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
 |    |    |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    |    +--- com.google.android.gms:play-services-basement:18.0.0
-|    |    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
-|    |    |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
-|    |    |    |    |    \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1
-|    |    |    |         \--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    |    +--- com.google.android.gms:play-services-identity:18.0.1
 |    |    |    |    +--- com.google.android.gms:play-services-base:18.0.1 (*)
@@ -807,11 +812,7 @@
 |    |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
 |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
-|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3
-|    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
-|    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
-|    |    |    |    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1 (*)
-|    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 (*)
 |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2 (*)
 |    |    |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 |    |    |    +--- project :stripe-ui-core (*)

--- a/paymentsheet/dependencies/dependencies.txt
+++ b/paymentsheet/dependencies/dependencies.txt
@@ -699,6 +699,15 @@
 |    +--- com.google.dagger:dagger:2.50 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
+|    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1
+|    |    |    \--- com.google.android.gms:play-services-basement:18.0.0
+|    |    |         +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |         +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
+|    |    |         \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    +--- com.google.android.material:material:1.11.0 (*)
 |    +--- com.google.android.gms:play-services-wallet:19.2.1
 |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
@@ -706,12 +715,8 @@
 |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
 |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
 |    |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    +--- com.google.android.gms:play-services-basement:18.0.0
-|    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
-|    |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
-|    |    |    |    \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1
-|    |    |         \--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    +--- com.google.android.gms:play-services-identity:18.0.1
 |    |    |    +--- com.google.android.gms:play-services-base:18.0.1 (*)
@@ -785,11 +790,7 @@
 |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3
-|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
-|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
-|    |    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2 (*)
 |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
 |    +--- project :stripe-ui-core (*)

--- a/stripe-test-e2e/dependencies/dependencies.txt
+++ b/stripe-test-e2e/dependencies/dependencies.txt
@@ -701,6 +701,15 @@
      |    +--- com.google.dagger:dagger:2.50 (*)
      |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
      |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
+     |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3
+     |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+     |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
+     |    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1
+     |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0
+     |    |    |         +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+     |    |    |         +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
+     |    |    |         \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
+     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
      |    +--- com.google.android.material:material:1.11.0 (*)
      |    +--- com.google.android.gms:play-services-wallet:19.2.1
      |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
@@ -708,12 +717,8 @@
      |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
      |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
      |    |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-     |    |    |    +--- com.google.android.gms:play-services-basement:18.0.0
-     |    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
-     |    |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
-     |    |    |    |    \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-     |    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1
-     |    |    |         \--- com.google.android.gms:play-services-basement:18.0.0 (*)
+     |    |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
+     |    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
      |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
      |    |    +--- com.google.android.gms:play-services-identity:18.0.1
      |    |    |    +--- com.google.android.gms:play-services-base:18.0.1 (*)
@@ -789,11 +794,7 @@
      |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
      |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
      |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
-     |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3
-     |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
-     |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
-     |    |    |    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1 (*)
-     |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
+     |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 (*)
      |    |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2 (*)
      |    |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.22 (*)
      |    |    +--- project :stripe-ui-core (*)

--- a/wechatpay/dependencies/dependencies.txt
+++ b/wechatpay/dependencies/dependencies.txt
@@ -40,7 +40,8 @@
 |    |    |    |    |    |    |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3
 |    |    |    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (c)
 |    |    |    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.3 (c)
-|    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (c)
+|    |    |    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (c)
+|    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 (c)
 |    |    |    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22
 |    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 (*)
 |    |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10
@@ -669,6 +670,15 @@
 |    +--- com.google.dagger:dagger:2.50 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
+|    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.0.1
+|    |    |    \--- com.google.android.gms:play-services-basement:18.0.0
+|    |    |         +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |         +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
+|    |    |         \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |    +--- com.google.android.material:material:1.11.0 (*)
 |    +--- com.google.android.gms:play-services-wallet:19.2.1
 |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
@@ -676,12 +686,8 @@
 |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
 |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
 |    |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    +--- com.google.android.gms:play-services-basement:18.0.0
-|    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
-|    |    |    |    +--- androidx.core:core:1.2.0 -> 1.12.0 (*)
-|    |    |    |    \--- androidx.fragment:fragment:1.0.0 -> 1.6.2 (*)
-|    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1
-|    |    |         \--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
+|    |    |    \--- com.google.android.gms:play-services-tasks:18.0.1 (*)
 |    |    +--- com.google.android.gms:play-services-basement:18.0.0 (*)
 |    |    +--- com.google.android.gms:play-services-identity:18.0.1
 |    |    |    +--- com.google.android.gms:play-services-base:18.0.1 (*)


### PR DESCRIPTION
# Summary
Refactors the `isReady` function for `GooglePayRepository` to use the `flow` builder function rather than a `MutableStateFlow`. `isReady` always emits a single flow so we should close the flow rather than keep it open. An additional helper function called `isReadyAsync` is added which performs the same logic as the current `isReady` but is suspendable and returns the `Boolean` result. In a major breaking change update, we should replace `isReady` with `isReadyAsync` since we only ever return a single value when calling the function so it doesn't need to return a flow. `DefaultGooglePayRepository` is also refactored to accept a `PaymentsClientFactory` rather than create the `PaymentsClient` instance internally, making is easier to provide a mock so that the class can be testable as opposed to need to mock the static `Wallet` object.

# Motivation
- Makes testing upcoming changes with `ErrorReporter` easier.
- Makes `isReady` more clear and concise.
- Makes refactor #7161 easier to perform in a major breaking change update.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
