### PR TITLE
Remove the PaymentMethodDefinition to SupportedPaymentMethod helper.

### DIFF
--- a/payments-core/detekt-baseline.xml
+++ b/payments-core/detekt-baseline.xml
@@ -199,9 +199,7 @@
     <ID>MaxLineLength:WebIntentAuthenticatorTest.kt$WebIntentAuthenticatorTest$expectedUrl = "https://pm-redirects.stripe.com/authorize/acct_1HvTI7Lu5o3P18Zp/pa_nonce_NC1mezV544wpYmFaXyJpnleeurKO3TZ"</ID>
     <ID>MaximumLineLength:com.stripe.android.PaymentRelayContract.kt:9</ID>
     <ID>SwallowedException:ActivityUtils.kt$e: IllegalArgumentException</ID>
-    <ID>SwallowedException:DefaultPaymentAuthenticatorRegistry.kt$e: Exception</ID>
     <ID>SwallowedException:PaymentUtils.kt$PaymentUtils$e: ClassCastException</ID>
-    <ID>SwallowedException:StripeBrowserLauncherActivity.kt$StripeBrowserLauncherActivity$e: ActivityNotFoundException</ID>
     <ID>ThrowsCount:StripeApiRepository.kt$StripeApiRepository$@Throws( InvalidRequestException::class, AuthenticationException::class, CardException::class, APIException::class ) private fun handleApiError(response: StripeResponse&lt;String>)</ID>
     <ID>TooGenericExceptionCaught:DefaultPaymentAuthenticatorRegistry.kt$e: Exception</ID>
     <ID>TooGenericExceptionThrown:DefaultAlipayRepository.kt$DefaultAlipayRepository$throw RuntimeException("Unable to authenticate Payment Intent with Alipay SDK")</ID>

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -34,7 +34,7 @@
     <ID>LongMethod:USBankAccountEmitters.kt$@Composable internal fun USBankAccountEmitters( viewModel: USBankAccountFormViewModel, usBankAccountFormArgs: USBankAccountFormArguments, )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable internal fun BillingDetailsForm( formArgs: FormArguments, isProcessing: Boolean, isPaymentFlow: Boolean, nameController: TextFieldController, emailController: TextFieldController, phoneController: PhoneNumberController, addressController: AddressController, lastTextFieldIdentifier: IdentifierSpec?, sameAsShippingElement: SameAsShippingElement?, )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable internal fun USBankAccountForm( formArgs: FormArguments, usBankAccountFormArgs: USBankAccountFormArguments, modifier: Modifier = Modifier, )</ID>
-    <ID>LongMethod:USBankAccountForm.kt$@Composable private fun AccountDetailsForm( formArgs: FormArguments, isProcessing: Boolean, bankName: String?, last4: String?, saveForFutureUseElement: SaveForFutureUseElement, onRemoveAccount: () -> Unit, )</ID>
+    <ID>LongMethod:USBankAccountForm.kt$@Composable private fun AccountDetailsForm( showCheckbox: Boolean, isProcessing: Boolean, bankName: String?, last4: String?, saveForFutureUseElement: SaveForFutureUseElement, onRemoveAccount: () -> Unit, )</ID>
     <ID>LongMethod:USBankAccountFormViewModelTest.kt$USBankAccountFormViewModelTest$@Test fun `Restores screen state when re-opening screen`()</ID>
     <ID>MagicNumber:AutocompleteScreen.kt$0.07f</ID>
     <ID>MagicNumber:BaseSheetActivity.kt$BaseSheetActivity$30</ID>
@@ -56,10 +56,8 @@
     <ID>MaxLineLength:DefaultFlowControllerTest.kt$DefaultFlowControllerTest$fun</ID>
     <ID>MaxLineLength:DefaultPaymentSheetLoaderTest.kt$DefaultPaymentSheetLoaderTest$fun</ID>
     <ID>MaxLineLength:FlowControllerConfigurationHandlerTest.kt$FlowControllerConfigurationHandlerTest$.</ID>
-    <ID>MaxLineLength:FormArgumentsFactoryTest.kt$FormArgumentsFactoryTest$fun</ID>
     <ID>MaxLineLength:InjectableActivityScenario.kt$InjectableActivityScenario$delegate ?: throw IllegalStateException("Cannot move to state $newState since the activity hasn't been launched.")</ID>
     <ID>MaxLineLength:InjectableActivityScenario.kt$InjectableActivityScenario$val d = delegate ?: throw IllegalStateException("Cannot run onActivity since the activity hasn't been launched.")</ID>
-    <ID>MaxLineLength:PaymentMethodDefinitionTest.kt$PaymentMethodDefinitionTest$fun</ID>
     <ID>MaxLineLength:PaymentSheet.kt$PaymentSheet.Address$*</ID>
     <ID>MaxLineLength:PaymentSheet.kt$PaymentSheet.BillingDetails$*</ID>
     <ID>MaxLineLength:PaymentSheet.kt$PaymentSheet.Configuration$*</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -136,6 +136,7 @@ internal class DefaultCustomerSheetLoader(
                 merchantName = configuration.merchantDisplayName,
                 defaultBillingDetails = configuration.defaultBillingDetails,
                 shippingDetails = null,
+                hasCustomerConfiguration = true,
                 sharedDataSpecs = sharedDataSpecs,
                 financialConnectionsAvailable = isFinancialConnectionsAvailable()
             )

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -781,6 +781,7 @@ internal class CustomerSheetViewModel(
                 ),
                 formArguments = formArguments,
                 usBankAccountFormArguments = USBankAccountFormArguments(
+                    showCheckbox = false,
                     onBehalfOf = null,
                     isCompleteFlow = false,
                     isPaymentFlow = false,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -34,7 +34,6 @@ import com.stripe.android.ui.core.elements.SimpleDialogElementUI
 import com.stripe.android.ui.core.elements.events.CardNumberCompletedEventReporter
 import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventReporter
 import com.stripe.android.uicore.strings.resolve
-import kotlinx.coroutines.flow.flowOf
 import com.stripe.android.R as PaymentsCoreR
 
 @Composable
@@ -222,7 +221,6 @@ internal fun AddPaymentMethod(
                     formElements = viewState.formViewData.elements,
                     linkSignupMode = null,
                     linkConfigurationCoordinator = null,
-                    showCheckboxFlow = flowOf(false),
                     onItemSelectedListener = {
                         viewActionHandler(CustomerSheetViewAction.OnAddPaymentMethodItemChanged(it))
                     },

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelper.kt
@@ -4,12 +4,10 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.SetupIntent
-import com.stripe.android.paymentsheet.PaymentSheet
 
 internal fun isSaveForFutureUseValueChangeable(
     code: PaymentMethodCode,
     metadata: PaymentMethodMetadata,
-    customerConfiguration: PaymentSheet.CustomerConfiguration?,
 ): Boolean {
     return when (metadata.stripeIntent) {
         is PaymentIntent -> {
@@ -18,7 +16,7 @@ internal fun isSaveForFutureUseValueChangeable(
             if (isSetupFutureUsageSet) {
                 false
             } else {
-                customerConfiguration != null
+                metadata.hasCustomerConfiguration
             }
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelper.kt
@@ -1,0 +1,29 @@
+package com.stripe.android.lpmfoundations.luxe
+
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.paymentsheet.PaymentSheet
+
+internal fun isSaveForFutureUseValueChangeable(
+    code: PaymentMethodCode,
+    metadata: PaymentMethodMetadata,
+    customerConfiguration: PaymentSheet.CustomerConfiguration?,
+): Boolean {
+    return when (metadata.stripeIntent) {
+        is PaymentIntent -> {
+            val isSetupFutureUsageSet = metadata.stripeIntent.isSetupFutureUsageSet(code)
+
+            if (isSetupFutureUsageSet) {
+                false
+            } else {
+                customerConfiguration != null
+            }
+        }
+
+        is SetupIntent -> {
+            false
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SetupFutureUsageFieldConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SetupFutureUsageFieldConfiguration.kt
@@ -1,6 +1,0 @@
-package com.stripe.android.lpmfoundations.luxe
-
-internal data class SetupFutureUsageFieldConfiguration(
-    val isSaveForFutureUseValueChangeable: Boolean,
-    val saveForFutureUseInitialValue: Boolean
-)

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SupportedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SupportedPaymentMethod.kt
@@ -3,7 +3,6 @@ package com.stripe.android.lpmfoundations.luxe
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodRegistry
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.ui.core.elements.SharedDataSpec
 
@@ -45,8 +44,4 @@ internal data class SupportedPaymentMethod(
         darkThemeIconUrl = sharedDataSpec?.selectorIcon?.darkThemePng,
         tintIconOnSelection = tintIconOnSelection,
     )
-
-    internal fun paymentMethodDefinition(): PaymentMethodDefinition {
-        return requireNotNull(PaymentMethodRegistry.definitionsByCode[code])
-    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodDefinition.kt
@@ -1,10 +1,6 @@
 package com.stripe.android.lpmfoundations.paymentmethod
 
-import com.stripe.android.lpmfoundations.luxe.SetupFutureUsageFieldConfiguration
-import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.model.SetupIntent
-import com.stripe.android.paymentsheet.PaymentSheet
 
 internal interface PaymentMethodDefinition {
     /**
@@ -33,51 +29,5 @@ internal fun PaymentMethodDefinition.isSupported(metadata: PaymentMethodMetadata
     }
     return requirementsToBeUsedAsNewPaymentMethod(metadata.hasIntentToSetup()).all { requirement ->
         requirement.isMetBy(metadata)
-    }
-}
-
-internal fun PaymentMethodDefinition.getSetupFutureUsageFieldConfiguration(
-    metadata: PaymentMethodMetadata,
-    customerConfiguration: PaymentSheet.CustomerConfiguration?,
-): SetupFutureUsageFieldConfiguration? {
-    val oneTimeUse = SetupFutureUsageFieldConfiguration(
-        isSaveForFutureUseValueChangeable = false,
-        saveForFutureUseInitialValue = false
-    )
-    val merchantRequestedSave = SetupFutureUsageFieldConfiguration(
-        isSaveForFutureUseValueChangeable = false,
-        saveForFutureUseInitialValue = true
-    )
-    val userSelectableSave = SetupFutureUsageFieldConfiguration(
-        isSaveForFutureUseValueChangeable = true,
-        saveForFutureUseInitialValue = false
-    )
-
-    return when (metadata.stripeIntent) {
-        is PaymentIntent -> {
-            val isSetupFutureUsageSet = metadata.stripeIntent.isSetupFutureUsageSet(type.code)
-
-            if (isSetupFutureUsageSet) {
-                if (supportedAsSavedPaymentMethod) {
-                    merchantRequestedSave
-                } else {
-                    null
-                }
-            } else {
-                if (customerConfiguration != null) {
-                    userSelectableSave
-                } else {
-                    oneTimeUse
-                }
-            }
-        }
-
-        is SetupIntent -> {
-            if (supportedAsSavedPaymentMethod) {
-                merchantRequestedSave
-            } else {
-                null
-            }
-        }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -40,6 +40,7 @@ internal data class PaymentMethodMetadata(
     val defaultBillingDetails: PaymentSheet.BillingDetails?,
     val shippingDetails: AddressDetails?,
     val sharedDataSpecs: List<SharedDataSpec>,
+    val hasCustomerConfiguration: Boolean,
     val financialConnectionsAvailable: Boolean = DefaultIsFinancialConnectionsAvailable(),
 ) : Parcelable {
     @IgnoredOnParcel

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -2,6 +2,7 @@ package com.stripe.android.lpmfoundations.paymentmethod.definitions
 
 import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.luxe.isSaveForFutureUseValueChangeable
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -83,7 +84,14 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
                     )
                 )
             }
-            add(SaveForFutureUseElement(arguments.saveForFutureUseInitialValue, arguments.merchantName))
+            if (
+                isSaveForFutureUseValueChangeable(
+                    code = PaymentMethod.Type.Card.code,
+                    metadata = metadata,
+                )
+            ) {
+                add(SaveForFutureUseElement(arguments.saveForFutureUseInitialValue, arguments.merchantName))
+            }
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
@@ -3,10 +3,8 @@ package com.stripe.android.paymentsheet.forms
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
-import com.stripe.android.lpmfoundations.luxe.isSaveForFutureUseValueChangeable
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodCode
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 
@@ -15,17 +13,9 @@ internal object FormArgumentsFactory {
     fun create(
         paymentMethod: SupportedPaymentMethod,
         metadata: PaymentMethodMetadata,
-        customerConfig: PaymentSheet.CustomerConfiguration?,
     ): FormArguments {
-        val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
-            code = paymentMethod.code,
-            metadata = metadata,
-            customerConfiguration = customerConfig,
-        )
-
         return FormArguments(
             paymentMethodCode = paymentMethod.code,
-            showCheckbox = isSaveForFutureUseValueChangeable,
             merchantName = metadata.merchantName,
             amount = metadata.amount(),
             billingDetails = metadata.defaultBillingDetails,
@@ -44,7 +34,6 @@ internal object FormArgumentsFactory {
     ): FormArguments {
         return FormArguments(
             paymentMethodCode = paymentMethodCode,
-            showCheckbox = false,
             merchantName = merchantName,
             billingDetails = configuration.defaultBillingDetails,
             billingDetailsCollectionConfiguration = configuration.billingDetailsCollectionConfiguration,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
@@ -3,8 +3,8 @@ package com.stripe.android.paymentsheet.forms
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.luxe.isSaveForFutureUseValueChangeable
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.lpmfoundations.paymentmethod.getSetupFutureUsageFieldConfiguration
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
@@ -17,15 +17,15 @@ internal object FormArgumentsFactory {
         metadata: PaymentMethodMetadata,
         customerConfig: PaymentSheet.CustomerConfiguration?,
     ): FormArguments {
-        val setupFutureUsageFieldConfiguration =
-            paymentMethod.paymentMethodDefinition().getSetupFutureUsageFieldConfiguration(
-                metadata = metadata,
-                customerConfiguration = customerConfig,
-            )
+        val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
+            code = paymentMethod.code,
+            metadata = metadata,
+            customerConfiguration = customerConfig,
+        )
 
         return FormArguments(
             paymentMethodCode = paymentMethod.code,
-            showCheckbox = setupFutureUsageFieldConfiguration?.isSaveForFutureUseValueChangeable == true,
+            showCheckbox = isSaveForFutureUseValueChangeable,
             merchantName = metadata.merchantName,
             amount = metadata.amount(),
             billingDetails = metadata.defaultBillingDetails,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
@@ -17,7 +17,6 @@ import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flattenConcat
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -34,12 +33,10 @@ import javax.inject.Inject
 internal class FormViewModel @Inject internal constructor(
     val elements: List<FormElement>,
     val formArguments: FormArguments,
-    val showCheckboxFlow: Flow<Boolean>
 ) : ViewModel() {
     internal class Factory(
         val formElements: List<FormElement>,
         val formArguments: FormArguments,
-        val showCheckboxFlow: Flow<Boolean>,
     ) : ViewModelProvider.Factory {
 
         @Suppress("UNCHECKED_CAST")
@@ -47,7 +44,6 @@ internal class FormViewModel @Inject internal constructor(
             return FormViewModel(
                 elements = formElements,
                 formArguments = formArguments,
-                showCheckboxFlow = showCheckboxFlow,
             ) as T
         }
     }
@@ -77,13 +73,12 @@ internal class FormViewModel @Inject internal constructor(
     }
 
     internal val hiddenIdentifiers = combine(
-        showCheckboxFlow,
         cardBillingElement?.hiddenIdentifiers ?: flowOf(emptySet()),
         externalHiddenIdentifiers
-    ) { showFutureUse, cardBillingIdentifiers, externalHiddenIdentifiers ->
+    ) { cardBillingIdentifiers, externalHiddenIdentifiers ->
         val hiddenIdentifiers = externalHiddenIdentifiers.plus(cardBillingIdentifiers)
 
-        if (!showFutureUse && saveForFutureUseElement != null) {
+        if (!formArguments.showCheckbox && saveForFutureUseElement != null) {
             hiddenIdentifiers
                 .plus(saveForFutureUseElement.identifier)
         } else {
@@ -99,24 +94,22 @@ internal class FormViewModel @Inject internal constructor(
     }
 
     // This will convert the save for future use value into a CustomerRequestedSave operation
-    private val userRequestedReuse = showCheckboxFlow.map { showCheckbox ->
-        currentFieldValues().map { currentFieldValues ->
-            currentFieldValues.filter { it.first == IdentifierSpec.SaveForFutureUse }
-                .map { it.second.value.toBoolean() }
-                .map { saveForFutureUse ->
-                    if (showCheckbox) {
-                        if (saveForFutureUse) {
-                            PaymentSelection.CustomerRequestedSave.RequestReuse
-                        } else {
-                            PaymentSelection.CustomerRequestedSave.RequestNoReuse
-                        }
+    private val userRequestedReuse = currentFieldValues().map { currentFieldValues ->
+        currentFieldValues.filter { it.first == IdentifierSpec.SaveForFutureUse }
+            .map { it.second.value.toBoolean() }
+            .map { saveForFutureUse ->
+                if (formArguments.showCheckbox) {
+                    if (saveForFutureUse) {
+                        PaymentSelection.CustomerRequestedSave.RequestReuse
                     } else {
-                        PaymentSelection.CustomerRequestedSave.NoRequest
+                        PaymentSelection.CustomerRequestedSave.RequestNoReuse
                     }
+                } else {
+                    PaymentSelection.CustomerRequestedSave.NoRequest
                 }
-                .firstOrNull() ?: PaymentSelection.CustomerRequestedSave.NoRequest
-        }
-    }.flattenConcat()
+            }
+            .firstOrNull() ?: PaymentSelection.CustomerRequestedSave.NoRequest
+    }
 
     val completeFormValues =
         CompleteFormFieldValueFilter(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
@@ -76,14 +76,7 @@ internal class FormViewModel @Inject internal constructor(
         cardBillingElement?.hiddenIdentifiers ?: flowOf(emptySet()),
         externalHiddenIdentifiers
     ) { cardBillingIdentifiers, externalHiddenIdentifiers ->
-        val hiddenIdentifiers = externalHiddenIdentifiers.plus(cardBillingIdentifiers)
-
-        if (!formArguments.showCheckbox && saveForFutureUseElement != null) {
-            hiddenIdentifiers
-                .plus(saveForFutureUseElement.identifier)
-        } else {
-            hiddenIdentifiers
-        }
+        externalHiddenIdentifiers.plus(cardBillingIdentifiers)
     }
 
     // Mandate is showing if it is an element of the form and it isn't hidden
@@ -98,14 +91,10 @@ internal class FormViewModel @Inject internal constructor(
         currentFieldValues.filter { it.first == IdentifierSpec.SaveForFutureUse }
             .map { it.second.value.toBoolean() }
             .map { saveForFutureUse ->
-                if (formArguments.showCheckbox) {
-                    if (saveForFutureUse) {
-                        PaymentSelection.CustomerRequestedSave.RequestReuse
-                    } else {
-                        PaymentSelection.CustomerRequestedSave.RequestNoReuse
-                    }
+                if (saveForFutureUse) {
+                    PaymentSelection.CustomerRequestedSave.RequestReuse
                 } else {
-                    PaymentSelection.CustomerRequestedSave.NoRequest
+                    PaymentSelection.CustomerRequestedSave.RequestNoReuse
                 }
             }
             .firstOrNull() ?: PaymentSelection.CustomerRequestedSave.NoRequest

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArguments.kt
@@ -8,7 +8,6 @@ import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 
 internal data class FormArguments(
     val paymentMethodCode: PaymentMethodCode,
-    val showCheckbox: Boolean,
     val cbcEligibility: CardBrandChoiceEligibility,
     val merchantName: String,
     val amount: Amount? = null,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
@@ -60,6 +60,7 @@ internal fun USBankAccountForm(
         factory = USBankAccountFormViewModel.Factory {
             USBankAccountFormViewModel.Args(
                 formArgs = formArgs,
+                showCheckbox = usBankAccountFormArgs.showCheckbox,
                 isCompleteFlow = usBankAccountFormArgs.isCompleteFlow,
                 isPaymentFlow = usBankAccountFormArgs.isPaymentFlow,
                 stripeIntentId = usBankAccountFormArgs.stripeIntentId,
@@ -97,6 +98,7 @@ internal fun USBankAccountForm(
             is USBankAccountFormScreenState.MandateCollection -> {
                 MandateCollectionScreen(
                     formArgs = formArgs,
+                    showCheckbox = usBankAccountFormArgs.showCheckbox,
                     isProcessing = screenState.isProcessing,
                     isPaymentFlow = usBankAccountFormArgs.isPaymentFlow,
                     screenState = screenState,
@@ -113,6 +115,7 @@ internal fun USBankAccountForm(
             is USBankAccountFormScreenState.VerifyWithMicrodeposits -> {
                 VerifyWithMicrodepositsScreen(
                     formArgs = formArgs,
+                    showCheckbox = usBankAccountFormArgs.showCheckbox,
                     isProcessing = screenState.isProcessing,
                     isPaymentFlow = usBankAccountFormArgs.isPaymentFlow,
                     screenState = screenState,
@@ -129,6 +132,7 @@ internal fun USBankAccountForm(
             is USBankAccountFormScreenState.SavedAccount -> {
                 SavedAccountScreen(
                     formArgs = formArgs,
+                    showCheckbox = usBankAccountFormArgs.showCheckbox,
                     isProcessing = screenState.isProcessing,
                     isPaymentFlow = usBankAccountFormArgs.isPaymentFlow,
                     screenState = screenState,
@@ -176,6 +180,7 @@ internal fun BillingDetailsCollectionScreen(
 @Composable
 internal fun MandateCollectionScreen(
     formArgs: FormArguments,
+    showCheckbox: Boolean,
     isProcessing: Boolean,
     isPaymentFlow: Boolean,
     screenState: USBankAccountFormScreenState.MandateCollection,
@@ -201,7 +206,7 @@ internal fun MandateCollectionScreen(
             sameAsShippingElement = sameAsShippingElement,
         )
         AccountDetailsForm(
-            formArgs = formArgs,
+            showCheckbox = showCheckbox,
             isProcessing = isProcessing,
             bankName = screenState.paymentAccount.institutionName,
             last4 = screenState.paymentAccount.last4,
@@ -214,6 +219,7 @@ internal fun MandateCollectionScreen(
 @Composable
 internal fun VerifyWithMicrodepositsScreen(
     formArgs: FormArguments,
+    showCheckbox: Boolean,
     isProcessing: Boolean,
     isPaymentFlow: Boolean,
     screenState: USBankAccountFormScreenState.VerifyWithMicrodeposits,
@@ -239,7 +245,7 @@ internal fun VerifyWithMicrodepositsScreen(
             sameAsShippingElement = sameAsShippingElement,
         )
         AccountDetailsForm(
-            formArgs = formArgs,
+            showCheckbox = showCheckbox,
             isProcessing = isProcessing,
             bankName = screenState.paymentAccount.bankName,
             last4 = screenState.paymentAccount.last4,
@@ -252,6 +258,7 @@ internal fun VerifyWithMicrodepositsScreen(
 @Composable
 internal fun SavedAccountScreen(
     formArgs: FormArguments,
+    showCheckbox: Boolean,
     isProcessing: Boolean,
     isPaymentFlow: Boolean,
     screenState: USBankAccountFormScreenState.SavedAccount,
@@ -277,7 +284,7 @@ internal fun SavedAccountScreen(
             sameAsShippingElement = sameAsShippingElement,
         )
         AccountDetailsForm(
-            formArgs = formArgs,
+            showCheckbox = showCheckbox,
             isProcessing = isProcessing,
             bankName = screenState.bankName,
             last4 = screenState.last4,
@@ -439,7 +446,7 @@ private fun AddressSection(
 
 @Composable
 private fun AccountDetailsForm(
-    formArgs: FormArguments,
+    showCheckbox: Boolean,
     isProcessing: Boolean,
     bankName: String?,
     last4: String?,
@@ -495,7 +502,7 @@ private fun AccountDetailsForm(
                 )
             }
         }
-        if (formArgs.showCheckbox) {
+        if (showCheckbox) {
             SaveForFutureUseElementUI(
                 enabled = true,
                 element = saveForFutureUseElement,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
@@ -29,6 +29,7 @@ import com.stripe.android.paymentsheet.ui.PrimaryButton
  */
 internal class USBankAccountFormArguments(
     val onBehalfOf: String?,
+    val showCheckbox: Boolean,
     val isCompleteFlow: Boolean,
     val isPaymentFlow: Boolean,
     val stripeIntentId: String?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -469,7 +469,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         linkAccountId: String,
     ): PaymentSelection.New.USBankAccount {
         val customerRequestedSave = customerRequestedSave(
-            showCheckbox = args.formArgs.showCheckbox,
+            showCheckbox = args.showCheckbox,
             saveForFutureUse = saveForFutureUse.value
         )
         return PaymentSelection.New.USBankAccount(
@@ -551,6 +551,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
 
     data class Args(
         val formArgs: FormArguments,
+        val showCheckbox: Boolean,
         val isCompleteFlow: Boolean,
         val isPaymentFlow: Boolean,
         val stripeIntentId: String?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -10,9 +10,8 @@ import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.LinkUi
 import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
+import com.stripe.android.lpmfoundations.luxe.isSaveForFutureUseValueChangeable
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.lpmfoundations.paymentmethod.definitions.CardDefinition
-import com.stripe.android.lpmfoundations.paymentmethod.getSetupFutureUsageFieldConfiguration
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
@@ -314,17 +313,16 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
 
         val merchantName = config.merchantDisplayName
 
-        val setupFutureUsageFieldConfiguration = requireNotNull(
-            CardDefinition.getSetupFutureUsageFieldConfiguration(
-                metadata = metadata,
-                customerConfiguration = config.customer,
-            )
+        val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
+            code = PaymentMethod.Type.Card.code,
+            metadata = metadata,
+            customerConfiguration = config.customer,
         )
         val hasUsedLink = linkStore.hasUsedLink()
 
         val linkSignupMode = if (hasUsedLink || linkSignUpDisabled) {
             null
-        } else if (setupFutureUsageFieldConfiguration.isSaveForFutureUseValueChangeable) {
+        } else if (isSaveForFutureUseValueChangeable) {
             LinkSignupMode.AlongsideSaveForFutureUse
         } else {
             LinkSignupMode.InsteadOfSaveForFutureUse

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -102,6 +102,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
                 merchantName = paymentSheetConfiguration.merchantDisplayName,
                 defaultBillingDetails = paymentSheetConfiguration.defaultBillingDetails,
                 shippingDetails = paymentSheetConfiguration.shippingDetails,
+                hasCustomerConfiguration = paymentSheetConfiguration.customer != null,
                 sharedDataSpecs = sharedDataSpecsResult.sharedDataSpecs,
             )
 
@@ -316,7 +317,6 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
             code = PaymentMethod.Type.Card.code,
             metadata = metadata,
-            customerConfiguration = config.customer,
         )
         val hasUsedLink = linkStore.hasUsedLink()
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -34,7 +34,6 @@ import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventR
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.LocalAutofillEventReporter
 import com.stripe.android.uicore.elements.ParameterDestination
-import kotlinx.coroutines.flow.MutableStateFlow
 
 @Composable
 internal fun AddPaymentMethod(
@@ -50,10 +49,6 @@ internal fun AddPaymentMethod(
     }
     val arguments = remember(selectedItem) {
         sheetViewModel.createFormArguments(selectedItem)
-    }
-    val showCheckboxFlow = remember { MutableStateFlow(false) }
-    LaunchedEffect(arguments) {
-        showCheckboxFlow.emit(arguments.showCheckbox)
     }
 
     val paymentSelection by sheetViewModel.selection.collectAsState()
@@ -107,7 +102,6 @@ internal fun AddPaymentMethod(
                 formElements = formElements,
                 linkSignupMode = linkInlineSignupMode,
                 linkConfigurationCoordinator = sheetViewModel.linkConfigurationCoordinator,
-                showCheckboxFlow = showCheckboxFlow,
                 onItemSelectedListener = { selectedLpm ->
                     if (selectedItem != selectedLpm) {
                         selectedPaymentMethodCode = selectedLpm.code

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import com.stripe.android.link.ui.inline.InlineSignupViewState
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.luxe.isSaveForFutureUseValueChangeable
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntent
@@ -95,6 +96,13 @@ internal fun AddPaymentMethod(
                 sheetViewModel.formElementsForCode(selectedItem.code)
             }
 
+            val isSaveForFutureUseValueChangeable = paymentMethodMetadata?.let {
+                isSaveForFutureUseValueChangeable(
+                    code = arguments.paymentMethodCode,
+                    metadata = it,
+                )
+            } ?: false
+
             PaymentElement(
                 enabled = !processing,
                 supportedPaymentMethods = supportedPaymentMethods,
@@ -113,6 +121,7 @@ internal fun AddPaymentMethod(
                 },
                 formArguments = arguments,
                 usBankAccountFormArguments = USBankAccountFormArguments(
+                    showCheckbox = isSaveForFutureUseValueChangeable,
                     onBehalfOf = onBehalfOf,
                     isCompleteFlow = sheetViewModel is PaymentSheetViewModel,
                     isPaymentFlow = stripeIntent is PaymentIntent,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
@@ -33,7 +33,6 @@ import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFo
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.image.StripeImageLoader
-import kotlinx.coroutines.flow.Flow
 import java.util.UUID
 
 @Composable
@@ -44,7 +43,6 @@ internal fun PaymentElement(
     formElements: List<FormElement>,
     linkSignupMode: LinkSignupMode?,
     linkConfigurationCoordinator: LinkConfigurationCoordinator?,
-    showCheckboxFlow: Flow<Boolean>,
     onItemSelectedListener: (SupportedPaymentMethod) -> Unit,
     onLinkSignupStateChanged: (LinkConfiguration, InlineSignupViewState) -> Unit,
     formArguments: FormArguments,
@@ -81,7 +79,6 @@ internal fun PaymentElement(
             enabled = enabled,
             selectedItem = selectedItem,
             formElements = formElements,
-            showCheckboxFlow = showCheckboxFlow,
             formArguments = formArguments,
             usBankAccountFormArguments = usBankAccountFormArguments,
             horizontalPadding = horizontalPadding,
@@ -104,7 +101,6 @@ private fun FormElement(
     enabled: Boolean,
     selectedItem: SupportedPaymentMethod,
     formElements: List<FormElement>,
-    showCheckboxFlow: Flow<Boolean>,
     formArguments: FormArguments,
     usBankAccountFormArguments: USBankAccountFormArguments,
     horizontalPadding: Dp,
@@ -146,7 +142,6 @@ private fun FormElement(
                 args = formArguments,
                 enabled = enabled,
                 onFormFieldValuesChanged = onFormFieldValuesChanged,
-                showCheckboxFlow = showCheckboxFlow,
                 formElements = formElements,
                 modifier = Modifier.padding(horizontal = horizontalPadding)
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
@@ -21,7 +21,6 @@ internal fun PaymentMethodForm(
     args: FormArguments,
     enabled: Boolean,
     onFormFieldValuesChanged: (FormFieldValues?) -> Unit,
-    showCheckboxFlow: Flow<Boolean>,
     formElements: List<FormElement>,
     modifier: Modifier = Modifier,
 ) {
@@ -30,7 +29,6 @@ internal fun PaymentMethodForm(
         factory = FormViewModel.Factory(
             formElements = formElements,
             formArguments = args,
-            showCheckboxFlow = showCheckboxFlow,
         )
     )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -65,7 +65,6 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.io.Closeable
-import java.lang.IllegalStateException
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -708,7 +707,6 @@ internal abstract class BaseSheetViewModel(
         return FormArgumentsFactory.create(
             paymentMethod = selectedItem,
             metadata = metadata,
-            customerConfig = config.customer,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
@@ -335,7 +335,6 @@ internal class CustomerSheetActivityTest {
             ),
             formArguments = FormArguments(
                 paymentMethodCode = PaymentMethod.Type.Card.code,
-                showCheckbox = false,
                 cbcEligibility = CardBrandChoiceEligibility.Ineligible,
                 merchantName = ""
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -37,6 +37,7 @@ internal class CustomerSheetScreenshotTest {
     )
 
     private val usBankAccountFormArguments = USBankAccountFormArguments(
+        showCheckbox = false,
         onBehalfOf = null,
         isCompleteFlow = false,
         isPaymentFlow = false,
@@ -76,7 +77,6 @@ internal class CustomerSheetScreenshotTest {
         ),
         formArguments = FormArguments(
             paymentMethodCode = PaymentMethod.Type.Card.code,
-            showCheckbox = false,
             cbcEligibility = CardBrandChoiceEligibility.Ineligible,
             merchantName = ""
         ),

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -46,7 +46,6 @@ import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.ui.core.elements.CardBillingAddressElement
 import com.stripe.android.ui.core.elements.CardDetailsSectionElement
-import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionElement
@@ -439,7 +438,7 @@ class CustomerSheetViewModelTest {
     }
 
     @Test
-    fun `When CustomerViewAction#OnAddCardPressed, view state is updated to CustomerViewAction#AddPaymentMethod and fields are shwon`() = runTest(testDispatcher) {
+    fun `When CustomerViewAction#OnAddCardPressed, view state is updated to CustomerViewAction#AddPaymentMethod and fields are shown`() = runTest(testDispatcher) {
         val viewModel = createViewModel(
             workContext = testDispatcher
         )
@@ -458,31 +457,6 @@ class CustomerSheetViewModelTest {
             assertThat(formElements[1]).isInstanceOf(SectionElement::class.java)
             assertThat(formElements[1].asSectionElement().fields[0])
                 .isInstanceOf(CardBillingAddressElement::class.java)
-            assertThat(formElements[2]).isInstanceOf(SaveForFutureUseElement::class.java)
-        }
-    }
-
-    @Test
-    fun `When CustomerViewAction#OnAddCardPressed & ACHv2 disabled, view state is updated to CustomerViewAction#AddPaymentMethod and fields are shwon`() = runTest(testDispatcher) {
-        val viewModel = createViewModel(
-            workContext = testDispatcher
-        )
-
-        viewModel.viewState.test {
-            assertThat(awaitItem())
-                .isInstanceOf(SelectPaymentMethod::class.java)
-            viewModel.handleViewAction(CustomerSheetViewAction.OnAddCardPressed)
-
-            val item = awaitItem()
-            assertThat(item).isInstanceOf(AddPaymentMethod::class.java)
-
-            val formElements = item.asAddState().formViewData.elements
-
-            assertThat(formElements[0]).isInstanceOf(CardDetailsSectionElement::class.java)
-            assertThat(formElements[1]).isInstanceOf(SectionElement::class.java)
-            assertThat(formElements[1].asSectionElement().fields[0])
-                .isInstanceOf(CardBillingAddressElement::class.java)
-            assertThat(formElements[2]).isInstanceOf(SaveForFutureUseElement::class.java)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -107,6 +107,7 @@ class DefaultCustomerSheetLoaderTest {
         assertThat(state.config).isEqualTo(config)
         assertThat(state.paymentMethodMetadata.stripeIntent).isEqualTo(STRIPE_INTENT)
         assertThat(state.paymentMethodMetadata.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
+        assertThat(state.paymentMethodMetadata.hasCustomerConfiguration).isTrue()
         assertThat(state.customerPaymentMethods).containsExactly(
             PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             PaymentMethodFixtures.US_BANK_ACCOUNT,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -52,6 +52,7 @@ internal object CustomerSheetTestHelper {
     internal val application = ApplicationProvider.getApplicationContext<Application>()
 
     internal val usBankAccountFormArguments = USBankAccountFormArguments(
+        showCheckbox = false,
         onBehalfOf = null,
         isCompleteFlow = false,
         isPaymentFlow = false,
@@ -91,7 +92,6 @@ internal object CustomerSheetTestHelper {
         ),
         formArguments = FormArguments(
             paymentMethodCode = PaymentMethod.Type.Card.code,
-            showCheckbox = false,
             cbcEligibility = CardBrandChoiceEligibility.Ineligible,
             merchantName = ""
         ),

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelperKtTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelperKtTest.kt
@@ -6,7 +6,6 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.paymentsheet.PaymentSheet
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -20,7 +19,6 @@ class SaveForFutureUseHelperKtTest {
             metadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
             ),
-            customerConfiguration = null,
         )
         assertThat(isSaveForFutureUseValueChangeable).isFalse()
     }
@@ -34,7 +32,6 @@ class SaveForFutureUseHelperKtTest {
                     setupFutureUsage = StripeIntent.Usage.OnSession,
                 ),
             ),
-            customerConfiguration = null,
         )
         assertThat(isSaveForFutureUseValueChangeable).isFalse()
     }
@@ -47,8 +44,8 @@ class SaveForFutureUseHelperKtTest {
                 stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
                     setupFutureUsage = StripeIntent.Usage.OnSession,
                 ),
+                hasCustomerConfiguration = true,
             ),
-            customerConfiguration = PaymentSheet.CustomerConfiguration("123", "123"),
         )
         assertThat(isSaveForFutureUseValueChangeable).isFalse()
     }
@@ -61,8 +58,8 @@ class SaveForFutureUseHelperKtTest {
                 stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
                     setupFutureUsage = null,
                 ),
+                hasCustomerConfiguration = true,
             ),
-            customerConfiguration = PaymentSheet.CustomerConfiguration("123", "123"),
         )
         assertThat(isSaveForFutureUseValueChangeable).isTrue()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelperKtTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelperKtTest.kt
@@ -1,0 +1,69 @@
+package com.stripe.android.lpmfoundations.luxe
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.SetupIntentFixtures
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentsheet.PaymentSheet
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+@RunWith(RobolectricTestRunner::class)
+class SaveForFutureUseHelperKtTest {
+    @Test
+    fun `isSaveForFutureUseValueChangeable returns false for SetupIntents`() {
+        val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
+            code = PaymentMethod.Type.Card.code,
+            metadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            ),
+            customerConfiguration = null,
+        )
+        assertThat(isSaveForFutureUseValueChangeable).isFalse()
+    }
+
+    @Test
+    fun `isSaveForFutureUseValueChangeable returns false for PaymentIntents with SFU and null customerConfig`() {
+        val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
+            code = PaymentMethod.Type.Card.code,
+            metadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    setupFutureUsage = StripeIntent.Usage.OnSession,
+                ),
+            ),
+            customerConfiguration = null,
+        )
+        assertThat(isSaveForFutureUseValueChangeable).isFalse()
+    }
+
+    @Test
+    fun `isSaveForFutureUseValueChangeable returns false for PaymentIntents with SFU and valid customerConfig`() {
+        val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
+            code = PaymentMethod.Type.Card.code,
+            metadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    setupFutureUsage = StripeIntent.Usage.OnSession,
+                ),
+            ),
+            customerConfiguration = PaymentSheet.CustomerConfiguration("123", "123"),
+        )
+        assertThat(isSaveForFutureUseValueChangeable).isFalse()
+    }
+
+    @Test
+    fun `isSaveForFutureUseValueChangeable returns true for PaymentIntents without SFU and valid customerConfig`() {
+        val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
+            code = PaymentMethod.Type.Card.code,
+            metadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    setupFutureUsage = null,
+                ),
+            ),
+            customerConfiguration = PaymentSheet.CustomerConfiguration("123", "123"),
+        )
+        assertThat(isSaveForFutureUseValueChangeable).isTrue()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodDefinitionTest.kt
@@ -4,10 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.CardDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.GrabPayDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.KlarnaDefinition
-import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.SetupIntentFixtures
-import com.stripe.android.model.StripeIntent
-import com.stripe.android.paymentsheet.PaymentSheet
 import org.junit.Test
 
 internal class PaymentMethodDefinitionTest {
@@ -29,79 +26,5 @@ internal class PaymentMethodDefinitionTest {
     @Test
     fun `isSupported returns true for supported PaymentMethodDefinitions`() {
         assertThat(CardDefinition.isSupported(PaymentMethodMetadataFactory.create())).isTrue()
-    }
-
-    @Test
-    fun `getFormLayoutConfiguration returns the config for merchantRequestedSave for SetupIntents`() {
-        assertThat(CardDefinition.supportedAsSavedPaymentMethod).isTrue()
-        val config = CardDefinition.getSetupFutureUsageFieldConfiguration(
-            metadata = PaymentMethodMetadataFactory.create(
-                stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
-            ),
-            customerConfiguration = null,
-        )!!
-        assertThat(config.isSaveForFutureUseValueChangeable).isFalse()
-        assertThat(config.saveForFutureUseInitialValue).isTrue()
-    }
-
-    @Test
-    fun `getFormLayoutConfiguration returns null for SetupIntents when supportedAsSavedPaymentMethod is false`() {
-        assertThat(KlarnaDefinition.supportedAsSavedPaymentMethod).isFalse()
-        val config = KlarnaDefinition.getSetupFutureUsageFieldConfiguration(
-            metadata = PaymentMethodMetadataFactory.create(
-                stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
-            ),
-            customerConfiguration = null,
-        )
-        assertThat(config).isNull()
-    }
-
-    @Test
-    fun `getFormLayoutConfiguration returns the config for merchantRequestedSave for PaymentIntents`() {
-        assertThat(CardDefinition.supportedAsSavedPaymentMethod).isTrue()
-        val config = CardDefinition.getSetupFutureUsageFieldConfiguration(
-            metadata = PaymentMethodMetadataFactory.create(
-                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                    setupFutureUsage = StripeIntent.Usage.OnSession,
-                ),
-            ),
-            customerConfiguration = null,
-        )!!
-        assertThat(config.isSaveForFutureUseValueChangeable).isFalse()
-        assertThat(config.saveForFutureUseInitialValue).isTrue()
-    }
-
-    @Test
-    fun `getFormLayoutConfiguration returns null for PaymentIntents when supportedAsSavedPaymentMethod is false and setupFutureUsage is set`() {
-        assertThat(KlarnaDefinition.supportedAsSavedPaymentMethod).isFalse()
-        val config = KlarnaDefinition.getSetupFutureUsageFieldConfiguration(
-            metadata = PaymentMethodMetadataFactory.create(
-                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                    setupFutureUsage = StripeIntent.Usage.OnSession,
-                ),
-            ),
-            customerConfiguration = null,
-        )
-        assertThat(config).isNull()
-    }
-
-    @Test
-    fun `getFormLayoutConfiguration returns config for userSelectableSave for PaymentIntents when no setupFutureUsage is set and customerConfig is not null`() {
-        val config = CardDefinition.getSetupFutureUsageFieldConfiguration(
-            metadata = PaymentMethodMetadataFactory.create(),
-            customerConfiguration = PaymentSheet.CustomerConfiguration("123", "123"),
-        )!!
-        assertThat(config.isSaveForFutureUseValueChangeable).isTrue()
-        assertThat(config.saveForFutureUseInitialValue).isFalse()
-    }
-
-    @Test
-    fun `getSetupFutureUsageFieldConfiguration returns config for oneTimeUse for PaymentIntents when no setupFutureUsage is set and customerConfig is null`() {
-        val config = CardDefinition.getSetupFutureUsageFieldConfiguration(
-            metadata = PaymentMethodMetadataFactory.create(),
-            customerConfiguration = null,
-        )!!
-        assertThat(config.isSaveForFutureUseValueChangeable).isFalse()
-        assertThat(config.saveForFutureUseInitialValue).isFalse()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -22,6 +22,7 @@ internal object PaymentMethodMetadataFactory {
         paymentMethodOrder: List<String> = emptyList(),
         shippingDetails: AddressDetails? = null,
         cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
+        hasCustomerConfiguration: Boolean = false,
         sharedDataSpecs: List<SharedDataSpec> = createSharedDataSpecs(),
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
@@ -35,6 +36,7 @@ internal object PaymentMethodMetadataFactory {
             merchantName = PaymentSheetFixtures.MERCHANT_DISPLAY_NAME,
             defaultBillingDetails = PaymentSheet.BillingDetails(),
             shippingDetails = shippingDetails,
+            hasCustomerConfiguration = hasCustomerConfiguration,
             sharedDataSpecs = sharedDataSpecs,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
@@ -21,18 +21,16 @@ class CardDefinitionTest {
                 )
             )
         )
-        assertThat(formElements).hasSize(2)
+        assertThat(formElements).hasSize(1)
         assertThat(formElements[0].identifier.v1).isEqualTo("card_details")
-        assertThat(formElements[1].identifier.v1).isEqualTo("save_for_future_use")
     }
 
     @Test
     fun `createFormElements returns default set of fields`() {
         val formElements = CardDefinition.formElements(PaymentMethodMetadataFactory.create())
-        assertThat(formElements).hasSize(3)
+        assertThat(formElements).hasSize(2)
         assertThat(formElements[0].identifier.v1).isEqualTo("card_details")
         assertThat(formElements[1].identifier.v1).isEqualTo("credit_billing_section")
-        assertThat(formElements[2].identifier.v1).isEqualTo("save_for_future_use")
     }
 
     @Test
@@ -47,11 +45,10 @@ class CardDefinitionTest {
                 )
             )
         )
-        assertThat(formElements).hasSize(4)
+        assertThat(formElements).hasSize(3)
         assertThat(formElements[0].identifier.v1).isEqualTo("billing_details[email]_section")
         assertThat(formElements[1].identifier.v1).isEqualTo("card_details")
         assertThat(formElements[2].identifier.v1).isEqualTo("credit_billing_section")
-        assertThat(formElements[3].identifier.v1).isEqualTo("save_for_future_use")
 
         val contactElement = formElements[0] as SectionElement
         assertThat(contactElement.fields).hasSize(2)
@@ -66,14 +63,28 @@ class CardDefinitionTest {
                 shippingDetails = AddressDetails(isCheckboxSelected = true)
             )
         )
-        assertThat(formElements).hasSize(3)
+        assertThat(formElements).hasSize(2)
         assertThat(formElements[0].identifier.v1).isEqualTo("card_details")
         assertThat(formElements[1].identifier.v1).isEqualTo("credit_billing_section")
-        assertThat(formElements[2].identifier.v1).isEqualTo("save_for_future_use")
 
         val billingDetailsElement = formElements[1] as SectionElement
         assertThat(billingDetailsElement.fields).hasSize(2)
         assertThat(billingDetailsElement.fields[0].identifier.v1).isEqualTo("credit_billing")
         assertThat(billingDetailsElement.fields[1].identifier.v1).isEqualTo("same_as_shipping")
+    }
+
+    @Test
+    fun `createFormElements returns save_for_future_use`() {
+        val formElements = CardDefinition.formElements(
+            PaymentMethodMetadataFactory.create(
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
+                ),
+                hasCustomerConfiguration = true,
+            )
+        )
+        assertThat(formElements).hasSize(2)
+        assertThat(formElements[0].identifier.v1).isEqualTo("card_details")
+        assertThat(formElements[1].identifier.v1).isEqualTo("save_for_future_use")
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -173,7 +173,6 @@ internal object PaymentSheetFixtures {
     internal val COMPOSE_FRAGMENT_ARGS
         get() = FormArguments(
             PaymentMethod.Type.Bancontact.code,
-            showCheckbox = true,
             merchantName = "Merchant, Inc.",
             billingDetails = PaymentSheet.BillingDetails(
                 address = PaymentSheet.Address(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1412,7 +1412,6 @@ internal class PaymentSheetViewModelTest {
                     value = 1099,
                     currencyCode = "usd",
                 ),
-                showCheckbox = false,
                 billingDetails = PaymentSheet.BillingDetails(),
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
@@ -3,9 +3,6 @@ package com.stripe.android.paymentsheet.forms
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.lpmfoundations.paymentmethod.definitions.BancontactDefinition
-import com.stripe.android.model.PaymentIntentFixtures
-import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
@@ -15,41 +12,6 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class FormArgumentsFactoryTest {
-    @Test
-    fun `Create correct FormArguments for new generic payment method with customer requested save`() {
-        val metadata = PaymentMethodMetadataFactory.create(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                paymentMethodTypes = listOf("card", "bancontact")
-            )
-        )
-        val actualArgs = FormArgumentsFactory.create(
-            paymentMethod = metadata.supportedPaymentMethodForCode("bancontact")!!,
-            metadata = metadata,
-            customerConfig = null,
-        )
-
-        assertThat(actualArgs.showCheckbox).isFalse()
-    }
-
-    @Test
-    fun `Create correct FormArguments for null newLpm with setup intent and paymentMethod not supportedAsSavedPaymentMethod`() {
-        val metadata = PaymentMethodMetadataFactory.create(
-            stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD.copy(
-                paymentMethodTypes = listOf("bancontact")
-            ),
-        )
-        assertThat(BancontactDefinition.supportedAsSavedPaymentMethod).isFalse()
-        val supportedPaymentMethod = metadata.supportedPaymentMethodForCode("bancontact")!!
-
-        val actualArgs = FormArgumentsFactory.create(
-            paymentMethod = supportedPaymentMethod,
-            metadata = metadata,
-            customerConfig = null,
-        )
-
-        assertThat(actualArgs.showCheckbox).isFalse()
-    }
-
     @Test
     fun `Create correct FormArguments with custom billing details collection`() {
         val actualFromArguments = testCardFormArguments(
@@ -75,7 +37,6 @@ class FormArgumentsFactoryTest {
             metadata = PaymentMethodMetadataFactory.create(
                 billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
             ),
-            customerConfig = config.customer,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -73,7 +73,6 @@ internal class FormViewModelTest {
     fun `Verify setting save for future use value is updated in flowable`() = runTest {
         val args = COMPOSE_FRAGMENT_ARGS.copy(
             paymentMethodCode = PaymentMethod.Type.Card.code,
-            showCheckbox = true,
         )
         val formViewModel = createViewModel(
             arguments = args,
@@ -112,25 +111,6 @@ internal class FormViewModelTest {
             receiver.cancel()
         }
     }
-
-    @Test
-    fun `Verify setting save for future use visibility removes it from completed values`() =
-        runTest {
-            val args = COMPOSE_FRAGMENT_ARGS.copy(
-                paymentMethodCode = PaymentMethod.Type.Card.code,
-                showCheckbox = false,
-            )
-            val formViewModel = createViewModel(
-                arguments = args,
-                formElements = listOf(
-                    SaveForFutureUseElement(true, ""),
-                ),
-            )
-
-            formViewModel.hiddenIdentifiers.test {
-                assertThat(awaitItem()).containsExactly(IdentifierSpec.SaveForFutureUse)
-            }
-        }
 
     @Test
     fun `Verify if there are no text fields, there is no last text field id`() = runTest {
@@ -257,7 +237,6 @@ internal class FormViewModelTest {
         val args = COMPOSE_FRAGMENT_ARGS.copy(
             paymentMethodCode = PaymentMethod.Type.P24.code,
             billingDetails = null,
-            showCheckbox = true,
         )
         val formViewModel = createViewModel(
             args,
@@ -309,7 +288,6 @@ internal class FormViewModelTest {
     fun `Verify params are set when element address fields are complete`() = runTest {
         val args = COMPOSE_FRAGMENT_ARGS.copy(
             paymentMethodCode = PaymentMethod.Type.SepaDebit.code,
-            showCheckbox = false,
             billingDetails = null
         )
         val formViewModel = createViewModel(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -35,7 +35,6 @@ import com.stripe.android.uicore.elements.SectionSingleFieldElement
 import com.stripe.android.uicore.elements.SimpleTextFieldController
 import com.stripe.android.uicore.elements.TextFieldController
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -55,8 +54,6 @@ internal class FormViewModelTest {
         StripeR.style.StripeDefaultTheme
     )
 
-    private val showCheckboxFlow = MutableStateFlow(false)
-
     @Test
     fun `Verify completeFormValues is not null when no elements exist`() = runTest {
         val args = COMPOSE_FRAGMENT_ARGS.copy(
@@ -75,17 +72,16 @@ internal class FormViewModelTest {
     @Test
     fun `Verify setting save for future use value is updated in flowable`() = runTest {
         val args = COMPOSE_FRAGMENT_ARGS.copy(
-            paymentMethodCode = PaymentMethod.Type.Card.code
+            paymentMethodCode = PaymentMethod.Type.Card.code,
+            showCheckbox = true,
         )
         val formViewModel = createViewModel(
-            args,
-            listOf(
+            arguments = args,
+            formElements = listOf(
                 SectionElement.wrap(EmailElement()),
                 SaveForFutureUseElement(true, ""),
-            )
+            ),
         )
-
-        showCheckboxFlow.emit(true)
 
         // Set all the card fields, billing is set in the args
         val emailController =
@@ -121,22 +117,17 @@ internal class FormViewModelTest {
     fun `Verify setting save for future use visibility removes it from completed values`() =
         runTest {
             val args = COMPOSE_FRAGMENT_ARGS.copy(
-                paymentMethodCode = PaymentMethod.Type.Card.code
+                paymentMethodCode = PaymentMethod.Type.Card.code,
+                showCheckbox = false,
             )
             val formViewModel = createViewModel(
-                args,
-                listOf(
+                arguments = args,
+                formElements = listOf(
                     SaveForFutureUseElement(true, ""),
-                )
+                ),
             )
 
             formViewModel.hiddenIdentifiers.test {
-                assertThat(awaitItem()).containsExactly(IdentifierSpec.SaveForFutureUse)
-
-                showCheckboxFlow.tryEmit(true)
-                assertThat(awaitItem()).isEmpty()
-
-                showCheckboxFlow.tryEmit(false)
                 assertThat(awaitItem()).containsExactly(IdentifierSpec.SaveForFutureUse)
             }
         }
@@ -798,7 +789,6 @@ internal class FormViewModelTest {
         formElements: List<FormElement>,
     ) = FormViewModel(
         formArguments = arguments,
-        showCheckboxFlow = showCheckboxFlow,
         elements = formElements,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -51,7 +51,6 @@ class USBankAccountFormViewModelTest {
     private val defaultArgs = USBankAccountFormViewModel.Args(
         formArgs = FormArguments(
             paymentMethodCode = PaymentMethod.Type.USBankAccount.code,
-            showCheckbox = false,
             merchantName = MERCHANT_NAME,
             amount = Amount(5099, "usd"),
             billingDetails = PaymentSheet.BillingDetails(
@@ -60,6 +59,7 @@ class USBankAccountFormViewModelTest {
             ),
             cbcEligibility = CardBrandChoiceEligibility.Ineligible,
         ),
+        showCheckbox = false,
         isCompleteFlow = true,
         isPaymentFlow = true,
         stripeIntentId = "id_12345",
@@ -201,7 +201,8 @@ class USBankAccountFormViewModelTest {
     fun `when payment options, verified bank account, then result has correct paymentMethodOptionsParams`() = runTest {
         val viewModel = createViewModel(
             defaultArgs.copy(
-                formArgs = defaultArgs.formArgs.copy(showCheckbox = true)
+                formArgs = defaultArgs.formArgs,
+                showCheckbox = true,
             )
         )
         val bankAccount = mockVerifiedBankAccount()
@@ -628,9 +629,8 @@ class USBankAccountFormViewModelTest {
     fun `Doesn't save for future use by default`() = runTest {
         val viewModel = createViewModel(
             args = defaultArgs.copy(
-                formArgs = defaultArgs.formArgs.copy(
-                    showCheckbox = true,
-                ),
+                formArgs = defaultArgs.formArgs,
+                showCheckbox = true,
             ),
         )
         assertThat(viewModel.saveForFutureUse.value).isFalse()
@@ -640,9 +640,8 @@ class USBankAccountFormViewModelTest {
     fun `Produces correct lastTextFieldIdentifier for default config`() = runTest {
         val viewModel = createViewModel(
             args = defaultArgs.copy(
-                formArgs = defaultArgs.formArgs.copy(
-                    showCheckbox = true,
-                ),
+                formArgs = defaultArgs.formArgs,
+                showCheckbox = true,
             ),
         )
 
@@ -664,9 +663,9 @@ class USBankAccountFormViewModelTest {
         val viewModel = createViewModel(
             args = defaultArgs.copy(
                 formArgs = defaultArgs.formArgs.copy(
-                    showCheckbox = true,
                     billingDetailsCollectionConfiguration = billingDetailsConfig,
                 ),
+                showCheckbox = true,
             ),
         )
 
@@ -689,13 +688,13 @@ class USBankAccountFormViewModelTest {
         val viewModel = createViewModel(
             args = defaultArgs.copy(
                 formArgs = defaultArgs.formArgs.copy(
-                    showCheckbox = true,
                     billingDetailsCollectionConfiguration = billingDetailsConfig,
                     billingDetails = PaymentSheet.BillingDetails(
                         name = "My myself and I",
                         email = "myself@me.com",
                     ),
                 ),
+                showCheckbox = true,
             ),
         )
 
@@ -717,13 +716,13 @@ class USBankAccountFormViewModelTest {
         val viewModel = createViewModel(
             args = defaultArgs.copy(
                 formArgs = defaultArgs.formArgs.copy(
-                    showCheckbox = true,
                     billingDetailsCollectionConfiguration = billingDetailsConfig,
                     billingDetails = PaymentSheet.BillingDetails(
                         name = "My myself and I",
                         email = "myself@me.com",
                     ),
                 ),
+                showCheckbox = true,
             ),
         )
 
@@ -745,13 +744,13 @@ class USBankAccountFormViewModelTest {
         val viewModel = createViewModel(
             args = defaultArgs.copy(
                 formArgs = defaultArgs.formArgs.copy(
-                    showCheckbox = true,
                     billingDetailsCollectionConfiguration = billingDetailsConfig,
                     billingDetails = PaymentSheet.BillingDetails(
                         name = "My myself and I",
                         email = "myself@me.com",
                     ),
                 ),
+                showCheckbox = true,
             ),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -121,9 +121,25 @@ internal class DefaultPaymentSheetLoaderTest {
                     stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
                     allowsDelayedPaymentMethods = false,
                     sharedDataSpecs = emptyList(),
+                    hasCustomerConfiguration = true,
                 ),
             )
         )
+    }
+
+    @Test
+    fun `load without customer should return expected result`() = runTest {
+        val loader = createPaymentSheetLoader(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
+        )
+
+        val result = loader.load(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+            ),
+            PaymentSheetFixtures.CONFIG_MINIMUM
+        ).getOrThrow()
+        assertThat(result.paymentMethodMetadata.hasCustomerConfiguration).isFalse()
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
The abstractions are supposed to always go one way (PaymentMethodMetadata -> PaymentMethodDefinition -> SupportedPaymentMethod). Going from SupportedPaymentMethod back to a PaymentMethodDefinition breaks the abstractions I was trying to put in place.

I moved a lot of the logic out of FormViewModel to make things more clear!
