### PR TITLE
Display merchant EPM error message in PaymentSheet

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/FawryActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/FawryActivity.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.graphics.Color
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
 import com.stripe.android.paymentsheet.ExternalPaymentMethodResult
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentSheetExampleTheme
 
 class FawryActivity : AppCompatActivity() {
@@ -28,7 +27,7 @@ class FawryActivity : AppCompatActivity() {
             )
         }
 
-        val billingDetails: PaymentSheet.BillingDetails? =
+        val billingDetails: PaymentMethod.BillingDetails? =
             intent.getParcelableExtra(EXTRA_BILLING_DETAILS)
 
         setContent {
@@ -57,13 +56,13 @@ class FawryActivity : AppCompatActivity() {
 
     @Composable
     fun ResultButton(result: ExternalPaymentMethodResult) {
-        Button(onClick = { finishWithResult(result, errorMessage = "Payment Failed!") }) {
+        Button(onClick = { finishWithResult(result, errorMessage = "Payment failed!") }) {
             Text(text = result.toString())
         }
     }
 
     @Composable
-    fun BillingDetails(billingDetails: PaymentSheet.BillingDetails) {
+    fun BillingDetails(billingDetails: PaymentMethod.BillingDetails) {
         Text("Billing details: $billingDetails", color = Color.White)
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExternalPaymentMethodContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExternalPaymentMethodContract.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet
 import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
+import com.stripe.android.core.exception.LocalStripeException
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import java.lang.IllegalArgumentException
@@ -22,9 +23,9 @@ internal class ExternalPaymentMethodContract : ActivityResultContract<ExternalPa
             ExternalPaymentMethodResult.Canceled.resultCode -> PaymentResult.Canceled
             ExternalPaymentMethodResult.Failed.resultCode ->
                 PaymentResult.Failed(
-                    throwable = Throwable(
-                        cause = null,
-                        message = intent?.getStringExtra(ExternalPaymentMethodResult.Failed.ERROR_MESSAGE_EXTRA)
+                    throwable = LocalStripeException(
+                        displayMessage = intent?.getStringExtra(ExternalPaymentMethodResult.Failed.ERROR_MESSAGE_EXTRA),
+                        analyticsValue = "externalPaymentMethodFailure"
                     )
                 )
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Display merchant's external payment method error message in payment sheet

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-1993

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screenshots

https://github.com/stripe/stripe-android/assets/160939932/f999c0db-5903-4500-ba04-c95f00b05349

