### PR TITLE
Migrate `AddressController` & `AddressElementUI` to `StateFlow`

### DIFF
--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressController.kt
@@ -5,7 +5,7 @@ import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.flatMapLatest
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AddressController(
-    val fieldsFlowable: Flow<List<SectionFieldElement>>
+    val fieldsFlowable: StateFlow<List<SectionFieldElement>>
 ) : SectionFieldErrorController, SectionFieldComposable {
     @StringRes
     val label: Int? = null

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElementUI.kt
@@ -21,11 +21,11 @@ fun AddressElementUI(
     hiddenIdentifiers: Set<IdentifierSpec>,
     lastTextFieldIdentifier: IdentifierSpec?
 ) {
-    val fields by controller.fieldsFlowable.collectAsState(null)
+    val fields by controller.fieldsFlowable.collectAsState()
 
     // The last rendered field is not always the last field in the list.
     // So we need to pre filter so we know when to stop drawing dividers.
-    fields?.filterNot { hiddenIdentifiers.contains(it.identifier) }?.let { fieldList ->
+    fields.filterNot { hiddenIdentifiers.contains(it.identifier) }.let { fieldList ->
         Column {
             fieldList.forEachIndexed { index, field ->
                 SectionFieldElementUI(


### PR DESCRIPTION
# Summary
Migrate `AddressController` & `AddressElementUI` to `StateFlow`

# Motivation
Allows loading `AddressElement` items synchronously. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
