### PR TITLE
Fetch and use `CustomerSession` in `PaymentSheet`.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
@@ -11,6 +11,7 @@ sealed interface ElementsSessionParams : Parcelable {
 
     val type: String
     val clientSecret: String?
+    val customerSessionClientSecret: String?
     val locale: String?
     val expandFields: List<String>
     val externalPaymentMethods: List<String>?
@@ -20,6 +21,7 @@ sealed interface ElementsSessionParams : Parcelable {
     data class PaymentIntentType(
         override val clientSecret: String,
         override val locale: String? = Locale.getDefault().toLanguageTag(),
+        override val customerSessionClientSecret: String? = null,
         override val externalPaymentMethods: List<String>?,
     ) : ElementsSessionParams {
 
@@ -35,6 +37,7 @@ sealed interface ElementsSessionParams : Parcelable {
     data class SetupIntentType(
         override val clientSecret: String,
         override val locale: String? = Locale.getDefault().toLanguageTag(),
+        override val customerSessionClientSecret: String? = null,
         override val externalPaymentMethods: List<String>?,
     ) : ElementsSessionParams {
 
@@ -51,6 +54,7 @@ sealed interface ElementsSessionParams : Parcelable {
         override val locale: String? = Locale.getDefault().toLanguageTag(),
         val deferredIntentParams: DeferredIntentParams,
         override val externalPaymentMethods: List<String>?,
+        override val customerSessionClientSecret: String? = null,
     ) : ElementsSessionParams {
 
         override val clientSecret: String?

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1492,6 +1492,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
             this["type"] = params.type
             params.clientSecret?.let { this["client_secret"] = it }
             params.locale.let { this["locale"] = it }
+            params.customerSessionClientSecret?.let { this["customer_session_client_secret"] = it }
             params.externalPaymentMethods?.takeIf { it.isNotEmpty() }?.let { this["external_payment_methods"] = it }
             (params as? ElementsSessionParams.DeferredIntentType)?.let { type ->
                 this.putAll(type.deferredIntentParams.toQueryParams())

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -489,6 +489,7 @@ class ElementsSessionJsonParserTest {
         val parser = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
                 clientSecret = "secret",
+                customerSessionClientSecret = "customer_session_client_secret",
                 externalPaymentMethods = null,
             ),
             apiKey = "test",

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -2572,8 +2572,8 @@ internal class StripeApiRepositoryTest {
         )
 
         with(params) {
-            assertThat("payment_intent").isEqualTo(this["type"])
-            assertThat("en-US").isEqualTo(this["locale"])
+            assertThat(this["type"]).isEqualTo("payment_intent")
+            assertThat(this["locale"]).isEqualTo("en-US")
             assertThat(this["customer_session_client_secret"]).isNull()
         }
     }
@@ -2608,9 +2608,9 @@ internal class StripeApiRepositoryTest {
         )
 
         with(params) {
-            assertThat("payment_intent").isEqualTo(this["type"])
-            assertThat("en-US").isEqualTo(this["locale"])
-            assertThat("customer_session_client_secret").isEqualTo(this["customer_session_client_secret"])
+            assertThat(this["type"]).isEqualTo("payment_intent")
+            assertThat(this["locale"]).isEqualTo("en-US")
+            assertThat(this["customer_session_client_secret"]).isEqualTo("customer_session_client_secret")
         }
     }
 

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -2543,6 +2543,78 @@ internal class StripeApiRepositoryTest {
         }
 
     @Test
+    fun `Verify customer session client secret not in params when null`() = runTest {
+        val stripeResponse = StripeResponse(
+            200,
+            ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_JSON.toString(),
+            emptyMap()
+        )
+
+        whenever(stripeNetworkClient.executeRequest(any<ApiRequest>())).thenReturn(stripeResponse)
+
+        create().retrieveElementsSession(
+            params = ElementsSessionParams.PaymentIntentType(
+                clientSecret = "client_secret",
+                customerSessionClientSecret = null,
+                externalPaymentMethods = null,
+            ),
+            options = DEFAULT_OPTIONS,
+        )
+
+        verify(stripeNetworkClient).executeRequest(apiRequestArgumentCaptor.capture())
+
+        val request = apiRequestArgumentCaptor.firstValue
+        val params = requireNotNull(request.params)
+
+        assertEquals(
+            "https://api.stripe.com/v1/elements/sessions",
+            request.baseUrl
+        )
+
+        with(params) {
+            assertThat("payment_intent").isEqualTo(this["type"])
+            assertThat("en-US").isEqualTo(this["locale"])
+            assertThat(this["customer_session_client_secret"]).isNull()
+        }
+    }
+
+    @Test
+    fun `Verify customer session client secret in params when provided`() = runTest {
+        val stripeResponse = StripeResponse(
+            200,
+            ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_JSON.toString(),
+            emptyMap()
+        )
+
+        whenever(stripeNetworkClient.executeRequest(any<ApiRequest>())).thenReturn(stripeResponse)
+
+        create().retrieveElementsSession(
+            params = ElementsSessionParams.PaymentIntentType(
+                clientSecret = "client_secret",
+                customerSessionClientSecret = "customer_session_client_secret",
+                externalPaymentMethods = null,
+            ),
+            options = DEFAULT_OPTIONS,
+        )
+
+        verify(stripeNetworkClient).executeRequest(apiRequestArgumentCaptor.capture())
+
+        val request = apiRequestArgumentCaptor.firstValue
+        val params = requireNotNull(request.params)
+
+        assertEquals(
+            "https://api.stripe.com/v1/elements/sessions",
+            request.baseUrl
+        )
+
+        with(params) {
+            assertThat("payment_intent").isEqualTo(this["type"])
+            assertThat("en-US").isEqualTo(this["locale"])
+            assertThat("customer_session_client_secret").isEqualTo(this["customer_session_client_secret"])
+        }
+    }
+
+    @Test
     fun `Verify that the elements session endpoint has the right query params for setup intents`() = runTest {
         val stripeResponse = StripeResponse(
             200,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -114,7 +114,11 @@ internal class DefaultCustomerSheetLoader(
                 paymentMethodTypes = paymentMethodTypes,
             )
         )
-        return elementsSessionRepository.get(initializationMode, externalPaymentMethods = null).map { elementsSession ->
+        return elementsSessionRepository.get(
+            initializationMode,
+            customer = null,
+            externalPaymentMethods = null,
+        ).map { elementsSession ->
             val billingDetailsCollectionConfig = configuration.billingDetailsCollectionConfiguration
             val sharedDataSpecs = lpmRepository.getSharedDataSpecs(
                 stripeIntent = elementsSession.stripeIntent,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
@@ -75,7 +75,7 @@ internal object DeferredIntentValidator {
         intentConfiguration: PaymentSheet.IntentConfiguration,
     ): DeferredIntentParams {
         val initializationMode = PaymentSheet.InitializationMode.DeferredIntent(intentConfiguration)
-        val params = initializationMode.toElementsSessionParams(externalPaymentMethods = null)
+        val params = initializationMode.toElementsSessionParams(customer = null, externalPaymentMethods = null)
         return (params as ElementsSessionParams.DeferredIntentType).deferredIntentParams
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -171,15 +171,20 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             isGooglePayReady(config, elementsSession)
         }
 
+        val customerConfig = config.customer
+
         val paymentMethods = async {
-            elementsSession.customer?.paymentMethods ?: run {
-                when (val customerConfig = config.customer) {
-                    null -> emptyList()
-                    else -> retrieveCustomerPaymentMethods(
+            when (customerConfig?.accessType) {
+                is PaymentSheet.CustomerAccessType.CustomerSession -> {
+                    elementsSession.customer?.paymentMethods ?: emptyList()
+                }
+                is PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey -> {
+                    retrieveCustomerPaymentMethods(
                         metadata = metadata,
                         customerConfig = customerConfig,
                     )
                 }
+                null -> emptyList()
             }
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -112,7 +112,8 @@ class DefaultCustomerSheetLoaderTest {
         )
         assertThat(state.validationError).isNull()
 
-        val mode = elementsSessionRepository.lastGetParam as PaymentSheet.InitializationMode.DeferredIntent
+        val mode = elementsSessionRepository.lastParams?.initializationMode
+            as PaymentSheet.InitializationMode.DeferredIntent
         assertThat(mode.intentConfiguration.paymentMethodTypes)
             .isEmpty()
     }
@@ -164,7 +165,8 @@ class DefaultCustomerSheetLoaderTest {
         assertThat(state.paymentMethodMetadata.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
         assertThat(state.validationError).isNull()
 
-        val mode = elementsSessionRepository.lastGetParam as PaymentSheet.InitializationMode.DeferredIntent
+        val mode = elementsSessionRepository.lastParams?.initializationMode
+            as PaymentSheet.InitializationMode.DeferredIntent
         assertThat(mode.intentConfiguration.paymentMethodTypes)
             .isEqualTo(listOf("card", "us_bank_account"))
     }
@@ -222,8 +224,10 @@ class DefaultCustomerSheetLoaderTest {
         )
 
         assertThat(loader.load(config).getOrThrow()).isNotNull()
-        val params = elementsSessionRepository.lastGetParam?.toElementsSessionParams(externalPaymentMethods = null)
-            as ElementsSessionParams.DeferredIntentType
+        val params = elementsSessionRepository.lastParams?.initializationMode?.toElementsSessionParams(
+            customer = null,
+            externalPaymentMethods = null
+        ) as ElementsSessionParams.DeferredIntentType
         assertThat(params.deferredIntentParams.paymentMethodTypes).containsExactly("card")
     }
 
@@ -253,8 +257,10 @@ class DefaultCustomerSheetLoaderTest {
         )
 
         assertThat(loader.load(config).getOrThrow()).isNotNull()
-        val params = elementsSessionRepository.lastGetParam?.toElementsSessionParams(externalPaymentMethods = null)
-            as ElementsSessionParams.DeferredIntentType
+        val params = elementsSessionRepository.lastParams?.initializationMode?.toElementsSessionParams(
+            customer = null,
+            externalPaymentMethods = null
+        ) as ElementsSessionParams.DeferredIntentType
         assertThat(params.deferredIntentParams.paymentMethodTypes).containsExactly("card")
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.ElementsSessionParams
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
 import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -16,6 +17,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -48,6 +50,7 @@ internal class ElementsSessionRepositoryTest {
                 initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
                     clientSecret = "client_secret",
                 ),
+                customer = null,
                 externalPaymentMethods = null,
             ).getOrThrow()
         }
@@ -75,6 +78,7 @@ internal class ElementsSessionRepositoryTest {
                     initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
                         clientSecret = "client_secret",
                     ),
+                    customer = null,
                     externalPaymentMethods = null,
                 ).getOrThrow()
             }
@@ -99,6 +103,7 @@ internal class ElementsSessionRepositoryTest {
                     initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
                         clientSecret = "client_secret",
                     ),
+                    customer = null,
                     externalPaymentMethods = null,
                 ).getOrThrow()
             }
@@ -129,6 +134,7 @@ internal class ElementsSessionRepositoryTest {
             initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
                 clientSecret = "client_secret",
             ),
+            customer = null,
             externalPaymentMethods = null,
         ).getOrThrow()
 
@@ -164,11 +170,55 @@ internal class ElementsSessionRepositoryTest {
                     )
                 )
             ),
+            customer = null,
             externalPaymentMethods = null,
         )
 
         assertThat(session.getOrNull()).isNull()
         assertThat(session.exceptionOrNull()).isEqualTo(endpointException)
+    }
+
+    @OptIn(ExperimentalCustomerSessionApi::class)
+    @Test
+    fun `Verify customer session client secret is passed to 'StripeRepository'`() = runTest {
+        whenever(
+            stripeRepository.retrieveElementsSession(any(), any())
+        ).thenReturn(
+            Result.success(
+                ElementsSession.createFromFallback(
+                    stripeIntent = PaymentIntentFixtures.PI_WITH_SHIPPING,
+                    sessionsError = null,
+                )
+            )
+        )
+
+        val repository = RealElementsSessionRepository(
+            stripeRepository,
+            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
+            testDispatcher,
+        )
+
+        repository.get(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = "client_secret"
+            ),
+            customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
+                id = "cus_1",
+                clientSecret = "customer_session_client_secret"
+            ),
+            externalPaymentMethods = null,
+        )
+
+        verify(stripeRepository).retrieveElementsSession(
+            params = eq(
+                ElementsSessionParams.PaymentIntentType(
+                    clientSecret = "client_secret",
+                    customerSessionClientSecret = "customer_session_client_secret",
+                    externalPaymentMethods = null
+                )
+            ),
+            options = any()
+        )
     }
 
     private fun createRepository() = RealElementsSessionRepository(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -1211,7 +1211,7 @@ internal class DefaultPaymentSheetLoaderTest {
             error = error,
             sessionsError = fallbackError,
             linkSettings = linkSettings,
-            customer = customer,
+            sessionsCustomer = customer,
             isGooglePayEnabled = isGooglePayEnabledFromBackend,
             isCbcEligible = isCbcEligible,
             externalPaymentMethodData = externalPaymentMethodData,

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
@@ -15,14 +15,24 @@ internal class FakeElementsSessionRepository(
     private val isCbcEligible: Boolean = false,
     private val externalPaymentMethodData: String? = null,
 ) : ElementsSessionRepository {
+    data class Params(
+        val initializationMode: PaymentSheet.InitializationMode,
+        val customer: PaymentSheet.CustomerConfiguration?,
+        val externalPaymentMethods: List<String>?,
+    )
 
-    var lastGetParam: PaymentSheet.InitializationMode? = null
+    var lastParams: Params? = null
 
     override suspend fun get(
         initializationMode: PaymentSheet.InitializationMode,
+        customer: PaymentSheet.CustomerConfiguration?,
         externalPaymentMethods: List<String>?,
     ): Result<ElementsSession> {
-        lastGetParam = initializationMode
+        lastParams = Params(
+            initializationMode = initializationMode,
+            customer = customer,
+            externalPaymentMethods = externalPaymentMethods
+        )
         return if (error != null) {
             Result.failure(error)
         } else {
@@ -36,7 +46,7 @@ internal class FakeElementsSessionRepository(
                     isGooglePayEnabled = isGooglePayEnabled,
                     sessionsError = sessionsError,
                     externalPaymentMethodData = externalPaymentMethodData,
-                    customer = customer,
+                    customer = this.customer,
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
@@ -10,7 +10,7 @@ internal class FakeElementsSessionRepository(
     private val error: Throwable?,
     private val sessionsError: Throwable? = null,
     private val linkSettings: ElementsSession.LinkSettings?,
-    private val customer: ElementsSession.Customer? = null,
+    private val sessionsCustomer: ElementsSession.Customer? = null,
     private val isGooglePayEnabled: Boolean = true,
     private val isCbcEligible: Boolean = false,
     private val externalPaymentMethodData: String? = null,
@@ -46,7 +46,7 @@ internal class FakeElementsSessionRepository(
                     isGooglePayEnabled = isGooglePayEnabled,
                     sessionsError = sessionsError,
                     externalPaymentMethodData = externalPaymentMethodData,
-                    customer = this.customer,
+                    customer = sessionsCustomer,
                 )
             )
         }


### PR DESCRIPTION
# Summary
Fetches `CustomerSession` uses its information in `PaymentSheet`. Payment methods found in the `Customer` object returned from `ElementsSession` will be favored over payment methods fetched directly from the Stripe API.

# Motivation
Payment methods in the `Customer` object of `ElementsSession` are deduped on the server-side and also only return the payment methods that are allowed to be displayed to the user based on their permissions and merchant-configured settings.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified