### PR TITLE
Add `CustomerSheetEvent.Init` & update `PaymentSheetEvent.Init` with missing fields

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/analytics/AnalyticsKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/analytics/AnalyticsKtx.kt
@@ -1,0 +1,67 @@
+package com.stripe.android.common.analytics
+
+import com.stripe.android.model.CardBrand
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.uicore.StripeThemeDefaults
+
+internal const val FIELD_APPEARANCE_USAGE = "usage"
+internal const val FIELD_COLORS_LIGHT = "colorsLight"
+internal const val FIELD_COLORS_DARK = "colorsDark"
+internal const val FIELD_CORNER_RADIUS = "corner_radius"
+internal const val FIELD_BORDER_WIDTH = "border_width"
+internal const val FIELD_FONT = "font"
+internal const val FIELD_SIZE_SCALE_FACTOR = "size_scale_factor"
+internal const val FIELD_PRIMARY_BUTTON = "primary_button"
+internal const val FIELD_ATTACH_DEFAULTS = "attach_defaults"
+internal const val FIELD_COLLECT_NAME = "name"
+internal const val FIELD_COLLECT_EMAIL = "email"
+internal const val FIELD_COLLECT_PHONE = "phone"
+internal const val FIELD_COLLECT_ADDRESS = "address"
+
+internal fun PaymentSheet.Appearance.toAnalyticsMap(): Map<String, Any?> {
+    val primaryButtonConfig = primaryButton
+
+    val primaryButtonConfigMap = mapOf(
+        FIELD_COLORS_LIGHT to (primaryButton.colorsLight != PaymentSheet.PrimaryButtonColors.defaultLight),
+        FIELD_COLORS_DARK to (primaryButton.colorsDark != PaymentSheet.PrimaryButtonColors.defaultDark),
+        FIELD_CORNER_RADIUS to (primaryButtonConfig.shape.cornerRadiusDp != null),
+        FIELD_BORDER_WIDTH to (primaryButtonConfig.shape.borderStrokeWidthDp != null),
+        FIELD_FONT to (primaryButtonConfig.typography.fontResId != null)
+    )
+
+    val appearanceConfigMap = mutableMapOf(
+        FIELD_COLORS_LIGHT to (colorsLight != PaymentSheet.Colors.defaultLight),
+        FIELD_COLORS_DARK to (colorsDark != PaymentSheet.Colors.defaultDark),
+        FIELD_CORNER_RADIUS to (shapes.cornerRadiusDp != StripeThemeDefaults.shapes.cornerRadius),
+        FIELD_BORDER_WIDTH to (shapes.borderStrokeWidthDp != StripeThemeDefaults.shapes.borderStrokeWidth),
+        FIELD_FONT to (typography.fontResId != null),
+        FIELD_SIZE_SCALE_FACTOR to (typography.sizeScaleFactor != StripeThemeDefaults.typography.fontSizeMultiplier),
+        FIELD_PRIMARY_BUTTON to primaryButtonConfigMap
+    )
+
+    // We add a usage field to make queries easier.
+    val usedPrimaryButtonApi = primaryButtonConfigMap.values.contains(true)
+    val usedAppearanceApi = appearanceConfigMap.values.filterIsInstance<Boolean>().contains(true)
+
+    appearanceConfigMap[FIELD_APPEARANCE_USAGE] = usedAppearanceApi || usedPrimaryButtonApi
+
+    return appearanceConfigMap
+}
+
+internal fun PaymentSheet.BillingDetailsCollectionConfiguration.toAnalyticsMap(): Map<String, Any?> {
+    return mapOf(
+        FIELD_ATTACH_DEFAULTS to attachDefaultsToPaymentMethod,
+        FIELD_COLLECT_NAME to name.name,
+        FIELD_COLLECT_EMAIL to email.name,
+        FIELD_COLLECT_PHONE to phone.name,
+        FIELD_COLLECT_ADDRESS to address.name,
+    )
+}
+
+internal fun List<CardBrand>.toAnalyticsValue(): String? {
+    return takeIf { brands ->
+        brands.isNotEmpty()
+    }?.joinToString { brand ->
+        brand.code
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEvent.kt
@@ -1,11 +1,40 @@
 package com.stripe.android.customersheet.analytics
 
+import com.stripe.android.common.analytics.toAnalyticsMap
+import com.stripe.android.common.analytics.toAnalyticsValue
 import com.stripe.android.core.networking.AnalyticsEvent
+import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.model.CardBrand
 
 internal sealed class CustomerSheetEvent : AnalyticsEvent {
 
     abstract val additionalParams: Map<String, Any?>
+
+    @OptIn(ExperimentalCustomerSheetApi::class)
+    class Init(
+        private val configuration: CustomerSheet.Configuration,
+    ) : CustomerSheetEvent() {
+        override val eventName: String = CS_INIT
+        override val additionalParams: Map<String, Any?>
+            get() {
+                val configurationMap = mapOf(
+                    FIELD_GOOGLE_PAY_ENABLED to configuration.googlePayEnabled,
+                    FIELD_BILLING to configuration.defaultBillingDetails.isFilledOut(),
+                    FIELD_APPEARANCE to configuration.appearance.toAnalyticsMap(),
+                    FIELD_ALLOWS_REMOVAL_OF_LAST_SAVED_PAYMENT_METHOD to
+                        configuration.allowsRemovalOfLastSavedPaymentMethod,
+                    FIELD_PAYMENT_METHOD_ORDER to configuration.paymentMethodOrder,
+                    FIELD_BILLING_DETAILS_COLLECTION_CONFIGURATION to (
+                        configuration.billingDetailsCollectionConfiguration.toAnalyticsMap()
+                        ),
+                    FIELD_PREFERRED_NETWORKS to configuration.preferredNetworks.toAnalyticsValue()
+                )
+                return mapOf(
+                    FIELD_CUSTOMER_SHEET_CONFIGURATION to configurationMap,
+                )
+            }
+    }
 
     class ScreenPresented(
         screen: CustomerSheetEventReporter.Screen,
@@ -162,6 +191,8 @@ internal sealed class CustomerSheetEvent : AnalyticsEvent {
     }
 
     internal companion object {
+        const val CS_INIT = "cs_init"
+
         const val CS_ADD_PAYMENT_METHOD_SCREEN_PRESENTED =
             "cs_add_payment_method_screen_presented"
         const val CS_SELECT_PAYMENT_METHOD_SCREEN_PRESENTED =
@@ -206,6 +237,14 @@ internal sealed class CustomerSheetEvent : AnalyticsEvent {
         const val CS_UPDATE_PAYMENT_METHOD = "cs_update_card"
         const val CS_UPDATE_PAYMENT_METHOD_FAILED = "cs_update_card_failed"
 
+        const val FIELD_GOOGLE_PAY_ENABLED = "google_pay_enabled"
+        const val FIELD_BILLING = "default_billing_details"
+        const val FIELD_PREFERRED_NETWORKS = "preferred_networks"
+        const val FIELD_CUSTOMER_SHEET_CONFIGURATION = "cs_config"
+        const val FIELD_APPEARANCE = "appearance"
+        const val FIELD_PAYMENT_METHOD_ORDER = "payment_method_order"
+        const val FIELD_BILLING_DETAILS_COLLECTION_CONFIGURATION = "billing_details_collection_configuration"
+        const val FIELD_ALLOWS_REMOVAL_OF_LAST_SAVED_PAYMENT_METHOD = "allows_removal_of_last_saved_payment_method"
         const val FIELD_CBC_EVENT_SOURCE = "cbc_event_source"
         const val FIELD_SELECTED_CARD_BRAND = "selected_card_brand"
         const val FIELD_ERROR_MESSAGE = "error_message"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.paymentsheet.analytics
 
+import com.stripe.android.common.analytics.toAnalyticsMap
+import com.stripe.android.common.analytics.toAnalyticsValue
 import com.stripe.android.core.networking.AnalyticsEvent
 import com.stripe.android.model.CardBrand
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -7,7 +9,6 @@ import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.asPaymentSheetLoadingException
-import com.stripe.android.uicore.StripeThemeDefaults
 import com.stripe.android.utils.filterNotNullValues
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
@@ -98,91 +99,23 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
         override val additionalParams: Map<String, Any?>
             get() {
-                val primaryButtonConfig = configuration.appearance.primaryButton
-                val primaryButtonConfigMap = mapOf(
-                    FIELD_COLORS_LIGHT to (
-                        primaryButtonConfig.colorsLight
-                            != PaymentSheet.PrimaryButtonColors.defaultLight
-                        ),
-                    FIELD_COLORS_DARK to (
-                        primaryButtonConfig.colorsDark
-                            != PaymentSheet.PrimaryButtonColors.defaultDark
-                        ),
-                    FIELD_CORNER_RADIUS to (primaryButtonConfig.shape.cornerRadiusDp != null),
-                    FIELD_BORDER_WIDTH to (primaryButtonConfig.shape.borderStrokeWidthDp != null),
-                    FIELD_FONT to (primaryButtonConfig.typography.fontResId != null)
-                )
-                val appearanceConfigMap = mutableMapOf(
-                    FIELD_COLORS_LIGHT to (
-                        configuration.appearance.colorsLight
-                            != PaymentSheet.Colors.defaultLight
-                        ),
-                    FIELD_COLORS_DARK to (
-                        configuration.appearance.colorsDark
-                            != PaymentSheet.Colors.defaultDark
-                        ),
-                    FIELD_CORNER_RADIUS to (
-                        configuration.appearance.shapes.cornerRadiusDp
-                            != StripeThemeDefaults.shapes.cornerRadius
-                        ),
-                    FIELD_BORDER_WIDTH to (
-                        configuration.appearance.shapes.borderStrokeWidthDp
-                            != StripeThemeDefaults.shapes.borderStrokeWidth
-                        ),
-                    FIELD_FONT to (configuration.appearance.typography.fontResId != null),
-                    FIELD_SIZE_SCALE_FACTOR to (
-                        configuration.appearance.typography.sizeScaleFactor
-                            != StripeThemeDefaults.typography.fontSizeMultiplier
-                        ),
-                    FIELD_PRIMARY_BUTTON to primaryButtonConfigMap
-                )
-                // We add a usage field to make queries easier.
-                val usedPrimaryButtonApi = primaryButtonConfigMap.values.contains(true)
-                val usedAppearanceApi = appearanceConfigMap
-                    .values.filterIsInstance<Boolean>().contains(true)
-
-                appearanceConfigMap[FIELD_APPEARANCE_USAGE] =
-                    usedAppearanceApi || usedPrimaryButtonApi
-
-                val billingDetailsCollectionConfigMap = mapOf(
-                    FIELD_ATTACH_DEFAULTS to configuration
-                        .billingDetailsCollectionConfiguration
-                        .attachDefaultsToPaymentMethod,
-                    FIELD_COLLECT_NAME to configuration
-                        .billingDetailsCollectionConfiguration
-                        .name
-                        .name,
-                    FIELD_COLLECT_EMAIL to configuration
-                        .billingDetailsCollectionConfiguration
-                        .email
-                        .name,
-                    FIELD_COLLECT_PHONE to configuration
-                        .billingDetailsCollectionConfiguration
-                        .phone
-                        .name,
-                    FIELD_COLLECT_ADDRESS to configuration
-                        .billingDetailsCollectionConfiguration
-                        .address
-                        .name,
-                )
-
-                val preferredNetworks = configuration.preferredNetworks.takeIf { brands ->
-                    brands.isNotEmpty()
-                }?.joinToString { brand ->
-                    brand.code
-                }
-
                 @Suppress("DEPRECATION")
                 val configurationMap = mapOf(
                     FIELD_CUSTOMER to (configuration.customer != null),
                     FIELD_GOOGLE_PAY to (configuration.googlePay != null),
                     FIELD_PRIMARY_BUTTON_COLOR to (configuration.primaryButtonColor != null),
                     FIELD_BILLING to (configuration.defaultBillingDetails?.isFilledOut() == true),
-                    FIELD_DELAYED_PMS to (configuration.allowsDelayedPaymentMethods),
-                    FIELD_APPEARANCE to appearanceConfigMap,
-                    FIELD_BILLING_DETAILS_COLLECTION_CONFIGURATION to
-                        billingDetailsCollectionConfigMap,
-                    FIELD_PREFERRED_NETWORKS to preferredNetworks
+                    FIELD_DELAYED_PMS to configuration.allowsDelayedPaymentMethods,
+                    FIELD_APPEARANCE to configuration.appearance.toAnalyticsMap(),
+                    FIELD_PAYMENT_METHOD_ORDER to configuration.paymentMethodOrder,
+                    FIELD_ALLOWS_PAYMENT_METHODS_REQUIRING_SHIPPING_ADDRESS to
+                        configuration.allowsPaymentMethodsRequiringShippingAddress,
+                    FIELD_ALLOWS_REMOVAL_OF_LAST_SAVED_PAYMENT_METHOD to
+                        configuration.allowsRemovalOfLastSavedPaymentMethod,
+                    FIELD_BILLING_DETAILS_COLLECTION_CONFIGURATION to (
+                        configuration.billingDetailsCollectionConfiguration.toAnalyticsMap()
+                        ),
+                    FIELD_PREFERRED_NETWORKS to configuration.preferredNetworks.toAnalyticsValue()
                 )
                 return mapOf(
                     FIELD_MOBILE_PAYMENT_ELEMENT_CONFIGURATION to configurationMap,
@@ -509,23 +442,15 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_DELAYED_PMS = "allows_delayed_payment_methods"
         const val FIELD_MOBILE_PAYMENT_ELEMENT_CONFIGURATION = "mpe_config"
         const val FIELD_APPEARANCE = "appearance"
-        const val FIELD_APPEARANCE_USAGE = "usage"
-        const val FIELD_COLORS_LIGHT = "colorsLight"
-        const val FIELD_COLORS_DARK = "colorsDark"
-        const val FIELD_CORNER_RADIUS = "corner_radius"
-        const val FIELD_BORDER_WIDTH = "border_width"
-        const val FIELD_FONT = "font"
-        const val FIELD_SIZE_SCALE_FACTOR = "size_scale_factor"
-        const val FIELD_PRIMARY_BUTTON = "primary_button"
+        const val FIELD_ALLOWS_PAYMENT_METHODS_REQUIRING_SHIPPING_ADDRESS =
+            "allows_payment_methods_requiring_shipping_address"
+        const val FIELD_ALLOWS_REMOVAL_OF_LAST_SAVED_PAYMENT_METHOD =
+            "allows_removal_of_last_saved_payment_method"
         const val FIELD_BILLING_DETAILS_COLLECTION_CONFIGURATION =
             "billing_details_collection_configuration"
+        const val FIELD_PAYMENT_METHOD_ORDER = "payment_method_order"
         const val FIELD_IS_DECOUPLED = "is_decoupled"
         const val FIELD_DEFERRED_INTENT_CONFIRMATION_TYPE = "deferred_intent_confirmation_type"
-        const val FIELD_ATTACH_DEFAULTS = "attach_defaults"
-        const val FIELD_COLLECT_NAME = "name"
-        const val FIELD_COLLECT_EMAIL = "email"
-        const val FIELD_COLLECT_PHONE = "phone"
-        const val FIELD_COLLECT_ADDRESS = "address"
         const val FIELD_DURATION = "duration"
         const val FIELD_LINK_ENABLED = "link_enabled"
         const val FIELD_CURRENCY = "currency"

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetFixtures.kt
@@ -1,0 +1,62 @@
+package com.stripe.android.customersheet
+
+import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
+import com.stripe.android.model.CardBrand
+import com.stripe.android.paymentsheet.PaymentSheet
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+internal object CustomerSheetFixtures {
+    val MINIMUM_CONFIG = CustomerSheet.Configuration
+        .builder(merchantDisplayName = "Merchant, Inc")
+        .build()
+
+    val CONFIG_WITH_GOOGLE_PAY_ENABLED = CustomerSheet.Configuration
+        .builder(merchantDisplayName = "Merchant, Inc")
+        .googlePayEnabled(googlePayConfiguration = true)
+        .build()
+
+    @OptIn(ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi::class)
+    val CONFIG_WITH_EVERYTHING = CustomerSheet.Configuration
+        .builder(merchantDisplayName = "Merchant, Inc")
+        .defaultBillingDetails(PaymentSheet.BillingDetails(name = "Skyler"))
+        .headerTextForSelectionScreen("Select a payment method!")
+        .appearance(
+            PaymentSheet.Appearance(
+                colorsLight = PaymentSheet.Colors.defaultLight.copy(primary = 0),
+                colorsDark = PaymentSheet.Colors.defaultDark.copy(primary = 0),
+                shapes = PaymentSheet.Shapes(
+                    cornerRadiusDp = 0.0f,
+                    borderStrokeWidthDp = 0.0f
+                ),
+                typography = PaymentSheet.Typography.default.copy(
+                    sizeScaleFactor = 1.1f,
+                    fontResId = 0
+                ),
+                primaryButton = PaymentSheet.PrimaryButton(
+                    colorsLight = PaymentSheet.PrimaryButtonColors.defaultLight.copy(background = 0),
+                    colorsDark = PaymentSheet.PrimaryButtonColors.defaultLight.copy(background = 0),
+                    shape = PaymentSheet.PrimaryButtonShape(
+                        cornerRadiusDp = 0.0f,
+                        borderStrokeWidthDp = 20.0f
+                    ),
+                    typography = PaymentSheet.PrimaryButtonTypography(
+                        fontResId = 0
+                    )
+                )
+            )
+        )
+        .billingDetailsCollectionConfiguration(
+            PaymentSheet.BillingDetailsCollectionConfiguration(
+                name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                attachDefaultsToPaymentMethod = true,
+            )
+        )
+        .preferredNetworks(listOf(CardBrand.CartesBancaires, CardBrand.Visa))
+        .allowsRemovalOfLastSavedPaymentMethod(false)
+        .paymentMethodOrder(listOf("klarna", "afterpay", "card"))
+        .googlePayEnabled(googlePayConfiguration = true)
+        .build()
+}

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/analytics/CustomerSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/analytics/CustomerSheetEventTest.kt
@@ -1,0 +1,143 @@
+package com.stripe.android.customersheet.analytics
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.customersheet.CustomerSheetFixtures
+import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import kotlin.test.Test
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+class CustomerSheetEventTest {
+    @Test
+    fun `Init event with full config should return expected params`() {
+        val event = CustomerSheetEvent.Init(
+            configuration = CustomerSheetFixtures.CONFIG_WITH_GOOGLE_PAY_ENABLED,
+        )
+
+        assertThat(event.eventName).isEqualTo("cs_init")
+
+        val expectedConfigAnalyticsValue = mapOf(
+            "google_pay_enabled" to true,
+            "default_billing_details" to false,
+            "appearance" to mapOf(
+                "colorsLight" to false,
+                "colorsDark" to false,
+                "corner_radius" to false,
+                "border_width" to false,
+                "font" to false,
+                "size_scale_factor" to false,
+                "primary_button" to mapOf(
+                    "colorsLight" to false,
+                    "colorsDark" to false,
+                    "corner_radius" to false,
+                    "border_width" to false,
+                    "font" to false,
+                ),
+                "usage" to false,
+            ),
+            "payment_method_order" to listOf<String>(),
+            "allows_removal_of_last_saved_payment_method" to true,
+            "billing_details_collection_configuration" to mapOf(
+                "attach_defaults" to false,
+                "name" to "Automatic",
+                "email" to "Automatic",
+                "phone" to "Automatic",
+                "address" to "Automatic",
+            ),
+            "preferred_networks" to null,
+        )
+
+        assertThat(event.additionalParams)
+            .containsEntry("cs_config", expectedConfigAnalyticsValue)
+    }
+
+    @Test
+    fun `Init event with minimum config should return expected params`() {
+        val event = CustomerSheetEvent.Init(
+            configuration = CustomerSheetFixtures.MINIMUM_CONFIG,
+        )
+
+        assertThat(event.eventName).isEqualTo("cs_init")
+
+        val expectedConfigAnalyticsValue = mapOf(
+            "google_pay_enabled" to false,
+            "default_billing_details" to false,
+            "appearance" to mapOf(
+                "colorsLight" to false,
+                "colorsDark" to false,
+                "corner_radius" to false,
+                "border_width" to false,
+                "font" to false,
+                "size_scale_factor" to false,
+                "primary_button" to mapOf(
+                    "colorsLight" to false,
+                    "colorsDark" to false,
+                    "corner_radius" to false,
+                    "border_width" to false,
+                    "font" to false,
+                ),
+                "usage" to false,
+            ),
+            "payment_method_order" to listOf<String>(),
+            "allows_removal_of_last_saved_payment_method" to true,
+            "billing_details_collection_configuration" to mapOf(
+                "attach_defaults" to false,
+                "name" to "Automatic",
+                "email" to "Automatic",
+                "phone" to "Automatic",
+                "address" to "Automatic",
+            ),
+            "preferred_networks" to null,
+        )
+
+        assertThat(event.additionalParams)
+            .containsEntry("cs_config", expectedConfigAnalyticsValue)
+    }
+
+    @Test
+    fun `Init event should should mark all optional params present if they are there`() {
+        val expectedPrimaryButton = mapOf(
+            "colorsLight" to true,
+            "colorsDark" to true,
+            "corner_radius" to true,
+            "border_width" to true,
+            "font" to true
+        )
+
+        val expectedAppearance = mapOf(
+            "colorsLight" to true,
+            "colorsDark" to true,
+            "corner_radius" to true,
+            "border_width" to true,
+            "font" to true,
+            "size_scale_factor" to true,
+            "primary_button" to expectedPrimaryButton,
+            "usage" to true
+        )
+
+        val expectedBillingDetailsCollection = mapOf(
+            "attach_defaults" to true,
+            "name" to "Always",
+            "email" to "Always",
+            "phone" to "Always",
+            "address" to "Full",
+        )
+
+        val expectedConfigMap = mapOf(
+            "google_pay_enabled" to true,
+            "default_billing_details" to true,
+            "appearance" to expectedAppearance,
+            "allows_removal_of_last_saved_payment_method" to false,
+            "payment_method_order" to listOf("klarna", "afterpay", "card"),
+            "billing_details_collection_configuration" to expectedBillingDetailsCollection,
+            "preferred_networks" to "cartes_bancaires, visa",
+        )
+
+        val event = CustomerSheetEvent.Init(CustomerSheetFixtures.CONFIG_WITH_EVERYTHING)
+
+        assertThat(event.additionalParams).isEqualTo(
+            mapOf(
+                "cs_config" to expectedConfigMap,
+            )
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -41,6 +41,9 @@ internal object PaymentSheetFixtures {
         primaryButtonColor = ColorStateList.valueOf(Color.BLACK),
         defaultBillingDetails = PaymentSheet.BillingDetails(name = "Skyler"),
         allowsDelayedPaymentMethods = true,
+        allowsPaymentMethodsRequiringShippingAddress = true,
+        allowsRemovalOfLastSavedPaymentMethod = false,
+        paymentMethodOrder = listOf("klarna", "afterpay", "card"),
         appearance = PaymentSheet.Appearance(
             colorsLight = PaymentSheet.Colors.defaultLight.copy(primary = 0),
             colorsDark = PaymentSheet.Colors.defaultDark.copy(primary = 0),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -59,6 +59,9 @@ class PaymentSheetEventTest {
                 ),
                 "usage" to false,
             ),
+            "payment_method_order" to listOf<String>(),
+            "allows_payment_methods_requiring_shipping_address" to false,
+            "allows_removal_of_last_saved_payment_method" to true,
             "billing_details_collection_configuration" to mapOf(
                 "attach_defaults" to false,
                 "name" to "Automatic",
@@ -79,6 +82,65 @@ class PaymentSheetEventTest {
 
     @Test
     fun `Init event with minimum config should return expected params`() {
+        val event = PaymentSheetEvent.Init(
+            mode = EventReporter.Mode.Complete,
+            configuration = PaymentSheetFixtures.CONFIG_MINIMUM,
+            isDeferred = false,
+            linkEnabled = false,
+            googlePaySupported = false,
+        )
+
+        assertThat(
+            event.eventName
+        ).isEqualTo(
+            "mc_complete_init_default"
+        )
+
+        val expectedConfig = mapOf(
+            "customer" to false,
+            "googlepay" to false,
+            "primary_button_color" to false,
+            "default_billing_details" to false,
+            "allows_delayed_payment_methods" to false,
+            "appearance" to mapOf(
+                "colorsLight" to false,
+                "colorsDark" to false,
+                "corner_radius" to false,
+                "border_width" to false,
+                "font" to false,
+                "size_scale_factor" to false,
+                "primary_button" to mapOf(
+                    "colorsLight" to false,
+                    "colorsDark" to false,
+                    "corner_radius" to false,
+                    "border_width" to false,
+                    "font" to false,
+                ),
+                "usage" to false,
+            ),
+            "payment_method_order" to listOf<String>(),
+            "allows_payment_methods_requiring_shipping_address" to false,
+            "allows_removal_of_last_saved_payment_method" to true,
+            "billing_details_collection_configuration" to mapOf(
+                "attach_defaults" to false,
+                "name" to "Automatic",
+                "email" to "Automatic",
+                "phone" to "Automatic",
+                "address" to "Automatic",
+            ),
+            "preferred_networks" to null,
+        )
+
+        assertThat(event.params).run {
+            containsEntry("link_enabled", false)
+            containsEntry("google_pay_enabled", false)
+            containsEntry("is_decoupled", false)
+            containsEntry("mpe_config", expectedConfig)
+        }
+    }
+
+    @Test
+    fun `Init event with preferred networks`() {
         val event = PaymentSheetEvent.Init(
             mode = EventReporter.Mode.Complete,
             configuration = PaymentSheetFixtures.CONFIG_MINIMUM.copy(
@@ -117,6 +179,9 @@ class PaymentSheetEventTest {
                 ),
                 "usage" to false,
             ),
+            "payment_method_order" to listOf<String>(),
+            "allows_payment_methods_requiring_shipping_address" to false,
+            "allows_removal_of_last_saved_payment_method" to true,
             "billing_details_collection_configuration" to mapOf(
                 "attach_defaults" to false,
                 "name" to "Automatic",
@@ -125,62 +190,6 @@ class PaymentSheetEventTest {
                 "address" to "Automatic",
             ),
             "preferred_networks" to "cartes_bancaires, visa",
-        )
-
-        assertThat(event.params).run {
-            containsEntry("link_enabled", false)
-            containsEntry("google_pay_enabled", false)
-            containsEntry("is_decoupled", false)
-            containsEntry("mpe_config", expectedConfig)
-        }
-    }
-
-    @Test
-    fun `Init event with preferred networks`() {
-        val event = PaymentSheetEvent.Init(
-            mode = EventReporter.Mode.Complete,
-            configuration = PaymentSheetFixtures.CONFIG_MINIMUM,
-            isDeferred = false,
-            linkEnabled = false,
-            googlePaySupported = false,
-        )
-
-        assertThat(
-            event.eventName
-        ).isEqualTo(
-            "mc_complete_init_default"
-        )
-
-        val expectedConfig = mapOf(
-            "customer" to false,
-            "googlepay" to false,
-            "primary_button_color" to false,
-            "default_billing_details" to false,
-            "allows_delayed_payment_methods" to false,
-            "appearance" to mapOf(
-                "colorsLight" to false,
-                "colorsDark" to false,
-                "corner_radius" to false,
-                "border_width" to false,
-                "font" to false,
-                "size_scale_factor" to false,
-                "primary_button" to mapOf(
-                    "colorsLight" to false,
-                    "colorsDark" to false,
-                    "corner_radius" to false,
-                    "border_width" to false,
-                    "font" to false,
-                ),
-                "usage" to false,
-            ),
-            "billing_details_collection_configuration" to mapOf(
-                "attach_defaults" to false,
-                "name" to "Automatic",
-                "email" to "Automatic",
-                "phone" to "Automatic",
-                "address" to "Automatic",
-            ),
-            "preferred_networks" to null,
         )
 
         assertThat(event.params).run {
@@ -957,6 +966,9 @@ class PaymentSheetEventTest {
             "primary_button_color" to false,
             "default_billing_details" to false,
             "allows_delayed_payment_methods" to false,
+            "payment_method_order" to listOf<String>(),
+            "allows_payment_methods_requiring_shipping_address" to false,
+            "allows_removal_of_last_saved_payment_method" to true,
             "appearance" to expectedAppearance,
             "billing_details_collection_configuration" to expectedBillingDetailsCollection,
             "preferred_networks" to null,
@@ -1011,6 +1023,9 @@ class PaymentSheetEventTest {
             "primary_button_color" to true,
             "default_billing_details" to true,
             "allows_delayed_payment_methods" to true,
+            "payment_method_order" to listOf("klarna", "afterpay", "card"),
+            "allows_payment_methods_requiring_shipping_address" to true,
+            "allows_removal_of_last_saved_payment_method" to false,
             "appearance" to expectedAppearance,
             "billing_details_collection_configuration" to expectedBillingDetailsCollection,
             "preferred_networks" to null,


### PR DESCRIPTION
# Summary
Adds `CustomerSheetEvent.Init` and passing the `CustomerSheet.Configuration` settings with it. Also updates `PaymentSheetEvent.Init` with some missing fields.

# Motivation
Adds ability to track how merchants are initializing `CustomerSheet`. Also adds more data into how merchants are initializing `PaymentSheet`.
