### PR TITLE
Prepare PaymentSheet for Instant Debits changes

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
@@ -217,8 +217,8 @@ internal fun MandateCollectionScreen(
         AccountDetailsForm(
             showCheckbox = showCheckbox,
             isProcessing = isProcessing,
-            bankName = screenState.paymentAccount.institutionName,
-            last4 = screenState.paymentAccount.last4,
+            bankName = screenState.bankName,
+            last4 = screenState.last4,
             saveForFutureUseElement = saveForFutureUseElement,
             onRemoveAccount = onRemoveAccount,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet.paymentdatacollection.ach
 import android.os.Parcelable
 import androidx.annotation.StringRes
 import com.stripe.android.financialconnections.model.BankAccount
-import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
 import kotlinx.parcelize.Parcelize
 
 internal sealed class USBankAccountFormScreenState(
@@ -26,7 +25,8 @@ internal sealed class USBankAccountFormScreenState(
 
     @Parcelize
     data class MandateCollection(
-        val paymentAccount: FinancialConnectionsAccount,
+        val bankName: String,
+        val last4: String?,
         val financialConnectionsSessionId: String,
         val intentId: String?,
         override val primaryButtonText: String,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -290,9 +290,9 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
                     is FinancialConnectionsAccount -> {
                         _currentScreenState.update {
                             USBankAccountFormScreenState.MandateCollection(
-                                paymentAccount = paymentAccount,
-                                financialConnectionsSessionId =
-                                usBankAccountData.financialConnectionsSession.id,
+                                financialConnectionsSessionId = usBankAccountData.financialConnectionsSession.id,
+                                bankName = paymentAccount.institutionName,
+                                last4 = paymentAccount.last4,
                                 intentId = result.response.intent?.id,
                                 primaryButtonText = buildPrimaryButtonText(),
                                 mandateText = buildMandateText(),
@@ -328,8 +328,8 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
             is USBankAccountFormScreenState.MandateCollection ->
                 updatePaymentSelection(
                     linkAccountId = screenState.financialConnectionsSessionId,
-                    bankName = screenState.paymentAccount.institutionName,
-                    last4 = screenState.paymentAccount.last4
+                    bankName = screenState.bankName,
+                    last4 = screenState.last4,
                 )
 
             is USBankAccountFormScreenState.VerifyWithMicrodeposits ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -384,13 +384,8 @@ class USBankAccountFormViewModelTest {
             USBankAccountFormScreenState.MandateCollection(
                 financialConnectionsSessionId = "session_1234",
                 intentId = "intent_1234",
-                paymentAccount = FinancialConnectionsAccount(
-                    created = 0,
-                    id = "fc_id",
-                    institutionName = "Stripe Bank",
-                    livemode = false,
-                    supportedPaymentMethodTypes = emptyList(),
-                ),
+                bankName = "Stripe Bank",
+                last4 = null,
                 primaryButtonText = "Continue",
                 mandateText = null,
             ),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request prepares PaymentSheet for the upcoming Instant Debits changes:
1. Adds a new method `create(paymentMethodId, paymentMethodType)` to `ConfirmStripeIntentParamsFactory` to make it easier to create the factory when you don’t have the actual `PaymentMethod` object.
2. Add `bankName` and `last4` to `USBankAccountFormScreenState. MandateCollection` and remove `paymentAccount`, so we can reuse the same state for Instant Debits.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Instant Debits in PaymentSheet.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
