### PR TITLE
Add `CustomerSession` API integration to `PaymentSheet`

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -655,14 +655,30 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration$Cr
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentsheet/PaymentSheet$CustomerAccessType$CustomerSession$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerAccessType$CustomerSession;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerAccessType$CustomerSession;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$CustomerAccessType$LegacyCustomerEphemeralKey$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerAccessType$LegacyCustomerEphemeralKey;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerAccessType$LegacyCustomerEphemeralKey;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerAccessType;)Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerAccessType;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEphemeralKeySecret ()Ljava/lang/String;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExperimentalCustomerSessionApi.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExperimentalCustomerSessionApi.kt
@@ -1,0 +1,13 @@
+package com.stripe.android.paymentsheet
+
+import androidx.annotation.RestrictTo
+
+@RequiresOptIn(message = "Customer session support is beta. It may be changed in the future without notice.")
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY
+)
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+annotation class ExperimentalCustomerSessionApi

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -1348,12 +1348,12 @@ class PaymentSheet internal constructor(
             @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             fun createWithCustomerSession(
                 id: String,
-                customerSessionClientSecret: String
+                clientSecret: String
             ): CustomerConfiguration {
                 return CustomerConfiguration(
                     id = id,
                     ephemeralKeySecret = "",
-                    accessType = CustomerAccessType.CustomerSession(customerSessionClientSecret)
+                    accessType = CustomerAccessType.CustomerSession(clientSecret)
                 )
             }
         }


### PR DESCRIPTION
# Summary
Add `CustomerSession` API integration to `PaymentSheet` per the integration specified in the [API review](https://docs.google.com/document/d/1tmwosYcor4RoyYqeGu-cG-duvZj8vicRl9OyMp6GwsU/edit#heading=h.570u4leviueu)

# Motivation
Integrates the access point for `CustomerSession` in `PaymentSheet` but restricted to just library usage while in development.
