### PR TITLE
Re-add some FC merchants for Maestro tests

### DIFF
--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -321,6 +321,8 @@ enum class Merchant(
     PartnerM("partner_m", canSwitchBetweenTestAndLive = false),
     PlatformC("strash"),
     Networking("networking"),
+    LiveTesting("live_testing", canSwitchBetweenTestAndLive = false),
+    TestMode("testmode", canSwitchBetweenTestAndLive = false),
     Custom("other");
 
     companion object {

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
@@ -24,5 +24,7 @@ tags:
 - tapOn: "Down Bank (unscheduled)"
 # Close flow from error page
 - tapOn: "Close icon"
-- assertVisible: "Failed! Request-id: .*"
+- scrollUntilVisible:
+    element:
+      text: "Failed! Request-id: .*"
 - stopRecording

--- a/maestro/financial-connections/disabled/Web-Testmode-Data-TestOauthInstitution.yaml
+++ b/maestro/financial-connections/disabled/Web-Testmode-Data-TestOauthInstitution.yaml
@@ -7,7 +7,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/web-testmode-data-testoauthinstitution-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?flow=Data&financial_connections_override_native=web&merchant=testmode
+- openLink: stripeconnectionsexample://playground?flow=Data&financial_connections_override_native=web&merchant=testmode&financial_connections_test_mode=true
 - tapOn:
     id: "connect_accounts"
 - extendedWaitUntil:


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds `live_testing` and `testmode` merchants back to the FC Playground.

Long-term, we want to have merchants with both a test mode and live mode configuration, but we’re not there yet.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
