### PR TITLE
Refactor SupportedPaymentMethod to enable icon resource to be missing

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -166,6 +166,9 @@ interface ErrorReporter {
         INTENT_CONFIRMATION_INTERCEPTOR_INVALID_PAYMENT_SELECTION(
             partialEventName = "intent_confirmation_interceptor.intercept.invalid_payment_selection"
         ),
+        PAYMENT_OPTION_MISSING_ICON_URL_AND_RES(
+            partialEventName = "paymentsheet.payment_option_factory.icon_res_and_urls_missing"
+        )
         ;
 
         override val eventName: String

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -221,6 +221,22 @@ public abstract interface class com/stripe/android/customersheet/SetupIntentClie
 	public abstract fun provideSetupIntentClientSecret (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/stripe/android/lpmfoundations/luxe/PaymentMethodIcon$Resource$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/lpmfoundations/luxe/PaymentMethodIcon$Resource;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/lpmfoundations/luxe/PaymentMethodIcon$Resource;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/lpmfoundations/luxe/PaymentMethodIcon$Url$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/lpmfoundations/luxe/PaymentMethodIcon$Url;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/lpmfoundations/luxe/PaymentMethodIcon$Url;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata;

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -12,6 +12,7 @@ import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.customersheet.util.CustomerSheetHacks
 import com.stripe.android.model.CardBrand
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentOptionFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -371,6 +372,7 @@ class CustomerSheet @Inject internal constructor(
                 paymentOptionFactory = PaymentOptionFactory(
                     resources = application.resources,
                     imageLoader = StripeImageLoader(application),
+                    errorReporter = ErrorReporter.createFallbackInstance(application)
                 ),
                 callback = callback,
                 statusBarColor = statusBarColor,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/PaymentMethodIcon.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/PaymentMethodIcon.kt
@@ -5,52 +5,44 @@ import androidx.annotation.DrawableRes
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-sealed class PaymentMethodIcon : Parcelable {
-    data class UrlOrResource(
-        /** This describes the image in the LPM selector.  These can be found internally [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0) */
-        @DrawableRes val iconResource: Int,
+internal sealed class PaymentMethodIcon : Parcelable {
 
+    internal data class Resource(
+        /**
+         * This describes the image in the LPM selector.
+         *
+         * These can be found internally
+         * [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0).
+         * */
+        @DrawableRes val iconResource: Int,
+    ) : PaymentMethodIcon()
+
+    internal data class Url(
         /** A light theme icon url. */
         val lightThemeIconUrl: String,
 
         /** An optional dark theme icon url. */
         val darkThemeIconUrl: String?,
-    ): PaymentMethodIcon()
-
-    data class ResourceOnly(
-        /** This describes the image in the LPM selector.  These can be found internally [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0) */
-        @DrawableRes val iconResource: Int,
-    ): PaymentMethodIcon()
-
-    data class UrlsOnly(
-        /** A light theme icon url. */
-        val lightThemeIconUrl: String,
-
-        /** An optional dark theme icon url. */
-        val darkThemeIconUrl: String?,
-    ): PaymentMethodIcon()
+    ) : PaymentMethodIcon()
 
     fun getNullableIconResource(): Int? {
         return when (this) {
-            is UrlOrResource -> iconResource
-            is ResourceOnly -> iconResource
-            is UrlsOnly -> null
+            is Resource -> iconResource
+            is Url -> null
         }
     }
 
     fun getNullableLightThemeIconUrl(): String? {
         return when (this) {
-            is UrlOrResource -> lightThemeIconUrl
-            is UrlsOnly -> lightThemeIconUrl
-            is ResourceOnly -> null
+            is Url -> lightThemeIconUrl
+            is Resource -> null
         }
     }
 
     fun getNullableDarkThemeIconUrl(): String? {
         return when (this) {
-            is UrlOrResource -> darkThemeIconUrl
-            is UrlsOnly -> darkThemeIconUrl
-            is ResourceOnly -> null
+            is Url -> darkThemeIconUrl
+            is Resource -> null
         }
     }
 
@@ -61,10 +53,9 @@ sealed class PaymentMethodIcon : Parcelable {
             darkThemeIconUrl: String?
         ): PaymentMethodIcon {
             return if (lightThemeIconUrl == null) {
-                ResourceOnly(iconResource = iconResource)
+                Resource(iconResource = iconResource)
             } else {
-                UrlOrResource(
-                    iconResource = iconResource,
+                Url(
                     lightThemeIconUrl = lightThemeIconUrl,
                     darkThemeIconUrl = darkThemeIconUrl,
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/PaymentMethodIcon.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/PaymentMethodIcon.kt
@@ -1,0 +1,74 @@
+package com.stripe.android.lpmfoundations.luxe
+
+import android.os.Parcelable
+import androidx.annotation.DrawableRes
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+sealed class PaymentMethodIcon : Parcelable {
+    data class UrlOrResource(
+        /** This describes the image in the LPM selector.  These can be found internally [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0) */
+        @DrawableRes val iconResource: Int,
+
+        /** A light theme icon url. */
+        val lightThemeIconUrl: String,
+
+        /** An optional dark theme icon url. */
+        val darkThemeIconUrl: String?,
+    ): PaymentMethodIcon()
+
+    data class ResourceOnly(
+        /** This describes the image in the LPM selector.  These can be found internally [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0) */
+        @DrawableRes val iconResource: Int,
+    ): PaymentMethodIcon()
+
+    data class UrlsOnly(
+        /** A light theme icon url. */
+        val lightThemeIconUrl: String,
+
+        /** An optional dark theme icon url. */
+        val darkThemeIconUrl: String?,
+    ): PaymentMethodIcon()
+
+    fun getNullableIconResource(): Int? {
+        return when (this) {
+            is UrlOrResource -> iconResource
+            is ResourceOnly -> iconResource
+            is UrlsOnly -> null
+        }
+    }
+
+    fun getNullableLightThemeIconUrl(): String? {
+        return when (this) {
+            is UrlOrResource -> lightThemeIconUrl
+            is UrlsOnly -> lightThemeIconUrl
+            is ResourceOnly -> null
+        }
+    }
+
+    fun getNullableDarkThemeIconUrl(): String? {
+        return when (this) {
+            is UrlOrResource -> darkThemeIconUrl
+            is UrlsOnly -> darkThemeIconUrl
+            is ResourceOnly -> null
+        }
+    }
+
+    companion object {
+        fun create(
+            @DrawableRes iconResource: Int,
+            lightThemeIconUrl: String?,
+            darkThemeIconUrl: String?
+        ): PaymentMethodIcon {
+            return if (lightThemeIconUrl == null) {
+                ResourceOnly(iconResource = iconResource)
+            } else {
+                UrlOrResource(
+                    iconResource = iconResource,
+                    lightThemeIconUrl = lightThemeIconUrl,
+                    darkThemeIconUrl = darkThemeIconUrl,
+                )
+            }
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/PaymentMethodIcon.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/PaymentMethodIcon.kt
@@ -7,6 +7,10 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 internal sealed class PaymentMethodIcon : Parcelable {
 
+    abstract val iconResource: Int?
+    abstract val lightThemeIconUrl: String?
+    abstract val darkThemeIconUrl: String?
+
     internal data class Resource(
         /**
          * This describes the image in the LPM selector.
@@ -14,37 +18,40 @@ internal sealed class PaymentMethodIcon : Parcelable {
          * These can be found internally
          * [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0).
          * */
-        @DrawableRes val iconResource: Int,
-    ) : PaymentMethodIcon()
+        @DrawableRes override val iconResource: Int,
+    ) : PaymentMethodIcon() {
+        override val lightThemeIconUrl: String?
+            get() = null
+        override val darkThemeIconUrl: String?
+            get() = null
+    }
 
     internal data class Url(
         /** A light theme icon url. */
-        val lightThemeIconUrl: String,
+        override val lightThemeIconUrl: String,
 
         /** An optional dark theme icon url. */
-        val darkThemeIconUrl: String?,
+        override val darkThemeIconUrl: String?,
+    ) : PaymentMethodIcon() {
+        override val iconResource: Int?
+            get() = null
+    }
+
+    internal data class UrlOrResource(
+        /**
+         * This describes the image in the LPM selector.
+         *
+         * These can be found internally
+         * [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0).
+         * */
+        @DrawableRes override val iconResource: Int,
+
+        /** A light theme icon url. */
+        override val lightThemeIconUrl: String,
+
+        /** An optional dark theme icon url. */
+        override val darkThemeIconUrl: String?,
     ) : PaymentMethodIcon()
-
-    fun getNullableIconResource(): Int? {
-        return when (this) {
-            is Resource -> iconResource
-            is Url -> null
-        }
-    }
-
-    fun getNullableLightThemeIconUrl(): String? {
-        return when (this) {
-            is Url -> lightThemeIconUrl
-            is Resource -> null
-        }
-    }
-
-    fun getNullableDarkThemeIconUrl(): String? {
-        return when (this) {
-            is Url -> darkThemeIconUrl
-            is Resource -> null
-        }
-    }
 
     companion object {
         fun create(
@@ -55,7 +62,8 @@ internal sealed class PaymentMethodIcon : Parcelable {
             return if (lightThemeIconUrl == null) {
                 Resource(iconResource = iconResource)
             } else {
-                Url(
+                UrlOrResource(
+                    iconResource = iconResource,
                     lightThemeIconUrl = lightThemeIconUrl,
                     darkThemeIconUrl = darkThemeIconUrl,
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SupportedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SupportedPaymentMethod.kt
@@ -18,14 +18,8 @@ internal data class SupportedPaymentMethod(
     /** This describes the name that appears under the selector. */
     val displayName: ResolvableString,
 
-    /** This describes the image in the LPM selector.  These can be found internally [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0) */
-    @DrawableRes val iconResource: Int,
-
-    /** An optional light theme icon url if it's supported. */
-    val lightThemeIconUrl: String?,
-
-    /** An optional dark theme icon url if it's supported. */
-    val darkThemeIconUrl: String?,
+    /** This describes the image in the LPM selector. */
+    val paymentMethodIcon: PaymentMethodIcon,
 
     /** Indicates if the lpm icon in the selector is a single color and should be tinted
      * on selection.
@@ -41,9 +35,11 @@ internal data class SupportedPaymentMethod(
     ) : this(
         code = paymentMethodDefinition.type.code,
         displayName = resolvableString(id = displayNameResource),
-        iconResource = iconResource,
-        lightThemeIconUrl = sharedDataSpec?.selectorIcon?.lightThemePng,
-        darkThemeIconUrl = sharedDataSpec?.selectorIcon?.darkThemePng,
+        paymentMethodIcon = PaymentMethodIcon.create(
+            iconResource = iconResource,
+            lightThemeIconUrl = sharedDataSpec?.selectorIcon?.lightThemePng,
+            darkThemeIconUrl = sharedDataSpec?.selectorIcon?.darkThemePng,
+        ),
         tintIconOnSelection = tintIconOnSelection,
     )
 
@@ -57,9 +53,11 @@ internal data class SupportedPaymentMethod(
     ) : this(
         code = code,
         displayName = resolvableString(id = displayNameResource),
-        iconResource = iconResource,
-        lightThemeIconUrl = lightThemeIconUrl,
-        darkThemeIconUrl = darkThemeIconUrl,
+        paymentMethodIcon = PaymentMethodIcon.create(
+            iconResource = iconResource,
+            lightThemeIconUrl = lightThemeIconUrl,
+            darkThemeIconUrl = darkThemeIconUrl,
+        ),
         tintIconOnSelection = tintIconOnSelection,
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
@@ -247,19 +247,13 @@ private fun PaymentMethodIconUi(
     }
 
     when (paymentMethodIcon) {
-        is PaymentMethodIcon.ResourceOnly ->
+        is PaymentMethodIcon.Resource ->
             Image(
                 painter = painterResource(paymentMethodIcon.iconResource),
                 contentDescription = null,
                 colorFilter = colorFilter,
             )
-        is PaymentMethodIcon.UrlOrResource ->
-            IconFromUrl(
-                lightThemeIconUrl = paymentMethodIcon.lightThemeIconUrl,
-                darkThemeIconUrl = paymentMethodIcon.darkThemeIconUrl,
-                imageLoader = imageLoader
-            )
-        is PaymentMethodIcon.UrlsOnly ->
+        is PaymentMethodIcon.Url ->
             IconFromUrl(
                 lightThemeIconUrl = paymentMethodIcon.lightThemeIconUrl,
                 darkThemeIconUrl = paymentMethodIcon.darkThemeIconUrl,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
@@ -259,6 +259,12 @@ private fun PaymentMethodIconUi(
                 darkThemeIconUrl = paymentMethodIcon.darkThemeIconUrl,
                 imageLoader = imageLoader
             )
+        is PaymentMethodIcon.UrlOrResource ->
+            IconFromUrl(
+                lightThemeIconUrl = paymentMethodIcon.lightThemeIconUrl,
+                darkThemeIconUrl = paymentMethodIcon.darkThemeIconUrl,
+                imageLoader = imageLoader
+            )
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
@@ -21,8 +21,6 @@ internal class PaymentOptionFactory @Inject constructor(
     private val imageLoader: StripeImageLoader,
     private val errorReporter: ErrorReporter,
 ) {
-    private val MISSING_DRAWABLE_RESOURCE = 0
-
     private fun isDarkTheme(): Boolean {
         return resources.configuration?.uiMode?.and(Configuration.UI_MODE_NIGHT_MASK) ==
             Configuration.UI_MODE_NIGHT_YES
@@ -116,7 +114,8 @@ internal class PaymentOptionFactory @Inject constructor(
             }
             is PaymentSelection.New.GenericPaymentMethod -> {
                 PaymentOption(
-                    drawableResourceId = selection.paymentMethodIcon.getNullableIconResource() ?: MISSING_DRAWABLE_RESOURCE,
+                    drawableResourceId = selection.paymentMethodIcon.getNullableIconResource()
+                        ?: MISSING_DRAWABLE_RESOURCE,
                     lightThemeIconUrl = selection.paymentMethodIcon.getNullableLightThemeIconUrl(),
                     darkThemeIconUrl = selection.paymentMethodIcon.getNullableDarkThemeIconUrl(),
                     label = selection.labelResource,
@@ -156,5 +155,9 @@ internal class PaymentOptionFactory @Inject constructor(
             }
             else -> resourceId
         }
+    }
+
+    companion object {
+        private const val MISSING_DRAWABLE_RESOURCE = 0
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
@@ -50,7 +50,7 @@ internal class PaymentOptionFactory @Inject constructor(
             loadIcon(darkThemeIconUrl)
         } else if (lightThemeIconUrl != null) {
             loadIcon(lightThemeIconUrl)
-        } else if (paymentOption.drawableResourceId == MISSING_DRAWABLE_RESOURCE) {
+        } else if (@Suppress("DEPRECATION") paymentOption.drawableResourceId == MISSING_DRAWABLE_RESOURCE) {
             errorReporter.report(
                 ErrorReporter.UnexpectedErrorEvent.PAYMENT_OPTION_MISSING_ICON_URL_AND_RES,
                 additionalNonPiiParams = mapOf("payment_option" to paymentOption.label)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
@@ -46,14 +46,17 @@ internal class PaymentOptionFactory @Inject constructor(
         // Some payment options don't have an icon URL, and are loaded locally via resource.
         val lightThemeIconUrl = paymentOption.lightThemeIconUrl
         val darkThemeIconUrl = paymentOption.darkThemeIconUrl
+
+        @Suppress("DEPRECATION")
+        val drawableIsMissing = paymentOption.drawableResourceId == MISSING_DRAWABLE_RESOURCE
+
         return if (isDarkTheme() && darkThemeIconUrl != null) {
             loadIcon(darkThemeIconUrl)
         } else if (lightThemeIconUrl != null) {
             loadIcon(lightThemeIconUrl)
-        } else if (@Suppress("DEPRECATION") paymentOption.drawableResourceId == MISSING_DRAWABLE_RESOURCE) {
+        } else if (drawableIsMissing) {
             errorReporter.report(
                 ErrorReporter.UnexpectedErrorEvent.PAYMENT_OPTION_MISSING_ICON_URL_AND_RES,
-                additionalNonPiiParams = mapOf("payment_option" to paymentOption.label)
             )
             throw IllegalStateException("Missing icon resource and icon URLs - can't load")
         } else {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Parcelable
 import androidx.annotation.DrawableRes
 import com.stripe.android.link.LinkPaymentDetails
+import com.stripe.android.lpmfoundations.luxe.PaymentMethodIcon
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
@@ -217,9 +218,7 @@ internal sealed class PaymentSelection : Parcelable {
         @Parcelize
         data class GenericPaymentMethod(
             val labelResource: String,
-            @DrawableRes val iconResource: Int,
-            val lightThemeIconUrl: String?,
-            val darkThemeIconUrl: String?,
+            val paymentMethodIcon: PaymentMethodIcon,
             override val paymentMethodCreateParams: PaymentMethodCreateParams,
             override val customerRequestedSave: CustomerRequestedSave,
             override val paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -216,9 +216,7 @@ internal fun FormFieldValues.transformToPaymentSelection(
     } else {
         PaymentSelection.New.GenericPaymentMethod(
             labelResource = paymentMethod.displayName.resolve(context),
-            iconResource = paymentMethod.iconResource,
-            lightThemeIconUrl = paymentMethod.lightThemeIconUrl,
-            darkThemeIconUrl = paymentMethod.darkThemeIconUrl,
+            paymentMethodIcon = paymentMethod.paymentMethodIcon,
             paymentMethodCreateParams = params,
             paymentMethodOptionsParams = options,
             paymentMethodExtraParams = extras,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -4,11 +4,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.versionedparcelable.R
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.customersheet.ui.CustomerSheetScreen
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
+import com.stripe.android.lpmfoundations.luxe.PaymentMethodIcon
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.forms.FormViewModel
@@ -338,5 +341,66 @@ internal class CustomerSheetScreenshotTest {
                 paymentMethodNameProvider = { it!! },
             )
         }
+    }
+
+    @Test
+    fun testIconUrlFailsToLoad_noResource_paymentSelectionShowsEmptyIcon() {
+        paparazzi.snapshot {
+            var counter = 0
+            CustomerSheetScreen(
+                viewState = selectPaymentMethodViewState.copy(
+                    title = "Screenshot testing",
+                    savedPaymentMethods = emptyList(),
+                    paymentSelection = getPaymentSelectionWithInvalidIconUrl(hasIconResource = false),
+                    primaryButtonLabel = "Continue",
+                    errorMessage = "This is an error message.",
+                ),
+                paymentMethodNameProvider = {
+                    counter++
+                    "424$counter"
+                },
+            )
+        }
+    }
+
+    @Test
+    fun testIconUrlFailsToLoad_paymentSelectionIconUsesResourceAsFallback() {
+        paparazzi.snapshot {
+            var counter = 0
+            CustomerSheetScreen(
+                viewState = selectPaymentMethodViewState.copy(
+                    title = "Screenshot testing",
+                    savedPaymentMethods = emptyList(),
+                    paymentSelection = getPaymentSelectionWithInvalidIconUrl(hasIconResource = true),
+                    primaryButtonLabel = "Continue",
+                    errorMessage = "This is an error message.",
+                ),
+                paymentMethodNameProvider = {
+                    counter++
+                    "424$counter"
+                },
+            )
+        }
+    }
+
+    private fun getPaymentSelectionWithInvalidIconUrl(hasIconResource: Boolean): PaymentSelection {
+        val paymentMethodIcon = if (hasIconResource) {
+            PaymentMethodIcon.UrlOrResource(
+                iconResource = com.stripe.android.ui.core.R.drawable.stripe_ic_paymentsheet_pm_cash_app_pay,
+                lightThemeIconUrl = "fake url",
+                darkThemeIconUrl = null,
+            )
+        } else {
+            PaymentMethodIcon.Url(
+                lightThemeIconUrl = "fake url",
+                darkThemeIconUrl = null,
+            )
+        }
+        return PaymentSelection.New.GenericPaymentMethod(
+            labelResource = "",
+            paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.US_BANK_ACCOUNT,
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
+            paymentMethodIcon = paymentMethodIcon,
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.UserInput
+import com.stripe.android.lpmfoundations.luxe.PaymentMethodIcon
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntentFixtures
@@ -501,12 +502,14 @@ internal class PaymentOptionsViewModelTest {
             // Simulate user filling out a different payment method, but not confirming it
             viewModel.updateSelection(
                 PaymentSelection.New.GenericPaymentMethod(
-                    iconResource = 0,
                     labelResource = "",
                     paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.US_BANK_ACCOUNT,
                     customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
-                    lightThemeIconUrl = null,
-                    darkThemeIconUrl = null,
+                    paymentMethodIcon = PaymentMethodIcon.create(
+                        iconResource = 0,
+                        lightThemeIconUrl = null,
+                        darkThemeIconUrl = null,
+                    ),
                 )
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -30,6 +30,7 @@ import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
+import com.stripe.android.lpmfoundations.luxe.PaymentMethodIcon
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.CardDefinition
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
@@ -1222,12 +1223,14 @@ internal class PaymentSheetViewModelTest {
 
         viewModel.updateSelection(
             PaymentSelection.New.GenericPaymentMethod(
-                iconResource = 0,
                 labelResource = "",
                 paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.US_BANK_ACCOUNT,
                 customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
-                lightThemeIconUrl = null,
-                darkThemeIconUrl = null,
+                paymentMethodIcon = PaymentMethodIcon.create(
+                    iconResource = 0,
+                    lightThemeIconUrl = null,
+                    darkThemeIconUrl = null,
+                ),
             )
         )
 
@@ -2747,7 +2750,6 @@ internal class PaymentSheetViewModelTest {
     private fun createBacsPaymentSelection(): PaymentSelection {
         return PaymentSelection.New.GenericPaymentMethod(
             labelResource = "Test",
-            iconResource = 0,
             paymentMethodCreateParams = PaymentMethodCreateParams.Companion.create(
                 bacsDebit = PaymentMethodCreateParams.BacsDebit(
                     accountNumber = BACS_ACCOUNT_NUMBER,
@@ -2759,8 +2761,11 @@ internal class PaymentSheetViewModelTest {
                 )
             ),
             customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
-            lightThemeIconUrl = null,
-            darkThemeIconUrl = null,
+            paymentMethodIcon = PaymentMethodIcon.create(
+                iconResource = 0,
+                lightThemeIconUrl = null,
+                darkThemeIconUrl = null,
+            ),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.utils.DurationProvider
+import com.stripe.android.lpmfoundations.luxe.PaymentMethodIcon
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
@@ -489,9 +490,11 @@ class DefaultEventReporterTest {
         customEventReporter.onPressConfirmButton(
             PaymentSelection.New.GenericPaymentMethod(
                 labelResource = "Cash App Pay",
-                iconResource = 0,
-                lightThemeIconUrl = null,
-                darkThemeIconUrl = null,
+                paymentMethodIcon = PaymentMethodIcon.create(
+                    iconResource = 0,
+                    lightThemeIconUrl = null,
+                    darkThemeIconUrl = null,
+                ),
                 paymentMethodCreateParams = PaymentMethodCreateParams.createCashAppPay(),
                 customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -23,6 +23,7 @@ import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.lpmfoundations.luxe.PaymentMethodIcon
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
@@ -74,6 +75,7 @@ import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.paymentsheet.ui.SepaMandateContract
 import com.stripe.android.paymentsheet.ui.SepaMandateResult
 import com.stripe.android.paymentsheet.utils.RecordingGooglePayPaymentMethodLauncherFactory
+import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor
 import com.stripe.android.utils.FakePaymentSheetLoader
@@ -1892,6 +1894,7 @@ internal class DefaultFlowControllerTest {
         paymentOptionFactory = PaymentOptionFactory(
             resources = context.resources,
             imageLoader = StripeImageLoader(context),
+            errorReporter = FakeErrorReporter(),
         ),
         paymentOptionCallback = paymentOptionCallback,
         paymentResultCallback = paymentResultCallback,
@@ -1928,7 +1931,6 @@ internal class DefaultFlowControllerTest {
     private fun createBacsPaymentSelection(): PaymentSelection {
         return PaymentSelection.New.GenericPaymentMethod(
             labelResource = "Test",
-            iconResource = 0,
             paymentMethodCreateParams = PaymentMethodCreateParams.Companion.create(
                 bacsDebit = PaymentMethodCreateParams.BacsDebit(
                     accountNumber = BACS_ACCOUNT_NUMBER,
@@ -1940,8 +1942,11 @@ internal class DefaultFlowControllerTest {
                 )
             ),
             customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
-            lightThemeIconUrl = null,
-            darkThemeIconUrl = null,
+            paymentMethodIcon = PaymentMethodIcon.create(
+                iconResource = 0,
+                lightThemeIconUrl = null,
+                darkThemeIconUrl = null,
+            ),
         )
     }
 
@@ -1952,12 +1957,14 @@ internal class DefaultFlowControllerTest {
             PaymentSelection.CustomerRequestedSave.NoRequest
         )
         private val GENERIC_PAYMENT_SELECTION = PaymentSelection.New.GenericPaymentMethod(
-            iconResource = R.drawable.stripe_ic_paymentsheet_card_visa,
             labelResource = "Bancontact",
             paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.BANCONTACT,
             customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
-            lightThemeIconUrl = null,
-            darkThemeIconUrl = null,
+            paymentMethodIcon = PaymentMethodIcon.create(
+                iconResource = R.drawable.stripe_ic_paymentsheet_card_visa,
+                lightThemeIconUrl = null,
+                darkThemeIconUrl = null,
+            ),
         )
         private val VISA_PAYMENT_OPTION = PaymentOption(
             drawableResourceId = R.drawable.stripe_ic_paymentsheet_card_visa,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
@@ -4,6 +4,7 @@ import android.content.res.ColorStateList
 import android.graphics.Color
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.model.CountryCode
+import com.stripe.android.lpmfoundations.luxe.PaymentMethodIcon
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
@@ -41,9 +42,11 @@ class PaymentSelectionUpdaterTest {
     fun `Can use existing payment selection if it's still supported`() {
         val existingSelection = PaymentSelection.New.GenericPaymentMethod(
             labelResource = "Sofort",
-            iconResource = StripeUiCoreR.drawable.stripe_ic_paymentsheet_pm_klarna,
-            lightThemeIconUrl = null,
-            darkThemeIconUrl = null,
+            paymentMethodIcon = PaymentMethodIcon.create(
+                iconResource = StripeUiCoreR.drawable.stripe_ic_paymentsheet_pm_klarna,
+                lightThemeIconUrl = null,
+                darkThemeIconUrl = null,
+            ),
             paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.SOFORT,
             customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
         )
@@ -141,9 +144,11 @@ class PaymentSelectionUpdaterTest {
     fun `PaymentSelection is reset when payment method requires mandate after updating intent`() {
         val existingSelection = PaymentSelection.New.GenericPaymentMethod(
             labelResource = "paypal",
-            iconResource = StripeUiCoreR.drawable.stripe_ic_paymentsheet_pm_paypal,
-            lightThemeIconUrl = null,
-            darkThemeIconUrl = null,
+            paymentMethodIcon = PaymentMethodIcon.create(
+                iconResource = StripeUiCoreR.drawable.stripe_ic_paymentsheet_pm_paypal,
+                lightThemeIconUrl = null,
+                darkThemeIconUrl = null,
+            ),
             paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.PAYPAL,
             customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
         )
@@ -169,9 +174,11 @@ class PaymentSelectionUpdaterTest {
     fun `PaymentSelection is preserved when payment method no longer requires mandate after updating intent`() {
         val existingSelection = PaymentSelection.New.GenericPaymentMethod(
             labelResource = "paypal",
-            iconResource = StripeUiCoreR.drawable.stripe_ic_paymentsheet_pm_paypal,
-            lightThemeIconUrl = null,
-            darkThemeIconUrl = null,
+            paymentMethodIcon = PaymentMethodIcon.create(
+                iconResource = StripeUiCoreR.drawable.stripe_ic_paymentsheet_pm_paypal,
+                lightThemeIconUrl = null,
+                darkThemeIconUrl = null,
+            ),
             paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.PAYPAL.copy(
                 requiresMandate = true
             ),
@@ -199,9 +206,11 @@ class PaymentSelectionUpdaterTest {
     fun `PaymentSelection is preserved when payment method still requires mandate after updating intent`() {
         val existingSelection = PaymentSelection.New.GenericPaymentMethod(
             labelResource = "paypal",
-            iconResource = StripeUiCoreR.drawable.stripe_ic_paymentsheet_pm_paypal,
-            lightThemeIconUrl = null,
-            darkThemeIconUrl = null,
+            paymentMethodIcon = PaymentMethodIcon.create(
+                iconResource = StripeUiCoreR.drawable.stripe_ic_paymentsheet_pm_paypal,
+                lightThemeIconUrl = null,
+                darkThemeIconUrl = null,
+            ),
             paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.PAYPAL.copy(
                 requiresMandate = true
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.uicore.image.StripeImageLoader
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -19,7 +20,8 @@ class PaymentOptionFactoryTest {
 
     private val factory = PaymentOptionFactory(
         ApplicationProvider.getApplicationContext<Context>().resources,
-        StripeImageLoader(ApplicationProvider.getApplicationContext())
+        StripeImageLoader(ApplicationProvider.getApplicationContext()),
+        errorReporter = FakeErrorReporter(),
     )
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateDataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateDataTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.paymentdatacollection.bacs
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.luxe.PaymentMethodIcon
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -11,10 +12,12 @@ class BacsMandateDataTest {
     fun `when payment selection is Bacs and name & email are provided, 'fromPaymentSelection' should return data`() {
         val selection = PaymentSelection.New.GenericPaymentMethod(
             labelResource = "",
-            iconResource = 0,
             customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
-            lightThemeIconUrl = null,
-            darkThemeIconUrl = null,
+            paymentMethodIcon = PaymentMethodIcon.create(
+                iconResource = 0,
+                lightThemeIconUrl = null,
+                darkThemeIconUrl = null,
+            ),
             paymentMethodCreateParams = PaymentMethodCreateParams.Companion.create(
                 bacsDebit = PaymentMethodCreateParams.BacsDebit(
                     accountNumber = "00012345",
@@ -41,10 +44,12 @@ class BacsMandateDataTest {
     fun `when payment selection is Bacs but without name or email, 'fromPaymentSelection' should return null`() {
         val selection = PaymentSelection.New.GenericPaymentMethod(
             labelResource = "",
-            iconResource = 0,
             customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
-            lightThemeIconUrl = null,
-            darkThemeIconUrl = null,
+            paymentMethodIcon = PaymentMethodIcon.create(
+                iconResource = 0,
+                lightThemeIconUrl = null,
+                darkThemeIconUrl = null,
+            ),
             paymentMethodCreateParams = PaymentMethodCreateParams.Companion.create(
                 bacsDebit = PaymentMethodCreateParams.BacsDebit(
                     accountNumber = "00012345",
@@ -61,10 +66,12 @@ class BacsMandateDataTest {
     fun `when payment selection is not Bacs, 'fromPaymentSelection' should return null`() {
         val selection = PaymentSelection.New.GenericPaymentMethod(
             labelResource = "",
-            iconResource = 0,
             customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
-            lightThemeIconUrl = null,
-            darkThemeIconUrl = null,
+            paymentMethodIcon = PaymentMethodIcon.create(
+                iconResource = 0,
+                lightThemeIconUrl = null,
+                darkThemeIconUrl = null,
+            ),
             paymentMethodCreateParams = PaymentMethodCreateParams.Companion.create(
                 card = PaymentMethodCreateParams.Card(),
                 billingDetails = PaymentMethod.BillingDetails()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodUIScreenshotTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.ui
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.stripe.android.lpmfoundations.luxe.PaymentMethodIcon
 import com.stripe.android.paymentsheet.PaymentMethodUI
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
@@ -28,8 +29,11 @@ internal class PaymentMethodUIScreenshotTest {
         paparazziRule.snapshot {
             PaymentMethodUI(
                 minViewWidth = 100.dp,
-                iconRes = R.drawable.stripe_ic_paymentsheet_pm_card,
-                iconUrl = null,
+                paymentMethodIcon = PaymentMethodIcon.create(
+                    iconResource = R.drawable.stripe_ic_paymentsheet_pm_card,
+                    lightThemeIconUrl = null,
+                    darkThemeIconUrl = null,
+                ),
                 imageLoader = mock(),
                 title = "Card",
                 isSelected = true,
@@ -46,8 +50,11 @@ internal class PaymentMethodUIScreenshotTest {
         paparazziRule.snapshot {
             PaymentMethodUI(
                 minViewWidth = 100.dp,
-                iconRes = R.drawable.stripe_ic_paymentsheet_pm_card,
-                iconUrl = null,
+                paymentMethodIcon = PaymentMethodIcon.create(
+                    iconResource = R.drawable.stripe_ic_paymentsheet_pm_card,
+                    lightThemeIconUrl = null,
+                    darkThemeIconUrl = null,
+                ),
                 imageLoader = mock(),
                 title = "Card",
                 isSelected = false,
@@ -64,8 +71,11 @@ internal class PaymentMethodUIScreenshotTest {
         paparazziRule.snapshot {
             PaymentMethodUI(
                 minViewWidth = 100.dp,
-                iconRes = R.drawable.stripe_ic_paymentsheet_pm_card,
-                iconUrl = null,
+                PaymentMethodIcon.create(
+                    iconResource = R.drawable.stripe_ic_paymentsheet_pm_card,
+                    lightThemeIconUrl = null,
+                    darkThemeIconUrl = null,
+                ),
                 imageLoader = mock(),
                 title = "Card",
                 isSelected = false,
@@ -82,8 +92,11 @@ internal class PaymentMethodUIScreenshotTest {
         paparazziRule.snapshot {
             PaymentMethodUI(
                 minViewWidth = 100.dp,
-                iconRes = R.drawable.stripe_ic_paymentsheet_pm_card,
-                iconUrl = null,
+                PaymentMethodIcon.create(
+                    iconResource = R.drawable.stripe_ic_paymentsheet_pm_card,
+                    lightThemeIconUrl = null,
+                    darkThemeIconUrl = null,
+                ),
                 imageLoader = mock(),
                 title = "The Greatest US Bank Account",
                 isSelected = false,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Change the icon types used in SupportedPaymentMethod to enable not having an icon resource

Introduces a new Icon type, which is either:
- `Resource` - indicates we should use the icon resource because we don't have an iconUrl
- `Urls` - indicates we should use an icon URL, because we have at least the light theme icon URL. This is what external payment methods will use

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
External payment methods will not have an icon resource, we need to be able to represent this. The current type requires iconResource to be non-null even though we don't use it when there is an iconUrl.

https://jira.corp.stripe.com/browse/MOBILESDK-1976

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

No tests -- no behavior change, compilation shows that the new types work
