### PR TITLE
Adds customer payment method attach tests for `CustomerSheetTest`.

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
@@ -85,30 +85,7 @@ internal class CustomerSheetTest {
             response.testBodyFromFile("payment-methods-create.json")
         }
 
-        when (customerSheetTestType) {
-            CustomerSheetTestType.AttachToCustomer -> {
-                networkRule.enqueue(
-                    attachPaymentMethodRequest(),
-                ) { response ->
-                    response.testBodyFromFile("payment-methods-create.json")
-                }
-            }
-            CustomerSheetTestType.AttachToSetupIntent -> {
-                networkRule.enqueue(
-                    retrieveSetupIntentRequest(),
-                    retrieveSetupIntentParams(),
-                ) { response ->
-                    response.testBodyFromFile("setup-intent-get.json")
-                }
-
-                networkRule.enqueue(
-                    confirmSetupIntentRequest(),
-                    confirmSetupIntentParams()
-                ) { response ->
-                    response.testBodyFromFile("setup-intent-confirm.json")
-                }
-            }
-        }
+        networkRule.enqueueAttachRequests(customerSheetTestType)
 
         page.clickSaveButton()
         page.clickConfirmButton()
@@ -171,30 +148,7 @@ internal class CustomerSheetTest {
             response.testBodyFromFile("payment-methods-create.json")
         }
 
-        when (customerSheetTestType) {
-            CustomerSheetTestType.AttachToCustomer -> {
-                networkRule.enqueue(
-                    attachPaymentMethodRequest(),
-                ) { response ->
-                    response.testBodyFromFile("payment-methods-create.json")
-                }
-            }
-            CustomerSheetTestType.AttachToSetupIntent -> {
-                networkRule.enqueue(
-                    retrieveSetupIntentRequest(),
-                    retrieveSetupIntentParams(),
-                ) { response ->
-                    response.testBodyFromFile("setup-intent-get.json")
-                }
-
-                networkRule.enqueue(
-                    confirmSetupIntentRequest(),
-                    confirmSetupIntentParams()
-                ) { response ->
-                    response.testBodyFromFile("setup-intent-confirm.json")
-                }
-            }
-        }
+        networkRule.enqueueAttachRequests(customerSheetTestType)
 
         page.clickSaveButton()
         page.clickConfirmButton()
@@ -251,30 +205,7 @@ internal class CustomerSheetTest {
             response.testBodyFromFile("payment-methods-create.json")
         }
 
-        when (customerSheetTestType) {
-            CustomerSheetTestType.AttachToCustomer -> {
-                networkRule.enqueue(
-                    attachPaymentMethodRequest(),
-                ) { response ->
-                    response.testBodyFromFile("payment-methods-create.json")
-                }
-            }
-            CustomerSheetTestType.AttachToSetupIntent -> {
-                networkRule.enqueue(
-                    retrieveSetupIntentRequest(),
-                    retrieveSetupIntentParams(),
-                ) { response ->
-                    response.testBodyFromFile("setup-intent-get.json")
-                }
-
-                networkRule.enqueue(
-                    confirmSetupIntentRequest(),
-                    confirmSetupIntentParams()
-                ) { response ->
-                    response.testBodyFromFile("setup-intent-confirm.json")
-                }
-            }
-        }
+        networkRule.enqueueAttachRequests(customerSheetTestType)
 
         page.clickSaveButton()
         page.clickConfirmButton()
@@ -340,6 +271,33 @@ internal class CustomerSheetTest {
         page.waitForText("Your card's security code is incorrect.")
 
         context.markTestSucceeded()
+    }
+
+    private fun NetworkRule.enqueueAttachRequests(customerSheetTestType: CustomerSheetTestType) {
+        when (customerSheetTestType) {
+            CustomerSheetTestType.AttachToCustomer -> {
+                enqueue(
+                    attachPaymentMethodRequest(),
+                ) { response ->
+                    response.testBodyFromFile("payment-methods-create.json")
+                }
+            }
+            CustomerSheetTestType.AttachToSetupIntent -> {
+                enqueue(
+                    retrieveSetupIntentRequest(),
+                    retrieveSetupIntentParams(),
+                ) { response ->
+                    response.testBodyFromFile("setup-intent-get.json")
+                }
+
+                enqueue(
+                    confirmSetupIntentRequest(),
+                    confirmSetupIntentParams()
+                ) { response ->
+                    response.testBodyFromFile("setup-intent-confirm.json")
+                }
+            }
+        }
     }
 
     private fun retrieveElementsSessionRequest(): RequestMatcher {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestFactory.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestFactory.kt
@@ -12,6 +12,7 @@ import com.stripe.android.customersheet.rememberCustomerSheet
 @OptIn(ExperimentalCustomerSheetApi::class)
 internal class CustomerSheetTestFactory(
     private val integrationType: IntegrationType,
+    private val customerSheetTestType: CustomerSheetTestType,
     private val configuration: CustomerSheet.Configuration,
     private val resultCallback: CustomerSheetResultCallback,
 ) {
@@ -29,7 +30,7 @@ internal class CustomerSheetTestFactory(
         return CustomerSheet.create(
             activity = activity,
             configuration = configuration,
-            customerAdapter = createCustomerAdapter(activity),
+            customerAdapter = createCustomerAdapter(customerSheetTestType, activity),
             callback = resultCallback,
         )
     }
@@ -42,7 +43,7 @@ internal class CustomerSheetTestFactory(
         activity.setContent {
             customerSheet = rememberCustomerSheet(
                 configuration = configuration,
-                customerAdapter = createCustomerAdapter(activity),
+                customerAdapter = createCustomerAdapter(customerSheetTestType, activity),
                 callback = resultCallback,
             )
         }
@@ -51,6 +52,7 @@ internal class CustomerSheetTestFactory(
     }
 
     private fun createCustomerAdapter(
+        customerSheetTestType: CustomerSheetTestType,
         activity: ComponentActivity
     ): CustomerAdapter {
         return CustomerAdapter.create(
@@ -63,8 +65,11 @@ internal class CustomerSheetTestFactory(
                     )
                 )
             },
-            setupIntentClientSecretProvider = {
-                CustomerAdapter.Result.success("seti_12345_secret_12345")
+            setupIntentClientSecretProvider = when (customerSheetTestType) {
+                CustomerSheetTestType.AttachToCustomer -> null
+                CustomerSheetTestType.AttachToSetupIntent -> {
+                    { CustomerAdapter.Result.success("seti_12345_secret_12345") }
+                }
             }
         )
     }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestRunner.kt
@@ -1,11 +1,14 @@
 package com.stripe.android.paymentsheet.utils
 
+import android.content.Context
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.customersheet.CustomerAdapter
+import com.stripe.android.customersheet.CustomerEphemeralKey
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetActivity
 import com.stripe.android.customersheet.CustomerSheetResultCallback
@@ -39,6 +42,7 @@ internal class CustomerSheetTestRunnerContext(
 @OptIn(ExperimentalCustomerSheetApi::class)
 internal fun ActivityScenarioRule<MainActivity>.runCustomerSheetTest(
     integrationType: IntegrationType,
+    customerSheetTestType: CustomerSheetTestType,
     configuration: CustomerSheet.Configuration = CustomerSheet.Configuration(
         merchantDisplayName = "Merchant Inc."
     ),
@@ -49,6 +53,7 @@ internal fun ActivityScenarioRule<MainActivity>.runCustomerSheetTest(
 
     val factory = CustomerSheetTestFactory(
         integrationType = integrationType,
+        customerSheetTestType = customerSheetTestType,
         configuration = configuration,
         resultCallback = {
             resultCallback.onCustomerSheetResult(it)
@@ -61,6 +66,30 @@ internal fun ActivityScenarioRule<MainActivity>.runCustomerSheetTest(
         makeCustomerSheet = factory::make,
         block = block,
     )
+}
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+internal fun createTestAdapter(
+    useSetupIntent: Boolean
+): (context: Context) -> CustomerAdapter {
+    return { context ->
+        CustomerAdapter.create(
+            context = context,
+            customerEphemeralKeyProvider = {
+                CustomerAdapter.Result.success(
+                    CustomerEphemeralKey(
+                        customerId = "cus_1",
+                        ephemeralKey = "ek_test_123"
+                    )
+                )
+            },
+            setupIntentClientSecretProvider = if (useSetupIntent) {
+                { CustomerAdapter.Result.success("seti_12345_secret_12345") }
+            } else {
+                null
+            }
+        )
+    }
 }
 
 @OptIn(ExperimentalCustomerSheetApi::class)

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestRunner.kt
@@ -1,14 +1,11 @@
 package com.stripe.android.paymentsheet.utils
 
-import android.content.Context
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.customersheet.CustomerAdapter
-import com.stripe.android.customersheet.CustomerEphemeralKey
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetActivity
 import com.stripe.android.customersheet.CustomerSheetResultCallback
@@ -66,30 +63,6 @@ internal fun ActivityScenarioRule<MainActivity>.runCustomerSheetTest(
         makeCustomerSheet = factory::make,
         block = block,
     )
-}
-
-@OptIn(ExperimentalCustomerSheetApi::class)
-internal fun createTestAdapter(
-    useSetupIntent: Boolean
-): (context: Context) -> CustomerAdapter {
-    return { context ->
-        CustomerAdapter.create(
-            context = context,
-            customerEphemeralKeyProvider = {
-                CustomerAdapter.Result.success(
-                    CustomerEphemeralKey(
-                        customerId = "cus_1",
-                        ephemeralKey = "ek_test_123"
-                    )
-                )
-            },
-            setupIntentClientSecretProvider = if (useSetupIntent) {
-                { CustomerAdapter.Result.success("seti_12345_secret_12345") }
-            } else {
-                null
-            }
-        )
-    }
 }
 
 @OptIn(ExperimentalCustomerSheetApi::class)

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestType.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestType.kt
@@ -1,0 +1,14 @@
+package com.stripe.android.paymentsheet.utils
+
+import com.google.testing.junit.testparameterinjector.TestParameter
+
+internal enum class CustomerSheetTestType {
+    AttachToCustomer,
+    AttachToSetupIntent,
+}
+
+internal object CustomerSheetTestTypeProvider : TestParameter.TestParameterValuesProvider {
+    override fun provideValues(): List<CustomerSheetTestType> {
+        return CustomerSheetTestType.entries
+    }
+}


### PR DESCRIPTION
# Summary
Adds tests for networks requests when attaching a payment method to a customer.

# Motivation
Validates network requests used when attaching a payment method directly to a customer rather than attaching it through a `SetupIntent`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified