### PR TITLE
Display external payment methods in the UI

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
@@ -29,7 +29,7 @@ internal sealed interface UiDefinitionFactory {
         interface Factory {
             fun create(
                 metadata: PaymentMethodMetadata,
-                definition: PaymentMethodDefinition,
+                requiresMandate: Boolean,
             ): Arguments
 
             class Default(
@@ -39,7 +39,7 @@ internal sealed interface UiDefinitionFactory {
             ) : Factory {
                 override fun create(
                     metadata: PaymentMethodMetadata,
-                    definition: PaymentMethodDefinition,
+                    requiresMandate: Boolean,
                 ): Arguments {
                     return Arguments(
                         cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
@@ -54,7 +54,7 @@ internal sealed interface UiDefinitionFactory {
                         shippingValues = metadata.shippingDetails?.toIdentifierMap(metadata.defaultBillingDetails),
                         saveForFutureUseInitialValue = false,
                         billingDetailsCollectionConfiguration = metadata.billingDetailsCollectionConfiguration,
-                        requiresMandate = definition.requiresMandate(metadata),
+                        requiresMandate = requiresMandate,
                     )
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/ExternalPaymentMethodUiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/ExternalPaymentMethodUiDefinitionFactory.kt
@@ -1,0 +1,31 @@
+package com.stripe.android.lpmfoundations.paymentmethod.definitions
+
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.lpmfoundations.luxe.FormElementsBuilder
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
+import com.stripe.android.ui.core.elements.ExternalPaymentMethodSpec
+import com.stripe.android.uicore.elements.FormElement
+
+internal class ExternalPaymentMethodUiDefinitionFactory(
+    private val externalPaymentMethodSpec: ExternalPaymentMethodSpec
+) : UiDefinitionFactory.Simple {
+    override fun createSupportedPaymentMethod(): SupportedPaymentMethod {
+        return SupportedPaymentMethod(
+            code = externalPaymentMethodSpec.type,
+            displayName = resolvableString(externalPaymentMethodSpec.label),
+            lightThemeIconUrl = externalPaymentMethodSpec.lightImageUrl,
+            darkThemeIconUrl = externalPaymentMethodSpec.darkImageUrl,
+            iconResource = 0,
+            tintIconOnSelection = false,
+        )
+    }
+
+    override fun createFormElements(
+        metadata: PaymentMethodMetadata,
+        arguments: UiDefinitionFactory.Arguments
+    ): List<FormElement> {
+        return FormElementsBuilder(arguments).build()
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
@@ -34,7 +34,7 @@ internal class DefaultPaymentSelectionUpdater @Inject constructor() : PaymentSel
         state: PaymentSheetState.Full,
     ): Boolean {
         // The types that are allowed for this intent, as returned by the backend
-        val allowedTypes = state.paymentMethodMetadata.supportedPaymentMethodDefinitions().map { it.type.code }
+        val allowedTypes = state.paymentMethodMetadata.supportedPaymentMethodTypes()
 
         return when (selection) {
             is PaymentSelection.New -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -410,7 +410,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
     private fun supportsIntent(
         metadata: PaymentMethodMetadata,
     ): Boolean {
-        return metadata.supportedPaymentMethodDefinitions().isNotEmpty()
+        return metadata.supportedPaymentMethodTypes().isNotEmpty()
     }
 
     private fun reportSuccessfulLoad(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -6,6 +6,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import com.stripe.android.ui.core.elements.ExternalPaymentMethodSpec
 import com.stripe.android.ui.core.elements.LpmSerializer
 import com.stripe.android.ui.core.elements.SharedDataSpec
 
@@ -22,6 +23,7 @@ internal object PaymentMethodMetadataFactory {
         cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
         hasCustomerConfiguration: Boolean = false,
         sharedDataSpecs: List<SharedDataSpec> = createSharedDataSpecs(),
+        externalPaymentMethodSpecs: List<ExternalPaymentMethodSpec> = emptyList()
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,
@@ -36,7 +38,7 @@ internal object PaymentMethodMetadataFactory {
             shippingDetails = shippingDetails,
             hasCustomerConfiguration = hasCustomerConfiguration,
             sharedDataSpecs = sharedDataSpecs,
-            externalPaymentMethodSpecs = emptyList(),
+            externalPaymentMethodSpecs = externalPaymentMethodSpecs,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -446,7 +446,7 @@ internal class PaymentMethodMetadataTest {
     }
 
     @Test
-    fun `When external payment methods are present and no payment method order, external payment methods are shown last`() =
+    fun `When external payment methods are present and no payment method order, EPMs are shown last`() =
         runTest {
             val metadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update PaymentMethodMetadata to read its externalPaymentMethodSpecs, so that EPMs are shown in the UI when they should be

At this point, when you try to confirm an external payment method, the confirmation fails. So the next step is to set up the external payment method handler so that we can actually confirm these payment methods.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
EPMs!

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screen recording
https://github.com/stripe/stripe-android/assets/160939932/3e6ad140-c91a-4049-bd7d-1a44a7e47aef