### PR TITLE
Don't log default status code for StripeException

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -59,9 +59,15 @@ interface ErrorReporter {
         }
 
         fun getAdditionalParamsFromStripeException(stripeException: StripeException): Map<String, String> {
+            val statusCode =
+                if (stripeException.statusCode == StripeException.DEFAULT_STATUS_CODE) {
+                    null
+                } else {
+                    stripeException.statusCode
+                }
             return mapOf(
                 "analytics_value" to stripeException.analyticsValue(),
-                "status_code" to stripeException.statusCode.toString(),
+                "status_code" to statusCode?.toString(),
                 "request_id" to stripeException.requestId,
                 "error_type" to stripeException.stripeError?.type,
                 "error_code" to stripeException.stripeError?.code,

--- a/payments-core/src/test/java/com/stripe/android/payments/core/analytics/RealErrorReporterTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/analytics/RealErrorReporterTest.kt
@@ -37,7 +37,6 @@ class RealErrorReporterTest {
     fun `RealErrorReporter logs correct info via analyticsRequestExecutor`() {
         val exception = StripeException.create(IllegalArgumentException("this arg isn't legal"))
         val expectedAnalyticsValue = exception.analyticsValue()
-        val expectedStatusCode = exception.statusCode.toString()
 
         realErrorReporter.report(ErrorReporter.ExpectedErrorEvent.GET_SAVED_PAYMENT_METHODS_FAILURE, exception)
 
@@ -45,7 +44,6 @@ class RealErrorReporterTest {
         assertThat(executedAnalyticsRequests.size).isEqualTo(1)
         val analyticsRequestParams = executedAnalyticsRequests.get(0).params
         assertThat(analyticsRequestParams.get("analytics_value")).isEqualTo(expectedAnalyticsValue)
-        assertThat(analyticsRequestParams.get("status_code")).isEqualTo(expectedStatusCode)
         assertThat(analyticsRequestParams.get("request_id")).isNull()
     }
 
@@ -62,6 +60,7 @@ class RealErrorReporterTest {
         assertThat(executedAnalyticsRequests.size).isEqualTo(1)
         val analyticsRequestParams = executedAnalyticsRequests.get(0).params
         assertThat(analyticsRequestParams.get("analytics_value")).isEqualTo(expectedAnalyticsValue)
+        assertThat(analyticsRequestParams.get("status_code")).isNotEqualTo(StripeException.DEFAULT_STATUS_CODE)
         assertThat(analyticsRequestParams.get("status_code")).isEqualTo(expectedStatusCode)
         assertThat(analyticsRequestParams.get("request_id")).isEqualTo(expectedRequestId)
     }
@@ -90,7 +89,6 @@ class RealErrorReporterTest {
     fun `RealErrorReporter logs additionalNonPiiParams via analyticsRequestExecutor`() {
         val exception = StripeException.create(IllegalArgumentException("this arg isn't legal"))
         val expectedAnalyticsValue = exception.analyticsValue()
-        val expectedStatusCode = exception.statusCode.toString()
 
         realErrorReporter.report(
             errorEvent = ErrorReporter.ExpectedErrorEvent.GET_SAVED_PAYMENT_METHODS_FAILURE,
@@ -102,7 +100,6 @@ class RealErrorReporterTest {
         assertThat(executedAnalyticsRequests.size).isEqualTo(1)
         val analyticsRequestParams = executedAnalyticsRequests.get(0).params
         assertThat(analyticsRequestParams.get("analytics_value")).isEqualTo(expectedAnalyticsValue)
-        assertThat(analyticsRequestParams.get("status_code")).isEqualTo(expectedStatusCode)
         assertThat(analyticsRequestParams.get("request_id")).isNull()
         assertThat(analyticsRequestParams.get("foo")).isEqualTo("bar")
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -919,7 +919,6 @@ class PaymentSheetEventTest {
                 "request_id" to "request_123",
                 "error_type" to "network_error",
                 "error_code" to "error_123",
-                "status_code" to "0"
             )
         )
     }

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/StripeException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/StripeException.kt
@@ -12,7 +12,7 @@ import java.util.Objects
 abstract class StripeException(
     val stripeError: StripeError? = null,
     val requestId: String? = null,
-    val statusCode: Int = 0,
+    val statusCode: Int = DEFAULT_STATUS_CODE,
     cause: Throwable? = null,
     message: String? = stripeError?.message
 ) : Exception(message, cause) {
@@ -50,6 +50,9 @@ abstract class StripeException(
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
+
+        const val DEFAULT_STATUS_CODE = 0
+
         fun create(throwable: Throwable): StripeException {
             return when (throwable) {
                 is StripeException -> throwable

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/StripeException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/StripeException.kt
@@ -51,6 +51,7 @@ abstract class StripeException(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
 
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         const val DEFAULT_STATUS_CODE = 0
 
         fun create(throwable: Throwable): StripeException {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Don't log status code when it's equal to 0 (the default value)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We are now logging this status code to analytics and logging a default code of 0 is unnecessary and noisy

A more principled change would be to make status code nullable and not log when it's null, but StripeException is part of our public API so we can't do that 😭

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

# Screenshots
No UI change

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
No user facing changes
