### PR TITLE
Update `GooglePayLauncherViewModel` to not make network calls in the Activity.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
@@ -5,7 +5,9 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.bundleOf
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.wallet.AutoResolveHelper
 import com.google.android.gms.wallet.PaymentData
@@ -64,10 +66,12 @@ internal class GooglePayLauncherActivity : AppCompatActivity() {
         }
 
         lifecycleScope.launch {
-            viewModel.googlePayLaunchTask.collect { task ->
-                if (task != null) {
-                    payWithGoogle(task)
-                    viewModel.markTaskAsLaunched()
+            repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                viewModel.googlePayLaunchTask.collect { task ->
+                    if (task != null) {
+                        payWithGoogle(task)
+                        viewModel.markTaskAsLaunched()
+                    }
                 }
             }
         }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
@@ -37,9 +37,9 @@ import com.stripe.android.view.AuthActivityStarterHost
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 @Suppress("LongParameterList")
@@ -53,18 +53,39 @@ internal class GooglePayLauncherViewModel(
     private val googlePayRepository: GooglePayRepository,
     private val savedStateHandle: SavedStateHandle,
     private val errorReporter: ErrorReporter,
+    private val workContext: CoroutineContext,
 ) : ViewModel() {
     /**
      * [hasLaunched] indicates whether Google Pay has already been launched, and must be persisted
      * across process death in case the Activity and ViewModel are destroyed while the user is
      * interacting with Google Pay.
      */
-    var hasLaunched: Boolean
+    private var hasLaunched: Boolean
         get() = savedStateHandle.get<Boolean>(HAS_LAUNCHED_KEY) == true
         set(value) = savedStateHandle.set(HAS_LAUNCHED_KEY, value)
 
     private val _googleResult = MutableStateFlow<GooglePayLauncher.Result?>(null)
     internal val googlePayResult = _googleResult.asSharedFlow()
+
+    private val _googlePayLaunchTask = MutableStateFlow<Task<PaymentData>?>(null)
+    val googlePayLaunchTask = _googlePayLaunchTask.asStateFlow()
+
+    init {
+        viewModelScope.launch(workContext) {
+            if (!hasLaunched) {
+                createLoadPaymentDataTask().fold(
+                    onSuccess = {
+                        _googlePayLaunchTask.value = it
+                    },
+                    onFailure = {
+                        updateResult(
+                            GooglePayLauncher.Result.Failed(it)
+                        )
+                    }
+                )
+            }
+        }
+    }
 
     fun updateResult(result: GooglePayLauncher.Result) {
         _googleResult.value = result
@@ -160,7 +181,7 @@ internal class GooglePayLauncherViewModel(
         }
     }
 
-    suspend fun createLoadPaymentDataTask(): Result<Task<PaymentData>> {
+    private suspend fun createLoadPaymentDataTask(): Result<Task<PaymentData>> {
         return runCatching {
             check(isReadyToPay()) { "Google Pay is unavailable." }
         }.mapResult {
@@ -172,39 +193,39 @@ internal class GooglePayLauncherViewModel(
         }
     }
 
-    suspend fun confirmStripeIntent(
+    fun confirmStripeIntent(
         host: AuthActivityStarterHost,
         params: PaymentMethodCreateParams
     ) {
-        val confirmStripeIntentParams = when (args) {
-            is GooglePayLauncherContract.PaymentIntentArgs ->
-                ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
-                    paymentMethodCreateParams = params,
-                    clientSecret = args.clientSecret
-                )
-            is GooglePayLauncherContract.SetupIntentArgs ->
-                ConfirmSetupIntentParams.create(
-                    paymentMethodCreateParams = params,
-                    clientSecret = args.clientSecret
-                )
-        }
+        viewModelScope.launch(workContext) {
+            val confirmStripeIntentParams = when (args) {
+                is GooglePayLauncherContract.PaymentIntentArgs ->
+                    ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
+                        paymentMethodCreateParams = params,
+                        clientSecret = args.clientSecret
+                    )
+                is GooglePayLauncherContract.SetupIntentArgs ->
+                    ConfirmSetupIntentParams.create(
+                        paymentMethodCreateParams = params,
+                        clientSecret = args.clientSecret
+                    )
+            }
 
-        paymentController.startConfirmAndAuth(
-            host,
-            confirmStripeIntentParams,
-            requestOptions
-        )
+            paymentController.startConfirmAndAuth(
+                host,
+                confirmStripeIntentParams,
+                requestOptions
+            )
+        }
     }
 
     fun onConfirmResult(
         requestCode: Int,
         data: Intent
     ) {
-        viewModelScope.launch {
+        viewModelScope.launch(workContext) {
             val result = getResultFromConfirmation(requestCode, data)
-            withContext(Dispatchers.Main) {
-                _googleResult.value = result
-            }
+            _googleResult.value = result
         }
     }
 
@@ -235,6 +256,11 @@ internal class GooglePayLauncherViewModel(
             onSuccess = { GooglePayLauncher.Result.Completed },
             onFailure = { GooglePayLauncher.Result.Failed(it) },
         )
+    }
+
+    fun markTaskAsLaunched() {
+        hasLaunched = true
+        _googlePayLaunchTask.value = null
     }
 
     internal class Factory(
@@ -282,27 +308,28 @@ internal class GooglePayLauncherViewModel(
             val errorReporter = ErrorReporter.createFallbackInstance(context = application)
 
             return GooglePayLauncherViewModel(
-                DefaultPaymentsClientFactory(application).create(googlePayEnvironment),
-                ApiRequest.Options(
+                paymentsClient = DefaultPaymentsClientFactory(context = application).create(googlePayEnvironment),
+                requestOptions = ApiRequest.Options(
                     publishableKey,
                     stripeAccountId
                 ),
-                args,
-                stripeRepository,
-                StripePaymentController(
+                args = args,
+                stripeRepository = stripeRepository,
+                paymentController = StripePaymentController(
                     application,
                     { publishableKey },
                     stripeRepository,
                     enableLogging,
                     workContext = workContext
                 ),
-                GooglePayJsonFactory(
+                googlePayJsonFactory = GooglePayJsonFactory(
                     googlePayConfig = GooglePayConfig(publishableKey, stripeAccountId),
                     isJcbEnabled = args.config.isJcbEnabled
                 ),
-                googlePayRepository,
-                extras.createSavedStateHandle(),
-                errorReporter
+                googlePayRepository = googlePayRepository,
+                savedStateHandle = extras.createSavedStateHandle(),
+                errorReporter = errorReporter,
+                workContext = workContext,
             ) as T
         }
     }

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.googlepaylauncher
 
 import android.content.Intent
 import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.wallet.PaymentData
 import com.google.android.gms.wallet.PaymentsClient
@@ -23,10 +24,13 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.SetupIntentFixtures
+import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.AbsPaymentController
 import com.stripe.android.testing.FakeErrorReporter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.mockito.kotlin.KArgumentCaptor
@@ -40,7 +44,6 @@ import kotlin.test.Test
 
 @RunWith(RobolectricTestRunner::class)
 class GooglePayLauncherViewModelTest {
-    private val stripeRepository = FakeStripeRepository()
     private val savedStateHandle = SavedStateHandle()
     private val googlePayJsonFactory = GooglePayJsonFactory(
         googlePayConfig = GooglePayConfig(
@@ -50,6 +53,7 @@ class GooglePayLauncherViewModelTest {
     )
 
     private val googlePayRepository = FakeGooglePayRepository(true)
+    private val testDispatcher = StandardTestDispatcher()
 
     private val task = mock<Task<PaymentData>>()
     private val paymentsClient = mock<PaymentsClient>().also {
@@ -57,11 +61,9 @@ class GooglePayLauncherViewModelTest {
             .thenReturn(task)
     }
 
-    private val viewModel = createViewModel()
-
     @Test
     fun `isReadyToPay() should return expected value`() = runTest {
-        assertThat(viewModel.isReadyToPay())
+        assertThat(createViewModel().isReadyToPay())
             .isTrue()
     }
 
@@ -69,21 +71,28 @@ class GooglePayLauncherViewModelTest {
     fun `createLoadPaymentDataTask() should throw expected exception when Google Pay is not available`() =
         runTest {
             googlePayRepository.value = false
-
-            val error = viewModel.createLoadPaymentDataTask().exceptionOrNull()
-            assertThat(error).isInstanceOf(IllegalStateException::class.java)
-            assertThat(error?.message).isEqualTo("Google Pay is unavailable.")
+            createViewModel().googlePayResult.test {
+                assertThat(awaitItem()).isNull() // Initial Value.
+                testDispatcher.scheduler.advanceUntilIdle()
+                val failed = awaitItem() as GooglePayLauncher.Result.Failed
+                val error = failed.error
+                assertThat(error).isInstanceOf(IllegalStateException::class.java)
+                assertThat(error.message).isEqualTo("Google Pay is unavailable.")
+            }
         }
 
     @Test
-    fun `createLoadPaymentDataTask() should return task when Google Pay is available`() =
-        runTest {
-            assertThat(viewModel.createLoadPaymentDataTask().isSuccess).isTrue()
+    fun `googlePayLaunchTask should return task when Google Pay is available`() = runTest {
+        createViewModel().googlePayLaunchTask.test {
+            assertThat(awaitItem()).isNull() // Initial Value.
+            testDispatcher.scheduler.advanceUntilIdle()
+            assertThat(awaitItem()).isNotNull()
         }
+    }
 
     @Test
     fun `createTransactionInfo() with PaymentIntent should return expected TransactionInfo`() {
-        val transactionInfo = viewModel.createTransactionInfo(
+        val transactionInfo = createViewModel().createTransactionInfo(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
             currencyCode = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.currency.orEmpty(),
         )
@@ -103,7 +112,7 @@ class GooglePayLauncherViewModelTest {
 
     @Test
     fun `createTransactionInfo() with SetupIntent should return expected TransactionInfo`() {
-        val transactionInfo = viewModel.createTransactionInfo(
+        val transactionInfo = createViewModel().createTransactionInfo(
             stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
             currencyCode = "usd",
         )
@@ -122,20 +131,31 @@ class GooglePayLauncherViewModelTest {
     }
 
     @Test
-    fun `hasLaunched is stored in savedStateHandle`() {
+    fun `hasLaunched is stored in savedStateHandle`() = runTest {
         val viewModel = createViewModel()
 
-        assertThat(viewModel.hasLaunched).isFalse()
+        viewModel.googlePayLaunchTask.test {
+            assertThat(awaitItem()).isNull() // Initial Value.
+            testDispatcher.scheduler.advanceUntilIdle()
+            assertThat(awaitItem()).isNotNull()
+            assertThat(savedStateHandle.get<Boolean>(HAS_LAUNCHED_KEY)).isNull()
+            viewModel.markTaskAsLaunched()
+            assertThat(awaitItem()).isNull()
+            assertThat(savedStateHandle.get<Boolean>(HAS_LAUNCHED_KEY)).isTrue()
+        }
+    }
 
-        viewModel.hasLaunched = true
-
-        assertThat(savedStateHandle.get<Boolean>(HAS_LAUNCHED_KEY)).isTrue()
+    @Test
+    fun `hasLaunched=true prevents initial loading of googlePayLaunchTask`() = runTest {
+        savedStateHandle[HAS_LAUNCHED_KEY] = true
+        val viewModel = createViewModel()
+        assertThat(viewModel.googlePayLaunchTask.first()).isNull()
     }
 
     @Test
     fun `getResultFromConfirmation() using PaymentIntent should return expected result`() =
         runTest {
-            val result = viewModel.getResultFromConfirmation(
+            val result = createViewModel().getResultFromConfirmation(
                 StripePaymentController.PAYMENT_REQUEST_CODE,
                 Intent()
                     .putExtras(
@@ -151,7 +171,7 @@ class GooglePayLauncherViewModelTest {
     @Test
     fun `getResultFromConfirmation() using SetupIntent should return expected result`() =
         runTest {
-            val result = viewModel.getResultFromConfirmation(
+            val result = createViewModel().getResultFromConfirmation(
                 StripePaymentController.SETUP_REQUEST_CODE,
                 Intent()
                     .putExtras(
@@ -168,7 +188,7 @@ class GooglePayLauncherViewModelTest {
     fun `getResultFromConfirmation() with failed confirmation should return expected result`() =
         runTest {
             val exception = StripeException.create(Exception("Failure"))
-            val result = viewModel.getResultFromConfirmation(
+            val result = createViewModel().getResultFromConfirmation(
                 StripePaymentController.PAYMENT_REQUEST_CODE,
                 Intent()
                     .putExtras(
@@ -188,6 +208,8 @@ class GooglePayLauncherViewModelTest {
             val mockPaymentController: PaymentController = mock()
             createViewModel(paymentController = mockPaymentController)
                 .confirmStripeIntent(mock(), mock())
+
+            testDispatcher.scheduler.advanceUntilIdle()
 
             val argumentCaptor: KArgumentCaptor<ConfirmStripeIntentParams> = argumentCaptor()
             verify(mockPaymentController)
@@ -209,6 +231,8 @@ class GooglePayLauncherViewModelTest {
                 paymentController = mockPaymentController
             ).confirmStripeIntent(mock(), mock())
 
+            testDispatcher.scheduler.advanceUntilIdle()
+
             val argumentCaptor: KArgumentCaptor<ConfirmStripeIntentParams> = argumentCaptor()
             verify(mockPaymentController)
                 .startConfirmAndAuth(any(), argumentCaptor.capture(), any())
@@ -218,17 +242,19 @@ class GooglePayLauncherViewModelTest {
 
     private fun createViewModel(
         args: GooglePayLauncherContract.Args = ARGS,
-        paymentController: PaymentController = FakePaymentController()
+        paymentController: PaymentController = FakePaymentController(),
+        stripeRepository: StripeRepository = FakeStripeRepository(),
     ) = GooglePayLauncherViewModel(
-        paymentsClient,
-        REQUEST_OPTIONS,
-        args,
-        stripeRepository,
-        paymentController,
-        googlePayJsonFactory,
-        googlePayRepository,
-        savedStateHandle,
-        errorReporter = FakeErrorReporter()
+        paymentsClient = paymentsClient,
+        requestOptions = REQUEST_OPTIONS,
+        args = args,
+        stripeRepository = stripeRepository,
+        paymentController = paymentController,
+        googlePayJsonFactory = googlePayJsonFactory,
+        googlePayRepository = googlePayRepository,
+        savedStateHandle = savedStateHandle,
+        errorReporter = FakeErrorReporter(),
+        workContext = testDispatcher,
     )
 
     private class FakePaymentController : AbsPaymentController() {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I noticed a crash: https://play.google.com/sdk-console/u/0/accounts/3509857389984124436/sdks/6864602985443203626/crashes/fcf61d42/details?timeRange=LAST_28_DAYS&affectedApps=AFFECTED_APPS_FIVE_OR_MORE&crashStatuses=SDK_CRASH_STATUS_OPEN

This would happen if the task was returned after the user backgrounded the activity. Now we will only try to launch when the activity is in resumed state.
