### PR TITLE
Remove unnecessary content size animation.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.ui
 
-import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -114,7 +113,6 @@ private fun FormElement(
 
     Box(
         modifier = Modifier
-            .animateContentSize()
             .pointerInput("AddPaymentMethod") {
                 awaitEachGesture {
                     val gesture = awaitPointerEvent()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -138,7 +138,7 @@ internal fun PaymentSheetScreenContent(
     val currentScreen by viewModel.currentScreen.collectAsState()
     val mandateText by viewModel.mandateText.collectAsState()
 
-    Column(modifier) {
+    Column(modifier.animateContentSize()) {
         PaymentSheetContent(
             viewModel = viewModel,
             type = type,
@@ -219,7 +219,7 @@ private fun PaymentSheetContent(
         )
     }
 
-    Box(modifier = Modifier.animateContentSize()) {
+    Box {
         currentScreen.Content(
             viewModel = viewModel,
             modifier = Modifier.padding(bottom = 8.dp),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -138,7 +138,7 @@ internal fun PaymentSheetScreenContent(
     val currentScreen by viewModel.currentScreen.collectAsState()
     val mandateText by viewModel.mandateText.collectAsState()
 
-    Column(modifier.animateContentSize()) {
+    Column(modifier) {
         PaymentSheetContent(
             viewModel = viewModel,
             type = type,
@@ -219,7 +219,7 @@ private fun PaymentSheetContent(
         )
     }
 
-    Box {
+    Box(modifier = Modifier.animateContentSize()) {
         currentScreen.Content(
             viewModel = viewModel,
             modifier = Modifier.padding(bottom = 8.dp),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I was digging through performance improvements, and noticed we had an extra animation causing issues. This removes it.

# Screenshots
The delay screenshots have a 3 second animation setup for invocations of `animateContentSize`.

| Before  | After |
| ------------- | ------------- |
| [before](https://github.com/stripe/stripe-android/assets/116920913/e6c4fdd3-a8d5-49ef-a25e-75da1d46cb88) | [after](https://github.com/stripe/stripe-android/assets/116920913/97edab8b-c6da-4c73-baf6-39b19a9c6a36) |
| [before with delay](https://github.com/stripe/stripe-android/assets/116920913/5d2fa534-3f81-4b81-9c91-f1f859602971) | [after with delay](https://github.com/stripe/stripe-android/assets/116920913/5478a936-a756-466a-818f-57d5e45fa611) |

Notice how the videos with delay seems like when I click something it just freezes for 3 seconds. This is what the extra animation was causing.