### PR TITLE
Render FC auth flow in bottom sheet

### DIFF
--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -5,13 +5,6 @@ public final class com/stripe/android/financialconnections/BuildConfig {
 	public fun <init> ()V
 }
 
-public final class com/stripe/android/financialconnections/ComposableSingletons$FinancialConnectionsSheetActivityKt {
-	public static final field INSTANCE Lcom/stripe/android/financialconnections/ComposableSingletons$FinancialConnectionsSheetActivityKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
-	public fun <init> ()V
-	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function2;
-}
-
 public final class com/stripe/android/financialconnections/FinancialConnections {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/financialconnections/FinancialConnections;

--- a/financial-connections/res/values/themes.xml
+++ b/financial-connections/res/values/themes.xml
@@ -1,14 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="StripeBaseTheme" parent="@style/Theme.AppCompat.DayNight.NoActionBar">
+    <style name="StripeFinancialConnectionsBaseTheme" parent="@style/Theme.AppCompat.DayNight.NoActionBar">
         <item name="colorAccent">@color/stripe_accent_color_default</item>
         <item name="colorControlNormal">@color/stripe_control_normal_color_default</item>
         <item name="colorPrimary">@color/stripe_toolbar_color_default</item>
         <item name="colorPrimaryDark">@color/stripe_toolbar_color_default_dark</item>
         <item name="titleTextColor">@color/stripe_title_text_color</item>
         <item name="android:textColorSecondary">@color/stripe_text_color_secondary</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:backgroundDimEnabled">true</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:windowAnimationStyle">@null</item>
     </style>
 
-    <style name="StripeDefaultTheme" parent="StripeBaseTheme" />
+    <style name="StripeFinancialConnectionsDefaultTheme" parent="StripeFinancialConnectionsBaseTheme">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+    </style>
 </resources>

--- a/financial-connections/src/main/AndroidManifest.xml
+++ b/financial-connections/src/main/AndroidManifest.xml
@@ -52,13 +52,13 @@
         <activity
             android:name=".FinancialConnectionsSheetActivity"
             android:exported="false"
-            android:theme="@style/StripeDefaultTheme" />
+            android:theme="@style/StripeFinancialConnectionsDefaultTheme" />
 
         <activity
             android:name="com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity"
             android:exported="false"
             android:windowSoftInputMode="adjustResize"
-            android:theme="@style/StripeDefaultTheme" />
+            android:theme="@style/StripeFinancialConnectionsDefaultTheme" />
     </application>
 
     <!--

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -72,7 +72,7 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
     private val analyticsTracker: FinancialConnectionsAnalyticsTracker,
     private val nativeRouter: NativeAuthFlowRouter,
     nativeAuthFlowCoordinator: NativeAuthFlowCoordinator,
-    initialState: FinancialConnectionsSheetState
+    initialState: FinancialConnectionsSheetState,
 ) : FinancialConnectionsViewModel<FinancialConnectionsSheetState>(initialState, nativeAuthFlowCoordinator) {
 
     private val mutex = Mutex()
@@ -130,7 +130,7 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
         val manifest = sync.manifest
         val isInstantDebits = stateFlow.value.isInstantDebits
         val nativeAuthFlowEnabled = nativeRouter.nativeAuthFlowEnabled(manifest, isInstantDebits)
-        viewModelScope.launch { nativeRouter.logExposure(manifest, isInstantDebits) }
+        nativeRouter.logExposure(manifest, isInstantDebits)
         val hostedAuthUrl = buildHostedAuthUrl(manifest.hostedAuthUrl, isInstantDebits)
         if (hostedAuthUrl == null) {
             finishWithResult(
@@ -210,6 +210,13 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
                 activityRecreated = true
             )
         }
+    }
+
+    fun onDismissed() {
+        finishWithResult(
+            state = stateFlow.value,
+            result = Canceled
+        )
     }
 
     /**

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowRouter.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowRouter.kt
@@ -28,7 +28,7 @@ internal class NativeAuthFlowRouter @Inject constructor(
         return isInstantDebits.not() && killSwitchEnabled.not() && nativeExperimentEnabled
     }
 
-    suspend fun logExposure(
+    fun logExposure(
         manifest: FinancialConnectionsSessionManifest,
         isInstantDebits: Boolean,
     ) {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -48,12 +48,14 @@ import com.stripe.android.financialconnections.navigation.topappbar.TopAppBarHos
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewEffect.Finish
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewEffect.OpenUrl
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewModel
+import com.stripe.android.financialconnections.ui.components.FinancialConnectionsBottomSheetLayout
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsModalBottomSheetLayout
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsScaffold
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsTopAppBar
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
 import com.stripe.android.financialconnections.utils.KeyboardController
 import com.stripe.android.financialconnections.utils.rememberKeyboardController
+import com.stripe.android.uicore.elements.bottomsheet.rememberStripeBottomSheetState
 import com.stripe.android.uicore.image.StripeImageLoader
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -98,10 +100,19 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity() {
         setContent {
             FinancialConnectionsTheme {
                 val state by viewModel.stateFlow.collectAsState()
-                NavHost(
-                    initialPane = state.initialPane,
-                    testMode = state.testMode,
+                val bottomSheetState = rememberStripeBottomSheetState(
+                    initialValue = ModalBottomSheetValue.Expanded,
                 )
+
+                FinancialConnectionsBottomSheetLayout(
+                    state = bottomSheetState,
+                    onDismissed = viewModel::onBackPressed,
+                ) {
+                    NavHost(
+                        initialPane = state.initialPane,
+                        testMode = state.testMode,
+                    )
+                }
             }
         }
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/BottomSheet.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/BottomSheet.kt
@@ -1,22 +1,56 @@
 package com.stripe.android.financialconnections.ui.components
 
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.financialconnections.navigation.bottomsheet.BottomSheetNavigator
+import com.stripe.android.financialconnections.navigation.bottomsheet.ModalBottomSheetLayout
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.colors
 import com.stripe.android.financialconnections.ui.theme.Neutral900
+import com.stripe.android.uicore.elements.bottomsheet.StripeBottomSheetLayout
+import com.stripe.android.uicore.elements.bottomsheet.StripeBottomSheetLayoutInfo
+import com.stripe.android.uicore.elements.bottomsheet.StripeBottomSheetState
+import com.stripe.android.uicore.elements.bottomsheet.rememberStripeBottomSheetLayoutInfo
+
+@Composable
+internal fun FinancialConnectionsBottomSheetLayout(
+    state: StripeBottomSheetState,
+    modifier: Modifier = Modifier,
+    onDismissed: () -> Unit,
+    content: @Composable () -> Unit,
+) {
+    val layoutInfo = rememberFinancialConnectionsBottomSheetLayoutInfo()
+
+    StripeBottomSheetLayout(
+        state = state,
+        layoutInfo = layoutInfo,
+        modifier = modifier,
+        onDismissed = onDismissed,
+        sheetContent = content,
+    )
+}
 
 @Composable
 internal fun FinancialConnectionsModalBottomSheetLayout(
     bottomSheetNavigator: BottomSheetNavigator,
     content: @Composable () -> Unit
 ) {
-    com.stripe.android.financialconnections.navigation.bottomsheet.ModalBottomSheetLayout(
+    val layoutInfo = rememberFinancialConnectionsBottomSheetLayoutInfo()
+
+    ModalBottomSheetLayout(
         bottomSheetNavigator = bottomSheetNavigator,
-        sheetBackgroundColor = colors.backgroundSurface,
-        sheetShape = RoundedCornerShape(20.dp, 20.dp, 0.dp, 0.dp),
-        scrimColor = Neutral900.copy(alpha = 0.32f),
+        sheetBackgroundColor = layoutInfo.sheetBackgroundColor,
+        sheetShape = layoutInfo.sheetShape,
+        scrimColor = layoutInfo.scrimColor,
         content = content,
+    )
+}
+
+@Composable
+private fun rememberFinancialConnectionsBottomSheetLayoutInfo(): StripeBottomSheetLayoutInfo {
+    return rememberStripeBottomSheetLayoutInfo(
+        cornerRadius = 20.dp,
+        sheetBackgroundColor = colors.backgroundSurface,
+        scrimColor = Neutral900.copy(alpha = 0.32f),
     )
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Theme.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Theme.kt
@@ -185,9 +185,7 @@ internal fun FinancialConnectionsTheme(
             SideEffect {
                 window?.let { window ->
                     val insets = WindowCompat.getInsetsController(window, view)
-                    window.statusBarColor = barColor.toArgb()
                     window.navigationBarColor = barColor.toArgb()
-                    insets.isAppearanceLightStatusBars = true
                     insets.isAppearanceLightNavigationBars = true
                 }
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/Experiments.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/Experiments.kt
@@ -12,7 +12,7 @@ internal fun FinancialConnectionsSessionManifest.experimentAssignment(
     experiment: Experiment
 ): String? = experimentAssignments?.get(experiment.key)
 
-internal suspend fun FinancialConnectionsAnalyticsTracker.trackExposure(
+internal fun FinancialConnectionsAnalyticsTracker.trackExposure(
     experiment: Experiment,
     manifest: FinancialConnectionsSessionManifest
 ) {

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -984,12 +984,16 @@ internal class PlaygroundTestDriver(
     }
 
     private fun doUSBankAccountAuthorization() {
-        while (currentActivity[0]?.javaClass?.name != FINANCIAL_CONNECTIONS_NATIVE_ACTIVITY) {
+        while (currentActivity[0]?.javaClass?.name != FINANCIAL_CONNECTIONS_ACTIVITY) {
             TimeUnit.MILLISECONDS.sleep(250)
         }
 
-        Espresso.onIdle()
-        composeTestRule.waitForIdle()
+        composeTestRule.waitUntil {
+            composeTestRule
+                .onAllNodesWithText("Agree and continue")
+                .fetchSemanticsNodes()
+                .size == 1
+        }
 
         if (testParameters.authorizationAction == AuthorizeAction.Cancel) {
             selectors.authorizeAction?.click()
@@ -1056,7 +1060,5 @@ internal class PlaygroundTestDriver(
         const val ADD_PAYMENT_METHOD_NODE_TAG = "${PAYMENT_OPTION_CARD_TEST_TAG}_+ Add"
         const val FINANCIAL_CONNECTIONS_ACTIVITY =
             "com.stripe.android.financialconnections.FinancialConnectionsSheetActivity"
-        const val FINANCIAL_CONNECTIONS_NATIVE_ACTIVITY =
-            "com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity"
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request is a follow-up to https://github.com/stripe/stripe-android/pull/8442. It transitions the Financial Connections auth flow from a full-screen view to a sheet.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screen recording

<details><summary>Recording</summary>
<p>

[sheet.webm](https://github.com/stripe/stripe-android/assets/110940675/169eb529-6973-4fe2-8089-670c8988ecb3)

</p>
</details> 

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
