### PR TITLE
Add better handling for launching PaymentSheet.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetCompose.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetCompose.kt
@@ -42,6 +42,7 @@ fun rememberPaymentSheet(
             activity = activity,
             application = context.applicationContext as Application,
             lifecycleOwner = lifecycleOwner,
+            callback = paymentResultCallback,
         )
         PaymentSheet(launcher)
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When digging through our crash reports, I noticed many merchants were launching PaymentSheet after the host activity was destroyed. This causes runtime exceptions, and looks bad on us. We can easily handle this gracefully, so that's what this change does.
