### PR TITLE
Update PaymentOptionsStateMapper to return a state flow.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -60,7 +60,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -228,12 +227,6 @@ internal abstract class BaseSheetViewModel(
     }
 
     val paymentOptionsState: StateFlow<PaymentOptionsState> = paymentOptionsStateMapper()
-        .filterNotNull()
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(),
-            initialValue = PaymentOptionsState(),
-        )
 
     private val canEdit: StateFlow<Boolean> = paymentOptionsState.mapAsStateFlow { state ->
         val paymentMethods = state.items.filterIsInstance<PaymentOptionsItem.SavedPaymentMethod>()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsStateMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsStateMapper.kt
@@ -6,9 +6,8 @@ import com.stripe.android.paymentsheet.PaymentOptionsState
 import com.stripe.android.paymentsheet.PaymentOptionsStateFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.GooglePayState
-import kotlinx.coroutines.flow.Flow
+import com.stripe.android.uicore.utils.combineAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
 
 internal class PaymentOptionsStateMapper(
     private val paymentMethods: StateFlow<List<PaymentMethod>?>,
@@ -20,8 +19,8 @@ internal class PaymentOptionsStateMapper(
     private val isCbcEligible: () -> Boolean
 ) {
 
-    operator fun invoke(): Flow<PaymentOptionsState?> {
-        return combine(
+    operator fun invoke(): StateFlow<PaymentOptionsState> {
+        return combineAsStateFlow(
             paymentMethods,
             currentSelection,
             isLinkEnabled,
@@ -32,7 +31,7 @@ internal class PaymentOptionsStateMapper(
                 currentSelection = currentSelection,
                 isLinkEnabled = isLinkEnabled,
                 googlePayState = googlePayState,
-            )
+            ) ?: PaymentOptionsState()
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This is a little bit of a trickier one. There is some behavior change in PaymentOptionsStateMapper, but the way it was used inside BaseSheetViewModel (the only place it's used) was doing this logic.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Less usage of stateIn
