### PR TITLE
Migrate `SectionFieldErrorController` to `StateFlow`

### DIFF
--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
@@ -240,7 +240,7 @@ internal fun LinkFields(
 ) {
     var didShowAllFields by rememberSaveable { mutableStateOf(false) }
 
-    val sectionError by sectionController.error.collectAsState(null)
+    val sectionError by sectionController.error.collectAsState()
 
     AnimatedVisibility(visible = expanded) {
         Column(

--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkOptionalInlineSignup.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkOptionalInlineSignup.kt
@@ -122,7 +122,7 @@ internal fun LinkOptionalInlineSignup(
         val nameFocusRequester = remember { FocusRequester() }
 
         var didShowAllFields by rememberSaveable { mutableStateOf(false) }
-        val sectionError by sectionController.error.collectAsState(null)
+        val sectionError by sectionController.error.collectAsState()
 
         if (signUpState == SignUpState.InputtingRemainingFields) {
             LaunchedEffect(signUpState) {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbElementUI.kt
@@ -21,7 +21,7 @@ fun BsbElementUI(
     element: BsbElement,
     lastTextFieldIdentifier: IdentifierSpec?
 ) {
-    val error by element.textElement.controller.error.collectAsState(null)
+    val error by element.textElement.controller.error.collectAsState()
     val bankName by element.bankName.collectAsState()
     val sectionErrorString = error?.let {
         it.formatArgs?.let { args ->

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -18,8 +18,7 @@ import com.stripe.android.uicore.elements.SectionFieldErrorController
 import com.stripe.android.uicore.elements.SimpleTextElement
 import com.stripe.android.uicore.elements.SimpleTextFieldConfig
 import com.stripe.android.uicore.elements.SimpleTextFieldController
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.distinctUntilChanged
+import com.stripe.android.uicore.utils.combineAsStateFlow
 import java.util.UUID
 
 internal class CardDetailsController(
@@ -95,7 +94,7 @@ internal class CardDetailsController(
         )
     )
 
-    override val error = combine(
+    override val error = combineAsStateFlow(
         listOfNotNull(
             nameElement,
             numberElement,
@@ -106,7 +105,7 @@ internal class CardDetailsController(
             .map { it.error }
     ) {
         it.filterNotNull().firstOrNull()
-    }.distinctUntilChanged()
+    }
 
     @Composable
     override fun ComposeUI(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -33,12 +33,10 @@ import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.drop
 import kotlin.coroutines.CoroutineContext
 import com.stripe.android.R as PaymentsCoreR
@@ -278,8 +276,8 @@ internal class DefaultCardNumberController(
     /**
      * An error must be emitted if it is visible or not visible.
      **/
-    override val error: Flow<FieldError?> =
-        combine(visibleError, _fieldState) { visibleError, fieldState ->
+    override val error: StateFlow<FieldError?> =
+        combineAsStateFlow(visibleError, _fieldState) { visibleError, fieldState ->
             fieldState.getError()?.takeIf { visibleError }
         }
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
@@ -16,11 +16,9 @@ import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
 import com.stripe.android.R as StripeR
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -72,8 +70,8 @@ class CvcController constructor(
     /**
      * An error must be emitted if it is visible or not visible.
      **/
-    override val error: Flow<FieldError?> =
-        combine(visibleError, _fieldState) { visibleError, fieldState ->
+    override val error: StateFlow<FieldError?> =
+        combineAsStateFlow(visibleError, _fieldState) { visibleError, fieldState ->
             fieldState.getError()?.takeIf { visibleError }
         }
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseController.kt
@@ -8,7 +8,6 @@ import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -24,7 +23,7 @@ class SaveForFutureUseController(
     override val fieldValue: StateFlow<String> = saveForFutureUse.mapAsStateFlow { it.toString() }
     override val rawFieldValue: StateFlow<String?> = fieldValue
 
-    override val error: Flow<FieldError?> = MutableStateFlow(null)
+    override val error: StateFlow<FieldError?> = MutableStateFlow(null)
     override val showOptionalLabel: Boolean = false
     override val isComplete: StateFlow<Boolean> = stateFlowOf(true)
     override val formFieldValue: StateFlow<FormFieldEntry> =

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
@@ -398,7 +398,7 @@ private fun PhoneSection(
     phoneController: PhoneNumberController,
     imeAction: ImeAction,
 ) {
-    val error by phoneController.error.collectAsState(null)
+    val error by phoneController.error.collectAsState()
 
     val sectionErrorString = error?.let {
         it.formatArgs?.let { args ->
@@ -433,7 +433,7 @@ private fun AddressSection(
     lastTextFieldIdentifier: IdentifierSpec?,
     sameAsShippingElement: SameAsShippingElement?,
 ) {
-    val error by addressController.error.collectAsState(null)
+    val error by addressController.error.collectAsState()
 
     val sectionErrorString = error?.let {
         it.formatArgs?.let { args ->

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressController.kt
@@ -5,9 +5,9 @@ import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
+import com.stripe.android.uicore.utils.combineAsStateFlow
+import com.stripe.android.uicore.utils.flatMapLatestAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flatMapLatest
 
 /**
  * This is the controller for a section with a changing number and set of fields.
@@ -21,8 +21,8 @@ class AddressController(
     @StringRes
     val label: Int? = null
 
-    override val error = fieldsFlowable.flatMapLatest { sectionFieldElements ->
-        combine(
+    override val error = fieldsFlowable.flatMapLatestAsStateFlow { sectionFieldElements ->
+        combineAsStateFlow(
             sectionFieldElements.map { it.sectionFieldErrorController().error }
         ) { fieldErrors ->
             fieldErrors.filterNotNull().firstOrNull()

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
@@ -12,11 +12,9 @@ import androidx.compose.ui.text.input.VisualTransformation
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.map
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AddressTextFieldController(
@@ -65,7 +63,7 @@ class AddressTextFieldController(
     /**
      * An error must be emitted if it is visible or not visible.
      **/
-    override val error: Flow<FieldError?> = visibleError.map { visibleError ->
+    override val error: StateFlow<FieldError?> = visibleError.mapAsStateFlow { visibleError ->
         _fieldState.value.getError()?.takeIf { visibleError }
     }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CheckboxFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CheckboxFieldController.kt
@@ -6,10 +6,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import com.stripe.android.uicore.R
-import kotlinx.coroutines.flow.Flow
+import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class CheckboxFieldController constructor(
@@ -30,7 +29,7 @@ class CheckboxFieldController constructor(
     val isChecked: StateFlow<Boolean>
         get() = _isChecked
 
-    override val error: Flow<FieldError?> = _isChecked.map { value ->
+    override val error: StateFlow<FieldError?> = _isChecked.mapAsStateFlow { value ->
         when {
             !value && hasBeenEdited -> FieldError(errorMessage = R.string.stripe_field_required)
             else -> null

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldController.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.focus.FocusDirection
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -28,7 +27,7 @@ class DropdownFieldController(
     override val label: StateFlow<Int> = MutableStateFlow(config.label)
     override val fieldValue = selectedIndex.mapAsStateFlow { displayItems[it] }
     override val rawFieldValue = selectedIndex.mapAsStateFlow { config.rawItems[it] }
-    override val error: Flow<FieldError?> = MutableStateFlow(null)
+    override val error: StateFlow<FieldError?> = MutableStateFlow(null)
     override val showOptionalLabel: Boolean = false // not supported yet
     override val isComplete: StateFlow<Boolean> = MutableStateFlow(true)
     override val formFieldValue: StateFlow<FormFieldEntry> =

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberController.kt
@@ -10,11 +10,9 @@ import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
 import com.stripe.android.core.R as CoreR
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
@@ -83,7 +81,7 @@ class PhoneNumberController private constructor(
         FormFieldEntry(fieldValue, isComplete)
     }
 
-    override val error: Flow<FieldError?> = combine(
+    override val error: StateFlow<FieldError?> = combineAsStateFlow(
         fieldValue,
         isComplete,
         _hasFocus

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberElementUI.kt
@@ -68,7 +68,7 @@ fun PhoneNumberCollectionSection(
     focusRequester: FocusRequester = remember { FocusRequester() },
     imeAction: ImeAction = ImeAction.Done
 ) {
-    val error by phoneNumberController.error.collectAsState(null)
+    val error by phoneNumberController.error.collectAsState()
 
     val sectionErrorString = error?.let {
         it.formatArgs?.let { args ->
@@ -118,7 +118,7 @@ fun PhoneNumberElementUI(
 
     val value by controller.fieldValue.collectAsState()
     val isComplete by controller.isComplete.collectAsState()
-    val shouldShowError by controller.error.collectAsState(null)
+    val shouldShowError by controller.error.collectAsState()
     val label by controller.label.collectAsState()
     val placeholder by controller.placeholder.collectAsState()
     val visualTransformation by controller.visualTransformation.collectAsState()

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowController.kt
@@ -4,14 +4,14 @@ import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
-import kotlinx.coroutines.flow.combine
+import com.stripe.android.uicore.utils.combineAsStateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class RowController(
     val fields: List<SectionSingleFieldElement>
 ) : SectionFieldErrorController, SectionFieldComposable {
 
-    override val error = combine(
+    override val error = combineAsStateFlow(
         fields.map { it.sectionFieldErrorController().error }
     ) {
         it.filterNotNull().firstOrNull()

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingController.kt
@@ -8,11 +8,9 @@ import com.stripe.android.uicore.R
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.flowOf
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class SameAsShippingController(
@@ -24,7 +22,7 @@ class SameAsShippingController(
     override val fieldValue: StateFlow<String> = value.mapAsStateFlow { it.toString() }
     override val rawFieldValue: StateFlow<String?> = fieldValue
 
-    override val error: Flow<FieldError?> = flowOf(null)
+    override val error: StateFlow<FieldError?> = stateFlowOf(null)
     override val showOptionalLabel: Boolean = false
     override val isComplete: StateFlow<Boolean> = stateFlowOf(true)
     override val formFieldValue: StateFlow<FormFieldEntry> =

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionController.kt
@@ -2,8 +2,8 @@ package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
 import androidx.annotation.StringRes
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
+import com.stripe.android.uicore.utils.combineAsStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * This is the controller for a section with a static number of fields.
@@ -13,7 +13,7 @@ class SectionController(
     @StringRes val label: Int?,
     sectionFieldErrorControllers: List<SectionFieldErrorController>
 ) : Controller {
-    val error: Flow<FieldError?> = combine(
+    val error: StateFlow<FieldError?> = combineAsStateFlow(
         sectionFieldErrorControllers.map {
             it.error
         }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElementUI.kt
@@ -29,7 +29,7 @@ fun SectionElementUI(
     if (!hiddenIdentifiers.contains(element.identifier)) {
         val controller = element.controller
 
-        val error by controller.error.collectAsState(null)
+        val error by controller.error.collectAsState()
         val sectionErrorString = error?.let {
             it.formatArgs?.let { args ->
                 stringResource(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionFieldErrorController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionFieldErrorController.kt
@@ -2,7 +2,7 @@ package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
 import androidx.annotation.StringRes
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Any element in a section must have a controller that provides
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.Flow
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface SectionFieldErrorController : Controller {
-    val error: Flow<FieldError?>
+    val error: StateFlow<FieldError?>
 }
 
 /**

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
@@ -18,11 +18,9 @@ import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.map
 
 @OptIn(ExperimentalComposeUiApi::class)
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
@@ -170,7 +168,7 @@ class SimpleTextFieldController(
     /**
      * An error must be emitted if it is visible or not visible.
      **/
-    override val error: Flow<FieldError?> = visibleError.map { visibleError ->
+    override val error: StateFlow<FieldError?> = visibleError.mapAsStateFlow { visibleError ->
         _fieldState.value.getError()?.takeIf { visibleError }
     }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
@@ -95,7 +95,7 @@ fun TextFieldSection(
     @StringRes sectionTitle: Int? = null,
     onTextStateChanged: (TextFieldState?) -> Unit = {}
 ) {
-    val error by textFieldController.error.collectAsState(null)
+    val error by textFieldController.error.collectAsState()
 
     val sectionErrorString = error?.let {
         it.formatArgs?.let { args ->

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/CheckboxFieldControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/CheckboxFieldControllerTest.kt
@@ -3,7 +3,6 @@ package com.stripe.android.uicore.elements
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.uicore.R
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -33,19 +32,18 @@ class CheckboxFieldControllerTest {
         assertThat(controller.isChecked.value).isTrue()
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `on value change from true then back to false, error should be propagated`() = runTest {
         val controller = CheckboxFieldController()
 
         controller.error.test {
             // Consume initial null event
-            awaitItem()
+            assertThat(awaitItem()).isNull()
 
             controller.onValueChange(value = true)
 
-            // Consume next null event
-            awaitItem()
+            // No error yet so expect nothing
+            expectNoEvents()
 
             controller.onValueChange(value = false)
 


### PR DESCRIPTION
# Summary
Migrate `SectionFieldErrorController ` to `StateFlow`

# Motivation
Helps move effort to migrate our `Flow` UI fields to `StateFlow`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
