### PR TITLE
[FC] Add confirm intent toggle on playground app

### DIFF
--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -16,11 +16,13 @@ import com.stripe.android.financialconnections.FinancialConnectionsSheetResult
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent
 import com.stripe.android.financialconnections.example.data.BackendRepository
 import com.stripe.android.financialconnections.example.data.Settings
+import com.stripe.android.financialconnections.example.settings.ConfirmIntentSetting
 import com.stripe.android.financialconnections.example.settings.FinancialConnectionsPlaygroundUrlHelper
 import com.stripe.android.financialconnections.example.settings.FlowSetting
 import com.stripe.android.financialconnections.example.settings.PlaygroundSettings
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResponse
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResult
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -217,28 +219,23 @@ internal class FinancialConnectionsPlaygroundViewModel(
                     val account = session.accounts.data.firstOrNull()
                     it.copy(
                         status = it.status + listOf(
-                            "Session Completed! ${session.id} (account: ${account?.id})",
-                            "Confirming Intent: ${result.response.intent.id}",
+                            "Session Completed! ${session.id} (account: ${account?.id})"
                         )
                     )
                 }
-                val params = ConfirmPaymentIntentParams.create(
-                    clientSecret = requireNotNull(result.response.intent.clientSecret),
-                    paymentMethodType = PaymentMethod.Type.USBankAccount
-                )
-                stripe(_state.value.publishableKey!!).confirmPaymentIntent(params)
+                confirmIntentIfNeeded(result.response)
             }.onSuccess {
                 _state.update {
                     it.copy(
                         loading = false,
-                        status = it.status + "Intent Confirmed!"
+                        status = it.status + "Completed!"
                     )
                 }
             }.onFailure { error ->
                 _state.update {
                     it.copy(
                         loading = false,
-                        status = it.status + "Confirming intent Failed!: $error"
+                        status = it.status + "Failed!: $error"
                     )
                 }
             }
@@ -254,6 +251,24 @@ internal class FinancialConnectionsPlaygroundViewModel(
 
             is CollectBankAccountResult.Cancelled -> {
                 _state.update { it.copy(loading = false, status = it.status + "Cancelled!") }
+            }
+        }
+    }
+
+    private suspend fun confirmIntentIfNeeded(response: CollectBankAccountResponse) {
+        val shouldConfirmIntent = state.value.settings.get<ConfirmIntentSetting>().selectedOption
+        if (shouldConfirmIntent) {
+            val params = ConfirmPaymentIntentParams.create(
+                clientSecret = requireNotNull(response.intent.clientSecret),
+                paymentMethodType = PaymentMethod.Type.USBankAccount
+            )
+            stripe(_state.value.publishableKey!!).confirmPaymentIntent(params)
+            _state.update {
+                it.copy(status = it.status + "Intent Confirmed!")
+            }
+        } else {
+            _state.update {
+                it.copy(status = it.status + "Skipping intent confirmation.")
             }
         }
     }

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/ConfirmIntentSetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/ConfirmIntentSetting.kt
@@ -9,8 +9,8 @@ data class ConfirmIntentSetting(
 ) : Saveable<Boolean>, SingleChoiceSetting<Boolean>(
     displayName = "Confirm Intent",
     options = listOf(
-        Option("True", true),
-        Option("False", false),
+        Option("On", true),
+        Option("Off", false),
     ),
     selectedOption = selectedOption
 ) {

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/ConfirmIntentSetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/ConfirmIntentSetting.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.financialconnections.example.settings
+
+import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
+import com.stripe.android.financialconnections.example.data.model.PaymentIntentBody
+
+data class ConfirmIntentSetting(
+    override val selectedOption: Boolean = false,
+    override val key: String = "financial_connections_confirm_intent",
+) : Saveable<Boolean>, SingleChoiceSetting<Boolean>(
+    displayName = "Confirm Intent",
+    options = listOf(
+        Option("True", true),
+        Option("False", false),
+    ),
+    selectedOption = selectedOption
+) {
+    override fun lasRequest(
+        body: LinkAccountSessionBody,
+    ): LinkAccountSessionBody = body
+
+    override fun paymentIntentRequest(
+        body: PaymentIntentBody,
+    ): PaymentIntentBody = body
+
+    override fun valueUpdated(currentSettings: List<Setting<*>>, value: Boolean): List<Setting<*>> {
+        return replace(currentSettings, this.copy(selectedOption = value))
+    }
+
+    override fun convertToValue(value: String): Boolean = value.toBoolean()
+
+    override fun convertToString(value: Boolean): String = value.toString()
+}

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/FlowSetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/FlowSetting.kt
@@ -44,5 +44,4 @@ data class FlowSetting(
             updatedSettings
         }
     }
-
 }

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PlaygroundSettings.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PlaygroundSettings.kt
@@ -149,6 +149,7 @@ internal data class PlaygroundSettings(
             FlowSetting(),
             NativeSetting(),
             PermissionsSetting(),
+            ConfirmIntentSetting(),
             EmailSetting(),
         )
     }

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/SettingsUi.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/SettingsUi.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectable
@@ -16,6 +17,7 @@ import androidx.compose.material.ExposedDropdownMenuDefaults
 import androidx.compose.material.LocalMinimumInteractiveComponentEnforcement
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.RadioButton
+import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
@@ -84,26 +86,58 @@ private fun <T> SingleSelectSetting(
     value: T,
     onOptionChanged: (T) -> Unit,
 ) {
-    if (options.isEmpty() && value is String) {
-        @Suppress("UNCHECKED_CAST")
-        TextSetting(
-            name = name,
-            value = value as String,
-            onOptionChanged = onOptionChanged as (String) -> Unit,
+    when {
+        value is Boolean -> {
+            ToggleSetting(
+                name = name,
+                value = value,
+                onOptionChanged = onOptionChanged as (Boolean) -> Unit,
+            )
+        }
+        options.isEmpty() && value is String -> {
+            @Suppress("UNCHECKED_CAST")
+            TextSetting(
+                name = name,
+                value = value as String,
+                onOptionChanged = onOptionChanged as (String) -> Unit,
+            )
+        }
+        options.size < MAX_RADIO_BUTTON_OPTIONS -> {
+            RadioButtonSetting(
+                name = name,
+                options = options,
+                value = value,
+                onOptionChanged = onOptionChanged,
+            )
+        }
+        else -> {
+            DropdownSetting(
+                name = name,
+                options = options,
+                value = value,
+                onOptionChanged = onOptionChanged,
+            )
+        }
+    }
+}
+
+@Composable
+fun ToggleSetting(
+    name: String,
+    value: Boolean,
+    onOptionChanged: (Boolean) -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(text = name,
         )
-    } else if (options.size < MAX_RADIO_BUTTON_OPTIONS) {
-        RadioButtonSetting(
-            name = name,
-            options = options,
-            value = value,
-            onOptionChanged = onOptionChanged,
-        )
-    } else {
-        DropdownSetting(
-            name = name,
-            options = options,
-            value = value,
-            onOptionChanged = onOptionChanged,
+        Switch(
+            modifier = Modifier.padding(0.dp).defaultMinSize(minWidth = 1.dp, minHeight = 1.dp),
+            checked = value,
+            onCheckedChange = {
+                onOptionChanged(it)
+            },
         )
     }
 }

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/SettingsUi.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/SettingsUi.kt
@@ -130,7 +130,8 @@ fun ToggleSetting(
     Row(
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(text = name,
+        Text(
+            text = name,
         )
         Switch(
             modifier = Modifier.padding(0.dp).defaultMinSize(minWidth = 1.dp, minHeight = 1.dp),


### PR DESCRIPTION
# Summary

- Adds an optional confirm intent toggle to payment flows.

https://github.com/stripe/stripe-android/assets/99293320/05f54ef1-bc5f-4a53-a048-89a3a15b8d11


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
