### PR TITLE
Add retries to network tests.

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetPage.kt
@@ -4,19 +4,18 @@ import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isEnabled
-import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextReplacement
 import androidx.test.espresso.Espresso
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.stripe.android.customersheet.ui.CUSTOMER_SHEET_CONFIRM_BUTTON_TEST_TAG
 import com.stripe.android.customersheet.ui.CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
 import com.stripe.android.uicore.elements.DROPDOWN_MENU_CLICKABLE_TEST_TAG
 
 internal class CustomerSheetPage(
-    private val composeTestRule: AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>,
+    private val composeTestRule: ComposeTestRule,
 ) {
     fun waitForText(text: String, substring: Boolean = false) {
         waitUntil(hasText(text, substring = substring))

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.paymentsheet
 
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
@@ -27,18 +27,21 @@ import com.stripe.android.paymentsheet.utils.PrefsTestStore
 import com.stripe.android.paymentsheet.utils.runCustomerSheetTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 @RunWith(TestParameterInjector::class)
 internal class CustomerSheetTest {
-    @get:Rule
-    val composeTestRule = createAndroidComposeRule<MainActivity>()
+    private val retryRule = RetryRule(5)
+    private val networkRule = NetworkRule()
+    private val composeTestRule = createEmptyComposeRule()
 
-    private val activityScenarioRule = composeTestRule.activityRule
-
     @get:Rule
-    val networkRule = NetworkRule()
+    val chain: RuleChain = RuleChain.emptyRuleChain()
+        .around(networkRule)
+        .around(composeTestRule)
+        .around(retryRule)
 
     private val page: CustomerSheetPage = CustomerSheetPage(composeTestRule)
 
@@ -49,7 +52,7 @@ internal class CustomerSheetTest {
     fun testSuccessfulCardSave(
         @TestParameter(valuesProvider = CustomerSheetTestTypeProvider::class)
         customerSheetTestType: CustomerSheetTestType,
-    ) = activityScenarioRule.runCustomerSheetTest(
+    ) = runCustomerSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
         customerSheetTestType = customerSheetTestType,
@@ -96,7 +99,7 @@ internal class CustomerSheetTest {
     }
 
     @Test
-    fun testSavedCardReturnedInResultCallback() = activityScenarioRule.runCustomerSheetTest(
+    fun testSavedCardReturnedInResultCallback() = runCustomerSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
         customerSheetTestType = CustomerSheetTestType.AttachToSetupIntent,
@@ -149,7 +152,7 @@ internal class CustomerSheetTest {
     fun testSuccessfulCardSaveWithFullBillingDetailsCollection(
         @TestParameter(valuesProvider = CustomerSheetTestTypeProvider::class)
         customerSheetTestType: CustomerSheetTestType,
-    ) = activityScenarioRule.runCustomerSheetTest(
+    ) = runCustomerSheetTest(
         networkRule = networkRule,
         configuration = CustomerSheet.Configuration.builder("Merchant, Inc.")
             .billingDetailsCollectionConfiguration(
@@ -213,7 +216,7 @@ internal class CustomerSheetTest {
     fun testSuccessfulCardSaveWithCardBrandChoice(
         @TestParameter(valuesProvider = CustomerSheetTestTypeProvider::class)
         customerSheetTestType: CustomerSheetTestType,
-    ) = activityScenarioRule.runCustomerSheetTest(
+    ) = runCustomerSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
         customerSheetTestType = customerSheetTestType,
@@ -268,7 +271,7 @@ internal class CustomerSheetTest {
     }
 
     @Test
-    fun testCardNotAttachedOnError() = activityScenarioRule.runCustomerSheetTest(
+    fun testCardNotAttachedOnError() = runCustomerSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
         customerSheetTestType = CustomerSheetTestType.AttachToSetupIntent,

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet
 
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.closeSoftKeyboard
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
@@ -23,21 +24,26 @@ import com.stripe.android.paymentsheet.utils.assertCompleted
 import com.stripe.android.paymentsheet.utils.runLinkTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import java.util.UUID
 import kotlin.time.Duration.Companion.seconds
 
 @RunWith(TestParameterInjector::class)
 internal class LinkTest {
-    @get:Rule
-    val composeTestRule = createAndroidComposeRule<MainActivity>()
-
-    private val activityScenarioRule = composeTestRule.activityRule
+    private val retryRule = RetryRule(5)
 
     // The /v1/consumers/sessions/log_out request is launched async from a GlobalScope. We want to make sure it happens,
     // but it's okay if it takes a bit to happen.
+    private val networkRule = NetworkRule(validationTimeout = 5.seconds)
+
+    private val composeTestRule = createEmptyComposeRule()
+
     @get:Rule
-    val networkRule = NetworkRule(validationTimeout = 5.seconds)
+    val chain: RuleChain = RuleChain.emptyRuleChain()
+        .around(networkRule)
+        .around(composeTestRule)
+        .around(retryRule)
 
     private val page: PaymentSheetPage = PaymentSheetPage(composeTestRule)
 
@@ -45,7 +51,7 @@ internal class LinkTest {
     lateinit var integrationType: LinkIntegrationType
 
     @Test
-    fun testSuccessfulCardPaymentWithLinkSignUp() = activityScenarioRule.runLinkTest(
+    fun testSuccessfulCardPaymentWithLinkSignUp() = runLinkTest(
         networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
@@ -129,7 +135,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUpAndSaveForFutureUsage() =
-        activityScenarioRule.runLinkTest(
+        runLinkTest(
             networkRule = networkRule,
             integrationType = integrationType,
             paymentOptionCallback = { paymentOption ->
@@ -244,7 +250,7 @@ internal class LinkTest {
         }
 
     @Test
-    fun testSuccessfulCardPaymentWithLinkSignUpAndCardBrandChoice() = activityScenarioRule.runLinkTest(
+    fun testSuccessfulCardPaymentWithLinkSignUpAndCardBrandChoice() = runLinkTest(
         networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
@@ -332,7 +338,7 @@ internal class LinkTest {
     }
 
     @Test
-    fun testSuccessfulCardPaymentWithLinkSignUpAndLinkPassthroughMode() = activityScenarioRule.runLinkTest(
+    fun testSuccessfulCardPaymentWithLinkSignUpAndLinkPassthroughMode() = runLinkTest(
         networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
@@ -431,7 +437,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUpAndLinkPassthroughModeAndSaveForFutureUsage() =
-        activityScenarioRule.runLinkTest(
+        runLinkTest(
             networkRule = networkRule,
             integrationType = integrationType,
             paymentOptionCallback = { paymentOption ->
@@ -553,7 +559,7 @@ internal class LinkTest {
         }
 
     @Test
-    fun testSuccessfulCardPaymentWithLinkSignUpPassthroughModeAndCardBrandChoice() = activityScenarioRule.runLinkTest(
+    fun testSuccessfulCardPaymentWithLinkSignUpPassthroughModeAndCardBrandChoice() = runLinkTest(
         networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
@@ -656,7 +662,7 @@ internal class LinkTest {
     }
 
     @Test
-    fun testSuccessfulCardPaymentWithLinkSignUpFailure() = activityScenarioRule.runLinkTest(
+    fun testSuccessfulCardPaymentWithLinkSignUpFailure() = runLinkTest(
         networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
@@ -715,7 +721,7 @@ internal class LinkTest {
     }
 
     @Test
-    fun testSuccessfulCardPaymentWithLinkSignUpFailureInPassthroughMode() = activityScenarioRule.runLinkTest(
+    fun testSuccessfulCardPaymentWithLinkSignUpFailureInPassthroughMode() = runLinkTest(
         networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
@@ -774,7 +780,7 @@ internal class LinkTest {
     }
 
     @Test
-    fun testSuccessfulCardPaymentWithLinkSignUpShareFailureInPassthroughMode() = activityScenarioRule.runLinkTest(
+    fun testSuccessfulCardPaymentWithLinkSignUpShareFailureInPassthroughMode() = runLinkTest(
         networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
@@ -840,7 +846,7 @@ internal class LinkTest {
     }
 
     @Test
-    fun testSuccessfulCardPaymentWithExistingLinkEmailUsed() = activityScenarioRule.runLinkTest(
+    fun testSuccessfulCardPaymentWithExistingLinkEmailUsed() = runLinkTest(
         networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
@@ -891,7 +897,7 @@ internal class LinkTest {
     }
 
     @Test
-    fun testSuccessfulCardPaymentWithLinkPreviouslyUsed() = activityScenarioRule.runLinkTest(
+    fun testSuccessfulCardPaymentWithLinkPreviouslyUsed() = runLinkTest(
         networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
@@ -907,9 +913,7 @@ internal class LinkTest {
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }
 
-        testContext.scenario.onActivity {
-            LinkStore(it).markLinkAsUsed()
-        }
+        LinkStore(ApplicationProvider.getApplicationContext()).markLinkAsUsed()
 
         testContext.launch()
 
@@ -927,7 +931,7 @@ internal class LinkTest {
     }
 
     @Test
-    fun testLogoutAfterLinkTransaction() = activityScenarioRule.runLinkTest(
+    fun testLogoutAfterLinkTransaction() = runLinkTest(
         networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->
@@ -1009,7 +1013,7 @@ internal class LinkTest {
     }
 
     @Test
-    fun testSuccessfulCardPaymentWithLinkSignUpWithAlbaniaPhoneNumber() = activityScenarioRule.runLinkTest(
+    fun testSuccessfulCardPaymentWithLinkSignUpWithAlbaniaPhoneNumber() = runLinkTest(
         networkRule = networkRule,
         integrationType = integrationType,
         paymentOptionCallback = { paymentOption ->

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
@@ -3,17 +3,14 @@ package com.stripe.android.paymentsheet
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isEnabled
-import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onParent
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextReplacement
 import androidx.test.espresso.Espresso
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.uicore.elements.DROPDOWN_MENU_CLICKABLE_TEST_TAG
-
-private typealias ComposeTestRule = AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>
 
 internal class PaymentSheetPage(
     private val composeTestRule: ComposeTestRule,

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.paymentsheet
 
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.stripe.android.core.utils.urlEncode
@@ -20,17 +20,20 @@ import com.stripe.android.paymentsheet.utils.runPaymentSheetTest
 import okhttp3.mockwebserver.SocketPolicy
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @RunWith(TestParameterInjector::class)
 internal class PaymentSheetTest {
-    @get:Rule
-    val composeTestRule = createAndroidComposeRule<MainActivity>()
+    private val retryRule = RetryRule(5)
+    private val networkRule = NetworkRule()
+    private val composeTestRule = createEmptyComposeRule()
 
-    private val activityScenarioRule = composeTestRule.activityRule
-
     @get:Rule
-    val networkRule = NetworkRule()
+    val chain: RuleChain = RuleChain.emptyRuleChain()
+        .around(networkRule)
+        .around(composeTestRule)
+        .around(retryRule)
 
     private val page: PaymentSheetPage = PaymentSheetPage(composeTestRule)
 
@@ -38,7 +41,7 @@ internal class PaymentSheetTest {
     lateinit var integrationType: IntegrationType
 
     @Test
-    fun testSuccessfulCardPayment() = activityScenarioRule.runPaymentSheetTest(
+    fun testSuccessfulCardPayment() = runPaymentSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -71,7 +74,7 @@ internal class PaymentSheetTest {
     }
 
     @Test
-    fun testSocketErrorCardPayment() = activityScenarioRule.runPaymentSheetTest(
+    fun testSocketErrorCardPayment() = runPaymentSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::expectNoResult,
@@ -106,7 +109,7 @@ internal class PaymentSheetTest {
     }
 
     @Test
-    fun testInsufficientFundsCardPayment() = activityScenarioRule.runPaymentSheetTest(
+    fun testInsufficientFundsCardPayment() = runPaymentSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::expectNoResult,
@@ -142,7 +145,7 @@ internal class PaymentSheetTest {
     }
 
     @Test
-    fun testSuccessfulDelayedSuccessPayment() = activityScenarioRule.runPaymentSheetTest(
+    fun testSuccessfulDelayedSuccessPayment() = runPaymentSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -181,7 +184,7 @@ internal class PaymentSheetTest {
     }
 
     @Test
-    fun testFailureWhenSetupRequestsFail() = activityScenarioRule.runPaymentSheetTest(
+    fun testFailureWhenSetupRequestsFail() = runPaymentSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertFailed,
@@ -209,7 +212,7 @@ internal class PaymentSheetTest {
     }
 
     @Test
-    fun testDeferredIntentCardPayment() = activityScenarioRule.runPaymentSheetTest(
+    fun testDeferredIntentCardPayment() = runPaymentSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
         createIntentCallback = { _, _ -> CreateIntentResult.Success("pi_example_secret_example") },
@@ -271,7 +274,7 @@ internal class PaymentSheetTest {
     }
 
     @Test
-    fun testDeferredIntentFailedCardPayment() = activityScenarioRule.runPaymentSheetTest(
+    fun testDeferredIntentFailedCardPayment() = runPaymentSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
         createIntentCallback = { _, _ ->
@@ -322,7 +325,7 @@ internal class PaymentSheetTest {
 
     @OptIn(DelicatePaymentSheetApi::class)
     @Test
-    fun testDeferredIntentCardPaymentWithForcedSuccess() = activityScenarioRule.runPaymentSheetTest(
+    fun testDeferredIntentCardPaymentWithForcedSuccess() = runPaymentSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
         createIntentCallback = { _, _ ->
@@ -366,7 +369,7 @@ internal class PaymentSheetTest {
     }
 
     @Test
-    fun testPaymentIntentWithCardBrandChoiceSuccess() = activityScenarioRule.runPaymentSheetTest(
+    fun testPaymentIntentWithCardBrandChoiceSuccess() = runPaymentSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -403,7 +406,7 @@ internal class PaymentSheetTest {
     }
 
     @Test
-    fun testPaymentIntentReturnsFailureWhenAlreadySucceeded() = activityScenarioRule.runPaymentSheetTest(
+    fun testPaymentIntentReturnsFailureWhenAlreadySucceeded() = runPaymentSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertFailed,

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/RetryRule.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/RetryRule.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.paymentsheet
+
+import android.util.Log
+import org.junit.AssumptionViolatedException
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+internal class RetryRule(private val attempts: Int) : TestRule {
+    override fun apply(base: Statement, description: Description): Statement {
+        val logTag = description.className
+        return object : Statement() {
+            @Throws
+            override fun evaluate() {
+                for (attempt in 1..attempts) {
+                    val isLast = attempts == attempt
+                    val error = runCatching { base.evaluate() }.exceptionOrNull()
+
+                    if (error != null) {
+                        if (isLast || error is AssumptionViolatedException) {
+                            throw error
+                        }
+                        Log.d(logTag, "Failed attempt $attempt out of $attempts with error")
+                    } else {
+                        // The test succeeded
+                        return
+                    }
+                }
+            }
+        }
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestRunner.kt
@@ -3,9 +3,6 @@ package com.stripe.android.paymentsheet.utils
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
-import androidx.test.espresso.IdlingRegistry
-import androidx.test.espresso.IdlingResource
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.link.account.LinkStore
@@ -36,7 +33,7 @@ internal class FlowControllerTestRunnerContext(
     }
 }
 
-internal fun ActivityScenarioRule<MainActivity>.runFlowControllerTest(
+internal fun runFlowControllerTest(
     networkRule: NetworkRule,
     integrationType: IntegrationType,
     createIntentCallback: CreateIntentCallback? = null,
@@ -64,79 +61,38 @@ internal fun ActivityScenarioRule<MainActivity>.runFlowControllerTest(
     )
 }
 
-private fun ActivityScenarioRule<MainActivity>.runFlowControllerTest(
+private fun runFlowControllerTest(
     networkRule: NetworkRule,
     countDownLatch: CountDownLatch,
     makeFlowController: (ComponentActivity) -> PaymentSheet.FlowController,
     block: (FlowControllerTestRunnerContext) -> Unit,
 ) {
-    scenario.moveToState(Lifecycle.State.CREATED)
+    ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+        scenario.moveToState(Lifecycle.State.CREATED)
 
-    scenario.onActivity {
-        PaymentConfiguration.init(it, "pk_test_123")
-        LinkStore(it.applicationContext).clear()
-    }
+        scenario.onActivity {
+            PaymentConfiguration.init(it, "pk_test_123")
+            LinkStore(it.applicationContext).clear()
+        }
 
-   var flowController: SynchronizedTestFlowController? = null
+        var flowController: PaymentSheet.FlowController? = null
 
-   try {
-       scenario.onActivity { activity ->
-           flowController = SynchronizedTestFlowController(makeFlowController(activity))
-       }
+        scenario.onActivity { activity ->
+            flowController = makeFlowController(activity)
+        }
 
-       scenario.moveToState(Lifecycle.State.RESUMED)
+        scenario.moveToState(Lifecycle.State.RESUMED)
 
-       val testContext = FlowControllerTestRunnerContext(
-           scenario = scenario,
-           flowController = flowController ?: throw IllegalStateException(
-               "FlowController should have been created!"
-           )
-       )
-       block(testContext)
+        val testContext = FlowControllerTestRunnerContext(
+            scenario = scenario,
+            flowController = flowController ?: throw IllegalStateException(
+                "FlowController should have been created!"
+            )
+        )
+        block(testContext)
 
-       val didCompleteSuccessfully = countDownLatch.await(5, TimeUnit.SECONDS)
-       networkRule.validate()
-       assertThat(didCompleteSuccessfully).isTrue()
-   } catch (exception: Exception) {
-       flowController?.manuallyRelease()
-
-       throw exception
-   }
-}
-
-internal class SynchronizedTestFlowController(
-    private val flowController: PaymentSheet.FlowController
-) : PaymentSheet.FlowController by flowController, IdlingResource {
-    private var isIdleNow: Boolean = false
-    private var onIdleTransitionCallback: IdlingResource.ResourceCallback? = null
-
-    init {
-        IdlingRegistry.getInstance().register(this)
-    }
-
-    override fun presentPaymentOptions() {
-        flowController.presentPaymentOptions()
-        manuallyRelease()
-    }
-
-    override fun getName(): String = FLOW_CONTROLLER_RESOURCE
-
-    override fun registerIdleTransitionCallback(callback: IdlingResource.ResourceCallback?) {
-        onIdleTransitionCallback = callback
-    }
-
-    override fun isIdleNow(): Boolean {
-        return isIdleNow
-    }
-
-    fun manuallyRelease() {
-        isIdleNow = true
-        onIdleTransitionCallback?.onTransitionToIdle()
-        IdlingRegistry.getInstance().unregister(this)
-        onIdleTransitionCallback = null
-    }
-
-    companion object {
-        private const val FLOW_CONTROLLER_RESOURCE = "FlowControllerResource"
+        val didCompleteSuccessfully = countDownLatch.await(5, TimeUnit.SECONDS)
+        networkRule.validate()
+        assertThat(didCompleteSuccessfully).isTrue()
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/LinkTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/LinkTestRunner.kt
@@ -1,16 +1,13 @@
 package com.stripe.android.paymentsheet.utils
 
-import androidx.test.core.app.ActivityScenario
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.paymentsheet.CreateIntentCallback
-import com.stripe.android.paymentsheet.MainActivity
 import com.stripe.android.paymentsheet.PaymentOptionCallback
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
 
-internal fun ActivityScenarioRule<MainActivity>.runLinkTest(
+internal fun runLinkTest(
     networkRule: NetworkRule,
     integrationType: LinkIntegrationType,
     createIntentCallback: CreateIntentCallback? = null,
@@ -25,7 +22,7 @@ internal fun ActivityScenarioRule<MainActivity>.runLinkTest(
                 integrationType = IntegrationType.Compose,
                 resultCallback = resultCallback,
                 block = { context ->
-                    block(LinkTestRunnerContext.WithPaymentSheet(scenario, context))
+                    block(LinkTestRunnerContext.WithPaymentSheet(context))
                 },
             )
         }
@@ -37,7 +34,7 @@ internal fun ActivityScenarioRule<MainActivity>.runLinkTest(
                 paymentOptionCallback = paymentOptionCallback,
                 resultCallback = resultCallback,
                 block = { context ->
-                    block(LinkTestRunnerContext.WithFlowController(scenario, context))
+                    block(LinkTestRunnerContext.WithFlowController(context))
                 }
             )
         }
@@ -45,7 +42,6 @@ internal fun ActivityScenarioRule<MainActivity>.runLinkTest(
 }
 
 internal sealed interface LinkTestRunnerContext {
-    val scenario: ActivityScenario<MainActivity>
 
     fun launch(
         configuration: PaymentSheet.Configuration = PaymentSheet.Configuration(
@@ -54,7 +50,6 @@ internal sealed interface LinkTestRunnerContext {
     )
 
     class WithPaymentSheet(
-        override val scenario: ActivityScenario<MainActivity>,
         private val context: PaymentSheetTestRunnerContext
     ) : LinkTestRunnerContext {
         override fun launch(configuration: PaymentSheet.Configuration) {
@@ -68,7 +63,6 @@ internal sealed interface LinkTestRunnerContext {
     }
 
     class WithFlowController(
-        override val scenario: ActivityScenario<MainActivity>,
         private val context: FlowControllerTestRunnerContext
     ) : LinkTestRunnerContext {
         override fun launch(configuration: PaymentSheet.Configuration) {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetTestRunner.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet.utils
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.link.account.LinkStore
@@ -43,7 +42,7 @@ internal class PaymentSheetTestRunnerContext(
     }
 }
 
-internal fun ActivityScenarioRule<MainActivity>.runPaymentSheetTest(
+internal fun runPaymentSheetTest(
     networkRule: NetworkRule,
     integrationType: IntegrationType,
     createIntentCallback: CreateIntentCallback? = null,
@@ -69,29 +68,31 @@ internal fun ActivityScenarioRule<MainActivity>.runPaymentSheetTest(
     )
 }
 
-private fun ActivityScenarioRule<MainActivity>.runPaymentSheetTestInternal(
+private fun runPaymentSheetTestInternal(
     networkRule: NetworkRule,
     countDownLatch: CountDownLatch,
     makePaymentSheet: (ComponentActivity) -> PaymentSheet,
     block: (PaymentSheetTestRunnerContext) -> Unit,
 ) {
-    scenario.moveToState(Lifecycle.State.CREATED)
-    scenario.onActivity {
-        PaymentConfiguration.init(it, "pk_test_123")
-        LinkStore(it.applicationContext).clear()
+    ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+        scenario.moveToState(Lifecycle.State.CREATED)
+        scenario.onActivity {
+            PaymentConfiguration.init(it, "pk_test_123")
+            LinkStore(it.applicationContext).clear()
+        }
+
+        lateinit var paymentSheet: PaymentSheet
+        scenario.onActivity {
+            paymentSheet = makePaymentSheet(it)
+        }
+
+        scenario.moveToState(Lifecycle.State.RESUMED)
+
+        val testContext = PaymentSheetTestRunnerContext(scenario, paymentSheet, countDownLatch)
+        block(testContext)
+
+        val didCompleteSuccessfully = countDownLatch.await(5, TimeUnit.SECONDS)
+        networkRule.validate()
+        assertThat(didCompleteSuccessfully).isTrue()
     }
-
-    lateinit var paymentSheet: PaymentSheet
-    scenario.onActivity {
-        paymentSheet = makePaymentSheet(it)
-    }
-
-    scenario.moveToState(Lifecycle.State.RESUMED)
-
-    val testContext = PaymentSheetTestRunnerContext(scenario, paymentSheet, countDownLatch)
-    block(testContext)
-
-    val didCompleteSuccessfully = countDownLatch.await(5, TimeUnit.SECONDS)
-    networkRule.validate()
-    assertThat(didCompleteSuccessfully).isTrue()
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We've seen some flakes in network tests. This change will allow the CustomerSheet flakes to pass eventually, however, I'm not sure this fixes the CBC flakes.