### PR TITLE
Add initial `CustomerSheet` network tests.

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetPage.kt
@@ -1,0 +1,81 @@
+package com.stripe.android.paymentsheet
+
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isEnabled
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextReplacement
+import androidx.test.espresso.Espresso
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import com.stripe.android.customersheet.ui.CUSTOMER_SHEET_CONFIRM_BUTTON_TEST_TAG
+import com.stripe.android.customersheet.ui.CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG
+
+internal class CustomerSheetPage(
+    private val composeTestRule: AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>,
+) {
+    fun waitForText(text: String, substring: Boolean = false) {
+        waitUntil(hasText(text, substring = substring))
+    }
+
+    fun fillOutCardDetails() {
+        replaceText("Card number", CARD_NUMBER)
+        replaceText("MM / YY", "$EXPIRY_MONTH/$${EXPIRY_YEAR.substring(startIndex = 2)}")
+        replaceText("CVC", CVC)
+        replaceText("ZIP Code", ZIP_CODE)
+    }
+
+    fun clickSaveButton() {
+        clickPrimaryButton(CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG)
+    }
+
+    fun clickConfirmButton() {
+        clickPrimaryButton(CUSTOMER_SHEET_CONFIRM_BUTTON_TEST_TAG)
+    }
+
+    private fun clickPrimaryButton(tag: String) {
+        waitUntil(hasTestTag(tag).and(isEnabled()))
+        click(hasTestTag(tag))
+        waitForIdle()
+    }
+
+    private fun waitForIdle() {
+        Espresso.onIdle()
+        composeTestRule.waitForIdle()
+    }
+
+    private fun waitUntil(matcher: SemanticsMatcher) {
+        waitForIdle()
+
+        composeTestRule.waitUntil(5_000) {
+            composeTestRule
+                .onAllNodes(matcher.and(isEnabled()))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun click(matcher: SemanticsMatcher) {
+        composeTestRule.onNode(matcher)
+            .performScrollTo()
+            .performClick()
+    }
+
+    private fun replaceText(label: String, text: String, isLabelSubstring: Boolean = false) {
+        waitForText(label, substring = isLabelSubstring)
+
+        composeTestRule.onNode(hasText(label, substring = isLabelSubstring))
+            .performScrollTo()
+            .performTextReplacement(text)
+    }
+
+    companion object {
+        const val CARD_NUMBER = "4242424242424242"
+        const val EXPIRY_MONTH = "12"
+        const val EXPIRY_YEAR = "2034"
+        const val CVC = "123"
+        const val ZIP_CODE = "12345"
+        const val COUNTRY = "US"
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
@@ -1,0 +1,200 @@
+package com.stripe.android.paymentsheet
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.customersheet.CustomerSheetResult
+import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.RequestMatcher
+import com.stripe.android.networktesting.RequestMatchers
+import com.stripe.android.networktesting.RequestMatchers.bodyPart
+import com.stripe.android.networktesting.RequestMatchers.host
+import com.stripe.android.networktesting.RequestMatchers.method
+import com.stripe.android.networktesting.RequestMatchers.path
+import com.stripe.android.networktesting.RequestMatchers.query
+import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.paymentsheet.utils.IntegrationType
+import com.stripe.android.paymentsheet.utils.IntegrationTypeProvider
+import com.stripe.android.paymentsheet.utils.runCustomerSheetTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+@RunWith(TestParameterInjector::class)
+internal class CustomerSheetTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    private val activityScenarioRule = composeTestRule.activityRule
+
+    @get:Rule
+    val networkRule = NetworkRule()
+
+    private val page: CustomerSheetPage = CustomerSheetPage(composeTestRule)
+
+    @TestParameter(valuesProvider = IntegrationTypeProvider::class)
+    lateinit var integrationType: IntegrationType
+
+    @Test
+    fun testSuccessfulCardSave() = activityScenarioRule.runCustomerSheetTest(
+        integrationType = integrationType,
+        resultCallback = { result ->
+            assert(result is CustomerSheetResult.Selected)
+        }
+    ) { context ->
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("GET"),
+            path("/v1/elements/sessions"),
+        ) { response ->
+            response.testBodyFromFile("elements-sessions-requires_payment_method.json")
+        }
+
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("GET"),
+            path("/v1/payment_methods"),
+            query("type", "card")
+        ) { response ->
+            response.testBodyFromFile("payment-methods-get-success-empty.json")
+        }
+
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("GET"),
+            path("/v1/payment_methods"),
+            query("type", "us_bank_account")
+        ) { response ->
+            response.testBodyFromFile("payment-methods-get-success-empty.json")
+        }
+
+        context.presentCustomerSheet()
+
+        page.fillOutCardDetails()
+
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("POST"),
+            path("/v1/payment_methods"),
+            cardDetails(),
+        ) { response ->
+            response.testBodyFromFile("payment-methods-create.json")
+        }
+
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("GET"),
+            path("/v1/setup_intents/seti_12345"),
+            query("client_secret", "seti_12345_secret_12345"),
+        ) { response ->
+            response.testBodyFromFile("setup-intent-get.json")
+        }
+
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("POST"),
+            path("/v1/setup_intents/seti_12345/confirm"),
+            confirmParams()
+        ) { response ->
+            response.testBodyFromFile("setup-intent-confirm.json")
+        }
+
+        page.clickSaveButton()
+        page.clickConfirmButton()
+    }
+
+    @Test
+    fun testCardNotSavedOnConnfirmError() = activityScenarioRule.runCustomerSheetTest(
+        integrationType = integrationType,
+        resultCallback = {
+            error("Shouldn't call CustomerSheetResultCallback")
+        }
+    ) { context ->
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("GET"),
+            path("/v1/elements/sessions"),
+        ) { response ->
+            response.testBodyFromFile("elements-sessions-requires_payment_method.json")
+        }
+
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("GET"),
+            path("/v1/payment_methods"),
+            query("type", "card")
+        ) { response ->
+            response.testBodyFromFile("payment-methods-get-success-empty.json")
+        }
+
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("GET"),
+            path("/v1/payment_methods"),
+            query("type", "us_bank_account")
+        ) { response ->
+            response.testBodyFromFile("payment-methods-get-success-empty.json")
+        }
+
+        context.presentCustomerSheet()
+
+        page.fillOutCardDetails()
+
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("POST"),
+            path("/v1/payment_methods"),
+            cardDetails(),
+        ) { response ->
+            response.testBodyFromFile("payment-methods-create.json")
+        }
+
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("GET"),
+            path("/v1/setup_intents/seti_12345"),
+            query("client_secret", "seti_12345_secret_12345"),
+        ) { response ->
+            response.testBodyFromFile("setup-intent-get.json")
+        }
+
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("POST"),
+            path("/v1/setup_intents/seti_12345/confirm"),
+            confirmParams()
+        ) { response ->
+            response.setResponseCode(402)
+            response.testBodyFromFile("setup-intent-confirm_incorrect_cvc.json")
+        }
+
+        page.clickSaveButton()
+
+        page.waitForText("Your card's security code is incorrect.")
+
+        context.markTestSucceeded()
+    }
+
+    private fun cardDetails(): RequestMatcher {
+        return RequestMatchers.composite(
+            bodyPart("type", "card"),
+            bodyPart("card%5Bnumber%5D", CustomerSheetPage.CARD_NUMBER),
+            bodyPart("card%5Bexp_month%5D", CustomerSheetPage.EXPIRY_MONTH),
+            bodyPart("card%5Bexp_year%5D", CustomerSheetPage.EXPIRY_YEAR),
+            bodyPart("card%5Bcvc%5D", CustomerSheetPage.CVC),
+            bodyPart("billing_details%5Baddress%5D%5Bpostal_code%5D", CustomerSheetPage.ZIP_CODE),
+            bodyPart("billing_details%5Baddress%5D%5Bcountry%5D", CustomerSheetPage.COUNTRY)
+        )
+    }
+
+    private fun confirmParams(): RequestMatcher {
+        return RequestMatchers.composite(
+            bodyPart("payment_method", "pm_12345"),
+            bodyPart("client_secret", "seti_12345_secret_12345"),
+            bodyPart("mandate_data%5Bcustomer_acceptance%5D%5Btype%5D", "online"),
+            bodyPart("mandate_data%5Bcustomer_acceptance%5D%5Bonline%5D%5Binfer_from_client%5D", "true"),
+        )
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestFactory.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestFactory.kt
@@ -1,0 +1,71 @@
+package com.stripe.android.paymentsheet.utils
+
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import com.stripe.android.customersheet.CustomerAdapter
+import com.stripe.android.customersheet.CustomerEphemeralKey
+import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.customersheet.CustomerSheetResultCallback
+import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.customersheet.rememberCustomerSheet
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+internal class CustomerSheetTestFactory(
+    private val integrationType: IntegrationType,
+    private val configuration: CustomerSheet.Configuration,
+    private val resultCallback: CustomerSheetResultCallback,
+) {
+
+    fun make(activity: ComponentActivity): CustomerSheet {
+        return when (integrationType) {
+            IntegrationType.Activity -> forActivity(activity)
+            IntegrationType.Compose -> forCompose(activity)
+        }
+    }
+
+    private fun forActivity(
+        activity: ComponentActivity
+    ): CustomerSheet {
+        return CustomerSheet.create(
+            activity = activity,
+            configuration = configuration,
+            customerAdapter = createCustomerAdapter(activity),
+            callback = resultCallback,
+        )
+    }
+
+    private fun forCompose(
+        activity: ComponentActivity
+    ): CustomerSheet {
+        lateinit var customerSheet: CustomerSheet
+
+        activity.setContent {
+            customerSheet = rememberCustomerSheet(
+                configuration = configuration,
+                customerAdapter = createCustomerAdapter(activity),
+                callback = resultCallback,
+            )
+        }
+
+        return customerSheet
+    }
+
+    private fun createCustomerAdapter(
+        activity: ComponentActivity
+    ): CustomerAdapter {
+        return CustomerAdapter.create(
+            context = activity,
+            customerEphemeralKeyProvider = {
+                CustomerAdapter.Result.success(
+                    CustomerEphemeralKey(
+                        customerId = "cus_1",
+                        ephemeralKey = "ek_test_123"
+                    )
+                )
+            },
+            setupIntentClientSecretProvider = {
+                CustomerAdapter.Result.success("seti_12345_secret_12345")
+            }
+        )
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestRunner.kt
@@ -1,0 +1,97 @@
+package com.stripe.android.paymentsheet.utils
+
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.customersheet.CustomerSheetActivity
+import com.stripe.android.customersheet.CustomerSheetResultCallback
+import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.link.account.LinkStore
+import com.stripe.android.paymentsheet.MainActivity
+import java.lang.IllegalStateException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+internal class CustomerSheetTestRunnerContext(
+    private val scenario: ActivityScenario<MainActivity>,
+    private val customerSheet: CustomerSheet,
+    private val countDownLatch: CountDownLatch,
+) {
+    fun presentCustomerSheet() {
+        val activityLaunchObserver = ActivityLaunchObserver(CustomerSheetActivity::class.java)
+        scenario.onActivity {
+            activityLaunchObserver.prepareForLaunch(it)
+            customerSheet.present()
+        }
+        activityLaunchObserver.awaitLaunch()
+    }
+
+    fun markTestSucceeded() {
+        countDownLatch.countDown()
+    }
+}
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+internal fun ActivityScenarioRule<MainActivity>.runCustomerSheetTest(
+    integrationType: IntegrationType,
+    configuration: CustomerSheet.Configuration = CustomerSheet.Configuration(
+        merchantDisplayName = "Merchant Inc."
+    ),
+    resultCallback: CustomerSheetResultCallback,
+    block: (CustomerSheetTestRunnerContext) -> Unit,
+) {
+    val countDownLatch = CountDownLatch(1)
+
+    val factory = CustomerSheetTestFactory(
+        integrationType = integrationType,
+        configuration = configuration,
+        resultCallback = {
+            resultCallback.onCustomerSheetResult(it)
+            countDownLatch.countDown()
+        },
+    )
+
+    runCustomerSheetTest(
+        countDownLatch = countDownLatch,
+        makeCustomerSheet = factory::make,
+        block = block,
+    )
+}
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+private fun ActivityScenarioRule<MainActivity>.runCustomerSheetTest(
+    countDownLatch: CountDownLatch,
+    makeCustomerSheet: (ComponentActivity) -> CustomerSheet,
+    block: (CustomerSheetTestRunnerContext) -> Unit,
+) {
+    scenario.moveToState(Lifecycle.State.CREATED)
+
+    scenario.onActivity {
+        PaymentConfiguration.init(it, "pk_test_123")
+        LinkStore(it.applicationContext).clear()
+    }
+
+    var customerSheet: CustomerSheet? = null
+
+    scenario.onActivity { activity ->
+        customerSheet = makeCustomerSheet(activity)
+    }
+
+    scenario.moveToState(Lifecycle.State.RESUMED)
+
+    val testContext = CustomerSheetTestRunnerContext(
+        scenario = scenario,
+        customerSheet = customerSheet ?: throw IllegalStateException(
+            "CustomerSheet should have been created!"
+        ),
+        countDownLatch = countDownLatch,
+    )
+    block(testContext)
+
+    assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
+}

--- a/paymentsheet/src/androidTest/resources/payment-methods-create.json
+++ b/paymentsheet/src/androidTest/resources/payment-methods-create.json
@@ -1,5 +1,5 @@
 {
-  "id": "pm_1Mm373Lu5o3P18ZpnD3lp6Du",
+  "id": "pm_12345",
   "object": "payment_method",
   "billing_details": {
     "address": {

--- a/paymentsheet/src/androidTest/resources/setup-intent-confirm.json
+++ b/paymentsheet/src/androidTest/resources/setup-intent-confirm.json
@@ -1,0 +1,71 @@
+{
+  "id": "seti_12345",
+  "object": "setup_intent",
+  "automatic_payment_methods": null,
+  "cancellation_reason": null,
+  "client_secret": "seti_12345_secret_12345",
+  "created": 1712345260,
+  "description": null,
+  "last_setup_error": null,
+  "livemode": false,
+  "next_action": null,
+  "payment_method": {
+    "id": "pm_12345",
+    "object": "payment_method",
+    "billing_details": {
+      "address": {
+        "city": "Seattle",
+        "country": "US",
+        "line1": "123 Main St.",
+        "line2": null,
+        "postal_code": "99999",
+        "state": null
+      },
+      "email": "jenny@example.com",
+      "name": "Jenny Rosen",
+      "phone": null
+    },
+    "card": {
+      "brand": "visa",
+      "checks": {
+        "address_line1_check": null,
+        "address_postal_code_check": null,
+        "cvc_check": null
+      },
+      "country": "US",
+      "display_brand": "visa",
+      "exp_month": 4,
+      "exp_year": 2025,
+      "funding": "credit",
+      "generated_from": null,
+      "last4": "4242",
+      "networks": {
+        "available": [
+          "visa"
+        ],
+        "preferred": null
+      },
+      "three_d_secure_usage": {
+        "supported": true
+      },
+      "wallet": null
+    },
+    "created": 1712345259,
+    "customer": "cus_12345",
+    "livemode": false,
+    "type": "card"
+  },
+  "payment_method_configuration_details": null,
+  "payment_method_options": {
+    "us_bank_account": {
+      "verification_method": "automatic"
+    }
+  },
+  "payment_method_types": [
+    "card",
+    "us_bank_account",
+    "sepa_debit"
+  ],
+  "status": "succeeded",
+  "usage": "off_session"
+}

--- a/paymentsheet/src/androidTest/resources/setup-intent-confirm_incorrect_cvc.json
+++ b/paymentsheet/src/androidTest/resources/setup-intent-confirm_incorrect_cvc.json
@@ -1,0 +1,133 @@
+{
+  "error": {
+    "code": "incorrect_cvc",
+    "doc_url": "https://stripe.com/docs/error-codes/incorrect-cvc",
+    "message": "Your card's security code is incorrect.",
+    "param": "cvc",
+    "payment_method": {
+      "id": "pm_1234",
+      "object": "payment_method",
+      "billing_details": {
+        "address": {
+          "city": "Seattle",
+          "country": "US",
+          "line1": "123 Main St.",
+          "line2": null,
+          "postal_code": "99999",
+          "state": null
+        },
+        "email": "jenny@example.com",
+        "name": "Jenny Rosen",
+        "phone": null
+      },
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": null,
+          "address_postal_code_check": null,
+          "cvc_check": null
+        },
+        "country": "US",
+        "display_brand": "visa",
+        "exp_month": 5,
+        "exp_year": 2025,
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "0101",
+        "networks": {
+          "available": [
+            "visa"],
+          "preferred": null
+        },
+        "three_d_secure_usage": {
+          "supported": true
+        },
+        "wallet": null
+      },
+      "created": 1712347494,
+      "customer": null,
+      "livemode": false,
+      "type": "card"
+    },
+    "request_log_url": "https://dashboard.stripe.com/test/logs/req_1",
+    "setup_intent": {
+      "id": "seti_12345",
+      "object": "setup_intent",
+      "automatic_payment_methods": null,
+      "cancellation_reason": null,
+      "client_secret": "seti_12345_secret_12345",
+      "created": 1712347495,
+      "description": null,
+      "last_setup_error": {
+        "code": "incorrect_cvc",
+        "doc_url": "https://stripe.com/docs/error-codes/incorrect-cvc",
+        "message": "Your card's security code is incorrect.",
+        "param": "cvc",
+        "payment_method": {
+          "id": "pm_12345",
+          "object": "payment_method",
+          "billing_details": {
+            "address": {
+              "city": "Seattle",
+              "country": "US",
+              "line1": "123 Main St.",
+              "line2": null,
+              "postal_code": "99999",
+              "state": null
+            },
+            "email": "jenny@example.com",
+            "name": "Jenny Rosen",
+            "phone": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": null
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 5,
+            "exp_year": 2025,
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0101",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1712347494,
+          "customer": null,
+          "livemode": false,
+          "type": "card"
+        },
+        "type": "card_error"
+      },
+      "livemode": false,
+      "next_action": null,
+      "payment_method": null,
+      "payment_method_configuration_details": null,
+      "payment_method_options": {
+        "us_bank_account": {
+          "verification_method": "automatic"
+        }
+      },
+      "payment_method_types": [
+        "card",
+        "us_bank_account",
+        "sepa_debit"
+      ],
+      "status": "requires_payment_method",
+      "usage": "off_session"
+    },
+    "type": "card_error"
+  }
+}

--- a/paymentsheet/src/androidTest/resources/setup-intent-get.json
+++ b/paymentsheet/src/androidTest/resources/setup-intent-get.json
@@ -1,0 +1,26 @@
+{
+  "id": "seti_12345",
+  "object": "setup_intent",
+  "automatic_payment_methods": null,
+  "cancellation_reason": null,
+  "client_secret": "seti_12345_secret_12345",
+  "created": 1712345260,
+  "description": null,
+  "last_setup_error": null,
+  "livemode": false,
+  "next_action": null,
+  "payment_method": null,
+  "payment_method_configuration_details": null,
+  "payment_method_options": {
+    "us_bank_account": {
+      "verification_method": "automatic"
+    }
+  },
+  "payment_method_types": [
+    "card",
+    "us_bank_account",
+    "sepa_debit"
+  ],
+  "status": "requires_payment_method",
+  "usage": "off_session"
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -153,6 +154,7 @@ internal fun SelectPaymentMethod(
                         viewActionHandler(CustomerSheetViewAction.OnPrimaryButtonPressed)
                     },
                     modifier = Modifier
+                        .testTag(CUSTOMER_SHEET_CONFIRM_BUTTON_TEST_TAG)
                         .padding(top = 20.dp)
                         .padding(horizontal = horizontalPadding),
                 )
@@ -263,6 +265,7 @@ internal fun AddPaymentMethod(
                 viewActionHandler(CustomerSheetViewAction.OnPrimaryButtonPressed)
             },
             modifier = Modifier
+                .testTag(CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG)
                 .padding(top = 10.dp)
                 .padding(horizontal = horizontalPadding),
         )
@@ -300,6 +303,9 @@ private fun EditPaymentMethod(
         )
     }
 }
+
+internal const val CUSTOMER_SHEET_CONFIRM_BUTTON_TEST_TAG = "CustomerSheetConfirmButton"
+internal const val CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG = "CustomerSheetSaveButton"
 
 private class DefaultCardNumberCompletedEventReporter(
     private val viewActionHandler: (CustomerSheetViewAction) -> Unit


### PR DESCRIPTION
# Summary
Add an initial set `CustomerSheet` network tests along with some base helpers. More specific behavior tests will be added in future PRs. This PR just gets the ball rolling. 

# Motivation
Helps ensure that `CustomerSheet` behavior is maintained across future changes.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
