### PR TITLE
Validate network requests before successful completion.

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -28,16 +28,16 @@ pipelines:
 stages:
   stage-trigger-run-all:
     workflows:
-#      - check: { }
-#      - test: { }
-#      - run-instrumentation-tests: { }
+      - check: { }
+      - test: { }
+      - run-instrumentation-tests: { }
       - run-paymentsheet-instrumentation-tests: { }
-#      - run-example-instrumentation-tests: { }
-#      - run-financial-connections-instrumentation-tests: { }
-#      - run-cardscan-instrumentation-tests: { }
-#      - run-paymentsheet-end-to-end-tests: { }
-#      - run-paymentsheet-screenshot-tests: { }
-#      - check-dependencies: { }
+      - run-example-instrumentation-tests: { }
+      - run-financial-connections-instrumentation-tests: { }
+      - run-cardscan-instrumentation-tests: { }
+      - run-paymentsheet-end-to-end-tests: { }
+      - run-paymentsheet-screenshot-tests: { }
+      - check-dependencies: { }
   stage-build-connections-debug:
     workflows:
       - build-connections-debug: { }

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -28,16 +28,16 @@ pipelines:
 stages:
   stage-trigger-run-all:
     workflows:
-      - check: { }
-      - test: { }
-      - run-instrumentation-tests: { }
+#      - check: { }
+#      - test: { }
+#      - run-instrumentation-tests: { }
       - run-paymentsheet-instrumentation-tests: { }
-      - run-example-instrumentation-tests: { }
-      - run-financial-connections-instrumentation-tests: { }
-      - run-cardscan-instrumentation-tests: { }
-      - run-paymentsheet-end-to-end-tests: { }
-      - run-paymentsheet-screenshot-tests: { }
-      - check-dependencies: { }
+#      - run-example-instrumentation-tests: { }
+#      - run-financial-connections-instrumentation-tests: { }
+#      - run-cardscan-instrumentation-tests: { }
+#      - run-paymentsheet-end-to-end-tests: { }
+#      - run-paymentsheet-screenshot-tests: { }
+#      - check-dependencies: { }
   stage-build-connections-debug:
     workflows:
       - build-connections-debug: { }

--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
@@ -47,17 +47,23 @@ internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dis
     }
 
     fun validate() {
+        val exceptionMessage = StringBuilder()
         if (hasResponsesInQueue()) {
-            throw IllegalStateException(
-                "Mock responses is not empty. Remaining: ${numberRemainingInQueue()}.\nRemaining Matchers: " +
+            exceptionMessage.append(
+                "Mock responses is not empty. Remaining: ${enqueuedResponses.size}.\nRemaining Matchers: " +
                     remainingMatchersDescription()
             )
         }
-        val extraRequests = extraRequestDescriptions()
         if (extraRequests.isNotEmpty()) {
-            throw IllegalStateException(
-                "Extra Requests: $extraRequests"
+            if (exceptionMessage.isNotEmpty()) {
+                exceptionMessage.append('\n')
+            }
+            exceptionMessage.append(
+                "Extra requests is not empty. Remaining: ${extraRequests.size}.\n${extraRequestDescriptions()}"
             )
+        }
+        if (exceptionMessage.isNotEmpty()) {
+            throw IllegalStateException(exceptionMessage.toString())
         }
     }
 
@@ -73,10 +79,6 @@ internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dis
             timeWaited = timeWaited.plus(sleepDuration)
         }
         return enqueuedResponses.size != 0
-    }
-
-    private fun numberRemainingInQueue(): Int {
-        return enqueuedResponses.size
     }
 
     private fun remainingMatchersDescription(): String {

--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
@@ -46,7 +46,22 @@ internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dis
         extraRequests.clear()
     }
 
-    fun hasResponsesInQueue(): Boolean {
+    fun validate() {
+        if (hasResponsesInQueue()) {
+            throw IllegalStateException(
+                "Mock responses is not empty. Remaining: ${numberRemainingInQueue()}.\nRemaining Matchers: " +
+                    remainingMatchersDescription()
+            )
+        }
+        val extraRequests = extraRequestDescriptions()
+        if (extraRequests.isNotEmpty()) {
+            throw IllegalStateException(
+                "Extra Requests: $extraRequests"
+            )
+        }
+    }
+
+    private fun hasResponsesInQueue(): Boolean {
         if (validationTimeout == null) {
             return enqueuedResponses.size != 0
         }
@@ -60,15 +75,15 @@ internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dis
         return enqueuedResponses.size != 0
     }
 
-    fun numberRemainingInQueue(): Int {
+    private fun numberRemainingInQueue(): Int {
         return enqueuedResponses.size
     }
 
-    fun remainingMatchersDescription(): String {
+    private fun remainingMatchersDescription(): String {
         return enqueuedResponses.joinToString { it.requestMatcher.toString() }
     }
 
-    fun extraRequestDescriptions(): String {
+    private fun extraRequestDescriptions(): String {
         return extraRequests.joinToString { it.requestUrl.toString() }
     }
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
@@ -50,6 +50,7 @@ internal class CustomerSheetTest {
         @TestParameter(valuesProvider = CustomerSheetTestTypeProvider::class)
         customerSheetTestType: CustomerSheetTestType,
     ) = activityScenarioRule.runCustomerSheetTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         customerSheetTestType = customerSheetTestType,
         resultCallback = { result ->
@@ -96,6 +97,7 @@ internal class CustomerSheetTest {
 
     @Test
     fun testSavedCardReturnedInResultCallback() = activityScenarioRule.runCustomerSheetTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         customerSheetTestType = CustomerSheetTestType.AttachToSetupIntent,
         resultCallback = { result ->
@@ -148,6 +150,7 @@ internal class CustomerSheetTest {
         @TestParameter(valuesProvider = CustomerSheetTestTypeProvider::class)
         customerSheetTestType: CustomerSheetTestType,
     ) = activityScenarioRule.runCustomerSheetTest(
+        networkRule = networkRule,
         configuration = CustomerSheet.Configuration.builder("Merchant, Inc.")
             .billingDetailsCollectionConfiguration(
                 PaymentSheet.BillingDetailsCollectionConfiguration(
@@ -211,6 +214,7 @@ internal class CustomerSheetTest {
         @TestParameter(valuesProvider = CustomerSheetTestTypeProvider::class)
         customerSheetTestType: CustomerSheetTestType,
     ) = activityScenarioRule.runCustomerSheetTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         customerSheetTestType = customerSheetTestType,
         resultCallback = { result ->
@@ -265,6 +269,7 @@ internal class CustomerSheetTest {
 
     @Test
     fun testCardNotAttachedOnError() = activityScenarioRule.runCustomerSheetTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         customerSheetTestType = CustomerSheetTestType.AttachToSetupIntent,
         resultCallback = {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -40,6 +40,7 @@ internal class FlowControllerTest {
     fun testSuccessfulCardPayment(
         @TestParameter integrationType: IntegrationType,
     ) = composeTestRule.activityRule.runFlowControllerTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
             assertThat(paymentOption?.label).endsWith("4242")
@@ -81,6 +82,7 @@ internal class FlowControllerTest {
     fun testFailedElementsSessionCall(
         @TestParameter integrationType: IntegrationType,
     ) = composeTestRule.activityRule.runFlowControllerTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
             assertThat(paymentOption?.label).endsWith("4242")
@@ -130,6 +132,7 @@ internal class FlowControllerTest {
         @TestParameter integrationType: IntegrationType,
     ) {
         composeTestRule.activityRule.runFlowControllerTest(
+            networkRule = networkRule,
             integrationType = integrationType,
             paymentOptionCallback = { paymentOption ->
                 assertThat(paymentOption?.label).endsWith("4242")
@@ -309,6 +312,7 @@ internal class FlowControllerTest {
     fun testDeferredIntentCardPayment(
         @TestParameter integrationType: IntegrationType,
     ) = composeTestRule.activityRule.runFlowControllerTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         createIntentCallback = { _, _ -> CreateIntentResult.Success("pi_example_secret_example") },
         paymentOptionCallback = { paymentOption ->
@@ -380,6 +384,7 @@ internal class FlowControllerTest {
     fun testDeferredIntentFailedCardPayment(
         @TestParameter integrationType: IntegrationType,
     ) = composeTestRule.activityRule.runFlowControllerTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         createIntentCallback = { _, _ ->
             CreateIntentResult.Failure(
@@ -441,6 +446,7 @@ internal class FlowControllerTest {
     fun testDeferredIntentCardPaymentWithForcedSuccess(
         @TestParameter integrationType: IntegrationType,
     ) = composeTestRule.activityRule.runFlowControllerTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         createIntentCallback = { _, _ ->
             CreateIntentResult.Success(PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT)
@@ -494,6 +500,7 @@ internal class FlowControllerTest {
     fun testDeferredIntentCardPaymentWithInvalidStripeIntent(
         @TestParameter integrationType: IntegrationType,
     ) = composeTestRule.activityRule.runFlowControllerTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         createIntentCallback = { _, _ -> CreateIntentResult.Success("pi_example_secret_example") },
         paymentOptionCallback = { paymentOption ->

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
@@ -46,6 +46,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUp() = activityScenarioRule.runLinkTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
             assertThat(paymentOption?.label).endsWith("4242")
@@ -129,6 +130,7 @@ internal class LinkTest {
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUpAndSaveForFutureUsage() =
         activityScenarioRule.runLinkTest(
+            networkRule = networkRule,
             integrationType = integrationType,
             paymentOptionCallback = { paymentOption ->
                 assertThat(paymentOption?.label).endsWith("4242")
@@ -243,6 +245,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUpAndCardBrandChoice() = activityScenarioRule.runLinkTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
             assertThat(paymentOption?.label).endsWith("4242")
@@ -330,6 +333,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUpAndLinkPassthroughMode() = activityScenarioRule.runLinkTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
             assertThat(paymentOption?.label).endsWith("4242")
@@ -428,6 +432,7 @@ internal class LinkTest {
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUpAndLinkPassthroughModeAndSaveForFutureUsage() =
         activityScenarioRule.runLinkTest(
+            networkRule = networkRule,
             integrationType = integrationType,
             paymentOptionCallback = { paymentOption ->
                 assertThat(paymentOption?.label).endsWith("4242")
@@ -549,6 +554,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUpPassthroughModeAndCardBrandChoice() = activityScenarioRule.runLinkTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
             assertThat(paymentOption?.label).endsWith("1001")
@@ -651,6 +657,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUpFailure() = activityScenarioRule.runLinkTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
             assertThat(paymentOption?.label).endsWith("4242")
@@ -709,6 +716,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUpFailureInPassthroughMode() = activityScenarioRule.runLinkTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
             assertThat(paymentOption?.label).endsWith("4242")
@@ -767,6 +775,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUpShareFailureInPassthroughMode() = activityScenarioRule.runLinkTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
             assertThat(paymentOption?.label).endsWith("4242")
@@ -832,6 +841,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithExistingLinkEmailUsed() = activityScenarioRule.runLinkTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
             assertThat(paymentOption?.label).endsWith("4242")
@@ -882,6 +892,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithLinkPreviouslyUsed() = activityScenarioRule.runLinkTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
             assertThat(paymentOption?.label).endsWith("4242")
@@ -917,6 +928,7 @@ internal class LinkTest {
 
     @Test
     fun testLogoutAfterLinkTransaction() = activityScenarioRule.runLinkTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
             assertThat(paymentOption?.label).endsWith("4242")
@@ -998,6 +1010,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUpWithAlbaniaPhoneNumber() = activityScenarioRule.runLinkTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
             assertThat(paymentOption?.label).endsWith("4242")

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
@@ -44,6 +44,7 @@ internal class PaymentSheetAnalyticsTest {
 
     @Test
     fun testSuccessfulCardPayment() = activityScenarioRule.runPaymentSheetTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -102,6 +103,7 @@ internal class PaymentSheetAnalyticsTest {
 
     @Test
     fun testSuccessfulCardPaymentInFlowController() = activityScenarioRule.runFlowControllerTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
             assertThat(paymentOption?.label).endsWith("4242")

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -39,6 +39,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testSuccessfulCardPayment() = activityScenarioRule.runPaymentSheetTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -71,6 +72,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testSocketErrorCardPayment() = activityScenarioRule.runPaymentSheetTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::expectNoResult,
     ) { testContext ->
@@ -105,6 +107,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testInsufficientFundsCardPayment() = activityScenarioRule.runPaymentSheetTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::expectNoResult,
     ) { testContext ->
@@ -140,6 +143,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testSuccessfulDelayedSuccessPayment() = activityScenarioRule.runPaymentSheetTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -178,6 +182,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testFailureWhenSetupRequestsFail() = activityScenarioRule.runPaymentSheetTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertFailed,
     ) { testContext ->
@@ -205,6 +210,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testDeferredIntentCardPayment() = activityScenarioRule.runPaymentSheetTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         createIntentCallback = { _, _ -> CreateIntentResult.Success("pi_example_secret_example") },
         resultCallback = ::assertCompleted,
@@ -266,6 +272,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testDeferredIntentFailedCardPayment() = activityScenarioRule.runPaymentSheetTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         createIntentCallback = { _, _ ->
             CreateIntentResult.Failure(
@@ -316,6 +323,7 @@ internal class PaymentSheetTest {
     @OptIn(DelicatePaymentSheetApi::class)
     @Test
     fun testDeferredIntentCardPaymentWithForcedSuccess() = activityScenarioRule.runPaymentSheetTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         createIntentCallback = { _, _ ->
             CreateIntentResult.Success(PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT)
@@ -359,6 +367,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testPaymentIntentWithCardBrandChoiceSuccess() = activityScenarioRule.runPaymentSheetTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -395,6 +404,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testPaymentIntentReturnsFailureWhenAlreadySucceeded() = activityScenarioRule.runPaymentSheetTest(
+        networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertFailed,
     ) { testContext ->

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestRunner.kt
@@ -11,6 +11,7 @@ import com.stripe.android.customersheet.CustomerSheetActivity
 import com.stripe.android.customersheet.CustomerSheetResultCallback
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.link.account.LinkStore
+import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.paymentsheet.MainActivity
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -37,6 +38,7 @@ internal class CustomerSheetTestRunnerContext(
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 internal fun ActivityScenarioRule<MainActivity>.runCustomerSheetTest(
+    networkRule: NetworkRule,
     integrationType: IntegrationType,
     customerSheetTestType: CustomerSheetTestType,
     configuration: CustomerSheet.Configuration = CustomerSheet.Configuration(
@@ -58,6 +60,7 @@ internal fun ActivityScenarioRule<MainActivity>.runCustomerSheetTest(
     )
 
     runCustomerSheetTest(
+        networkRule = networkRule,
         countDownLatch = countDownLatch,
         makeCustomerSheet = factory::make,
         block = block,
@@ -66,6 +69,7 @@ internal fun ActivityScenarioRule<MainActivity>.runCustomerSheetTest(
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 private fun ActivityScenarioRule<MainActivity>.runCustomerSheetTest(
+    networkRule: NetworkRule,
     countDownLatch: CountDownLatch,
     makeCustomerSheet: (ComponentActivity) -> CustomerSheet,
     block: (CustomerSheetTestRunnerContext) -> Unit,
@@ -94,5 +98,7 @@ private fun ActivityScenarioRule<MainActivity>.runCustomerSheetTest(
     )
     block(testContext)
 
-    assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
+    val didCompleteSuccessfully = countDownLatch.await(5, TimeUnit.SECONDS)
+    networkRule.validate()
+    assertThat(didCompleteSuccessfully).isTrue()
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/LinkTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/LinkTestRunner.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.utils
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.MainActivity
 import com.stripe.android.paymentsheet.PaymentOptionCallback
@@ -10,6 +11,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
 
 internal fun ActivityScenarioRule<MainActivity>.runLinkTest(
+    networkRule: NetworkRule,
     integrationType: LinkIntegrationType,
     createIntentCallback: CreateIntentCallback? = null,
     paymentOptionCallback: PaymentOptionCallback,
@@ -19,6 +21,7 @@ internal fun ActivityScenarioRule<MainActivity>.runLinkTest(
     when (integrationType) {
         LinkIntegrationType.PaymentSheet -> {
             runPaymentSheetTest(
+                networkRule = networkRule,
                 integrationType = IntegrationType.Compose,
                 resultCallback = resultCallback,
                 block = { context ->
@@ -28,6 +31,7 @@ internal fun ActivityScenarioRule<MainActivity>.runLinkTest(
         }
         LinkIntegrationType.FlowController -> {
             runFlowControllerTest(
+                networkRule = networkRule,
                 integrationType = IntegrationType.Compose,
                 createIntentCallback = createIntentCallback,
                 paymentOptionCallback = paymentOptionCallback,

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetTestRunner.kt
@@ -7,6 +7,7 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.link.account.LinkStore
+import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.MainActivity
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -43,6 +44,7 @@ internal class PaymentSheetTestRunnerContext(
 }
 
 internal fun ActivityScenarioRule<MainActivity>.runPaymentSheetTest(
+    networkRule: NetworkRule,
     integrationType: IntegrationType,
     createIntentCallback: CreateIntentCallback? = null,
     resultCallback: PaymentSheetResultCallback,
@@ -60,6 +62,7 @@ internal fun ActivityScenarioRule<MainActivity>.runPaymentSheetTest(
     )
 
     runPaymentSheetTestInternal(
+        networkRule = networkRule,
         countDownLatch = countDownLatch,
         makePaymentSheet = factory::make,
         block = block,
@@ -67,6 +70,7 @@ internal fun ActivityScenarioRule<MainActivity>.runPaymentSheetTest(
 }
 
 private fun ActivityScenarioRule<MainActivity>.runPaymentSheetTestInternal(
+    networkRule: NetworkRule,
     countDownLatch: CountDownLatch,
     makePaymentSheet: (ComponentActivity) -> PaymentSheet,
     block: (PaymentSheetTestRunnerContext) -> Unit,
@@ -87,5 +91,7 @@ private fun ActivityScenarioRule<MainActivity>.runPaymentSheetTestInternal(
     val testContext = PaymentSheetTestRunnerContext(scenario, paymentSheet, countDownLatch)
     block(testContext)
 
-    assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
+    val didCompleteSuccessfully = countDownLatch.await(5, TimeUnit.SECONDS)
+    networkRule.validate()
+    assertThat(didCompleteSuccessfully).isTrue()
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This makes network failures more obvious. 

It changes

```
expected to be true
at com.stripe.android.paymentsheet.utils.PaymentSheetTestRunnerKt.runPaymentSheetTestInternal(PaymentSheetTestRunner.kt:90)
at com.stripe.android.paymentsheet.utils.PaymentSheetTestRunnerKt.runPaymentSheetTest(PaymentSheetTestRunner.kt:62)
at com.stripe.android.paymentsheet.utils.PaymentSheetTestRunnerKt.runPaymentSheetTest$default(PaymentSheetTestRunner.kt:45)
at com.stripe.android.paymentsheet.PaymentSheetTest.testPaymentIntentWithCardBrandChoiceSuccess(PaymentSheetTest.kt:360)
```
to
```
java.lang.IllegalStateException: Mock responses is not empty. Remaining: 1.
Remaining Matchers: composite(method(POST), path(/v1/payment_intents/pi_example/confirm), bodyPart(payment_method_data%5Bcard%5D%5Bnetworks%5D%5Bpreferred%5D, cartes_bancaires))
at com.stripe.android.networktesting.NetworkDispatcher.validate(NetworkDispatcher.kt:51)
at com.stripe.android.networktesting.NetworkRule.validate(NetworkRule.kt:64)
at com.stripe.android.paymentsheet.utils.PaymentSheetTestRunnerKt.runPaymentSheetTestInternal(PaymentSheetTestRunner.kt:95)
at com.stripe.android.paymentsheet.utils.PaymentSheetTestRunnerKt.runPaymentSheetTest(PaymentSheetTestRunner.kt:64)
at com.stripe.android.paymentsheet.utils.PaymentSheetTestRunnerKt.runPaymentSheetTest$default(PaymentSheetTestRunner.kt:46)
at com.stripe.android.paymentsheet.PaymentSheetTest.testPaymentIntentWithCardBrandChoiceSuccess(PaymentSheetTest.kt:369)
```
