### PR TITLE
Handle Instant Debits result in PaymentSheet

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -283,6 +283,12 @@ data class PaymentMethodCreateParams internal constructor(
         return ((toParamMap()["card"] as? Map<*, *>?)?.get("number") as? String)?.takeLast(4)
     }
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun instantDebitsPaymentMethodId(): String? {
+        val linkParams = (toParamMap()["link"] as? Map<*, *>) ?: return null
+        return linkParams["payment_method_id"] as? String
+    }
+
     @Parcelize
     data class Card
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -1127,6 +1133,24 @@ data class PaymentMethodCreateParams internal constructor(
                     consumerSessionClientSecret,
                     extraParams
                 )
+            )
+        }
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet
+        fun createInstantDebits(
+            paymentMethodId: String,
+            requiresMandate: Boolean,
+            productUsage: Set<String>,
+        ): PaymentMethodCreateParams {
+            return PaymentMethodCreateParams(
+                code = PaymentMethod.Type.Link.code,
+                requiresMandate = requiresMandate,
+                overrideParamMap = mapOf(
+                    "link" to mapOf(
+                        "payment_method_id" to paymentMethodId,
+                    ),
+                ),
+                productUsage = productUsage,
             )
         }
 

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1586,6 +1586,14 @@ public final class com/stripe/android/paymentsheet/model/PaymentSelection$New$US
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentsheet/model/PaymentSelection$New$USBankAccount$InstantDebitsInfo$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/model/PaymentSelection$New$USBankAccount$InstantDebitsInfo;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/model/PaymentSelection$New$USBankAccount$InstantDebitsInfo;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/paymentsheet/model/PaymentSelection$Saved$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/model/PaymentSelection$Saved;
@@ -1647,6 +1655,22 @@ public final class com/stripe/android/paymentsheet/paymentdatacollection/ach/USB
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState$MandateCollection;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState$MandateCollection;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState$ResultIdentifier$PaymentMethod$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState$ResultIdentifier$PaymentMethod;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState$ResultIdentifier$PaymentMethod;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState$ResultIdentifier$Session$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState$ResultIdentifier$Session;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState$ResultIdentifier$Session;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptor.kt
@@ -347,10 +347,21 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
             clientSecret = clientSecret,
             shipping = shippingValues,
         )
-        val confirmParams = paramsFactory.create(
-            paymentMethodCreateParams,
-            paymentMethodOptionsParams,
-        )
+
+        val instantDebitsPaymentMethodId = paymentMethodCreateParams.instantDebitsPaymentMethodId()
+
+        val confirmParams = if (instantDebitsPaymentMethodId != null) {
+            // Instant Debits is a new payment selection, but we need to confirm the intent with a PaymentMethod ID.
+            paramsFactory.create(
+                paymentMethodId = instantDebitsPaymentMethodId,
+                paymentMethodType = PaymentMethod.Type.Link,
+            )
+        } else {
+            paramsFactory.create(
+                paymentMethodCreateParams,
+                paymentMethodOptionsParams,
+            )
+        }
 
         return NextStep.Confirm(
             confirmParams = confirmParams,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -153,6 +153,7 @@ internal sealed class PaymentSelection : Parcelable {
             @DrawableRes val iconResource: Int,
             val input: Input,
             val screenState: USBankAccountFormScreenState,
+            val instantDebits: InstantDebitsInfo?,
             override val paymentMethodCreateParams: PaymentMethodCreateParams,
             override val customerRequestedSave: CustomerRequestedSave,
             override val paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,
@@ -167,6 +168,11 @@ internal sealed class PaymentSelection : Parcelable {
             ): String? {
                 return screenState.mandateText
             }
+
+            @Parcelize
+            data class InstantDebitsInfo(
+                val paymentMethodId: String,
+            ) : Parcelable
 
             @Parcelize
             data class Input(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState.kt
@@ -25,9 +25,9 @@ internal sealed class USBankAccountFormScreenState(
 
     @Parcelize
     data class MandateCollection(
-        val bankName: String,
+        val resultIdentifier: ResultIdentifier,
+        val bankName: String?,
         val last4: String?,
-        val financialConnectionsSessionId: String,
         val intentId: String?,
         override val primaryButtonText: String,
         override val mandateText: String?,
@@ -51,4 +51,12 @@ internal sealed class USBankAccountFormScreenState(
         override val primaryButtonText: String,
         override val mandateText: String?,
     ) : USBankAccountFormScreenState()
+
+    internal sealed interface ResultIdentifier : Parcelable {
+        @Parcelize
+        data class Session(val id: String) : ResultIdentifier
+
+        @Parcelize
+        data class PaymentMethod(val id: String) : ResultIdentifier
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -1865,6 +1865,7 @@ class CustomerSheetViewModelTest {
                 address = null,
                 saveForFutureUse = false,
             ),
+            instantDebits = null,
             screenState = USBankAccountFormScreenState.SavedAccount(
                 financialConnectionsSessionId = "session_1234",
                 intentId = "intent_1234",
@@ -2489,6 +2490,7 @@ class CustomerSheetViewModelTest {
                 address = null,
                 saveForFutureUse = false,
             ),
+            instantDebits = null,
             screenState = USBankAccountFormScreenState.SavedAccount(
                 financialConnectionsSessionId = "session_1234",
                 intentId = "intent_1234",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1950,6 +1950,7 @@ internal class PaymentSheetViewModelTest {
                 address = null,
                 saveForFutureUse = false,
             ),
+            instantDebits = null,
             screenState = USBankAccountFormScreenState.SavedAccount(
                 financialConnectionsSessionId = "session_1234",
                 intentId = "intent_1234",
@@ -1990,6 +1991,7 @@ internal class PaymentSheetViewModelTest {
                 address = null,
                 saveForFutureUse = false,
             ),
+            instantDebits = null,
             screenState = USBankAccountFormScreenState.SavedAccount(
                 financialConnectionsSessionId = "session_1234",
                 intentId = "intent_1234",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
@@ -57,6 +57,7 @@ class PaymentSelectionTest {
                     address = null,
                     saveForFutureUse = false,
                 ),
+                instantDebits = null,
                 screenState = USBankAccountFormScreenState.SavedAccount(
                     financialConnectionsSessionId = "session_1234",
                     intentId = "intent_1234",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -281,6 +281,7 @@ class USBankAccountFormViewModelTest {
                     paymentMethodCreateParams = mock(),
                     customerRequestedSave = mock(),
                     input = input,
+                    instantDebits = null,
                     screenState = USBankAccountFormScreenState.SavedAccount(
                         financialConnectionsSessionId = "session_1234",
                         intentId = "intent_1234",
@@ -332,6 +333,7 @@ class USBankAccountFormViewModelTest {
                     paymentMethodCreateParams = mock(),
                     customerRequestedSave = mock(),
                     input = input,
+                    instantDebits = null,
                     screenState = USBankAccountFormScreenState.SavedAccount(
                         financialConnectionsSessionId = "session_1234",
                         intentId = "intent_1234",
@@ -384,7 +386,7 @@ class USBankAccountFormViewModelTest {
                 isProcessing = false,
             ),
             USBankAccountFormScreenState.MandateCollection(
-                financialConnectionsSessionId = "session_1234",
+                resultIdentifier = USBankAccountFormScreenState.ResultIdentifier.Session("session_1234"),
                 intentId = "intent_1234",
                 bankName = "Stripe Bank",
                 last4 = null,
@@ -426,6 +428,7 @@ class USBankAccountFormViewModelTest {
                             address = CUSTOMER_ADDRESS.asAddressModel(),
                             saveForFutureUse = true,
                         ),
+                        instantDebits = null,
                         screenState = screenState,
                     )
                 )
@@ -452,6 +455,7 @@ class USBankAccountFormViewModelTest {
                             address = null,
                             saveForFutureUse = false,
                         ),
+                        instantDebits = null,
                         screenState = USBankAccountFormScreenState.SavedAccount(
                             financialConnectionsSessionId = "session_1234",
                             intentId = "intent_1234",


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request completes the main Instant Debits work (minus deferred intents). We use the existing US Bank Account structs to forward any Instant Debits metadata, and add specific confirmation logic for Instant Debits.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screen recording

<details><summary>Recording</summary>
<p>

[instant-debits-end-to-end.webm](https://github.com/stripe/stripe-android/assets/110940675/1ddc122a-31ed-4e49-8b93-1cc4ab7399f6)

</p>
</details> 

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
