### PR TITLE
Add billing details to external payment methods

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/Address.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/Address.kt
@@ -38,6 +38,10 @@ data class Address @VisibleForTesting constructor(
         ).filterValues { it.isNotEmpty() }
     }
 
+    internal fun isFilledOut(): Boolean {
+        return city != null || country != null || line1 != null || line2 != null || postalCode != null || state != null
+    }
+
     class Builder {
         private var city: String? = null
         private var country: String? = null

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -655,6 +655,11 @@ constructor(
                 )
         }
 
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        fun isFilledOut(): Boolean {
+            return (address != null && address.isFilledOut()) || email != null || name != null || phone != null
+        }
+
         class Builder {
             private var address: Address? = null
             private var email: String? = null

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -1157,12 +1157,14 @@ data class PaymentMethodCreateParams internal constructor(
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet
         fun createWithOverride(
             code: PaymentMethodCode,
+            billingDetails: PaymentMethod.BillingDetails?,
             requiresMandate: Boolean,
             overrideParamMap: Map<String, @RawValue Any>?,
             productUsage: Set<String>
         ): PaymentMethodCreateParams {
             return PaymentMethodCreateParams(
                 code = code,
+                billingDetails = billingDetails,
                 requiresMandate = requiresMandate,
                 overrideParamMap = overrideParamMap,
                 productUsage = productUsage

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
@@ -291,6 +291,7 @@ class PaymentMethodCreateParamsTest {
                 )
             ),
             productUsage = setOf(),
+            billingDetails = null,
             requiresMandate = false
         )
 
@@ -325,6 +326,7 @@ class PaymentMethodCreateParamsTest {
                 )
             ),
             productUsage = setOf(),
+            billingDetails = null,
             requiresMandate = false
         )
 
@@ -354,6 +356,7 @@ class PaymentMethodCreateParamsTest {
                 )
             ),
             productUsage = setOf(),
+            billingDetails = null,
             requiresMandate = false
         )
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
@@ -50,7 +50,7 @@ class FieldValuesToParamsMapConverter {
 
         private fun createBillingDetails(
             fieldValuePairs: Map<IdentifierSpec, FormFieldEntry>,
-        ): PaymentMethod.BillingDetails {
+        ): PaymentMethod.BillingDetails? {
             val billingDetails = PaymentMethod.BillingDetails.Builder()
 
             billingDetails.setName(fieldValuePairs[IdentifierSpec.Name]?.value)
@@ -58,7 +58,12 @@ class FieldValuesToParamsMapConverter {
             billingDetails.setPhone(fieldValuePairs[IdentifierSpec.Phone]?.value)
             billingDetails.setAddress(createAddress(fieldValuePairs))
 
-            return billingDetails.build()
+            val builtBillingDetails = billingDetails.build()
+            return if (builtBillingDetails.isFilledOut()) {
+                builtBillingDetails
+            } else {
+                null
+            }
         }
 
         private fun createAddress(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
@@ -2,6 +2,7 @@ package com.stripe.android.ui.core
 
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
+import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -40,10 +41,40 @@ class FieldValuesToParamsMapConverter {
                     PaymentMethodCreateParams.createWithOverride(
                         code,
                         requiresMandate = requiresMandate,
+                        billingDetails = createBillingDetails(fieldValuePairsForCreateParams),
                         overrideParamMap = this,
                         productUsage = setOf("PaymentSheet")
                     )
                 }
+        }
+
+        // TODO: update tests
+        private fun createBillingDetails(
+            fieldValuePairs: Map<IdentifierSpec, FormFieldEntry>,
+        ): PaymentMethod.BillingDetails {
+            val billingDetails = PaymentMethod.BillingDetails.Builder()
+
+            billingDetails.setName(fieldValuePairs[IdentifierSpec.Name]?.value)
+            billingDetails.setEmail(fieldValuePairs[IdentifierSpec.Email]?.value)
+            billingDetails.setPhone(fieldValuePairs[IdentifierSpec.Phone]?.value)
+            billingDetails.setAddress(createAddress(fieldValuePairs))
+
+            return billingDetails.build()
+        }
+
+        private fun createAddress(
+            fieldValuePairs: Map<IdentifierSpec, FormFieldEntry>,
+        ): Address {
+            val address = Address.Builder()
+
+            address.setLine1(fieldValuePairs[IdentifierSpec.Line1]?.value)
+            address.setLine2(fieldValuePairs[IdentifierSpec.Line2]?.value)
+            address.setCity(fieldValuePairs[IdentifierSpec.City]?.value)
+            address.setState(fieldValuePairs[IdentifierSpec.State]?.value)
+            address.setCountry(fieldValuePairs[IdentifierSpec.Country]?.value)
+            address.setPostalCode(fieldValuePairs[IdentifierSpec.PostalCode]?.value)
+
+            return address.build()
         }
 
         /**

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
@@ -48,7 +48,6 @@ class FieldValuesToParamsMapConverter {
                 }
         }
 
-        // TODO: update tests
         private fun createBillingDetails(
             fieldValuePairs: Map<IdentifierSpec, FormFieldEntry>,
         ): PaymentMethod.BillingDetails {

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
@@ -125,7 +125,7 @@ class FieldValuesToParamsMapConverterTest {
                 PaymentMethod.Type.Sofort.requiresMandate
             )
 
-        assertThat(paymentMethodParams.billingDetails?.toParamMap()).isEmpty()
+        assertThat(paymentMethodParams.billingDetails).isNull()
     }
 
     @Test

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
@@ -117,7 +117,7 @@ class FieldValuesToParamsMapConverterTest {
     }
 
     @Test
-    fun `billing details are null if billing details are not collected`() {
+    fun `billing details are empty if billing details are not collected`() {
         val paymentMethodParams = FieldValuesToParamsMapConverter
             .transformToPaymentMethodCreateParams(
                 emptyMap(),
@@ -125,7 +125,7 @@ class FieldValuesToParamsMapConverterTest {
                 PaymentMethod.Type.Sofort.requiresMandate
             )
 
-        assertThat(paymentMethodParams.billingDetails).isNull()
+        assertThat(paymentMethodParams.billingDetails?.toParamMap()).isEmpty()
     }
 
     @Test

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
@@ -117,6 +117,18 @@ class FieldValuesToParamsMapConverterTest {
     }
 
     @Test
+    fun `billing details are null if billing details are not collected`() {
+        val paymentMethodParams = FieldValuesToParamsMapConverter
+            .transformToPaymentMethodCreateParams(
+                emptyMap(),
+                PaymentMethod.Type.Sofort.code,
+                PaymentMethod.Type.Sofort.requiresMandate
+            )
+
+        assertThat(paymentMethodParams.billingDetails).isNull()
+    }
+
+    @Test
     fun `transform to payment method params - ignores options params`() {
         val paymentMethodParams = FieldValuesToParamsMapConverter
             .transformToPaymentMethodCreateParams(

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
@@ -66,23 +66,27 @@ class FieldValuesToParamsMapConverterTest {
 
     @Test
     fun `transform to payment method params`() {
+        val name = "joe"
+        val email = "joe@gmail.com"
+        val country = "US"
+        val line1 = "123 Main Street"
         val paymentMethodParams = FieldValuesToParamsMapConverter
             .transformToPaymentMethodCreateParams(
                 mapOf(
                     IdentifierSpec.Name to FormFieldEntry(
-                        "joe",
+                        name,
                         true
                     ),
                     IdentifierSpec.Email to FormFieldEntry(
-                        "joe@gmail.com",
+                        email,
                         true
                     ),
                     IdentifierSpec.Generic("billing_details[address][country]") to FormFieldEntry(
-                        "US",
+                        country,
                         true
                     ),
                     IdentifierSpec.Line1 to FormFieldEntry(
-                        "123 Main Street",
+                        line1,
                         true
                     )
                 ),
@@ -105,6 +109,11 @@ class FieldValuesToParamsMapConverterTest {
                 "}" +
                 "}"
         )
+        assertThat(paymentMethodParams.billingDetails?.name).isEqualTo(name)
+        assertThat(paymentMethodParams.billingDetails?.email).isEqualTo(email)
+        assertThat(paymentMethodParams.billingDetails?.address?.country).isEqualTo(country)
+        assertThat(paymentMethodParams.billingDetails?.address?.line1).isEqualTo(line1)
+        assertThat(paymentMethodParams.billingDetails?.address?.postalCode).isNull()
     }
 
     @Test

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/FawryActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/FawryActivity.kt
@@ -2,19 +2,25 @@ package com.stripe.android.paymentsheet.example.playground.activity
 
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
 import com.stripe.android.paymentsheet.ExternalPaymentMethodResult
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentSheetExampleTheme
 
 class FawryActivity : AppCompatActivity() {
 
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -25,9 +31,15 @@ class FawryActivity : AppCompatActivity() {
             )
         }
 
+        val billingDetails: PaymentSheet.BillingDetails? =
+            intent.getParcelableExtra(EXTRA_BILLING_DETAILS, PaymentSheet.BillingDetails::class.java)
+
         setContent {
             PaymentSheetExampleTheme {
                 Column {
+                    if (billingDetails != null) {
+                        BillingDetails(billingDetails = billingDetails)
+                    }
                     ResultButton(result = ExternalPaymentMethodResult.Completed)
                     ResultButton(result = ExternalPaymentMethodResult.Canceled)
                     ResultButton(result = ExternalPaymentMethodResult.Failed)
@@ -53,19 +65,28 @@ class FawryActivity : AppCompatActivity() {
         }
     }
 
+    @Composable
+    fun BillingDetails(billingDetails: PaymentSheet.BillingDetails) {
+        Text("Billing details: $billingDetails", color = Color.White)
+    }
+
     companion object {
         private const val EXTRA_EXTERNAL_PAYMENT_METHOD_TYPE = "external_payment_method_type"
+        private const val EXTRA_BILLING_DETAILS = "external_payment_method_billing_details"
     }
 
     object FawryConfirmHandler : ExternalPaymentMethodConfirmHandler {
         override fun createIntent(
             context: Context,
             externalPaymentMethodType: String,
+            billingDetails: PaymentSheet.BillingDetails,
         ): Intent {
             return Intent().setClass(
                 context,
                 FawryActivity::class.java
-            ).putExtra(EXTRA_EXTERNAL_PAYMENT_METHOD_TYPE, externalPaymentMethodType)
+            )
+                .putExtra(EXTRA_EXTERNAL_PAYMENT_METHOD_TYPE, externalPaymentMethodType)
+                .putExtra(EXTRA_BILLING_DETAILS, billingDetails)
         }
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/FawryActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/FawryActivity.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
 import com.stripe.android.paymentsheet.ExternalPaymentMethodResult

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/FawryActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/FawryActivity.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
 import com.stripe.android.paymentsheet.ExternalPaymentMethodResult
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -75,7 +76,7 @@ class FawryActivity : AppCompatActivity() {
         override fun createIntent(
             context: Context,
             externalPaymentMethodType: String,
-            billingDetails: PaymentSheet.BillingDetails,
+            billingDetails: PaymentMethod.BillingDetails?,
         ): Intent {
             return Intent().setClass(
                 context,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/FawryActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/FawryActivity.kt
@@ -2,10 +2,8 @@ package com.stripe.android.paymentsheet.example.playground.activity
 
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
-import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.Button
@@ -19,7 +17,6 @@ import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentSheetExa
 
 class FawryActivity : AppCompatActivity() {
 
-    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -31,7 +28,7 @@ class FawryActivity : AppCompatActivity() {
         }
 
         val billingDetails: PaymentSheet.BillingDetails? =
-            intent.getParcelableExtra(EXTRA_BILLING_DETAILS, PaymentSheet.BillingDetails::class.java)
+            intent.getParcelableExtra(EXTRA_BILLING_DETAILS)
 
         setContent {
             PaymentSheetExampleTheme {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExternalPaymentMethodConfirmHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExternalPaymentMethodConfirmHandler.kt
@@ -11,6 +11,7 @@ interface ExternalPaymentMethodConfirmHandler {
     fun createIntent(
         context: Context,
         externalPaymentMethodType: String,
+        billingDetails: PaymentSheet.BillingDetails,
     ): Intent
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExternalPaymentMethodConfirmHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExternalPaymentMethodConfirmHandler.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import androidx.annotation.RestrictTo
+import com.stripe.android.model.PaymentMethod
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface ExternalPaymentMethodConfirmHandler {
@@ -11,7 +12,7 @@ interface ExternalPaymentMethodConfirmHandler {
     fun createIntent(
         context: Context,
         externalPaymentMethodType: String,
-        billingDetails: PaymentSheet.BillingDetails,
+        billingDetails: PaymentMethod.BillingDetails?,
     ): Intent
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExternalPaymentMethodContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExternalPaymentMethodContract.kt
@@ -12,7 +12,7 @@ internal class ExternalPaymentMethodContract : ActivityResultContract<ExternalPa
         return input.externalPaymentMethodConfirmHandler.createIntent(
             context = context,
             externalPaymentMethodType = input.type,
-            billingDetails = input.billingDetails.toPaymentSheetBillingDetails(),
+            billingDetails = input.billingDetails,
         )
     }
 
@@ -36,31 +36,6 @@ internal class ExternalPaymentMethodContract : ActivityResultContract<ExternalPa
                 )
         }
     }
-}
-
-private fun PaymentMethod.BillingDetails?.toPaymentSheetBillingDetails(): PaymentSheet.BillingDetails {
-    if (this == null) {
-        return PaymentSheet.BillingDetails()
-    }
-
-    val billingDetails = PaymentSheet.BillingDetails.Builder()
-
-    billingDetails.name(this.name)
-    billingDetails.phone(this.phone)
-    billingDetails.email(this.email)
-
-    if (this.address != null) {
-        val address = PaymentSheet.Address.Builder()
-        address.line1(this.address?.line1)
-        address.line2(this.address?.line2)
-        address.city(this.address?.city)
-        address.state(this.address?.state)
-        address.country(this.address?.country)
-        address.postalCode(this.address?.postalCode)
-        billingDetails.address(address)
-    }
-
-    return billingDetails.build()
 }
 
 internal data class ExternalPaymentMethodInput(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExternalPaymentMethodContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExternalPaymentMethodContract.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet
 import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import java.lang.IllegalArgumentException
 
@@ -11,6 +12,7 @@ internal class ExternalPaymentMethodContract : ActivityResultContract<ExternalPa
         return input.externalPaymentMethodConfirmHandler.createIntent(
             context = context,
             externalPaymentMethodType = input.type,
+            billingDetails = input.billingDetails.toPaymentSheetBillingDetails(),
         )
     }
 
@@ -36,7 +38,33 @@ internal class ExternalPaymentMethodContract : ActivityResultContract<ExternalPa
     }
 }
 
+private fun PaymentMethod.BillingDetails?.toPaymentSheetBillingDetails(): PaymentSheet.BillingDetails {
+    if (this == null) {
+        return PaymentSheet.BillingDetails()
+    }
+
+    val billingDetails = PaymentSheet.BillingDetails.Builder()
+
+    billingDetails.name(this.name)
+    billingDetails.phone(this.phone)
+    billingDetails.email(this.email)
+
+    if (this.address != null) {
+        val address = PaymentSheet.Address.Builder()
+        address.line1(this.address?.line1)
+        address.line2(this.address?.line2)
+        address.city(this.address?.city)
+        address.state(this.address?.state)
+        address.country(this.address?.country)
+        address.postalCode(this.address?.postalCode)
+        billingDetails.address(address)
+    }
+
+    return billingDetails.build()
+}
+
 internal data class ExternalPaymentMethodInput(
     val externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler,
     val type: String,
+    val billingDetails: PaymentMethod.BillingDetails?,
 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExternalPaymentMethodInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExternalPaymentMethodInterceptor.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet
 
 import androidx.activity.result.ActivityResultLauncher
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import java.lang.IllegalStateException
 
@@ -10,6 +11,7 @@ internal object ExternalPaymentMethodInterceptor {
 
     fun intercept(
         externalPaymentMethodType: String,
+        billingDetails: PaymentMethod.BillingDetails?,
         onPaymentResult: (PaymentResult) -> Unit,
         externalPaymentMethodLauncher: ActivityResultLauncher<ExternalPaymentMethodInput>?
     ) {
@@ -36,6 +38,7 @@ internal object ExternalPaymentMethodInterceptor {
             externalPaymentMethodLauncher.launch(
                 ExternalPaymentMethodInput(
                     type = externalPaymentMethodType,
+                    billingDetails = billingDetails,
                     externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler
                 )
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -462,6 +462,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         } else if (paymentSelection is PaymentSelection.ExternalPaymentMethod) {
             ExternalPaymentMethodInterceptor.intercept(
                 externalPaymentMethodType = paymentSelection.type,
+                billingDetails = paymentSelection.billingDetails,
                 onPaymentResult = ::onPaymentResult,
                 externalPaymentMethodLauncher,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -340,6 +340,7 @@ internal class DefaultFlowController @Inject internal constructor(
             is PaymentSelection.New.LinkInline -> confirmLink(paymentSelection, state)
             is PaymentSelection.ExternalPaymentMethod -> ExternalPaymentMethodInterceptor.intercept(
                 externalPaymentMethodType = paymentSelection.type,
+                billingDetails = paymentSelection.billingDetails,
                 onPaymentResult = ::onPaymentResult,
                 externalPaymentMethodLauncher = externalPaymentMethodLauncher,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -69,7 +69,6 @@ internal sealed class PaymentSelection : Parcelable {
     @Parcelize
     data class ExternalPaymentMethod(
         val type: String,
-        // TODO: thread through to payment method input, etc
         val billingDetails: PaymentMethod.BillingDetails?,
         val label: String,
         // In practice, we don't have an iconResource for external payment methods.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -13,6 +13,7 @@ import com.stripe.android.model.PaymentMethod.Type.USBankAccount
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormScreenState
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountTextBuilder
@@ -68,6 +69,8 @@ internal sealed class PaymentSelection : Parcelable {
     @Parcelize
     data class ExternalPaymentMethod(
         val type: String,
+        // TODO: thread through to payment method input, etc
+        val billingDetails: PaymentMethod.BillingDetails?,
         val label: String,
         // In practice, we don't have an iconResource for external payment methods.
         @DrawableRes val iconResource: Int,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -13,7 +13,6 @@ import com.stripe.android.model.PaymentMethod.Type.USBankAccount
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormScreenState
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountTextBuilder

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -205,8 +205,10 @@ internal fun FormFieldValues.transformToPaymentSelection(
             customerRequestedSave = userRequestedReuse,
         )
     } else if (paymentMethodMetadata.isExternalPaymentMethod(paymentMethod.code)) {
+        // TODO: update tests to show that billingDetails exists now
         PaymentSelection.ExternalPaymentMethod(
             type = paymentMethod.code,
+            billingDetails = params.billingDetails,
             label = paymentMethod.displayName.resolve(context),
             iconResource = paymentMethod.iconResource,
             lightThemeIconUrl = paymentMethod.lightThemeIconUrl,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -205,7 +205,6 @@ internal fun FormFieldValues.transformToPaymentSelection(
             customerRequestedSave = userRequestedReuse,
         )
     } else if (paymentMethodMetadata.isExternalPaymentMethod(paymentMethod.code)) {
-        // TODO: update tests to show that billingDetails exists now
         PaymentSelection.ExternalPaymentMethod(
             type = paymentMethod.code,
             billingDetails = params.billingDetails,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/InitialValuesFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/InitialValuesFactoryTest.kt
@@ -38,9 +38,10 @@ class InitialValuesFactoryTest {
     )
 
     private val paymentMethodCreateParams = PaymentMethodCreateParams.createWithOverride(
-        PaymentMethod.Type.Card.code,
-        PaymentMethod.Type.Card.requiresMandate,
-        mapOf(
+        code = PaymentMethod.Type.Card.code,
+        billingDetails = null,
+        requiresMandate = PaymentMethod.Type.Card.requiresMandate,
+        overrideParamMap = mapOf(
             "type" to "card",
             parameterMapBillingDetails,
             "card" to mapOf(
@@ -50,7 +51,7 @@ class InitialValuesFactoryTest {
                 "cvc" to "111"
             )
         ),
-        emptySet()
+        productUsage = emptySet(),
     )
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardUiDefinitionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardUiDefinitionFactoryTest.kt
@@ -35,6 +35,8 @@ class CardUiDefinitionFactoryTest {
                 metadata = metadata,
                 paymentMethodCreateParams = PaymentMethodCreateParams.createWithOverride(
                     code = "card",
+                    // TODO: should we set billing details here instead of in the map?
+                    billingDetails = null,
                     requiresMandate = false,
                     overrideParamMap = mapOf(
                         "type" to "card",

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardUiDefinitionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardUiDefinitionFactoryTest.kt
@@ -35,7 +35,6 @@ class CardUiDefinitionFactoryTest {
                 metadata = metadata,
                 paymentMethodCreateParams = PaymentMethodCreateParams.createWithOverride(
                     code = "card",
-                    // TODO: should we set billing details here instead of in the map?
                     billingDetails = null,
                     requiresMandate = false,
                     overrideParamMap = mapOf(

--- a/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
@@ -498,6 +498,7 @@ internal object PaymentMethodFixtures {
             iconResource = 0,
             lightThemeIconUrl = spec.lightImageUrl,
             darkThemeIconUrl = spec.darkImageUrl,
+            billingDetails = null,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
@@ -56,8 +56,10 @@ internal class AddPaymentMethodTest {
     fun `transformToPaymentSelection transforms external payment methods correctly`() {
         val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
         val paypalSpec = PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC
+        val name = "Joe"
+        val addressLine1 = "123 Main Street"
         val formFieldValues = FormFieldValues(
-            fieldValuePairs = mapOf(),
+            fieldValuePairs = mapOf(IdentifierSpec.Name to FormFieldEntry(name, true), IdentifierSpec.Line1 to FormFieldEntry(addressLine1, true)),
             showsMandate = false,
             userRequestedReuse = customerRequestedSave,
         )
@@ -75,6 +77,8 @@ internal class AddPaymentMethodTest {
         assertThat(externalPaymentSelection.lightThemeIconUrl).isEqualTo(paypalSpec.lightImageUrl)
         assertThat(externalPaymentSelection.darkThemeIconUrl).isEqualTo(paypalSpec.darkImageUrl)
         assertThat(externalPaymentSelection.iconResource).isEqualTo(0)
+        assertThat(externalPaymentSelection.billingDetails?.name).isEqualTo(name)
+        assertThat(externalPaymentSelection.billingDetails?.address?.line1).isEqualTo(addressLine1)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
@@ -59,7 +59,10 @@ internal class AddPaymentMethodTest {
         val name = "Joe"
         val addressLine1 = "123 Main Street"
         val formFieldValues = FormFieldValues(
-            fieldValuePairs = mapOf(IdentifierSpec.Name to FormFieldEntry(name, true), IdentifierSpec.Line1 to FormFieldEntry(addressLine1, true)),
+            fieldValuePairs = mapOf(
+                IdentifierSpec.Name to FormFieldEntry(name, true),
+                IdentifierSpec.Line1 to FormFieldEntry(addressLine1, true)
+            ),
             showsMandate = false,
             userRequestedReuse = customerRequestedSave,
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Thread billing details from the UI to the ExternalPaymentMethodConfirmHandler

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. --> 
https://jira.corp.stripe.com/browse/MOBILESDK-1994

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

Manually verified in the playground app by:
- setting billing address collection to "full"
- confirming payment for Fawry and confirming that billing address details showed up correctly in the FawryActivity