### PR TITLE
[FC] partner_auth logging partner_auth_drawer on some analytics events


### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsAnalyticsEvent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsAnalyticsEvent.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.analytics
 
+import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.ConsentAgree.analyticsValue
 import com.stripe.android.financialconnections.domain.ConfirmVerification.OTPError
 import com.stripe.android.financialconnections.exception.FinancialConnectionsError
 import com.stripe.android.financialconnections.exception.WebAuthFlowFailedException
@@ -24,7 +25,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
         "pane.launched",
         mapOf(
             "referrer_pane" to referrer?.value,
-            "pane" to pane.value,
+            "pane" to pane.analyticsValue,
         ).filterNotNullValues()
     )
 
@@ -34,7 +35,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
     ) : FinancialConnectionsAnalyticsEvent(
         if (backgrounded) "mobile.app_entered_background" else "mobile.app_entered_foreground",
         mapOf(
-            "pane" to pane.value,
+            "pane" to pane.analyticsValue,
         ).filterNotNullValues()
     )
 
@@ -43,7 +44,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
     ) : FinancialConnectionsAnalyticsEvent(
         "pane.loaded",
         mapOf(
-            "pane" to pane.value,
+            "pane" to pane.analyticsValue,
         ).filterNotNullValues()
     )
 
@@ -52,7 +53,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
     ) : FinancialConnectionsAnalyticsEvent(
         name = "click.nav_bar.back",
         mapOf(
-            "pane" to pane.value,
+            "pane" to pane.analyticsValue,
         ).filterNotNullValues()
     )
 
@@ -61,7 +62,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
     ) : FinancialConnectionsAnalyticsEvent(
         name = "click.nav_bar.close",
         mapOf(
-            "pane" to pane.value,
+            "pane" to pane.analyticsValue,
         ).filterNotNullValues()
     )
 
@@ -84,7 +85,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
     ) : FinancialConnectionsAnalyticsEvent(
         name = "click.data_access.learn_more",
         mapOf(
-            "pane" to pane.value,
+            "pane" to pane.analyticsValue,
         ).filterNotNullValues()
     )
 
@@ -93,7 +94,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
     ) : FinancialConnectionsAnalyticsEvent(
         name = "click.disconnect_link",
         mapOf(
-            "pane" to pane.value,
+            "pane" to pane.analyticsValue,
         ).filterNotNullValues()
     )
 
@@ -103,7 +104,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
     ) : FinancialConnectionsAnalyticsEvent(
         name = eventName,
         mapOf(
-            "pane" to pane.value,
+            "pane" to pane.analyticsValue,
         ).filterNotNullValues()
     )
 
@@ -119,7 +120,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
                 .toMap()
                 .plus(
                     mapOf(
-                        "pane" to pane.value,
+                        "pane" to pane.analyticsValue,
                         "result_count" to institutionIds.size.toString(),
                         "duration" to duration.toString(),
                     )
@@ -137,7 +138,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
                 .mapIndexed { index, id -> "institution_ids[$index]" to id }
                 .toMap()
                 .plus(
-                    mapOf("pane" to pane.value)
+                    mapOf("pane" to pane.analyticsValue)
                 )
             ).filterNotNullValues()
     )
@@ -149,7 +150,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
     ) : FinancialConnectionsAnalyticsEvent(
         name = if (fromFeatured) "search.featured_institution_selected" else "search.search_result_selected",
         mapOf(
-            "pane" to pane.value,
+            "pane" to pane.analyticsValue,
             "institution_id" to institutionId
         ).filterNotNullValues()
     )
@@ -162,7 +163,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
     ) : FinancialConnectionsAnalyticsEvent(
         name = "search.succeeded",
         mapOf(
-            "pane" to pane.value,
+            "pane" to pane.analyticsValue,
             "query" to query,
             "duration" to duration.toString(),
             "result_count" to resultCount.toString()
@@ -203,7 +204,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
     ) : FinancialConnectionsAnalyticsEvent(
         name = "account_picker.accounts_submitted",
         mapOf(
-            "pane" to pane.value,
+            "pane" to pane.analyticsValue,
             "account_ids" to accountIds.joinToString(" "),
             "is_skip_account_selection" to isSkipAccountSelection.toString(),
         ).filterNotNullValues()
@@ -236,7 +237,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
     ) : FinancialConnectionsAnalyticsEvent(
         name = "click.link_accounts",
         mapOf(
-            "pane" to pane.value,
+            "pane" to pane.analyticsValue,
         ).filterNotNullValues()
     )
 
@@ -245,7 +246,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
     ) : FinancialConnectionsAnalyticsEvent(
         name = "networking.new_consumer",
         mapOf(
-            "pane" to pane.value,
+            "pane" to pane.analyticsValue,
         ).filterNotNullValues()
     )
 
@@ -254,7 +255,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
     ) : FinancialConnectionsAnalyticsEvent(
         name = "networking.returning_consumer",
         mapOf(
-            "pane" to pane.value,
+            "pane" to pane.analyticsValue,
         ).filterNotNullValues()
     )
 
@@ -263,7 +264,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
     ) : FinancialConnectionsAnalyticsEvent(
         name = "networking.verification.success",
         mapOf(
-            "pane" to pane.value,
+            "pane" to pane.analyticsValue,
         ).filterNotNullValues()
     )
 
@@ -272,7 +273,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
     ) : FinancialConnectionsAnalyticsEvent(
         name = "networking.verification.success_no_accounts",
         mapOf(
-            "pane" to pane.value,
+            "pane" to pane.analyticsValue,
         ).filterNotNullValues()
     )
 
@@ -282,7 +283,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
     ) : FinancialConnectionsAnalyticsEvent(
         name = "networking.verification.error",
         mapOf(
-            "pane" to pane.value,
+            "pane" to pane.analyticsValue,
             "error" to error.value,
         ).filterNotNullValues()
     ) {
@@ -301,7 +302,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
     ) : FinancialConnectionsAnalyticsEvent(
         name = "networking.verification.step_up.success",
         mapOf(
-            "pane" to pane.value,
+            "pane" to pane.analyticsValue,
         ).filterNotNullValues()
     )
 
@@ -311,7 +312,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
     ) : FinancialConnectionsAnalyticsEvent(
         name = "networking.verification.step_up.error",
         mapOf(
-            "pane" to pane.value,
+            "pane" to pane.analyticsValue,
             "error" to error.value,
         ).filterNotNullValues()
     ) {
@@ -328,7 +329,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
     ) : FinancialConnectionsAnalyticsEvent(
         name = "click.done",
         mapOf(
-            "pane" to pane.value,
+            "pane" to pane.analyticsValue,
         ).filterNotNullValues()
     )
 
@@ -345,7 +346,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
             else -> "error.unexpected"
         },
         params = (
-            mapOf("pane" to pane.value)
+            mapOf("pane" to pane.analyticsValue)
                 .plus(exception.toEventParams(extraMessage))
                 .filterNotNullValues()
             )
@@ -393,7 +394,7 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
         pane: Pane
     ) : FinancialConnectionsAnalyticsEvent(
         name = "click.prepane.continue",
-        mapOf("pane" to pane.value)
+        mapOf("pane" to pane.analyticsValue)
     )
 
     class AuthSessionOpened(
@@ -405,11 +406,19 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
         "auth_session.opened",
         mapOf(
             "auth_session_id" to id,
-            "pane" to pane.value,
+            "pane" to pane.analyticsValue,
             "flow" to (flow ?: "unknown"),
             "browser" to (defaultBrowser ?: "unknown")
         ).filterNotNullValues()
     )
+
+    internal val Pane.analyticsValue
+        get() = when (this) {
+            // We want to log partner_auth regardless of the pane being shown full-screen or as a drawer.
+            Pane.PARTNER_AUTH_DRAWER,
+            Pane.PARTNER_AUTH -> Pane.PARTNER_AUTH.value
+            else -> value
+        }
 
     override fun toString(): String {
         return "FinancialConnectionsEvent(name='$name', params=$params)"

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModelTest.kt
@@ -87,28 +87,28 @@ internal class PartnerAuthViewModelTest {
 
     @Test
     fun `init - when existing auth session available, payload succeeds pane loaded emits`() = runTest {
-            val activeAuthSession = authorizationSession()
-            val activeInstitution = institution()
-            val manifest = sessionManifest().copy(
-                activeInstitution = activeInstitution,
-                activeAuthSession = activeAuthSession
+        val activeAuthSession = authorizationSession()
+        val activeInstitution = institution()
+        val manifest = sessionManifest().copy(
+            activeInstitution = activeInstitution,
+            activeAuthSession = activeAuthSession
+        )
+        whenever(getSync()).thenReturn(syncResponse(manifest))
+
+        val viewModel = createViewModel(SharedPartnerAuthState(Pane.PARTNER_AUTH_DRAWER))
+
+        eventTracker.assertContainsEvent(
+            "linked_accounts.pane.loaded",
+            mapOf(
+                "pane" to Pane.PARTNER_AUTH.value,
             )
-            whenever(getSync()).thenReturn(syncResponse(manifest))
+        )
 
-            val viewModel = createViewModel(SharedPartnerAuthState(Pane.PARTNER_AUTH_DRAWER))
-
-            eventTracker.assertContainsEvent(
-                "linked_accounts.pane.loaded",
-                mapOf(
-                    "pane" to Pane.PARTNER_AUTH.value,
-                )
-            )
-
-            withState(viewModel) {
-                assertThat(it.payload).isInstanceOf(Async.Success::class.java)
-                assertEquals(requireNotNull(it.payload()).authSession, activeAuthSession)
-            }
+        withState(viewModel) {
+            assertThat(it.payload).isInstanceOf(Async.Success::class.java)
+            assertEquals(requireNotNull(it.payload()).authSession, activeAuthSession)
         }
+    }
 
     @Test
     fun `onWebAuthFlowFinished - when webStatus Success, polls accounts and authorizes with token`() =

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModelTest.kt
@@ -8,8 +8,8 @@ import com.stripe.android.financialconnections.ApiKeyFixtures.institution
 import com.stripe.android.financialconnections.ApiKeyFixtures.sessionManifest
 import com.stripe.android.financialconnections.ApiKeyFixtures.syncResponse
 import com.stripe.android.financialconnections.CoroutineTestRule
+import com.stripe.android.financialconnections.TestFinancialConnectionsAnalyticsTracker
 import com.stripe.android.financialconnections.analytics.AuthSessionEvent
-import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
 import com.stripe.android.financialconnections.domain.CancelAuthorizationSession
 import com.stripe.android.financialconnections.domain.CompleteAuthorizationSession
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
@@ -21,7 +21,9 @@ import com.stripe.android.financialconnections.domain.RetrieveAuthorizationSessi
 import com.stripe.android.financialconnections.exception.InstitutionUnplannedDowntimeError
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.model.MixedOAuthParams
+import com.stripe.android.financialconnections.presentation.Async
 import com.stripe.android.financialconnections.presentation.WebAuthFlowState
+import com.stripe.android.financialconnections.presentation.withState
 import com.stripe.android.financialconnections.utils.TestHandleError
 import com.stripe.android.financialconnections.utils.TestNavigationManager
 import com.stripe.android.financialconnections.utils.UriUtils
@@ -35,6 +37,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
 
 @Suppress("MaxLineLength")
 @ExperimentalCoroutinesApi
@@ -47,7 +50,7 @@ internal class PartnerAuthViewModelTest {
     private val getSync = mock<GetOrFetchSync>()
     private val postAuthSessionEvent = mock<PostAuthSessionEvent>()
     private val retrieveAuthorizationSession = mock<RetrieveAuthorizationSession>()
-    private val eventTracker = mock<FinancialConnectionsAnalyticsTracker>()
+    private val eventTracker = TestFinancialConnectionsAnalyticsTracker()
     private val pollAuthorizationSessionOAuthResults = mock<PollAuthorizationSessionOAuthResults>()
     private val completeAuthorizationSession = mock<CompleteAuthorizationSession>()
     private val cancelAuthorizationSession = mock<CancelAuthorizationSession>()
@@ -80,6 +83,31 @@ internal class PartnerAuthViewModelTest {
                 pane = Pane.PARTNER_AUTH,
                 displayErrorScreen = true
             )
+        }
+
+    @Test
+    fun `init - when existing auth session available, payload succeeds pane loaded emits`() = runTest {
+            val activeAuthSession = authorizationSession()
+            val activeInstitution = institution()
+            val manifest = sessionManifest().copy(
+                activeInstitution = activeInstitution,
+                activeAuthSession = activeAuthSession
+            )
+            whenever(getSync()).thenReturn(syncResponse(manifest))
+
+            val viewModel = createViewModel(SharedPartnerAuthState(Pane.PARTNER_AUTH_DRAWER))
+
+            eventTracker.assertContainsEvent(
+                "linked_accounts.pane.loaded",
+                mapOf(
+                    "pane" to Pane.PARTNER_AUTH.value,
+                )
+            )
+
+            withState(viewModel) {
+                assertThat(it.payload).isInstanceOf(Async.Success::class.java)
+                assertEquals(requireNotNull(it.payload()).authSession, activeAuthSession)
+            }
         }
 
     @Test


### PR DESCRIPTION
# Summary
- We're logging `partner_auth_drawer` (an client-side only pane) wrongly instead of the corresponding analytics value, `partner_auth`. 

# Motivation
:notebook_with_decorative_cover: &nbsp;**Android - partner_auth logging partner_auth_drawer on some analytics events**
:globe_with_meridians: &nbsp;[BANKCON-10107](https://jira.corp.stripe.com/browse/BANKCON-10107)
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->