### PR TITLE
Add external payment methods to playground settings

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/ExternalPaymentMethodSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/ExternalPaymentMethodSettingsDefinition.kt
@@ -1,0 +1,29 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.playground.PlaygroundState
+
+internal object ExternalPaymentMethodSettingsDefinition :
+    PlaygroundSettingDefinition<String>,
+    PlaygroundSettingDefinition.Saveable<String>,
+    PlaygroundSettingDefinition.Displayable<String> {
+    override val key: String = "externalPaymentMethods"
+    override val displayName: String = "External payment methods"
+    override val options: List<PlaygroundSettingDefinition.Displayable.Option<String>> = emptyList()
+    override val defaultValue: String = ""
+
+    override fun convertToValue(value: String): String = value
+
+    override fun convertToString(value: String): String = value
+
+    override fun configure(
+        value: String,
+        configurationBuilder: PaymentSheet.Configuration.Builder,
+        playgroundState: PlaygroundState,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData
+    ) {
+        if (value.isNotEmpty()) {
+            configurationBuilder.externalPaymentMethods(value.split(",").map { it.trim() })
+        }
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -206,8 +206,8 @@ internal class PlaygroundSettings private constructor(
             PreferredNetworkSettingsDefinition,
             AllowsRemovalOfLastSavedPaymentMethodSettingsDefinition,
             PaymentMethodOrderSettingsDefinition,
-            IntegrationTypeSettingsDefinition,
             ExternalPaymentMethodSettingsDefinition,
+            IntegrationTypeSettingsDefinition,
         )
 
         private val nonUiSettingDefinitions: List<PlaygroundSettingDefinition<*>> = listOf(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -207,6 +207,7 @@ internal class PlaygroundSettings private constructor(
             AllowsRemovalOfLastSavedPaymentMethodSettingsDefinition,
             PaymentMethodOrderSettingsDefinition,
             IntegrationTypeSettingsDefinition,
+            ExternalPaymentMethodSettingsDefinition,
         )
 
         private val nonUiSettingDefinitions: List<PlaygroundSettingDefinition<*>> = listOf(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add external payment methods to playground settings

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
To make it easier to test external payment methods

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Added an external payment method type and verified via the debugger that it was present in PaymentMethodMetadata (which is where I've plumbed EPMs to so far)

# Screenshots
![epms in playground](https://github.com/stripe/stripe-android/assets/160939932/9343338b-43ac-43c9-b5e6-72111ef89ae9)


