### PR TITLE
Send EPMs to elements session

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
@@ -13,12 +13,14 @@ sealed interface ElementsSessionParams : Parcelable {
     val clientSecret: String?
     val locale: String?
     val expandFields: List<String>
+    val externalPaymentMethods: List<String>?
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     data class PaymentIntentType(
         override val clientSecret: String,
         override val locale: String? = Locale.getDefault().toLanguageTag(),
+        override val externalPaymentMethods: List<String>?,
     ) : ElementsSessionParams {
 
         override val type: String
@@ -33,6 +35,7 @@ sealed interface ElementsSessionParams : Parcelable {
     data class SetupIntentType(
         override val clientSecret: String,
         override val locale: String? = Locale.getDefault().toLanguageTag(),
+        override val externalPaymentMethods: List<String>?,
     ) : ElementsSessionParams {
 
         override val type: String
@@ -47,6 +50,7 @@ sealed interface ElementsSessionParams : Parcelable {
     data class DeferredIntentType(
         override val locale: String? = Locale.getDefault().toLanguageTag(),
         val deferredIntentParams: DeferredIntentParams,
+        override val externalPaymentMethods: List<String>?,
     ) : ElementsSessionParams {
 
         override val clientSecret: String?

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1492,6 +1492,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
             this["type"] = params.type
             params.clientSecret?.let { this["client_secret"] = it }
             params.locale.let { this["locale"] = it }
+            params.externalPaymentMethods?.takeIf { it.isNotEmpty() }?.let { this["external_payment_methods"] = it }
             (params as? ElementsSessionParams.DeferredIntentType)?.let { type ->
                 this.putAll(type.deferredIntentParams.toQueryParams())
             }

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -16,7 +16,8 @@ class ElementsSessionJsonParserTest {
     fun parsePaymentIntent_shouldCreateObjectWithOrderedPaymentMethods() {
         val elementsSession = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
-                clientSecret = "secret"
+                clientSecret = "secret",
+                externalPaymentMethods = null,
             ),
             apiKey = "test"
         ).parse(
@@ -41,7 +42,8 @@ class ElementsSessionJsonParserTest {
     fun parseSetupIntent_shouldCreateObjectWithOrderedPaymentMethods() {
         val elementsSession = ElementsSessionJsonParser(
             ElementsSessionParams.SetupIntentType(
-                clientSecret = "secret"
+                clientSecret = "secret",
+                externalPaymentMethods = null,
             ),
             apiKey = "test"
         ).parse(
@@ -65,7 +67,8 @@ class ElementsSessionJsonParserTest {
     fun parsePaymentIntent_shouldCreateObjectLinkFundingSources() {
         val elementsSession = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
-                clientSecret = "secret"
+                clientSecret = "secret",
+                externalPaymentMethods = null,
             ),
             apiKey = "test"
         ).parse(
@@ -81,7 +84,8 @@ class ElementsSessionJsonParserTest {
     fun parsePaymentIntent_shouldCreateMapLinkFlags() {
         val elementsSession = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
-                clientSecret = "secret"
+                clientSecret = "secret",
+                externalPaymentMethods = null,
             ),
             apiKey = "test"
         ).parse(
@@ -107,7 +111,8 @@ class ElementsSessionJsonParserTest {
     fun parsePaymentIntent_shouldDisableLinkSignUp() {
         val elementsSession = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
-                clientSecret = "secret"
+                clientSecret = "secret",
+                externalPaymentMethods = null,
             ),
             apiKey = "test"
         ).parse(
@@ -121,7 +126,8 @@ class ElementsSessionJsonParserTest {
     fun parsePaymentIntent_shouldSetDisableLinkSignUpToFalse() {
         val elementsSession = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
-                clientSecret = "secret"
+                clientSecret = "secret",
+                externalPaymentMethods = null,
             ),
             apiKey = "test"
         ).parse(
@@ -135,7 +141,8 @@ class ElementsSessionJsonParserTest {
     fun parseSetupIntent_shouldCreateObjectLinkFundingSources() {
         val elementsSession = ElementsSessionJsonParser(
             ElementsSessionParams.SetupIntentType(
-                clientSecret = "secret"
+                clientSecret = "secret",
+                externalPaymentMethods = null,
             ),
             apiKey = "test"
         ).parse(
@@ -151,7 +158,8 @@ class ElementsSessionJsonParserTest {
     fun `Test ordered payment methods returned in PI payment_method_type variable`() {
         val parsedData = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
-                clientSecret = "secret"
+                clientSecret = "secret",
+                externalPaymentMethods = null,
             ),
             apiKey = "test"
         ).parse(
@@ -172,7 +180,8 @@ class ElementsSessionJsonParserTest {
     fun `Test ordered payment methods not required in response`() {
         val parsedData = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
-                clientSecret = "secret"
+                clientSecret = "secret",
+                externalPaymentMethods = null,
             ),
             apiKey = "test"
         ).parse(
@@ -194,7 +203,8 @@ class ElementsSessionJsonParserTest {
     fun `Test ordered payment methods is not required`() {
         val parsedData = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
-                clientSecret = "secret"
+                clientSecret = "secret",
+                externalPaymentMethods = null,
             ),
             apiKey = "test"
         ).parse(
@@ -217,7 +227,8 @@ class ElementsSessionJsonParserTest {
     fun `Test fail to parse the payment intent`() {
         val parsedData = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
-                clientSecret = "secret"
+                clientSecret = "secret",
+                externalPaymentMethods = null,
             ),
             apiKey = "test"
         ).parse(
@@ -240,7 +251,8 @@ class ElementsSessionJsonParserTest {
     fun `Test fail to find the payment intent`() {
         val parsedData = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
-                clientSecret = "secret"
+                clientSecret = "secret",
+                externalPaymentMethods = null,
             ),
             apiKey = "test"
         ).parse(
@@ -261,7 +273,8 @@ class ElementsSessionJsonParserTest {
     fun `Test PI with country code`() {
         val parsedData = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
-                clientSecret = "secret"
+                clientSecret = "secret",
+                externalPaymentMethods = null,
             ),
             apiKey = "test"
         ).parse(
@@ -281,7 +294,8 @@ class ElementsSessionJsonParserTest {
     fun `Test SI with country code`() {
         val parsedData = ElementsSessionJsonParser(
             ElementsSessionParams.SetupIntentType(
-                clientSecret = "secret"
+                clientSecret = "secret",
+                externalPaymentMethods = null,
             ),
             apiKey = "test"
         ).parse(
@@ -311,7 +325,8 @@ class ElementsSessionJsonParserTest {
                     paymentMethodTypes = emptyList(),
                     paymentMethodConfigurationId = null,
                     onBehalfOf = null,
-                )
+                ),
+                externalPaymentMethods = null,
             ),
             apiKey = "test",
             timeProvider = { 1 }
@@ -352,7 +367,8 @@ class ElementsSessionJsonParserTest {
                     paymentMethodTypes = emptyList(),
                     paymentMethodConfigurationId = null,
                     onBehalfOf = null,
-                )
+                ),
+                externalPaymentMethods = null,
             ),
             apiKey = "test",
             timeProvider = { 1 }
@@ -388,7 +404,8 @@ class ElementsSessionJsonParserTest {
     fun `Is eligible for CBC if response says so`() {
         val parser = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
-                clientSecret = "secret"
+                clientSecret = "secret",
+                externalPaymentMethods = null,
             ),
             apiKey = "test",
         )
@@ -403,7 +420,8 @@ class ElementsSessionJsonParserTest {
     fun `Is not eligible for CBC if response says so`() {
         val parser = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
-                clientSecret = "secret"
+                clientSecret = "secret",
+                externalPaymentMethods = null,
             ),
             apiKey = "test",
         )
@@ -418,7 +436,8 @@ class ElementsSessionJsonParserTest {
     fun `Is not eligible for CBC if no info in the response`() {
         val parser = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
-                clientSecret = "secret"
+                clientSecret = "secret",
+                externalPaymentMethods = null,
             ),
             apiKey = "test",
         )
@@ -433,7 +452,8 @@ class ElementsSessionJsonParserTest {
     fun parsePaymentIntent_shouldCreateObjectWithCorrectGooglePayEnabled() {
         val parser = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
-                clientSecret = "secret"
+                clientSecret = "secret",
+                externalPaymentMethods = null,
             ),
             apiKey = "test"
         )

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -114,7 +114,7 @@ internal class DefaultCustomerSheetLoader(
                 paymentMethodTypes = paymentMethodTypes,
             )
         )
-        return elementsSessionRepository.get(initializationMode).map { elementsSession ->
+        return elementsSessionRepository.get(initializationMode, externalPaymentMethods = null).map { elementsSession ->
             val billingDetailsCollectionConfig = configuration.billingDetailsCollectionConfiguration
             val sharedDataSpecs = lpmRepository.getSharedDataSpecs(
                 stripeIntent = elementsSession.stripeIntent,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
@@ -75,7 +75,7 @@ internal object DeferredIntentValidator {
         intentConfiguration: PaymentSheet.IntentConfiguration,
     ): DeferredIntentParams {
         val initializationMode = PaymentSheet.InitializationMode.DeferredIntent(intentConfiguration)
-        val params = initializationMode.toElementsSessionParams()
+        val params = initializationMode.toElementsSessionParams(externalPaymentMethods = null)
         return (params as ElementsSessionParams.DeferredIntentType).deferredIntentParams
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -107,20 +107,20 @@ private fun StripeIntent.withoutWeChatPay(): StripeIntent {
 }
 
 internal fun PaymentSheet.InitializationMode.toElementsSessionParams(
-    externalPaymentMethods: List<String>?
+    externalPaymentMethods: List<String>?,
 ): ElementsSessionParams {
     return when (this) {
         is PaymentSheet.InitializationMode.PaymentIntent -> {
             ElementsSessionParams.PaymentIntentType(
                 clientSecret = clientSecret,
-                externalPaymentMethods = externalPaymentMethods
+                externalPaymentMethods = externalPaymentMethods,
             )
         }
 
         is PaymentSheet.InitializationMode.SetupIntent -> {
             ElementsSessionParams.SetupIntentType(
                 clientSecret = clientSecret,
-                externalPaymentMethods = externalPaymentMethods
+                externalPaymentMethods = externalPaymentMethods,
             )
         }
 
@@ -132,7 +132,7 @@ internal fun PaymentSheet.InitializationMode.toElementsSessionParams(
                     onBehalfOf = intentConfiguration.onBehalfOf,
                     paymentMethodConfigurationId = intentConfiguration.paymentMethodConfigurationId,
                 ),
-                externalPaymentMethods = externalPaymentMethods
+                externalPaymentMethods = externalPaymentMethods,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -71,6 +71,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
 
         val elementsSessionResult = retrieveElementsSession(
             initializationMode = initializationMode,
+            externalPaymentMethods = null,
         )
 
         elementsSessionResult.mapCatching { elementsSession ->
@@ -241,8 +242,9 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
 
     private suspend fun retrieveElementsSession(
         initializationMode: PaymentSheet.InitializationMode,
+        externalPaymentMethods: List<String>?,
     ): Result<ElementsSession> {
-        return elementsSessionRepository.get(initializationMode)
+        return elementsSessionRepository.get(initializationMode, externalPaymentMethods)
     }
 
     private suspend fun loadLinkState(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -222,7 +222,7 @@ class DefaultCustomerSheetLoaderTest {
         )
 
         assertThat(loader.load(config).getOrThrow()).isNotNull()
-        val params = elementsSessionRepository.lastGetParam?.toElementsSessionParams()
+        val params = elementsSessionRepository.lastGetParam?.toElementsSessionParams(externalPaymentMethods = null)
             as ElementsSessionParams.DeferredIntentType
         assertThat(params.deferredIntentParams.paymentMethodTypes).containsExactly("card")
     }
@@ -253,7 +253,7 @@ class DefaultCustomerSheetLoaderTest {
         )
 
         assertThat(loader.load(config).getOrThrow()).isNotNull()
-        val params = elementsSessionRepository.lastGetParam?.toElementsSessionParams()
+        val params = elementsSessionRepository.lastGetParam?.toElementsSessionParams(externalPaymentMethods = null)
             as ElementsSessionParams.DeferredIntentType
         assertThat(params.deferredIntentParams.paymentMethodTypes).containsExactly("card")
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
@@ -48,6 +48,7 @@ internal class ElementsSessionRepositoryTest {
                 initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
                     clientSecret = "client_secret",
                 ),
+                externalPaymentMethods = null,
             ).getOrThrow()
         }
 
@@ -74,6 +75,7 @@ internal class ElementsSessionRepositoryTest {
                     initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
                         clientSecret = "client_secret",
                     ),
+                    externalPaymentMethods = null,
                 ).getOrThrow()
             }
 
@@ -97,6 +99,7 @@ internal class ElementsSessionRepositoryTest {
                     initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
                         clientSecret = "client_secret",
                     ),
+                    externalPaymentMethods = null,
                 ).getOrThrow()
             }
 
@@ -126,6 +129,7 @@ internal class ElementsSessionRepositoryTest {
             initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
                 clientSecret = "client_secret",
             ),
+            externalPaymentMethods = null,
         ).getOrThrow()
 
         val argumentCaptor: KArgumentCaptor<ElementsSessionParams> = argumentCaptor()
@@ -160,6 +164,7 @@ internal class ElementsSessionRepositoryTest {
                     )
                 )
             ),
+            externalPaymentMethods = null,
         )
 
         assertThat(session.getOrNull()).isNull()

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
@@ -18,6 +18,7 @@ internal class FakeElementsSessionRepository(
 
     override suspend fun get(
         initializationMode: PaymentSheet.InitializationMode,
+        externalPaymentMethods: List<String>?,
     ): Result<ElementsSession> {
         lastGetParam = initializationMode
         return if (error != null) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Send external payment methods elements/session

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-1951

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

Manually tested by hard-coding `listOf(external_paypal)` as the `external_payment_methods` in `PaymentSheetLoader.load` and used the debugger to inspect the elements/session response, which included external payment method info for Paypal.