### PR TITLE
Update rule order to allow network rule failures to pass on retry.

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
@@ -34,15 +34,15 @@ import org.junit.runner.RunWith
 @OptIn(ExperimentalCustomerSheetApi::class)
 @RunWith(TestParameterInjector::class)
 internal class CustomerSheetTest {
+    private val composeTestRule = createEmptyComposeRule()
     private val retryRule = RetryRule(5)
     private val networkRule = NetworkRule()
-    private val composeTestRule = createEmptyComposeRule()
 
     @get:Rule
     val chain: RuleChain = RuleChain.emptyRuleChain()
-        .around(networkRule)
         .around(composeTestRule)
         .around(retryRule)
+        .around(networkRule)
 
     private val page: CustomerSheetPage = CustomerSheetPage(composeTestRule)
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -30,15 +30,15 @@ import java.util.concurrent.TimeUnit
 
 @RunWith(TestParameterInjector::class)
 internal class FlowControllerTest {
+    private val composeTestRule = createEmptyComposeRule()
     private val retryRule = RetryRule(5)
     private val networkRule = NetworkRule()
-    private val composeTestRule = createEmptyComposeRule()
 
     @get:Rule
     val chain: RuleChain = RuleChain.emptyRuleChain()
-        .around(networkRule)
         .around(composeTestRule)
         .around(retryRule)
+        .around(networkRule)
 
     private val page: PaymentSheetPage = PaymentSheetPage(composeTestRule)
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
@@ -32,19 +32,18 @@ import kotlin.time.Duration.Companion.seconds
 
 @RunWith(TestParameterInjector::class)
 internal class LinkTest {
+    private val composeTestRule = createEmptyComposeRule()
     private val retryRule = RetryRule(5)
 
     // The /v1/consumers/sessions/log_out request is launched async from a GlobalScope. We want to make sure it happens,
     // but it's okay if it takes a bit to happen.
     private val networkRule = NetworkRule(validationTimeout = 5.seconds)
 
-    private val composeTestRule = createEmptyComposeRule()
-
     @get:Rule
     val chain: RuleChain = RuleChain.emptyRuleChain()
-        .around(networkRule)
         .around(composeTestRule)
         .around(retryRule)
+        .around(networkRule)
 
     private val page: PaymentSheetPage = PaymentSheetPage(composeTestRule)
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
@@ -28,18 +28,18 @@ import kotlin.time.Duration.Companion.seconds
 
 @RunWith(TestParameterInjector::class)
 internal class PaymentSheetAnalyticsTest {
+    private val composeTestRule = createEmptyComposeRule()
     private val retryRule = RetryRule(5)
     private val networkRule = NetworkRule(
         hostsToTrack = listOf(ApiRequest.API_HOST, AnalyticsRequest.HOST),
         validationTimeout = 1.seconds, // Analytics requests happen async.
     )
-    private val composeTestRule = createEmptyComposeRule()
 
     @get:Rule
     val chain: RuleChain = RuleChain.emptyRuleChain()
-        .around(networkRule)
         .around(composeTestRule)
         .around(retryRule)
+        .around(networkRule)
 
     private val page: PaymentSheetPage = PaymentSheetPage(composeTestRule)
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -26,15 +26,15 @@ import org.junit.runner.RunWith
 
 @RunWith(TestParameterInjector::class)
 internal class PaymentSheetTest {
+    private val composeTestRule = createEmptyComposeRule()
     private val retryRule = RetryRule(5)
     private val networkRule = NetworkRule()
-    private val composeTestRule = createEmptyComposeRule()
 
     @get:Rule
     val chain: RuleChain = RuleChain.emptyRuleChain()
-        .around(networkRule)
         .around(composeTestRule)
         .around(retryRule)
+        .around(networkRule)
 
     private val page: PaymentSheetPage = PaymentSheetPage(composeTestRule)
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I was digging into the CBC test flakes, and noticed network rule failures cause every retry to fail as well.
