### PR TITLE
Animate all of PaymentSheet.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -138,7 +138,7 @@ internal fun PaymentSheetScreenContent(
     val currentScreen by viewModel.currentScreen.collectAsState()
     val mandateText by viewModel.mandateText.collectAsState()
 
-    Column(modifier) {
+    Column(modifier = modifier.animateContentSize()) {
         PaymentSheetContent(
             viewModel = viewModel,
             type = type,
@@ -219,7 +219,7 @@ private fun PaymentSheetContent(
         )
     }
 
-    Box(modifier = Modifier.animateContentSize()) {
+    Box {
         currentScreen.Content(
             viewModel = viewModel,
             modifier = Modifier.padding(bottom = 8.dp),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
CustomerSheet already animates the entire content. So making PaymentSheet do the same.
In practice this probably only matters for errors.
