### PR TITLE
Add ability to set on_behalf_of for CBC elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## 20.41.1 - 2024-04-22
 
+### Payments
+* [ADDED][8344](https://github.com/stripe/stripe-android/pull/8344) Added support for `onBehalfOf` to `CardInputWidget`, `CardMultilineWidget`, and `CardFormView`. This parameter may be required when setting a connected account as the merchant of record for a payment. For more information, see the [Connect docs](https://docs.stripe.com/connect/charges#on_behalf_of).
+
 ### PaymentSheet
 * [FIXED][8297](https://github.com/stripe/stripe-android/pull/8297) Improve `PaymentSheet` and `CustomerSheet` loading user experience.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
-## 20.41.1 - 2024-04-22
-
 ### Payments
 * [ADDED][8344](https://github.com/stripe/stripe-android/pull/8344) Added support for `onBehalfOf` to `CardInputWidget`, `CardMultilineWidget`, and `CardFormView`. This parameter may be required when setting a connected account as the merchant of record for a payment. For more information, see the [Connect docs](https://docs.stripe.com/connect/charges#on_behalf_of).
+
+## 20.41.1 - 2024-04-22
 
 ### PaymentSheet
 * [FIXED][8297](https://github.com/stripe/stripe-android/pull/8297) Improve `PaymentSheet` and `CustomerSheet` loading user experience.

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -431,6 +431,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
 
     override suspend fun retrieveCardElementConfig(
         requestOptions: ApiRequest.Options,
+        params: Map<String, String>?
     ): Result<MobileCardElementConfig> {
         TODO("Not yet implemented")
     }

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -7415,6 +7415,7 @@ public final class com/stripe/android/view/CardFormView : android/widget/LinearL
 	public final fun getPaymentMethodCreateParams ()Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun setCardValidCallback (Lcom/stripe/android/view/CardValidCallback;)V
 	public fun setEnabled (Z)V
+	public final fun setOnBehalfOf (Ljava/lang/String;)V
 	public final fun setPreferredNetworks (Ljava/util/List;)V
 }
 
@@ -7463,6 +7464,7 @@ public final class com/stripe/android/view/CardInputWidget : android/widget/Line
 	public fun setEnabled (Z)V
 	public fun setExpiryDate (II)V
 	public fun setExpiryDateTextWatcher (Landroid/text/TextWatcher;)V
+	public final fun setOnBehalfOf (Ljava/lang/String;)V
 	public final fun setPostalCodeEnabled (Z)V
 	public final fun setPostalCodeRequired (Z)V
 	public fun setPostalCodeTextWatcher (Landroid/text/TextWatcher;)V
@@ -7499,6 +7501,7 @@ public final class com/stripe/android/view/CardMultilineWidget : android/widget/
 	public fun setEnabled (Z)V
 	public fun setExpiryDate (II)V
 	public fun setExpiryDateTextWatcher (Landroid/text/TextWatcher;)V
+	public final fun setOnBehalfOf (Ljava/lang/String;)V
 	public final fun setPostalCodeRequired (Z)V
 	public fun setPostalCodeTextWatcher (Landroid/text/TextWatcher;)V
 	public final fun setPreferredNetworks (Ljava/util/List;)V

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -7412,6 +7412,7 @@ public final class com/stripe/android/view/CardFormView : android/widget/LinearL
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getBrand ()Lcom/stripe/android/model/CardBrand;
 	public final fun getCardParams ()Lcom/stripe/android/model/CardParams;
+	public final fun getOnBehalfOf ()Ljava/lang/String;
 	public final fun getPaymentMethodCreateParams ()Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun setCardValidCallback (Lcom/stripe/android/view/CardValidCallback;)V
 	public fun setEnabled (Z)V
@@ -7446,6 +7447,7 @@ public final class com/stripe/android/view/CardInputWidget : android/widget/Line
 	public fun clear ()V
 	public final fun getBrand ()Lcom/stripe/android/model/CardBrand;
 	public fun getCardParams ()Lcom/stripe/android/model/CardParams;
+	public final fun getOnBehalfOf ()Ljava/lang/String;
 	public fun getPaymentMethodCard ()Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
 	public fun getPaymentMethodCreateParams ()Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun getPostalCodeEnabled ()Z
@@ -7482,6 +7484,7 @@ public final class com/stripe/android/view/CardMultilineWidget : android/widget/
 	public fun clear ()V
 	public final synthetic fun getBrand ()Lcom/stripe/android/model/CardBrand;
 	public fun getCardParams ()Lcom/stripe/android/model/CardParams;
+	public final fun getOnBehalfOf ()Ljava/lang/String;
 	public final fun getPaymentMethodBillingDetails ()Lcom/stripe/android/model/PaymentMethod$BillingDetails;
 	public final fun getPaymentMethodBillingDetailsBuilder ()Lcom/stripe/android/model/PaymentMethod$BillingDetails$Builder;
 	public fun getPaymentMethodCard ()Lcom/stripe/android/model/PaymentMethodCreateParams$Card;

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1460,12 +1460,13 @@ class StripeApiRepository @JvmOverloads internal constructor(
 
     override suspend fun retrieveCardElementConfig(
         requestOptions: ApiRequest.Options,
+        params: Map<String, String>?
     ): Result<MobileCardElementConfig> {
         return fetchStripeModelResult(
             apiRequestFactory.createGet(
                 url = mobileCardElementConfigUrl,
                 options = requestOptions,
-                params = null,
+                params = params,
             ),
             jsonParser = MobileCardElementConfigParser(),
         )

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -394,6 +394,7 @@ interface StripeRepository {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun retrieveCardElementConfig(
         requestOptions: ApiRequest.Options,
+        params: Map<String, String>? = null
     ): Result<MobileCardElementConfig>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
@@ -233,8 +233,10 @@ class CardFormView @JvmOverloads constructor(
      * provided on the Intent used when confirming payment.
      */
     fun setOnBehalfOf(onBehalfOf: String) {
-        doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
-            viewModel.onBehalfOf = onBehalfOf
+        if (isAttachedToWindow) {
+            doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
+                viewModel.onBehalfOf = onBehalfOf
+            }
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
@@ -225,6 +225,19 @@ class CardFormView @JvmOverloads constructor(
         cardValidCallback?.onInputChanged(invalidFields.isEmpty(), invalidFields)
     }
 
+    /**
+     * The account (if any) for which the funds of the intent are intended.
+     * The Stripe account ID (if any) which is the business of record.
+     * See [use cases](https://docs.stripe.com/connect/charges#on_behalf_of) to determine if this option is relevant for your integration.
+     * This should match the [on_behalf_of](https://docs.stripe.com/api/payment_intents/create#create_payment_intent-on_behalf_of)
+     * provided on the Intent used when confirming payment.
+     */
+    fun setOnBehalfOf(onBehalfOf: String) {
+        doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
+            viewModel.onBehalfOf = onBehalfOf
+        }
+    }
+
     private fun setupCountryAndPostal() {
         // wire up postal code and country
         updatePostalCodeViewLocale(countryLayout.selectedCountryCode)

--- a/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
@@ -228,8 +228,9 @@ class CardFormView @JvmOverloads constructor(
     /**
      * The account (if any) for which the funds of the intent are intended.
      * The Stripe account ID (if any) which is the business of record.
-     * See [use cases](https://docs.stripe.com/connect/charges#on_behalf_of) to determine if this option is relevant for your integration.
-     * This should match the [on_behalf_of](https://docs.stripe.com/api/payment_intents/create#create_payment_intent-on_behalf_of)
+     * See [use cases](https://docs.stripe.com/connect/charges#on_behalf_of) to determine if this option is relevant
+     * for your integration. This should match the
+     * [on_behalf_of](https://docs.stripe.com/api/payment_intents/create#create_payment_intent-on_behalf_of)
      * provided on the Intent used when confirming payment.
      */
     fun setOnBehalfOf(onBehalfOf: String) {

--- a/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
@@ -183,6 +183,23 @@ class CardFormView @JvmOverloads constructor(
     val paymentMethodCreateParams: PaymentMethodCreateParams?
         get() = paymentMethodCard?.let { PaymentMethodCreateParams.create(it) }
 
+    /**
+     * The Stripe account ID (if any) which is the business of record.
+     * See [use cases](https://docs.stripe.com/connect/charges#on_behalf_of) to determine if this option is relevant
+     * for your integration. This should match the
+     * [on_behalf_of](https://docs.stripe.com/api/payment_intents/create#create_payment_intent-on_behalf_of)
+     * provided on the Intent used when confirming payment.
+     */
+    var onBehalfOf: String? = null
+        set(value) {
+            if (isAttachedToWindow) {
+                doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
+                    viewModel.onBehalfOf = value
+                }
+            }
+            field = value
+        }
+
     init {
         orientation = VERTICAL
 
@@ -223,22 +240,6 @@ class CardFormView @JvmOverloads constructor(
         }
         // call immediately after setting
         cardValidCallback?.onInputChanged(invalidFields.isEmpty(), invalidFields)
-    }
-
-    /**
-     * The account (if any) for which the funds of the intent are intended.
-     * The Stripe account ID (if any) which is the business of record.
-     * See [use cases](https://docs.stripe.com/connect/charges#on_behalf_of) to determine if this option is relevant
-     * for your integration. This should match the
-     * [on_behalf_of](https://docs.stripe.com/api/payment_intents/create#create_payment_intent-on_behalf_of)
-     * provided on the Intent used when confirming payment.
-     */
-    fun setOnBehalfOf(onBehalfOf: String) {
-        if (isAttachedToWindow) {
-            doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
-                viewModel.onBehalfOf = onBehalfOf
-            }
-        }
     }
 
     private fun setupCountryAndPostal() {

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -488,8 +488,9 @@ class CardInputWidget @JvmOverloads constructor(
     /**
      * The account (if any) for which the funds of the intent are intended.
      * The Stripe account ID (if any) which is the business of record.
-     * See [use cases](https://docs.stripe.com/connect/charges#on_behalf_of) to determine if this option is relevant for your integration.
-     * This should match the [on_behalf_of](https://docs.stripe.com/api/payment_intents/create#create_payment_intent-on_behalf_of)
+     * See [use cases](https://docs.stripe.com/connect/charges#on_behalf_of) to determine if this option is relevant
+     * for your integration. This should match the
+     * [on_behalf_of](https://docs.stripe.com/api/payment_intents/create#create_payment_intent-on_behalf_of)
      * provided on the Intent used when confirming payment.
      */
     fun setOnBehalfOf(onBehalfOf: String) {

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -392,6 +392,7 @@ class CardInputWidget @JvmOverloads constructor(
 
         doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
             viewModel.isCbcEligible.launchAndCollect { isCbcEligible ->
+                println("YEET CardInputWidget updating isCbcEligible with value: $isCbcEligible")
                 cardBrandView.isCbcEligible = isCbcEligible
             }
         }
@@ -483,6 +484,19 @@ class CardInputWidget @JvmOverloads constructor(
      */
     fun setPreferredNetworks(preferredNetworks: List<CardBrand>) {
         cardBrandView.merchantPreferredNetworks = preferredNetworks
+    }
+
+    /**
+     * The account (if any) for which the funds of the intent are intended.
+     * The Stripe account ID (if any) which is the business of record.
+     * See [use cases](https://docs.stripe.com/connect/charges#on_behalf_of) to determine if this option is relevant for your integration.
+     * This should match the [on_behalf_of](https://docs.stripe.com/api/payment_intents/create#create_payment_intent-on_behalf_of)
+     * provided on the Intent used when confirming payment.
+     */
+    fun setOnBehalfOf(onBehalfOf: String) {
+        doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
+            viewModel.onBehalfOf = onBehalfOf
+        }
     }
 
     /**

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -493,8 +493,10 @@ class CardInputWidget @JvmOverloads constructor(
      * provided on the Intent used when confirming payment.
      */
     fun setOnBehalfOf(onBehalfOf: String) {
-        doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
-            viewModel.onBehalfOf = onBehalfOf
+        if (isAttachedToWindow) {
+            doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
+                viewModel.onBehalfOf = onBehalfOf
+            }
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -345,6 +345,23 @@ class CardInputWidget @JvmOverloads constructor(
         updatePostalRequired()
     }
 
+    /**
+     * The Stripe account ID (if any) which is the business of record.
+     * See [use cases](https://docs.stripe.com/connect/charges#on_behalf_of) to determine if this option is relevant
+     * for your integration. This should match the
+     * [on_behalf_of](https://docs.stripe.com/api/payment_intents/create#create_payment_intent-on_behalf_of)
+     * provided on the Intent used when confirming payment.
+     */
+    var onBehalfOf: String? = null
+        set(value) {
+            if (isAttachedToWindow) {
+                doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
+                    viewModel.onBehalfOf = value
+                }
+            }
+            field = value
+        }
+
     private fun updatePostalRequired() {
         if (isPostalRequired()) {
             requiredFields.add(postalCodeEditText)
@@ -483,22 +500,6 @@ class CardInputWidget @JvmOverloads constructor(
      */
     fun setPreferredNetworks(preferredNetworks: List<CardBrand>) {
         cardBrandView.merchantPreferredNetworks = preferredNetworks
-    }
-
-    /**
-     * The account (if any) for which the funds of the intent are intended.
-     * The Stripe account ID (if any) which is the business of record.
-     * See [use cases](https://docs.stripe.com/connect/charges#on_behalf_of) to determine if this option is relevant
-     * for your integration. This should match the
-     * [on_behalf_of](https://docs.stripe.com/api/payment_intents/create#create_payment_intent-on_behalf_of)
-     * provided on the Intent used when confirming payment.
-     */
-    fun setOnBehalfOf(onBehalfOf: String) {
-        if (isAttachedToWindow) {
-            doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
-                viewModel.onBehalfOf = onBehalfOf
-            }
-        }
     }
 
     /**

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -392,7 +392,6 @@ class CardInputWidget @JvmOverloads constructor(
 
         doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
             viewModel.isCbcEligible.launchAndCollect { isCbcEligible ->
-                println("YEET CardInputWidget updating isCbcEligible with value: $isCbcEligible")
                 cardBrandView.isCbcEligible = isCbcEligible
             }
         }

--- a/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -212,6 +212,23 @@ class CardMultilineWidget @JvmOverloads constructor(
         }
 
     /**
+     * The Stripe account ID (if any) which is the business of record.
+     * See [use cases](https://docs.stripe.com/connect/charges#on_behalf_of) to determine if this option is relevant
+     * for your integration. This should match the
+     * [on_behalf_of](https://docs.stripe.com/api/payment_intents/create#create_payment_intent-on_behalf_of)
+     * provided on the Intent used when confirming payment.
+     */
+    var onBehalfOf: String? = null
+        set(value) {
+            if (isAttachedToWindow) {
+                doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
+                    viewModel.onBehalfOf = value
+                }
+            }
+            field = value
+        }
+
+    /**
      * A [CardParams] representing the card details and postal code if all fields are valid;
      * otherwise `null`
      */
@@ -456,22 +473,6 @@ class CardMultilineWidget @JvmOverloads constructor(
         doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
             viewModel.isCbcEligible.launchAndCollect { isCbcEligible ->
                 cardBrandView.isCbcEligible = isCbcEligible
-            }
-        }
-    }
-
-    /**
-     * The account (if any) for which the funds of the intent are intended.
-     * The Stripe account ID (if any) which is the business of record.
-     * See [use cases](https://docs.stripe.com/connect/charges#on_behalf_of) to determine if this option is relevant
-     * for your integration. This should match the
-     * [on_behalf_of](https://docs.stripe.com/api/payment_intents/create#create_payment_intent-on_behalf_of)
-     * provided on the Intent used when confirming payment.
-     */
-    fun setOnBehalfOf(onBehalfOf: String) {
-        if (isAttachedToWindow) {
-            doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
-                viewModel.onBehalfOf = onBehalfOf
             }
         }
     }

--- a/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -463,8 +463,9 @@ class CardMultilineWidget @JvmOverloads constructor(
     /**
      * The account (if any) for which the funds of the intent are intended.
      * The Stripe account ID (if any) which is the business of record.
-     * See [use cases](https://docs.stripe.com/connect/charges#on_behalf_of) to determine if this option is relevant for your integration.
-     * This should match the [on_behalf_of](https://docs.stripe.com/api/payment_intents/create#create_payment_intent-on_behalf_of)
+     * See [use cases](https://docs.stripe.com/connect/charges#on_behalf_of) to determine if this option is relevant
+     * for your integration. This should match the
+     * [on_behalf_of](https://docs.stripe.com/api/payment_intents/create#create_payment_intent-on_behalf_of)
      * provided on the Intent used when confirming payment.
      */
     fun setOnBehalfOf(onBehalfOf: String) {

--- a/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -456,7 +456,6 @@ class CardMultilineWidget @JvmOverloads constructor(
         // do stuff
         doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
             viewModel.isCbcEligible.launchAndCollect { isCbcEligible ->
-                println("YEET CardMultilineWidget updating isCbcEligible with value: $isCbcEligible")
                 cardBrandView.isCbcEligible = isCbcEligible
             }
         }

--- a/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -453,10 +453,25 @@ class CardMultilineWidget @JvmOverloads constructor(
         // see https://github.com/stripe/stripe-android/pull/3154
         cvcEditText.hint = null
 
+        // do stuff
         doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
             viewModel.isCbcEligible.launchAndCollect { isCbcEligible ->
+                println("YEET CardMultilineWidget updating isCbcEligible with value: $isCbcEligible")
                 cardBrandView.isCbcEligible = isCbcEligible
             }
+        }
+    }
+
+    /**
+     * The account (if any) for which the funds of the intent are intended.
+     * The Stripe account ID (if any) which is the business of record.
+     * See [use cases](https://docs.stripe.com/connect/charges#on_behalf_of) to determine if this option is relevant for your integration.
+     * This should match the [on_behalf_of](https://docs.stripe.com/api/payment_intents/create#create_payment_intent-on_behalf_of)
+     * provided on the Intent used when confirming payment.
+     */
+    fun setOnBehalfOf(onBehalfOf: String) {
+        doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
+            viewModel.onBehalfOf = onBehalfOf
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -453,7 +453,6 @@ class CardMultilineWidget @JvmOverloads constructor(
         // see https://github.com/stripe/stripe-android/pull/3154
         cvcEditText.hint = null
 
-        // do stuff
         doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
             viewModel.isCbcEligible.launchAndCollect { isCbcEligible ->
                 cardBrandView.isCbcEligible = isCbcEligible
@@ -469,8 +468,10 @@ class CardMultilineWidget @JvmOverloads constructor(
      * provided on the Intent used when confirming payment.
      */
     fun setOnBehalfOf(onBehalfOf: String) {
-        doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
-            viewModel.onBehalfOf = onBehalfOf
+        if (isAttachedToWindow) {
+            doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
+                viewModel.onBehalfOf = onBehalfOf
+            }
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/view/CardWidgetViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardWidgetViewModel.kt
@@ -3,9 +3,11 @@ package com.stripe.android.view
 import android.view.View
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import androidx.lifecycle.lifecycleScope
@@ -30,13 +32,15 @@ internal class CardWidgetViewModel(
     private val paymentConfigProvider: Provider<PaymentConfiguration>,
     private val stripeRepository: StripeRepository,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val handle: SavedStateHandle
 ) : ViewModel() {
 
     private val _isCbcEligible = MutableStateFlow(false)
     val isCbcEligible: StateFlow<Boolean> = _isCbcEligible
-    var onBehalfOf: String? = null
+    var onBehalfOf: String? = handle[ON_BEHALF_OF]
         set(value) {
             field = value
+            handle[ON_BEHALF_OF] = value
             getEligibility()
         }
 
@@ -81,8 +85,13 @@ internal class CardWidgetViewModel(
             return CardWidgetViewModel(
                 paymentConfigProvider = { PaymentConfiguration.getInstance(context) },
                 stripeRepository = stripeRepository,
+                handle = extras.createSavedStateHandle()
             ) as T
         }
+    }
+
+    companion object {
+        internal const val ON_BEHALF_OF = "on_behalf_of"
     }
 }
 

--- a/payments-core/src/test/java/com/stripe/android/utils/CardElementTestHelper.kt
+++ b/payments-core/src/test/java/com/stripe/android/utils/CardElementTestHelper.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.utils
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.ViewModelStoreOwner
 import com.stripe.android.ApiKeyFixtures
@@ -24,6 +25,7 @@ internal object CardElementTestHelper {
             stripeRepository = object : AbsFakeStripeRepository() {
                 override suspend fun retrieveCardElementConfig(
                     requestOptions: ApiRequest.Options,
+                    params: Map<String, String>?
                 ): Result<MobileCardElementConfig> {
                     return Result.success(
                         MobileCardElementConfig(
@@ -34,6 +36,7 @@ internal object CardElementTestHelper {
                     )
                 }
             },
+            handle = SavedStateHandle()
         )
 
         val viewModelStore = ViewModelStore().apply {

--- a/payments-core/src/test/java/com/stripe/android/utils/FakeCardElementConfigRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/utils/FakeCardElementConfigRepository.kt
@@ -33,6 +33,7 @@ class FakeCardElementConfigRepository : AbsFakeStripeRepository() {
 
     override suspend fun retrieveCardElementConfig(
         requestOptions: ApiRequest.Options,
+        params: Map<String, String>?
     ): Result<MobileCardElementConfig> {
         return channel.receive()
     }

--- a/payments-core/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.view
 import android.text.TextWatcher
 import android.view.ViewGroup
 import androidx.appcompat.view.ContextThemeWrapper
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.test.core.app.ApplicationProvider
@@ -1072,6 +1073,7 @@ internal class CardNumberEditTextTest {
             paymentConfigProvider = { PaymentConfiguration.getInstance(context) },
             stripeRepository = repository,
             dispatcher = dispatcher,
+            handle = SavedStateHandle()
         )
 
         val store = ViewModelStore().apply {

--- a/payments-core/src/test/java/com/stripe/android/view/CardWidgetViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardWidgetViewModelTest.kt
@@ -7,7 +7,6 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.utils.FakeCardElementConfigRepository
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import okhttp3.internal.wait
 import org.junit.Test
 
 private val paymentConfig = PaymentConfiguration(

--- a/payments-core/src/test/java/com/stripe/android/view/CardWidgetViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardWidgetViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.view
 
+import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
@@ -26,6 +27,7 @@ class CardWidgetViewModelTest {
                 paymentConfigProvider = { paymentConfig },
                 stripeRepository = stripeRepository,
                 dispatcher = testDispatcher,
+                handle = SavedStateHandle()
             )
 
             viewModel.isCbcEligible.test {
@@ -44,6 +46,7 @@ class CardWidgetViewModelTest {
                 paymentConfigProvider = { paymentConfig },
                 stripeRepository = stripeRepository,
                 dispatcher = testDispatcher,
+                handle = SavedStateHandle()
             )
 
             viewModel.isCbcEligible.test {
@@ -61,6 +64,7 @@ class CardWidgetViewModelTest {
             paymentConfigProvider = { paymentConfig },
             stripeRepository = stripeRepository,
             dispatcher = testDispatcher,
+            handle = SavedStateHandle()
         )
 
         viewModel.isCbcEligible.test {

--- a/payments-core/src/test/java/com/stripe/android/view/CardWidgetViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardWidgetViewModelTest.kt
@@ -73,4 +73,21 @@ class CardWidgetViewModelTest {
             expectNoEvents()
         }
     }
+
+    @Test
+    fun `Saves OBO to savedStateHandle`() = runTest(testDispatcher) {
+        val stripeRepository = FakeCardElementConfigRepository()
+        val handle = SavedStateHandle()
+
+        val viewModel = CardWidgetViewModel(
+            paymentConfigProvider = { paymentConfig },
+            stripeRepository = stripeRepository,
+            dispatcher = testDispatcher,
+            handle = handle
+        )
+
+        viewModel.onBehalfOf = "test"
+        val obo: String? = handle["on_behalf_of"]
+        assertThat(obo).isEqualTo("test")
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Adds ability for merchant to set onBehalfOf for CardInputWidget, CardFormView, and CardMultilineWidget

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[MOBILESDK-1969](https://jira.corp.stripe.com/browse/MOBILESDK-1969)
[API REVIEW](https://docs.google.com/document/d/1jrq8bNVEBpMY0YMyAAipC07AreDv2wpiYxbMEl4N18s/edit?pli=1#heading=h.qarkdnrrshe0)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
See `CHANGELOG.md`
