### PR TITLE
Add tests for AddPaymentMethod#transformToPaymentSelection

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
@@ -25,7 +25,7 @@ class FieldValuesToParamsMapConverter {
             code: PaymentMethodCode,
             requiresMandate: Boolean
         ): PaymentMethodCreateParams {
-            val fieldValuePairsForCreateParams =  fieldValuePairs.filter { entry ->
+            val fieldValuePairsForCreateParams = fieldValuePairs.filter { entry ->
                 entry.key.destination == ParameterDestination.Api.Params
             }.filterNot { entry ->
                 entry.key == IdentifierSpec.SaveForFutureUse || entry.key == IdentifierSpec.CardBrand
@@ -86,12 +86,13 @@ class FieldValuesToParamsMapConverter {
             code: PaymentMethodCode,
         ): PaymentMethodExtraParams? {
             val fieldValuePairsForExtras = fieldValuePairs.filter { entry ->
-                    entry.key.destination == ParameterDestination.Local.Extras
-                }
+                entry.key.destination == ParameterDestination.Local.Extras
+            }
             return when (code) {
                 PaymentMethod.Type.BacsDebit.code -> PaymentMethodExtraParams.BacsDebit(
                     confirmed = fieldValuePairsForExtras[IdentifierSpec.BacsDebitConfirmed]?.value?.toBoolean()
                 )
+
                 else -> null
             }
         }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
@@ -282,7 +282,6 @@ class FieldValuesToParamsMapConverterTest {
                 PaymentMethod.Type.Blik.requiresMandate
             )
 
-        // TODO: never actually updates the billing details
         assertThat(
             paymentMethodParams.toParamMap().toString()
         ).isEqualTo(

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
@@ -108,6 +108,104 @@ class FieldValuesToParamsMapConverterTest {
     }
 
     @Test
+    fun `transform to payment method params - ignores options params`() {
+        val paymentMethodParams = FieldValuesToParamsMapConverter
+            .transformToPaymentMethodCreateParams(
+                mapOf(
+                    IdentifierSpec.Name to FormFieldEntry(
+                        "joe",
+                        true
+                    ),
+                    IdentifierSpec.Email to FormFieldEntry(
+                        "joe@gmail.com",
+                        true
+                    ),
+                    IdentifierSpec.Generic("billing_details[address][country]") to FormFieldEntry(
+                        "US",
+                        true
+                    ),
+                    IdentifierSpec.Line1 to FormFieldEntry(
+                        "123 Main Street",
+                        true
+                    ),
+                    IdentifierSpec.BlikCode to FormFieldEntry(
+                        "example_blik_code",
+                        true,
+                    )
+                ),
+                PaymentMethod.Type.Blik.code,
+                PaymentMethod.Type.Blik.requiresMandate
+            )
+
+        assertThat(
+            paymentMethodParams.toParamMap().toString()
+        ).isEqualTo(
+            "{" +
+                "type=blik, " +
+                "billing_details={" +
+                "name=joe, " +
+                "email=joe@gmail.com, " +
+                "address={" +
+                "country=US, " +
+                "line1=123 Main Street" +
+                "}" +
+                "}" +
+                "}"
+        )
+    }
+
+    @Test
+    fun `transform to payment method params - ignores SFU and CardBrand params`() {
+        val paymentMethodParams = FieldValuesToParamsMapConverter
+            .transformToPaymentMethodCreateParams(
+                mapOf(
+                    IdentifierSpec.Name to FormFieldEntry(
+                        "joe",
+                        true
+                    ),
+                    IdentifierSpec.Email to FormFieldEntry(
+                        "joe@gmail.com",
+                        true
+                    ),
+                    IdentifierSpec.Generic("billing_details[address][country]") to FormFieldEntry(
+                        "US",
+                        true
+                    ),
+                    IdentifierSpec.Line1 to FormFieldEntry(
+                        "123 Main Street",
+                        true
+                    ),
+                    IdentifierSpec.SaveForFutureUse to FormFieldEntry(
+                        "true",
+                        true,
+                    ),
+                    IdentifierSpec.CardBrand to FormFieldEntry(
+                        "visa",
+                        true,
+                    )
+                ),
+                PaymentMethod.Type.Card.code,
+                PaymentMethod.Type.Card.requiresMandate
+            )
+
+        assertThat(
+            paymentMethodParams.toParamMap().toString()
+        ).isEqualTo(
+            "{" +
+                "type=card, " +
+                "billing_details={" +
+                "name=joe, " +
+                "email=joe@gmail.com, " +
+                "address={" +
+                "country=US, " +
+                "line1=123 Main Street" +
+                "}" +
+                "}" +
+                "}"
+        )
+    }
+
+    @Test
     fun `transform to extra params if bacs`() {
         val paymentMethodParams = FieldValuesToParamsMapConverter
             .transformToPaymentMethodExtraParams(
@@ -152,5 +250,151 @@ class FieldValuesToParamsMapConverterTest {
         ).isEqualTo(
             "{type=some code, billing_details={name=joe}}"
         )
+    }
+
+    @Test
+    fun `transformToPaymentMethodOptionsParams returns correct params for Blik`() {
+        val paymentMethodParams = FieldValuesToParamsMapConverter
+            .transformToPaymentMethodCreateParams(
+                mapOf(
+                    IdentifierSpec.Name to FormFieldEntry(
+                        "joe",
+                        true
+                    ),
+                    IdentifierSpec.Email to FormFieldEntry(
+                        "joe@gmail.com",
+                        true
+                    ),
+                    IdentifierSpec.Generic("billing_details[address][country]") to FormFieldEntry(
+                        "US",
+                        true
+                    ),
+                    IdentifierSpec.Line1 to FormFieldEntry(
+                        "123 Main Street",
+                        true
+                    ),
+                    IdentifierSpec.BlikCode to FormFieldEntry(
+                        "example_blik_code",
+                        true,
+                    )
+                ),
+                PaymentMethod.Type.Blik.code,
+                PaymentMethod.Type.Blik.requiresMandate
+            )
+
+        // TODO: never actually updates the billing details
+        assertThat(
+            paymentMethodParams.toParamMap().toString()
+        ).isEqualTo(
+            "{" +
+                "type=blik, " +
+                "billing_details={" +
+                "name=joe, " +
+                "email=joe@gmail.com, " +
+                "address={" +
+                "country=US, " +
+                "line1=123 Main Street" +
+                "}" +
+                "}" +
+                "}"
+        )
+    }
+
+    @Test
+    fun `transformToPaymentMethodOptionsParams returns correct params for WeChat`() {
+        val paymentMethodParams = FieldValuesToParamsMapConverter
+            .transformToPaymentMethodOptionsParams(
+                mapOf(
+                    IdentifierSpec.Name to FormFieldEntry(
+                        "joe",
+                        true
+                    ),
+                    IdentifierSpec.Email to FormFieldEntry(
+                        "joe@gmail.com",
+                        true
+                    ),
+                    IdentifierSpec.Generic("billing_details[address][country]") to FormFieldEntry(
+                        "US",
+                        true
+                    ),
+                    IdentifierSpec.Line1 to FormFieldEntry(
+                        "123 Main Street",
+                        true
+                    ),
+                ),
+                PaymentMethod.Type.WeChatPay.code,
+            )
+
+        assertThat(paymentMethodParams).isNotNull()
+        assertThat(
+            paymentMethodParams?.toParamMap().toString()
+        ).isEqualTo("{wechat_pay={client=mobile_web}}")
+    }
+
+    @Test
+    fun `transformToPaymentMethodOptionsParams returns correct params for Konbini`() {
+        val paymentMethodParams = FieldValuesToParamsMapConverter
+            .transformToPaymentMethodOptionsParams(
+                mapOf(
+                    IdentifierSpec.Name to FormFieldEntry(
+                        "joe",
+                        true
+                    ),
+                    IdentifierSpec.Email to FormFieldEntry(
+                        "joe@gmail.com",
+                        true
+                    ),
+                    IdentifierSpec.Generic("billing_details[address][country]") to FormFieldEntry(
+                        "US",
+                        true
+                    ),
+                    IdentifierSpec.Line1 to FormFieldEntry(
+                        "123 Main Street",
+                        true
+                    ),
+                    IdentifierSpec.KonbiniConfirmationNumber to FormFieldEntry(
+                        "example_confirmation_number",
+                        true,
+                    )
+                ),
+                PaymentMethod.Type.Konbini.code,
+            )
+
+        assertThat(paymentMethodParams).isNotNull()
+        assertThat(
+            paymentMethodParams?.toParamMap().toString()
+        ).isEqualTo("{konbini={confirmation_number=example_confirmation_number}}")
+    }
+
+    @Test
+    fun `transformToPaymentMethodOptionsParams returns null for card`() {
+        val paymentMethodParams = FieldValuesToParamsMapConverter
+            .transformToPaymentMethodOptionsParams(
+                mapOf(
+                    IdentifierSpec.Name to FormFieldEntry(
+                        "joe",
+                        true
+                    ),
+                    IdentifierSpec.Email to FormFieldEntry(
+                        "joe@gmail.com",
+                        true
+                    ),
+                    IdentifierSpec.Generic("billing_details[address][country]") to FormFieldEntry(
+                        "US",
+                        true
+                    ),
+                    IdentifierSpec.Line1 to FormFieldEntry(
+                        "123 Main Street",
+                        true
+                    ),
+                    IdentifierSpec.BlikCode to FormFieldEntry(
+                        "example_blik_code",
+                        true,
+                    )
+                ),
+                PaymentMethod.Type.Card.code,
+            )
+
+        assertThat(paymentMethodParams).isNull()
     }
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
@@ -255,7 +255,7 @@ class FieldValuesToParamsMapConverterTest {
     @Test
     fun `transformToPaymentMethodOptionsParams returns correct params for Blik`() {
         val paymentMethodParams = FieldValuesToParamsMapConverter
-            .transformToPaymentMethodCreateParams(
+            .transformToPaymentMethodOptionsParams(
                 mapOf(
                     IdentifierSpec.Name to FormFieldEntry(
                         "joe",
@@ -279,23 +279,13 @@ class FieldValuesToParamsMapConverterTest {
                     )
                 ),
                 PaymentMethod.Type.Blik.code,
-                PaymentMethod.Type.Blik.requiresMandate
             )
 
+        assertThat(paymentMethodParams).isNotNull()
         assertThat(
-            paymentMethodParams.toParamMap().toString()
+            paymentMethodParams?.toParamMap().toString()
         ).isEqualTo(
-            "{" +
-                "type=blik, " +
-                "billing_details={" +
-                "name=joe, " +
-                "email=joe@gmail.com, " +
-                "address={" +
-                "country=US, " +
-                "line1=123 Main Street" +
-                "}" +
-                "}" +
-                "}"
+            "{blik={code=example_blik_code}}"
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -164,11 +164,7 @@ internal fun FormFieldValues.transformToPaymentMethodCreateParams(
     paymentMethodMetadata: PaymentMethodMetadata,
 ): PaymentMethodCreateParams {
     return FieldValuesToParamsMapConverter.transformToPaymentMethodCreateParams(
-        fieldValuePairs = fieldValuePairs.filter { entry ->
-            entry.key.destination == ParameterDestination.Api.Params
-        }.filterNot { entry ->
-            entry.key == IdentifierSpec.SaveForFutureUse || entry.key == IdentifierSpec.CardBrand
-        },
+        fieldValuePairs = fieldValuePairs,
         code = paymentMethod.code,
         requiresMandate = paymentMethodMetadata.requiresMandate(paymentMethod.code),
     )
@@ -178,9 +174,7 @@ internal fun FormFieldValues.transformToPaymentMethodOptionsParams(
     paymentMethod: SupportedPaymentMethod
 ): PaymentMethodOptionsParams? {
     return FieldValuesToParamsMapConverter.transformToPaymentMethodOptionsParams(
-        fieldValuePairs = fieldValuePairs.filter { entry ->
-            entry.key.destination == ParameterDestination.Api.Options
-        },
+        fieldValuePairs = fieldValuePairs,
         code = paymentMethod.code,
     )
 }
@@ -189,9 +183,7 @@ internal fun FormFieldValues.transformToExtraParams(
     paymentMethod: SupportedPaymentMethod
 ): PaymentMethodExtraParams? {
     return FieldValuesToParamsMapConverter.transformToPaymentMethodExtraParams(
-        fieldValuePairs = fieldValuePairs.filter { entry ->
-            entry.key.destination == ParameterDestination.Local.Extras
-        },
+        fieldValuePairs = fieldValuePairs,
         code = paymentMethod.code,
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -34,7 +34,6 @@ import com.stripe.android.ui.core.FieldValuesToParamsMapConverter
 import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventReporter
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.LocalAutofillEventReporter
-import com.stripe.android.uicore.elements.ParameterDestination
 
 @Composable
 internal fun AddPaymentMethod(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
@@ -15,7 +15,6 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 
-
 @RunWith(RobolectricTestRunner::class)
 internal class AddPaymentMethodTest {
 
@@ -70,7 +69,8 @@ internal class AddPaymentMethodTest {
             metadata
         ) as PaymentSelection.ExternalPaymentMethod
 
-        assertThat(externalPaymentSelection.type).isEqualTo(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC.type)
+        assertThat(externalPaymentSelection.type)
+            .isEqualTo(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC.type)
         assertThat(externalPaymentSelection.label).isEqualTo(paypalSpec.label)
         assertThat(externalPaymentSelection.lightThemeIconUrl).isEqualTo(paypalSpec.lightImageUrl)
         assertThat(externalPaymentSelection.darkThemeIconUrl).isEqualTo(paypalSpec.darkImageUrl)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
@@ -1,24 +1,17 @@
 package com.stripe.android.paymentsheet.ui
 
 import android.content.Context
-import androidx.compose.ui.platform.LocalContext
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.lpmfoundations.paymentmethod.definitions.BlikDefinition
 import com.stripe.android.model.PaymentIntentFixtures
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams.Companion.getNameFromParams
 import com.stripe.android.model.PaymentMethodFixtures
-import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.uicore.elements.IdentifierSpec
-import com.stripe.android.uicore.elements.TextFieldStateConstants
 import com.stripe.android.uicore.forms.FormFieldEntry
 import org.junit.runner.RunWith
-import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 
@@ -62,28 +55,52 @@ internal class AddPaymentMethodTest {
 
     @Test
     fun `transformToPaymentSelection transforms external payment methods correctly`() {
-        // TODO: update to be epms
-        val cardBrand = "visa"
-        val name = "Joe"
         val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
+        val paypalSpec = PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC
+        val formFieldValues = FormFieldValues(
+            fieldValuePairs = mapOf(),
+            showsMandate = false,
+            userRequestedReuse = customerRequestedSave,
+        )
+        val externalPaymentMethod = metadata.supportedPaymentMethodForCode(paypalSpec.type)!!
+
+        val externalPaymentSelection = formFieldValues.transformToPaymentSelection(
+            context,
+            externalPaymentMethod,
+            metadata
+        ) as PaymentSelection.ExternalPaymentMethod
+
+        assertThat(externalPaymentSelection.type).isEqualTo(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC.type)
+        assertThat(externalPaymentSelection.label).isEqualTo(paypalSpec.label)
+        assertThat(externalPaymentSelection.lightThemeIconUrl).isEqualTo(paypalSpec.lightImageUrl)
+        assertThat(externalPaymentSelection.darkThemeIconUrl).isEqualTo(paypalSpec.darkImageUrl)
+        assertThat(externalPaymentSelection.iconResource).isEqualTo(0)
+    }
+
+    @Test
+    fun `transformToPaymentSelection transforms generic payment methods correctly`() {
+        val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
+        val name = "Joe"
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.CardBrand to FormFieldEntry(cardBrand, true),
                 IdentifierSpec.Name to FormFieldEntry(name, true),
             ),
             showsMandate = false,
             userRequestedReuse = customerRequestedSave,
         )
-        val cardPaymentMethod = metadata.supportedPaymentMethodForCode("card")!!
+        val klarnaPaymentMethod = metadata.supportedPaymentMethodForCode("klarna")!!
 
-        val cardPaymentSelection = formFieldValues.transformToPaymentSelection(
+        val klarnaPaymentSelection = formFieldValues.transformToPaymentSelection(
             context,
-            cardPaymentMethod,
+            klarnaPaymentMethod,
             metadata
-        ) as PaymentSelection.New.Card
+        ) as PaymentSelection.New.GenericPaymentMethod
 
-        assertThat(cardPaymentSelection.brand.code).isEqualTo(cardBrand)
-        assertThat(cardPaymentSelection.customerRequestedSave).isEqualTo(customerRequestedSave)
-        assertThat(getNameFromParams(cardPaymentSelection.paymentMethodCreateParams)).isEqualTo(name)
+        assertThat(klarnaPaymentSelection.paymentMethodCreateParams.typeCode).isEqualTo(klarnaPaymentMethod.code)
+        assertThat(klarnaPaymentSelection.labelResource).isEqualTo(klarnaPaymentMethod.displayName.resolve(context))
+        assertThat(klarnaPaymentSelection.lightThemeIconUrl).isEqualTo(klarnaPaymentMethod.lightThemeIconUrl)
+        assertThat(klarnaPaymentSelection.darkThemeIconUrl).isEqualTo(klarnaPaymentMethod.darkThemeIconUrl)
+        assertThat(klarnaPaymentSelection.iconResource).isEqualTo(klarnaPaymentMethod.iconResource)
+        assertThat(getNameFromParams(klarnaPaymentSelection.paymentMethodCreateParams)).isEqualTo(name)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
@@ -1,0 +1,89 @@
+package com.stripe.android.paymentsheet.ui
+
+import android.content.Context
+import androidx.compose.ui.platform.LocalContext
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.definitions.BlikDefinition
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParams.Companion.getNameFromParams
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.PaymentMethodOptionsParams
+import com.stripe.android.paymentsheet.forms.FormFieldValues
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.TextFieldStateConstants
+import com.stripe.android.uicore.forms.FormFieldEntry
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+
+@RunWith(RobolectricTestRunner::class)
+internal class AddPaymentMethodTest {
+
+    val context: Context = getApplicationContext()
+    val metadata = PaymentMethodMetadataFactory.create(
+        stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+            paymentMethodTypes = listOf("card", "klarna")
+        ),
+        externalPaymentMethodSpecs = listOf(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC)
+    )
+
+    @Test
+    fun `transformToPaymentSelection transforms cards correctly`() {
+        val cardBrand = "visa"
+        val name = "Joe"
+        val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
+        val formFieldValues = FormFieldValues(
+            fieldValuePairs = mapOf(
+                IdentifierSpec.CardBrand to FormFieldEntry(cardBrand, true),
+                IdentifierSpec.Name to FormFieldEntry(name, true),
+            ),
+            showsMandate = false,
+            userRequestedReuse = customerRequestedSave,
+        )
+        val cardPaymentMethod = metadata.supportedPaymentMethodForCode("card")!!
+
+        val cardPaymentSelection = formFieldValues.transformToPaymentSelection(
+            context,
+            cardPaymentMethod,
+            metadata
+        ) as PaymentSelection.New.Card
+
+        assertThat(cardPaymentSelection.brand.code).isEqualTo(cardBrand)
+        assertThat(cardPaymentSelection.customerRequestedSave).isEqualTo(customerRequestedSave)
+        assertThat(getNameFromParams(cardPaymentSelection.paymentMethodCreateParams)).isEqualTo(name)
+    }
+
+    @Test
+    fun `transformToPaymentSelection transforms external payment methods correctly`() {
+        // TODO: update to be epms
+        val cardBrand = "visa"
+        val name = "Joe"
+        val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
+        val formFieldValues = FormFieldValues(
+            fieldValuePairs = mapOf(
+                IdentifierSpec.CardBrand to FormFieldEntry(cardBrand, true),
+                IdentifierSpec.Name to FormFieldEntry(name, true),
+            ),
+            showsMandate = false,
+            userRequestedReuse = customerRequestedSave,
+        )
+        val cardPaymentMethod = metadata.supportedPaymentMethodForCode("card")!!
+
+        val cardPaymentSelection = formFieldValues.transformToPaymentSelection(
+            context,
+            cardPaymentMethod,
+            metadata
+        ) as PaymentSelection.New.Card
+
+        assertThat(cardPaymentSelection.brand.code).isEqualTo(cardBrand)
+        assertThat(cardPaymentSelection.customerRequestedSave).isEqualTo(customerRequestedSave)
+        assertThat(getNameFromParams(cardPaymentSelection.paymentMethodCreateParams)).isEqualTo(name)
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add tests for AddPaymentMethod#transformToPaymentSelection

A lot of the logic used in this function is actually in FieldValuesToParamsMapConverter, which is already somewhat tested but I added more tests. I refactoring the filtering of field values that we do in AddPaymentMethod to be in FieldValuesToParamsMapConverter, because in order to test that filtering, you end up testing the internals of FieldValuesToParamsMapConverter. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project 
that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-1987

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified