### PR TITLE
Make statusCode default to null

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/AnalyticsMappers.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/AnalyticsMappers.kt
@@ -30,7 +30,7 @@ internal fun Throwable.toEventParams(
             stripeError?.message ?: message,
             extraMessage
         ).joinToString(" "),
-        "code" to (stripeError?.code ?: statusCode.toString())
+        "code" to (stripeError?.code ?: statusCode?.toString())
     )
 
     is StripeException -> mapOf(
@@ -41,7 +41,7 @@ internal fun Throwable.toEventParams(
             (stripeError?.message ?: message)?.take(MAX_LOG_LENGTH),
             extraMessage
         ).joinToString(" "),
-        "code" to (stripeError?.code ?: statusCode.toString())
+        "code" to (stripeError?.code ?: statusCode?.toString())
     )
 
     else -> mapOf(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/AppInitializationError.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/exception/AppInitializationError.kt
@@ -7,7 +7,6 @@ class AppInitializationError(message: String) : StripeException(
     message = message,
     cause = null,
     requestId = null,
-    statusCode = 0,
     stripeError = null
 ) {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-core/src/main/java/com/stripe/android/CustomerSessionOperationExecutor.kt
+++ b/payments-core/src/main/java/com/stripe/android/CustomerSessionOperationExecutor.kt
@@ -201,13 +201,13 @@ internal class CustomerSessionOperationExecutor(
 
         when (listener) {
             is CustomerSession.RetrievalWithExceptionListener -> listener.onError(
-                statusCode,
+                statusCode ?: 0,
                 message,
                 stripeError,
                 error,
             )
             is CustomerSession.RetrievalListener -> listener.onError(
-                statusCode,
+                statusCode ?: 0,
                 message,
                 stripeError,
             )

--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -61,7 +61,7 @@ interface ErrorReporter {
         fun getAdditionalParamsFromStripeException(stripeException: StripeException): Map<String, String> {
             return mapOf(
                 "analytics_value" to stripeException.analyticsValue(),
-                "status_code" to stripeException.statusCode.toString(),
+                "status_code" to stripeException.statusCode?.toString(),
                 "request_id" to stripeException.requestId,
                 "error_type" to stripeException.stripeError?.type,
                 "error_code" to stripeException.stripeError?.code,

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
@@ -287,7 +287,7 @@ class PaymentMethodsActivity : AppCompatActivity() {
                             when (it) {
                                 is StripeException -> {
                                     TranslatorManager.getErrorMessageTranslator()
-                                        .translate(it.statusCode, it.message, it.stripeError)
+                                        .translate(it.statusCode ?: 0, it.message, it.stripeError)
                                 }
                                 else -> {
                                     it.message.orEmpty()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -919,7 +919,6 @@ class PaymentSheetEventTest {
                 "request_id" to "request_123",
                 "error_type" to "network_error",
                 "error_code" to "error_123",
-                "status_code" to "0"
             )
         )
     }

--- a/stripe-core/api/stripe-core.api
+++ b/stripe-core/api/stripe-core.api
@@ -88,8 +88,8 @@ public final class com/stripe/android/core/exception/APIConnectionException$Comp
 
 public final class com/stripe/android/core/exception/APIException : com/stripe/android/core/exception/StripeException {
 	public fun <init> ()V
-	public fun <init> (Lcom/stripe/android/core/StripeError;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Throwable;)V
-	public synthetic fun <init> (Lcom/stripe/android/core/StripeError;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/stripe/android/core/StripeError;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Lcom/stripe/android/core/StripeError;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/stripe/android/core/exception/AuthenticationException : com/stripe/android/core/exception/StripeException {
@@ -114,11 +114,11 @@ public final class com/stripe/android/core/exception/RateLimitException : com/st
 
 public abstract class com/stripe/android/core/exception/StripeException : java/lang/Exception {
 	public fun <init> ()V
-	public fun <init> (Lcom/stripe/android/core/StripeError;Ljava/lang/String;ILjava/lang/Throwable;Ljava/lang/String;)V
-	public synthetic fun <init> (Lcom/stripe/android/core/StripeError;Ljava/lang/String;ILjava/lang/Throwable;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/stripe/android/core/StripeError;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Throwable;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/stripe/android/core/StripeError;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Throwable;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRequestId ()Ljava/lang/String;
-	public final fun getStatusCode ()I
+	public final fun getStatusCode ()Ljava/lang/Integer;
 	public final fun getStripeError ()Lcom/stripe/android/core/StripeError;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/APIException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/APIException.kt
@@ -9,7 +9,7 @@ import com.stripe.android.core.StripeError
 class APIException(
     stripeError: StripeError? = null,
     requestId: String? = null,
-    statusCode: Int = 0,
+    statusCode: Int? = null,
     message: String? = stripeError?.message,
     cause: Throwable? = null
 ) : StripeException(

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/StripeException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/StripeException.kt
@@ -12,7 +12,7 @@ import java.util.Objects
 abstract class StripeException(
     val stripeError: StripeError? = null,
     val requestId: String? = null,
-    val statusCode: Int = 0,
+    val statusCode: Int? = null,
     cause: Throwable? = null,
     message: String? = stripeError?.message
 ) : Exception(message, cause) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Make the statusCode field of StripeException nullable with a default of null

In some cases, I made changes so we're still using 0 as a default when the status code is null, just so behavior in those places doesn't change

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We are now logging this status code to analytics and logging a default code of 0 is unnecessary and noisy

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
No UI change

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
