### PR TITLE
Move `consent_acquired` event emission after network call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
-## XX.XX.XX - 2023-XX-XX
+## XX.XX.XX - 20XX-XX-XX
+
+### Financial Connections
+* [Changed][8377](https://github.com/stripe/stripe-android/pull/8377) The `FinancialConnectionsEvent.Name.CONSENT_ACQUIRED` event is now emitted when the consent has been acquired _and_ successfully confirmed with the Stripe backend. Previously, the event was emitted before the confirmation, making it possible to receive multiple `CONSENT_ACQUIRED` events in a single session.
 
 ## 20.41.1 - 2024-04-22
 
@@ -20,7 +23,7 @@
 ## 20.40.4 - 2024-04-04
 
 ### Financial Connections
-[Fixed][8223](https://github.com/stripe/stripe-android/pull/8223) Fixed a crash that occurred when using Compose 1.6.
+* [Fixed][8223](https://github.com/stripe/stripe-android/pull/8223) Fixed a crash that occurred when using Compose 1.6.
 
 ## 20.40.3 - 2024-04-01
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentViewModel.kt
@@ -93,8 +93,8 @@ internal class ConsentViewModel @AssistedInject constructor(
     fun onContinueClick() {
         suspend {
             eventTracker.track(ConsentAgree)
-            FinancialConnections.emitEvent(Name.CONSENT_ACQUIRED)
             val updatedManifest: FinancialConnectionsSessionManifest = acceptConsent()
+            FinancialConnections.emitEvent(Name.CONSENT_ACQUIRED)
             navigationManager.tryNavigateTo(updatedManifest.nextPane.destination(referrer = Pane.CONSENT))
             updatedManifest
         }.execute { copy(acceptConsent = it) }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request changes when we emit the `CONSENT_ACQUIRED` event.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
