### PR TITLE
Update PrimaryButtonUiStateMapper to return state flow.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -33,14 +33,12 @@ import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.PrimaryButtonUiStateMapper
 import com.stripe.android.uicore.utils.combineAsStateFlow
+import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
@@ -79,7 +77,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
         isProcessingPayment = args.state.stripeIntent is PaymentIntent,
         currentScreenFlow = currentScreen,
         buttonsEnabledFlow = buttonsEnabled,
-        amountFlow = paymentMethodMetadata.map { it?.amount() },
+        amountFlow = paymentMethodMetadata.mapAsStateFlow { it?.amount() },
         selectionFlow = selection,
         customPrimaryButtonUiStateFlow = customPrimaryButtonUiState,
         onClick = {
@@ -129,11 +127,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     override var newPaymentSelection: PaymentSelection.New? =
         args.state.paymentSelection as? PaymentSelection.New
 
-    override val primaryButtonUiState = primaryButtonUiStateMapper.forCustomFlow().stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(),
-        initialValue = null,
-    )
+    override val primaryButtonUiState = primaryButtonUiStateMapper.forCustomFlow()
 
     init {
         SessionSavedStateHandler.attachTo(this, savedStateHandle)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -37,8 +37,10 @@ import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
@@ -127,7 +129,11 @@ internal class PaymentOptionsViewModel @Inject constructor(
     override var newPaymentSelection: PaymentSelection.New? =
         args.state.paymentSelection as? PaymentSelection.New
 
-    override val primaryButtonUiState = primaryButtonUiStateMapper.forCustomFlow()
+    override val primaryButtonUiState = primaryButtonUiStateMapper.forCustomFlow().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(),
+        initialValue = null,
+    )
 
     init {
         SessionSavedStateHandler.attachTo(this, savedStateHandle)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -71,12 +71,9 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -128,7 +125,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         isProcessingPayment = isProcessingPaymentIntent,
         currentScreenFlow = currentScreen,
         buttonsEnabledFlow = buttonsEnabled,
-        amountFlow = paymentMethodMetadata.map { it?.amount() },
+        amountFlow = paymentMethodMetadata.mapAsStateFlow { it?.amount() },
         selectionFlow = selection,
         customPrimaryButtonUiStateFlow = customPrimaryButtonUiState,
         onClick = {
@@ -202,11 +199,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             }
         }
 
-    override val primaryButtonUiState = primaryButtonUiStateMapper.forCompleteFlow().stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(),
-        initialValue = null,
-    )
+    override val primaryButtonUiState = primaryButtonUiStateMapper.forCompleteFlow()
 
     override val error: StateFlow<String?> = buyButtonState.mapAsStateFlow { it?.errorMessage?.message }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -71,9 +71,11 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -199,7 +201,11 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             }
         }
 
-    override val primaryButtonUiState = primaryButtonUiStateMapper.forCompleteFlow()
+    override val primaryButtonUiState = primaryButtonUiStateMapper.forCompleteFlow().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(),
+        initialValue = null,
+    )
 
     override val error: StateFlow<String?> = buyButtonState.mapAsStateFlow { it?.errorMessage?.message }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PrimaryButtonUiStateMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PrimaryButtonUiStateMapper.kt
@@ -7,8 +7,9 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.ui.core.Amount
-import com.stripe.android.uicore.utils.combineAsStateFlow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import com.stripe.android.ui.core.R as StripeUiCoreR
 
 internal class PrimaryButtonUiStateMapper(
@@ -23,8 +24,8 @@ internal class PrimaryButtonUiStateMapper(
     private val onClick: () -> Unit,
 ) {
 
-    fun forCompleteFlow(): StateFlow<PrimaryButton.UIState?> {
-        return combineAsStateFlow(
+    fun forCompleteFlow(): Flow<PrimaryButton.UIState?> {
+        return combine(
             currentScreenFlow,
             buttonsEnabledFlow,
             amountFlow,
@@ -40,8 +41,8 @@ internal class PrimaryButtonUiStateMapper(
         }
     }
 
-    fun forCustomFlow(): StateFlow<PrimaryButton.UIState?> {
-        return combineAsStateFlow(
+    fun forCustomFlow(): Flow<PrimaryButton.UIState?> {
+        return combine(
             currentScreenFlow,
             buttonsEnabledFlow,
             selectionFlow,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PrimaryButtonUiStateMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PrimaryButtonUiStateMapper.kt
@@ -7,24 +7,24 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.ui.core.Amount
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
+import com.stripe.android.uicore.utils.combineAsStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import com.stripe.android.ui.core.R as StripeUiCoreR
 
 internal class PrimaryButtonUiStateMapper(
     private val context: Context,
     private val config: PaymentSheet.Configuration,
     private val isProcessingPayment: Boolean,
-    private val currentScreenFlow: Flow<PaymentSheetScreen>,
-    private val buttonsEnabledFlow: Flow<Boolean>,
-    private val amountFlow: Flow<Amount?>,
-    private val selectionFlow: Flow<PaymentSelection?>,
-    private val customPrimaryButtonUiStateFlow: Flow<PrimaryButton.UIState?>,
+    private val currentScreenFlow: StateFlow<PaymentSheetScreen>,
+    private val buttonsEnabledFlow: StateFlow<Boolean>,
+    private val amountFlow: StateFlow<Amount?>,
+    private val selectionFlow: StateFlow<PaymentSelection?>,
+    private val customPrimaryButtonUiStateFlow: StateFlow<PrimaryButton.UIState?>,
     private val onClick: () -> Unit,
 ) {
 
-    fun forCompleteFlow(): Flow<PrimaryButton.UIState?> {
-        return combine(
+    fun forCompleteFlow(): StateFlow<PrimaryButton.UIState?> {
+        return combineAsStateFlow(
             currentScreenFlow,
             buttonsEnabledFlow,
             amountFlow,
@@ -40,8 +40,8 @@ internal class PrimaryButtonUiStateMapper(
         }
     }
 
-    fun forCustomFlow(): Flow<PrimaryButton.UIState?> {
-        return combine(
+    fun forCustomFlow(): StateFlow<PrimaryButton.UIState?> {
+        return combineAsStateFlow(
             currentScreenFlow,
             buttonsEnabledFlow,
             selectionFlow,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Continuing to move away from stateIn if we can avoid it. This is for PrimaryButtonUiStateMapper. We can't actually do the combineAsStateFlow in PrimaryButtonUiStateMapper, but this will get us ready to do it.

