### PR TITLE
Fix a screenshot flake.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
@@ -244,13 +244,12 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
     @Test
     fun testPaymentSheetMandate() {
         testDriver.screenshotRegression(
-            testParameters = TestParameters.create(
-                paymentMethodCode = "sepa_debit",
-            ) { settings ->
+            testParameters = testParams.copyPlaygroundSettings { settings ->
                 settings[CountrySettingsDefinition] = Country.FR
                 settings[DelayedPaymentMethodsSettingsDefinition] = true
                 settings[GooglePaySettingsDefinition] = false
             }.copy(
+                paymentMethodCode = "sepa_debit",
                 authorizationAction = null,
             ),
             customOperations = {
@@ -263,9 +262,7 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
     @Test
     fun testDefaultBillingAndPhoneDetails() {
         testDriver.screenshotRegression(
-            testParameters = TestParameters.create(
-                paymentMethodCode = "card",
-            ) { settings ->
+            testParameters = testParams.copyPlaygroundSettings { settings ->
                 settings[CountrySettingsDefinition] = Country.US
                 settings[CollectPhoneSettingsDefinition] = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always
             },


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We were setting the order properly in the field level `testParams`, but we weren't using that in the flakey test.

Follow up to #8275 

