### PR TITLE
Re-populate `formElements` in `CustomerSheetViewModel` when switching payment method types.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -417,6 +417,12 @@ internal class CustomerSheetViewModel(
                     merchantName = configuration.merchantDisplayName,
                     cbcEligibility = it.cbcEligibility,
                 ),
+                formElements = paymentMethodMetadata?.formElementsForCode(
+                    code = paymentMethod.code,
+                    uiDefinitionFactoryArgumentsFactory = UiDefinitionFactory.Arguments.Factory.Default(
+                        cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
+                    ),
+                ) ?: listOf(),
                 selectedPaymentMethod = paymentMethod,
                 primaryButtonLabel = if (
                     paymentMethod.code == PaymentMethod.Type.USBankAccount.code &&

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -1720,6 +1720,58 @@ class CustomerSheetViewModelTest {
     }
 
     @Test
+    fun `Payment method form elements are populated when switching payment method types`() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            workContext = testDispatcher,
+            initialBackStack = listOf(
+                selectPaymentMethodViewState,
+                addPaymentMethodViewState,
+            ),
+        )
+
+        viewModel.viewState.test {
+            awaitViewState<SelectPaymentMethod>()
+
+            viewModel.handleViewAction(CustomerSheetViewAction.OnAddCardPressed)
+
+            var viewState = awaitViewState<AddPaymentMethod>()
+            assertThat(viewState.selectedPaymentMethod.code)
+                .isEqualTo("card")
+
+            viewModel.handleViewAction(
+                CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
+                    LpmRepositoryTestHelpers.usBankAccount
+                )
+            )
+
+            viewState = awaitViewState()
+            assertThat(viewState.selectedPaymentMethod.code)
+                .isEqualTo("us_bank_account")
+
+            viewModel.handleViewAction(CustomerSheetViewAction.OnBackPressed)
+
+            awaitViewState<SelectPaymentMethod>()
+
+            viewModel.handleViewAction(CustomerSheetViewAction.OnAddCardPressed)
+
+            viewState = awaitViewState()
+            assertThat(viewState.selectedPaymentMethod.code)
+                .isEqualTo("us_bank_account")
+
+            viewModel.handleViewAction(
+                CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
+                    LpmRepositoryTestHelpers.card
+                )
+            )
+
+            viewState = awaitViewState()
+            assertThat(viewState.selectedPaymentMethod.code)
+                .isEqualTo("card")
+            assertThat(viewState.formElements).isNotEmpty()
+        }
+    }
+
+    @Test
     fun `Payment method user selection saved after returning to add screen`() = runTest(testDispatcher) {
         val viewModel = createViewModel(
             workContext = testDispatcher,


### PR DESCRIPTION
# Summary
When switching between payment method types, `formElements` are not re-populated from the updated payment method type.

# Motivation
Ensures correct form elements are shown when switching between payment method types

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
