### PR TITLE
Make things that do work happen on the work context in view models.

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -16,6 +16,7 @@
     <ID>LargeClass:CustomerSheetViewModelTest.kt$CustomerSheetViewModelTest</ID>
     <ID>LargeClass:DefaultFlowControllerTest.kt$DefaultFlowControllerTest</ID>
     <ID>LargeClass:DefaultPaymentSheetLoaderTest.kt$DefaultPaymentSheetLoaderTest</ID>
+    <ID>LargeClass:PaymentOptionsViewModelTest.kt$PaymentOptionsViewModelTest</ID>
     <ID>LargeClass:PaymentSheetActivityTest.kt$PaymentSheetActivityTest</ID>
     <ID>LargeClass:PaymentSheetViewModel.kt$PaymentSheetViewModel : BaseSheetViewModel</ID>
     <ID>LargeClass:PaymentSheetViewModelTest.kt$PaymentSheetViewModelTest</ID>
@@ -35,7 +36,6 @@
     <ID>LongMethod:USBankAccountForm.kt$@Composable internal fun BillingDetailsForm( instantDebits: Boolean, formArgs: FormArguments, isProcessing: Boolean, isPaymentFlow: Boolean, nameController: TextFieldController, emailController: TextFieldController, phoneController: PhoneNumberController, addressController: AddressController, lastTextFieldIdentifier: IdentifierSpec?, sameAsShippingElement: SameAsShippingElement?, )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable internal fun USBankAccountForm( formArgs: FormArguments, usBankAccountFormArgs: USBankAccountFormArguments, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable private fun AccountDetailsForm( showCheckbox: Boolean, isProcessing: Boolean, bankName: String?, last4: String?, saveForFutureUseElement: SaveForFutureUseElement, onRemoveAccount: () -> Unit, )</ID>
-    <ID>LongMethod:USBankAccountFormViewModelTest.kt$USBankAccountFormViewModelTest$@Test fun `Restores screen state when re-opening screen`()</ID>
     <ID>MagicNumber:AutocompleteScreen.kt$0.07f</ID>
     <ID>MagicNumber:BaseSheetActivity.kt$BaseSheetActivity$30</ID>
     <ID>MagicNumber:BottomSheet.kt$BottomSheetState$10</ID>

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestRunner.kt
@@ -12,7 +12,6 @@ import com.stripe.android.customersheet.CustomerSheetResultCallback
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.link.account.LinkStore
 import com.stripe.android.paymentsheet.MainActivity
-import java.lang.IllegalStateException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -158,7 +158,7 @@ internal class CustomerSheetViewModel(
         configuration.appearance.parseAppearance()
 
         if (viewState.value is CustomerSheetViewState.Loading) {
-            viewModelScope.launch {
+            viewModelScope.launch(workContext) {
                 loadCustomerSheetState()
             }
         }
@@ -465,7 +465,7 @@ internal class CustomerSheetViewModel(
     }
 
     private fun onItemRemoved(paymentMethod: PaymentMethod) {
-        viewModelScope.launch {
+        viewModelScope.launch(workContext) {
             val result = removePaymentMethod(paymentMethod)
 
             result.fold(
@@ -615,7 +615,7 @@ internal class CustomerSheetViewModel(
     }
 
     private fun removePaymentMethodFromState(paymentMethod: PaymentMethod) {
-        viewModelScope.launch {
+        viewModelScope.launch(workContext) {
             delay(PaymentMethodRemovalDelayMillis)
 
             val newSavedPaymentMethods = viewState.value.savedPaymentMethods - paymentMethod
@@ -725,7 +725,7 @@ internal class CustomerSheetViewModel(
     private fun createAndAttach(
         paymentMethodCreateParams: PaymentMethodCreateParams,
     ) {
-        viewModelScope.launch {
+        viewModelScope.launch(workContext) {
             createPaymentMethod(paymentMethodCreateParams)
                 .onSuccess { paymentMethod ->
                     if (paymentMethod.isUnverifiedUSBankAccount()) {
@@ -908,7 +908,7 @@ internal class CustomerSheetViewModel(
     }
 
     private fun attachPaymentMethodToCustomer(paymentMethod: PaymentMethod) {
-        viewModelScope.launch {
+        viewModelScope.launch(workContext) {
             if (awaitCustomerAdapter().canCreateSetupIntents) {
                 attachWithSetupIntent(paymentMethod = paymentMethod)
             } else {
@@ -1098,7 +1098,7 @@ internal class CustomerSheetViewModel(
     }
 
     private fun selectSavedPaymentMethod(savedPaymentSelection: PaymentSelection.Saved?) {
-        viewModelScope.launch {
+        viewModelScope.launch(workContext) {
             awaitCustomerAdapter().setSelectedPaymentOption(
                 savedPaymentSelection?.toPaymentOption()
             ).onSuccess {
@@ -1118,7 +1118,7 @@ internal class CustomerSheetViewModel(
     }
 
     private fun selectGooglePay() {
-        viewModelScope.launch {
+        viewModelScope.launch(workContext) {
             awaitCustomerAdapter().setSelectedPaymentOption(CustomerAdapter.PaymentOption.GooglePay)
                 .onSuccess {
                     confirmPaymentSelection(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -273,7 +273,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             isDeferred = isDeferred,
         )
 
-        viewModelScope.launch {
+        viewModelScope.launch(workContext) {
             loadPaymentSheetState()
         }
     }
@@ -590,7 +590,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     private fun confirmPaymentSelection(paymentSelection: PaymentSelection?) {
-        viewModelScope.launch {
+        viewModelScope.launch(workContext) {
             val stripeIntent = awaitStripeIntent()
 
             val nextStep = intentConfirmationInterceptor.intercept(
@@ -622,7 +622,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     override fun onPaymentResult(paymentResult: PaymentResult) {
-        viewModelScope.launch {
+        viewModelScope.launch(workContext) {
             val stripeIntent = awaitStripeIntent()
             processPayment(stripeIntent, paymentResult)
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -494,7 +494,7 @@ internal abstract class BaseSheetViewModel(
     fun removePaymentMethod(paymentMethod: PaymentMethod) {
         val paymentMethodId = paymentMethod.id ?: return
 
-        viewModelScope.launch {
+        viewModelScope.launch(workContext) {
             removeDeletedPaymentMethodFromState(paymentMethodId)
             removePaymentMethodInternal(paymentMethodId)
         }
@@ -597,7 +597,7 @@ internal abstract class BaseSheetViewModel(
         val result = removePaymentMethodInternal(paymentMethodId)
 
         if (result.isSuccess) {
-            viewModelScope.launch {
+            viewModelScope.launch(workContext) {
                 onUserBack()
                 delay(PaymentMethodRemovalDelayMillis)
                 removeDeletedPaymentMethodFromState(paymentMethodId = paymentMethodId)
@@ -677,7 +677,7 @@ internal abstract class BaseSheetViewModel(
     abstract val shouldCompleteLinkFlowInline: Boolean
 
     private fun payWithLinkInline(userInput: UserInput?) {
-        viewModelScope.launch {
+        viewModelScope.launch(workContext) {
             linkHandler.payWithLinkInline(
                 userInput = userInput,
                 paymentSelection = selection.value,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.runner.RunWith
@@ -70,7 +71,8 @@ internal class PaymentOptionsViewModelTest {
     private val customerRepository = mock<CustomerRepository>()
 
     @Before
-    fun before() {
+    @After
+    fun resetMainDispatcher() {
         Dispatchers.resetMain()
     }
 
@@ -180,6 +182,7 @@ internal class PaymentOptionsViewModelTest {
         )
 
         viewModel.removePaymentMethod(cards[1])
+        testDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(viewModel.paymentMethods.value)
             .containsExactly(cards[0], cards[2])
@@ -197,6 +200,7 @@ internal class PaymentOptionsViewModelTest {
         assertThat(viewModel.selection.value).isEqualTo(selection)
 
         viewModel.removePaymentMethod(selection.paymentMethod)
+        testDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(viewModel.selection.value).isNull()
     }
@@ -211,6 +215,7 @@ internal class PaymentOptionsViewModelTest {
         )
 
         viewModel.removePaymentMethod(paymentMethod)
+        testDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(viewModel.paymentMethods.value).isEmpty()
         assertThat(viewModel.primaryButtonUiState.value).isNull()
@@ -462,6 +467,7 @@ internal class PaymentOptionsViewModelTest {
         viewModel.paymentOptionResult.test {
             // Simulate user removing the selected payment method
             viewModel.removePaymentMethod(selection.paymentMethod)
+            testDispatcher.scheduler.advanceUntilIdle()
 
             viewModel.onUserCancel()
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I was digging into some test flakes, and I noticed that CustomerSheet was SUPER janky on confirm. We were moving things to corountines via `viewModelScope.launch`. Unfortunately we weren't actually switching off the main thread. Where we're actually doing work that needs to be off the main thread, we should move it!
