### PR TITLE
Reset customer when country changes.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CountrySettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CountrySettingsDefinition.kt
@@ -45,6 +45,11 @@ internal object CountrySettingsDefinition :
         }.let { currency ->
             playgroundSettings[CurrencySettingsDefinition] = currency
         }
+
+        // When the changes via the UI, reset the customer.
+        if (playgroundSettings[CustomerSettingsDefinition].value is CustomerType.Existing) {
+            playgroundSettings[CustomerSettingsDefinition] = CustomerType.NEW
+        }
     }
 }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When updating a country, after using a new customer, it would fail to reload the playground. That was because customers are tied to a merchant, and changing countries changes merchants, so it can't reuse the customer from a different merchant.