### PR TITLE
Move `SectionFieldElement` to `StateFlow`.

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BlikElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BlikElement.kt
@@ -6,8 +6,8 @@ import com.stripe.android.uicore.elements.InputController
 import com.stripe.android.uicore.elements.SectionSingleFieldElement
 import com.stripe.android.uicore.elements.SimpleTextFieldController
 import com.stripe.android.uicore.forms.FormFieldEntry
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
+import com.stripe.android.uicore.utils.mapAsStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 class BlikElement(
@@ -17,8 +17,8 @@ class BlikElement(
     )
 ) : SectionSingleFieldElement(identifier = identifier) {
 
-    override fun getFormFieldValueFlow(): Flow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
-        return controller.formFieldValue.map { entry ->
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
+        return controller.formFieldValue.mapAsStateFlow { entry ->
             listOf(identifier to entry)
         }
     }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
@@ -8,10 +8,10 @@ import com.stripe.android.uicore.elements.SectionFieldErrorController
 import com.stripe.android.uicore.elements.SectionMultiFieldElement
 import com.stripe.android.uicore.elements.convertTo4DigitDate
 import com.stripe.android.uicore.forms.FormFieldEntry
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
+import com.stripe.android.uicore.utils.combineAsStateFlow
+import com.stripe.android.uicore.utils.mapAsStateFlow
+import com.stripe.android.uicore.utils.stateFlowOf
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * This is the element that represent the collection of all the card details:
@@ -39,8 +39,8 @@ internal class CardDetailsElement(
         // Nothing from FormArguments to populate
     }
 
-    override fun getTextFieldIdentifiers(): Flow<List<IdentifierSpec>> =
-        MutableStateFlow(
+    override fun getTextFieldIdentifiers(): StateFlow<List<IdentifierSpec>> =
+        stateFlowOf(
             listOfNotNull(
                 controller.nameElement?.identifier,
                 controller.numberElement.identifier,
@@ -49,33 +49,33 @@ internal class CardDetailsElement(
             )
         )
 
-    override fun getFormFieldValueFlow(): Flow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
         val flows = buildList {
             if (controller.nameElement != null) {
                 add(
-                    controller.nameElement.controller.formFieldValue.map {
+                    controller.nameElement.controller.formFieldValue.mapAsStateFlow {
                         controller.nameElement.identifier to it
                     }
                 )
             }
             add(
-                controller.numberElement.controller.formFieldValue.map {
+                controller.numberElement.controller.formFieldValue.mapAsStateFlow {
                     controller.numberElement.identifier to it
                 }
             )
             add(
-                controller.cvcElement.controller.formFieldValue.map {
+                controller.cvcElement.controller.formFieldValue.mapAsStateFlow {
                     controller.cvcElement.identifier to it
                 }
             )
             add(
-                controller.numberElement.controller.cardBrandFlow.map {
+                controller.numberElement.controller.cardBrandFlow.mapAsStateFlow {
                     IdentifierSpec.CardBrand to FormFieldEntry(it.code, true)
                 }
             )
             if (cbcEligibility is CardBrandChoiceEligibility.Eligible) {
                 add(
-                    controller.numberElement.controller.selectedCardBrandFlow.map { brand ->
+                    controller.numberElement.controller.selectedCardBrandFlow.mapAsStateFlow { brand ->
                         IdentifierSpec.PreferredCardBrand to FormFieldEntry(
                             value = brand.code.takeUnless { brand == CardBrand.Unknown },
                             isComplete = true
@@ -84,17 +84,17 @@ internal class CardDetailsElement(
                 )
             }
             add(
-                controller.expirationDateElement.controller.formFieldValue.map {
+                controller.expirationDateElement.controller.formFieldValue.mapAsStateFlow {
                     IdentifierSpec.CardExpMonth to getExpiryMonthFormFieldEntry(it)
                 }
             )
             add(
-                controller.expirationDateElement.controller.formFieldValue.map {
+                controller.expirationDateElement.controller.formFieldValue.mapAsStateFlow {
                     IdentifierSpec.CardExpYear to getExpiryYearFormFieldEntry(it)
                 }
             )
         }
-        return combine(flows) { it.toList() }
+        return combineAsStateFlow(flows) { it.toList() }
     }
 }
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/UpiElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/UpiElement.kt
@@ -5,9 +5,6 @@ import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.InputController
 import com.stripe.android.uicore.elements.SectionSingleFieldElement
 import com.stripe.android.uicore.elements.SimpleTextFieldController
-import com.stripe.android.uicore.forms.FormFieldEntry
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 class UpiElement(
@@ -16,10 +13,4 @@ class UpiElement(
     )
 ) : SectionSingleFieldElement(identifier = IdentifierSpec.Vpa) {
     override val identifier: IdentifierSpec = IdentifierSpec.Vpa
-
-    override fun getFormFieldValueFlow(): Flow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
-        return controller.formFieldValue.map { entry ->
-            listOf(identifier to entry)
-        }
-    }
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
@@ -28,34 +28,31 @@ internal class CardBillingAddressElementTest {
     fun `Verify that when US is selected postal is not hidden`() = runTest {
         cardBillingElement.hiddenIdentifiers.test {
             dropdownFieldController.onRawValueChange("US")
-            verifyPostalShown(awaitItem())
+            verifyPostalShown(expectMostRecentItem())
         }
     }
 
     @Test
     fun `Verify that when GB is selected postal is not hidden`() = runTest {
         cardBillingElement.hiddenIdentifiers.test {
-            skipItems(1)
             dropdownFieldController.onRawValueChange("GB")
-            verifyPostalShown(awaitItem())
+            verifyPostalShown(expectMostRecentItem())
         }
     }
 
     @Test
     fun `Verify that when CA is selected postal is not hidden`() = runTest {
         cardBillingElement.hiddenIdentifiers.test {
-            skipItems(1)
             dropdownFieldController.onRawValueChange("CA")
-            verifyPostalShown(awaitItem())
+            verifyPostalShown(expectMostRecentItem())
         }
     }
 
     @Test
     fun `Verify that when DE is selected postal IS hidden`() = runTest {
         cardBillingElement.hiddenIdentifiers.test {
-            skipItems(1)
             dropdownFieldController.onRawValueChange("DE")
-            verifyPostalHidden(awaitItem())
+            verifyPostalHidden(expectMostRecentItem())
         }
     }
 

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
@@ -46,8 +46,6 @@ class CardDetailsControllerTest {
             cardController.numberElement.controller.onValueChange("4242424242424242")
             idleLooper()
 
-            skipItems(1)
-
             assertThat(awaitItem()?.errorMessage).isEqualTo(
                 UiCoreR.string.stripe_incomplete_expiry_date
             )

--- a/stripe-ui-core/detekt-baseline.xml
+++ b/stripe-ui-core/detekt-baseline.xml
@@ -33,6 +33,7 @@
     <ID>MagicNumber:StripeTheme.kt$0.32</ID>
     <ID>MagicNumber:StripeTheme.kt$3</ID>
     <ID>MagicNumber:TextFieldUI.kt$1000</ID>
+    <ID>MatchingDeclarationName:StateFlows.kt$FlowToStateFlow&lt;T> : StateFlow</ID>
     <ID>MaxLineLength:DrawablePainter.kt$*</ID>
     <ID>MaxLineLength:Html.kt$*</ID>
     <ID>MaxLineLength:UiUtils.kt$*</ID>

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
@@ -7,7 +7,6 @@ import com.stripe.android.uicore.address.AddressSchemaRegistry
 import com.stripe.android.uicore.address.AutocompleteCapableAddressType
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.flatMapLatestAsStateFlow
-import com.stripe.android.uicore.utils.flattenConcatAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
@@ -124,7 +123,7 @@ open class AddressElement constructor(
     private val fieldsUpdatedFlow =
         combineAsStateFlow(
             countryElement.controller.rawFieldValue,
-            otherFields.mapAsStateFlow { fieldElements ->
+            otherFields.flatMapLatestAsStateFlow { fieldElements ->
                 combineAsStateFlow(
                     fieldElements
                         .map {
@@ -133,7 +132,7 @@ open class AddressElement constructor(
                 ) {
                     it.toList().flatten()
                 }
-            }.flattenConcatAsStateFlow()
+            }
         ) { country, values ->
             country?.let {
                 currentValuesMap[IdentifierSpec.Country] = it

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
@@ -68,9 +68,7 @@ open class AddressElement constructor(
     private val otherFields = countryElement.controller.rawFieldValue
         .mapAsStateFlow { countryCode ->
             countryCode?.let {
-                if (phoneNumberElement.controller.fieldValue.value.isBlank()) {
-                    phoneNumberElement.controller.countryDropdownController.onRawValueChange(it)
-                }
+                phoneNumberElement.controller.countryDropdownController.onRawValueChange(it)
             }
             (elementsRegistry.get(countryCode) ?: emptyList()).onEach { field ->
                 updateLine1WithAutocompleteAffordance(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowElement.kt
@@ -2,8 +2,8 @@ package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.uicore.forms.FormFieldEntry
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
+import com.stripe.android.uicore.utils.combineAsStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class RowElement constructor(
@@ -11,8 +11,8 @@ class RowElement constructor(
     val fields: List<SectionSingleFieldElement>,
     val controller: RowController
 ) : SectionMultiFieldElement(_identifier) {
-    override fun getFormFieldValueFlow(): Flow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
-        combine(fields.map { it.getFormFieldValueFlow() }) {
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
+        combineAsStateFlow(fields.map { it.getFormFieldValueFlow() }) {
             it.toList().flatten()
         }
 
@@ -24,6 +24,6 @@ class RowElement constructor(
         }
     }
 
-    override fun getTextFieldIdentifiers(): Flow<List<IdentifierSpec>> =
+    override fun getTextFieldIdentifiers(): StateFlow<List<IdentifierSpec>> =
         fields.map { it.getTextFieldIdentifiers() }.last()
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingElement.kt
@@ -1,9 +1,6 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
-import com.stripe.android.uicore.forms.FormFieldEntry
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class SameAsShippingElement(
@@ -12,14 +9,6 @@ data class SameAsShippingElement(
 ) : SectionSingleFieldElement(identifier) {
     override val shouldRenderOutsideCard: Boolean
         get() = true
-
-    override fun getFormFieldValueFlow(): Flow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
-        return controller.formFieldValue.map {
-            listOf(
-                identifier to it
-            )
-        }
-    }
 
     override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
         rawValuesMap[identifier]?.let {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionFieldElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionFieldElement.kt
@@ -2,7 +2,7 @@ package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.uicore.forms.FormFieldEntry
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface SectionFieldElement {
@@ -10,8 +10,8 @@ interface SectionFieldElement {
     val shouldRenderOutsideCard: Boolean
         get() = false
 
-    fun getFormFieldValueFlow(): Flow<List<Pair<IdentifierSpec, FormFieldEntry>>>
+    fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>>
     fun sectionFieldErrorController(): SectionFieldErrorController
     fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>)
-    fun getTextFieldIdentifiers(): Flow<List<IdentifierSpec>>
+    fun getTextFieldIdentifiers(): StateFlow<List<IdentifierSpec>>
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionSingleFieldElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionSingleFieldElement.kt
@@ -2,9 +2,9 @@ package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.uicore.forms.FormFieldEntry
-import kotlinx.coroutines.flow.Flow
+import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * This is an element that is in a section and accepts user input.
@@ -23,8 +23,8 @@ abstract class SectionSingleFieldElement(
      */
     override fun sectionFieldErrorController(): SectionFieldErrorController = controller
 
-    override fun getFormFieldValueFlow(): Flow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
-        return controller.formFieldValue.map { formFieldEntry ->
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
+        return controller.formFieldValue.mapAsStateFlow { formFieldEntry ->
             listOf(identifier to formFieldEntry)
         }
     }
@@ -33,7 +33,7 @@ abstract class SectionSingleFieldElement(
         rawValuesMap[identifier]?.let { controller.onRawValueChange(it) }
     }
 
-    override fun getTextFieldIdentifiers(): Flow<List<IdentifierSpec>> =
+    override fun getTextFieldIdentifiers(): StateFlow<List<IdentifierSpec>> =
         MutableStateFlow(
             listOf(identifier).takeIf { controller is TextFieldController }
                 ?: emptyList()

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/utils/StateFlows.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/utils/StateFlows.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 
@@ -63,7 +64,7 @@ fun <T, R> StateFlow<T>.mapAsStateFlow(
 ): StateFlow<R> {
     @Suppress("DEPRECATION")
     return FlowToStateFlow(
-        flow = map(transform),
+        flow = map(transform).distinctUntilChanged(),
         produceValue = { transform(value) },
     )
 }
@@ -78,7 +79,7 @@ fun <T, R> StateFlow<T>.flatMapLatestAsStateFlow(
 ): StateFlow<R> {
     @Suppress("DEPRECATION")
     return FlowToStateFlow(
-        flow = flatMapLatest(transform),
+        flow = flatMapLatest(transform).distinctUntilChanged(),
         produceValue = {
             transform(value).value
         },
@@ -96,7 +97,7 @@ fun <T1, T2, R> combineAsStateFlow(
 ): StateFlow<R> {
     @Suppress("DEPRECATION")
     return FlowToStateFlow(
-        flow = combine(flow1, flow2, transform),
+        flow = combine(flow1, flow2, transform).distinctUntilChanged(),
         produceValue = { transform(flow1.value, flow2.value) },
     )
 }
@@ -113,7 +114,7 @@ fun <T1, T2, T3, R> combineAsStateFlow(
 ): StateFlow<R> {
     @Suppress("DEPRECATION")
     return FlowToStateFlow(
-        flow = combine(flow1, flow2, flow3, transform),
+        flow = combine(flow1, flow2, flow3, transform).distinctUntilChanged(),
         produceValue = { transform(flow1.value, flow2.value, flow3.value) },
     )
 }
@@ -131,7 +132,7 @@ fun <T1, T2, T3, T4, R> combineAsStateFlow(
 ): StateFlow<R> {
     @Suppress("DEPRECATION")
     return FlowToStateFlow(
-        flow = combine(flow1, flow2, flow3, flow4, transform),
+        flow = combine(flow1, flow2, flow3, flow4, transform).distinctUntilChanged(),
         produceValue = { transform(flow1.value, flow2.value, flow3.value, flow4.value) },
     )
 }
@@ -159,7 +160,7 @@ fun <T1, T2, T3, T4, T5, T6, R> combineAsStateFlow(
             val flow5Value = values[4] as T5
             val flow6Value = values[5] as T6
             transform(flow1Value, flow2Value, flow3Value, flow4Value, flow5Value, flow6Value)
-        },
+        }.distinctUntilChanged(),
         produceValue = { transform(flow1.value, flow2.value, flow3.value, flow4.value, flow5.value, flow6.value) },
     )
 }
@@ -176,7 +177,7 @@ inline fun <reified T, R> combineAsStateFlow(
     return FlowToStateFlow(
         flow = combine(flows) { values ->
             transform(values.toList())
-        },
+        }.distinctUntilChanged(),
         produceValue = { transform(flows.map { it.value }) },
     )
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/utils/StateFlows.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/utils/StateFlows.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 
 /**
@@ -23,7 +22,10 @@ import kotlinx.coroutines.flow.map
  * @param produceValue The producer of the [StateFlow's] value
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-@Deprecated("Use helpers such as 'mapAsStateFlow' rather than use this class directly")
+@Deprecated(
+    message = "Use helpers such as 'mapAsStateFlow' rather than use this class directly. " +
+        "This is only public to allow for the inline function usage below."
+)
 class FlowToStateFlow<T>(
     private val flow: Flow<T>,
     private val produceValue: () -> T,
@@ -79,26 +81,6 @@ fun <T, R> StateFlow<T>.flatMapLatestAsStateFlow(
         flow = flatMapLatest(transform),
         produceValue = {
             transform(value).value
-        },
-    )
-}
-
-/**
- * Combines a list of [StateFlow]s into another, instead of loosening the result to a [Flow].
- */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun <T> StateFlow<StateFlow<T>>.flattenConcatAsStateFlow(): StateFlow<T> {
-    @Suppress("DEPRECATION")
-    return FlowToStateFlow(
-        flow = flow {
-            this@flattenConcatAsStateFlow.collect { internalStateFlow ->
-                internalStateFlow.collect { value ->
-                    emit(value)
-                }
-            }
-        },
-        produceValue = {
-            value.value
         },
     )
 }

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SimpleTextFieldControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SimpleTextFieldControllerTest.kt
@@ -95,7 +95,7 @@ internal class SimpleTextFieldControllerTest {
         controller.isComplete.test {
             assertThat(awaitItem()).isEqualTo(false)
             controller.onValueChange("invalid")
-            assertThat(awaitItem()).isEqualTo(false)
+            expectNoEvents()
 
             controller.onValueChange("limitless")
             assertThat(awaitItem()).isEqualTo(true)

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/utils/StateFlowsTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/utils/StateFlowsTest.kt
@@ -1,0 +1,91 @@
+package com.stripe.android.uicore.utils
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class StateFlowsTest {
+    @Test
+    fun `'flatMapLatestAsStateFlow' should only emit latest value of initially received 'StateFlow'`() = runTest {
+        val nestedFlow = MutableStateFlow(0)
+
+        nestedFlow.value = 1
+
+        val state = MutableStateFlow(nestedFlow)
+
+        val flattened = state.flatMapLatestAsStateFlow { it }
+
+        flattened.test {
+            assertThat(awaitItem()).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `'flatMapLatestAsStateFlow' should emit produced values of received 'StateFlow'`() = runTest {
+        val nestedFlow = MutableStateFlow(0)
+        val state = MutableStateFlow(nestedFlow)
+
+        val flattened = state.flatMapLatestAsStateFlow { it }
+
+        flattened.test {
+            assertThat(awaitItem()).isEqualTo(0)
+
+            nestedFlow.value = 1
+
+            assertThat(awaitItem()).isEqualTo(1)
+
+            nestedFlow.value = 2
+
+            assertThat(awaitItem()).isEqualTo(2)
+        }
+    }
+
+    @Test
+    fun `'flatMapLatestAsStateFlow' should only emit latest value of next received 'StateFlow'`() = runTest {
+        val initialNestedFlow = MutableStateFlow(0)
+        val state = MutableStateFlow(initialNestedFlow)
+
+        val flattened = state.flatMapLatestAsStateFlow { it }
+
+        flattened.test {
+            assertThat(awaitItem()).isEqualTo(0)
+
+            initialNestedFlow.value = 1
+
+            assertThat(awaitItem()).isEqualTo(1)
+
+            val nextNestedFlow = MutableStateFlow(2)
+
+            nextNestedFlow.value = 3
+            nextNestedFlow.value = 4
+
+            state.value = nextNestedFlow
+
+            assertThat(awaitItem()).isEqualTo(4)
+        }
+    }
+
+    @Test
+    fun `'flatMapLatestAsStateFlow' should emit any values from previous 'StateFlow'`() = runTest {
+        val initialNestedFlow = MutableStateFlow(0)
+        val state = MutableStateFlow(initialNestedFlow)
+
+        val flattened = state.flatMapLatestAsStateFlow { it }
+
+        flattened.test {
+            assertThat(awaitItem()).isEqualTo(0)
+
+            val nextNestedFlow = MutableStateFlow(1)
+
+            state.value = nextNestedFlow
+
+            assertThat(awaitItem()).isEqualTo(1)
+
+            initialNestedFlow.value = 2
+
+            assertThat(flattened.value).isEqualTo(1)
+        }
+    }
+}


### PR DESCRIPTION
# Summary
Moves `SectionFieldElement` to use `StateFlow`. Added additional helpers to `StateFlows` to help the migration across `SectionFieldElement` implementations. There is also some cleanup of overridden functions performing the same task as their superclass equivalents.

# Motivation
Continues our effort to migrate our UI elements to use `StateFlow` rather than `Flow` so that an initial value is made immediately available. Helps fix janky UI appearance and allows for screenshot tests to be performed on those components.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified