### PR TITLE
Remove usage of `PaymentSheet.CustomerConfiguration` from `CustomerRepository`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
@@ -64,7 +64,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
 
         return getCustomerEphemeralKey().map { customerEphemeralKey ->
             customerRepository.getPaymentMethods(
-                customerConfig = PaymentSheet.CustomerConfiguration(
+                customerInfo = CustomerRepository.CustomerInfo(
                     id = customerEphemeralKey.customerId,
                     ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 ),
@@ -84,7 +84,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
     ): CustomerAdapter.Result<PaymentMethod> {
         return getCustomerEphemeralKey().map { customerEphemeralKey ->
             customerRepository.attachPaymentMethod(
-                customerConfig = PaymentSheet.CustomerConfiguration(
+                customerInfo = CustomerRepository.CustomerInfo(
                     id = customerEphemeralKey.customerId,
                     ephemeralKeySecret = customerEphemeralKey.ephemeralKey
                 ),
@@ -103,7 +103,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
     ): CustomerAdapter.Result<PaymentMethod> {
         return getCustomerEphemeralKey().mapCatching { customerEphemeralKey ->
             customerRepository.detachPaymentMethod(
-                customerConfig = PaymentSheet.CustomerConfiguration(
+                customerInfo = CustomerRepository.CustomerInfo(
                     id = customerEphemeralKey.customerId,
                     ephemeralKeySecret = customerEphemeralKey.ephemeralKey
                 ),
@@ -123,7 +123,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
     ): CustomerAdapter.Result<PaymentMethod> {
         return getCustomerEphemeralKey().mapCatching { customerEphemeralKey ->
             customerRepository.updatePaymentMethod(
-                customerConfig = PaymentSheet.CustomerConfiguration(
+                customerInfo = CustomerRepository.CustomerInfo(
                     id = customerEphemeralKey.customerId,
                     ephemeralKeySecret = customerEphemeralKey.ephemeralKey
                 ),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerRepository.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet.repositories
 import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
-import com.stripe.android.paymentsheet.PaymentSheet
 
 /**
  * Interface for fetching and modifying information about a Customer.
@@ -12,10 +11,7 @@ internal interface CustomerRepository {
     /**
      * Retrieve a Customer by ID using an ephemeral key.
      */
-    suspend fun retrieveCustomer(
-        customerId: String,
-        ephemeralKeySecret: String
-    ): Customer?
+    suspend fun retrieveCustomer(customerInfo: CustomerInfo): Customer?
 
     /**
      * Retrieve a Customer's payment methods of all types requested.
@@ -23,7 +19,7 @@ internal interface CustomerRepository {
      * types that failed.
      */
     suspend fun getPaymentMethods(
-        customerConfig: PaymentSheet.CustomerConfiguration,
+        customerInfo: CustomerInfo,
         types: List<PaymentMethod.Type>,
         silentlyFail: Boolean,
     ): Result<List<PaymentMethod>>
@@ -32,7 +28,7 @@ internal interface CustomerRepository {
      * Detach a payment method from the Customer and return the modified [PaymentMethod].
      */
     suspend fun detachPaymentMethod(
-        customerConfig: PaymentSheet.CustomerConfiguration,
+        customerInfo: CustomerInfo,
         paymentMethodId: String
     ): Result<PaymentMethod>
 
@@ -40,13 +36,18 @@ internal interface CustomerRepository {
      * Attach a payment method to the Customer and return the modified [PaymentMethod].
      */
     suspend fun attachPaymentMethod(
-        customerConfig: PaymentSheet.CustomerConfiguration,
+        customerInfo: CustomerInfo,
         paymentMethodId: String
     ): Result<PaymentMethod>
 
     suspend fun updatePaymentMethod(
-        customerConfig: PaymentSheet.CustomerConfiguration,
+        customerInfo: CustomerInfo,
         paymentMethodId: String,
         params: PaymentMethodUpdateParams
     ): Result<PaymentMethod>
+
+    data class CustomerInfo(
+        val id: String,
+        val ephemeralKeySecret: String,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -226,7 +226,10 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         val paymentMethodTypes = metadata.supportedSavedPaymentMethodTypes()
 
         val paymentMethods = customerRepository.getPaymentMethods(
-            customerConfig = customerConfig,
+            customerInfo = CustomerRepository.CustomerInfo(
+                id = customerConfig.id,
+                ephemeralKeySecret = customerConfig.ephemeralKeySecret
+            ),
             types = paymentMethodTypes,
             silentlyFail = metadata.stripeIntent.isLiveMode,
         ).getOrThrow()
@@ -297,8 +300,10 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
 
         val customerEmail = config.defaultBillingDetails?.email ?: config.customer?.let {
             customerRepository.retrieveCustomer(
-                it.id,
-                it.ephemeralKeySecret
+                CustomerRepository.CustomerInfo(
+                    id = it.id,
+                    ephemeralKeySecret = it.ephemeralKeySecret
+                )
             )
         }?.email
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -513,8 +513,14 @@ internal abstract class BaseSheetViewModel(
             updateSelection(null)
         }
 
+        // TODO(samer-stripe): Improve this by either throwing an unexpected error or returning a failure result
+        val requiredConfig = requireNotNull(customerConfig)
+
         return customerRepository.detachPaymentMethod(
-            customerConfig!!,
+            CustomerRepository.CustomerInfo(
+                id = requiredConfig.id,
+                ephemeralKeySecret = requiredConfig.ephemeralKeySecret
+            ),
             paymentMethodId
         )
     }
@@ -593,10 +599,14 @@ internal abstract class BaseSheetViewModel(
         paymentMethod: PaymentMethod,
         brand: CardBrand
     ): Result<PaymentMethod> {
-        val customerConfig = config.customer
+        // TODO(samer-stripe): Improve this by returning a failure result and throwing an unexpected result
+        val customerConfig = requireNotNull(config.customer)
 
         return customerRepository.updatePaymentMethod(
-            customerConfig = customerConfig!!,
+            customerInfo = CustomerRepository.CustomerInfo(
+                id = customerConfig.id,
+                ephemeralKeySecret = customerConfig.ephemeralKeySecret
+            ),
             paymentMethodId = paymentMethod.id!!,
             params = PaymentMethodUpdateParams.createCard(
                 networks = PaymentMethodUpdateParams.Card.Networks(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -157,7 +157,7 @@ class CustomerAdapterTest {
         )
         adapter.retrievePaymentMethods()
         verify(customerRepository).getPaymentMethods(
-            customerConfig = any(),
+            customerInfo = any(),
             types = eq(
                 listOf(
                     PaymentMethod.Type.Card,
@@ -206,7 +206,7 @@ class CustomerAdapterTest {
         adapter.retrievePaymentMethods()
 
         verify(customerRepository).getPaymentMethods(
-            customerConfig = any(),
+            customerInfo = any(),
             types = eq(
                 listOf(
                     PaymentMethod.Type.Card,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
@@ -11,7 +11,6 @@ import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.analytics.ErrorReporter
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.testing.FakeErrorReporter
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -56,7 +55,7 @@ internal class CustomerRepositoryTest {
             )
 
             repository.getPaymentMethods(
-                PaymentSheet.CustomerConfiguration(
+                CustomerRepository.CustomerInfo(
                     "customer_id",
                     "ephemeral_key"
                 ),
@@ -86,7 +85,7 @@ internal class CustomerRepositoryTest {
             )
 
             repository.getPaymentMethods(
-                PaymentSheet.CustomerConfiguration(
+                CustomerRepository.CustomerInfo(
                     "customer_id",
                     "ephemeral_key"
                 ),
@@ -159,7 +158,7 @@ internal class CustomerRepositoryTest {
             }
 
             val result = repository.getPaymentMethods(
-                PaymentSheet.CustomerConfiguration(
+                CustomerRepository.CustomerInfo(
                     "customer_id",
                     "ephemeral_key"
                 ),
@@ -217,7 +216,7 @@ internal class CustomerRepositoryTest {
         }
 
         val result = repository.getPaymentMethods(
-            PaymentSheet.CustomerConfiguration(
+            CustomerRepository.CustomerInfo(
                 "customer_id",
                 "ephemeral_key"
             ),
@@ -238,7 +237,7 @@ internal class CustomerRepositoryTest {
             )
 
             val result = repository.getPaymentMethods(
-                PaymentSheet.CustomerConfiguration(
+                CustomerRepository.CustomerInfo(
                     "customer_id",
                     "ephemeral_key"
                 ),
@@ -259,7 +258,7 @@ internal class CustomerRepositoryTest {
             )
 
             val result = repository.getPaymentMethods(
-                PaymentSheet.CustomerConfiguration(
+                CustomerRepository.CustomerInfo(
                     "customer_id",
                     "ephemeral_key"
                 ),
@@ -287,7 +286,7 @@ internal class CustomerRepositoryTest {
 
             // Requesting 3 payment method types, the first request will fail
             val result = repository.getPaymentMethods(
-                PaymentSheet.CustomerConfiguration(
+                CustomerRepository.CustomerInfo(
                     "customer_id",
                     "ephemeral_key"
                 ),
@@ -317,7 +316,7 @@ internal class CustomerRepositoryTest {
 
             // Requesting 3 payment method types, the first request will fail
             val result = repository.getPaymentMethods(
-                PaymentSheet.CustomerConfiguration(
+                CustomerRepository.CustomerInfo(
                     "customer_id",
                     "ephemeral_key"
                 ),
@@ -341,7 +340,7 @@ internal class CustomerRepositoryTest {
             )
 
             val result = repository.detachPaymentMethod(
-                PaymentSheet.CustomerConfiguration(
+                CustomerRepository.CustomerInfo(
                     "customer_id",
                     "ephemeral_key"
                 ),
@@ -359,7 +358,7 @@ internal class CustomerRepositoryTest {
             )
 
             val result = repository.detachPaymentMethod(
-                PaymentSheet.CustomerConfiguration(
+                CustomerRepository.CustomerInfo(
                     "customer_id",
                     "ephemeral_key"
                 ),
@@ -379,7 +378,7 @@ internal class CustomerRepositoryTest {
             )
 
             val result = repository.attachPaymentMethod(
-                PaymentSheet.CustomerConfiguration(
+                CustomerRepository.CustomerInfo(
                     "customer_id",
                     "ephemeral_key"
                 ),
@@ -398,7 +397,7 @@ internal class CustomerRepositoryTest {
             givenAttachPaymentMethodReturns(error)
 
             val result = repository.attachPaymentMethod(
-                PaymentSheet.CustomerConfiguration(
+                CustomerRepository.CustomerInfo(
                     "customer_id",
                     "ephemeral_key"
                 ),
@@ -415,7 +414,7 @@ internal class CustomerRepositoryTest {
             givenUpdatePaymentMethodReturns(success)
 
             val result = repository.updatePaymentMethod(
-                PaymentSheet.CustomerConfiguration(
+                CustomerRepository.CustomerInfo(
                     "customer_id",
                     "ephemeral_key"
                 ),
@@ -433,7 +432,7 @@ internal class CustomerRepositoryTest {
             givenUpdatePaymentMethodReturns(error)
 
             val result = repository.updatePaymentMethod(
-                PaymentSheet.CustomerConfiguration(
+                CustomerRepository.CustomerInfo(
                     "customer_id",
                     "ephemeral_key"
                 ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -357,7 +357,7 @@ internal class DefaultPaymentSheetLoaderTest {
         val result = createPaymentSheetLoader(
             customerRepo = object : FakeCustomerRepository() {
                 override suspend fun getPaymentMethods(
-                    customerConfig: PaymentSheet.CustomerConfiguration,
+                    customerInfo: CustomerRepository.CustomerInfo,
                     types: List<PaymentMethod.Type>,
                     silentlyFail: Boolean
                 ): Result<List<PaymentMethod>> {

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
@@ -3,7 +3,6 @@ package com.stripe.android.utils
 import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 
 internal open class FakeCustomerRepository(
@@ -25,28 +24,27 @@ internal open class FakeCustomerRepository(
     var error: Throwable? = null
 
     override suspend fun retrieveCustomer(
-        customerId: String,
-        ephemeralKeySecret: String
+        customerInfo: CustomerRepository.CustomerInfo
     ): Customer? = customer
 
     override suspend fun getPaymentMethods(
-        customerConfig: PaymentSheet.CustomerConfiguration,
+        customerInfo: CustomerRepository.CustomerInfo,
         types: List<PaymentMethod.Type>,
         silentlyFail: Boolean,
     ): Result<List<PaymentMethod>> = onGetPaymentMethods()
 
     override suspend fun detachPaymentMethod(
-        customerConfig: PaymentSheet.CustomerConfiguration,
+        customerInfo: CustomerRepository.CustomerInfo,
         paymentMethodId: String
     ): Result<PaymentMethod> = onDetachPaymentMethod()
 
     override suspend fun attachPaymentMethod(
-        customerConfig: PaymentSheet.CustomerConfiguration,
+        customerInfo: CustomerRepository.CustomerInfo,
         paymentMethodId: String
     ): Result<PaymentMethod> = onAttachPaymentMethod()
 
     override suspend fun updatePaymentMethod(
-        customerConfig: PaymentSheet.CustomerConfiguration,
+        customerInfo: CustomerRepository.CustomerInfo,
         paymentMethodId: String,
         params: PaymentMethodUpdateParams
     ): Result<PaymentMethod> = onUpdatePaymentMethod()


### PR DESCRIPTION
# Summary
Removes usage of `PaymentSheet.CustomerConfiguration` from `CustomerRepository`. This PR adds a new `CustomerInfo` type nested inside of `CustomerRepository`.

# Motivation
We share `CustomerRepository` between `PaymentSheet` & `CustomerSheet`. We shouldn't need to reference `PaymentSheet` types within `CustomerRepository` & `CustomerSheet` especially if their API can change.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified
