### PR TITLE
Create shared extension function for creating `DeferredIntentParams`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
@@ -1,12 +1,10 @@
 package com.stripe.android.paymentsheet
 
 import com.stripe.android.model.DeferredIntentParams
-import com.stripe.android.model.ElementsSessionParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntent.ConfirmationMethod.Manual
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.paymentsheet.repositories.toElementsSessionParams
 
 internal object DeferredIntentValidator {
 
@@ -19,7 +17,7 @@ internal object DeferredIntentValidator {
         intentConfiguration: PaymentSheet.IntentConfiguration,
         isFlowController: Boolean,
     ): StripeIntent {
-        val params = mapToDeferredIntentParams(intentConfiguration)
+        val params = intentConfiguration.toDeferredIntentParams()
 
         when (stripeIntent) {
             is PaymentIntent -> {
@@ -69,13 +67,5 @@ internal object DeferredIntentValidator {
         }
 
         return stripeIntent
-    }
-
-    private fun mapToDeferredIntentParams(
-        intentConfiguration: PaymentSheet.IntentConfiguration,
-    ): DeferredIntentParams {
-        val initializationMode = PaymentSheet.InitializationMode.DeferredIntent(intentConfiguration)
-        val params = initializationMode.toElementsSessionParams(customer = null, externalPaymentMethods = null)
-        return (params as ElementsSessionParams.DeferredIntentType).deferredIntentParams
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfigurationKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfigurationKtx.kt
@@ -1,0 +1,48 @@
+package com.stripe.android.paymentsheet
+
+import com.stripe.android.model.DeferredIntentParams
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.StripeIntent
+
+internal fun PaymentSheet.IntentConfiguration.toDeferredIntentParams(): DeferredIntentParams {
+    return DeferredIntentParams(
+        mode = mode.toDeferredIntentMode(),
+        paymentMethodTypes = paymentMethodTypes,
+        onBehalfOf = onBehalfOf,
+        paymentMethodConfigurationId = paymentMethodConfigurationId,
+    )
+}
+
+private fun PaymentSheet.IntentConfiguration.Mode.toDeferredIntentMode(): DeferredIntentParams.Mode {
+    return when (this) {
+        is PaymentSheet.IntentConfiguration.Mode.Payment -> {
+            DeferredIntentParams.Mode.Payment(
+                amount = amount,
+                currency = currency,
+                setupFutureUsage = setupFutureUse?.toIntentUsage(),
+                captureMethod = captureMethod.toIntentCaptureMethod(),
+            )
+        }
+        is PaymentSheet.IntentConfiguration.Mode.Setup -> {
+            DeferredIntentParams.Mode.Setup(
+                currency = currency,
+                setupFutureUsage = setupFutureUse.toIntentUsage(),
+            )
+        }
+    }
+}
+
+private fun PaymentSheet.IntentConfiguration.SetupFutureUse.toIntentUsage(): StripeIntent.Usage {
+    return when (this) {
+        PaymentSheet.IntentConfiguration.SetupFutureUse.OnSession -> StripeIntent.Usage.OnSession
+        PaymentSheet.IntentConfiguration.SetupFutureUse.OffSession -> StripeIntent.Usage.OffSession
+    }
+}
+
+private fun PaymentSheet.IntentConfiguration.CaptureMethod.toIntentCaptureMethod(): PaymentIntent.CaptureMethod {
+    return when (this) {
+        PaymentSheet.IntentConfiguration.CaptureMethod.Automatic -> PaymentIntent.CaptureMethod.Automatic
+        PaymentSheet.IntentConfiguration.CaptureMethod.AutomaticAsync -> PaymentIntent.CaptureMethod.AutomaticAsync
+        PaymentSheet.IntentConfiguration.CaptureMethod.Manual -> PaymentIntent.CaptureMethod.Manual
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -3,18 +3,15 @@ package com.stripe.android.paymentsheet.repositories
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.networking.ApiRequest
-import com.stripe.android.model.DeferredIntentParams
-import com.stripe.android.model.DeferredIntentParams.Mode
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.ElementsSessionParams
 import com.stripe.android.model.PaymentIntent
-import com.stripe.android.model.PaymentIntent.CaptureMethod
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.model.StripeIntent.Usage
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.toDeferredIntentParams
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Provider
@@ -136,50 +133,11 @@ internal fun PaymentSheet.InitializationMode.toElementsSessionParams(
 
         is PaymentSheet.InitializationMode.DeferredIntent -> {
             ElementsSessionParams.DeferredIntentType(
-                deferredIntentParams = DeferredIntentParams(
-                    mode = intentConfiguration.mode.toElementsSessionParam(),
-                    paymentMethodTypes = intentConfiguration.paymentMethodTypes,
-                    onBehalfOf = intentConfiguration.onBehalfOf,
-                    paymentMethodConfigurationId = intentConfiguration.paymentMethodConfigurationId,
-                ),
+                deferredIntentParams = intentConfiguration.toDeferredIntentParams(),
                 externalPaymentMethods = externalPaymentMethods,
                 customerSessionClientSecret = customerSessionClientSecret,
             )
         }
-    }
-}
-
-private fun PaymentSheet.IntentConfiguration.Mode.toElementsSessionParam(): Mode {
-    return when (this) {
-        is PaymentSheet.IntentConfiguration.Mode.Payment -> {
-            Mode.Payment(
-                amount = amount,
-                currency = currency,
-                setupFutureUsage = setupFutureUse?.toElementsSessionParam(),
-                captureMethod = captureMethod.toElementsSessionParam(),
-            )
-        }
-        is PaymentSheet.IntentConfiguration.Mode.Setup -> {
-            Mode.Setup(
-                currency = currency,
-                setupFutureUsage = setupFutureUse.toElementsSessionParam(),
-            )
-        }
-    }
-}
-
-private fun PaymentSheet.IntentConfiguration.SetupFutureUse.toElementsSessionParam(): Usage {
-    return when (this) {
-        PaymentSheet.IntentConfiguration.SetupFutureUse.OnSession -> Usage.OnSession
-        PaymentSheet.IntentConfiguration.SetupFutureUse.OffSession -> Usage.OffSession
-    }
-}
-
-private fun PaymentSheet.IntentConfiguration.CaptureMethod.toElementsSessionParam(): CaptureMethod {
-    return when (this) {
-        PaymentSheet.IntentConfiguration.CaptureMethod.Automatic -> CaptureMethod.Automatic
-        PaymentSheet.IntentConfiguration.CaptureMethod.AutomaticAsync -> CaptureMethod.AutomaticAsync
-        PaymentSheet.IntentConfiguration.CaptureMethod.Manual -> CaptureMethod.Manual
     }
 }
 


### PR DESCRIPTION
# Summary
Create shared extension function for creating `DeferredIntentParams` between `DeferredIntentValidator` and `ElementsSessionRepository`.

# Motivation
Moves logic to a shared location and also removes usage of `toElementsSessionParam` in `DeferredIntentValidator` which has to define parameters that are unused by the class.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
