### PR TITLE
Better handle errors in IntentConfirmationInterceptor.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -160,6 +160,9 @@ interface ErrorReporter {
         PAYMENT_SHEET_AUTHENTICATORS_NOT_FOUND(
             partialEventName = "paymentsheet.authenticators.not_found"
         ),
+        INTENT_CONFIRMATION_INTERCEPTOR_INVALID_PAYMENT_SELECTION(
+            partialEventName = "intent_confirmation_interceptor.intercept.invalid_payment_selection"
+        ),
         ;
 
         override val eventName: String

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElements.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElements.kt
@@ -77,7 +77,7 @@ internal class TransformSpecToElements(
                     arguments.shippingValues
                 )
                 is SepaMandateTextSpec -> it.transform(arguments.merchantName)
-                is PlaceholderSpec -> error("Placeholders should be processed before calling transform.")
+                is PlaceholderSpec -> null // Placeholders should be processed before calling transform.
                 is CashAppPayMandateTextSpec -> it.transform(arguments.merchantName)
                 is KlarnaMandateTextSpec -> it.transform(arguments.merchantName)
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
@@ -41,12 +41,10 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
         else -> {
             val exception =
                 IllegalStateException("Attempting to confirm intent for invalid payment selection: $paymentSelection")
-            val paymentSelectionName = paymentSelection.javaClass.name
             val errorReporter = ErrorReporter.createFallbackInstance(context)
             errorReporter.report(
                 errorEvent = UnexpectedErrorEvent.INTENT_CONFIRMATION_INTERCEPTOR_INVALID_PAYMENT_SELECTION,
                 stripeException = StripeException.create(exception),
-                additionalNonPiiParams = mapOf("payment_section" to paymentSelectionName)
             )
             IntentConfirmationInterceptor.NextStep.Fail(
                 cause = exception,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
@@ -32,10 +32,16 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
                 requiresSaveOnConfirmation = paymentSelection.requiresSaveOnConfirmation,
             )
         }
+        null -> {
+            IntentConfirmationInterceptor.NextStep.Fail(
+                cause = IllegalStateException("Nothing selected."),
+                message = context.getString(R.string.stripe_something_went_wrong),
+            )
+        }
         else -> {
             val exception =
                 IllegalStateException("Attempting to confirm intent for invalid payment selection: $paymentSelection")
-            val paymentSelectionName = paymentSelection?.javaClass?.name ?: "empty"
+            val paymentSelectionName = paymentSelection.javaClass.name
             val errorReporter = ErrorReporter.createFallbackInstance(context)
             errorReporter.report(
                 errorEvent = UnexpectedErrorEvent.INTENT_CONFIRMATION_INTERCEPTOR_INVALID_PAYMENT_SELECTION,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -597,6 +597,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 initializationMode = args.initializationMode,
                 paymentSelection = paymentSelection,
                 shippingValues = args.config.shippingDetails?.toConfirmPaymentIntentShipping(),
+                context = getApplication(),
             )
 
             deferredIntentConfirmationType = nextStep.deferredIntentConfirmationType

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -384,14 +384,13 @@ internal class DefaultFlowController @Inject internal constructor(
     }
 
     private fun confirmStripeIntent(confirmStripeIntentParams: ConfirmStripeIntentParams) {
-        val paymentLauncher = requireNotNull(paymentLauncher)
         when (confirmStripeIntentParams) {
             is ConfirmPaymentIntentParams -> {
-                paymentLauncher.confirm(confirmStripeIntentParams)
+                paymentLauncher?.confirm(confirmStripeIntentParams)
             }
 
             is ConfirmSetupIntentParams -> {
-                paymentLauncher.confirm(confirmStripeIntentParams)
+                paymentLauncher?.confirm(confirmStripeIntentParams)
             }
         }
     }
@@ -400,14 +399,13 @@ internal class DefaultFlowController @Inject internal constructor(
         clientSecret: String,
         stripeIntent: StripeIntent,
     ) {
-        val paymentLauncher = requireNotNull(paymentLauncher)
         when (stripeIntent) {
             is PaymentIntent -> {
-                paymentLauncher.handleNextActionForPaymentIntent(clientSecret)
+                paymentLauncher?.handleNextActionForPaymentIntent(clientSecret)
             }
 
             is SetupIntent -> {
-                paymentLauncher.handleNextActionForSetupIntent(clientSecret)
+                paymentLauncher?.handleNextActionForSetupIntent(clientSecret)
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -354,6 +354,7 @@ internal class DefaultFlowController @Inject internal constructor(
                 initializationMode = initializationMode!!,
                 paymentSelection = paymentSelection,
                 shippingValues = state.config.shippingDetails?.toConfirmPaymentIntentShipping(),
+                context = context.applicationContext,
             )
 
             viewModel.deferredIntentConfirmationType = nextStep.deferredIntentConfirmationType
@@ -383,42 +384,32 @@ internal class DefaultFlowController @Inject internal constructor(
     }
 
     private fun confirmStripeIntent(confirmStripeIntentParams: ConfirmStripeIntentParams) {
-        runCatching {
-            requireNotNull(paymentLauncher)
-        }.fold(
-            onSuccess = {
-                when (confirmStripeIntentParams) {
-                    is ConfirmPaymentIntentParams -> {
-                        it.confirm(confirmStripeIntentParams)
-                    }
-                    is ConfirmSetupIntentParams -> {
-                        it.confirm(confirmStripeIntentParams)
-                    }
-                }
-            },
-            onFailure = ::error
-        )
+        val paymentLauncher = requireNotNull(paymentLauncher)
+        when (confirmStripeIntentParams) {
+            is ConfirmPaymentIntentParams -> {
+                paymentLauncher.confirm(confirmStripeIntentParams)
+            }
+
+            is ConfirmSetupIntentParams -> {
+                paymentLauncher.confirm(confirmStripeIntentParams)
+            }
+        }
     }
 
     private fun handleNextAction(
         clientSecret: String,
         stripeIntent: StripeIntent,
     ) {
-        runCatching {
-            requireNotNull(paymentLauncher)
-        }.fold(
-            onSuccess = {
-                when (stripeIntent) {
-                    is PaymentIntent -> {
-                        it.handleNextActionForPaymentIntent(clientSecret)
-                    }
-                    is SetupIntent -> {
-                        it.handleNextActionForSetupIntent(clientSecret)
-                    }
-                }
-            },
-            onFailure = ::error
-        )
+        val paymentLauncher = requireNotNull(paymentLauncher)
+        when (stripeIntent) {
+            is PaymentIntent -> {
+                paymentLauncher.handleNextActionForPaymentIntent(clientSecret)
+            }
+
+            is SetupIntent -> {
+                paymentLauncher.handleNextActionForSetupIntent(clientSecret)
+            }
+        }
     }
 
     internal fun onGooglePayResult(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -384,30 +384,42 @@ internal class DefaultFlowController @Inject internal constructor(
     }
 
     private fun confirmStripeIntent(confirmStripeIntentParams: ConfirmStripeIntentParams) {
-        when (confirmStripeIntentParams) {
-            is ConfirmPaymentIntentParams -> {
-                paymentLauncher?.confirm(confirmStripeIntentParams)
-            }
-
-            is ConfirmSetupIntentParams -> {
-                paymentLauncher?.confirm(confirmStripeIntentParams)
-            }
-        }
+        runCatching {
+            requireNotNull(paymentLauncher)
+        }.fold(
+            onSuccess = {
+                when (confirmStripeIntentParams) {
+                    is ConfirmPaymentIntentParams -> {
+                        it.confirm(confirmStripeIntentParams)
+                    }
+                    is ConfirmSetupIntentParams -> {
+                        it.confirm(confirmStripeIntentParams)
+                    }
+                }
+            },
+            onFailure = ::error
+        )
     }
 
     private fun handleNextAction(
         clientSecret: String,
         stripeIntent: StripeIntent,
     ) {
-        when (stripeIntent) {
-            is PaymentIntent -> {
-                paymentLauncher?.handleNextActionForPaymentIntent(clientSecret)
-            }
-
-            is SetupIntent -> {
-                paymentLauncher?.handleNextActionForSetupIntent(clientSecret)
-            }
-        }
+        runCatching {
+            requireNotNull(paymentLauncher)
+        }.fold(
+            onSuccess = {
+                when (stripeIntent) {
+                    is PaymentIntent -> {
+                        it.handleNextActionForPaymentIntent(clientSecret)
+                    }
+                    is SetupIntent -> {
+                        it.handleNextActionForSetupIntent(clientSecret)
+                    }
+                }
+            },
+            onFailure = ::error
+        )
     }
 
     internal fun onGooglePayResult(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
@@ -102,6 +102,7 @@ class DefaultIntentConfirmationInterceptorTest {
                     requiresSaveOnConfirmation = true
                 ),
                 shippingValues = null,
+                context = context,
             )
 
             val confirmNextStep = nextStep as? IntentConfirmationInterceptor.NextStep.Confirm

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/StripeException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/StripeException.kt
@@ -63,8 +63,19 @@ abstract class StripeException(
                     message = throwable.message,
                     cause = throwable
                 )
-                else -> GenericStripeException(throwable)
+                else -> GenericStripeException(throwable, analyticsValue = analyticsValueForThrowable(throwable))
             }
+        }
+
+        private fun analyticsValueForThrowable(throwable: Throwable): String? {
+            val throwableClass = throwable.javaClass
+            if (throwableClass.name.startsWith("android.")) {
+                return throwableClass.name
+            }
+            if (throwableClass.name.startsWith("java.")) {
+                return throwableClass.name
+            }
+            return null
         }
     }
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/StripeException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/StripeException.kt
@@ -69,10 +69,7 @@ abstract class StripeException(
 
         private fun analyticsValueForThrowable(throwable: Throwable): String? {
             val throwableClass = throwable.javaClass
-            if (throwableClass.name.startsWith("android.")) {
-                return throwableClass.name
-            }
-            if (throwableClass.name.startsWith("java.")) {
+            if (throwableClass.name.startsWith("android.") || throwableClass.name.startsWith("java.")) {
                 return throwableClass.name
             }
             return null


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I saw some crashes here in our dashboard, trying to figure out what's causing them. My guess is it's null values. This will send us alerts to diagnose the issue, and no longer crash the merchant application, but rather show an unexpected error to the user.