### PR TITLE
Fallback to icon resource if icon url fails to load in PaymentMethodsUI

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet
 
+import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -48,6 +49,10 @@ private object Spacing {
 
 @VisibleForTesting
 const val TEST_TAG_LIST = "PaymentMethodsUITestTag"
+
+@VisibleForTesting
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val TEST_TAG_ICON_FROM_RES = "PaymentMethodsUIIconFomRes"
 
 @Composable
 internal fun PaymentMethodsUI(
@@ -260,12 +265,29 @@ private fun PaymentMethodIconUi(
             imageLoader = imageLoader,
             contentDescription = null,
             contentScale = ContentScale.Fit,
+            errorContent = {
+                PaymentMethodIconFromResource(
+                    iconRes = iconRes,
+                    colorFilter = colorFilter
+                )
+            },
         )
-    } else if (iconRes != 0) {
+    } else {
+        PaymentMethodIconFromResource(iconRes = iconRes, colorFilter = colorFilter)
+    }
+}
+
+@Composable
+private fun PaymentMethodIconFromResource(
+    iconRes: Int,
+    colorFilter: ColorFilter?,
+) {
+    if (iconRes != 0) {
         Image(
             painter = painterResource(iconRes),
             contentDescription = null,
             colorFilter = colorFilter,
+            modifier = Modifier.testTag(TEST_TAG_ICON_FROM_RES)
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentMethodsUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentMethodsUITest.kt
@@ -1,0 +1,99 @@
+package com.stripe.android.paymentsheet
+
+import android.graphics.Bitmap
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.ui.core.R
+import com.stripe.android.uicore.image.StripeImageLoader
+import com.stripe.android.uicore.image.TEST_TAG_IMAGE_FROM_URL
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+@RunWith(RobolectricTestRunner::class)
+class PaymentMethodsUITest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val workingUrl = "working-url"
+    private val brokenUrl = "broken-url"
+    private val simpleBitmap = Bitmap.createBitmap(
+        10,
+        10,
+        Bitmap.Config.ARGB_8888
+    )
+
+    @Test
+    fun whenIconUrlIsPresent_iconUrlIsUsed() = runTest {
+        testIcons(
+            iconRes = R.drawable.stripe_ic_paymentsheet_pm_affirm,
+            iconUrl = workingUrl,
+            expectedTestTag = TEST_TAG_IMAGE_FROM_URL
+        )
+    }
+
+    @Test
+    fun whenIconUrlIsMissing_iconFromResIsUsed() = runTest {
+        testIcons(
+            iconRes = R.drawable.stripe_ic_paymentsheet_pm_affirm,
+            iconUrl = null,
+            expectedTestTag = TEST_TAG_ICON_FROM_RES
+        )
+    }
+
+    @Test
+    fun whenIconUrlIsPresent_failsToLoad_fallsBackToIconFromRes() = runTest {
+        testIcons(
+            iconRes = R.drawable.stripe_ic_paymentsheet_pm_affirm,
+            iconUrl = brokenUrl,
+            expectedTestTag = TEST_TAG_ICON_FROM_RES
+        )
+    }
+
+    suspend fun testIcons(
+        iconRes: Int?,
+        iconUrl: String?,
+        expectedTestTag: String,
+    ) {
+        val imageLoader = mock<StripeImageLoader>().also {
+            whenever(it.load(eq(workingUrl), any(), any())).thenReturn(
+                Result.success(
+                    simpleBitmap
+                )
+            )
+        }.also {
+            whenever(it.load(eq(brokenUrl), any(), any())).thenReturn(Result.failure(Throwable()))
+        }
+
+        val paymentMethods = listOf(
+            SupportedPaymentMethod(
+                code = "example_pm",
+                displayNameResource = R.string.stripe_paymentsheet_payment_method_affirm,
+                iconResource = iconRes ?: 0,
+                lightThemeIconUrl = iconUrl,
+                darkThemeIconUrl = null,
+                tintIconOnSelection = false,
+            )
+        )
+        composeTestRule.setContent {
+            PaymentMethodsUI(
+                paymentMethods = paymentMethods,
+                selectedIndex = 0,
+                isEnabled = true,
+                onItemSelectedListener = {},
+                imageLoader = imageLoader,
+            )
+        }
+
+        with(composeTestRule) {
+            onNodeWithTag(expectedTestTag, useUnmergedTree = true).assertExists()
+        }
+    }
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/StripeImage.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/StripeImage.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.uicore.image
 
 import androidx.annotation.RestrictTo
+import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -17,6 +18,7 @@ import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp.Companion.Infinity
 import androidx.compose.ui.unit.IntSize.Companion.Zero
 import com.stripe.android.uicore.image.StripeImageState.Error
@@ -82,7 +84,7 @@ fun StripeImage(
                 Error -> errorContent()
                 Loading -> loadingContent()
                 is Success -> Image(
-                    modifier = modifier,
+                    modifier = modifier.testTag(TEST_TAG_IMAGE_FROM_URL),
                     colorFilter = colorFilter,
                     contentDescription = contentDescription,
                     contentScale = contentScale,
@@ -123,3 +125,7 @@ private sealed class StripeImageState {
     data class Success(val painter: Painter) : StripeImageState()
     object Error : StripeImageState()
 }
+
+@VisibleForTesting
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val TEST_TAG_IMAGE_FROM_URL = "StripeImageFromUrl"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fallback to using icon resource if the icon url fails to load in PaymentMethodsUI

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Matches behavior for PaymentOptions. Also I wanted to add more tests for this part of our codebase: https://jira.corp.stripe.com/browse/MOBILESDK-1986

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified
