### PR TITLE
Improve CustomerSheet animations.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.customersheet.ui
 
 import androidx.compose.animation.animateContentSize
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -59,7 +58,7 @@ internal fun CustomerSheetScreen(
             )
         },
         content = {
-            Column(modifier = Modifier.animateContentSize(tween(3000))) {
+            Column(modifier = Modifier.animateContentSize()) {
                 when (viewState) {
                     is CustomerSheetViewState.Loading -> {
                         BottomSheetLoadingIndicator()

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -140,19 +140,21 @@ internal fun SelectPaymentMethod(
             )
         }
 
-        viewState.primaryButtonLabel?.let {
-            PrimaryButton(
-                label = it,
-                isEnabled = viewState.primaryButtonEnabled,
-                isLoading = viewState.isProcessing,
-                onButtonClick = {
-                    viewActionHandler(CustomerSheetViewAction.OnPrimaryButtonPressed)
-                },
-                modifier = Modifier
-                    .testTag(CUSTOMER_SHEET_CONFIRM_BUTTON_TEST_TAG)
-                    .padding(top = 20.dp)
-                    .padding(horizontal = horizontalPadding),
-            )
+        if (viewState.primaryButtonVisible) {
+            viewState.primaryButtonLabel?.let {
+                PrimaryButton(
+                    label = it,
+                    isEnabled = viewState.primaryButtonEnabled,
+                    isLoading = viewState.isProcessing,
+                    onButtonClick = {
+                        viewActionHandler(CustomerSheetViewAction.OnPrimaryButtonPressed)
+                    },
+                    modifier = Modifier
+                        .testTag(CUSTOMER_SHEET_CONFIRM_BUTTON_TEST_TAG)
+                        .padding(top = 20.dp)
+                        .padding(horizontal = horizontalPadding),
+                )
+            }
         }
 
         Mandate(

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.customersheet.ui
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -59,7 +59,7 @@ internal fun CustomerSheetScreen(
             )
         },
         content = {
-            Column(modifier = Modifier.animateContentSize()) {
+            Column(modifier = Modifier.animateContentSize(tween(3000))) {
                 when (viewState) {
                     is CustomerSheetViewState.Loading -> {
                         BottomSheetLoadingIndicator()
@@ -132,43 +132,37 @@ internal fun SelectPaymentMethod(
             modifier = Modifier.padding(bottom = 2.dp),
         )
 
-        AnimatedVisibility(visible = viewState.errorMessage != null) {
-            viewState.errorMessage?.let { error ->
-                ErrorMessage(
-                    error = error,
-                    modifier = Modifier
-                        .padding(vertical = 2.dp)
-                        .padding(horizontal = horizontalPadding),
-                )
-            }
-        }
-
-        AnimatedVisibility(visible = viewState.primaryButtonVisible) {
-            viewState.primaryButtonLabel?.let {
-                PrimaryButton(
-                    label = it,
-                    isEnabled = viewState.primaryButtonEnabled,
-                    isLoading = viewState.isProcessing,
-                    onButtonClick = {
-                        viewActionHandler(CustomerSheetViewAction.OnPrimaryButtonPressed)
-                    },
-                    modifier = Modifier
-                        .testTag(CUSTOMER_SHEET_CONFIRM_BUTTON_TEST_TAG)
-                        .padding(top = 20.dp)
-                        .padding(horizontal = horizontalPadding),
-                )
-            }
-        }
-
-        AnimatedVisibility(visible = viewState.mandateText != null) {
-            Mandate(
-                mandateText = viewState.mandateText,
+        viewState.errorMessage?.let { error ->
+            ErrorMessage(
+                error = error,
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 8.dp)
+                    .padding(vertical = 2.dp)
                     .padding(horizontal = horizontalPadding),
             )
         }
+
+        viewState.primaryButtonLabel?.let {
+            PrimaryButton(
+                label = it,
+                isEnabled = viewState.primaryButtonEnabled,
+                isLoading = viewState.isProcessing,
+                onButtonClick = {
+                    viewActionHandler(CustomerSheetViewAction.OnPrimaryButtonPressed)
+                },
+                modifier = Modifier
+                    .testTag(CUSTOMER_SHEET_CONFIRM_BUTTON_TEST_TAG)
+                    .padding(top = 20.dp)
+                    .padding(horizontal = horizontalPadding),
+            )
+        }
+
+        Mandate(
+            mandateText = viewState.mandateText,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp)
+                .padding(horizontal = horizontalPadding),
+        )
     }
 }
 
@@ -198,85 +192,81 @@ internal fun AddPaymentMethod(
     }
 
     // TODO (jameswoo) make sure that the spacing is consistent with paymentsheet
-    Column {
-        H4Text(
-            text = stringResource(id = R.string.stripe_paymentsheet_save_a_new_payment_method),
-            modifier = Modifier
-                .padding(bottom = 4.dp)
-                .padding(horizontal = horizontalPadding)
-        )
+    H4Text(
+        text = stringResource(id = R.string.stripe_paymentsheet_save_a_new_payment_method),
+        modifier = Modifier
+            .padding(bottom = 4.dp)
+            .padding(horizontal = horizontalPadding)
+    )
 
-        val eventReporter = remember(viewActionHandler) {
-            DefaultCardNumberCompletedEventReporter(viewActionHandler)
-        }
+    val eventReporter = remember(viewActionHandler) {
+        DefaultCardNumberCompletedEventReporter(viewActionHandler)
+    }
 
-        if (displayForm) {
-            CompositionLocalProvider(
-                LocalCardNumberCompletedEventReporter provides eventReporter
-            ) {
-                PaymentElement(
-                    enabled = viewState.enabled,
-                    supportedPaymentMethods = viewState.supportedPaymentMethods,
-                    selectedItem = viewState.selectedPaymentMethod,
-                    formElements = viewState.formElements,
-                    linkSignupMode = null,
-                    linkConfigurationCoordinator = null,
-                    onItemSelectedListener = {
-                        viewActionHandler(CustomerSheetViewAction.OnAddPaymentMethodItemChanged(it))
-                    },
-                    onLinkSignupStateChanged = { _, _ -> },
-                    formArguments = viewState.formArguments,
-                    usBankAccountFormArguments = viewState.usBankAccountFormArguments,
-                    onFormFieldValuesChanged = {
-                        // This only gets emitted if form field values are complete
-                        viewActionHandler(CustomerSheetViewAction.OnFormFieldValuesCompleted(it))
-                    }
-                )
-            }
-        }
-
-        AnimatedVisibility(visible = viewState.errorMessage != null) {
-            viewState.errorMessage?.let { error ->
-                ErrorMessage(
-                    error = error,
-                    modifier = Modifier.padding(horizontal = horizontalPadding)
-                )
-            }
-        }
-
-        if (viewState.showMandateAbovePrimaryButton) {
-            Mandate(
-                mandateText = viewState.mandateText,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 8.dp)
-                    .padding(horizontal = horizontalPadding),
+    if (displayForm) {
+        CompositionLocalProvider(
+            LocalCardNumberCompletedEventReporter provides eventReporter
+        ) {
+            PaymentElement(
+                enabled = viewState.enabled,
+                supportedPaymentMethods = viewState.supportedPaymentMethods,
+                selectedItem = viewState.selectedPaymentMethod,
+                formElements = viewState.formElements,
+                linkSignupMode = null,
+                linkConfigurationCoordinator = null,
+                onItemSelectedListener = {
+                    viewActionHandler(CustomerSheetViewAction.OnAddPaymentMethodItemChanged(it))
+                },
+                onLinkSignupStateChanged = { _, _ -> },
+                formArguments = viewState.formArguments,
+                usBankAccountFormArguments = viewState.usBankAccountFormArguments,
+                onFormFieldValuesChanged = {
+                    // This only gets emitted if form field values are complete
+                    viewActionHandler(CustomerSheetViewAction.OnFormFieldValuesCompleted(it))
+                }
             )
         }
+    }
 
-        PrimaryButton(
-            label = viewState.primaryButtonLabel.resolve(),
-            isEnabled = viewState.primaryButtonEnabled,
-            isLoading = viewState.isProcessing,
-            displayLockIcon = true,
-            onButtonClick = {
-                viewActionHandler(CustomerSheetViewAction.OnPrimaryButtonPressed)
-            },
+    viewState.errorMessage?.let { error ->
+        ErrorMessage(
+            error = error,
+            modifier = Modifier.padding(horizontal = horizontalPadding)
+        )
+    }
+
+    if (viewState.showMandateAbovePrimaryButton) {
+        Mandate(
+            mandateText = viewState.mandateText,
             modifier = Modifier
-                .testTag(CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG)
-                .padding(top = 10.dp)
+                .fillMaxWidth()
+                .padding(top = 8.dp)
                 .padding(horizontal = horizontalPadding),
         )
+    }
 
-        if (!viewState.showMandateAbovePrimaryButton) {
-            Mandate(
-                mandateText = viewState.mandateText,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 8.dp)
-                    .padding(horizontal = horizontalPadding),
-            )
-        }
+    PrimaryButton(
+        label = viewState.primaryButtonLabel.resolve(),
+        isEnabled = viewState.primaryButtonEnabled,
+        isLoading = viewState.isProcessing,
+        displayLockIcon = true,
+        onButtonClick = {
+            viewActionHandler(CustomerSheetViewAction.OnPrimaryButtonPressed)
+        },
+        modifier = Modifier
+            .testTag(CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG)
+            .padding(top = 10.dp)
+            .padding(horizontal = horizontalPadding),
+    )
+
+    if (!viewState.showMandateAbovePrimaryButton) {
+        Mandate(
+            mandateText = viewState.mandateText,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp)
+                .padding(horizontal = horizontalPadding),
+        )
     }
 }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I noticed this when working on PaymentSheet animations.

It's still not ideal, as switching between LPMs is a little "bouncy", but it should put us on the right track.

# Screenshots
| Before  | After |
| ------------- | ------------- |
| [before](https://github.com/stripe/stripe-android/assets/116920913/dd8d520a-2c53-492b-8c63-595205bdf0eb)  | [after](https://github.com/stripe/stripe-android/assets/116920913/5c3e13bf-318f-4d9f-8e4f-02a771797c14) |





