### PR TITLE
Rewrite `retryOnException` without delicate Coroutines API

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionOAuthResults.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionOAuthResults.kt
@@ -26,7 +26,7 @@ internal class PollAuthorizationSessionOAuthResults @Inject constructor(
         return retryOnException(
             PollTimingOptions(
                 initialDelayMs = 0,
-                maxNumberOfRetries = 300, // Stripe.js has 600 second timeout, 600 / 2 = 300 retries
+                attempts = 300, // Stripe.js has 600 second timeout, 600 / 2 = 300 retries
                 retryInterval = 2.seconds.inWholeMilliseconds
             ),
             retryCondition = { exception -> exception.shouldRetry }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SaveAccountToLink.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SaveAccountToLink.kt
@@ -90,10 +90,10 @@ internal class SaveAccountToLink @Inject constructor(
         return retryOnException(
             options = PollTimingOptions(
                 initialDelayMs = 1.seconds.inWholeMilliseconds,
-                maxNumberOfRetries = 20,
+                attempts = 20,
             ),
             retryCondition = { it.shouldRetry },
-            block = { accountsRepository.pollAccountNumbers(linkedAccountIds) },
+            action = { accountsRepository.pollAccountNumbers(linkedAccountIds) },
         )
     }
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccountsTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccountsTest.kt
@@ -13,7 +13,6 @@ import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.financialconnections.model.PartnerAccountsList
 import com.stripe.android.financialconnections.repository.FinancialConnectionsAccountsRepository
 import junit.framework.TestCase.assertEquals
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.mockito.Mockito.mock
@@ -25,7 +24,6 @@ import org.mockito.kotlin.whenever
 import java.net.HttpURLConnection
 import kotlin.test.assertIs
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class PollAuthorizationSessionAccountsTest {
 
     private val repository: FinancialConnectionsAccountsRepository = mock()
@@ -81,7 +79,7 @@ internal class PollAuthorizationSessionAccountsTest {
 
         assertIs<AccountLoadError>(exception)
 
-        // Retries 180 times
+        // Attempts 180 times
         verify(repository, times(180)).postAuthorizationSessionAccounts(
             configuration.financialConnectionsSessionClientSecret,
             sync.manifest.activeAuthSession!!.id

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/utils/ErrorsKtTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/utils/ErrorsKtTest.kt
@@ -2,12 +2,10 @@ package com.stripe.android.financialconnections.utils
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.exception.APIException
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import java.net.HttpURLConnection
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class ErrorsKtTest {
 
     @Test
@@ -15,7 +13,7 @@ internal class ErrorsKtTest {
         val testResult = kotlin.runCatching {
             retryOnException(
                 PollTimingOptions(
-                    maxNumberOfRetries = 5,
+                    attempts = 5,
                     initialDelayMs = 0,
                     retryInterval = 1000
                 ),
@@ -34,7 +32,7 @@ internal class ErrorsKtTest {
         var counter = 0
         val result = retryOnException(
             PollTimingOptions(
-                maxNumberOfRetries = 5,
+                attempts = 5,
                 initialDelayMs = 0,
                 retryInterval = 1000
             ),
@@ -70,15 +68,16 @@ internal class ErrorsKtTest {
             var counter = 0
             retryOnException(
                 PollTimingOptions(
-                    maxNumberOfRetries = 2,
+                    attempts = 2,
                     initialDelayMs = 0,
                     retryInterval = 1000
                 ),
-                retryCondition = { exception -> exception.shouldRetry }
-            ) {
-                counter++
-                if (counter == 3) true else throw retryException()
-            }
+                retryCondition = { exception -> exception.shouldRetry },
+                action = {
+                    counter++
+                    if (counter == 3) true else throw retryException()
+                }
+            )
         }
         assertThat(testResult.exceptionOrNull()!!).isInstanceOf(PollingReachedMaxRetriesException::class.java)
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request rewrites the `retryOnException` method to avoid using the delicate `Channel.isClosedForSending` API. Instead, we use a simple while loop and break out of it once we receive a result or exceed the maximum number of retries.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Avoid delicate coroutines API.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
