### PR TITLE
Report `CustomerSheet` initialization events.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -154,6 +154,8 @@ internal class CustomerSheetViewModel(
     init {
         configuration.appearance.parseAppearance()
 
+        eventReporter.onInit(configuration)
+
         if (viewState.value is CustomerSheetViewState.Loading) {
             viewModelScope.launch(workContext) {
                 loadCustomerSheetState()

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEventReporter.kt
@@ -1,8 +1,16 @@
 package com.stripe.android.customersheet.analytics
 
+import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.model.CardBrand
 
 internal interface CustomerSheetEventReporter {
+
+    /**
+     * User entered the [CustomerSheet] flow
+     */
+    @OptIn(ExperimentalCustomerSheetApi::class)
+    fun onInit(configuration: CustomerSheet.Configuration)
 
     /**
      * [Screen] was presented to user

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/DefaultCustomerSheetEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/DefaultCustomerSheetEventReporter.kt
@@ -3,6 +3,8 @@ package com.stripe.android.customersheet.analytics
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.AnalyticsRequestFactory
+import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.model.CardBrand
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -14,6 +16,13 @@ internal class DefaultCustomerSheetEventReporter @Inject constructor(
     private val analyticsRequestFactory: AnalyticsRequestFactory,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSheetEventReporter {
+    @OptIn(ExperimentalCustomerSheetApi::class)
+    override fun onInit(configuration: CustomerSheet.Configuration) {
+        fireEvent(
+            CustomerSheetEvent.Init(configuration)
+        )
+    }
+
     override fun onScreenPresented(screen: CustomerSheetEventReporter.Screen) {
         fireEvent(
             CustomerSheetEvent.ScreenPresented(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetEventReporterTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.C
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_CARD_NUMBER_COMPLETED
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_HIDE_EDITABLE_PAYMENT_OPTION
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_HIDE_PAYMENT_OPTION_BRANDS
+import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_INIT
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_SELECT_PAYMENT_METHOD_CONFIRMED_SAVED_PM_FAILED
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_SELECT_PAYMENT_METHOD_CONFIRMED_SAVED_PM_SUCCEEDED
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_SELECT_PAYMENT_METHOD_DONE_TAPPED
@@ -60,6 +61,17 @@ class CustomerSheetEventReporterTest {
         analyticsRequestFactory = analyticsRequestFactory,
         workContext = testDispatcher,
     )
+
+    @OptIn(ExperimentalCustomerSheetApi::class)
+    @Test
+    fun `onInit should fire analytics request with expected event value`() {
+        eventReporter.onInit(configuration = CustomerSheetFixtures.MINIMUM_CONFIG)
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == CS_INIT
+            }
+        )
+    }
 
     @Test
     fun `onScreenPresented should fire analytics request with expected event value`() {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -143,6 +143,19 @@ class CustomerSheetViewModelTest {
     }
 
     @Test
+    fun `on init, sends 'onInit' event to event reporter`() = runTest(testDispatcher) {
+        val eventReporter: CustomerSheetEventReporter = mock()
+
+        createViewModel(
+            workContext = testDispatcher,
+            eventReporter = eventReporter,
+            configuration = CustomerSheetFixtures.MINIMUM_CONFIG,
+        )
+
+        verify(eventReporter).onInit(CustomerSheetFixtures.MINIMUM_CONFIG)
+    }
+
+    @Test
     fun `CustomerSheetViewAction#OnBackPressed emits canceled result`() = runTest(testDispatcher) {
         val viewModel = createViewModel(
             workContext = testDispatcher,


### PR DESCRIPTION
# Summary
Report `CustomerSheet` initialization events through `CustomerSheetEventReporter`

# Motivation
Allows us to track how merchants are initializing `CustomerSheet`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
