### PR TITLE
Add analytics for PaymentLauncher.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmStripeIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmStripeIntentParams.kt
@@ -27,3 +27,14 @@ sealed interface ConfirmStripeIntentParams : StripeParamsModel, Parcelable {
         internal const val PARAM_MANDATE_DATA = "mandate_data"
     }
 }
+
+internal fun ConfirmStripeIntentParams.createParams(): PaymentMethodCreateParams? {
+    return when (this) {
+        is ConfirmPaymentIntentParams -> {
+            paymentMethodCreateParams
+        }
+        is ConfirmSetupIntentParams -> {
+            paymentMethodCreateParams
+        }
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsEvent.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsEvent.kt
@@ -42,6 +42,12 @@ internal enum class PaymentAnalyticsEvent(val code: String) : AnalyticsEvent {
     SetupIntentRetrieveOrdered("setup_intent_retrieval_ordered"),
     SetupIntentCancelSource("setup_intent_cancel_source"),
 
+    // Payment Launcher
+    PaymentLauncherConfirmStarted("paymenthandler.confirm.started"),
+    PaymentLauncherConfirmFinished("paymenthandler.confirm.finished"),
+    PaymentLauncherNextActionStarted("paymenthandler.handle_next_action.started"),
+    PaymentLauncherNextActionFinished("paymenthandler.handle_next_action.finished"),
+
     // File
     FileCreate("create_file"),
 

--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -14,6 +14,7 @@ import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.utils.filterNotNullValues
 import dagger.Binds
 import dagger.BindsInstance
 import dagger.Component
@@ -73,9 +74,6 @@ interface ErrorReporter {
                 "error_code" to stripeException.stripeError?.code,
             ).filterNotNullValues()
         }
-
-        private fun <K, V> Map<K, V?>.filterNotNullValues(): Map<K, V> =
-            mapNotNull { (key, value) -> value?.let { key to it } }.toMap()
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -114,17 +114,7 @@ internal class PaymentLauncherViewModel @Inject constructor(
             savedStateHandle[KEY_HAS_STARTED] = true
             savedStateHandle[KEY_CONFIRM_ACTION_REQUESTED] = true
 
-            val analyticsParams: Map<String, String> = mapOf(
-                "payment_method_type" to confirmStripeIntentParams.createParams()?.code,
-                "intent_id" to confirmStripeIntentParams.clientSecret.toStripeId(),
-            ).filterNotNullValues()
-            analyticsRequestExecutor.executeAsync(
-                paymentAnalyticsRequestFactory.createRequest(
-                    event = PaymentAnalyticsEvent.PaymentLauncherConfirmStarted,
-                    additionalParams = analyticsParams,
-                )
-            )
-
+            val analyticsParams = logConfirmStarted(confirmStripeIntentParams)
             logReturnUrl(confirmStripeIntentParams.returnUrl)
             val returnUrl =
                 if (isInstantApp) {
@@ -170,6 +160,20 @@ internal class PaymentLauncherViewModel @Inject constructor(
         }
     }
 
+    private fun logConfirmStarted(confirmStripeIntentParams: ConfirmStripeIntentParams): Map<String, String> {
+        val analyticsParams: Map<String, String> = mapOf(
+            "payment_method_type" to confirmStripeIntentParams.createParams()?.code,
+            "intent_id" to confirmStripeIntentParams.clientSecret.toStripeId(),
+        ).filterNotNullValues()
+        analyticsRequestExecutor.executeAsync(
+            paymentAnalyticsRequestFactory.createRequest(
+                event = PaymentAnalyticsEvent.PaymentLauncherConfirmStarted,
+                additionalParams = analyticsParams,
+            )
+        )
+        return analyticsParams
+    }
+
     private suspend fun confirmIntent(
         confirmStripeIntentParams: ConfirmStripeIntentParams,
         returnUrl: String?
@@ -205,15 +209,7 @@ internal class PaymentLauncherViewModel @Inject constructor(
             savedStateHandle[KEY_HAS_STARTED] = true
             savedStateHandle[KEY_CONFIRM_ACTION_REQUESTED] = false
 
-            val analyticsParams = mapOf(
-                "intent_id" to clientSecret.toStripeId(),
-            )
-            analyticsRequestExecutor.executeAsync(
-                paymentAnalyticsRequestFactory.createRequest(
-                    event = PaymentAnalyticsEvent.PaymentLauncherNextActionStarted,
-                    additionalParams = analyticsParams,
-                )
-            )
+            val analyticsParams = logHandleNextActionStarted(clientSecret)
 
             stripeApiRepository.retrieveStripeIntent(
                 clientSecret = clientSecret,
@@ -238,6 +234,19 @@ internal class PaymentLauncherViewModel @Inject constructor(
                 }
             )
         }
+    }
+
+    private fun logHandleNextActionStarted(clientSecret: String): Map<String, String> {
+        val analyticsParams = mapOf(
+            "intent_id" to clientSecret.toStripeId(),
+        )
+        analyticsRequestExecutor.executeAsync(
+            paymentAnalyticsRequestFactory.createRequest(
+                event = PaymentAnalyticsEvent.PaymentLauncherNextActionStarted,
+                additionalParams = analyticsParams,
+            )
+        )
+        return analyticsParams
     }
 
     @VisibleForTesting

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.core.exception.LocalStripeException
+import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.ApiRequest
@@ -20,6 +21,7 @@ import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.model.createParams
 import com.stripe.android.networking.PaymentAnalyticsEvent
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networking.StripeRepository
@@ -27,10 +29,12 @@ import com.stripe.android.payments.DefaultReturnUrl
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.payments.PaymentIntentFlowResultProcessor
 import com.stripe.android.payments.SetupIntentFlowResultProcessor
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.authentication.PaymentAuthenticatorRegistry
 import com.stripe.android.payments.core.injection.DaggerPaymentLauncherViewModelFactoryComponent
 import com.stripe.android.payments.core.injection.IS_INSTANT_APP
 import com.stripe.android.payments.core.injection.IS_PAYMENT_INTENT
+import com.stripe.android.utils.filterNotNullValues
 import com.stripe.android.view.AuthActivityStarterHost
 import dagger.Lazy
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -68,7 +72,10 @@ internal class PaymentLauncherViewModel @Inject constructor(
      * confirm the same [StripeIntent] again.
      */
     private val hasStarted: Boolean
-        get() = savedStateHandle.get(KEY_HAS_STARTED) ?: false
+        get() = savedStateHandle[KEY_HAS_STARTED] ?: false
+
+    private val confirmActionRequested: Boolean
+        get() = savedStateHandle[KEY_CONFIRM_ACTION_REQUESTED] ?: true
 
     internal val internalPaymentResult = MutableStateFlow<InternalPaymentResult?>(null)
 
@@ -104,7 +111,20 @@ internal class PaymentLauncherViewModel @Inject constructor(
     ) {
         if (hasStarted) return
         viewModelScope.launch {
-            savedStateHandle.set(KEY_HAS_STARTED, true)
+            savedStateHandle[KEY_HAS_STARTED] = true
+            savedStateHandle[KEY_CONFIRM_ACTION_REQUESTED] = true
+
+            val analyticsParams: Map<String, String> = mapOf(
+                "payment_method_type" to confirmStripeIntentParams.createParams()?.code,
+                "intent_id" to confirmStripeIntentParams.clientSecret.toStripeId(),
+            ).filterNotNullValues()
+            analyticsRequestExecutor.executeAsync(
+                paymentAnalyticsRequestFactory.createRequest(
+                    event = PaymentAnalyticsEvent.PaymentLauncherConfirmStarted,
+                    additionalParams = analyticsParams,
+                )
+            )
+
             logReturnUrl(confirmStripeIntentParams.returnUrl)
             val returnUrl =
                 if (isInstantApp) {
@@ -125,7 +145,10 @@ internal class PaymentLauncherViewModel @Inject constructor(
                     }
                     if (!intent.requiresAction()) {
                         withContext(uiContext) {
-                            internalPaymentResult.value = InternalPaymentResult.Completed(intent)
+                            postInternalResult(
+                                stripeInternalResult = InternalPaymentResult.Completed(intent),
+                                intent = intent,
+                            )
                         }
                     } else {
                         authenticatorRegistry.getAuthenticator(intent).authenticate(
@@ -137,7 +160,10 @@ internal class PaymentLauncherViewModel @Inject constructor(
                 },
                 onFailure = {
                     withContext(uiContext) {
-                        internalPaymentResult.value = InternalPaymentResult.Failed(it)
+                        postInternalResult(
+                            stripeInternalResult = InternalPaymentResult.Failed(it),
+                            analyticsParams = analyticsParams,
+                        )
                     }
                 }
             )
@@ -176,7 +202,18 @@ internal class PaymentLauncherViewModel @Inject constructor(
     internal fun handleNextActionForStripeIntent(clientSecret: String, host: AuthActivityStarterHost) {
         if (hasStarted) return
         viewModelScope.launch {
-            savedStateHandle.set(KEY_HAS_STARTED, true)
+            savedStateHandle[KEY_HAS_STARTED] = true
+            savedStateHandle[KEY_CONFIRM_ACTION_REQUESTED] = false
+
+            val analyticsParams = mapOf(
+                "intent_id" to clientSecret.toStripeId(),
+            )
+            analyticsRequestExecutor.executeAsync(
+                paymentAnalyticsRequestFactory.createRequest(
+                    event = PaymentAnalyticsEvent.PaymentLauncherNextActionStarted,
+                    additionalParams = analyticsParams,
+                )
+            )
 
             stripeApiRepository.retrieveStripeIntent(
                 clientSecret = clientSecret,
@@ -193,7 +230,10 @@ internal class PaymentLauncherViewModel @Inject constructor(
                 },
                 onFailure = {
                     withContext(uiContext) {
-                        internalPaymentResult.value = InternalPaymentResult.Failed(it)
+                        postInternalResult(
+                            stripeInternalResult = InternalPaymentResult.Failed(it),
+                            analyticsParams = analyticsParams,
+                        )
                     }
                 }
             )
@@ -217,7 +257,7 @@ internal class PaymentLauncherViewModel @Inject constructor(
                 },
                 onFailure = {
                     withContext(uiContext) {
-                        internalPaymentResult.value = InternalPaymentResult.Failed(it)
+                        postInternalResult(stripeInternalResult = InternalPaymentResult.Failed(it))
                     }
                 }
             )
@@ -228,8 +268,8 @@ internal class PaymentLauncherViewModel @Inject constructor(
      * Parse [StripeIntentResult] into [PaymentResult].
      */
     private fun postResult(stripeIntentResult: StripeIntentResult<StripeIntent>) {
-        internalPaymentResult.value =
-            when (stripeIntentResult.outcome) {
+        postInternalResult(
+            stripeInternalResult = when (stripeIntentResult.outcome) {
                 StripeIntentResult.Outcome.SUCCEEDED ->
                     InternalPaymentResult.Completed(stripeIntentResult.intent)
                 StripeIntentResult.Outcome.FAILED ->
@@ -255,7 +295,43 @@ internal class PaymentLauncherViewModel @Inject constructor(
                             analyticsValue = "unknownIntentOutcomeError",
                         )
                     )
+            },
+            intent = stripeIntentResult.intent,
+        )
+    }
+
+    private fun postInternalResult(
+        stripeInternalResult: InternalPaymentResult,
+        intent: StripeIntent? = null,
+        analyticsParams: Map<String, String> = emptyMap(),
+    ) {
+        internalPaymentResult.value = stripeInternalResult.also {
+            val event = if (confirmActionRequested) {
+                PaymentAnalyticsEvent.PaymentLauncherConfirmFinished
+            } else {
+                PaymentAnalyticsEvent.PaymentLauncherNextActionFinished
             }
+
+            val intentParams = mapOf(
+                "intent_id" to intent?.clientSecret?.toStripeId(),
+                "status" to intent?.status?.code,
+                "payment_method_type" to intent?.paymentMethod?.type?.code,
+            ).filterNotNullValues()
+
+            val errorParams: Map<String, String> = if (stripeInternalResult is InternalPaymentResult.Failed) {
+                val stripeException = StripeException.create(stripeInternalResult.throwable)
+                ErrorReporter.getAdditionalParamsFromStripeException(stripeException)
+            } else {
+                emptyMap()
+            }
+
+            analyticsRequestExecutor.executeAsync(
+                paymentAnalyticsRequestFactory.createRequest(
+                    event = event,
+                    additionalParams = analyticsParams + intentParams + errorParams,
+                )
+            )
+        }
     }
 
     private fun logReturnUrl(returnUrl: String?) {
@@ -316,10 +392,15 @@ internal class PaymentLauncherViewModel @Inject constructor(
     internal companion object {
         const val TIMEOUT_ERROR = "Payment fails due to time out. \n"
         const val UNKNOWN_ERROR = "Payment fails due to unknown error. \n"
-        const val REQUIRED_ERROR = "API request returned an invalid response."
         val EXPAND_PAYMENT_METHOD = listOf("payment_method")
 
         @VisibleForTesting
         internal const val KEY_HAS_STARTED = "key_has_started"
+
+        private const val KEY_CONFIRM_ACTION_REQUESTED = "confirm_action_requested"
     }
+}
+
+private fun String.toStripeId(): String {
+    return substringBefore("_secret_")
 }

--- a/payments-core/src/main/java/com/stripe/android/utils/MapUtils.kt
+++ b/payments-core/src/main/java/com/stripe/android/utils/MapUtils.kt
@@ -1,0 +1,7 @@
+package com.stripe.android.utils
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun <K, V> Map<K, V?>.filterNotNullValues(): Map<K, V> =
+    mapNotNull { (key, value) -> value?.let { key to it } }.toMap()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
@@ -22,6 +22,7 @@ import com.stripe.android.paymentsheet.utils.runPaymentSheetTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import kotlin.time.Duration.Companion.seconds
 
 @RunWith(TestParameterInjector::class)
 internal class PaymentSheetAnalyticsTest {
@@ -35,6 +36,7 @@ internal class PaymentSheetAnalyticsTest {
     @get:Rule
     val networkRule = NetworkRule(
         hostsToTrack = listOf(ApiRequest.API_HOST, AnalyticsRequest.HOST),
+        validationTimeout = 1.seconds, // Analytics requests happen async.
     )
 
     @TestParameter(valuesProvider = IntegrationTypeProvider::class)
@@ -81,8 +83,18 @@ internal class PaymentSheetAnalyticsTest {
         }
 
         validateAnalyticsRequest(eventName = "mc_confirm_button_tapped")
+        validateAnalyticsRequest(
+            eventName = "stripe_android.paymenthandler.confirm.started",
+            query("intent_id", "pi_example"),
+            query("payment_method_type", "card"),
+        )
         validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
         validateAnalyticsRequest(eventName = "stripe_android.payment_intent_confirmation")
+        validateAnalyticsRequest(
+            eventName = "stripe_android.paymenthandler.confirm.finished",
+            query("intent_id", "pi_example"),
+            query("payment_method_type", "card"),
+        )
         validateAnalyticsRequest(eventName = "mc_complete_payment_newpm_success", hasQueryParam("duration"))
 
         page.clickPrimaryButton()
@@ -138,8 +150,18 @@ internal class PaymentSheetAnalyticsTest {
         }
 
         validateAnalyticsRequest(eventName = "mc_confirm_button_tapped")
+        validateAnalyticsRequest(
+            eventName = "stripe_android.paymenthandler.confirm.started",
+            query("intent_id", "pi_example"),
+            query("payment_method_type", "card"),
+        )
         validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
         validateAnalyticsRequest(eventName = "stripe_android.payment_intent_confirmation")
+        validateAnalyticsRequest(
+            eventName = "stripe_android.paymenthandler.confirm.finished",
+            query("intent_id", "pi_example"),
+            query("payment_method_type", "card"),
+        )
         validateAnalyticsRequest(eventName = "mc_custom_payment_newpm_success", hasQueryParam("duration"))
 
         page.clickPrimaryButton()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -8,6 +8,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.asPaymentSheetLoadingException
 import com.stripe.android.uicore.StripeThemeDefaults
+import com.stripe.android.utils.filterNotNullValues
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 
@@ -554,6 +555,3 @@ private fun PaymentSelection?.selectedPaymentMethodType(): Map<String, String> {
         mapOf(PaymentSheetEvent.FIELD_SELECTED_LPM to it)
     }.orEmpty()
 }
-
-private fun <K, V> Map<K, V?>.filterNotNullValues(): Map<K, V> =
-    mapNotNull { (key, value) -> value?.let { key to it } }.toMap()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
PaymentLauncher has a few key interactions, both from using PaymentLauncher directly, as well as transitively through PaymentSheet.

This add analytics for start/finish for the associated methods.
