### PR TITLE
Add test mode toggle and simplify playground logic

### DIFF
--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -311,21 +311,22 @@ internal class FinancialConnectionsPlaygroundViewModel(
     }
 }
 
-@Suppress("Unused")
-enum class Merchant(val apiValue: String) {
-    Test("testmode"),
-    PartnerM("partner_m"),
-    PartnerF("partner_f"),
-    PartnerD("partner_d"),
+enum class Merchant(
+    val apiValue: String,
+    val canSwitchBetweenTestAndLive: Boolean = true,
+) {
+    Default("default"),
+    PartnerD("partner_d", canSwitchBetweenTestAndLive = false),
+    PartnerF("partner_f", canSwitchBetweenTestAndLive = false),
+    PartnerM("partner_m", canSwitchBetweenTestAndLive = false),
     PlatformC("strash"),
-    App2App("app2app"),
     Networking("networking"),
-    NetworkingTestMode("networking_testmode"),
-    Livetesting("live_testing"),
-    Other("other");
+    Custom("other");
 
     companion object {
-        fun fromApiValue(apiValue: String): Merchant = entries.first { it.apiValue == apiValue }
+        fun fromApiValue(apiValue: String): Merchant {
+            return entries.firstOrNull { it.apiValue == apiValue } ?: Default
+        }
     }
 }
 

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/model/LinkAccountSessionBody.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/model/LinkAccountSessionBody.kt
@@ -18,5 +18,7 @@ data class LinkAccountSessionBody(
     @SerialName("customer_email")
     val customerEmail: String? = null,
     @SerialName("test_environment")
-    val testEnvironment: String? = null
+    val testEnvironment: String? = null,
+    @SerialName("test_mode")
+    val testMode: Boolean? = null,
 )

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/model/PaymentIntentBody.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/model/PaymentIntentBody.kt
@@ -24,5 +24,7 @@ data class PaymentIntentBody(
     @SerialName("customer_email")
     val customerEmail: String? = null,
     @SerialName("test_environment")
-    val testEnvironment: String? = null
+    val testEnvironment: String? = null,
+    @SerialName("test_mode")
+    val testMode: Boolean? = null,
 )

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/FlowSetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/FlowSetting.kt
@@ -25,23 +25,6 @@ data class FlowSetting(
     }
 
     override fun valueUpdated(currentSettings: List<Setting<*>>, value: Flow): List<Setting<*>> {
-        val flowSettings = listOfNotNull(
-            copy(selectedOption = value),
-            ConfirmIntentSetting().takeIf { value == Flow.PaymentIntent },
-        )
-        val updatedSettings = currentSettings
-            .filter { it !is ConfirmIntentSetting }
-            .flatMap { setting ->
-                when (setting) {
-                    is FlowSetting -> flowSettings
-                    else -> listOf(setting)
-                }
-            }
-
-        return if (currentSettings.none { it is FlowSetting }) {
-            updatedSettings + flowSettings
-        } else {
-            updatedSettings
-        }
+        return replace(currentSettings, this.copy(selectedOption = value))
     }
 }

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/MerchantSetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/MerchantSetting.kt
@@ -5,7 +5,7 @@ import com.stripe.android.financialconnections.example.data.model.LinkAccountSes
 import com.stripe.android.financialconnections.example.data.model.PaymentIntentBody
 
 data class MerchantSetting(
-    override val selectedOption: Merchant = Merchant.Test,
+    override val selectedOption: Merchant = Merchant.Default,
     override val key: String = "merchant"
 ) : Saveable<Merchant>, SingleChoiceSetting<Merchant>(
     displayName = "Merchant",
@@ -21,25 +21,7 @@ data class MerchantSetting(
     )
 
     override fun valueUpdated(currentSettings: List<Setting<*>>, value: Merchant): List<Setting<*>> {
-        val merchantSettings = listOfNotNull(
-            copy(selectedOption = value),
-            PublicKeySetting("").takeIf { value == Merchant.Other },
-            PrivateKeySetting("").takeIf { value == Merchant.Other }
-        )
-        val updatedSettings = currentSettings
-            .filter { it !is PublicKeySetting && it !is PrivateKeySetting }
-            .flatMap { setting ->
-                when (setting) {
-                    is MerchantSetting -> merchantSettings
-                    else -> listOf(setting)
-                }
-            }
-
-        return if (currentSettings.none { it is MerchantSetting }) {
-            updatedSettings + merchantSettings
-        } else {
-            updatedSettings
-        }
+        return replace(currentSettings, this.copy(selectedOption = value))
     }
 
     override fun convertToString(value: Merchant): String = value.apiValue

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PrivateKeySetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PrivateKeySetting.kt
@@ -1,12 +1,14 @@
 package com.stripe.android.financialconnections.example.settings
 
+import com.stripe.android.financialconnections.example.Flow
+import com.stripe.android.financialconnections.example.Merchant
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
 import com.stripe.android.financialconnections.example.data.model.PaymentIntentBody
 
 internal data class PrivateKeySetting(
-    override val selectedOption: String? = null,
+    override val selectedOption: String = "",
     override val key: String = "sk"
-) : Saveable<String?>, SingleChoiceSetting<String?>(
+) : Saveable<String>, SingleChoiceSetting<String>(
     displayName = "Private Key",
     options = emptyList(),
     selectedOption = selectedOption
@@ -21,12 +23,16 @@ internal data class PrivateKeySetting(
 
     override fun valueUpdated(
         currentSettings: List<Setting<*>>,
-        value: String?
+        value: String
     ): List<Setting<*>> {
         return replace(currentSettings, this.copy(selectedOption = value))
     }
 
-    override fun convertToString(value: String?): String? = value
+    override fun shouldDisplay(merchant: Merchant, flow: Flow): Boolean {
+        return merchant == Merchant.Custom
+    }
+
+    override fun convertToString(value: String): String = value
 
     override fun convertToValue(value: String): String = value
 }

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PublicKeySetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PublicKeySetting.kt
@@ -1,12 +1,14 @@
 package com.stripe.android.financialconnections.example.settings
 
+import com.stripe.android.financialconnections.example.Flow
+import com.stripe.android.financialconnections.example.Merchant
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
 import com.stripe.android.financialconnections.example.data.model.PaymentIntentBody
 
 internal data class PublicKeySetting(
-    override val selectedOption: String? = null,
+    override val selectedOption: String = "",
     override val key: String = "pk"
-) : Saveable<String?>, SingleChoiceSetting<String?>(
+) : Saveable<String>, SingleChoiceSetting<String>(
     displayName = "Publishable Key",
     options = emptyList(),
     selectedOption = selectedOption
@@ -22,12 +24,16 @@ internal data class PublicKeySetting(
 
     override fun valueUpdated(
         currentSettings: List<Setting<*>>,
-        value: String?
+        value: String
     ): List<Setting<*>> {
         return replace(currentSettings, this.copy(selectedOption = value))
     }
 
-    override fun convertToString(value: String?): String? = value
+    override fun shouldDisplay(merchant: Merchant, flow: Flow): Boolean {
+        return merchant == Merchant.Custom
+    }
+
+    override fun convertToString(value: String): String = value
 
     override fun convertToValue(value: String): String = value
 }

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/Setting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/Setting.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.financialconnections.example.settings
 
+import com.stripe.android.financialconnections.example.Flow
+import com.stripe.android.financialconnections.example.Merchant
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
 import com.stripe.android.financialconnections.example.data.model.PaymentIntentBody
 
@@ -18,6 +20,8 @@ sealed class Setting<T> {
         @Suppress("UNCHECKED_CAST")
         return this as? Saveable<T>?
     }
+
+    open fun shouldDisplay(merchant: Merchant, flow: Flow): Boolean = true
 
     abstract val displayName: String
     abstract val selectedOption: T

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/SettingsUi.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/SettingsUi.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.financialconnections.example.settings
 
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -41,11 +43,12 @@ internal fun SettingsUi(
     playgroundSettings: PlaygroundSettings,
     onSettingsChanged: (PlaygroundSettings) -> Unit,
 ) {
-    Column {
-        for (setting in playgroundSettings.settings) {
-            Row(modifier = Modifier.padding(bottom = 16.dp)) {
-                SingleSelectSetting(setting, playgroundSettings, onSettingsChanged)
-            }
+    Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = Modifier.animateContentSize(),
+    ) {
+        for (setting in playgroundSettings.displayableSettings) {
+            SingleSelectSetting(setting, playgroundSettings, onSettingsChanged)
         }
     }
 }

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/TestModeSetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/TestModeSetting.kt
@@ -5,11 +5,11 @@ import com.stripe.android.financialconnections.example.Merchant
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
 import com.stripe.android.financialconnections.example.data.model.PaymentIntentBody
 
-data class ConfirmIntentSetting(
+data class TestModeSetting(
     override val selectedOption: Boolean = false,
-    override val key: String = "financial_connections_confirm_intent",
+    override val key: String = "financial_connections_test_mode",
 ) : Saveable<Boolean>, SingleChoiceSetting<Boolean>(
-    displayName = "Confirm Intent",
+    displayName = "Enable Test Mode",
     options = listOf(
         Option("On", true),
         Option("Off", false),
@@ -18,18 +18,18 @@ data class ConfirmIntentSetting(
 ) {
     override fun lasRequest(
         body: LinkAccountSessionBody,
-    ): LinkAccountSessionBody = body
+    ): LinkAccountSessionBody = body.copy(testMode = selectedOption)
 
     override fun paymentIntentRequest(
         body: PaymentIntentBody,
-    ): PaymentIntentBody = body
+    ): PaymentIntentBody = body.copy(testMode = selectedOption)
 
     override fun valueUpdated(currentSettings: List<Setting<*>>, value: Boolean): List<Setting<*>> {
         return replace(currentSettings, this.copy(selectedOption = value))
     }
 
     override fun shouldDisplay(merchant: Merchant, flow: Flow): Boolean {
-        return flow == Flow.PaymentIntent
+        return merchant != Merchant.Custom && merchant.canSwitchBetweenTestAndLive
     }
 
     override fun convertToValue(value: String): Boolean = value.toBoolean()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request simplifies some logic in the FC playground and adds a test mode toggle the merchant profiles (except the custom one). We’ll follow up with adding the ability to create and store custom merchant profiles.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
