### PR TITLE
Persist selected account IDs to `SavedStateHandle`

### DIFF
--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -300,14 +300,6 @@ public final class com/stripe/android/financialconnections/domain/CachedPartnerA
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/financialconnections/domain/CachedPartnerAccountsState$Creator : android/os/Parcelable$Creator {
-	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/domain/CachedPartnerAccountsState;
-	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/financialconnections/domain/CachedPartnerAccountsState;
-	public synthetic fun newArray (I)[Ljava/lang/Object;
-}
-
 public final class com/stripe/android/financialconnections/exception/AppInitializationError : com/stripe/android/core/exception/StripeException {
 	public static final field $stable I
 	public fun <init> (Ljava/lang/String;)V

--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -292,6 +292,22 @@ public abstract interface class com/stripe/android/financialconnections/analytic
 	public abstract fun onEvent (Lcom/stripe/android/financialconnections/analytics/FinancialConnectionsEvent;)V
 }
 
+public final class com/stripe/android/financialconnections/domain/CachedPartnerAccount$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/domain/CachedPartnerAccount;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/financialconnections/domain/CachedPartnerAccount;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/financialconnections/domain/CachedPartnerAccountsState$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/domain/CachedPartnerAccountsState;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/financialconnections/domain/CachedPartnerAccountsState;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/financialconnections/exception/AppInitializationError : com/stripe/android/core/exception/StripeException {
 	public static final field $stable I
 	public fun <init> (Ljava/lang/String;)V

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.financialconnections.di
 
 import android.app.Application
+import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.Logger
 import com.stripe.android.core.networking.ApiRequest
@@ -115,12 +116,14 @@ internal interface FinancialConnectionsSheetNativeModule {
             requestExecutor: FinancialConnectionsRequestExecutor,
             apiOptions: ApiRequest.Options,
             apiRequestFactory: ApiRequest.Factory,
-            logger: Logger
+            logger: Logger,
+            savedStateHandle: SavedStateHandle,
         ) = FinancialConnectionsAccountsRepository(
             requestExecutor = requestExecutor,
             apiRequestFactory = apiRequestFactory,
             apiOptions = apiOptions,
-            logger = logger
+            logger = logger,
+            savedStateHandle = savedStateHandle,
         )
 
         @Singleton

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GetCachedAccounts.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GetCachedAccounts.kt
@@ -21,11 +21,6 @@ internal class GetCachedAccounts @Inject constructor(
 }
 
 @Parcelize
-internal data class CachedPartnerAccountsState(
-    val accounts: List<CachedPartnerAccount>,
-) : Parcelable
-
-@Parcelize
 internal data class CachedPartnerAccount(
     val id: String,
     val linkedAccountId: String?,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GetCachedAccounts.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GetCachedAccounts.kt
@@ -1,8 +1,10 @@
 package com.stripe.android.financialconnections.domain
 
+import android.os.Parcelable
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.model.PartnerAccount
 import com.stripe.android.financialconnections.repository.FinancialConnectionsAccountsRepository
+import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 /**
@@ -13,7 +15,22 @@ internal class GetCachedAccounts @Inject constructor(
     val configuration: FinancialConnectionsSheet.Configuration
 ) {
 
-    suspend operator fun invoke(): List<PartnerAccount> {
+    suspend operator fun invoke(): List<CachedPartnerAccount> {
         return requireNotNull(repository.getCachedAccounts())
     }
+}
+
+@Parcelize
+internal data class CachedPartnerAccountsState(
+    val accounts: List<CachedPartnerAccount>,
+) : Parcelable
+
+@Parcelize
+internal data class CachedPartnerAccount(
+    val id: String,
+    val linkedAccountId: String?,
+) : Parcelable
+
+internal fun List<PartnerAccount>.toCachedPartnerAccounts(): List<CachedPartnerAccount> {
+    return map { CachedPartnerAccount(id = it.id, linkedAccountId = it.linkedAccountId) }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SaveAccountToLink.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SaveAccountToLink.kt
@@ -3,7 +3,6 @@ package com.stripe.android.financialconnections.domain
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
-import com.stripe.android.financialconnections.model.PartnerAccount
 import com.stripe.android.financialconnections.repository.FinancialConnectionsAccountsRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
 import com.stripe.android.financialconnections.repository.SuccessContentRepository
@@ -26,7 +25,7 @@ internal class SaveAccountToLink @Inject constructor(
     suspend fun new(
         email: String,
         phoneNumber: String,
-        selectedAccounts: List<PartnerAccount>,
+        selectedAccounts: List<CachedPartnerAccount>,
         country: String,
         shouldPollAccountNumbers: Boolean,
     ): FinancialConnectionsSessionManifest {
@@ -45,7 +44,7 @@ internal class SaveAccountToLink @Inject constructor(
 
     suspend fun existing(
         consumerSessionClientSecret: String,
-        selectedAccounts: List<PartnerAccount>,
+        selectedAccounts: List<CachedPartnerAccount>,
         shouldPollAccountNumbers: Boolean,
     ): FinancialConnectionsSessionManifest {
         return ensureReadyAccounts(shouldPollAccountNumbers, selectedAccounts) { selectedAccountIds ->
@@ -63,7 +62,7 @@ internal class SaveAccountToLink @Inject constructor(
 
     private suspend fun ensureReadyAccounts(
         shouldPollAccountNumbers: Boolean,
-        partnerAccounts: List<PartnerAccount>,
+        partnerAccounts: List<CachedPartnerAccount>,
         action: suspend (Set<String>) -> FinancialConnectionsSessionManifest,
     ): FinancialConnectionsSessionManifest {
         val selectedAccountIds = partnerAccounts.map { it.id }.toSet()

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/UpdateCachedAccounts.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/UpdateCachedAccounts.kt
@@ -11,10 +11,7 @@ internal class UpdateCachedAccounts @Inject constructor(
     val repository: FinancialConnectionsAccountsRepository
 ) {
 
-    suspend operator fun invoke(
-        block: (List<PartnerAccount>?) -> List<PartnerAccount>?
-    ) {
-        val updatedAccounts = block(repository.getCachedAccounts())
-        repository.updateCachedAccounts(updatedAccounts)
+    suspend operator fun invoke(accounts: List<PartnerAccount>?) {
+        repository.updateCachedAccounts(accounts)
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
@@ -23,6 +23,7 @@ import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.PollAuthorizationSessionAccounts
 import com.stripe.android.financialconnections.domain.SaveAccountToLink
 import com.stripe.android.financialconnections.domain.SelectAccounts
+import com.stripe.android.financialconnections.domain.toCachedPartnerAccounts
 import com.stripe.android.financialconnections.features.accountpicker.AccountPickerClickableText.DATA
 import com.stripe.android.financialconnections.features.accountpicker.AccountPickerState.SelectionMode
 import com.stripe.android.financialconnections.features.accountpicker.AccountPickerState.ViewEffect
@@ -299,7 +300,7 @@ internal class AccountPickerViewModel @AssistedInject constructor(
                 // it happens in the AttachPaymentScreen.
                 saveAccountToLink.existing(
                     consumerSessionClientSecret = consumerSessionClientSecret,
-                    selectedAccounts = accountsList.data,
+                    selectedAccounts = accountsList.data.toCachedPartnerAccounts(),
                     shouldPollAccountNumbers = manifest.isDataFlow,
                 )
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
@@ -55,8 +55,7 @@ internal class AttachPaymentViewModel @AssistedInject constructor(
             val authSession = requireNotNull(manifest.activeAuthSession)
             val activeInstitution = requireNotNull(manifest.activeInstitution)
             val accounts = getCachedAccounts()
-            require(accounts.size == 1)
-            val id = accounts.first().linkedAccountId
+            val id = accounts.single().linkedAccountId
             val (result, millis) = measureTimeMillis {
                 pollAttachPaymentAccount(
                     sync = sync,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
@@ -185,7 +185,7 @@ internal class LinkAccountPickerViewModel @AssistedInject constructor(
             val payload = requireNotNull(state.payload())
 
             val accounts = payload.selectedPartnerAccounts(state.selectedAccountIds)
-            updateCachedAccounts { accounts }
+            updateCachedAccounts(accounts)
 
             // We assume that at this point, all selected accounts have the same next pane.
             // Otherwise, the user would have been presented with an update-required bottom

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsAccountsRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsAccountsRepository.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.core.Logger
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.financialconnections.domain.CachedPartnerAccount
-import com.stripe.android.financialconnections.domain.CachedPartnerAccountsState
 import com.stripe.android.financialconnections.domain.toCachedPartnerAccounts
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.InstitutionResponse
@@ -94,7 +93,7 @@ private class FinancialConnectionsAccountsRepositoryImpl(
 ) : FinancialConnectionsAccountsRepository {
 
     override suspend fun getCachedAccounts(): List<CachedPartnerAccount>? {
-        return savedStateHandle.get<CachedPartnerAccountsState>(CachedPartnerAccountsKey)?.accounts
+        return savedStateHandle[CachedPartnerAccountsKey]
     }
 
     override suspend fun updateCachedAccounts(partnerAccountsList: List<PartnerAccount>?) {
@@ -233,10 +232,8 @@ private class FinancialConnectionsAccountsRepositoryImpl(
         accounts: List<PartnerAccount>
     ) {
         logger.debug("updating local partner accounts from $source")
-        val state = CachedPartnerAccountsState(
-            accounts = accounts.toCachedPartnerAccounts(),
-        )
-        savedStateHandle[CachedPartnerAccountsKey] = state
+        val cachedAccounts = accounts.toCachedPartnerAccounts()
+        savedStateHandle[CachedPartnerAccountsKey] = cachedAccounts
     }
 
     companion object {

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/ApiKeyFixtures.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/ApiKeyFixtures.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections
 
+import com.stripe.android.financialconnections.domain.CachedPartnerAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccountList
 import com.stripe.android.financialconnections.model.FinancialConnectionsAuthorizationSession
@@ -112,6 +113,18 @@ internal object ApiKeyFixtures {
         status = FinancialConnectionsAccount.Status.ACTIVE,
         subcategory = FinancialConnectionsAccount.Subcategory.CHECKING,
         supportedPaymentMethodTypes = listOf(FinancialConnectionsAccount.SupportedPaymentMethodTypes.US_BANK_ACCOUNT)
+    )
+
+    fun cachedPartnerAccounts(): List<CachedPartnerAccount> {
+        return listOf(
+            CachedPartnerAccount(id = "id_1", linkedAccountId = "linked_id_1"),
+            CachedPartnerAccount(id = "id_2", linkedAccountId = "linked_id_2"),
+        )
+    }
+
+    fun cachedPartnerAccount() = CachedPartnerAccount(
+        id = "id",
+        linkedAccountId = "linked_id",
     )
 
     fun consumerSession() = ConsumerSession(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/SaveAccountToLinkTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/SaveAccountToLinkTest.kt
@@ -3,7 +3,6 @@ package com.stripe.android.financialconnections.domain
 import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.financialconnections.ApiKeyFixtures
-import com.stripe.android.financialconnections.ApiKeyFixtures.partnerAccount
 import com.stripe.android.financialconnections.ApiKeyFixtures.sessionManifest
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.R
@@ -30,10 +29,7 @@ internal class SaveAccountToLinkTest {
     fun `Polls account numbers if requested to do so`() = runTest(testDispatcher) {
         val polledAccountIds = mutableSetOf<String>()
 
-        val partnerAccounts = listOf(
-            partnerAccount().copy(id = "id_1", linkedAccountId = "lid_1"),
-            partnerAccount().copy(id = "id_2", linkedAccountId = "lid_2"),
-        )
+        val partnerAccounts = ApiKeyFixtures.cachedPartnerAccounts()
 
         val accountsRepository = mockAccountsRepository(
             onPollAccountNumbers = polledAccountIds::addAll,
@@ -49,17 +45,14 @@ internal class SaveAccountToLinkTest {
             shouldPollAccountNumbers = true,
         )
 
-        assertThat(polledAccountIds).containsExactly("lid_1", "lid_2")
+        assertThat(polledAccountIds).containsExactly("linked_id_1", "linked_id_2")
     }
 
     @Test
     fun `Skips polling account numbers if not requested to do so`() = runTest(testDispatcher) {
         val polledAccountIds = mutableSetOf<String>()
 
-        val partnerAccounts = listOf(
-            partnerAccount().copy(id = "id_1", linkedAccountId = "lid_1"),
-            partnerAccount().copy(id = "id_2", linkedAccountId = "lid_2"),
-        )
+        val partnerAccounts = ApiKeyFixtures.cachedPartnerAccounts()
 
         val accountsRepository = mockAccountsRepository(
             onPollAccountNumbers = polledAccountIds::addAll,
@@ -82,10 +75,7 @@ internal class SaveAccountToLinkTest {
     fun `Disables networking if polling account numbers fails`() = runTest(testDispatcher) {
         var disabledNetworking = false
 
-        val partnerAccounts = listOf(
-            partnerAccount().copy(id = "id_1", linkedAccountId = "lid_1"),
-            partnerAccount().copy(id = "id_2", linkedAccountId = "lid_2"),
-        )
+        val partnerAccounts = ApiKeyFixtures.cachedPartnerAccounts()
 
         val repository = mockManifestRepository(
             onDisabledNetworking = { disabledNetworking = true },
@@ -115,10 +105,7 @@ internal class SaveAccountToLinkTest {
 
     @Test
     fun `Sets custom success message if polling account numbers fails`() = runTest(testDispatcher) {
-        val partnerAccounts = listOf(
-            partnerAccount().copy(id = "id_1", linkedAccountId = "lid_1"),
-            partnerAccount().copy(id = "id_2", linkedAccountId = "lid_2"),
-        )
+        val partnerAccounts = ApiKeyFixtures.cachedPartnerAccounts()
 
         val accountsRepository = mockAccountsRepository(
             onPollAccountNumbers = { error("This is failing") },

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModelTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.financialconnections.ApiKeyFixtures.sessionManifest
 import com.stripe.android.financialconnections.ApiKeyFixtures.syncResponse
 import com.stripe.android.financialconnections.CoroutineTestRule
 import com.stripe.android.financialconnections.TestFinancialConnectionsAnalyticsTracker
+import com.stripe.android.financialconnections.domain.CachedPartnerAccount
 import com.stripe.android.financialconnections.domain.GetCachedConsumerSession
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
@@ -300,7 +301,7 @@ internal class AccountPickerViewModelTest {
 
         verify(saveAccountToLink).existing(
             consumerSessionClientSecret = consumerSession.clientSecret,
-            selectedAccounts = accounts.data,
+            selectedAccounts = accounts.data.map { CachedPartnerAccount(it.id, it.linkedAccountId) },
             shouldPollAccountNumbers = true,
         )
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModelTest.kt
@@ -21,7 +21,6 @@ import com.stripe.android.financialconnections.model.Image
 import com.stripe.android.financialconnections.model.InstitutionResponse
 import com.stripe.android.financialconnections.model.NetworkedAccount
 import com.stripe.android.financialconnections.model.NetworkedAccountsList
-import com.stripe.android.financialconnections.model.PartnerAccount
 import com.stripe.android.financialconnections.model.ReturningNetworkingUserAccountPicker
 import com.stripe.android.financialconnections.model.TextUpdate
 import com.stripe.android.financialconnections.navigation.Destination.LinkStepUpVerification
@@ -32,7 +31,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -157,10 +155,7 @@ class LinkAccountPickerViewModelTest {
         viewModel.onAccountClick(selectedAccount)
         viewModel.onSelectAccountsClick()
 
-        with(argumentCaptor<(List<PartnerAccount>?) -> List<PartnerAccount>?>()) {
-            verify(updateCachedAccounts).invoke(capture())
-            assertThat(firstValue(null)).isEqualTo(listOf(selectedAccount))
-        }
+        verify(updateCachedAccounts).invoke(listOf(selectedAccount))
         val destination = accounts.data.first().nextPaneOnSelection!!.destination
         navigationManager.assertNavigatedTo(destination, Pane.LINK_ACCOUNT_PICKER)
     }
@@ -200,10 +195,7 @@ class LinkAccountPickerViewModelTest {
             viewModel.onAccountClick(selectedAccount)
             viewModel.onSelectAccountsClick()
 
-            with(argumentCaptor<(List<PartnerAccount>?) -> List<PartnerAccount>?>()) {
-                verify(updateCachedAccounts).invoke(capture())
-                assertThat(firstValue(null)).isEqualTo(listOf(selectedAccount))
-            }
+            verify(updateCachedAccounts).invoke(listOf(selectedAccount))
             verifyNoInteractions(selectNetworkedAccounts)
             navigationManager.assertNavigatedTo(LinkStepUpVerification, Pane.LINK_ACCOUNT_PICKER)
         }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationViewModelTest.kt
@@ -4,7 +4,6 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.ApiKeyFixtures
-import com.stripe.android.financialconnections.ApiKeyFixtures.partnerAccount
 import com.stripe.android.financialconnections.ApiKeyFixtures.sessionManifest
 import com.stripe.android.financialconnections.CoroutineTestRule
 import com.stripe.android.financialconnections.TestFinancialConnectionsAnalyticsTracker
@@ -146,7 +145,7 @@ class LinkStepUpVerificationViewModelTest {
             val onStartVerificationCaptor = argumentCaptor<suspend () -> Unit>()
             val onVerificationStartedCaptor = argumentCaptor<suspend (ConsumerSession) -> Unit>()
             val linkVerifiedManifest = sessionManifest().copy(nextPane = Pane.INSTITUTION_PICKER)
-            val selectedAccount = partnerAccount()
+            val selectedAccount = ApiKeyFixtures.cachedPartnerAccount()
 
             // verify succeeds
             whenever(getManifest()).thenReturn(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModelTest.kt
@@ -2,8 +2,8 @@ package com.stripe.android.financialconnections.features.networkingsavetolinkver
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
+import com.stripe.android.financialconnections.ApiKeyFixtures.cachedPartnerAccount
 import com.stripe.android.financialconnections.ApiKeyFixtures.consumerSession
-import com.stripe.android.financialconnections.ApiKeyFixtures.partnerAccount
 import com.stripe.android.financialconnections.ApiKeyFixtures.sessionManifest
 import com.stripe.android.financialconnections.CoroutineTestRule
 import com.stripe.android.financialconnections.TestFinancialConnectionsAnalyticsTracker
@@ -82,7 +82,7 @@ class NetworkingSaveToLinkVerificationViewModelTest {
     fun `otpEntered - on valid OTP confirms, saves accounts and navigates to success pane`() =
         runTest {
             val consumerSession = consumerSession()
-            val selectedAccount = partnerAccount()
+            val selectedAccount = cachedPartnerAccount()
             val linkVerifiedManifest = sessionManifest().copy(nextPane = INSTITUTION_PICKER)
             whenever(getCachedConsumerSession()).thenReturn(consumerSession)
             whenever(getManifest()).thenReturn(sessionManifest())
@@ -122,7 +122,7 @@ class NetworkingSaveToLinkVerificationViewModelTest {
     fun `otpEntered - on valid OTP fails, sends event and navigates to terminal error`() =
         runTest {
             val consumerSession = consumerSession()
-            val selectedAccount = partnerAccount()
+            val selectedAccount = cachedPartnerAccount()
             val linkVerifiedManifest = sessionManifest().copy(nextPane = INSTITUTION_PICKER)
             whenever(getCachedConsumerSession()).thenReturn(consumerSession)
             whenever(getManifest()).thenReturn(sessionManifest())
@@ -161,7 +161,7 @@ class NetworkingSaveToLinkVerificationViewModelTest {
     @Test
     fun `onSkipClick - navigates to success without networking accounts`() = runTest {
         val consumerSession = consumerSession()
-        val selectedAccount = partnerAccount()
+        val selectedAccount = cachedPartnerAccount()
         val linkVerifiedManifest = sessionManifest()
         whenever(getCachedConsumerSession()).thenReturn(consumerSession)
         whenever(markLinkVerified()).thenReturn(linkVerifiedManifest)

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/success/SuccessViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/success/SuccessViewModelTest.kt
@@ -48,7 +48,7 @@ internal class SuccessViewModelTest {
 
     @Test
     fun `init - when skipSuccessPane is true, complete session and emit Finish`() = runTest {
-        val accounts = ApiKeyFixtures.partnerAccountList().data
+        val accounts = ApiKeyFixtures.cachedPartnerAccounts()
         val manifest = ApiKeyFixtures.sessionManifest().copy(
             skipSuccessPane = true,
             activeAuthSession = ApiKeyFixtures.authorizationSession(),
@@ -67,13 +67,13 @@ internal class SuccessViewModelTest {
 
     @Test
     fun `init - when skipSuccessPane is false, session is not auto completed`() = runTest {
-        val accounts = ApiKeyFixtures.partnerAccountList()
+        val accounts = ApiKeyFixtures.cachedPartnerAccounts()
         val manifest = ApiKeyFixtures.sessionManifest().copy(
             skipSuccessPane = false,
             activeAuthSession = ApiKeyFixtures.authorizationSession(),
             activeInstitution = ApiKeyFixtures.institution()
         )
-        whenever(getCachedAccounts()).thenReturn(accounts.data)
+        whenever(getCachedAccounts()).thenReturn(accounts)
         whenever(getManifest()).thenReturn(manifest)
 
         nativeAuthFlowCoordinator().filterIsInstance<Complete>().test {

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/AbsFinancialConnectionsAccountsRepository.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/AbsFinancialConnectionsAccountsRepository.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.networking
 
+import com.stripe.android.financialconnections.domain.CachedPartnerAccount
 import com.stripe.android.financialconnections.model.InstitutionResponse
 import com.stripe.android.financialconnections.model.LinkAccountSessionPaymentAccount
 import com.stripe.android.financialconnections.model.NetworkedAccountsList
@@ -10,7 +11,7 @@ import com.stripe.android.financialconnections.repository.FinancialConnectionsAc
 
 internal abstract class AbsFinancialConnectionsAccountsRepository : FinancialConnectionsAccountsRepository {
 
-    override suspend fun getCachedAccounts(): List<PartnerAccount>? {
+    override suspend fun getCachedAccounts(): List<CachedPartnerAccount>? {
         TODO("Not yet implemented")
     }
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsAccountsRepositoryImplTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsAccountsRepositoryImplTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.repository
 
+import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
 import com.stripe.android.core.networking.ApiRequest
@@ -7,6 +8,7 @@ import com.stripe.android.financialconnections.ApiKeyFixtures
 import com.stripe.android.financialconnections.ApiKeyFixtures.partnerAccount
 import com.stripe.android.financialconnections.ApiKeyFixtures.partnerAccountList
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
+import com.stripe.android.financialconnections.domain.CachedPartnerAccount
 import com.stripe.android.financialconnections.model.PartnerAccountsList
 import com.stripe.android.financialconnections.network.FinancialConnectionsRequestExecutor
 import kotlinx.coroutines.test.runTest
@@ -36,14 +38,15 @@ internal class FinancialConnectionsAccountsRepositoryImplTest {
         ),
         requestExecutor = mockRequestExecutor,
         apiRequestFactory = apiRequestFactory,
-        logger = Logger.noop()
+        logger = Logger.noop(),
+        savedStateHandle = SavedStateHandle(),
     )
 
     @Test
     fun `getCachedAccounts - When called twice, second call returns from cache`() = runTest {
         val repository = buildRepository()
         val expectedAccounts = partnerAccountList().copy(
-            data = listOf(partnerAccount())
+            data = listOf(partnerAccount().copy(id = "id_1", linkedAccountId = "linked_id_1"))
         )
         givenRequestReturnsAccounts(expectedAccounts)
 
@@ -61,7 +64,9 @@ internal class FinancialConnectionsAccountsRepositoryImplTest {
             any(),
             eq(PartnerAccountsList.serializer())
         )
-        assertThat(accounts).isEqualTo(expectedAccounts.data)
+        assertThat(accounts).containsExactly(
+            CachedPartnerAccount(id = "id_1", linkedAccountId = "linked_id_1")
+        )
     }
 
     /**


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request persists selected account IDs on the device to improve our process death handling.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screen recordings

<details><summary>Before</summary>
<p>

[broken-process-death-handling.webm](https://github.com/stripe/stripe-android/assets/110940675/5d5d9ac7-6977-45f9-95ac-70e018f97e3c)

</p>
</details> 

<details><summary>After</summary>
<p>

[fixed-process-death-handling.webm](https://github.com/stripe/stripe-android/assets/110940675/0f4e803a-7655-4d17-9b59-2fadcb3b3173)

</p>
</details> 

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
