### PR TITLE
Convert EditPaymentMethodViewInteractor Flows to StateFlows.

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditPaymentMethodViewInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditPaymentMethodViewInteractorTest.kt
@@ -8,7 +8,6 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -299,7 +298,6 @@ class DefaultEditPaymentMethodViewInteractorTest {
             eventHandler = eventHandler,
             removeExecutor = onRemove,
             updateExecutor = onUpdate,
-            viewStateSharingStarted = SharingStarted.Eagerly,
             workContext = workContext,
             canRemove = canRemove,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/FakeEditPaymentMethodInteractorFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/FakeEditPaymentMethodInteractorFactory.kt
@@ -7,7 +7,6 @@ import com.stripe.android.paymentsheet.ui.ModifiableEditPaymentMethodViewInterac
 import com.stripe.android.paymentsheet.ui.PaymentMethodRemoveOperation
 import com.stripe.android.paymentsheet.ui.PaymentMethodUpdateOperation
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.SharingStarted
 import kotlin.coroutines.CoroutineContext
 
 internal class FakeEditPaymentMethodInteractorFactory(
@@ -28,7 +27,6 @@ internal class FakeEditPaymentMethodInteractorFactory(
             updateExecutor = updateExecutor,
             displayName = displayName,
             workContext = context,
-            viewStateSharingStarted = SharingStarted.Eagerly,
             canRemove = canRemove,
         )
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Continuing to move away from stateIn if we can avoid it. This is for EditPaymentMethodViewInteractor.
