### PR TITLE
Fix link logout tests.

### DIFF
--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
@@ -49,9 +49,10 @@ internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dis
         }
 
         var timeWaited = 0.milliseconds
+        val sleepDuration = 100.milliseconds
         while (enqueuedResponses.size != 0 && timeWaited < validationTimeout) {
-            SystemClock.sleep(100)
-            timeWaited = timeWaited.plus(100.milliseconds)
+            SystemClock.sleep(sleepDuration.inWholeMilliseconds)
+            timeWaited = timeWaited.plus(sleepDuration)
         }
         return enqueuedResponses.size != 0
     }

--- a/network-testing/src/main/java/com/stripe/android/networktesting/TestMockWebServer.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/TestMockWebServer.kt
@@ -10,12 +10,13 @@ import java.security.cert.X509Certificate
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.X509TrustManager
+import kotlin.time.Duration
 
-internal class TestMockWebServer {
+internal class TestMockWebServer(validationTimeout: Duration?) {
     private val mockWebServer: MockWebServer = MockWebServer()
     private val localhostCertificate: HeldCertificate = localhostCertificate()
 
-    val dispatcher: NetworkDispatcher = NetworkDispatcher()
+    val dispatcher: NetworkDispatcher = NetworkDispatcher(validationTimeout)
     val baseUrl: HttpUrl
 
     init {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
@@ -24,6 +24,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.UUID
+import kotlin.time.Duration.Companion.seconds
 
 @RunWith(TestParameterInjector::class)
 internal class LinkTest {
@@ -32,8 +33,10 @@ internal class LinkTest {
 
     private val activityScenarioRule = composeTestRule.activityRule
 
+    // The /v1/consumers/sessions/log_out request is launched async from a GlobalScope. We want to make sure it happens,
+    // but it's okay if it takes a bit to happen.
     @get:Rule
-    val networkRule = NetworkRule()
+    val networkRule = NetworkRule(validationTimeout = 5.seconds)
 
     private val page: PaymentSheetPage = PaymentSheetPage(composeTestRule)
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
These tests were failing occasionally on CI, but more commonly locally. This was because the logout request does happen, but it may have happened after we called validate. Now validate will wait (when told to) for the response queue to drain.
