### PR TITLE
Re-use new customer ID in `PaymentSheetPlayground`

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -59,7 +59,7 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
         fun createTestIntent(settingsJson: String): Intent {
             return Intent(
                 Intent.ACTION_VIEW,
-                PaymentSheetPlaygroundUrlHelper.createUri(settingsJson)
+                PaymentSheetPlaygroundUrlHelper.createUri(settingsJson, inTestMode = true)
             )
         }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundUrlHelper.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundUrlHelper.kt
@@ -6,18 +6,25 @@ import okio.ByteString.Companion.decodeBase64
 import okio.ByteString.Companion.toByteString
 
 internal object PaymentSheetPlaygroundUrlHelper {
-    fun createUri(settingsJson: String): Uri {
+    fun createUri(settingsJson: String, inTestMode: Boolean = false): Uri {
         val base64Settings = settingsJson.encodeToByteArray().toByteString().base64Url()
             .trimEnd('=')
+
         return Uri.parse(
             "stripepaymentsheetexample://paymentsheetplayground?settings=" +
-                base64Settings
+                base64Settings +
+                "&inTestMode=$inTestMode"
         )
     }
 
     fun settingsFromUri(uri: Uri?): PlaygroundSettings? {
         val settingsJson = uri?.getQueryParameter("settings")
             ?.decodeBase64()?.utf8() ?: return null
+
         return PlaygroundSettings.createFromJsonString(settingsJson)
+    }
+
+    fun inTestModeFromUri(uri: Uri?): Boolean {
+        return uri?.getQueryParameter("inTestMode").toBoolean()
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
@@ -43,6 +43,7 @@ internal class PaymentSheetPlaygroundViewModel(
         Settings(application)
     }
 
+    private val inTestMode = PaymentSheetPlaygroundUrlHelper.inTestModeFromUri(launchUri)
     val playgroundSettingsFlow = MutableStateFlow<PlaygroundSettings?>(null)
     val status = MutableStateFlow<StatusMessage?>(null)
     val state = MutableStateFlow<PlaygroundState?>(null)
@@ -97,6 +98,7 @@ internal class PaymentSheetPlaygroundViewModel(
 
                     state.value = checkoutResponse.asPlaygroundState(
                         snapshot = playgroundSettingsSnapshot,
+                        inTestMode = inTestMode
                     )
                 }
             }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PlaygroundState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PlaygroundState.kt
@@ -19,6 +19,7 @@ internal data class PlaygroundState(
     val paymentMethodTypes: List<String>,
     val customerConfig: PaymentSheet.CustomerConfiguration?,
     val clientSecret: String,
+    val inTestMode: Boolean,
 ) {
     val initializationType = snapshot[InitializationTypeSettingsDefinition]
     val currencyCode = snapshot[CurrencySettingsDefinition]
@@ -37,6 +38,7 @@ internal data class PlaygroundState(
     companion object {
         fun CheckoutResponse.asPlaygroundState(
             snapshot: PlaygroundSettings.Snapshot,
+            inTestMode: Boolean,
         ): PlaygroundState {
             val paymentMethodTypes = if (snapshot[AutomaticPaymentMethodsSettingsDefinition]) {
                 emptyList()
@@ -51,6 +53,7 @@ internal data class PlaygroundState(
                 paymentMethodTypes = paymentMethodTypes,
                 customerConfig = makeCustomerConfig(snapshot.checkoutRequest().customerKeyType),
                 clientSecret = intentClientSecret,
+                inTestMode = inTestMode
             )
         }
     }


### PR DESCRIPTION
# Summary
This PR is a small improvement to the customer settings for the `PaymentSheetPlayground`. When selecting `NEW` as the Customer type, the generated customer ID will be retained for either the whole playground session or until manually changing the customer settings.

# Motivation
Allows developers to test all `PaymentSheet` features using a fresh customer without it being reset on every reload.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Video
https://github.com/stripe/stripe-android/assets/141707240/f7bda490-35a6-4e9b-9cd7-061d8bef74f7


