### PR TITLE
Retry failed Browserstack tests

### DIFF
--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-        run: python scripts/browserstack.py --test --apk paymentsheet-example/build/outputs/apk/debug/paymentsheet-example-debug.apk --espresso paymentsheet-example/build/outputs/apk/androidTest/debug/paymentsheet-example-debug-androidTest.apk --is-nightly
+        run: python scripts/browserstack.py --test --apk paymentsheet-example/build/outputs/apk/debug/paymentsheet-example-debug.apk --espresso paymentsheet-example/build/outputs/apk/androidTest/debug/paymentsheet-example-debug-androidTest.apk --is-nightly --num-retries 2
 
       - name: Notify failure endpoint
         id: notifyFailureEndpoint

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -344,7 +344,7 @@ workflows:
       - script@1:
           timeout: 2400
           inputs:
-            - content: python3 scripts/browserstack.py --test --apk paymentsheet-example/build/outputs/apk/debug/paymentsheet-example-debug.apk --espresso paymentsheet-example/build/outputs/apk/androidTest/debug/paymentsheet-example-debug-androidTest.apk
+            - content: python3 scripts/browserstack.py --test --apk paymentsheet-example/build/outputs/apk/debug/paymentsheet-example-debug.apk --espresso paymentsheet-example/build/outputs/apk/androidTest/debug/paymentsheet-example-debug-androidTest.apk --num-retries 2
   check-dependencies:
     envs:
       - INCLUDE_DEPENDENCIES_ON_FAILURE: true

--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -388,7 +388,7 @@ if __name__ == "__main__":
                   testClassesToRun = getFailedTestsForBuild(testResults["buildId"])
                   os.environ["BROWSERSTACK_RERUN"]="true"
 
-           del os.environ["BROWSERSTACK_RERUN"]
+           os.environ["BROWSERSTACK_RERUN"]="false"
            sys.exit(exitStatus)
     else:
        parser.print_help()

--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -264,7 +264,7 @@ def confirm(message):
     return answer == "y"
 
 def run_tests(appUrl, testUrl, isNightly, testClasses):
-   print("RUNNING " + str({len(testClasses)}) + " test cases")
+   print("RUNNING " + str(len(testClasses)) + " test cases")
    buildId = executeTests(appUrl, testUrl, isNightly, testClasses)
    exitStatus = 1
    if(buildId != None):

--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -186,7 +186,7 @@ def executeTests(appUrl, testUrl, isNightly, testClasses):
     url="https://api-cloud.browserstack.com/app-automate/espresso/v2/build"
     # firefox doesn't work on this samsung: Samsung Galaxy S9 Plus-9.0"]
     shards = testShards(isNightly, testClasses)
-    running_all_tests = len(testClasses) == len(get_all_test_class_names())
+    runningAllTests = len(testClasses) == len(get_all_test_class_names())
     devices = []
     if isNightly:
         devices = [
@@ -212,7 +212,7 @@ def executeTests(appUrl, testUrl, isNightly, testClasses):
             "numberOfShards": len(shards),
             "mapping": shards,
          },
-         "class": None if running_all_tests else testClasses
+         "class": None if runningAllTests else testClasses
       }, auth=(user, authKey))
     jsonResponse = response.json()
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Retry failed Browserstack tests

Browserstack allows us to retry failed test classes (not individual test cases). We can do this by:
- Getting all the failed test classes for a given test build by iterating through all sessions and test cases in that build.
- Re-running the failed test classes by passing the "class" parameter to the build endpoint. This parameter filters our test suite down to just the specified test classes. 

Changes include:
- Update Browserstack script to retry failed test cases
- Update our nightly runs + CI runs to retry twice

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Our Browserstack tests frequently fail due to flaky tests, this reduces the burden on us to manually retry.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Example output for a test run which failed on the first attempt, then retried one test case and then succeeded:
```
Running the test with:
App under test: paymentsheet-example/build/outputs/apk/debug/paymentsheet-example-debug.apk
Espresso test suite: paymentsheet-example/build/outputs/apk/androidTest/debug/paymentsheet-example-debug-androidTest.apk
-----------------
UPLOADING the file: paymentsheet-example/build/outputs/apk/debug/paymentsheet-example-debug.apk...DONE
RESULT app url: bs://aae6928fc552fec1a688e84a1a2c099a438e388d
-----------------
UPLOADING the file: paymentsheet-example/build/outputs/apk/androidTest/debug/paymentsheet-example-debug-androidTest.apk...DONE
RESULT test url: bs://74d1d2932739e009bb4fa05db22958f8cf7f9f21
-----------------
RUNNING 36 test cases
RUNNING the tests (appUrl: bs://aae6928fc552fec1a688e84a1a2c099a438e388d, testUrl: bs://74d1d2932739e009bb4fa05db22958f8cf7f9f21)...DONE
RESULT build Started: Success
RESULT build id: ba5fe5b7db823fdae6e4da4ea30007a7b253e6a4
RESULT see build here: https://app-automate.browserstack.com/dashboard/v2/builds/ba5fe5b7db823fdae6e4da4ea30007a7b253e6a4
WAITING for build id: ba5fe5b7db823fdae6e4da4ea30007a7b253e6a4..................................................DONE.
RESULT is: failed
-----------------
RUNNING 1 test cases
RUNNING the tests (appUrl: bs://aae6928fc552fec1a688e84a1a2c099a438e388d, testUrl: bs://74d1d2932739e009bb4fa05db22958f8cf7f9f21)...DONE
RESULT build Started: Success
RESULT build id: 05d44508ccb0625cb6c6da404348078adbb88a2e
RESULT see build here: https://app-automate.browserstack.com/dashboard/v2/builds/05d44508ccb0625cb6c6da404348078adbb88a2e
WAITING for build id: 05d44508ccb0625cb6c6da404348078adbb88a2e................DONE.
RESULT is: passed
-----------------
```

Example output when a test is actually failing:
```
Running the test with:
App under test: paymentsheet-example/build/outputs/apk/debug/paymentsheet-example-debug.apk
Espresso test suite: paymentsheet-example/build/outputs/apk/androidTest/debug/paymentsheet-example-debug-androidTest.apk
-----------------
UPLOADING the file: paymentsheet-example/build/outputs/apk/debug/paymentsheet-example-debug.apk...DONE
RESULT app url: bs://aae6928fc552fec1a688e84a1a2c099a438e388d
-----------------
UPLOADING the file: paymentsheet-example/build/outputs/apk/androidTest/debug/paymentsheet-example-debug-androidTest.apk...DONE
RESULT test url: bs://0f81f766ba202f670319584e11bf18fd62b00feb
-----------------
RUNNING 36 test cases
RUNNING the tests (appUrl: bs://aae6928fc552fec1a688e84a1a2c099a438e388d, testUrl: bs://0f81f766ba202f670319584e11bf18fd62b00feb)...DONE
RESULT build Started: Success
RESULT build id: e5dc0a274f8958fb8d705fccf7025754d871c9dd
RESULT see build here: https://app-automate.browserstack.com/dashboard/v2/builds/e5dc0a274f8958fb8d705fccf7025754d871c9dd
WAITING for build id: e5dc0a274f8958fb8d705fccf7025754d871c9dd.................................................DONE.
RESULT is: failed
-----------------
RUNNING 3 test cases
RUNNING the tests (appUrl: bs://aae6928fc552fec1a688e84a1a2c099a438e388d, testUrl: bs://0f81f766ba202f670319584e11bf18fd62b00feb)...DONE
RESULT build Started: Success
RESULT build id: 103163f9782db35ba96551fb5797c863e4ee0a2f
RESULT see build here: https://app-automate.browserstack.com/dashboard/v2/builds/103163f9782db35ba96551fb5797c863e4ee0a2f
WAITING for build id: 103163f9782db35ba96551fb5797c863e4ee0a2f................DONE.
RESULT is: failed
-----------------
RUNNING 1 test cases
RUNNING the tests (appUrl: bs://aae6928fc552fec1a688e84a1a2c099a438e388d, testUrl: bs://0f81f766ba202f670319584e11bf18fd62b00feb)...DONE
RESULT build Started: Success
RESULT build id: 2ce3e6333b9cef262d978fd36bf2c429c2430cac
RESULT see build here: https://app-automate.browserstack.com/dashboard/v2/builds/2ce3e6333b9cef262d978fd36bf2c429c2430cac
WAITING for build id: 2ce3e6333b9cef262d978fd36bf2c429c2430cac...........DONE.
RESULT is: failed
-----------------
```
The final failed test case was the actual failure. 