### PR TITLE
Properly attribute `product_usage` tokens in `PaymentAnalyticsRequestFactory`.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsRequestFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsRequestFactory.kt
@@ -7,6 +7,7 @@ import androidx.annotation.Keep
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
+import com.stripe.android.core.networking.AnalyticsEvent
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.NetworkTypeDetector
@@ -216,6 +217,22 @@ class PaymentAnalyticsRequestFactory @VisibleForTesting internal constructor(
                 threeDS2UiType = threeDS2UiType,
                 errorMessage = errorMessage,
             )
+        )
+    }
+
+    override fun createRequest(
+        event: AnalyticsEvent,
+        additionalParams: Map<String, Any?>
+    ): AnalyticsRequest {
+        val params = if (defaultProductUsageTokens.isNotEmpty()) {
+            mapOf(FIELD_PRODUCT_USAGE to defaultProductUsageTokens.toList()).plus(additionalParams)
+        } else {
+            additionalParams
+        }
+
+        return super.createRequest(
+            event,
+            params,
         )
     }
 

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
@@ -28,7 +28,7 @@ open class AnalyticsRequestFactory(
      * Ensure this common parameters are not already included in [standardParams].
      *
      */
-    fun createRequest(
+    open fun createRequest(
         event: AnalyticsEvent,
         additionalParams: Map<String, Any?>
     ): AnalyticsRequest {


### PR DESCRIPTION
# Summary
Overrides the base `createRequest` parameter to add product usage tokens when needed.

# Motivation
Resolves [RUN_MOBILESDK-2978](https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2978)

Helps properly attribute `PaymentSheet` analytics events (`mc_`) to the used product (`PaymentSheet` or `FlowController`).

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified