### PR TITLE
Encode `name` & `value` of body parameters in various network tests

### DIFF
--- a/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
@@ -6,6 +6,7 @@ import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
+import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.VerificationType
@@ -44,7 +45,7 @@ class ConsumersApiServiceImplTest {
             header("Authorization", "Bearer ${DEFAULT_OPTIONS.apiKey}"),
             header("User-Agent", "Stripe/v1 ${StripeSdkVersion.VERSION}"),
             bodyPart("email_address", "email%40example.com"),
-            bodyPart("cookies%5Bverification_session_client_secrets%5D%5B%5D", cookie),
+            bodyPart(urlEncode("cookies[verification_session_client_secrets][]"), cookie),
             bodyPart("request_surface", requestSurface),
         ) { response ->
             response.setBody(ConsumerFixtures.EXISTING_CONSUMER_JSON.toString())
@@ -103,10 +104,10 @@ class ConsumersApiServiceImplTest {
             header("Authorization", "Bearer ${DEFAULT_OPTIONS.apiKey}"),
             header("User-Agent", "Stripe/v1 ${StripeSdkVersion.VERSION}"),
             bodyPart("request_surface", "android_payment_element"),
-            bodyPart("credentials%5Bconsumer_session_client_secret%5D", clientSecret),
+            bodyPart(urlEncode("credentials[consumer_session_client_secret]"), clientSecret),
             bodyPart("type", "SMS"),
             bodyPart("locale", locale.toLanguageTag()),
-            bodyPart("cookies%5Bverification_session_client_secrets%5D%5B%5D", cookie),
+            bodyPart(urlEncode("cookies[verification_session_client_secrets][]"), cookie),
         ) { response ->
             response.setBody(ConsumerFixtures.CONSUMER_VERIFICATION_STARTED_JSON.toString())
         }
@@ -143,10 +144,10 @@ class ConsumersApiServiceImplTest {
             header("Authorization", "Bearer ${DEFAULT_OPTIONS.apiKey}"),
             header("User-Agent", "Stripe/v1 ${StripeSdkVersion.VERSION}"),
             bodyPart("request_surface", "android_payment_element"),
-            bodyPart("credentials%5Bconsumer_session_client_secret%5D", clientSecret),
+            bodyPart(urlEncode("credentials[consumer_session_client_secret]"), clientSecret),
             bodyPart("type", "SMS"),
             bodyPart("code", verificationCode),
-            bodyPart("cookies%5Bverification_session_client_secrets%5D%5B%5D", cookie),
+            bodyPart(urlEncode("cookies[verification_session_client_secrets][]"), cookie),
         ) { response ->
             response.setBody(ConsumerFixtures.CONSUMER_VERIFIED_JSON.toString())
         }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -6,6 +6,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.method
@@ -364,7 +365,7 @@ internal class FlowControllerTest {
             path("/v1/payment_intents/pi_example/confirm"),
             not(
                 bodyPart(
-                    "payment_method_data%5Bpayment_user_agent%5D",
+                    urlEncode("payment_method_data[payment_user_agent]"),
                     Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3BPaymentSheet%3Bdeferred-intent%3Bautopm")
                 )
             ),

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
@@ -5,6 +5,7 @@ import androidx.test.espresso.Espresso.closeSoftKeyboard
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.link.account.LinkStore
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatcher
@@ -89,16 +90,16 @@ internal class LinkTest {
             /*
              * Make sure card number is included
              */
-            bodyPart("card%5Bnumber%5D", "4242424242424242"),
+            bodyPart(urlEncode("card[number]"), "4242424242424242"),
             /*
              * Make sure card expiration month is included
              */
-            bodyPart("card%5Bexp_month%5D", "12"),
+            bodyPart(urlEncode("card[exp_month]"), "12"),
             /*
              * Ensures we are passing the full expiration year and not the
              * 2-digit shorthand (should send "2034", not "34")
              */
-            bodyPart("card%5Bexp_year%5D", "2034"),
+            bodyPart(urlEncode("card[exp_year]"), "2034"),
             /*
              * Should use the consumer's publishable key when creating payment details
              */
@@ -225,7 +226,7 @@ internal class LinkTest {
             networkRule.enqueue(
                 method("POST"),
                 path("/v1/payment_intents/pi_example/confirm"),
-                bodyPart("payment_method_options%5Bcard%5D%5Bsetup_future_usage%5D", "off_session"),
+                bodyPart(urlEncode("payment_method_options[card][setup_future_usage]"), "off_session"),
             ) { response ->
                 response.testBodyFromFile("payment-intent-confirm.json")
             }
@@ -287,20 +288,20 @@ internal class LinkTest {
             /*
              * Ensures card number is included
              */
-            bodyPart("card%5Bnumber%5D", "4000002500001001"),
+            bodyPart(urlEncode("card[number]"), "4000002500001001"),
             /*
              * Ensures card expiration month is included
              */
-            bodyPart("card%5Bexp_month%5D", "12"),
+            bodyPart(urlEncode("card[exp_month]"), "12"),
             /*
              * Ensures we are passing the full expiration year and not the
              * 2-digit shorthand (should send "2034", not "34")
              */
-            bodyPart("card%5Bexp_year%5D", "2034"),
+            bodyPart(urlEncode("card[exp_year]"), "2034"),
             /*
              * Ensures card brand choice is passed properly.
              */
-            bodyPart("card%5Bpreferred_network%5D", "cartes_bancaires"),
+            bodyPart(urlEncode("card[preferred_network]"), "cartes_bancaires"),
             /*
              * Should use the consumer's publishable key when creating payment details
              */
@@ -376,16 +377,16 @@ internal class LinkTest {
             /*
              * Make sure card number is included
              */
-            bodyPart("card%5Bnumber%5D", "4242424242424242"),
+            bodyPart(urlEncode("card[number]"), "4242424242424242"),
             /*
              * Make sure card expiration month is included
              */
-            bodyPart("card%5Bexp_month%5D", "12"),
+            bodyPart(urlEncode("card[exp_month]"), "12"),
             /*
              * Ensures we are passing the full expiration year and not the
              * 2-digit shorthand (should send "2034", not "34")
              */
-            bodyPart("card%5Bexp_year%5D", "2034"),
+            bodyPart(urlEncode("card[exp_year]"), "2034"),
             /*
              * In passthrough mode, this needs to be true
              */
@@ -531,7 +532,7 @@ internal class LinkTest {
             networkRule.enqueue(
                 method("POST"),
                 path("/v1/payment_intents/pi_example/confirm"),
-                bodyPart("payment_method_options%5Bcard%5D%5Bsetup_future_usage%5D", "off_session"),
+                bodyPart(urlEncode("payment_method_options[card][setup_future_usage]"), "off_session"),
             ) { response ->
                 response.testBodyFromFile("payment-intent-confirm.json")
             }
@@ -596,20 +597,20 @@ internal class LinkTest {
             /*
              * Make sure card number is included
              */
-            bodyPart("card%5Bnumber%5D", "4000002500001001"),
+            bodyPart(urlEncode("card[number]"), "4000002500001001"),
             /*
              * Make sure card expiration month is included
              */
-            bodyPart("card%5Bexp_month%5D", "12"),
+            bodyPart(urlEncode("card[exp_month]"), "12"),
             /*
              * Ensures we are passing the full expiration year and not the
              * 2-digit shorthand (should send "2034", not "34")
              */
-            bodyPart("card%5Bexp_year%5D", "2034"),
+            bodyPart(urlEncode("card[exp_year]"), "2034"),
             /*
              * Ensures card brand choice is passed properly.
              */
-            bodyPart("card%5Bpreferred_network%5D", "cartes_bancaires"),
+            bodyPart(urlEncode("card[preferred_network]"), "cartes_bancaires"),
             /*
              * In passthrough mode, this needs to be true
              */
@@ -1072,15 +1073,15 @@ internal class LinkTest {
     private fun linkInformation(): RequestMatcher {
         return composite(
             bodyPart(
-                name = "payment_method_data%5Blink%5D%5Bcard%5D%5Bcvc%5D",
+                name = urlEncode("payment_method_data[link][card][cvc]"),
                 value = "123"
             ),
             bodyPart(
-                name = "payment_method_data%5Blink%5D%5Bpayment_details_id%5D",
+                name = urlEncode("payment_method_data[link][payment_details_id]"),
                 value = "QAAAKJ6"
             ),
             bodyPart(
-                name = "payment_method_data%5Blink%5D%5Bcredentials%5D%5Bconsumer_session_client_secret%5D",
+                name = urlEncode("payment_method_data[link][credentials][consumer_session_client_secret]"),
                 value = "12oBEhVjc21yKkFYNnhMVTlXbXdBQUFJRmEaJDUzNTFkNjNhLTZkNGMtND"
             ),
         )

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetBillingConfigurationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetBillingConfigurationTest.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.method
@@ -82,11 +83,11 @@ internal class PaymentSheetBillingConfigurationTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
-            bodyPart("payment_method_data%5Bbilling_details%5D%5Bname%5D", "Jane+Doe"),
-            bodyPart("payment_method_data%5Bbilling_details%5D%5Bemail%5D", "mail%40mail.com"),
-            bodyPart("payment_method_data%5Bbilling_details%5D%5Bphone%5D", "%2B13105551234"),
-            bodyPart("payment_method_data%5Bbilling_details%5D%5Baddress%5D%5Bcountry%5D", "US"),
-            bodyPart("payment_method_data%5Bbilling_details%5D%5Baddress%5D%5Bpostal_code%5D", "94111"),
+            bodyPart(urlEncode("payment_method_data[billing_details][name]"), urlEncode("Jane Doe")),
+            bodyPart(urlEncode("payment_method_data[billing_details][email]"), urlEncode("mail@mail.com")),
+            bodyPart(urlEncode("payment_method_data[billing_details][phone]"), urlEncode("+13105551234")),
+            bodyPart(urlEncode("payment_method_data[billing_details][address][country]"), "US"),
+            bodyPart(urlEncode("payment_method_data[billing_details][address][postal_code]"), "94111"),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -154,11 +155,11 @@ internal class PaymentSheetBillingConfigurationTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
-            not(bodyPart("payment_method_data%5Bbilling_details%5D%5Bname%5D", "Jenny Rosen")),
-            not(bodyPart("payment_method_data%5Bbilling_details%5D%5Bemail%5D", "foo%40bar.com")),
-            not(bodyPart("payment_method_data%5Bbilling_details%5D%5Bphone%5D", "%2B13105551234")),
-            not(bodyPart("payment_method_data%5Bbilling_details%5D%5Baddress%5D%5Bcountry%5D", "US")),
-            not(bodyPart("payment_method_data%5Bbilling_details%5D%5Baddress%5D%5Bpostal_code%5D", "94111")),
+            not(bodyPart(urlEncode("payment_method_data[billing_details][name]"), urlEncode("Jenny Rosen"))),
+            not(bodyPart(urlEncode("payment_method_data[billing_details][email]"), urlEncode("foo@bar.com"))),
+            not(bodyPart(urlEncode("payment_method_data[billing_details][phone]"), urlEncode("+13105551234"))),
+            not(bodyPart(urlEncode("payment_method_data[billing_details][address][country]"), "US")),
+            not(bodyPart(urlEncode("payment_method_data[billing_details][address][postal_code]"), "94111")),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.host
@@ -252,7 +253,7 @@ internal class PaymentSheetTest {
             path("/v1/payment_intents/pi_example/confirm"),
             not(
                 bodyPart(
-                    "payment_method_data%5Bpayment_user_agent%5D",
+                    urlEncode("payment_method_data[payment_user_agent]"),
                     Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet%3Bdeferred-intent%3Bautopm")
                 )
             ),
@@ -382,7 +383,7 @@ internal class PaymentSheetTest {
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
             bodyPart(
-                "payment_method_data%5Bcard%5D%5Bnetworks%5D%5Bpreferred%5D",
+                urlEncode("payment_method_data[card][networks][preferred]"),
                 "cartes_bancaires"
             ),
         ) { response ->


### PR DESCRIPTION
# Summary
Encode `name` & `value` of body parameters in various network tests

# Motivation
Makes reading the network tests easier.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
