### PR TITLE
Generate in-code address schema definitions.

### DIFF
--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/AddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/AddressSchemaDefinition.kt
@@ -1,0 +1,6 @@
+package com.stripe.android.uicore.address
+
+internal interface AddressSchemaDefinition {
+    val countryCode: String
+    fun schemaElements(): List<CountryAddressSchema>
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/AddressSchemaRegistry.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/AddressSchemaRegistry.kt
@@ -1,0 +1,495 @@
+package com.stripe.android.uicore.address
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.uicore.address.schemas.AcAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.AdAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.AeAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.AfAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.AgAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.AiAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.AlAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.AmAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.AoAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.AqAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.ArAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.AtAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.AuAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.AwAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.AxAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.AzAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.BaAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.BbAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.BdAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.BeAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.BfAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.BgAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.BhAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.BiAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.BjAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.BlAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.BmAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.BnAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.BoAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.BqAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.BrAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.BsAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.BtAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.BvAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.BwAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.ByAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.BzAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.CaAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.CdAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.CfAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.CgAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.ChAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.CiAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.CkAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.ClAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.CmAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.CnAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.CoAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.CrAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.CvAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.CwAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.CyAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.CzAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.DeAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.DjAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.DkAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.DmAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.DoAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.DzAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.EcAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.EeAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.EgAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.EhAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.ErAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.EsAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.EtAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.FiAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.FjAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.FkAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.FoAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.FrAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.GaAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.GbAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.GdAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.GeAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.GfAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.GgAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.GhAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.GiAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.GlAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.GmAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.GnAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.GpAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.GqAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.GrAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.GsAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.GtAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.GuAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.GwAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.GyAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.HkAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.HnAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.HrAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.HtAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.HuAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.IdAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.IeAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.IlAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.ImAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.InAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.IoAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.IqAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.IsAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.ItAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.JeAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.JmAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.JoAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.JpAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.KeAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.KgAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.KhAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.KiAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.KmAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.KnAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.KrAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.KwAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.KyAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.KzAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.LaAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.LbAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.LcAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.LiAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.LkAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.LrAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.LsAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.LtAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.LuAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.LvAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.LyAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.MaAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.McAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.MdAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.MeAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.MfAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.MgAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.MkAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.MlAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.MmAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.MnAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.MoAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.MqAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.MrAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.MsAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.MtAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.MuAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.MvAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.MwAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.MxAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.MyAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.MzAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.NaAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.NcAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.NeAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.NgAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.NiAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.NlAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.NoAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.NpAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.NrAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.NuAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.NzAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.OmAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.PaAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.PeAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.PfAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.PgAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.PhAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.PkAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.PlAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.PmAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.PnAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.PrAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.PsAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.PtAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.PyAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.QaAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.ReAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.RoAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.RsAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.RuAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.RwAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.SaAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.SbAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.ScAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.SeAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.SgAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.ShAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.SiAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.SjAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.SkAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.SlAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.SmAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.SnAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.SoAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.SrAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.SsAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.StAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.SvAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.SxAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.SzAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.TaAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.TcAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.TdAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.TfAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.TgAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.ThAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.TjAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.TkAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.TlAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.TmAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.TnAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.ToAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.TrAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.TtAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.TvAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.TwAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.TzAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.UaAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.UgAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.UsAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.UyAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.UzAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.VaAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.VcAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.VeAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.VgAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.VnAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.VuAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.WfAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.WsAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.XkAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.YeAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.YtAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.ZaAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.ZmAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.ZwAddressSchemaDefinition
+import com.stripe.android.uicore.address.schemas.ZzAddressSchemaDefinition
+import kotlin.String
+import kotlin.collections.Map
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+object AddressSchemaRegistry {
+    internal val defaultSchema = ZzAddressSchemaDefinition
+
+    internal val all: Map<String, AddressSchemaDefinition> = mapOf(
+        AcAddressSchemaDefinition.countryCode to AcAddressSchemaDefinition,
+        AdAddressSchemaDefinition.countryCode to AdAddressSchemaDefinition,
+        AeAddressSchemaDefinition.countryCode to AeAddressSchemaDefinition,
+        AfAddressSchemaDefinition.countryCode to AfAddressSchemaDefinition,
+        AgAddressSchemaDefinition.countryCode to AgAddressSchemaDefinition,
+        AiAddressSchemaDefinition.countryCode to AiAddressSchemaDefinition,
+        AlAddressSchemaDefinition.countryCode to AlAddressSchemaDefinition,
+        AmAddressSchemaDefinition.countryCode to AmAddressSchemaDefinition,
+        AoAddressSchemaDefinition.countryCode to AoAddressSchemaDefinition,
+        AqAddressSchemaDefinition.countryCode to AqAddressSchemaDefinition,
+        ArAddressSchemaDefinition.countryCode to ArAddressSchemaDefinition,
+        AtAddressSchemaDefinition.countryCode to AtAddressSchemaDefinition,
+        AuAddressSchemaDefinition.countryCode to AuAddressSchemaDefinition,
+        AwAddressSchemaDefinition.countryCode to AwAddressSchemaDefinition,
+        AxAddressSchemaDefinition.countryCode to AxAddressSchemaDefinition,
+        AzAddressSchemaDefinition.countryCode to AzAddressSchemaDefinition,
+        BaAddressSchemaDefinition.countryCode to BaAddressSchemaDefinition,
+        BbAddressSchemaDefinition.countryCode to BbAddressSchemaDefinition,
+        BdAddressSchemaDefinition.countryCode to BdAddressSchemaDefinition,
+        BeAddressSchemaDefinition.countryCode to BeAddressSchemaDefinition,
+        BfAddressSchemaDefinition.countryCode to BfAddressSchemaDefinition,
+        BgAddressSchemaDefinition.countryCode to BgAddressSchemaDefinition,
+        BhAddressSchemaDefinition.countryCode to BhAddressSchemaDefinition,
+        BiAddressSchemaDefinition.countryCode to BiAddressSchemaDefinition,
+        BjAddressSchemaDefinition.countryCode to BjAddressSchemaDefinition,
+        BlAddressSchemaDefinition.countryCode to BlAddressSchemaDefinition,
+        BmAddressSchemaDefinition.countryCode to BmAddressSchemaDefinition,
+        BnAddressSchemaDefinition.countryCode to BnAddressSchemaDefinition,
+        BoAddressSchemaDefinition.countryCode to BoAddressSchemaDefinition,
+        BqAddressSchemaDefinition.countryCode to BqAddressSchemaDefinition,
+        BrAddressSchemaDefinition.countryCode to BrAddressSchemaDefinition,
+        BsAddressSchemaDefinition.countryCode to BsAddressSchemaDefinition,
+        BtAddressSchemaDefinition.countryCode to BtAddressSchemaDefinition,
+        BvAddressSchemaDefinition.countryCode to BvAddressSchemaDefinition,
+        BwAddressSchemaDefinition.countryCode to BwAddressSchemaDefinition,
+        ByAddressSchemaDefinition.countryCode to ByAddressSchemaDefinition,
+        BzAddressSchemaDefinition.countryCode to BzAddressSchemaDefinition,
+        CaAddressSchemaDefinition.countryCode to CaAddressSchemaDefinition,
+        CdAddressSchemaDefinition.countryCode to CdAddressSchemaDefinition,
+        CfAddressSchemaDefinition.countryCode to CfAddressSchemaDefinition,
+        CgAddressSchemaDefinition.countryCode to CgAddressSchemaDefinition,
+        ChAddressSchemaDefinition.countryCode to ChAddressSchemaDefinition,
+        CiAddressSchemaDefinition.countryCode to CiAddressSchemaDefinition,
+        CkAddressSchemaDefinition.countryCode to CkAddressSchemaDefinition,
+        ClAddressSchemaDefinition.countryCode to ClAddressSchemaDefinition,
+        CmAddressSchemaDefinition.countryCode to CmAddressSchemaDefinition,
+        CnAddressSchemaDefinition.countryCode to CnAddressSchemaDefinition,
+        CoAddressSchemaDefinition.countryCode to CoAddressSchemaDefinition,
+        CrAddressSchemaDefinition.countryCode to CrAddressSchemaDefinition,
+        CvAddressSchemaDefinition.countryCode to CvAddressSchemaDefinition,
+        CwAddressSchemaDefinition.countryCode to CwAddressSchemaDefinition,
+        CyAddressSchemaDefinition.countryCode to CyAddressSchemaDefinition,
+        CzAddressSchemaDefinition.countryCode to CzAddressSchemaDefinition,
+        DeAddressSchemaDefinition.countryCode to DeAddressSchemaDefinition,
+        DjAddressSchemaDefinition.countryCode to DjAddressSchemaDefinition,
+        DkAddressSchemaDefinition.countryCode to DkAddressSchemaDefinition,
+        DmAddressSchemaDefinition.countryCode to DmAddressSchemaDefinition,
+        DoAddressSchemaDefinition.countryCode to DoAddressSchemaDefinition,
+        DzAddressSchemaDefinition.countryCode to DzAddressSchemaDefinition,
+        EcAddressSchemaDefinition.countryCode to EcAddressSchemaDefinition,
+        EeAddressSchemaDefinition.countryCode to EeAddressSchemaDefinition,
+        EgAddressSchemaDefinition.countryCode to EgAddressSchemaDefinition,
+        EhAddressSchemaDefinition.countryCode to EhAddressSchemaDefinition,
+        ErAddressSchemaDefinition.countryCode to ErAddressSchemaDefinition,
+        EsAddressSchemaDefinition.countryCode to EsAddressSchemaDefinition,
+        EtAddressSchemaDefinition.countryCode to EtAddressSchemaDefinition,
+        FiAddressSchemaDefinition.countryCode to FiAddressSchemaDefinition,
+        FjAddressSchemaDefinition.countryCode to FjAddressSchemaDefinition,
+        FkAddressSchemaDefinition.countryCode to FkAddressSchemaDefinition,
+        FoAddressSchemaDefinition.countryCode to FoAddressSchemaDefinition,
+        FrAddressSchemaDefinition.countryCode to FrAddressSchemaDefinition,
+        GaAddressSchemaDefinition.countryCode to GaAddressSchemaDefinition,
+        GbAddressSchemaDefinition.countryCode to GbAddressSchemaDefinition,
+        GdAddressSchemaDefinition.countryCode to GdAddressSchemaDefinition,
+        GeAddressSchemaDefinition.countryCode to GeAddressSchemaDefinition,
+        GfAddressSchemaDefinition.countryCode to GfAddressSchemaDefinition,
+        GgAddressSchemaDefinition.countryCode to GgAddressSchemaDefinition,
+        GhAddressSchemaDefinition.countryCode to GhAddressSchemaDefinition,
+        GiAddressSchemaDefinition.countryCode to GiAddressSchemaDefinition,
+        GlAddressSchemaDefinition.countryCode to GlAddressSchemaDefinition,
+        GmAddressSchemaDefinition.countryCode to GmAddressSchemaDefinition,
+        GnAddressSchemaDefinition.countryCode to GnAddressSchemaDefinition,
+        GpAddressSchemaDefinition.countryCode to GpAddressSchemaDefinition,
+        GqAddressSchemaDefinition.countryCode to GqAddressSchemaDefinition,
+        GrAddressSchemaDefinition.countryCode to GrAddressSchemaDefinition,
+        GsAddressSchemaDefinition.countryCode to GsAddressSchemaDefinition,
+        GtAddressSchemaDefinition.countryCode to GtAddressSchemaDefinition,
+        GuAddressSchemaDefinition.countryCode to GuAddressSchemaDefinition,
+        GwAddressSchemaDefinition.countryCode to GwAddressSchemaDefinition,
+        GyAddressSchemaDefinition.countryCode to GyAddressSchemaDefinition,
+        HkAddressSchemaDefinition.countryCode to HkAddressSchemaDefinition,
+        HnAddressSchemaDefinition.countryCode to HnAddressSchemaDefinition,
+        HrAddressSchemaDefinition.countryCode to HrAddressSchemaDefinition,
+        HtAddressSchemaDefinition.countryCode to HtAddressSchemaDefinition,
+        HuAddressSchemaDefinition.countryCode to HuAddressSchemaDefinition,
+        IdAddressSchemaDefinition.countryCode to IdAddressSchemaDefinition,
+        IeAddressSchemaDefinition.countryCode to IeAddressSchemaDefinition,
+        IlAddressSchemaDefinition.countryCode to IlAddressSchemaDefinition,
+        ImAddressSchemaDefinition.countryCode to ImAddressSchemaDefinition,
+        InAddressSchemaDefinition.countryCode to InAddressSchemaDefinition,
+        IoAddressSchemaDefinition.countryCode to IoAddressSchemaDefinition,
+        IqAddressSchemaDefinition.countryCode to IqAddressSchemaDefinition,
+        IsAddressSchemaDefinition.countryCode to IsAddressSchemaDefinition,
+        ItAddressSchemaDefinition.countryCode to ItAddressSchemaDefinition,
+        JeAddressSchemaDefinition.countryCode to JeAddressSchemaDefinition,
+        JmAddressSchemaDefinition.countryCode to JmAddressSchemaDefinition,
+        JoAddressSchemaDefinition.countryCode to JoAddressSchemaDefinition,
+        JpAddressSchemaDefinition.countryCode to JpAddressSchemaDefinition,
+        KeAddressSchemaDefinition.countryCode to KeAddressSchemaDefinition,
+        KgAddressSchemaDefinition.countryCode to KgAddressSchemaDefinition,
+        KhAddressSchemaDefinition.countryCode to KhAddressSchemaDefinition,
+        KiAddressSchemaDefinition.countryCode to KiAddressSchemaDefinition,
+        KmAddressSchemaDefinition.countryCode to KmAddressSchemaDefinition,
+        KnAddressSchemaDefinition.countryCode to KnAddressSchemaDefinition,
+        KrAddressSchemaDefinition.countryCode to KrAddressSchemaDefinition,
+        KwAddressSchemaDefinition.countryCode to KwAddressSchemaDefinition,
+        KyAddressSchemaDefinition.countryCode to KyAddressSchemaDefinition,
+        KzAddressSchemaDefinition.countryCode to KzAddressSchemaDefinition,
+        LaAddressSchemaDefinition.countryCode to LaAddressSchemaDefinition,
+        LbAddressSchemaDefinition.countryCode to LbAddressSchemaDefinition,
+        LcAddressSchemaDefinition.countryCode to LcAddressSchemaDefinition,
+        LiAddressSchemaDefinition.countryCode to LiAddressSchemaDefinition,
+        LkAddressSchemaDefinition.countryCode to LkAddressSchemaDefinition,
+        LrAddressSchemaDefinition.countryCode to LrAddressSchemaDefinition,
+        LsAddressSchemaDefinition.countryCode to LsAddressSchemaDefinition,
+        LtAddressSchemaDefinition.countryCode to LtAddressSchemaDefinition,
+        LuAddressSchemaDefinition.countryCode to LuAddressSchemaDefinition,
+        LvAddressSchemaDefinition.countryCode to LvAddressSchemaDefinition,
+        LyAddressSchemaDefinition.countryCode to LyAddressSchemaDefinition,
+        MaAddressSchemaDefinition.countryCode to MaAddressSchemaDefinition,
+        McAddressSchemaDefinition.countryCode to McAddressSchemaDefinition,
+        MdAddressSchemaDefinition.countryCode to MdAddressSchemaDefinition,
+        MeAddressSchemaDefinition.countryCode to MeAddressSchemaDefinition,
+        MfAddressSchemaDefinition.countryCode to MfAddressSchemaDefinition,
+        MgAddressSchemaDefinition.countryCode to MgAddressSchemaDefinition,
+        MkAddressSchemaDefinition.countryCode to MkAddressSchemaDefinition,
+        MlAddressSchemaDefinition.countryCode to MlAddressSchemaDefinition,
+        MmAddressSchemaDefinition.countryCode to MmAddressSchemaDefinition,
+        MnAddressSchemaDefinition.countryCode to MnAddressSchemaDefinition,
+        MoAddressSchemaDefinition.countryCode to MoAddressSchemaDefinition,
+        MqAddressSchemaDefinition.countryCode to MqAddressSchemaDefinition,
+        MrAddressSchemaDefinition.countryCode to MrAddressSchemaDefinition,
+        MsAddressSchemaDefinition.countryCode to MsAddressSchemaDefinition,
+        MtAddressSchemaDefinition.countryCode to MtAddressSchemaDefinition,
+        MuAddressSchemaDefinition.countryCode to MuAddressSchemaDefinition,
+        MvAddressSchemaDefinition.countryCode to MvAddressSchemaDefinition,
+        MwAddressSchemaDefinition.countryCode to MwAddressSchemaDefinition,
+        MxAddressSchemaDefinition.countryCode to MxAddressSchemaDefinition,
+        MyAddressSchemaDefinition.countryCode to MyAddressSchemaDefinition,
+        MzAddressSchemaDefinition.countryCode to MzAddressSchemaDefinition,
+        NaAddressSchemaDefinition.countryCode to NaAddressSchemaDefinition,
+        NcAddressSchemaDefinition.countryCode to NcAddressSchemaDefinition,
+        NeAddressSchemaDefinition.countryCode to NeAddressSchemaDefinition,
+        NgAddressSchemaDefinition.countryCode to NgAddressSchemaDefinition,
+        NiAddressSchemaDefinition.countryCode to NiAddressSchemaDefinition,
+        NlAddressSchemaDefinition.countryCode to NlAddressSchemaDefinition,
+        NoAddressSchemaDefinition.countryCode to NoAddressSchemaDefinition,
+        NpAddressSchemaDefinition.countryCode to NpAddressSchemaDefinition,
+        NrAddressSchemaDefinition.countryCode to NrAddressSchemaDefinition,
+        NuAddressSchemaDefinition.countryCode to NuAddressSchemaDefinition,
+        NzAddressSchemaDefinition.countryCode to NzAddressSchemaDefinition,
+        OmAddressSchemaDefinition.countryCode to OmAddressSchemaDefinition,
+        PaAddressSchemaDefinition.countryCode to PaAddressSchemaDefinition,
+        PeAddressSchemaDefinition.countryCode to PeAddressSchemaDefinition,
+        PfAddressSchemaDefinition.countryCode to PfAddressSchemaDefinition,
+        PgAddressSchemaDefinition.countryCode to PgAddressSchemaDefinition,
+        PhAddressSchemaDefinition.countryCode to PhAddressSchemaDefinition,
+        PkAddressSchemaDefinition.countryCode to PkAddressSchemaDefinition,
+        PlAddressSchemaDefinition.countryCode to PlAddressSchemaDefinition,
+        PmAddressSchemaDefinition.countryCode to PmAddressSchemaDefinition,
+        PnAddressSchemaDefinition.countryCode to PnAddressSchemaDefinition,
+        PrAddressSchemaDefinition.countryCode to PrAddressSchemaDefinition,
+        PsAddressSchemaDefinition.countryCode to PsAddressSchemaDefinition,
+        PtAddressSchemaDefinition.countryCode to PtAddressSchemaDefinition,
+        PyAddressSchemaDefinition.countryCode to PyAddressSchemaDefinition,
+        QaAddressSchemaDefinition.countryCode to QaAddressSchemaDefinition,
+        ReAddressSchemaDefinition.countryCode to ReAddressSchemaDefinition,
+        RoAddressSchemaDefinition.countryCode to RoAddressSchemaDefinition,
+        RsAddressSchemaDefinition.countryCode to RsAddressSchemaDefinition,
+        RuAddressSchemaDefinition.countryCode to RuAddressSchemaDefinition,
+        RwAddressSchemaDefinition.countryCode to RwAddressSchemaDefinition,
+        SaAddressSchemaDefinition.countryCode to SaAddressSchemaDefinition,
+        SbAddressSchemaDefinition.countryCode to SbAddressSchemaDefinition,
+        ScAddressSchemaDefinition.countryCode to ScAddressSchemaDefinition,
+        SeAddressSchemaDefinition.countryCode to SeAddressSchemaDefinition,
+        SgAddressSchemaDefinition.countryCode to SgAddressSchemaDefinition,
+        ShAddressSchemaDefinition.countryCode to ShAddressSchemaDefinition,
+        SiAddressSchemaDefinition.countryCode to SiAddressSchemaDefinition,
+        SjAddressSchemaDefinition.countryCode to SjAddressSchemaDefinition,
+        SkAddressSchemaDefinition.countryCode to SkAddressSchemaDefinition,
+        SlAddressSchemaDefinition.countryCode to SlAddressSchemaDefinition,
+        SmAddressSchemaDefinition.countryCode to SmAddressSchemaDefinition,
+        SnAddressSchemaDefinition.countryCode to SnAddressSchemaDefinition,
+        SoAddressSchemaDefinition.countryCode to SoAddressSchemaDefinition,
+        SrAddressSchemaDefinition.countryCode to SrAddressSchemaDefinition,
+        SsAddressSchemaDefinition.countryCode to SsAddressSchemaDefinition,
+        StAddressSchemaDefinition.countryCode to StAddressSchemaDefinition,
+        SvAddressSchemaDefinition.countryCode to SvAddressSchemaDefinition,
+        SxAddressSchemaDefinition.countryCode to SxAddressSchemaDefinition,
+        SzAddressSchemaDefinition.countryCode to SzAddressSchemaDefinition,
+        TaAddressSchemaDefinition.countryCode to TaAddressSchemaDefinition,
+        TcAddressSchemaDefinition.countryCode to TcAddressSchemaDefinition,
+        TdAddressSchemaDefinition.countryCode to TdAddressSchemaDefinition,
+        TfAddressSchemaDefinition.countryCode to TfAddressSchemaDefinition,
+        TgAddressSchemaDefinition.countryCode to TgAddressSchemaDefinition,
+        ThAddressSchemaDefinition.countryCode to ThAddressSchemaDefinition,
+        TjAddressSchemaDefinition.countryCode to TjAddressSchemaDefinition,
+        TkAddressSchemaDefinition.countryCode to TkAddressSchemaDefinition,
+        TlAddressSchemaDefinition.countryCode to TlAddressSchemaDefinition,
+        TmAddressSchemaDefinition.countryCode to TmAddressSchemaDefinition,
+        TnAddressSchemaDefinition.countryCode to TnAddressSchemaDefinition,
+        ToAddressSchemaDefinition.countryCode to ToAddressSchemaDefinition,
+        TrAddressSchemaDefinition.countryCode to TrAddressSchemaDefinition,
+        TtAddressSchemaDefinition.countryCode to TtAddressSchemaDefinition,
+        TvAddressSchemaDefinition.countryCode to TvAddressSchemaDefinition,
+        TwAddressSchemaDefinition.countryCode to TwAddressSchemaDefinition,
+        TzAddressSchemaDefinition.countryCode to TzAddressSchemaDefinition,
+        UaAddressSchemaDefinition.countryCode to UaAddressSchemaDefinition,
+        UgAddressSchemaDefinition.countryCode to UgAddressSchemaDefinition,
+        UsAddressSchemaDefinition.countryCode to UsAddressSchemaDefinition,
+        UyAddressSchemaDefinition.countryCode to UyAddressSchemaDefinition,
+        UzAddressSchemaDefinition.countryCode to UzAddressSchemaDefinition,
+        VaAddressSchemaDefinition.countryCode to VaAddressSchemaDefinition,
+        VcAddressSchemaDefinition.countryCode to VcAddressSchemaDefinition,
+        VeAddressSchemaDefinition.countryCode to VeAddressSchemaDefinition,
+        VgAddressSchemaDefinition.countryCode to VgAddressSchemaDefinition,
+        VnAddressSchemaDefinition.countryCode to VnAddressSchemaDefinition,
+        VuAddressSchemaDefinition.countryCode to VuAddressSchemaDefinition,
+        WfAddressSchemaDefinition.countryCode to WfAddressSchemaDefinition,
+        WsAddressSchemaDefinition.countryCode to WsAddressSchemaDefinition,
+        XkAddressSchemaDefinition.countryCode to XkAddressSchemaDefinition,
+        YeAddressSchemaDefinition.countryCode to YeAddressSchemaDefinition,
+        YtAddressSchemaDefinition.countryCode to YtAddressSchemaDefinition,
+        ZaAddressSchemaDefinition.countryCode to ZaAddressSchemaDefinition,
+        ZmAddressSchemaDefinition.countryCode to ZmAddressSchemaDefinition,
+        ZwAddressSchemaDefinition.countryCode to ZwAddressSchemaDefinition,
+        ZzAddressSchemaDefinition.countryCode to ZzAddressSchemaDefinition,
+    )
+
+    fun get(countryCode: String?): List<CountryAddressSchema>? {
+        return if (countryCode != null) {
+            all[countryCode]?.schemaElements()
+        } else {
+            defaultSchema.schemaElements()
+        }
+    }
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AcAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AcAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object AcAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "AC"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AdAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AdAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object AdAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "AD"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AeAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AeAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object AeAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "AE"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Emirate,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AfAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AfAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object AfAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "AF"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AgAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AgAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object AgAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "AG"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AiAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AiAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object AiAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "AI"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AlAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AlAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object AlAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "AL"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AmAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AmAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object AmAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "AM"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AoAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AoAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object AoAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "AO"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AqAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AqAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object AqAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "AQ"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ArAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ArAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object ArAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "AR"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AtAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AtAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object AtAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "AT"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AuAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AuAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object AuAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "AU"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.SuburbOrCity,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.State,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AwAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AwAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object AwAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "AW"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AxAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AxAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object AxAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "AX"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AzAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/AzAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object AzAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "AZ"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BaAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BaAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object BaAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "BA"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BbAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BbAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object BbAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "BB"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Parish,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BdAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BdAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object BdAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "BD"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BeAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BeAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object BeAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "BE"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BfAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BfAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object BfAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "BF"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.SortingCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Cedex,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BgAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BgAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object BgAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "BG"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BhAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BhAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object BhAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "BH"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BiAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BiAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object BiAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "BI"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BjAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BjAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object BjAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "BJ"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BlAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BlAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object BlAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "BL"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.SortingCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Cedex,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BmAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BmAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object BmAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "BM"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BnAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BnAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object BnAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "BN"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BoAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BoAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object BoAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "BO"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BqAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BqAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object BqAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "BQ"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BrAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BrAddressSchemaDefinition.kt
@@ -1,0 +1,58 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object BrAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "BR"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.DependentLocality,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Neighborhood,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.State,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BsAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BsAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object BsAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "BS"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Island,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BtAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BtAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object BtAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "BT"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BvAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BvAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object BvAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "BV"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BwAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BwAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object BwAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "BW"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ByAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ByAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object ByAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "BY"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Oblast,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BzAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/BzAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object BzAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "BZ"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CaAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CaAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object CaAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "CA"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CdAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CdAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object CdAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "CD"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CfAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CfAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object CfAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "CF"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CgAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CgAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object CgAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "CG"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ChAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ChAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object ChAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "CH"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CiAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CiAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object CiAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "CI"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.SortingCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Cedex,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CkAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CkAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object CkAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "CK"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ClAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ClAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object ClAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "CL"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CmAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CmAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object CmAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "CM"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CnAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CnAddressSchemaDefinition.kt
@@ -1,0 +1,58 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object CnAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "CN"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.DependentLocality,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.District,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CoAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CoAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object CoAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "CO"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Department,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CrAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CrAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object CrAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "CR"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CvAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CvAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object CvAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "CV"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Island,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CwAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CwAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object CwAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "CW"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CyAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CyAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object CyAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "CY"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CzAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/CzAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object CzAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "CZ"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/DeAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/DeAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object DeAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "DE"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/DjAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/DjAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object DjAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "DJ"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/DkAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/DkAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object DkAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "DK"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/DmAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/DmAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object DmAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "DM"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/DoAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/DoAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object DoAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "DO"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/DzAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/DzAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object DzAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "DZ"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/EcAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/EcAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object EcAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "EC"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/EeAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/EeAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object EeAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "EE"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/EgAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/EgAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object EgAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "EG"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/EhAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/EhAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object EhAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "EH"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ErAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ErAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object ErAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "ER"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/EsAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/EsAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object EsAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "ES"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/EtAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/EtAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object EtAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "ET"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/FiAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/FiAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object FiAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "FI"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/FjAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/FjAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object FjAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "FJ"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/FkAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/FkAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object FkAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "FK"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/FoAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/FoAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object FoAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "FO"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/FrAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/FrAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object FrAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "FR"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GaAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GaAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object GaAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "GA"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GbAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GbAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object GbAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "GB"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.PostTown,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GdAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GdAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object GdAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "GD"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GeAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GeAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object GeAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "GE"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GfAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GfAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object GfAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "GF"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.SortingCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Cedex,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GgAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GgAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object GgAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "GG"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GhAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GhAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object GhAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "GH"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GiAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GiAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object GiAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "GI"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GlAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GlAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object GlAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "GL"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GmAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GmAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object GmAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "GM"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GnAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GnAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object GnAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "GN"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GpAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GpAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object GpAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "GP"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.SortingCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Cedex,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GqAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GqAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object GqAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "GQ"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GrAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GrAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object GrAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "GR"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GsAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GsAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object GsAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "GS"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GtAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GtAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object GtAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "GT"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GuAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GuAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object GuAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "GU"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Zip,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GwAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GwAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object GwAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "GW"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GyAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/GyAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object GyAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "GY"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/HkAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/HkAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object HkAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "HK"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Area,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.District,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/HnAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/HnAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object HnAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "HN"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Department,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/HrAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/HrAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object HrAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "HR"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/HtAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/HtAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object HtAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "HT"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/HuAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/HuAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object HuAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "HU"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/IdAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/IdAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object IdAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "ID"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/IeAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/IeAddressSchemaDefinition.kt
@@ -1,0 +1,58 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object IeAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "IE"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.DependentLocality,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Townload,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.County,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Eircode,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/IlAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/IlAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object IlAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "IL"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ImAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ImAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object ImAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "IM"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/InAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/InAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object InAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "IN"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Pin,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.State,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/IoAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/IoAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object IoAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "IO"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/IqAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/IqAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object IqAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "IQ"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/IsAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/IsAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object IsAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "IS"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ItAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ItAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object ItAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "IT"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/JeAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/JeAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object JeAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "JE"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/JmAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/JmAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object JmAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "JM"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Parish,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.SortingCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Cedex,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/JoAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/JoAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object JoAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "JO"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/JpAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/JpAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object JpAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "JP"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Perfecture,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/KeAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/KeAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object KeAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "KE"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/KgAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/KgAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object KgAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "KG"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/KhAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/KhAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object KhAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "KH"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/KiAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/KiAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object KiAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "KI"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Island,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/KmAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/KmAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object KmAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "KM"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/KnAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/KnAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object KnAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "KN"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Island,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/KrAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/KrAddressSchemaDefinition.kt
@@ -1,0 +1,58 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object KrAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "KR"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.DoSi,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.DependentLocality,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.District,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/KwAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/KwAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object KwAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "KW"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/KyAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/KyAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object KyAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "KY"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Island,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/KzAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/KzAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object KzAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "KZ"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LaAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LaAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object LaAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "LA"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LbAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LbAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object LbAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "LB"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LcAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LcAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object LcAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "LC"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LiAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LiAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object LiAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "LI"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LkAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LkAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object LkAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "LK"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LrAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LrAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object LrAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "LR"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LsAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LsAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object LsAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "LS"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LtAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LtAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object LtAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "LT"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LuAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LuAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object LuAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "LU"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LvAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LvAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object LvAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "LV"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LyAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/LyAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object LyAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "LY"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MaAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MaAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object MaAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "MA"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/McAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/McAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object McAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "MC"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.SortingCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Cedex,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MdAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MdAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object MdAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "MD"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MeAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MeAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object MeAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "ME"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MfAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MfAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object MfAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "MF"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.SortingCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Cedex,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MgAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MgAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object MgAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "MG"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MkAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MkAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object MkAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "MK"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MlAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MlAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object MlAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "ML"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MmAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MmAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object MmAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "MM"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MnAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MnAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object MnAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "MN"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MoAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MoAddressSchemaDefinition.kt
@@ -1,0 +1,24 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldType
+import kotlin.String
+import kotlin.collections.List
+
+internal object MoAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "MO"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MqAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MqAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object MqAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "MQ"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.SortingCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Cedex,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MrAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MrAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object MrAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "MR"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MsAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MsAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object MsAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "MS"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MtAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MtAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object MtAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "MT"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MuAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MuAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object MuAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "MU"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MvAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MvAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object MvAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "MV"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MwAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MwAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object MwAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "MW"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.SortingCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Cedex,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MxAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MxAddressSchemaDefinition.kt
@@ -1,0 +1,58 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object MxAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "MX"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.DependentLocality,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Neighborhood,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.State,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MyAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MyAddressSchemaDefinition.kt
@@ -1,0 +1,58 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object MyAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "MY"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.DependentLocality,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.VillageTownship,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.State,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MzAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/MzAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object MzAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "MZ"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NaAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NaAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object NaAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "NA"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NcAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NcAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object NcAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "NC"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.SortingCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Cedex,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NeAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NeAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object NeAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "NE"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NgAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NgAddressSchemaDefinition.kt
@@ -1,0 +1,58 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object NgAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "NG"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.DependentLocality,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Suburb,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.State,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NiAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NiAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object NiAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "NI"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Department,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NlAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NlAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object NlAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "NL"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NoAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NoAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object NoAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "NO"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.PostTown,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NpAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NpAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object NpAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "NP"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NrAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NrAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object NrAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "NR"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.District,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NuAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NuAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object NuAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "NU"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NzAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/NzAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object NzAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "NZ"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.DependentLocality,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Suburb,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/OmAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/OmAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object OmAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "OM"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PaAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PaAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object PaAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "PA"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PeAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PeAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object PeAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "PE"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.District,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PfAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PfAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object PfAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "PF"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Island,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PgAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PgAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object PgAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "PG"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PhAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PhAddressSchemaDefinition.kt
@@ -1,0 +1,58 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object PhAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "PH"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.DependentLocality,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Suburb,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PkAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PkAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object PkAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "PK"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PlAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PlAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object PlAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "PL"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PmAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PmAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object PmAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "PM"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.SortingCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Cedex,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PnAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PnAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object PnAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "PN"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PrAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PrAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object PrAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "PR"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Zip,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PsAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PsAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object PsAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "PS"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PtAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PtAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object PtAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "PT"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PyAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/PyAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object PyAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "PY"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/QaAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/QaAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object QaAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "QA"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ReAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ReAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object ReAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "RE"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.SortingCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Cedex,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/RoAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/RoAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object RoAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "RO"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/RsAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/RsAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object RsAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "RS"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/RuAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/RuAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object RuAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "RU"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Oblast,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/RwAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/RwAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object RwAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "RW"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SaAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SaAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object SaAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "SA"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SbAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SbAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object SbAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "SB"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ScAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ScAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object ScAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "SC"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Island,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SeAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SeAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object SeAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "SE"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.PostTown,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SgAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SgAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object SgAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "SG"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ShAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ShAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object ShAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "SH"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SiAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SiAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object SiAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "SI"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SjAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SjAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object SjAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "SJ"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.PostTown,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SkAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SkAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object SkAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "SK"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SlAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SlAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object SlAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "SL"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SmAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SmAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object SmAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "SM"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SnAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SnAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object SnAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "SN"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SoAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SoAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object SoAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "SO"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SrAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SrAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object SrAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "SR"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SsAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SsAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object SsAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "SS"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/StAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/StAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object StAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "ST"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SvAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SvAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object SvAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "SV"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SxAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SxAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object SxAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "SX"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SzAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/SzAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object SzAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "SZ"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TaAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TaAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object TaAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "TA"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TcAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TcAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object TcAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "TC"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TdAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TdAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object TdAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "TD"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TfAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TfAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object TfAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "TF"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TgAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TgAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object TgAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "TG"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ThAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ThAddressSchemaDefinition.kt
@@ -1,0 +1,58 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object ThAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "TH"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.DependentLocality,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Suburb,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TjAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TjAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object TjAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "TJ"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TkAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TkAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object TkAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "TK"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TlAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TlAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object TlAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "TL"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TmAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TmAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object TmAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "TM"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TnAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TnAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object TnAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "TN"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ToAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ToAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object ToAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "TO"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TrAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TrAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object TrAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "TR"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.District,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TtAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TtAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object TtAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "TT"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TvAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TvAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object TvAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "TV"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Island,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TwAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TwAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object TwAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "TW"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.County,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TzAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/TzAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object TzAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "TZ"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/UaAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/UaAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object UaAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "UA"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Oblast,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/UgAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/UgAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object UgAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "UG"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/UsAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/UsAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object UsAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "US"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Zip,
+                isNumeric = true,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.State,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/UyAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/UyAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object UyAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "UY"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/UzAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/UzAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object UzAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "UZ"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/VaAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/VaAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object VaAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "VA"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/VcAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/VcAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object VcAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "VC"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/VeAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/VeAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object VeAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "VE"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.State,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/VgAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/VgAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object VgAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "VG"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/VnAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/VnAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object VnAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "VN"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.AdministrativeArea,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Province,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/VuAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/VuAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object VuAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "VU"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/WfAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/WfAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object WfAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "WF"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.SortingCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Cedex,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/WsAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/WsAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object WsAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "WS"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/XkAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/XkAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object XkAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "XK"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/YeAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/YeAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object YeAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "YE"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/YtAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/YtAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object YtAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "YT"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.SortingCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Cedex,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ZaAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ZaAddressSchemaDefinition.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object ZaAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "ZA"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.DependentLocality,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Suburb,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ZmAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ZmAddressSchemaDefinition.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object ZmAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "ZM"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.PostalCode,
+            required = false,
+            schema = FieldSchema(
+                nameType = NameType.Postal,
+                isNumeric = false,
+            ),
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ZwAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ZwAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object ZwAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "ZW"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ZzAddressSchemaDefinition.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/schemas/ZzAddressSchemaDefinition.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.uicore.address.schemas
+
+import com.stripe.android.uicore.address.AddressSchemaDefinition
+import com.stripe.android.uicore.address.CountryAddressSchema
+import com.stripe.android.uicore.address.FieldSchema
+import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.address.NameType
+import kotlin.String
+import kotlin.collections.List
+
+internal object ZzAddressSchemaDefinition : AddressSchemaDefinition {
+    override val countryCode: String = "ZZ"
+
+    override fun schemaElements(): List<CountryAddressSchema> = listOf(
+        CountryAddressSchema(
+            type = FieldType.AddressLine1,
+            required = true,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.AddressLine2,
+            required = false,
+            schema = null,
+        ),
+        CountryAddressSchema(
+            type = FieldType.Locality,
+            required = true,
+            schema = FieldSchema(
+                nameType = NameType.City,
+                isNumeric = false,
+            ),
+        ),
+    )
+}


### PR DESCRIPTION
# Summary
Generate in-code address schema definitions that will replace the JSON files. The plan following this PR is:
- Replace usages of `AddressRepository` and `AddressSchemaRepository` with `AddressSchemaRegistry`
- Remove `AddressRepository` and `AddressSchemaRepository`
- Remove all address JSON files

# Motivation
Using in-code definitions avoids us having to load the definitions from JSON.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
