### PR TITLE
Fix isEditing state for CustomerSheet with allowsRemovalOfLastSavedPaymentMethod.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -535,11 +535,17 @@ internal class CustomerSheetViewModel(
                     originalPaymentSelection = null
                 }
 
+                val updatedStateCanUpdate = canEdit(
+                    viewState.allowsRemovalOfLastSavedPaymentMethod,
+                    newSavedPaymentMethods,
+                    viewState.cbcEligibility
+                )
                 viewState.copy(
                     savedPaymentMethods = newSavedPaymentMethods,
                     paymentSelection = viewState.paymentSelection.takeUnless {
                         didRemoveCurrentSelection
                     } ?: originalPaymentSelection,
+                    isEditing = viewState.isEditing && updatedStateCanUpdate
                 )
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -467,20 +467,50 @@ class CustomerSheetViewModelTest {
         )
         viewModel.viewState.test {
             var viewState = awaitViewState<SelectPaymentMethod>()
-            assertThat(viewState.isEditing)
-                .isFalse()
+            assertThat(viewState.isEditing).isFalse()
+            assertThat(viewState.topBarState.showEditMenu).isTrue()
 
             viewModel.handleViewAction(CustomerSheetViewAction.OnEditPressed)
 
             viewState = awaitViewState()
-            assertThat(viewState.isEditing)
-                .isTrue()
+            assertThat(viewState.isEditing).isTrue()
+            assertThat(viewState.topBarState.showEditMenu).isTrue()
 
             viewModel.handleViewAction(CustomerSheetViewAction.OnItemRemoved(CARD_PAYMENT_METHOD))
 
             viewState = awaitViewState()
-            assertThat(viewState.isEditing)
-                .isTrue()
+            assertThat(viewState.isEditing).isFalse()
+            assertThat(viewState.topBarState.showEditMenu).isFalse()
+        }
+    }
+
+    @Test
+    fun `When CustomerSheetViewAction#OnItemRemoved with allowsRemovalOfLastSavedPaymentMethod=false, view state isEditing should be updated`() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            workContext = testDispatcher,
+            configuration = CustomerSheet.Configuration(
+                merchantDisplayName = "Example",
+                googlePayEnabled = true,
+                allowsRemovalOfLastSavedPaymentMethod = false,
+            ),
+            customerPaymentMethods = listOf(CARD_PAYMENT_METHOD, CARD_PAYMENT_METHOD.copy(id = "pm_543")),
+        )
+        viewModel.viewState.test {
+            var viewState = awaitViewState<SelectPaymentMethod>()
+            assertThat(viewState.isEditing).isFalse()
+            assertThat(viewState.topBarState.showEditMenu).isTrue()
+
+            viewModel.handleViewAction(CustomerSheetViewAction.OnEditPressed)
+
+            viewState = awaitViewState()
+            assertThat(viewState.isEditing).isTrue()
+            assertThat(viewState.topBarState.showEditMenu).isTrue()
+
+            viewModel.handleViewAction(CustomerSheetViewAction.OnItemRemoved(CARD_PAYMENT_METHOD))
+
+            viewState = awaitViewState()
+            assertThat(viewState.isEditing).isFalse()
+            assertThat(viewState.topBarState.showEditMenu).isFalse()
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fix a bug where removing the second to last payment method in CustomerSheet would allow the user to continue editing (and removing the last payment method). Now we properly update the isEditing state, which prevents the user from removing additional payment methods.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
This isn't a feature we advertise, so not adding it to the changelog.
