### PR TITLE
Replace `networking_testmode` merchant with `networking`

### DIFF
--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking.yaml
@@ -6,7 +6,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-networking-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?flow=PaymentIntent&financial_connections_override_native=native&merchant=networking_testmode&financial_connections_test_mode=true&permissions=transactions,payment_method&financial_connections_confirm_intent=true
+- openLink: stripeconnectionsexample://playground?flow=PaymentIntent&financial_connections_override_native=native&merchant=networking&financial_connections_test_mode=true&permissions=transactions,payment_method&financial_connections_confirm_intent=true
 - tapOn:
     id: "Customer email setting"
 - inputRandomEmail


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request replaces the `networking_testmode` in the Maestro test with `networking`, after some consolidation in our Glitch backend.

Test run [here](https://app.bitrise.io/app/f5b7f5379a28eb07/pipelines/1eec4bd8-6751-49e9-a53a-c145bbc7281a).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
