### PR TITLE
Default feature flags to false in both debug and release.

### DIFF
--- a/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
@@ -9,20 +9,20 @@ object FeatureFlags
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class FeatureFlag {
 
-    private var overrideInTest: Boolean? = null
+    private var overrideEnabledValue: Boolean? = null
 
     val isEnabled: Boolean
         get() = if (BuildConfig.DEBUG) {
-            overrideInTest ?: false
+            overrideEnabledValue ?: false
         } else {
             false
         }
 
     fun setEnabled(isEnabled: Boolean) {
-        overrideInTest = isEnabled
+        overrideEnabledValue = isEnabled
     }
 
     fun reset() {
-        overrideInTest = null
+        overrideEnabledValue = null
     }
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
@@ -13,7 +13,7 @@ class FeatureFlag {
 
     val isEnabled: Boolean
         get() = if (BuildConfig.DEBUG) {
-            overrideInTest ?: true
+            overrideInTest ?: false
         } else {
             false
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We've had issue in the past where the default differing between debug and release caused problems. Let's disable everything by default.