### PR TITLE
Change separator text for SetupIntents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## XX.XX.XX - 2023-XX-XX
+### PaymentSheet
 * [CHANGED][8231](https://github.com/stripe/stripe-android/pull/8231) Separator text under Link/Google Pay button from "Or pay using"/"Or pay with a card" to "Or use"/"Or use a card" when using SetupIntent.
 
 ## 20.40.3 - 2024-04-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## XX.XX.XX - 2023-XX-XX
+* [CHANGED][8231](https://github.com/stripe/stripe-android/pull/8231) Separator text under Link/Google Pay button from "Or pay using"/"Or pay with a card" to "Or use"/"Or use a card" when using SetupIntent.
 
 ## 20.40.3 - 2024-04-01
 

--- a/payments-core/res/values-zh-rHK/strings.xml
+++ b/payments-core/res/values-zh-rHK/strings.xml
@@ -129,7 +129,7 @@
   <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
   <string name="stripe_failure_reason_authentication">我們未能驗證您的支付方式。請選擇另一支付方式並重試。</string>
   <!-- Error when 3DS2 authentication timed out. -->
-  <string name="stripe_failure_reason_timed_out">驗證您的支付方式時超時 -- 請重試</string>
+  <string name="stripe_failure_reason_timed_out">驗證您的支付方式時超時——請重試</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="stripe_fpx_bank_offline">%s - 線下</string>
   <!-- Error message when a payment method gets declined. -->

--- a/payments-core/res/values-zh-rTW/strings.xml
+++ b/payments-core/res/values-zh-rTW/strings.xml
@@ -113,7 +113,7 @@
   <!-- Text for close button -->
   <string name="stripe_close">關閉</string>
   <!-- Accessibility action for deleting a payment method -->
-  <string name="stripe_delete_payment_method">刪除付款方式</string>
+  <string name="stripe_delete_payment_method">刪除支付方式</string>
   <string name="stripe_delete_payment_method_prompt_title">刪除支付方式</string>
   <!-- Done button title -->
   <string name="stripe_done">完成</string>
@@ -129,7 +129,7 @@
   <!-- Error when 3DS2 authentication failed (e.g. customer entered the wrong code) -->
   <string name="stripe_failure_reason_authentication">我們未能驗證您的支付方式。請選擇另一支付方式並重試。</string>
   <!-- Error when 3DS2 authentication timed out. -->
-  <string name="stripe_failure_reason_timed_out">驗證您的付款方式時逾時 -- 請重試</string>
+  <string name="stripe_failure_reason_timed_out">驗證您的支付方式時逾時——請重試</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="stripe_fpx_bank_offline">%s - 線下</string>
   <!-- Error message when a payment method gets declined. -->
@@ -165,7 +165,7 @@
   <!-- Label for Bank Account selection or detail entry form -->
   <string name="stripe_title_bank_account">銀行帳戶</string>
   <!-- Title for Payment Method screen -->
-  <string name="stripe_title_payment_method">付款方式</string>
+  <string name="stripe_title_payment_method">支付方式</string>
   <!-- Screen title telling users they should select a shipping address -->
   <string name="stripe_title_select_shipping_method">選擇送貨方式</string>
   <!-- Title of screen to update a card -->

--- a/payments-ui-core/res/values-it/strings.xml
+++ b/payments-ui-core/res/values-it/strings.xml
@@ -80,7 +80,7 @@
   <!-- Payment method brand name -->
   <string name="stripe_paymentsheet_payment_method_sepa_debit">Addebito SEPA</string>
   <!-- PayPal mandate text -->
-  <string name="stripe_paypal_mandate">Confermando il tuo pagamento con PayPal, consenti a %s di addebitare i pagamenti futuri sul tuo account PayPal in base a quanto previsto dai relativi termini e condizioni.</string>
+  <string name="stripe_paypal_mandate">Confermando il tuo pagamento con PayPal, consenti a %s di addebitare i pagamenti futuri sul tuo conto PayPal in base a quanto previsto dai relativi termini e condizioni.</string>
   <!-- Revolut mandate text -->
   <string name="stripe_revolut_mandate">Confermando il tuo pagamento con RevolutPay, consenti a %s di addebitare i pagamenti futuri sul tuo account RevolutPay in base a quanto previsto dai relativi termini e condizioni.</string>
   <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->

--- a/paymentsheet/res/values-b+es+419/strings.xml
+++ b/paymentsheet/res/values-b+es+419/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">O pagar con</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">O pagar con tarjeta</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">También puedes usar</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">También puedes usar una tarjeta</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Pagar</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-ca-rES/strings.xml
+++ b/paymentsheet/res/values-ca-rES/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">O pagar fent servir</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">O pagar amb una targeta</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">O utilitzeu</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">O utilitzeu una targeta</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Pagar</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-cs-rCZ/strings.xml
+++ b/paymentsheet/res/values-cs-rCZ/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Nebo zaplatit pomocí</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Nebo zaplatit kartou</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Nebo použijte</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Nebo použijte kartu</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Zaplatit</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-da/strings.xml
+++ b/paymentsheet/res/values-da/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Eller betal med</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Eller betal med et kort</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Eller brug</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Eller brug et kort</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Betal</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-de/strings.xml
+++ b/paymentsheet/res/values-de/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Oder zahlen mit</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Oder mit Karte bezahlen</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Weitere Zahlungsmöglichkeiten</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Alternativ Karte verwenden</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Zahlen</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-el-rGR/strings.xml
+++ b/paymentsheet/res/values-el-rGR/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Ή πληρωμή χρησιμοποιώντας</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Ή πληρωμή με κάρτα</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Ή χρησιμοποιήστε</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Ή χρησιμοποιήστε μια κάρτα</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Πληρωμή</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-en-rGB/strings.xml
+++ b/paymentsheet/res/values-en-rGB/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Or pay using</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Or pay with a card</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Or use</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Or use a card</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Pay</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-es/strings.xml
+++ b/paymentsheet/res/values-es/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">O paga con</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">O paga con tarjeta</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">También puedes usar</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">También puedes usar una tarjeta</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Pagar</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-et-rEE/strings.xml
+++ b/paymentsheet/res/values-et-rEE/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Või kasuta makseviisi</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Või makske kaardiga</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Või kasuta</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Või kasuta kaarti</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Maksa</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-fi/strings.xml
+++ b/paymentsheet/res/values-fi/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Tai käytä maksutapaa</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Tai maksa kortilla</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Tai käytä</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Tai käytä korttia</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Maksa</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-fil/strings.xml
+++ b/paymentsheet/res/values-fil/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">O magbayad gamit ang</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">O magbayad gamit ang kard</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">O gumamit ng</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">O gumamit ng kard</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Magbayad</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-fr-rCA/strings.xml
+++ b/paymentsheet/res/values-fr-rCA/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Ou payer avec</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Ou payez par carte</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Ou utiliser</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Ou utiliser une carte</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Payer</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-fr/strings.xml
+++ b/paymentsheet/res/values-fr/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Ou payer avec</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Ou payez par carte bancaire</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Ou utilisez</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Ou utilisez une carte</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Payer</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-hr/strings.xml
+++ b/paymentsheet/res/values-hr/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Ili platite koristeći</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Ili plati karticom</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Ili upotrijebite</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Ili upotrijebite karticu</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Plati</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-hu/strings.xml
+++ b/paymentsheet/res/values-hu/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Vagy fizetés a következővel:</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Vagy fizetés kártyával</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Vagy használja ezeket</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Vagy fizessen kártyával</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Fizetés:</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-in/strings.xml
+++ b/paymentsheet/res/values-in/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Atau bayar menggunakan</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Atau bayar dengan kartu</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Atau gunakan</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Atau gunakan kartu</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Bayar</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-it/strings.xml
+++ b/paymentsheet/res/values-it/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">O paga con</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Oppure paga con carta</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Oppure usa</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Oppure usa una carta</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Paga</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-ja/strings.xml
+++ b/paymentsheet/res/values-ja/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">または別の方法で支払う</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">または、カードで支払う</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">または次を使用:</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">またはカードを使用</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">支払う: </string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-ko/strings.xml
+++ b/paymentsheet/res/values-ko/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">또는 다음 결제 방식 사용</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">또는 카드 결제</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">또는 다음 결제 방식을 사용하기</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">또는 카드를 사용하기</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">결제</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-lt-rLT/strings.xml
+++ b/paymentsheet/res/values-lt-rLT/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Arba mokėti naudojant</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Arba mokėti kortele</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Arba naudokite</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Arba naudokite kortelę</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Mokėti</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-lv-rLV/strings.xml
+++ b/paymentsheet/res/values-lv-rLV/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Vai maksāt, izmantojot</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Vai maksāt ar karti</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Vai izmantojiet</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Vai izmantojiet karti</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Maksāt</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-ms-rMY/strings.xml
+++ b/paymentsheet/res/values-ms-rMY/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Atau bayar menggunakan</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Atau bayar dengan kad</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Atau gunakan</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Atau gunakan kad</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Bayar</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-mt/strings.xml
+++ b/paymentsheet/res/values-mt/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Jew ħallas bil-</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Jew ħallas bil-kard</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Jew uża</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Jew uża karta</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Ħallas</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-nb/strings.xml
+++ b/paymentsheet/res/values-nb/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Eller betal med</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Eller betal med et kort</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Eller bruk</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Eller bruk et kort</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Betal</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-nl/strings.xml
+++ b/paymentsheet/res/values-nl/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Of betalen met</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Of met een kaart betalen</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Of gebruik</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Of gebruik een betaalkaart</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Betaal</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-nn-rNO/strings.xml
+++ b/paymentsheet/res/values-nn-rNO/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Eller betal ved å bruke</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Eller betal med eit kort</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Eller bruk</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Eller bruk eit kort</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Betal</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-pl-rPL/strings.xml
+++ b/paymentsheet/res/values-pl-rPL/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Lub zapłać, korzystając z</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Lub zapłać kartą</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Lub użyj</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Lub użyj karty</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Zapłać</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-pt-rBR/strings.xml
+++ b/paymentsheet/res/values-pt-rBR/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Ou pague com</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Ou pagar com cartão</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Ou use</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Ou use um cartão</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Pagar</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-pt-rPT/strings.xml
+++ b/paymentsheet/res/values-pt-rPT/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Ou pagar com</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Ou pagar com um cartão</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Ou utilize</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Ou utilize um cartão</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Pagar</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-ro-rRO/strings.xml
+++ b/paymentsheet/res/values-ro-rRO/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Sau folosiți ca metodă de plată</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Sau folosiți ca metodă de plată un card</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Sau utilizați</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Sau utilizați un card</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Plătiți</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-ru/strings.xml
+++ b/paymentsheet/res/values-ru/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Или оплатить с помощью</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Или оплатить картой</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Или используйте</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Или используйте карту</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Оплатить</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-sk-rSK/strings.xml
+++ b/paymentsheet/res/values-sk-rSK/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Alebo zaplaťte pomocou</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Alebo zaplaťte kartou</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Alebo použite</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Alebo použite kartu</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Zaplatiť</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-sl-rSI/strings.xml
+++ b/paymentsheet/res/values-sl-rSI/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Ali pa za plačilo uporabite</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Ali pa plačajte s kartico</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Ali uporabite</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Ali uporabite kartico</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Plačaj</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-sv/strings.xml
+++ b/paymentsheet/res/values-sv/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Eller betala genom att använda</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Eller betala med ett kort</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Eller använd</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Eller använd ett kort</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Betala</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-th/strings.xml
+++ b/paymentsheet/res/values-th/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">หรือชำระเงินด้วย</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">หรือชำระเงินด้วยบัตร</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">หรือใช้</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">หรือใช้บัตร</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">ชำระเงิน</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-tr/strings.xml
+++ b/paymentsheet/res/values-tr/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Veya şununla ödeyin:</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Ya da kartla ödeyin</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Veya şunu kullan:</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Veya kart kullan</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Öde</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-vi/strings.xml
+++ b/paymentsheet/res/values-vi/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">Hoặc thanh toán bằng</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Hoặc thanh toán bằng thẻ</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">Hoặc dùng</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Hoặc dùng thẻ</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Thanh toán</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-zh-rHK/strings.xml
+++ b/paymentsheet/res/values-zh-rHK/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">或用以下方式支付</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">或用銀行卡支付</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">或使用</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">或使用銀行卡</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">支付</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-zh-rTW/strings.xml
+++ b/paymentsheet/res/values-zh-rTW/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">或用以下方式支付</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">或用金融卡支付</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">或使用</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">或使用金融卡</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">支付</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values-zh/strings.xml
+++ b/paymentsheet/res/values-zh/strings.xml
@@ -53,6 +53,10 @@
   <string name="stripe_paymentsheet_or_pay_using">或用以下方式支付</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">或用银行卡支付</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
+  <string name="stripe_paymentsheet_or_use">或使用</string>
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
+  <string name="stripe_paymentsheet_or_use_a_card">或使用银行卡</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">支付</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -49,10 +49,14 @@
   <string name="stripe_paymentsheet_microdeposit">Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions to complete payment to %s.</string>
   <!-- Content for alert popup prompting to confirm modifying saved payment method. -->
   <string name="stripe_paymentsheet_modify_pm">Edit %s</string>
-  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user for a PaymentIntent. -->
   <string name="stripe_paymentsheet_or_pay_using">Or pay using</string>
-  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
+  <!-- Title of a section containing a card form that will collect the payment information from the user for a PaymentIntent. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Or pay with a card</string>
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user for a SetupIntent. -->
+  <string name="stripe_paymentsheet_or_use">Or use</string>
+  <!-- Title of a section containing a card form that will collect the payment information from the user for a SetupIntent. -->
+  <string name="stripe_paymentsheet_or_use_a_card">Or use a card</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Pay</string>
   <!-- Title shown above a section containing various payment options -->

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -49,13 +49,13 @@
   <string name="stripe_paymentsheet_microdeposit">Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions to complete payment to %s.</string>
   <!-- Content for alert popup prompting to confirm modifying saved payment method. -->
   <string name="stripe_paymentsheet_modify_pm">Edit %s</string>
-  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user for a PaymentIntent. -->
+  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Or pay using</string>
-  <!-- Title of a section containing a card form that will collect the payment information from the user for a PaymentIntent. -->
+  <!-- Title of a section containing a card form that will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_with_card">Or pay with a card</string>
-  <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user for a SetupIntent. -->
+  <!-- Title of a section displayed below an Apple Pay button. The section contains alternative ways to set up. -->
   <string name="stripe_paymentsheet_or_use">Or use</string>
-  <!-- Title of a section containing a card form that will collect the payment information from the user for a SetupIntent. -->
+  <!-- Title of a section displayed below an Apple Pay button. The section contains a credit card form as an alternative way to set up. -->
   <string name="stripe_paymentsheet_or_use_a_card">Or use a card</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Pay</string>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -14,6 +14,7 @@ import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.utils.requireApplication
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.injection.DaggerPaymentOptionsViewModelFactoryComponent
@@ -119,6 +120,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
                 updateSelection(PaymentSelection.Link)
                 onUserSelection()
             },
+            isSetupIntent = paymentMethodMetadata.value?.stripeIntent is SetupIntent
         )
     }.stateIn(
         scope = viewModelScope,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -232,6 +232,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             isCompleteFlow = true,
             onGooglePayPressed = this::checkoutWithGooglePay,
             onLinkPressed = linkHandler::launchLink,
+            isSetupIntent = paymentMethodMetadata.value?.stripeIntent is SetupIntent
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/WalletsState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/WalletsState.kt
@@ -42,6 +42,7 @@ internal data class WalletsState(
             isCompleteFlow: Boolean,
             onGooglePayPressed: () -> Unit,
             onLinkPressed: () -> Unit,
+            isSetupIntent: Boolean
         ): WalletsState? {
             if (!screen.showsWalletsHeader(isCompleteFlow)) {
                 return null
@@ -73,10 +74,14 @@ internal data class WalletsState(
                     link = link,
                     googlePay = googlePay,
                     buttonsEnabled = buttonsEnabled,
-                    dividerTextResource = if (paymentMethodTypes.singleOrNull() == Card.code) {
+                    dividerTextResource = if (paymentMethodTypes.singleOrNull() == Card.code && !isSetupIntent) {
                         R.string.stripe_paymentsheet_or_pay_with_card
-                    } else {
+                    } else if (paymentMethodTypes.singleOrNull() == null && !isSetupIntent) {
                         R.string.stripe_paymentsheet_or_pay_using
+                    } else if (paymentMethodTypes.singleOrNull() == Card.code && isSetupIntent) {
+                        R.string.stripe_paymentsheet_or_use_a_card
+                    } else {
+                        R.string.stripe_paymentsheet_or_use
                     },
                     onGooglePayPressed = onGooglePayPressed,
                     onLinkPressed = onLinkPressed,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1636,7 +1636,7 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `Shows the correct divider text if intent only supports card`() = runTest {
+    fun `Shows the correct divider text if PaymentIntent only supports card`() = runTest {
         val intent = PAYMENT_INTENT.copy(paymentMethodTypes = listOf("card"))
         val viewModel = createViewModel(
             isGooglePayReady = true,
@@ -1650,7 +1650,7 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `Shows the correct divider text if intent supports multiple payment method types`() = runTest {
+    fun `Shows the correct divider text if PaymentIntent supports multiple payment method types`() = runTest {
         val intent = PAYMENT_INTENT.copy(paymentMethodTypes = listOf("card", "cashapp"))
         val viewModel = createViewModel(
             isGooglePayReady = true,
@@ -1665,6 +1665,39 @@ internal class PaymentSheetViewModelTest {
         viewModel.walletsState.test {
             val textResource = awaitItem()?.dividerTextResource
             assertThat(textResource).isEqualTo(R.string.stripe_paymentsheet_or_pay_using)
+        }
+    }
+
+    @Test
+    fun `Shows the correct divider text if SetupIntent only supports card and`() = runTest {
+        val intent = SETUP_INTENT.copy(paymentMethodTypes = listOf("card"))
+        val viewModel = createViewModel(
+            isGooglePayReady = true,
+            stripeIntent = intent,
+        )
+
+        viewModel.walletsState.test {
+            val textResource = awaitItem()?.dividerTextResource
+            assertThat(textResource).isEqualTo(R.string.stripe_paymentsheet_or_use_a_card)
+        }
+    }
+
+    @Test
+    fun `Shows the correct divider text if SetupIntent supports multiple payment method types`() = runTest {
+        val intent = SETUP_INTENT.copy(paymentMethodTypes = listOf("card", "cashapp"))
+        val viewModel = createViewModel(
+            isGooglePayReady = true,
+            args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
+                    allowsDelayedPaymentMethods = true,
+                ),
+            ),
+            stripeIntent = intent,
+        )
+
+        viewModel.walletsState.test {
+            val textResource = awaitItem()?.dividerTextResource
+            assertThat(textResource).isEqualTo(R.string.stripe_paymentsheet_or_use)
         }
     }
 
@@ -2047,6 +2080,19 @@ internal class PaymentSheetViewModelTest {
             transactionId = anyOrNull(),
             label = eq(expectedLabel),
         )
+    }
+
+    @Test
+    fun `verify separator text resource id when is SetupIntent`() = runTest {
+        val viewModel = createViewModel(
+            stripeIntent = SETUP_INTENT
+        )
+
+        //viewModel.checkout()
+        viewModel.walletsState.test {
+            val state = awaitItem()
+            assertThat(state?.dividerTextResource).isEqualTo(R.string.stripe_paymentsheet_or_use)
+        }
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -2083,19 +2083,6 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `verify separator text resource id when is SetupIntent`() = runTest {
-        val viewModel = createViewModel(
-            stripeIntent = SETUP_INTENT
-        )
-
-        //viewModel.checkout()
-        viewModel.walletsState.test {
-            val state = awaitItem()
-            assertThat(state?.dividerTextResource).isEqualTo(R.string.stripe_paymentsheet_or_use)
-        }
-    }
-
-    @Test
     fun `Launch confirmation form when Bacs debit is selected and filled & succeeds payment`() = runTest {
         fakeIntentConfirmationInterceptor.enqueueCompleteStep()
 


### PR DESCRIPTION
# Summary
Change separator text to say "Or use a card"/"Or use" for SetupIntents

# Motivation
To remove customer FUD that they will be charged immediately
[MOBILESDK-1823](https://jira.corp.stripe.com/browse/MOBILESDK-1823)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| https://github.com/stripe/stripe-android/assets/163896025/0abb82ed-3806-415d-8a81-a70ef7dd23a5  | https://github.com/stripe/stripe-android/assets/163896025/dfcfaa9f-9b21-4f49-ab85-f6a9dab53c0b |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
