### PR TITLE
Add analytics when we fail to attach a new card to a link account

### DIFF
--- a/link/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/link/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -2,6 +2,7 @@ package com.stripe.android.link.account
 
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.core.Logger
+import com.stripe.android.core.exception.StripeException
 import com.stripe.android.link.BuildConfig
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkPaymentDetails
@@ -104,6 +105,7 @@ internal class LinkAccountManager @Inject constructor(
         }.onSuccess {
             Logger.getInstance(BuildConfig.DEBUG).debug("Logged out of Link successfully")
         }.onFailure { error ->
+            errorReporter.report(ErrorReporter.ExpectedErrorEvent.LINK_LOG_OUT_FAILURE, StripeException.create(error))
             Logger.getInstance(BuildConfig.DEBUG).warning("Failed to log out of Link: $error")
         }
     }
@@ -173,6 +175,8 @@ internal class LinkAccountManager @Inject constructor(
         linkRepository.consumerSignUp(email, phone, country, name, authSessionCookie, consentAction.consumerAction)
             .map { consumerSession ->
                 setAccount(consumerSession)
+            }.onFailure {
+                errorReporter.report(ErrorReporter.ExpectedErrorEvent.LINK_SIGN_UP_FAILURE, StripeException.create(it))
             }
 
     /**

--- a/link/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/link/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -15,7 +15,7 @@ import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.ConsumerSignUpConsentAction
 import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.android.model.StripeIntent
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
@@ -28,7 +28,8 @@ import javax.inject.Inject
 internal class LinkAccountManager @Inject constructor(
     private val config: LinkConfiguration,
     private val linkRepository: LinkRepository,
-    private val linkEventsReporter: LinkEventsReporter
+    private val linkEventsReporter: LinkEventsReporter,
+    private val errorReporter: ErrorReporter,
 ) {
     private val _linkAccount = MutableStateFlow<LinkAccount?>(null)
     val linkAccount: StateFlow<LinkAccount?> = _linkAccount
@@ -182,47 +183,37 @@ internal class LinkAccountManager @Inject constructor(
      */
     suspend fun createCardPaymentDetails(
         paymentMethodCreateParams: PaymentMethodCreateParams
-    ): Result<LinkPaymentDetails> =
-        linkAccount.value?.let { account ->
-            createCardPaymentDetails(
-                paymentMethodCreateParams,
-                account.email,
-                config.stripeIntent
-            ).mapCatching {
-                if (config.passthroughModeEnabled) {
-                    linkRepository.shareCardPaymentDetails(
-                        id = it.paymentDetails.id,
-                        last4 = paymentMethodCreateParams.cardLast4().orEmpty(),
-                        consumerSessionClientSecret = account.clientSecret,
-                        paymentMethodCreateParams = paymentMethodCreateParams,
-                    ).getOrThrow()
-                } else {
-                    it
+    ): Result<LinkPaymentDetails> {
+        val linkAccountValue = linkAccount.value
+        return if (linkAccountValue != null) {
+            linkAccountValue.let { account ->
+                linkRepository.createCardPaymentDetails(
+                    paymentMethodCreateParams = paymentMethodCreateParams,
+                    userEmail = account.email,
+                    stripeIntent = config.stripeIntent,
+                    consumerSessionClientSecret = account.clientSecret,
+                    consumerPublishableKey = if (config.passthroughModeEnabled) null else consumerPublishableKey,
+                    active = config.passthroughModeEnabled,
+                ).mapCatching {
+                    if (config.passthroughModeEnabled) {
+                        linkRepository.shareCardPaymentDetails(
+                            id = it.paymentDetails.id,
+                            last4 = paymentMethodCreateParams.cardLast4().orEmpty(),
+                            consumerSessionClientSecret = account.clientSecret,
+                            paymentMethodCreateParams = paymentMethodCreateParams,
+                        ).getOrThrow()
+                    } else {
+                        it
+                    }
                 }
             }
-        } ?: Result.failure(
-            IllegalStateException("A non-null Link account is needed to create payment details")
-        )
-
-    /**
-     * Create a new Card payment method attached to the consumer account.
-     */
-    suspend fun createCardPaymentDetails(
-        paymentMethodCreateParams: PaymentMethodCreateParams,
-        userEmail: String,
-        stripeIntent: StripeIntent
-    ): Result<LinkPaymentDetails.New> = linkAccount.value?.let { account ->
-        linkRepository.createCardPaymentDetails(
-            paymentMethodCreateParams = paymentMethodCreateParams,
-            userEmail = userEmail,
-            stripeIntent = stripeIntent,
-            consumerSessionClientSecret = account.clientSecret,
-            consumerPublishableKey = if (config.passthroughModeEnabled) null else consumerPublishableKey,
-            active = config.passthroughModeEnabled,
-        )
-    } ?: Result.failure(
-        IllegalStateException("User not signed in")
-    )
+        } else {
+            errorReporter.report(ErrorReporter.UnexpectedErrorEvent.LINK_ATTACH_CARD_WITH_NULL_ACCOUNT)
+            Result.failure(
+                IllegalStateException("A non-null Link account is needed to create payment details")
+            )
+        }
+    }
 
     private fun setAccount(consumerSession: ConsumerSession): LinkAccount {
         maybeUpdateConsumerPublishableKey(consumerSession)

--- a/link/src/test/java/com/stripe/android/link/account/LinkAccountManagerTest.kt
+++ b/link/src/test/java/com/stripe/android/link/account/LinkAccountManagerTest.kt
@@ -18,6 +18,7 @@ import com.stripe.android.model.ConsumerSessionLookup
 import com.stripe.android.model.ConsumerSignUpConsentAction
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.testing.FakeErrorReporter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -318,7 +319,7 @@ class LinkAccountManagerTest {
                 Result.success(mock())
             )
 
-            accountManager.createCardPaymentDetails(mock(), "", mock())
+            accountManager.createCardPaymentDetails(mock())
 
             verify(linkRepository)
                 .createCardPaymentDetails(
@@ -451,6 +452,7 @@ class LinkAccountManagerTest {
         ),
         linkRepository,
         linkEventsReporter,
+        errorReporter = FakeErrorReporter()
     )
 
     private fun createUserInputWithAction(consentAction: SignUpConsentAction): UserInput.SignUp {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -80,6 +80,12 @@ interface ErrorReporter {
         GET_SAVED_PAYMENT_METHODS_FAILURE(
             eventName = "elements.customer_repository.get_saved_payment_methods_failure"
         ),
+        LINK_CREATE_CARD_FAILURE(
+            eventName = "link.create_new_card.create_payment_details_failure"
+        ),
+        LINK_SHARE_CARD_FAILURE(
+            eventName = "link.create_new_card.share_payment_details_failure"
+        )
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -92,6 +98,9 @@ interface ErrorReporter {
         ),
         LINK_INVALID_SESSION_STATE(
             partialEventName = "link.signup.failure.invalidSessionState"
+        ),
+        LINK_ATTACH_CARD_WITH_NULL_ACCOUNT(
+            partialEventName = "link.create_new_card.missing_link_account"
         );
 
         override val eventName: String

--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -85,6 +85,12 @@ interface ErrorReporter {
         ),
         LINK_SHARE_CARD_FAILURE(
             eventName = "link.create_new_card.share_payment_details_failure"
+        ),
+        LINK_SIGN_UP_FAILURE(
+            eventName = "link.sign_up.failure"
+        ),
+        LINK_LOG_OUT_FAILURE(
+            eventName = "link.log_out.failure"
         )
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add analytics when we fail to attach a new card to a link account

Also refactor a bit to remove one possible failure spot which can be avoided

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
error visibility sprint!

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified
