### PR TITLE
When setting up a new customer, reuse it on subsequent invocations.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSettingsDefinition.kt
@@ -62,5 +62,9 @@ sealed class CustomerType(val value: String) {
 
     object RETURNING : CustomerType("returning")
 
-    class Existing(customerId: String) : CustomerType(customerId)
+    class Existing(val customerId: String) : CustomerType(customerId) {
+        override fun toString(): String {
+            return customerId
+        }
+    }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
@@ -114,8 +114,9 @@ private fun <T> RadioButtonSetting(
             )
         }
 
+        val selectedOption = remember(value) { options.firstOrNull { it.value == value } }
+
         Row {
-            val selectedOption = remember(value) { options.firstOrNull { it.value == value } }
             options.forEach { option ->
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
@@ -136,6 +137,14 @@ private fun <T> RadioButtonSetting(
                         text = option.name,
                     )
                 }
+            }
+        }
+
+        Row {
+            if (selectedOption == null) {
+                Text(
+                    text = value.toString(),
+                )
             }
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This makes it easy to have the same customer for multiple payment intents/setup intents.
