### PR TITLE
Add additional checks for `rememberCustomerSheet`.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetCompose.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetCompose.kt
@@ -31,7 +31,11 @@ fun rememberCustomerSheet(
         "CustomerSheet must be created in the context of an Activity"
     }
 
-    return remember(configuration) {
+    return remember(
+        configuration,
+        customerAdapter,
+        callback,
+    ) {
         CustomerSheet.getInstance(
             application = activity.application,
             lifecycleOwner = lifecycleOwner,


### PR DESCRIPTION
# Summary
Add additional checks for `rememberCustomerSheet`.

# Motivation
Fixes an issue where a `CustomerSheet` instance is not refetched when the `CustomerAdapter` or `callback` change.
