### PR TITLE
Add test for selecting saved PM in `CustomerSheet`.

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetPage.kt
@@ -12,6 +12,7 @@ import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.stripe.android.customersheet.ui.CUSTOMER_SHEET_CONFIRM_BUTTON_TEST_TAG
 import com.stripe.android.customersheet.ui.CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
 import com.stripe.android.uicore.elements.DROPDOWN_MENU_CLICKABLE_TEST_TAG
 
 internal class CustomerSheetPage(
@@ -63,6 +64,14 @@ internal class CustomerSheetPage(
 
     fun clickConfirmButton() {
         clickPrimaryButton(CUSTOMER_SHEET_CONFIRM_BUTTON_TEST_TAG)
+    }
+
+    fun clickSavedPaymentMethod(endsWith: String) {
+        val savedPaymentMethodMatcher = hasTestTag(SAVED_PAYMENT_OPTION_TEST_TAG)
+            .and(hasText(endsWith, substring = true))
+
+        waitUntil(savedPaymentMethodMatcher)
+        click(savedPaymentMethodMatcher)
     }
 
     private fun clickPrimaryButton(tag: String) {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
@@ -23,6 +23,7 @@ import com.stripe.android.paymentsheet.utils.CustomerSheetTestType
 import com.stripe.android.paymentsheet.utils.CustomerSheetTestTypeProvider
 import com.stripe.android.paymentsheet.utils.IntegrationType
 import com.stripe.android.paymentsheet.utils.IntegrationTypeProvider
+import com.stripe.android.paymentsheet.utils.PrefsTestStore
 import com.stripe.android.paymentsheet.utils.runCustomerSheetTest
 import org.junit.Rule
 import org.junit.Test
@@ -112,6 +113,10 @@ internal class CustomerSheetTest {
             assertThat(card?.brand).isEqualTo(CardBrand.Visa)
         }
     ) { context ->
+        context.scenario.onActivity {
+            PrefsTestStore(it).clear()
+        }
+
         networkRule.enqueue(
             retrieveElementsSessionRequest(),
         ) { response ->

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestRunner.kt
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 internal class CustomerSheetTestRunnerContext(
-    private val scenario: ActivityScenario<MainActivity>,
+    internal val scenario: ActivityScenario<MainActivity>,
     private val customerSheet: CustomerSheet,
     private val countDownLatch: CountDownLatch,
 ) {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PrefsTestStore.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PrefsTestStore.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.paymentsheet.utils
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.stripe.android.paymentsheet.DefaultPrefsRepository
+
+class PrefsTestStore(
+    context: Context,
+) {
+    private val prefs: SharedPreferences by lazy {
+        context.getSharedPreferences(DefaultPrefsRepository.PREF_FILE, Context.MODE_PRIVATE)
+    }
+
+    fun clear() {
+        prefs.edit().clear().apply()
+    }
+}

--- a/paymentsheet/src/androidTest/resources/payment-methods-get-success.json
+++ b/paymentsheet/src/androidTest/resources/payment-methods-get-success.json
@@ -1,0 +1,101 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "pm_12345",
+      "object": "payment_method",
+      "billing_details": {
+        "address": {
+          "city": null,
+          "country": "US",
+          "line1": null,
+          "line2": null,
+          "postal_code": "12342",
+          "state": null
+        },
+        "email": null,
+        "name": null,
+        "phone": null
+      },
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": null,
+          "address_postal_code_check": null,
+          "cvc_check": null
+        },
+        "country": "US",
+        "display_brand": "visa",
+        "exp_month": 12,
+        "exp_year": 2035,
+        "fingerprint": "IMwEhnDXJXJa55oU",
+        "funding": "debit",
+        "generated_from": null,
+        "last4": "5556",
+        "networks": {
+          "available": [
+            "visa"
+          ],
+          "preferred": null
+        },
+        "three_d_secure_usage": {
+          "supported": true
+        },
+        "wallet": null
+      },
+      "created": 1712746197,
+      "customer": "cus_1",
+      "livemode": false,
+      "type": "card"
+    },
+    {
+      "id": "pm_67890",
+      "object": "payment_method",
+      "billing_details": {
+        "address": {
+          "city": null,
+          "country": "AE",
+          "line1": null,
+          "line2": null,
+          "postal_code": null,
+          "state": null
+        },
+        "email": null,
+        "name": "CustomerSheet Testing",
+        "phone": null
+      },
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": null,
+          "address_postal_code_check": null,
+          "cvc_check": null
+        },
+        "country": "US",
+        "display_brand": "visa",
+        "exp_month": 12,
+        "exp_year": 2034,
+        "fingerprint": "LzD7yFi1Cp2DJQs7",
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "4242",
+        "networks": {
+          "available": [
+            "visa"
+          ],
+          "preferred": null
+        },
+        "three_d_secure_usage": {
+          "supported": true
+        },
+        "wallet": null
+      },
+      "created": 1712554485,
+      "customer": "cus_1",
+      "livemode": false,
+      "type": "card"
+    }
+  ],
+  "has_more": false,
+  "url": "/v1/payment_methods"
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultPrefsRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultPrefsRepository.kt
@@ -6,6 +6,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.toSavedSelection
 import kotlinx.coroutines.withContext
+import org.jetbrains.annotations.VisibleForTesting
 import kotlin.coroutines.CoroutineContext
 
 internal class DefaultPrefsRepository(
@@ -77,7 +78,8 @@ internal class DefaultPrefsRepository(
         return customerId?.let { "customer[$it]" } ?: "guest"
     }
 
-    private companion object {
-        private const val PREF_FILE = "DefaultPrefsRepository"
+    internal companion object {
+        @VisibleForTesting
+        internal const val PREF_FILE = "DefaultPrefsRepository"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsUI.kt
@@ -84,7 +84,7 @@ internal fun PaymentOptions(
                     onModifyItem = onModifyItem,
                     modifier = Modifier
                         .semantics { testTagsAsResourceId = true }
-                        .testTag(item.viewType.name)
+                        .testTag(item.key)
                         .animateItemPlacement(),
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsUI.kt
@@ -84,7 +84,7 @@ internal fun PaymentOptions(
                     onModifyItem = onModifyItem,
                     modifier = Modifier
                         .semantics { testTagsAsResourceId = true }
-                        .testTag(item.key)
+                        .testTag(item.viewType.name)
                         .animateItemPlacement(),
                 )
             }


### PR DESCRIPTION
# Summary
Add test for selecting saved PM in `CustomerSheet`.

# Motivation
Ensures `confirm` behavior with saved payment methods works as expected.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
