### PR TITLE
Remove extra link sign up failure event

### DIFF
--- a/link/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/link/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -175,8 +175,6 @@ internal class LinkAccountManager @Inject constructor(
         linkRepository.consumerSignUp(email, phone, country, name, authSessionCookie, consentAction.consumerAction)
             .map { consumerSession ->
                 setAccount(consumerSession)
-            }.onFailure {
-                errorReporter.report(ErrorReporter.ExpectedErrorEvent.LINK_SIGN_UP_FAILURE, StripeException.create(it))
             }
 
     /**

--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -92,9 +92,6 @@ interface ErrorReporter {
         LINK_SHARE_CARD_FAILURE(
             eventName = "link.create_new_card.share_payment_details_failure"
         ),
-        LINK_SIGN_UP_FAILURE(
-            eventName = "link.sign_up.failure"
-        ),
         LINK_LOG_OUT_FAILURE(
             eventName = "link.log_out.failure"
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove extra link sign up failure event

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
It already exists as a [LinkEvent](https://github.com/stripe/stripe-android/blob/423a5f7494a601f59f27e83574c37066276529bc/link/src/main/java/com/stripe/android/link/analytics/LinkEvent.kt#L20), which is logged [here](https://github.com/stripe/stripe-android/blob/423a5f7494a601f59f27e83574c37066276529bc/link/src/main/java/com/stripe/android/link/analytics/DefaultLinkEventsReporter.kt#L46-L50) with more info than is logged for this event. 

I just added this as part of the error visibility sprint (https://github.com/stripe/stripe-android/pull/8234/files#diff-b4cb156e4351ee95e6a218a9bd47d4081594d17486cd1e414a28d785e5a6abdc) and didn't realize it already existed. Oops.
