### PR TITLE
Add `link_context` to analytics events for Instant Debits metrics

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -199,7 +199,7 @@ internal class DefaultEventReporter @Inject internal constructor(
         )
     }
 
-    override fun onPressConfirmButton(paymentSelection: PaymentSelection?,) {
+    override fun onPressConfirmButton(paymentSelection: PaymentSelection?) {
         val duration = durationProvider.end(DurationProvider.Key.ConfirmButtonClicked)
 
         fireEvent(
@@ -207,6 +207,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 currency = currency,
                 duration = duration,
                 selectedLpm = paymentSelection.code(),
+                linkContext = paymentSelection.linkContext(),
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -570,6 +570,7 @@ internal fun PaymentSelection?.linkContext(): String? {
         is PaymentSelection.GooglePay,
         is PaymentSelection.New,
         is PaymentSelection.Saved,
+        is PaymentSelection.ExternalPaymentMethod,
         null -> null
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -382,6 +382,7 @@ class PaymentSheetEventTest {
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
                 "selected_lpm" to "link",
+                "link_context" to "wallet",
             )
         )
     }
@@ -564,6 +565,7 @@ class PaymentSheetEventTest {
                 "google_pay_enabled" to false,
                 "selected_lpm" to "link",
                 "error_message" to "apiError",
+                "link_context" to "wallet",
             )
         )
     }
@@ -1040,6 +1042,7 @@ class PaymentSheetEventTest {
             isDeferred = false,
             linkEnabled = false,
             googlePaySupported = false,
+            linkContext = null,
         )
         assertThat(
             event.eventName
@@ -1069,6 +1072,7 @@ class PaymentSheetEventTest {
             isDeferred = false,
             linkEnabled = false,
             googlePaySupported = false,
+            linkContext = null,
         )
         assertThat(
             event.eventName


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request enhances our logging for Instant Debits.

We now log a `link_context` that tells us whether the transaction with a `link` payment method is coming from a wallet button or from Instant Debits. This field is added for the`confirm_button_tapped` and `payment_success/failure` events.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[BANKCON-10306](https://jira.corp.stripe.com/browse/BANKCON-10306)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
