### PR TITLE
[FC] Launch ID non-native flow and collect result


### DIFF
--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -640,6 +640,14 @@ public final class com/stripe/android/financialconnections/launcher/FinancialCon
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/financialconnections/launcher/InstantDebitsResult$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/launcher/InstantDebitsResult;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/financialconnections/launcher/InstantDebitsResult;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/financialconnections/model/AccountHolder : android/os/Parcelable, com/stripe/android/core/model/StripeModel {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -439,27 +439,27 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
     }
 
     private fun onSuccessFromInstantDebits(url: Uri) {
-        kotlin.runCatching {
-            requireNotNull(url.getQueryParameter(QUERY_PARAM_PAYMENT_METHOD_ID))
-        }.onSuccess { paymentMethodId ->
-            withState {
-                finishWithResult(
-                    state = it,
-                    result = Completed(
-                        instantDebits = InstantDebitsResult(
-                            paymentMethodId = paymentMethodId,
-                            last4 = url.getQueryParameter(QUERY_PARAM_LAST4),
-                            bankName = url.getQueryParameter(QUERY_BANK_NAME)
-                        ),
-                        financialConnectionsSession = null,
-                        token = null
+        runCatching { requireNotNull(url.getQueryParameter(QUERY_PARAM_PAYMENT_METHOD_ID)) }
+            .onSuccess { paymentMethodId ->
+                withState {
+                    finishWithResult(
+                        state = it,
+                        result = Completed(
+                            instantDebits = InstantDebitsResult(
+                                paymentMethodId = paymentMethodId,
+                                last4 = url.getQueryParameter(QUERY_PARAM_LAST4),
+                                bankName = url.getQueryParameter(QUERY_BANK_NAME)
+                            ),
+                            financialConnectionsSession = null,
+                            token = null
+                        )
                     )
-                )
+                }
             }
-        }.onFailure { error ->
-            logger.error("Could not retrieve linked account from success url", error)
-            finishWithResult(stateFlow.value, Failed(error))
-        }
+            .onFailure { error ->
+                logger.error("Could not retrieve payment method parameters from success url", error)
+                finishWithResult(stateFlow.value, Failed(error))
+            }
     }
 
     private fun onFlowCancelled(state: FinancialConnectionsSheetState) {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -44,6 +44,7 @@ import com.stripe.android.financialconnections.launcher.FinancialConnectionsShee
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityResult.Canceled
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityResult.Completed
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityResult.Failed
+import com.stripe.android.financialconnections.launcher.InstantDebitsResult
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
@@ -437,9 +438,28 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
         }
     }
 
-    @Suppress("UNUSED_PARAMETER")
     private fun onSuccessFromInstantDebits(url: Uri) {
-        TODO("Instant Debits flow not yet implemented")
+        kotlin.runCatching {
+            requireNotNull(url.getQueryParameter(QUERY_PARAM_PAYMENT_METHOD_ID))
+        }.onSuccess { paymentMethodId ->
+            withState {
+                finishWithResult(
+                    state = it,
+                    result = Completed(
+                        instantDebits = InstantDebitsResult(
+                            paymentMethodId = paymentMethodId,
+                            last4 = url.getQueryParameter(QUERY_PARAM_LAST4),
+                            bankName = url.getQueryParameter(QUERY_BANK_NAME)
+                        ),
+                        financialConnectionsSession = null,
+                        token = null
+                    )
+                )
+            }
+        }.onFailure { error ->
+            logger.error("Could not retrieve linked account from success url", error)
+            finishWithResult(stateFlow.value, Failed(error))
+        }
     }
 
     private fun onFlowCancelled(state: FinancialConnectionsSheetState) {
@@ -503,6 +523,9 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
         }
 
         internal const val MAX_ACCOUNTS = 100
+        internal const val QUERY_PARAM_PAYMENT_METHOD_ID = "payment_method_id"
+        internal const val QUERY_PARAM_LAST4 = "last4"
+        internal const val QUERY_BANK_NAME = "bank_name"
     }
 
     override fun updateTopAppBar(state: FinancialConnectionsSheetState): TopAppBarStateUpdate? {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetActivityResult.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetActivityResult.kt
@@ -53,7 +53,7 @@ internal sealed class FinancialConnectionsSheetActivityResult : Parcelable {
 }
 
 @Parcelize
-data class InstantDebitsResult(
+internal data class InstantDebitsResult(
     val paymentMethodId: String,
     val last4: String?,
     val bankName: String?

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetActivityResult.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetActivityResult.kt
@@ -19,8 +19,8 @@ internal sealed class FinancialConnectionsSheetActivityResult : Parcelable {
      */
     @Parcelize
     data class Completed(
-        // Instant Debits: just return payment method id
-        val paymentMethodId: String? = null,
+        // Instant Debits sessions: return payment method id and bank details.
+        val instantDebits: InstantDebitsResult? = null,
         // non-Link sessions: return full LinkedAccountSession
         val financialConnectionsSession: FinancialConnectionsSession? = null,
         // Bank account Token sessions: session + token.
@@ -51,3 +51,10 @@ internal sealed class FinancialConnectionsSheetActivityResult : Parcelable {
             "com.stripe.android.financialconnections.ConnectionsSheetContract.extra_result"
     }
 }
+
+@Parcelize
+data class InstantDebitsResult(
+    val paymentMethodId: String,
+    val last4: String?,
+    val bankName: String?
+) : Parcelable

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForInstantDebitsContract.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForInstantDebitsContract.kt
@@ -40,7 +40,7 @@ class FinancialConnectionsSheetForInstantDebitsContract :
         is FinancialConnectionsSheetActivityResult.Canceled -> Canceled
         is FinancialConnectionsSheetActivityResult.Failed -> Failed(error)
         is FinancialConnectionsSheetActivityResult.Completed -> when (instantDebits) {
-            null -> Failed(IllegalArgumentException("payment method id is missing"))
+            null -> Failed(IllegalArgumentException("Instant debits result is missing"))
             else -> Completed(
                 paymentMethodId = instantDebits.paymentMethodId,
                 last4 = instantDebits.last4,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForInstantDebitsContract.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForInstantDebitsContract.kt
@@ -39,10 +39,13 @@ class FinancialConnectionsSheetForInstantDebitsContract :
         FinancialConnectionsSheetInstantDebitsResult = when (this) {
         is FinancialConnectionsSheetActivityResult.Canceled -> Canceled
         is FinancialConnectionsSheetActivityResult.Failed -> Failed(error)
-        is FinancialConnectionsSheetActivityResult.Completed -> when (paymentMethodId) {
-            null -> Failed(IllegalArgumentException("linkedAccountId not set for this session"))
-
-            else -> Completed(paymentMethodId)
+        is FinancialConnectionsSheetActivityResult.Completed -> when (instantDebits) {
+            null -> Failed(IllegalArgumentException("payment method id is missing"))
+            else -> Completed(
+                paymentMethodId = instantDebits.paymentMethodId,
+                last4 = instantDebits.last4,
+                bankName = instantDebits.bankName
+            )
         }
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForInstantDebitsLauncher.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForInstantDebitsLauncher.kt
@@ -2,8 +2,11 @@ package com.stripe.android.financialconnections.launcher
 
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.ActivityResultRegistry
 import androidx.annotation.RestrictTo
+import androidx.fragment.app.Fragment
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
+import org.jetbrains.annotations.TestOnly
 
 @Suppress("unused")
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -17,6 +20,19 @@ class FinancialConnectionsSheetForInstantDebitsLauncher(
     ) : this(
         activity.registerForActivityResult(
             FinancialConnectionsSheetForInstantDebitsContract(),
+            callback::invoke
+        )
+    )
+
+    @TestOnly
+    internal constructor(
+        fragment: Fragment,
+        registry: ActivityResultRegistry,
+        callback: (FinancialConnectionsSheetInstantDebitsResult) -> Unit
+    ) : this(
+        fragment.registerForActivityResult(
+            FinancialConnectionsSheetForInstantDebitsContract(),
+            registry,
             callback::invoke
         )
     )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetInstantDebitsResult.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetInstantDebitsResult.kt
@@ -11,12 +11,16 @@ import kotlinx.parcelize.Parcelize
 sealed class FinancialConnectionsSheetInstantDebitsResult : Parcelable {
     /**
      * The customer completed the connections session.
-     * @param paymentMethodId
+     * @param paymentMethodId The payment method id, that can be used to confirm the payment.
+     * @param last4 The last 4 digits of the bank account.
+     * @param bankName The name of the bank.
      */
     @Parcelize
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class Completed(
-        val paymentMethodId: String
+        val paymentMethodId: String,
+        val last4: String?,
+        val bankName: String?
     ) : FinancialConnectionsSheetInstantDebitsResult()
 
     /**

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForInstantDebitsLauncherTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForInstantDebitsLauncherTest.kt
@@ -1,0 +1,76 @@
+package com.stripe.android.financialconnections.launcher
+
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.lifecycle.Lifecycle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.financialconnections.FinancialConnectionsSheet
+import com.stripe.android.financialconnections.utils.FakeActivityResultRegistry
+import com.stripe.android.financialconnections.utils.TestFragment
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class FinancialConnectionsSheetForInstantDebitsLauncherTest {
+
+    private val configuration = FinancialConnectionsSheet.Configuration("", "")
+
+    @Test
+    fun `create and present should return expected ConnectionsSheetResult#Completed`() {
+        val testRegistry = FakeActivityResultRegistry(
+            FinancialConnectionsSheetInstantDebitsResult.Completed(
+                paymentMethodId = "pm_123",
+                last4 = "1234",
+                bankName = "Bank of America",
+            )
+        )
+
+        with(
+            launchFragmentInContainer(initialState = Lifecycle.State.CREATED) { TestFragment() }
+        ) {
+            onFragment { fragment ->
+                val results = mutableListOf<FinancialConnectionsSheetInstantDebitsResult>()
+                val launcher = FinancialConnectionsSheetForInstantDebitsLauncher(
+                    fragment,
+                    testRegistry
+                ) {
+                    results.add(it)
+                }
+
+                moveToState(Lifecycle.State.RESUMED)
+                launcher.present(configuration)
+                assertThat(results)
+                    .containsExactly(
+                        FinancialConnectionsSheetInstantDebitsResult.Completed(
+                            paymentMethodId = "pm_123",
+                            last4 = "1234",
+                            bankName = "Bank of America",
+                        )
+                    )
+            }
+        }
+    }
+
+    @Test
+    fun `create and present should return expected ConnectionsSheetResult#Cancelled`() {
+        val testRegistry = FakeActivityResultRegistry(FinancialConnectionsSheetInstantDebitsResult.Canceled)
+
+        with(
+            launchFragmentInContainer(initialState = Lifecycle.State.CREATED) { TestFragment() }
+        ) {
+            onFragment { fragment ->
+                val results = mutableListOf<FinancialConnectionsSheetInstantDebitsResult>()
+                val launcher = FinancialConnectionsSheetForInstantDebitsLauncher(
+                    fragment,
+                    testRegistry
+                ) {
+                    results.add(it)
+                }
+
+                moveToState(Lifecycle.State.RESUMED)
+                launcher.present(configuration)
+                assertThat(results).containsExactly(FinancialConnectionsSheetInstantDebitsResult.Canceled)
+            }
+        }
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/navigation/CollectBankAccountResultInternal.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/navigation/CollectBankAccountResultInternal.kt
@@ -52,7 +52,7 @@ data class CollectBankAccountResponseInternal(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class InstantDebitsData(
         val paymentMethodId: String,
-        val last4: String,
-        val bankName: String
+        val last4: String?,
+        val bankName: String?
     ) : StripeModel
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/financialconnections/FinancialConnectionsPaymentsProxy.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/financialconnections/FinancialConnectionsPaymentsProxy.kt
@@ -5,7 +5,10 @@ import com.stripe.android.BuildConfig
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.FinancialConnectionsSheetResult
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetForDataLauncher
+import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetForInstantDebitsLauncher
+import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetInstantDebitsResult
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetLauncher
+import kotlin.reflect.KFunction1
 
 /**
  * Proxy to access financial connections code safely in payments.
@@ -22,10 +25,10 @@ internal interface FinancialConnectionsPaymentsProxy {
 
         fun createForInstantDebits(
             activity: AppCompatActivity,
-            onComplete: (FinancialConnectionsSheetResult) -> Unit,
+            onComplete: KFunction1<FinancialConnectionsSheetInstantDebitsResult, Unit>,
             provider: () -> FinancialConnectionsPaymentsProxy = {
                 FinancialConnectionsLauncherProxy(
-                    FinancialConnectionsSheetForDataLauncher(
+                    FinancialConnectionsSheetForInstantDebitsLauncher(
                         activity,
                         onComplete
                     )
@@ -34,7 +37,7 @@ internal interface FinancialConnectionsPaymentsProxy {
             isFinancialConnectionsAvailable: IsFinancialConnectionsAvailable = DefaultIsFinancialConnectionsAvailable
         ): FinancialConnectionsPaymentsProxy {
             return if (isFinancialConnectionsAvailable()) {
-                TODO("Instant Debits not implemented yet.")
+                provider()
             } else {
                 UnsupportedFinancialConnectionsPaymentsProxy()
             }

--- a/payments-core/src/main/java/com/stripe/android/payments/financialconnections/FinancialConnectionsPaymentsProxy.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/financialconnections/FinancialConnectionsPaymentsProxy.kt
@@ -8,7 +8,6 @@ import com.stripe.android.financialconnections.launcher.FinancialConnectionsShee
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetForInstantDebitsLauncher
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetInstantDebitsResult
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetLauncher
-import kotlin.reflect.KFunction1
 
 /**
  * Proxy to access financial connections code safely in payments.
@@ -25,7 +24,7 @@ internal interface FinancialConnectionsPaymentsProxy {
 
         fun createForInstantDebits(
             activity: AppCompatActivity,
-            onComplete: KFunction1<FinancialConnectionsSheetInstantDebitsResult, Unit>,
+            onComplete: (FinancialConnectionsSheetInstantDebitsResult) -> Unit,
             provider: () -> FinancialConnectionsPaymentsProxy = {
                 FinancialConnectionsLauncherProxy(
                     FinancialConnectionsSheetForInstantDebitsLauncher(


### PR DESCRIPTION
# Summary
- Parses ID result from FC SDK and passes it down to CollectBankAccount.

# Motivation
:notebook_with_decorative_cover: &nbsp;**Launch ID non-native flow and collect result**
:globe_with_meridians: &nbsp;[BANKCON-10027](https://jira.corp.stripe.com/browse/BANKCON-10027)
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->