### PR TITLE
Sort amazon pay in screenshot tests.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
@@ -28,7 +28,7 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
     private val testParams = TestParameters.create(
         paymentMethodCode = "card",
     ) { settings ->
-        settings[PaymentMethodOrderSettingsDefinition] = "card,klarna,p24,eps"
+        settings[PaymentMethodOrderSettingsDefinition] = "card,amazon_pay,klarna,p24,eps"
     }.copy(
         saveForFutureUseCheckboxVisible = true,
         authorizationAction = null,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This was causing test flakes with recent ML model changes.
