### PR TITLE
Show Instant Debits in payment methods carousel

### DIFF
--- a/payments-ui-core/res/values/donottranslate.xml
+++ b/payments-ui-core/res/values/donottranslate.xml
@@ -12,6 +12,7 @@
     <string name="stripe_paymentsheet_payment_method_clearpay">Clearpay</string>
     <string name="stripe_paymentsheet_payment_method_paypal">PayPal</string>
     <string name="stripe_paymentsheet_payment_method_us_bank_account">US Bank Account</string>
+    <string name="stripe_paymentsheet_payment_method_instant_debits">Bank</string>
     <string name="stripe_paymentsheet_payment_method_upi">UPI</string>
     <string name="stripe_paymentsheet_payment_method_cashapp">Cash App Pay</string>
     <string name="stripe_paymentsheet_payment_method_grabpay">GrabPay</string>

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/EnableInstantDebitsSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/EnableInstantDebitsSettingsDefinition.kt
@@ -1,0 +1,13 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.core.utils.FeatureFlags
+
+internal object EnableInstantDebitsSettingsDefinition : BooleanSettingsDefinition(
+    key = "enableInstantDebits",
+    displayName = "Enable Instant Debits",
+    defaultValue = false,
+) {
+    override fun valueUpdated(value: Boolean, playgroundSettings: PlaygroundSettings) {
+        FeatureFlags.instantDebits.setEnabled(value)
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -187,6 +187,7 @@ internal class PlaygroundSettings private constructor(
             CustomerSettingsDefinition,
             CheckoutModeSettingsDefinition,
             LinkSettingsDefinition,
+            EnableInstantDebitsSettingsDefinition,
             CountrySettingsDefinition,
             CurrencySettingsDefinition,
             GooglePaySettingsDefinition,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirement.kt
@@ -2,7 +2,6 @@ package com.stripe.android.lpmfoundations.paymentmethod
 
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.model.PaymentIntent
-import com.stripe.android.model.PaymentMethod.Type.Link
 import com.stripe.android.model.PaymentMethod.Type.USBankAccount
 
 internal enum class AddPaymentMethodRequirement {
@@ -62,11 +61,11 @@ internal enum class AddPaymentMethodRequirement {
     InstantDebits {
         override fun isMetBy(metadata: PaymentMethodMetadata): Boolean {
             val paymentMethodTypes = metadata.stripeIntent.paymentMethodTypes
-            val validTypes = Link.code in paymentMethodTypes && USBankAccount.code !in paymentMethodTypes
+            val noUsBankAccount = USBankAccount.code !in paymentMethodTypes
             val supportsBankAccounts = "bank_account" in metadata.stripeIntent.linkFundingSources
             val isDeferred = metadata.stripeIntent.clientSecret == null
             val isEnabled = FeatureFlags.instantDebits.isEnabled
-            return validTypes && supportsBankAccounts && !isDeferred && isEnabled
+            return noUsBankAccount && supportsBankAccounts && !isDeferred && isEnabled
         }
     };
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodRegistry.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodRegistry.kt
@@ -17,6 +17,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.definitions.FpxDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.GiroPayDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.GrabPayDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.IdealDefinition
+import com.stripe.android.lpmfoundations.paymentmethod.definitions.InstantDebitsDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.KlarnaDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.KonbiniDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.MobilePayDefinition
@@ -53,6 +54,7 @@ internal object PaymentMethodRegistry {
         GiroPayDefinition,
         GrabPayDefinition,
         IdealDefinition,
+        InstantDebitsDefinition,
         KlarnaDefinition,
         KonbiniDefinition,
         MobilePayDefinition,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/InstantDebitsDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/InstantDebitsDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.lpmfoundations.paymentmethod.definitions
+
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.uicore.elements.FormElement
+import com.stripe.android.ui.core.R as PaymentsUiCoreR
+
+internal object InstantDebitsDefinition : PaymentMethodDefinition {
+
+    override val type: PaymentMethod.Type = PaymentMethod.Type.Link
+
+    override val supportedAsSavedPaymentMethod: Boolean = false
+
+    override fun requirementsToBeUsedAsNewPaymentMethod(
+        hasIntentToSetup: Boolean
+    ): Set<AddPaymentMethodRequirement> = setOf(
+        AddPaymentMethodRequirement.FinancialConnectionsSdk,
+        AddPaymentMethodRequirement.InstantDebits,
+    )
+
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = true
+
+    override fun uiDefinitionFactory(): UiDefinitionFactory = InstantDebitsUiDefinitionFactory
+}
+
+private object InstantDebitsUiDefinitionFactory : UiDefinitionFactory.Simple {
+
+    override fun createSupportedPaymentMethod(): SupportedPaymentMethod {
+        return SupportedPaymentMethod(
+            code = InstantDebitsDefinition.type.code,
+            displayNameResource = PaymentsUiCoreR.string.stripe_paymentsheet_payment_method_instant_debits,
+            iconResource = PaymentsUiCoreR.drawable.stripe_ic_paymentsheet_pm_bank,
+            tintIconOnSelection = true,
+            lightThemeIconUrl = null,
+            darkThemeIconUrl = null,
+        )
+    }
+
+    // Instant Debits uses its own mechanism, not these form elements.
+    override fun createFormElements(
+        metadata: PaymentMethodMetadata,
+        arguments: UiDefinitionFactory.Arguments,
+    ): List<FormElement> {
+        return emptyList()
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
@@ -24,7 +24,8 @@ import com.stripe.android.link.ui.inline.LinkInlineSignup
 import com.stripe.android.link.ui.inline.LinkOptionalInlineSignup
 import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
-import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethod.Type.Link
+import com.stripe.android.model.PaymentMethod.Type.USBankAccount
 import com.stripe.android.paymentsheet.PaymentMethodsUI
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.forms.FormFieldValues
@@ -130,7 +131,7 @@ private fun FormElement(
                 }
             }
     ) {
-        if (selectedItem.code == PaymentMethod.Type.USBankAccount.code) {
+        if (selectedItem.code == USBankAccount.code || selectedItem.code == Link.code) {
             USBankAccountForm(
                 formArgs = formArguments,
                 usBankAccountFormArgs = usBankAccountFormArguments,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirementTest.kt
@@ -193,7 +193,7 @@ internal class AddPaymentMethodRequirementTest {
 
     @Test
     fun testInstantDebitsReturnsFalseIfDeferredIntent() {
-        instantDebitsFeatureRule.setEnabled(false)
+        instantDebitsFeatureRule.setEnabled(true)
 
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = createValidInstantDebitsPaymentIntent().copy(
@@ -206,7 +206,7 @@ internal class AddPaymentMethodRequirementTest {
 
     @Test
     fun testInstantDebitsReturnsFalseIfShowingUsBankAccount() {
-        instantDebitsFeatureRule.setEnabled(false)
+        instantDebitsFeatureRule.setEnabled(true)
 
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = createValidInstantDebitsPaymentIntent().copy(
@@ -219,7 +219,7 @@ internal class AddPaymentMethodRequirementTest {
 
     @Test
     fun testInstantDebitsReturnsFalseIfOnlyCardFundingSource() {
-        instantDebitsFeatureRule.setEnabled(false)
+        instantDebitsFeatureRule.setEnabled(true)
 
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = createValidInstantDebitsPaymentIntent().copy(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirementTest.kt
@@ -1,14 +1,26 @@
 package com.stripe.android.lpmfoundations.paymentmethod
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.utils.FeatureFlags
+import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement.InstantDebits
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.testing.FeatureFlagTestRule
+import com.stripe.android.testing.PaymentIntentFactory
+import org.junit.Rule
 import org.junit.Test
 
 internal class AddPaymentMethodRequirementTest {
+
+    @get:Rule
+    val instantDebitsFeatureRule = FeatureFlagTestRule(
+        featureFlag = FeatureFlags.instantDebits,
+        isEnabled = false,
+    )
+
     @Test
     fun testUnsupportedReturnsFalse() {
         val metadata = PaymentMethodMetadataFactory.create()
@@ -155,5 +167,73 @@ internal class AddPaymentMethodRequirementTest {
     fun testValidUsBankVerificationMethodReturnsFalse() {
         val metadata = PaymentMethodMetadataFactory.create()
         assertThat(AddPaymentMethodRequirement.ValidUsBankVerificationMethod.isMetBy(metadata)).isFalse()
+    }
+
+    @Test
+    fun testInstantDebitsReturnsTrue() {
+        instantDebitsFeatureRule.setEnabled(true)
+
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = createValidInstantDebitsPaymentIntent(),
+        )
+
+        assertThat(InstantDebits.isMetBy(metadata)).isTrue()
+    }
+
+    @Test
+    fun testInstantDebitsReturnsFalseIfFeatureNotEnabled() {
+        instantDebitsFeatureRule.setEnabled(false)
+
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = createValidInstantDebitsPaymentIntent(),
+        )
+
+        assertThat(InstantDebits.isMetBy(metadata)).isFalse()
+    }
+
+    @Test
+    fun testInstantDebitsReturnsFalseIfDeferredIntent() {
+        instantDebitsFeatureRule.setEnabled(false)
+
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = createValidInstantDebitsPaymentIntent().copy(
+                clientSecret = null,
+            ),
+        )
+
+        assertThat(InstantDebits.isMetBy(metadata)).isFalse()
+    }
+
+    @Test
+    fun testInstantDebitsReturnsFalseIfShowingUsBankAccount() {
+        instantDebitsFeatureRule.setEnabled(false)
+
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = createValidInstantDebitsPaymentIntent().copy(
+                paymentMethodTypes = listOf("card", "link", "us_bank_account"),
+            ),
+        )
+
+        assertThat(InstantDebits.isMetBy(metadata)).isFalse()
+    }
+
+    @Test
+    fun testInstantDebitsReturnsFalseIfOnlyCardFundingSource() {
+        instantDebitsFeatureRule.setEnabled(false)
+
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = createValidInstantDebitsPaymentIntent().copy(
+                linkFundingSources = listOf("card"),
+            ),
+        )
+
+        assertThat(InstantDebits.isMetBy(metadata)).isFalse()
+    }
+
+    private fun createValidInstantDebitsPaymentIntent(): PaymentIntent {
+        return PaymentIntentFactory.create(
+            paymentMethodTypes = listOf("card", "link"),
+            linkFundingSources = listOf("card", "bank_account"),
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -59,7 +59,10 @@ internal class PaymentMethodMetadataTest {
 
     @Test
     fun `filterSupportedPaymentMethods removes unsupported paymentMethodTypes`() {
-        val metadata = PaymentMethodMetadataFactory.create()
+        val stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+            paymentMethodTypes = listOf("card", "pay_now"),
+        )
+        val metadata = PaymentMethodMetadataFactory.create(stripeIntent)
         val supportedPaymentMethods = metadata.supportedPaymentMethodDefinitions()
         assertThat(supportedPaymentMethods).hasSize(1)
         assertThat(supportedPaymentMethods.first().type.code).isEqualTo("card")

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -26,6 +26,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.ui.BottomSheetContentTestTag
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
@@ -171,8 +172,15 @@ internal class PaymentOptionsActivityTest {
 
     @Test
     fun `ContinueButton should be hidden when returning to payment options`() {
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card"),
+            )
+        )
+
         val args = PAYMENT_OPTIONS_CONTRACT_ARGS.updateState(
-            paymentMethods = PaymentMethodFixtures.createCards(5)
+            paymentMethods = PaymentMethodFixtures.createCards(5),
+            stripeIntent = paymentMethodMetadata.stripeIntent,
         )
 
         runActivityScenario(args) {

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
@@ -4,7 +4,9 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.core.BuildConfig
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-object FeatureFlags
+object FeatureFlags {
+    val instantDebits = FeatureFlag()
+}
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class FeatureFlag {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds Instant Debits to the list of supported payment method types.

We show Instant Debits (labeled simply as “Bank”) if the following conditions are true:
1. The `payment_method_types` contain `link` but not `us_bank_account`.
2. `bank_account` is a supported Link funding source.
3. We’re not dealing with a deferred intent.
4. And for now: `FeatureFlags.instantDebits` is enabled.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[BANKCON-10020](https://jira.corp.stripe.com/browse/BANKCON-10020)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
