### PR TITLE
Add validation for `CustomerSession` in `PaymentSheet`.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -21,7 +21,6 @@ import com.stripe.android.paymentsheet.ui.PaymentSheetScreen
 import com.stripe.android.paymentsheet.utils.applicationIsTaskOwner
 import com.stripe.android.uicore.StripeTheme
 import kotlinx.coroutines.flow.filterNotNull
-import java.security.InvalidParameterException
 
 internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
 
@@ -101,7 +100,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
                 starterArgs.config.validate()
                 starterArgs.config.appearance.parseAppearance()
                 Result.success(starterArgs)
-            } catch (e: InvalidParameterException) {
+            } catch (e: IllegalArgumentException) {
                 Result.failure(e)
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
@@ -11,19 +11,19 @@ import com.stripe.android.uicore.PrimaryButtonShape
 import com.stripe.android.uicore.PrimaryButtonTypography
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.StripeThemeDefaults
-import java.security.InvalidParameterException
+import java.lang.IllegalArgumentException
 
 internal fun PaymentSheet.Configuration.validate() {
     // These are not localized as they are not intended to be displayed to a user.
     when {
         merchantDisplayName.isBlank() -> {
-            throw InvalidParameterException(
+            throw IllegalArgumentException(
                 "When a Configuration is passed to PaymentSheet," +
                     " the Merchant display name cannot be an empty string."
             )
         }
         customer?.id?.isBlank() == true -> {
-            throw InvalidParameterException(
+            throw IllegalArgumentException(
                 "When a CustomerConfiguration is passed to PaymentSheet," +
                     " the Customer ID cannot be an empty string."
             )
@@ -34,7 +34,7 @@ internal fun PaymentSheet.Configuration.validate() {
         when (customerAccessType) {
             is PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey -> {
                 if (customerAccessType.ephemeralKeySecret.isBlank() || customer.ephemeralKeySecret.isBlank()) {
-                    throw InvalidParameterException(
+                    throw IllegalArgumentException(
                         "When a CustomerConfiguration is passed to PaymentSheet, " +
                             "the ephemeralKeySecret cannot be an empty string."
                     )
@@ -42,7 +42,7 @@ internal fun PaymentSheet.Configuration.validate() {
             }
             is PaymentSheet.CustomerAccessType.CustomerSession -> {
                 if (customerAccessType.customerSessionClientSecret.isBlank()) {
-                    throw InvalidParameterException(
+                    throw IllegalArgumentException(
                         "When a CustomerConfiguration is passed to PaymentSheet, " +
                             "the customerSessionClientSecret cannot be an empty string."
                     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
@@ -28,11 +28,26 @@ internal fun PaymentSheet.Configuration.validate() {
                     " the Customer ID cannot be an empty string."
             )
         }
-        customer?.ephemeralKeySecret?.isBlank() == true -> {
-            throw InvalidParameterException(
-                "When a CustomerConfiguration is passed to PaymentSheet, " +
-                    "the ephemeralKeySecret cannot be an empty string."
-            )
+    }
+
+    customer?.accessType?.let { customerAccessType ->
+        when (customerAccessType) {
+            is PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey -> {
+                if (customerAccessType.ephemeralKeySecret.isBlank() || customer.ephemeralKeySecret.isBlank()) {
+                    throw InvalidParameterException(
+                        "When a CustomerConfiguration is passed to PaymentSheet, " +
+                            "the ephemeralKeySecret cannot be an empty string."
+                    )
+                }
+            }
+            is PaymentSheet.CustomerAccessType.CustomerSession -> {
+                if (customerAccessType.customerSessionClientSecret.isBlank()) {
+                    throw InvalidParameterException(
+                        "When a CustomerConfiguration is passed to PaymentSheet, " +
+                            "the customerSessionClientSecret cannot be an empty string."
+                    )
+                }
+            }
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.security.InvalidParameterException
+import java.lang.IllegalArgumentException
 import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -70,7 +70,7 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
         try {
             initializationMode.validate()
             configuration.validate()
-        } catch (e: InvalidParameterException) {
+        } catch (e: IllegalArgumentException) {
             onConfigured(error = e)
             return
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/ClientSecret.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/ClientSecret.kt
@@ -4,7 +4,6 @@ import android.os.Parcelable
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
 import kotlinx.parcelize.Parcelize
-import java.security.InvalidParameterException
 
 /**
  * Represents the client secret for a [SetupIntent] or [PaymentIntent]
@@ -23,7 +22,7 @@ internal data class PaymentIntentClientSecret(
 ) : ClientSecret() {
     override fun validate() {
         if (value.isBlank()) {
-            throw InvalidParameterException(
+            throw IllegalArgumentException(
                 "The PaymentIntent client_secret cannot be an empty string."
             )
         }
@@ -39,7 +38,7 @@ internal data class SetupIntentClientSecret(
 ) : ClientSecret() {
     override fun validate() {
         if (value.isBlank()) {
-            throw InvalidParameterException(
+            throw IllegalArgumentException(
                 "The SetupIntent client_secret cannot be an empty string."
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
@@ -5,7 +5,7 @@ import android.graphics.Color
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import org.junit.Test
-import java.security.InvalidParameterException
+import java.lang.IllegalArgumentException
 import kotlin.test.assertFailsWith
 
 class PaymentSheetConfigurationKtxTest {
@@ -101,7 +101,11 @@ class PaymentSheetConfigurationKtxTest {
             ),
         )
 
-        assertFailsWith<InvalidParameterException> {
+        assertFailsWith(
+            IllegalArgumentException::class,
+            message = "When a CustomerConfiguration is passed to PaymentSheet, " +
+                "the ephemeralKeySecret cannot be an empty string."
+        )  {
             configWithBlankEphemeralKeySecret.validate()
         }
     }
@@ -116,7 +120,11 @@ class PaymentSheetConfigurationKtxTest {
             ),
         )
 
-        assertFailsWith<InvalidParameterException> {
+        assertFailsWith(
+            IllegalArgumentException::class,
+            message = "When a CustomerConfiguration is passed to PaymentSheet, " +
+                "the customerSessionClientSecret cannot be an empty string."
+        ) {
             configWithBlankCustomerSessionClientSecret.validate()
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
@@ -5,6 +5,8 @@ import android.graphics.Color
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import org.junit.Test
+import java.security.InvalidParameterException
+import kotlin.test.assertFailsWith
 
 class PaymentSheetConfigurationKtxTest {
     @Test
@@ -88,6 +90,35 @@ class PaymentSheetConfigurationKtxTest {
         assertThat(
             configuration.containsVolatileDifferences(configWithAllowRemovalOfLastPaymentMethodChanges)
         ).isTrue()
+    }
+
+    @Test
+    fun `'validate' should fail when ephemeral key secret is blank`() {
+        val configWithBlankEphemeralKeySecret = configuration.copy(
+            customer = PaymentSheet.CustomerConfiguration(
+                id = "cus_1",
+                ephemeralKeySecret = "   "
+            ),
+        )
+
+        assertFailsWith<InvalidParameterException> {
+            configWithBlankEphemeralKeySecret.validate()
+        }
+    }
+
+    @OptIn(ExperimentalCustomerSessionApi::class)
+    @Test
+    fun `'validate' should fail when customer client secret key is secret is blank`() {
+        val configWithBlankCustomerSessionClientSecret = configuration.copy(
+            customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
+                id = "cus_1",
+                clientSecret = "   "
+            ),
+        )
+
+        assertFailsWith<InvalidParameterException> {
+            configWithBlankCustomerSessionClientSecret.validate()
+        }
     }
 
     private companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
@@ -105,7 +105,7 @@ class PaymentSheetConfigurationKtxTest {
             IllegalArgumentException::class,
             message = "When a CustomerConfiguration is passed to PaymentSheet, " +
                 "the ephemeralKeySecret cannot be an empty string."
-        )  {
+        ) {
             configWithBlankEphemeralKeySecret.validate()
         }
     }


### PR DESCRIPTION
# Summary
Adds validation for `CustomerSession` parameters pass through `PaymentSheet.Configuration`.

# Motivation
Ensures developers are informed if their `CustomerSession` customer configuration is incorrectly provided.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified