### PR TITLE
Add support for parsing `customer` field from `ElementsSession`

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -2728,6 +2728,22 @@ public final class com/stripe/android/model/ElementsSession$Creator : android/os
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/model/ElementsSession$Customer$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ElementsSession$Customer;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/ElementsSession$Customer;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/ElementsSession$Customer$Session$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ElementsSession$Customer$Session;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/ElementsSession$Customer$Session;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/model/ElementsSession$LinkSettings$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ElementsSession$LinkSettings;

--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -14,6 +14,7 @@ data class ElementsSession(
     val paymentMethodSpecs: String?,
     val externalPaymentMethodData: String?,
     val stripeIntent: StripeIntent,
+    val customer: Customer?,
     val merchantCountry: String?,
     val isEligibleForCardBrandChoice: Boolean,
     val isGooglePayEnabled: Boolean,
@@ -46,6 +47,24 @@ data class ElementsSession(
     ) : StripeModel
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @Parcelize
+    data class Customer(
+        val paymentMethods: List<PaymentMethod>,
+        val defaultPaymentMethod: String?,
+        val session: Session,
+    ) : StripeModel {
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @Parcelize
+        data class Session(
+            val id: String,
+            val liveMode: Boolean,
+            val apiKey: String,
+            val apiKeyExpiry: Int,
+            val customerId: String
+        ) : StripeModel
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
         fun createFromFallback(
             stripeIntent: StripeIntent,
@@ -56,6 +75,7 @@ data class ElementsSession(
                 paymentMethodSpecs = null,
                 externalPaymentMethodData = null,
                 stripeIntent = stripeIntent,
+                customer = null,
                 merchantCountry = null,
                 isEligibleForCardBrandChoice = false,
                 isGooglePayEnabled = true,

--- a/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
@@ -166,6 +166,129 @@ internal object ElementsSessionFixtures {
         """.trimIndent()
     )
 
+    val EXPANDED_PAYMENT_INTENT_WITH_CUSTOMER_SESSION = JSONObject(
+        """
+        {
+          "business_name": "Mybusiness",
+          "link_settings": {
+            "link_bank_enabled": false,
+            "link_bank_onboarding_enabled": false
+          },
+          "merchant_country": "US",
+          "payment_method_preference": {
+            "object": "payment_method_preference",
+            "country_code": "US",
+            "ordered_payment_method_types": [
+              "card",
+              "ideal",
+              "sepa_debit",
+              "bancontact",
+              "sofort"
+            ],
+            "payment_intent": {
+              "id": "pi_123",
+              "object": "payment_intent",
+              "amount": 973,
+              "canceled_at": null,
+              "cancellation_reason": null,
+              "capture_method": "automatic",
+              "client_secret": "pi_1234567",
+              "confirmation_method": "automatic",
+              "created": 1630103948,
+              "currency": "eur",
+              "description": null,
+              "last_payment_error": null,
+              "livemode": false,
+              "next_action": null,
+              "payment_method": null,
+              "payment_method_types": [
+                "bancontact",
+                "card",
+                "sepa_debit",
+                "sofort",
+                "ideal"
+              ],
+              "receipt_email": null,
+              "setup_future_usage": null,
+              "shipping": {
+                "address": {
+                  "city": "San Francisco",
+                  "country": "US",
+                  "line1": "510 Townsend St",
+                  "line2": null,
+                  "postal_code": "94102",
+                  "state": "California"
+                },
+                "carrier": null,
+                "name": "Bruno",
+                "phone": null,
+                "tracking_number": null
+              },
+              "source": null,
+              "status": "requires_payment_method"
+            },
+            "type": "payment_intent"
+          },
+          "customer": {
+            "customer_session": {
+              "id": "cuss_123",
+              "object": "customer_session",
+              "api_key": "ek_test_1234",
+              "api_key_expiry": 1713890664,
+              "components": {
+                "buy_button": {
+                  "enabled": false
+                },
+                "payment_element": {
+                  "enabled": true,
+                  "features": {
+                    "payment_method_remove": "enabled",
+                    "payment_method_save": "enabled",
+                    "payment_method_set_as_default": "enabled",
+                    "payment_method_update": "enabled"
+                  }
+                },
+                "pricing_table": {
+                  "enabled": false
+                }
+              },
+              "customer": "cus_1",
+              "livemode": false
+            },
+            "default_payment_method": null,
+            "payment_methods": [
+              {
+                "id": "pm_123",
+                "created": 1550757934255,
+                "customer": "cus_1",
+                "livemode": false,
+                "metadata": null,
+                "type": "card",
+                "billing_details": null,
+                "card": {
+                  "brand": "visa",
+                  "checks": {
+                    "address_line1_check": "unchecked",
+                    "cvc_check": "unchecked"
+                  },
+                  "country": "US",
+                  "exp_month": 8,
+                  "exp_year": 2032,
+                  "funding": "credit",
+                  "fingerprint": "fingerprint123",
+                  "last4": "4242",
+                  "three_d_secure_usage": {
+                    "supported": true
+                  }
+                }
+              }
+            ],
+            "payment_methods_with_link_details": []
+          }
+        }
+        """.trimIndent()
+    )
+
     val EXPANDED_PAYMENT_INTENT_JSON_WITH_CBC_ELIGIBLE = JSONObject(
         """
         {

--- a/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
@@ -255,7 +255,7 @@ internal object ElementsSessionFixtures {
               "customer": "cus_1",
               "livemode": false
             },
-            "default_payment_method": null,
+            "default_payment_method": "pm_123",
             "payment_methods": [
               {
                 "id": "pm_123",

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -506,7 +506,7 @@ class ElementsSessionJsonParserTest {
                     customerId = "cus_1",
                     liveMode = false,
                 ),
-                defaultPaymentMethod = null,
+                defaultPaymentMethod = "pm_123",
                 paymentMethods = listOf(
                     PaymentMethod(
                         id = "pm_123",

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -2,10 +2,13 @@ package com.stripe.android.model.parsers
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.model.parsers.ModelJsonParser
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.DeferredIntentParams
+import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.ElementsSessionFixtures
 import com.stripe.android.model.ElementsSessionParams
 import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import org.json.JSONObject
@@ -479,6 +482,61 @@ class ElementsSessionJsonParserTest {
         val session = parser.parse(intent)
 
         assertThat(session?.externalPaymentMethodData).contains(venmo)
+    }
+
+    @Test
+    fun `has customer session information in the response`() {
+        val parser = ElementsSessionJsonParser(
+            ElementsSessionParams.PaymentIntentType(
+                clientSecret = "secret",
+                externalPaymentMethods = null,
+            ),
+            apiKey = "test",
+        )
+
+        val intent = ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_WITH_CUSTOMER_SESSION
+        val elementsSession = parser.parse(intent)
+
+        assertThat(elementsSession?.customer).isEqualTo(
+            ElementsSession.Customer(
+                session = ElementsSession.Customer.Session(
+                    id = "cuss_123",
+                    apiKey = "ek_test_1234",
+                    apiKeyExpiry = 1713890664,
+                    customerId = "cus_1",
+                    liveMode = false,
+                ),
+                defaultPaymentMethod = null,
+                paymentMethods = listOf(
+                    PaymentMethod(
+                        id = "pm_123",
+                        customerId = "cus_1",
+                        type = PaymentMethod.Type.Card,
+                        code = "card",
+                        created = 1550757934255,
+                        liveMode = false,
+                        billingDetails = null,
+                        card = PaymentMethod.Card(
+                            brand = CardBrand.Visa,
+                            last4 = "4242",
+                            expiryMonth = 8,
+                            expiryYear = 2032,
+                            country = "US",
+                            funding = "credit",
+                            fingerprint = "fingerprint123",
+                            checks = PaymentMethod.Card.Checks(
+                                addressLine1Check = "unchecked",
+                                cvcCheck = "unchecked",
+                                addressPostalCodeCheck = null,
+                            ),
+                            threeDSecureUsage = PaymentMethod.Card.ThreeDSecureUsage(
+                                isSupported = true
+                            )
+                        )
+                    )
+                )
+            )
+        )
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
@@ -10,6 +10,7 @@ internal class FakeElementsSessionRepository(
     private val error: Throwable?,
     private val sessionsError: Throwable? = null,
     private val linkSettings: ElementsSession.LinkSettings?,
+    private val customer: ElementsSession.Customer? = null,
     private val isGooglePayEnabled: Boolean = true,
     private val isCbcEligible: Boolean = false,
     private val externalPaymentMethodData: String? = null,
@@ -35,6 +36,7 @@ internal class FakeElementsSessionRepository(
                     isGooglePayEnabled = isGooglePayEnabled,
                     sessionsError = sessionsError,
                     externalPaymentMethodData = externalPaymentMethodData,
+                    customer = customer,
                 )
             )
         }


### PR DESCRIPTION
# Summary
Add support for parsing `customer` field from `ElementsSession`.

# Motivation
Allows for fetching claimed customer ephemeral key from `CustomerSession` as well as server-side deduped payment methods.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
