### PR TITLE
Add PaymentSelection.ExternalPaymentMethod type

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1546,6 +1546,14 @@ public final class com/stripe/android/paymentsheet/model/PaymentOption {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/stripe/android/paymentsheet/model/PaymentSelection$ExternalPaymentMethod$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/model/PaymentSelection$ExternalPaymentMethod;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/model/PaymentSelection$ExternalPaymentMethod;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/paymentsheet/model/PaymentSelection$GooglePay$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/model/PaymentSelection$GooglePay;

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -114,7 +114,7 @@ internal data class PaymentMethodMetadata(
         return externalPaymentMethodSpecs.map { it.type }
     }
 
-    private fun isExternalPaymentMethod(code: String): Boolean {
+    fun isExternalPaymentMethod(code: String): Boolean {
         return externalPaymentMethodTypes().contains(code)
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExternalPaymentMethodHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExternalPaymentMethodHandler.kt
@@ -1,0 +1,7 @@
+package com.stripe.android.paymentsheet
+
+internal object ExternalPaymentMethodHandler {
+    fun confirm(onComplete: (PaymentSheetResult) -> Unit) {
+        onComplete(PaymentSheetResult.Failed(error = NotImplementedError("Not implemented yet!")))
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
@@ -104,6 +104,7 @@ private fun List<PaymentOptionsItem>.findSelectedPosition(paymentSelection: Paym
                 }
             }
             is PaymentSelection.New -> false
+            is PaymentSelection.ExternalPaymentMethod -> false
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -276,7 +276,8 @@ internal class PaymentOptionsViewModel @Inject constructor(
                 is PaymentSelection.Saved,
                 is PaymentSelection.GooglePay,
                 is PaymentSelection.Link -> processExistingPaymentMethod(paymentSelection)
-                is PaymentSelection.New -> processNewPaymentMethod(paymentSelection)
+                is PaymentSelection.New -> processNewOrExternalPaymentMethod(paymentSelection)
+                is PaymentSelection.ExternalPaymentMethod -> processNewOrExternalPaymentMethod(paymentSelection)
             }
         }
     }
@@ -314,7 +315,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
         )
     }
 
-    private fun processNewPaymentMethod(paymentSelection: PaymentSelection) {
+    private fun processNewOrExternalPaymentMethod(paymentSelection: PaymentSelection) {
         _paymentOptionResult.tryEmit(
             PaymentOptionResult.Succeeded(
                 paymentSelection = paymentSelection,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -456,6 +456,8 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     label = args.googlePayConfig?.label,
                 )
             }
+        } else if (paymentSelection is PaymentSelection.ExternalPaymentMethod) {
+            ExternalPaymentMethodHandler.confirm(_paymentSheetResult::tryEmit)
         } else if (
             paymentSelection is PaymentSelection.New.GenericPaymentMethod &&
             paymentSelection.paymentMethodCreateParams.typeCode == PaymentMethod.Type.BacsDebit.code

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -546,6 +546,7 @@ internal fun PaymentSelection?.code(): String? {
         is PaymentSelection.Link -> "link"
         is PaymentSelection.New -> paymentMethodCreateParams.typeCode
         is PaymentSelection.Saved -> paymentMethod.type?.code
+        is PaymentSelection.ExternalPaymentMethod -> type
         null -> null
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
@@ -56,6 +56,9 @@ internal class DefaultPaymentSelectionUpdater @Inject constructor() : PaymentSel
             is PaymentSelection.Link -> {
                 state.linkState != null
             }
+            is PaymentSelection.ExternalPaymentMethod -> {
+                true
+            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
@@ -57,7 +57,7 @@ internal class DefaultPaymentSelectionUpdater @Inject constructor() : PaymentSel
                 state.linkState != null
             }
             is PaymentSelection.ExternalPaymentMethod -> {
-                true
+                state.paymentMethodMetadata.isExternalPaymentMethod(selection.type)
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
@@ -122,6 +122,15 @@ internal class PaymentOptionFactory @Inject constructor(
                     imageLoader = ::loadPaymentOption,
                 )
             }
+            is PaymentSelection.ExternalPaymentMethod -> {
+                PaymentOption(
+                    drawableResourceId = selection.iconResource,
+                    lightThemeIconUrl = selection.lightThemeIconUrl,
+                    darkThemeIconUrl = selection.darkThemeIconUrl,
+                    label = selection.label,
+                    imageLoader = ::loadPaymentOption
+                )
+            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -66,6 +66,27 @@ internal sealed class PaymentSelection : Parcelable {
     }
 
     @Parcelize
+    data class ExternalPaymentMethod(
+        val type: String,
+        val label: String,
+        @DrawableRes val iconResource: Int,
+        val lightThemeIconUrl: String?,
+        val darkThemeIconUrl: String?,
+    ) : PaymentSelection() {
+        override val requiresConfirmation: Boolean
+            get() = false
+
+        override fun mandateText(
+            context: Context,
+            merchantName: String,
+            isSaveForFutureUseSelected: Boolean,
+            isSetupFlow: Boolean
+        ): String? {
+            return null
+        }
+    }
+
+    @Parcelize
     data class Saved(
         val paymentMethod: PaymentMethod,
         val walletType: WalletType? = null,
@@ -242,4 +263,5 @@ internal val PaymentSelection.isLink: Boolean
         is PaymentSelection.New.LinkInline -> true
         is PaymentSelection.New -> false
         is PaymentSelection.Saved -> walletType == PaymentSelection.Saved.WalletType.Link
+        is PaymentSelection.ExternalPaymentMethod -> false
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -69,7 +69,9 @@ internal sealed class PaymentSelection : Parcelable {
     data class ExternalPaymentMethod(
         val type: String,
         val label: String,
+        // In practice, we don't have an iconResource for external payment methods.
         @DrawableRes val iconResource: Int,
+        // In practice, we always have a lightThemeIconUrl for external payment methods.
         val lightThemeIconUrl: String?,
         val darkThemeIconUrl: String?,
     ) : PaymentSelection() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -200,7 +200,7 @@ internal fun FormFieldValues.transformToPaymentSelection(
     context: Context,
     paymentMethod: SupportedPaymentMethod,
     paymentMethodMetadata: PaymentMethodMetadata,
-): PaymentSelection.New {
+): PaymentSelection {
     val params = transformToPaymentMethodCreateParams(paymentMethod, paymentMethodMetadata)
     val options = transformToPaymentMethodOptionsParams(paymentMethod)
     val extras = transformToExtraParams(paymentMethod)
@@ -212,6 +212,14 @@ internal fun FormFieldValues.transformToPaymentSelection(
             paymentMethodCreateParams = params,
             brand = CardBrand.fromCode(fieldValuePairs[IdentifierSpec.CardBrand]?.value),
             customerRequestedSave = userRequestedReuse,
+        )
+    } else if (paymentMethodMetadata.isExternalPaymentMethod(paymentMethod.code)) {
+        PaymentSelection.ExternalPaymentMethod(
+            type = paymentMethod.code,
+            label = paymentMethod.displayName.resolve(context),
+            iconResource = paymentMethod.iconResource,
+            lightThemeIconUrl = paymentMethod.lightThemeIconUrl,
+            darkThemeIconUrl = paymentMethod.darkThemeIconUrl,
         )
     } else {
         PaymentSelection.New.GenericPaymentMethod(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -12,7 +12,6 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.elements.EmailElement
-import com.stripe.android.ui.core.elements.ExternalPaymentMethodSpec
 import com.stripe.android.ui.core.elements.SharedDataSpec
 import com.stripe.android.uicore.elements.AddressElement
 import com.stripe.android.uicore.elements.CountryElement
@@ -635,5 +634,39 @@ internal class PaymentMethodMetadataTest {
         assertThat(actualSupportedPaymentMethod).isEqualTo(expectedSupportedPaymentMethod)
     }
 
+    @Test
+    fun `isExternalPaymentMethod returns true for supported EPM`() = runTest {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "klarna")
+            ),
+            externalPaymentMethodSpecs = listOf(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC)
+        )
 
+        assertThat(metadata.isExternalPaymentMethod("external_paypal")).isTrue()
+    }
+
+    @Test
+    fun `isExternalPaymentMethod returns false for unsupported EPM`() = runTest {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "klarna")
+            ),
+            externalPaymentMethodSpecs = listOf(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC)
+        )
+
+        assertThat(metadata.isExternalPaymentMethod("external_venmo")).isFalse()
+    }
+
+    @Test
+    fun `isExternalPaymentMethod returns false for non-external payment method`() = runTest {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "klarna")
+            ),
+            externalPaymentMethodSpecs = listOf(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC)
+        )
+
+        assertThat(metadata.isExternalPaymentMethod("card")).isFalse()
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -6,6 +6,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.AffirmDefinition
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -428,10 +429,10 @@ internal class PaymentMethodMetadataTest {
                 address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
                 attachDefaultsToPaymentMethod = false,
             ),
-            externalPaymentMethodSpecs = listOf(externalPaypalSpec),
+            externalPaymentMethodSpecs = listOf(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC),
         )
         val formElement = metadata.formElementsForCode(
-            code = externalPaypalSpec.type,
+            code = PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC.type,
             uiDefinitionFactoryArgumentsFactory = TestUiDefinitionFactoryArgumentsFactory.create(),
         )!!
 
@@ -465,10 +466,10 @@ internal class PaymentMethodMetadataTest {
                 paymentMethodTypes = listOf("card", "bancontact")
             ),
             billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
-            externalPaymentMethodSpecs = listOf(externalPaypalSpec),
+            externalPaymentMethodSpecs = listOf(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC),
         )
         val formElement = metadata.formElementsForCode(
-            code = externalPaypalSpec.type,
+            code = PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC.type,
             uiDefinitionFactoryArgumentsFactory = TestUiDefinitionFactoryArgumentsFactory.create(),
         )!!
 
@@ -518,7 +519,7 @@ internal class PaymentMethodMetadataTest {
                     SharedDataSpec("card"),
                     SharedDataSpec("klarna"),
                 ),
-                externalPaymentMethodSpecs = listOf(externalPaypalSpec),
+                externalPaymentMethodSpecs = listOf(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC),
             )
             val sortedSupportedPaymentMethods = metadata.sortedSupportedPaymentMethods()
             assertThat(sortedSupportedPaymentMethods).hasSize(4)
@@ -541,7 +542,7 @@ internal class PaymentMethodMetadataTest {
                     SharedDataSpec("card"),
                     SharedDataSpec("klarna"),
                 ),
-                externalPaymentMethodSpecs = listOf(externalPaypalSpec),
+                externalPaymentMethodSpecs = listOf(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC),
                 paymentMethodOrder = listOf("affirm", "external_paypal")
             )
             val sortedSupportedPaymentMethods = metadata.sortedSupportedPaymentMethods()
@@ -565,7 +566,7 @@ internal class PaymentMethodMetadataTest {
                     SharedDataSpec("card"),
                     SharedDataSpec("klarna"),
                 ),
-                externalPaymentMethodSpecs = listOf(externalPaypalSpec),
+                externalPaymentMethodSpecs = listOf(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC),
                 paymentMethodOrder = listOf("affirm")
             )
             val sortedSupportedPaymentMethods = metadata.sortedSupportedPaymentMethods()
@@ -582,7 +583,7 @@ internal class PaymentMethodMetadataTest {
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
                 paymentMethodTypes = listOf("card", "klarna")
             ),
-            externalPaymentMethodSpecs = listOf(externalPaypalSpec)
+            externalPaymentMethodSpecs = listOf(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC)
         )
 
         assertThat(metadata.requiresMandate("external_paypal")).isFalse()
@@ -594,7 +595,7 @@ internal class PaymentMethodMetadataTest {
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
                 paymentMethodTypes = listOf("card", "klarna")
             ),
-            externalPaymentMethodSpecs = listOf(externalPaypalSpec)
+            externalPaymentMethodSpecs = listOf(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC)
         )
 
         assertThat(metadata.supportedPaymentMethodTypes().contains("external_paypal")).isTrue()
@@ -606,7 +607,7 @@ internal class PaymentMethodMetadataTest {
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
                 paymentMethodTypes = listOf("card", "klarna")
             ),
-            externalPaymentMethodSpecs = listOf(externalPaypalSpec)
+            externalPaymentMethodSpecs = listOf(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC)
         )
 
         assertThat(metadata.supportedSavedPaymentMethodTypes().map { it.code }.contains("external_paypal")).isFalse()
@@ -618,7 +619,7 @@ internal class PaymentMethodMetadataTest {
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
                 paymentMethodTypes = listOf("card", "klarna")
             ),
-            externalPaymentMethodSpecs = listOf(externalPaypalSpec)
+            externalPaymentMethodSpecs = listOf(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC)
         )
         val expectedSupportedPaymentMethod = SupportedPaymentMethod(
             code = "external_paypal",
@@ -634,10 +635,5 @@ internal class PaymentMethodMetadataTest {
         assertThat(actualSupportedPaymentMethod).isEqualTo(expectedSupportedPaymentMethod)
     }
 
-    private val externalPaypalSpec = ExternalPaymentMethodSpec(
-        type = "external_paypal",
-        label = "PayPal",
-        lightImageUrl = "example_url",
-        darkImageUrl = null
-    )
+
 }

--- a/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.model
 
 import com.stripe.android.model.parsers.PaymentMethodJsonParser
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.ui.core.elements.ExternalPaymentMethodSpec
 import org.json.JSONObject
 import java.util.UUID
 import java.util.concurrent.ThreadLocalRandom
@@ -131,6 +133,13 @@ internal object PaymentMethodFixtures {
     )
 
     val SEPA_DEBIT_PAYMENT_METHOD = PaymentMethodJsonParser().parse(SEPA_DEBIT_JSON)
+
+    val PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC = ExternalPaymentMethodSpec(
+        type = "external_paypal",
+        label = "PayPal",
+        lightImageUrl = "example_url",
+        darkImageUrl = null
+    )
 
     //
 //    internal val CARD_JSON: JSONObject = JSONObject(
@@ -479,6 +488,16 @@ internal object PaymentMethodFixtures {
                 last4 = createLast4()
             ),
             code = "card"
+        )
+    }
+
+    fun createExternalPaymentMethod(spec: ExternalPaymentMethodSpec): PaymentSelection.ExternalPaymentMethod {
+        return PaymentSelection.ExternalPaymentMethod(
+            type = spec.type,
+            label = spec.type,
+            iconResource = 0,
+            lightThemeIconUrl = spec.lightImageUrl,
+            darkThemeIconUrl = spec.darkImageUrl,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FakePrefsRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FakePrefsRepository.kt
@@ -37,6 +37,7 @@ internal class FakePrefsRepository(
             is PaymentSelection.New.GenericPaymentMethod,
             is PaymentSelection.New.LinkInline,
             is PaymentSelection.New.USBankAccount,
+            is PaymentSelection.ExternalPaymentMethod,
             null -> SavedSelection.None
         }.let {
             savedSelection = it

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -124,6 +124,31 @@ internal class PaymentOptionsViewModelTest {
         }
 
     @Test
+    fun `onUserSelection() when external payment method should set the view state to process result`() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.paymentOptionResult.test {
+                viewModel.updateSelection(EXTERNAL_PAYMENT_METHOD_PAYMENT_SELECTION)
+                viewModel.onUserSelection()
+                assertThat(awaitItem())
+                    .isEqualTo(
+                        PaymentOptionResult.Succeeded(
+                            EXTERNAL_PAYMENT_METHOD_PAYMENT_SELECTION,
+                            listOf()
+                        )
+                    )
+                ensureAllEventsConsumed()
+            }
+
+            verify(eventReporter)
+                .onSelectPaymentOption(
+                    paymentSelection = EXTERNAL_PAYMENT_METHOD_PAYMENT_SELECTION
+                )
+            assertThat(prefsRepository.getSavedSelection(true, true))
+                .isEqualTo(SavedSelection.None)
+        }
+
+    @Test
     fun `onUserSelection() new card with save should complete with succeeded view state`() =
         runTest {
             val viewModel = createViewModel()
@@ -811,6 +836,8 @@ internal class PaymentOptionsViewModelTest {
             CardBrand.Visa,
             customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
         )
+        private val EXTERNAL_PAYMENT_METHOD_PAYMENT_SELECTION =
+            PaymentMethodFixtures.createExternalPaymentMethod(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC)
         private val NEW_CARD_PAYMENT_SELECTION = PaymentSelection.New.Card(
             DEFAULT_CARD,
             CardBrand.Discover,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add new PaymentSelection.ExternalPaymentMethod type

Also added a new ExternalPaymentConfirmHandler, which is very simple (immediately returns). My next PRs will be fleshing out that class to actually confirm EPMs.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Before this change, external payment methods were being treated as PaymentSelection.New.GenericPaymentMethod, which worked just fine for displaying them in the UI. But when it comes to confirming the payment, it's useful to have external payment methods as their own ExternalPaymentMethod types, so we can confirm them separately from other payment selections. 

In design review, I had suggested we might create a PaymentSelection.New.ExternalPaymentMethod type instead of PaymentSelection.ExternalPaymentMethod. But then we would end up needing to handle EPMs inside our confirm intent handler, which isn't quite right (confirming EPMs doesn't involve the confirm intent). 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Not sure what good automated tests for this would be. It would probably be integration tests, but I don't want to add those yet, as the confirm handler doesn't work. 

# Screen recordings

https://github.com/stripe/stripe-android/assets/160939932/237f4ae6-ae8e-4f2f-a4b9-6a98142c4d86


https://github.com/stripe/stripe-android/assets/160939932/7938aa8d-3514-4486-a126-4d23e2d27bd2

