### PR TITLE
Remove stateIn where it's not needed in tests.

### DIFF
--- a/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/PaymentMethodMessagingViewModelTest.kt
+++ b/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/PaymentMethodMessagingViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentmethodmessaging
 
-import androidx.lifecycle.viewModelScope
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.PaymentMethodMessage
 import com.stripe.android.networking.StripeRepository
@@ -10,7 +9,6 @@ import com.stripe.android.paymentmethodmessaging.view.PaymentMethodMessagingView
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -67,11 +65,11 @@ class PaymentMethodMessagingViewModelTest {
             learnMoreUrl = "some url"
         )
 
-        assertThat(viewModel.messageFlow.stateIn(viewModel.viewModelScope).value).isNull()
+        assertThat(viewModel.messageFlow.value).isNull()
 
         viewModel.loadMessage()
 
-        val result = viewModel.messageFlow.stateIn(viewModel.viewModelScope).value!!
+        val result = viewModel.messageFlow.value!!
 
         assertThat(result.isSuccess).isTrue()
         assertThat(result.getOrNull()?.message?.displayHtml)
@@ -104,11 +102,11 @@ class PaymentMethodMessagingViewModelTest {
             learnMoreUrl = "a"
         )
 
-        assertThat(viewModel.messageFlow.stateIn(viewModel.viewModelScope).value).isNull()
+        assertThat(viewModel.messageFlow.value).isNull()
 
         viewModel.loadMessage()
 
-        val result = viewModel.messageFlow.stateIn(viewModel.viewModelScope).value!!
+        val result = viewModel.messageFlow.value!!
 
         assertThat(result.isFailure).isTrue()
         assertThat(result.exceptionOrNull()?.message)
@@ -139,11 +137,11 @@ class PaymentMethodMessagingViewModelTest {
             learnMoreUrl = ""
         )
 
-        assertThat(viewModel.messageFlow.stateIn(viewModel.viewModelScope).value).isNull()
+        assertThat(viewModel.messageFlow.value).isNull()
 
         viewModel.loadMessage()
 
-        val result = viewModel.messageFlow.stateIn(viewModel.viewModelScope).value!!
+        val result = viewModel.messageFlow.value!!
 
         assertThat(result.isFailure).isTrue()
         assertThat(result.exceptionOrNull()?.message)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet.addresselement
 
 import android.app.Application
 import android.text.SpannableString
-import androidx.lifecycle.viewModelScope
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -14,7 +13,6 @@ import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePr
 import com.stripe.android.ui.core.elements.autocomplete.model.Place
 import com.stripe.android.uicore.elements.TextFieldIcon
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.resetMain
@@ -233,11 +231,11 @@ class AutocompleteViewModelTest {
 
         viewModel.textFieldController.onRawValueChange("")
 
-        assertThat(viewModel.textFieldController.trailingIcon.stateIn(viewModel.viewModelScope).value).isNull()
+        assertThat(viewModel.textFieldController.trailingIcon.value).isNull()
 
         viewModel.textFieldController.onRawValueChange("a")
 
-        assertThat(viewModel.textFieldController.trailingIcon.stateIn(viewModel.viewModelScope).value).isNotNull()
+        assertThat(viewModel.textFieldController.trailingIcon.value).isNotNull()
     }
 
     @Test
@@ -297,6 +295,6 @@ class AutocompleteViewModelTest {
         viewModel.clearQuery()
 
         assertThat(viewModel.predictions.value).isEqualTo(null)
-        assertThat(viewModel.textFieldController.rawFieldValue.stateIn(viewModel.viewModelScope).value).isEqualTo("")
+        assertThat(viewModel.textFieldController.rawFieldValue.value).isEqualTo("")
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Continuing to move away from stateIn if we can avoid it. This is in some unit tests.
