### PR TITLE
Add `CustomerState` to `PaymentSheetState.Full` and use in `PaymentSheet`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -166,6 +166,9 @@ interface ErrorReporter {
         PAYMENT_SHEET_AUTHENTICATORS_NOT_FOUND(
             partialEventName = "paymentsheet.authenticators.not_found"
         ),
+        PAYMENT_SHEET_LOADER_ELEMENTS_SESSION_CUSTOMER_NOT_FOUND(
+            partialEventName = "paymentsheet.loader.elements_session.customer.not_found"
+        ),
         EXTERNAL_PAYMENT_METHOD_SERIALIZATION_FAILURE(
             partialEventName = "elements.external_payment_methods_serializer.error"
         ),

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1782,6 +1782,14 @@ public final class com/stripe/android/paymentsheet/paymentdatacollection/polling
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentsheet/state/CustomerState$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/state/CustomerState;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/state/CustomerState;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/paymentsheet/state/GooglePayState$Available$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/state/GooglePayState$Available;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -168,7 +168,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
         if (paymentMethodMetadata.value == null) {
             setPaymentMethodMetadata(args.state.paymentMethodMetadata)
         }
-        savedStateHandle[SAVE_PAYMENT_METHODS] = args.state.customerPaymentMethods
+        customer = args.state.customer
         savedStateHandle[SAVE_PROCESSING] = false
 
         updateSelection(args.state.paymentSelection)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -378,7 +378,8 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     private suspend fun initializeWithState(state: PaymentSheetState.Full) {
-        savedStateHandle[SAVE_PAYMENT_METHODS] = state.customerPaymentMethods
+        customer = state.customer
+
         updateSelection(state.paymentSelection)
 
         savedStateHandle[SAVE_GOOGLE_PAY_STATE] = if (state.isGooglePayReady) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -572,7 +572,11 @@ internal class DefaultFlowController @Inject internal constructor(
         paymentOptionResult: PaymentOptionResult?
     ) {
         paymentOptionResult?.paymentMethods?.let {
-            viewModel.state = viewModel.state?.copy(customerPaymentMethods = it)
+            val currentState = viewModel.state
+
+            viewModel.state = currentState?.copy(
+                customer = currentState.customer?.copy(paymentMethods = it)
+            )
         }
         when (paymentOptionResult) {
             is PaymentOptionResult.Succeeded -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
@@ -48,7 +48,7 @@ internal class DefaultPaymentSelectionUpdater @Inject constructor() : PaymentSel
             is PaymentSelection.Saved -> {
                 val paymentMethod = selection.paymentMethod
                 val code = paymentMethod.type?.code
-                code in allowedTypes && paymentMethod in state.customerPaymentMethods
+                code in allowedTypes && paymentMethod in (state.customer?.paymentMethods ?: emptyList())
             }
             is PaymentSelection.GooglePay -> {
                 state.isGooglePayReady

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
@@ -1,0 +1,12 @@
+package com.stripe.android.paymentsheet.state
+
+import android.os.Parcelable
+import com.stripe.android.model.PaymentMethod
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+internal data class CustomerState(
+    val id: String,
+    val ephemeralKeySecret: String,
+    val paymentMethods: List<PaymentMethod>,
+) : Parcelable

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.state
 
 import com.stripe.android.core.Logger
+import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayRepository
@@ -14,6 +15,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
@@ -59,6 +61,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
     private val lpmRepository: LpmRepository,
     private val logger: Logger,
     private val eventReporter: EventReporter,
+    private val errorReporter: ErrorReporter,
     @IOContext private val workContext: CoroutineContext,
     private val accountStatusProvider: LinkAccountStatusProvider,
     private val linkStore: LinkStore,
@@ -173,21 +176,6 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
 
         val customerConfig = config.customer
 
-        val paymentMethods = async {
-            when (customerConfig?.accessType) {
-                is PaymentSheet.CustomerAccessType.CustomerSession -> {
-                    elementsSession.customer?.paymentMethods ?: emptyList()
-                }
-                is PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey -> {
-                    retrieveCustomerPaymentMethods(
-                        metadata = metadata,
-                        customerConfig = customerConfig,
-                    )
-                }
-                null -> emptyList()
-            }
-        }
-
         val savedSelection = async {
             retrieveSavedSelection(
                 config = config,
@@ -196,19 +184,55 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             )
         }
 
-        val sortedPaymentMethods = async {
-            paymentMethods.await().withLastUsedPaymentMethodFirst(savedSelection.await())
+        val customer = async {
+            when (customerConfig?.accessType) {
+                is PaymentSheet.CustomerAccessType.CustomerSession -> {
+                    elementsSession.customer?.let { customer ->
+                        CustomerState(
+                            id = customer.session.customerId,
+                            ephemeralKeySecret = customer.session.apiKey,
+                            paymentMethods = customer.paymentMethods
+                                .withLastUsedPaymentMethodFirst(savedSelection.await()),
+                        )
+                    } ?: run {
+                        val exception = IllegalStateException(
+                            "Excepted 'customer' attribute as part of 'elements_session' response!"
+                        )
+
+                        errorReporter.report(
+                            ErrorReporter
+                                .UnexpectedErrorEvent
+                                .PAYMENT_SHEET_LOADER_ELEMENTS_SESSION_CUSTOMER_NOT_FOUND,
+                            StripeException.create(exception)
+                        )
+
+                        throw exception
+                    }
+                }
+                is PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey -> {
+                    CustomerState(
+                        id = customerConfig.id,
+                        ephemeralKeySecret = customerConfig.ephemeralKeySecret,
+                        paymentMethods = retrieveCustomerPaymentMethods(
+                            metadata = metadata,
+                            customerConfig = customerConfig,
+                        ).withLastUsedPaymentMethodFirst(savedSelection.await())
+                    )
+                }
+                else -> null
+            }
         }
 
         val initialPaymentSelection = async {
-            retrieveInitialPaymentSelection(savedSelection, paymentMethods)
-                ?: sortedPaymentMethods.await().firstOrNull()?.toPaymentSelection()
+            retrieveInitialPaymentSelection(savedSelection, customer)
+                ?: customer.await()?.paymentMethods?.firstOrNull()?.toPaymentSelection()
         }
 
         val linkState = async {
             if (elementsSession.isLinkEnabled && !config.billingDetailsCollectionConfiguration.collectsAnything) {
                 loadLinkState(
                     config = config,
+                    customer = customer.await(),
                     metadata = metadata,
                     merchantCountry = merchantCountry,
                     passthroughModeEnabled = elementsSession.linkPassthroughModeEnabled,
@@ -225,7 +249,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         if (supportsIntent(metadata)) {
             PaymentSheetState.Full(
                 config = config,
-                customerPaymentMethods = sortedPaymentMethods.await(),
+                customer = customer.await(),
                 isGooglePayReady = isGooglePayReady.await(),
                 linkState = linkState.await(),
                 isEligibleForCardBrandChoice = elementsSession.isEligibleForCardBrandChoice,
@@ -269,6 +293,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
 
     private suspend fun loadLinkState(
         config: PaymentSheet.Configuration,
+        customer: CustomerState?,
         metadata: PaymentMethodMetadata,
         merchantCountry: String?,
         passthroughModeEnabled: Boolean,
@@ -277,6 +302,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
     ): LinkState {
         val linkConfig = createLinkConfiguration(
             config = config,
+            customer = customer,
             metadata = metadata,
             merchantCountry = merchantCountry,
             passthroughModeEnabled = passthroughModeEnabled,
@@ -300,6 +326,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
 
     private suspend fun createLinkConfiguration(
         config: PaymentSheet.Configuration,
+        customer: CustomerState?,
         metadata: PaymentMethodMetadata,
         merchantCountry: String?,
         passthroughModeEnabled: Boolean,
@@ -320,7 +347,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             null
         }
 
-        val customerEmail = config.defaultBillingDetails?.email ?: config.customer?.let {
+        val customerEmail = config.defaultBillingDetails?.email ?: customer?.let {
             customerRepository.retrieveCustomer(
                 CustomerRepository.CustomerInfo(
                     id = it.id,
@@ -366,13 +393,13 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
 
     private suspend fun retrieveInitialPaymentSelection(
         savedSelection: Deferred<SavedSelection>,
-        paymentMethods: Deferred<List<PaymentMethod>>
+        customer: Deferred<CustomerState?>
     ): PaymentSelection? {
         return when (val selection = savedSelection.await()) {
             is SavedSelection.GooglePay -> PaymentSelection.GooglePay
             is SavedSelection.Link -> PaymentSelection.Link
             is SavedSelection.PaymentMethod -> {
-                paymentMethods.await().find { it.id == selection.id }?.toPaymentSelection()
+                customer.await()?.paymentMethods?.find { it.id == selection.id }?.toPaymentSelection()
             }
             is SavedSelection.None -> null
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -52,6 +52,13 @@ internal interface PaymentSheetLoader {
     ): Result<PaymentSheetState.Full>
 }
 
+/**
+ * A default implementation of [PaymentSheetLoader] used to load necessary information for
+ * building [PaymentSheet]. See the linked flow diagram to understand how this implementation
+ * loads [PaymentSheet] information based its provided initialization options.
+ *
+ * @see <a href="https://whimsical.com/paymentsheet-loading-flow-diagram-EwTmrwvNmhcD9B2PKuSu82/">Flow Diagram</a>
+ */
 @Singleton
 internal class DefaultPaymentSheetLoader @Inject constructor(
     private val prefsRepositoryFactory: @JvmSuppressWildcards (PaymentSheet.CustomerConfiguration?) -> PrefsRepository,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -206,7 +206,11 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
                             StripeException.create(exception)
                         )
 
-                        throw exception
+                        if (!stripeIntent.isLiveMode) {
+                            throw exception
+                        }
+
+                        null
                     }
                 }
                 is PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetState.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet.state
 
 import android.os.Parcelable
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -16,7 +15,7 @@ internal sealed interface PaymentSheetState : Parcelable {
     @Parcelize
     data class Full(
         val config: PaymentSheet.Configuration,
-        val customerPaymentMethods: List<PaymentMethod>,
+        val customer: CustomerState?,
         val isGooglePayReady: Boolean,
         val linkState: LinkState?,
         val isEligibleForCardBrandChoice: Boolean,
@@ -24,9 +23,8 @@ internal sealed interface PaymentSheetState : Parcelable {
         val validationError: PaymentSheetLoadingException?,
         val paymentMethodMetadata: PaymentMethodMetadata,
     ) : PaymentSheetState {
-
         val showSavedPaymentMethods: Boolean
-            get() = customerPaymentMethods.isNotEmpty() || isGooglePayReady
+            get() = (customer != null && customer.paymentMethods.isNotEmpty()) || isGooglePayReady
 
         val stripeIntent: StripeIntent
             get() = paymentMethodMetadata.stripeIntent

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -353,10 +353,8 @@ internal class PaymentOptionsActivityTest {
 
     @Test
     fun `mandate text is shown below primary button when showAbove is false`() {
-        val args = PAYMENT_OPTIONS_CONTRACT_ARGS.copy(
-            state = PAYMENT_OPTIONS_CONTRACT_ARGS.state.copy(
-                customerPaymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
-            )
+        val args = PAYMENT_OPTIONS_CONTRACT_ARGS.updateState(
+            paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         )
         runActivityScenario(args) { scenario ->
             scenario.onActivity { activity ->
@@ -381,10 +379,8 @@ internal class PaymentOptionsActivityTest {
 
     @Test
     fun `mandate text is shown above primary button when showAbove is true`() {
-        val args = PAYMENT_OPTIONS_CONTRACT_ARGS.copy(
-            state = PAYMENT_OPTIONS_CONTRACT_ARGS.state.copy(
-                customerPaymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
-            )
+        val args = PAYMENT_OPTIONS_CONTRACT_ARGS.updateState(
+            paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         )
         runActivityScenario(args) { scenario ->
             scenario.onActivity { activity ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -442,11 +442,9 @@ internal class PaymentOptionsViewModelTest {
         val paymentMethods = PaymentMethodFixtures.createCards(3)
         val selection = PaymentSelection.Saved(paymentMethod = paymentMethods.random())
 
-        val args = PAYMENT_OPTION_CONTRACT_ARGS.copy(
-            state = PAYMENT_OPTION_CONTRACT_ARGS.state.copy(
-                paymentSelection = selection,
-                customerPaymentMethods = paymentMethods,
-            )
+        val args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(
+            paymentSelection = selection,
+            paymentMethods = paymentMethods,
         )
 
         val viewModel = createViewModel(args)
@@ -480,11 +478,9 @@ internal class PaymentOptionsViewModelTest {
         val paymentMethods = PaymentMethodFixtures.createCards(3)
         val selection = PaymentSelection.Saved(paymentMethod = paymentMethods.random())
 
-        val args = PAYMENT_OPTION_CONTRACT_ARGS.copy(
-            state = PAYMENT_OPTION_CONTRACT_ARGS.state.copy(
-                paymentSelection = selection,
-                customerPaymentMethods = paymentMethods,
-            )
+        val args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(
+            paymentSelection = selection,
+            paymentMethods = paymentMethods,
         )
 
         val viewModel = createViewModel(args)
@@ -577,7 +573,6 @@ internal class PaymentOptionsViewModelTest {
                     allowsDelayedPaymentMethods = false,
                 ),
                 isGooglePayReady = false,
-                customerPaymentMethods = emptyList(),
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                     stripeIntent = PAYMENT_INTENT.copy(
                         paymentMethodTypes = listOf(
@@ -608,10 +603,8 @@ internal class PaymentOptionsViewModelTest {
             Result.success(paymentMethodToRemove)
         )
 
-        val args = PAYMENT_OPTION_CONTRACT_ARGS.copy(
-            state = PAYMENT_OPTION_CONTRACT_ARGS.state.copy(
-                customerPaymentMethods = cards,
-            ),
+        val args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(
+            paymentMethods = cards,
         )
 
         val viewModel = createViewModel(
@@ -663,10 +656,8 @@ internal class PaymentOptionsViewModelTest {
             Result.failure(APIConnectionException())
         )
 
-        val args = PAYMENT_OPTION_CONTRACT_ARGS.copy(
-            state = PAYMENT_OPTION_CONTRACT_ARGS.state.copy(
-                customerPaymentMethods = cards,
-            ),
+        val args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(
+            paymentMethods = cards,
         )
 
         val viewModel = createViewModel(
@@ -845,7 +836,7 @@ internal class PaymentOptionsViewModelTest {
         )
         private val PAYMENT_OPTION_CONTRACT_ARGS = PaymentOptionContract.Args(
             state = PaymentSheetState.Full(
-                customerPaymentMethods = emptyList(),
+                customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
                 config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
                 isGooglePayReady = true,
                 paymentSelection = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -997,7 +997,7 @@ internal class PaymentSheetActivityTest {
                 lazyPaymentConfig = { PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY) },
                 paymentSheetLoader = FakePaymentSheetLoader(
                     stripeIntent = paymentIntent,
-                    customerPaymentMethods = paymentMethods,
+                    customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(paymentMethods = paymentMethods),
                     isGooglePayAvailable = isGooglePayAvailable,
                     linkState = LinkState(
                         configuration = mock(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -74,8 +74,8 @@ internal object PaymentSheetFixtures {
     )
 
     private val defaultCustomerConfig = PaymentSheet.CustomerConfiguration(
-        "customer_id",
-        "ephemeral_key"
+        id = "customer_id",
+        ephemeralKeySecret = "ephemeral_key"
     )
 
     internal val CONFIG_CUSTOMER = PaymentSheet.Configuration(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -9,6 +9,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
+import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
@@ -72,12 +73,20 @@ internal object PaymentSheetFixtures {
         )
     )
 
+    private val defaultCustomerConfig = PaymentSheet.CustomerConfiguration(
+        "customer_id",
+        "ephemeral_key"
+    )
+
     internal val CONFIG_CUSTOMER = PaymentSheet.Configuration(
         merchantDisplayName = MERCHANT_DISPLAY_NAME,
-        customer = PaymentSheet.CustomerConfiguration(
-            "customer_id",
-            "ephemeral_key"
-        )
+        customer = defaultCustomerConfig,
+    )
+
+    internal val EMPTY_CUSTOMER_STATE = CustomerState(
+        id = defaultCustomerConfig.id,
+        ephemeralKeySecret = defaultCustomerConfig.ephemeralKeySecret,
+        paymentMethods = listOf()
     )
 
     internal val CONFIG_GOOGLEPAY
@@ -104,7 +113,7 @@ internal object PaymentSheetFixtures {
 
     internal val PAYMENT_OPTIONS_CONTRACT_ARGS = PaymentOptionContract.Args(
         state = PaymentSheetState.Full(
-            customerPaymentMethods = emptyList(),
+            customer = EMPTY_CUSTOMER_STATE,
             config = CONFIG_GOOGLEPAY,
             isGooglePayReady = false,
             paymentSelection = null,
@@ -119,7 +128,7 @@ internal object PaymentSheetFixtures {
     )
 
     internal fun PaymentOptionContract.Args.updateState(
-        paymentMethods: List<PaymentMethod> = state.customerPaymentMethods,
+        paymentMethods: List<PaymentMethod> = state.customer?.paymentMethods ?: emptyList(),
         isGooglePayReady: Boolean = state.isGooglePayReady,
         stripeIntent: StripeIntent = state.stripeIntent,
         config: PaymentSheet.Configuration = state.config,
@@ -128,7 +137,11 @@ internal object PaymentSheetFixtures {
     ): PaymentOptionContract.Args {
         return copy(
             state = state.copy(
-                customerPaymentMethods = paymentMethods,
+                customer = CustomerState(
+                    id = config.customer?.id ?: "cus_1",
+                    ephemeralKeySecret = config.customer?.ephemeralKeySecret ?: "client_secret",
+                    paymentMethods = paymentMethods,
+                ),
                 isGooglePayReady = isGooglePayReady,
                 config = config,
                 paymentSelection = paymentSelection,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -263,7 +263,7 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `removePaymentMethod uses retrieved 'CustomerState' info, not 'CustomerConfiguration' info`() = runTest {
+    fun `removePaymentMethod should use loaded customer info when removing payment methods`() = runTest {
         val paymentMethods = PaymentMethodFactory.cards(1)
 
         val customerRepository = spy(
@@ -342,7 +342,7 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `modifyPaymentMethod uses retrieved 'CustomerState' info, not 'CustomerConfiguration' info`() = runTest {
+    fun `modifyPaymentMethod should use loaded customer info when modifying payment methods`() = runTest {
         val paymentMethods = listOf(CARD_WITH_NETWORKS_PAYMENT_METHOD)
 
         val customerRepository = spy(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -67,6 +67,7 @@ import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateCon
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncherFactory
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationResult
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateData
+import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetState
@@ -334,7 +335,7 @@ internal class DefaultFlowControllerTest {
         val last4 = paymentMethods.first().card?.last4.orEmpty()
 
         val flowController = createFlowController(
-            paymentMethods = paymentMethods,
+            customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(paymentMethods = paymentMethods),
             paymentSelection = PaymentSelection.Saved(paymentMethods.first()),
         )
 
@@ -358,7 +359,7 @@ internal class DefaultFlowControllerTest {
 
         // Initially configure for a customer with saved payment methods
         val paymentSheetLoader = FakePaymentSheetLoader(
-            customerPaymentMethods = paymentMethods,
+            customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(paymentMethods = paymentMethods),
             paymentSelection = PaymentSelection.Saved(paymentMethods.first()),
         )
 
@@ -406,7 +407,7 @@ internal class DefaultFlowControllerTest {
 
         val expectedArgs = PaymentOptionContract.Args(
             state = PaymentSheetState.Full(
-                customerPaymentMethods = emptyList(),
+                customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
                 config = PaymentSheet.Configuration("com.stripe.android.paymentsheet.test"),
                 isGooglePayReady = false,
                 paymentSelection = null,
@@ -515,7 +516,7 @@ internal class DefaultFlowControllerTest {
         // Create a default flow controller with the paymentMethods initialized with cards.
         val initialPaymentMethods = PaymentMethodFixtures.createCards(5)
         val flowController = createFlowController(
-            paymentMethods = initialPaymentMethods,
+            customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(paymentMethods = initialPaymentMethods),
             paymentSelection = PaymentSelection.Saved(initialPaymentMethods.first())
         )
         flowController.configureExpectingSuccess(
@@ -530,7 +531,7 @@ internal class DefaultFlowControllerTest {
         verify(paymentOptionActivityLauncher).launch(
             argWhere {
                 // Make sure that paymentMethods contains the new added payment methods and the initial payment methods.
-                it.state.customerPaymentMethods == initialPaymentMethods
+                it.state.customer?.paymentMethods == initialPaymentMethods
             },
             anyOrNull(),
         )
@@ -605,7 +606,9 @@ internal class DefaultFlowControllerTest {
             NEW_CARD_PAYMENT_SELECTION,
             PaymentSheetState.Full(
                 PaymentSheetFixtures.CONFIG_CUSTOMER,
-                customerPaymentMethods = PAYMENT_METHODS,
+                customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(
+                    paymentMethods = PAYMENT_METHODS
+                ),
                 isGooglePayReady = false,
                 linkState = null,
                 paymentSelection = initialSelection,
@@ -644,7 +647,9 @@ internal class DefaultFlowControllerTest {
             GENERIC_PAYMENT_SELECTION,
             PaymentSheetState.Full(
                 PaymentSheetFixtures.CONFIG_CUSTOMER,
-                customerPaymentMethods = PAYMENT_METHODS,
+                customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(
+                    paymentMethods = PAYMENT_METHODS
+                ),
                 isGooglePayReady = false,
                 linkState = null,
                 paymentSelection = initialSelection,
@@ -686,7 +691,9 @@ internal class DefaultFlowControllerTest {
             paymentSelection,
             PaymentSheetState.Full(
                 PaymentSheetFixtures.CONFIG_CUSTOMER,
-                customerPaymentMethods = PAYMENT_METHODS,
+                customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(
+                    paymentMethods = PAYMENT_METHODS
+                ),
                 isGooglePayReady = false,
                 linkState = null,
                 paymentSelection = initialSelection,
@@ -1876,7 +1883,7 @@ internal class DefaultFlowControllerTest {
     }
 
     private fun createFlowController(
-        paymentMethods: List<PaymentMethod> = emptyList(),
+        customer: CustomerState? = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
         paymentSelection: PaymentSelection? = null,
         stripeIntent: StripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
         linkState: LinkState? = LinkState(
@@ -1888,7 +1895,7 @@ internal class DefaultFlowControllerTest {
     ): DefaultFlowController {
         return createFlowController(
             FakePaymentSheetLoader(
-                customerPaymentMethods = paymentMethods,
+                customer = customer,
                 stripeIntent = stripeIntent,
                 paymentSelection = paymentSelection,
                 linkState = linkState,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
@@ -310,7 +310,7 @@ class FlowControllerConfigurationHandlerTest {
 
             val configurationHandler = createConfigurationHandler(
                 FakePaymentSheetLoader(
-                    customerPaymentMethods = emptyList(),
+                    customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
                     delay = 2.seconds,
                 )
             )
@@ -502,7 +502,7 @@ class FlowControllerConfigurationHandlerTest {
 
     private fun defaultPaymentSheetLoader(): PaymentSheetLoader {
         return FakePaymentSheetLoader(
-            customerPaymentMethods = emptyList(),
+            customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
             paymentSelection = PaymentSelection.Link,
             linkState = LinkState(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.testing.PaymentMethodFactory
@@ -339,7 +340,9 @@ class PaymentSelectionUpdaterTest {
 
         return PaymentSheetState.Full(
             config = config,
-            customerPaymentMethods = customerPaymentMethods,
+            customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(
+                paymentMethods = customerPaymentMethods
+            ),
             isGooglePayReady = true,
             linkState = null,
             paymentSelection = paymentSelection,
@@ -369,7 +372,9 @@ class PaymentSelectionUpdaterTest {
 
         return PaymentSheetState.Full(
             config = config,
-            customerPaymentMethods = customerPaymentMethods,
+            customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(
+                paymentMethods = customerPaymentMethods
+            ),
             isGooglePayReady = true,
             linkState = null,
             paymentSelection = paymentSelection,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.StripeIntent.Status.Canceled
 import com.stripe.android.model.StripeIntent.Status.Succeeded
 import com.stripe.android.model.wallets.Wallet
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
 import com.stripe.android.paymentsheet.FakePrefsRepository
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -46,6 +47,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.capture
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import kotlin.test.BeforeTest
@@ -94,17 +96,23 @@ internal class DefaultPaymentSheetLoaderTest {
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
         )
 
+        val config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
+
         assertThat(
             loader.load(
                 initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
                     clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
                 ),
-                PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
+                config
             ).getOrThrow()
         ).isEqualTo(
             PaymentSheetState.Full(
-                config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
-                customerPaymentMethods = PAYMENT_METHODS,
+                config = config,
+                customer = CustomerState(
+                    id = config.customer!!.id,
+                    ephemeralKeySecret = config.customer!!.ephemeralKeySecret,
+                    paymentMethods = PAYMENT_METHODS
+                ),
                 isGooglePayReady = true,
                 paymentSelection = PaymentSelection.Saved(
                     paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
@@ -332,7 +340,7 @@ internal class DefaultPaymentSheetLoaderTest {
                 PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
             ).getOrThrow()
 
-            assertThat(result.customerPaymentMethods)
+            assertThat(result.customer?.paymentMethods)
                 .containsExactly(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         }
 
@@ -358,7 +366,7 @@ internal class DefaultPaymentSheetLoaderTest {
                 PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
             ).getOrThrow()
 
-            assertThat(result.customerPaymentMethods)
+            assertThat(result.customer?.paymentMethods)
                 .containsExactly(PaymentMethodFixtures.CARD_PAYMENT_METHOD, cardWithAmexWallet)
         }
 
@@ -393,7 +401,7 @@ internal class DefaultPaymentSheetLoaderTest {
             ),
         ).getOrThrow()
 
-        assertThat(result.customerPaymentMethods)
+        assertThat(result.customer?.paymentMethods)
             .containsExactly(
                 PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
@@ -731,7 +739,7 @@ internal class DefaultPaymentSheetLoaderTest {
             ),
         ).getOrThrow()
 
-        val observedElements = result.customerPaymentMethods
+        val observedElements = result.customer?.paymentMethods
         val expectedElements = listOf(lastUsed) + (paymentMethods - lastUsed)
 
         assertThat(observedElements).containsExactlyElementsIn(expectedElements).inOrder()
@@ -1076,28 +1084,27 @@ internal class DefaultPaymentSheetLoaderTest {
             ).getOrThrow()
 
             assertThat(attemptedToRetrievePaymentMethods).isFalse()
-            assertThat(state.customerPaymentMethods).containsExactlyElementsIn(cards)
+
+            assertThat(state.customer).isEqualTo(
+                CustomerState(
+                    id = "cus_1",
+                    ephemeralKeySecret = "ek_123",
+                    paymentMethods = cards,
+                )
+            )
         }
 
     @OptIn(ExperimentalCustomerSessionApi::class)
     @Test
-    fun `When 'CustomerSession' config is provided but no customer object was returned, should not fetch and return no payment methods`() =
+    fun `When 'CustomerSession' config is provided but no customer object was returned, should report error and return error`() =
         runTest {
-            var attemptedToRetrievePaymentMethods = false
-
-            val repository = FakeCustomerRepository(
-                onGetPaymentMethods = {
-                    attemptedToRetrievePaymentMethods = true
-                    Result.success(listOf())
-                }
-            )
+            val errorReporter = FakeErrorReporter()
 
             val loader = createPaymentSheetLoader(
-                customerRepo = repository,
-                customer = null,
+                errorReporter = errorReporter,
             )
 
-            val state = loader.load(
+            val exception = loader.load(
                 initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
                     clientSecret = "client_secret"
                 ),
@@ -1108,10 +1115,17 @@ internal class DefaultPaymentSheetLoaderTest {
                         clientSecret = "customer_client_secret",
                     ),
                 )
-            ).getOrThrow()
+            ).exceptionOrNull()
 
-            assertThat(attemptedToRetrievePaymentMethods).isFalse()
-            assertThat(state.customerPaymentMethods).isEmpty()
+            assertThat(exception).isInstanceOf(IllegalStateException::class.java)
+
+            assertThat(errorReporter.getLoggedErrors())
+                .contains(
+                    ErrorReporter
+                        .UnexpectedErrorEvent
+                        .PAYMENT_SHEET_LOADER_ELEMENTS_SESSION_CUSTOMER_NOT_FOUND
+                        .eventName
+                )
         }
 
     @Test
@@ -1146,7 +1160,100 @@ internal class DefaultPaymentSheetLoaderTest {
             ).getOrThrow()
 
             assertThat(attemptedToRetrievePaymentMethods).isTrue()
-            assertThat(state.customerPaymentMethods).containsExactlyElementsIn(cards)
+
+            assertThat(state.customer).isEqualTo(
+                CustomerState(
+                    id = "cus_1",
+                    ephemeralKeySecret = "ephemeral_key_secret",
+                    paymentMethods = cards,
+                )
+            )
+        }
+
+    @OptIn(ExperimentalCustomerSessionApi::class)
+    @Test
+    fun `When using 'CustomerSession', move last-used customer payment method to the front of the list`() = runTest {
+        val paymentMethods = PaymentMethodFixtures.createCards(10)
+        val lastUsed = paymentMethods[6]
+
+        prefsRepository.savePaymentSelection(PaymentSelection.Saved(lastUsed))
+
+        val loader = createPaymentSheetLoader(
+            customer = ElementsSession.Customer(
+                paymentMethods = paymentMethods,
+                session = ElementsSession.Customer.Session(
+                    id = "cuss_1",
+                    customerId = "cus_1",
+                    liveMode = false,
+                    apiKey = "ek_123",
+                    apiKeyExpiry = 555555555
+                ),
+                defaultPaymentMethod = null,
+            )
+        )
+
+        val result = loader.load(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent("secret"),
+            paymentSheetConfiguration = mockConfiguration(
+                customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
+                    id = "id",
+                    clientSecret = "cuss_1",
+                ),
+            ),
+        ).getOrThrow()
+
+        val observedElements = result.customer?.paymentMethods
+        val expectedElements = listOf(lastUsed) + (paymentMethods - lastUsed)
+
+        assertThat(observedElements).containsExactlyElementsIn(expectedElements).inOrder()
+    }
+
+    @OptIn(ExperimentalCustomerSessionApi::class)
+    @Test
+    fun `When using 'CustomerSession' & no default billing details, customer email for Link config is fetched using 'elements_session' ephemeral key`() =
+        runTest {
+            val customerRepository = spy(
+                FakeCustomerRepository(
+                    onRetrieveCustomer = {
+                        mock {
+                            on { email } doReturn "email@stripe.com"
+                        }
+                    }
+                )
+            )
+
+            val loader = createPaymentSheetLoader(
+                customerRepo = customerRepository,
+                customer = ElementsSession.Customer(
+                    paymentMethods = PaymentMethodFactory.cards(1),
+                    session = ElementsSession.Customer.Session(
+                        id = "cuss_1",
+                        customerId = "cus_1",
+                        liveMode = false,
+                        apiKey = "ek_123",
+                        apiKeyExpiry = 555555555
+                    ),
+                    defaultPaymentMethod = null,
+                )
+            )
+
+            loader.load(
+                initializationMode = PaymentSheet.InitializationMode.PaymentIntent("secret"),
+                paymentSheetConfiguration = mockConfiguration(
+                    customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
+                        id = "id",
+                        clientSecret = "cuss_1",
+                    ),
+                    defaultBillingDetails = null
+                ),
+            )
+
+            verify(customerRepository).retrieveCustomer(
+                CustomerRepository.CustomerInfo(
+                    id = "cus_1",
+                    ephemeralKeySecret = "ek_123",
+                )
+            )
         }
 
     private suspend fun testExternalPaymentMethods(
@@ -1206,6 +1313,7 @@ internal class DefaultPaymentSheetLoaderTest {
         linkStore: LinkStore = mock(),
         customer: ElementsSession.Customer? = null,
         externalPaymentMethodData: String? = null,
+        errorReporter: ErrorReporter = FakeErrorReporter(),
         elementsSessionRepository: ElementsSessionRepository = FakeElementsSessionRepository(
             stripeIntent = stripeIntent,
             error = error,
@@ -1227,6 +1335,7 @@ internal class DefaultPaymentSheetLoaderTest {
             lpmRepository = lpmRepository,
             logger = Logger.noop(),
             eventReporter = eventReporter,
+            errorReporter = errorReporter,
             workContext = testDispatcher,
             accountStatusProvider = { linkAccountState },
             linkStore = linkStore,

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
@@ -8,6 +8,9 @@ import com.stripe.android.paymentsheet.repositories.CustomerRepository
 internal open class FakeCustomerRepository(
     private val paymentMethods: List<PaymentMethod> = emptyList(),
     private val customer: Customer? = null,
+    private val onRetrieveCustomer: () -> Customer? = {
+        customer
+    },
     private val onGetPaymentMethods: () -> Result<List<PaymentMethod>> = {
         Result.success(paymentMethods)
     },
@@ -25,7 +28,7 @@ internal open class FakeCustomerRepository(
 
     override suspend fun retrieveCustomer(
         customerInfo: CustomerRepository.CustomerInfo
-    ): Customer? = customer
+    ): Customer? = onRetrieveCustomer()
 
     override suspend fun getPaymentMethods(
         customerInfo: CustomerRepository.CustomerInfo,

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
@@ -6,6 +6,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException
@@ -16,7 +17,7 @@ import kotlin.time.Duration
 internal class FakePaymentSheetLoader(
     private val stripeIntent: StripeIntent = PaymentIntentFixtures.PI_SUCCEEDED,
     private val shouldFail: Boolean = false,
-    private var customerPaymentMethods: List<PaymentMethod> = emptyList(),
+    private var customer: CustomerState? = null,
     private var paymentSelection: PaymentSelection? = null,
     private val isGooglePayAvailable: Boolean = false,
     private val delay: Duration = Duration.ZERO,
@@ -25,7 +26,9 @@ internal class FakePaymentSheetLoader(
 ) : PaymentSheetLoader {
 
     fun updatePaymentMethods(paymentMethods: List<PaymentMethod>) {
-        this.customerPaymentMethods = paymentMethods
+        this.customer = customer?.copy(
+            paymentMethods = paymentMethods
+        )
         this.paymentSelection = paymentSelection.takeIf {
             (it !is PaymentSelection.Saved) || it.paymentMethod in paymentMethods
         }
@@ -43,7 +46,7 @@ internal class FakePaymentSheetLoader(
             Result.success(
                 PaymentSheetState.Full(
                     config = paymentSheetConfiguration,
-                    customerPaymentMethods = customerPaymentMethods,
+                    customer = customer,
                     isGooglePayReady = isGooglePayAvailable,
                     linkState = linkState,
                     paymentSelection = paymentSelection,

--- a/paymentsheet/src/test/java/com/stripe/android/utils/RelayingPaymentSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/RelayingPaymentSheetLoader.kt
@@ -20,7 +20,7 @@ internal class RelayingPaymentSheetLoader : PaymentSheetLoader {
         enqueue(
             Result.success(
                 PaymentSheetState.Full(
-                    customerPaymentMethods = emptyList(),
+                    customer = null,
                     config = PaymentSheet.Configuration("Example"),
                     isGooglePayReady = false,
                     paymentSelection = null,


### PR DESCRIPTION
# Summary
This PR adds a `CustomerState` as part of `PaymentSheetState.Full` that includes `id`, `ephemeralKeySecret`, and `paymentMethods` fields.

# Motivation
Prior to this PR, we relied solely on the `PaymentSheet.CustomerConfiguration` object provided to get a customer's `id` and `ephemeralKeySecret`. With `CustomerSession`, this is no longer a valid way to pull for the `ephemeralKeySecret` since the Elements Session endpoint will instead return a scoped `ephemeralKeySecret` after claiming the provided `customerSessionClientSecret` to use for the customer. 

Adding and using `CustomerState` instead allows us to separate the customer functionality in `PaymentSheet` from the `CustomerConfiguration` object. In future PRs, other customer related fields (such as `initialPaymentSelection`) will be moved into this state as well.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
