### PR TITLE
Add more GooglePay error analytics

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
@@ -120,12 +120,17 @@ internal class GooglePayLauncherActivity : AppCompatActivity() {
                             )
                         )
                     )
+                    errorReporter.report(
+                        ErrorReporter.ExpectedErrorEvent.GOOGLE_PAY_FAILED,
+                        additionalNonPiiParams = mapOf("status_message" to statusMessage)
+                    )
                 }
                 else -> {
+                    errorReporter.report(ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_UNEXPECTED_RESULT_CODE)
                     viewModel.updateResult(
                         GooglePayLauncher.Result.Failed(
                             RuntimeException(
-                                "Google Pay returned an expected result code."
+                                "Google Pay returned an unexpected result code."
                             )
                         )
                     )

--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -123,6 +123,9 @@ interface ErrorReporter {
         BROWSER_LAUNCHER_NULL_ARGS(
             eventName = "payments.browserlauncher.null_args"
         ),
+        GOOGLE_PAY_FAILED(
+            eventName = "google_pay.confirm.error"
+        ),
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -141,6 +144,9 @@ interface ErrorReporter {
         ),
         LINK_INVALID_SESSION_STATE(
             partialEventName = "link.signup.failure.invalidSessionState"
+        ),
+        GOOGLE_PAY_UNEXPECTED_RESULT_CODE(
+            partialEventName = "google_pay.confirm.unexpected_result_code"
         ),
         GOOGLE_PAY_UNEXPECTED_CONFIRM_RESULT(
             partialEventName = "google_pay.confirm.unexpected_result"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add more Google Pay error analytics

- for an unexpected result code (unexpected)
- for Google Pay failing (expected)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
error visibility sprint

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
