### PR TITLE
Fix issue when clicking `PrimaryButton` for LPMs does nothing when Link information is inputted.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import com.stripe.android.link.ui.inline.InlineSignupViewState
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.luxe.isSaveForFutureUseValueChangeable
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -57,22 +56,8 @@ internal fun AddPaymentMethod(
     val linkInlineSignupMode = remember(linkSignupMode, selectedPaymentMethodCode) {
         linkSignupMode.takeIf { selectedPaymentMethodCode == PaymentMethod.Type.Card.code }
     }
-    val linkInlineSelection by sheetViewModel.linkHandler.linkInlineSelection.collectAsState()
-    var linkSignupState by remember {
-        mutableStateOf<InlineSignupViewState?>(null)
-    }
 
-    LaunchedEffect(paymentSelection, linkSignupState, linkInlineSelection) {
-        val state = linkSignupState
-        val isUsingLinkInline = linkInlineSelection != null &&
-            paymentSelection is PaymentSelection.New.Card
-
-        if (state != null) {
-            sheetViewModel.updatePrimaryButtonForLinkSignup(state)
-        } else if (isUsingLinkInline) {
-            sheetViewModel.updatePrimaryButtonForLinkInline()
-        }
-
+    LaunchedEffect(paymentSelection) {
         sheetViewModel.clearErrorMessages()
     }
 
@@ -120,7 +105,7 @@ internal fun AddPaymentMethod(
                     }
                 },
                 onLinkSignupStateChanged = { _, inlineSignupViewState ->
-                    linkSignupState = inlineSignupViewState
+                    sheetViewModel.onLinkSignUpStateUpdated(inlineSignupViewState)
                 },
                 formArguments = arguments,
                 usBankAccountFormArguments = USBankAccountFormArguments(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -2404,10 +2404,7 @@ internal class PaymentSheetViewModelTest {
                 createViewModel(
                     customer = EMPTY_CUSTOMER_STATE,
                     intentConfirmationInterceptor = interceptor,
-                    linkState = LinkState(
-                        configuration = LINK_CONFIG,
-                        loginState = LinkState.LoginState.LoggedOut
-                    )
+                    linkState = LinkState(LINK_CONFIG, LinkState.LoginState.LoggedOut)
                 )
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -2412,7 +2412,7 @@ internal class PaymentSheetViewModelTest {
             )
 
             viewModel.primaryButtonUiState.test {
-                skipItems(1)
+                assertThat(awaitItem()?.enabled).isFalse()
 
                 viewModel.updateSelection(
                     PaymentSelection.New.Card(
@@ -2429,7 +2429,7 @@ internal class PaymentSheetViewModelTest {
                     )
                 )
 
-                skipItems(1)
+                assertThat(awaitItem()?.enabled).isTrue()
 
                 viewModel.onLinkSignUpStateUpdated(
                     InlineSignupViewState.create(config = LINK_CONFIG).copy(
@@ -2444,7 +2444,7 @@ internal class PaymentSheetViewModelTest {
                     )
                 )
 
-                skipItems(1)
+                assertThat(awaitItem()?.enabled).isTrue()
 
                 viewModel.updateSelection(
                     PaymentSelection.New.GenericPaymentMethod(
@@ -2457,9 +2457,13 @@ internal class PaymentSheetViewModelTest {
                     )
                 )
 
-                awaitItem()?.onClick?.invoke()
+                val buyButton = awaitItem()
 
-                cancelAndIgnoreRemainingEvents()
+                assertThat(buyButton?.enabled).isTrue()
+
+                buyButton?.onClick?.invoke()
+
+                assertThat(awaitItem()?.enabled).isFalse()
             }
 
             verify(interceptor).intercept(any(), any(), isNull(), isNull(), eq(false))

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/utils/Flows.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/utils/Flows.kt
@@ -1,0 +1,16 @@
+package com.stripe.android.uicore.utils
+
+import androidx.annotation.RestrictTo
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine as flowCombine
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun <T1, T2, T3> combine(
+    flow1: Flow<T1>,
+    flow2: Flow<T2>,
+    flow3: Flow<T3>,
+): Flow<Triple<T1, T2, T3>> {
+    return flowCombine(flow1, flow2, flow3) { flow1Value, flow2Value, flow3Value ->
+        Triple(flow1Value, flow2Value, flow3Value)
+    }
+}


### PR DESCRIPTION
# Summary
This PR fixes an issue where clicking the `PrimaryButton` for a non-card LPM does nothing when the user has entered information for signing up with Link when using the base card payment method but abandons it for another LPM. This issue results from not updating the primary button state when leaving the card payment method state.

# Motivation
Ensures other LPMs can still be used after abandoning Link signup

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Video
https://github.com/stripe/stripe-android/assets/141707240/f5bfcebe-7714-41b5-b6c9-2d7ce0ea872c