### PR TITLE
Make externalPaymentMethods config param non-nullable

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
@@ -14,7 +14,7 @@ sealed interface ElementsSessionParams : Parcelable {
     val customerSessionClientSecret: String?
     val locale: String?
     val expandFields: List<String>
-    val externalPaymentMethods: List<String>?
+    val externalPaymentMethods: List<String>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
@@ -22,7 +22,7 @@ sealed interface ElementsSessionParams : Parcelable {
         override val clientSecret: String,
         override val locale: String? = Locale.getDefault().toLanguageTag(),
         override val customerSessionClientSecret: String? = null,
-        override val externalPaymentMethods: List<String>?,
+        override val externalPaymentMethods: List<String>,
     ) : ElementsSessionParams {
 
         override val type: String
@@ -38,7 +38,7 @@ sealed interface ElementsSessionParams : Parcelable {
         override val clientSecret: String,
         override val locale: String? = Locale.getDefault().toLanguageTag(),
         override val customerSessionClientSecret: String? = null,
-        override val externalPaymentMethods: List<String>?,
+        override val externalPaymentMethods: List<String>,
     ) : ElementsSessionParams {
 
         override val type: String
@@ -53,7 +53,7 @@ sealed interface ElementsSessionParams : Parcelable {
     data class DeferredIntentType(
         override val locale: String? = Locale.getDefault().toLanguageTag(),
         val deferredIntentParams: DeferredIntentParams,
-        override val externalPaymentMethods: List<String>?,
+        override val externalPaymentMethods: List<String>,
         override val customerSessionClientSecret: String? = null,
     ) : ElementsSessionParams {
 

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1493,7 +1493,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
             params.clientSecret?.let { this["client_secret"] = it }
             params.locale.let { this["locale"] = it }
             params.customerSessionClientSecret?.let { this["customer_session_client_secret"] = it }
-            params.externalPaymentMethods?.takeIf { it.isNotEmpty() }?.let { this["external_payment_methods"] = it }
+            params.externalPaymentMethods.takeIf { it.isNotEmpty() }?.let { this["external_payment_methods"] = it }
             (params as? ElementsSessionParams.DeferredIntentType)?.let { type ->
                 this.putAll(type.deferredIntentParams.toQueryParams())
             }

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -20,7 +20,7 @@ class ElementsSessionJsonParserTest {
         val elementsSession = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
                 clientSecret = "secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             apiKey = "test"
         ).parse(
@@ -46,7 +46,7 @@ class ElementsSessionJsonParserTest {
         val elementsSession = ElementsSessionJsonParser(
             ElementsSessionParams.SetupIntentType(
                 clientSecret = "secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             apiKey = "test"
         ).parse(
@@ -71,7 +71,7 @@ class ElementsSessionJsonParserTest {
         val elementsSession = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
                 clientSecret = "secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             apiKey = "test"
         ).parse(
@@ -88,7 +88,7 @@ class ElementsSessionJsonParserTest {
         val elementsSession = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
                 clientSecret = "secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             apiKey = "test"
         ).parse(
@@ -115,7 +115,7 @@ class ElementsSessionJsonParserTest {
         val elementsSession = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
                 clientSecret = "secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             apiKey = "test"
         ).parse(
@@ -130,7 +130,7 @@ class ElementsSessionJsonParserTest {
         val elementsSession = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
                 clientSecret = "secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             apiKey = "test"
         ).parse(
@@ -145,7 +145,7 @@ class ElementsSessionJsonParserTest {
         val elementsSession = ElementsSessionJsonParser(
             ElementsSessionParams.SetupIntentType(
                 clientSecret = "secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             apiKey = "test"
         ).parse(
@@ -162,7 +162,7 @@ class ElementsSessionJsonParserTest {
         val parsedData = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
                 clientSecret = "secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             apiKey = "test"
         ).parse(
@@ -184,7 +184,7 @@ class ElementsSessionJsonParserTest {
         val parsedData = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
                 clientSecret = "secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             apiKey = "test"
         ).parse(
@@ -207,7 +207,7 @@ class ElementsSessionJsonParserTest {
         val parsedData = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
                 clientSecret = "secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             apiKey = "test"
         ).parse(
@@ -231,7 +231,7 @@ class ElementsSessionJsonParserTest {
         val parsedData = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
                 clientSecret = "secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             apiKey = "test"
         ).parse(
@@ -255,7 +255,7 @@ class ElementsSessionJsonParserTest {
         val parsedData = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
                 clientSecret = "secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             apiKey = "test"
         ).parse(
@@ -277,7 +277,7 @@ class ElementsSessionJsonParserTest {
         val parsedData = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
                 clientSecret = "secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             apiKey = "test"
         ).parse(
@@ -298,7 +298,7 @@ class ElementsSessionJsonParserTest {
         val parsedData = ElementsSessionJsonParser(
             ElementsSessionParams.SetupIntentType(
                 clientSecret = "secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             apiKey = "test"
         ).parse(
@@ -329,7 +329,7 @@ class ElementsSessionJsonParserTest {
                     paymentMethodConfigurationId = null,
                     onBehalfOf = null,
                 ),
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             apiKey = "test",
             timeProvider = { 1 }
@@ -371,7 +371,7 @@ class ElementsSessionJsonParserTest {
                     paymentMethodConfigurationId = null,
                     onBehalfOf = null,
                 ),
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             apiKey = "test",
             timeProvider = { 1 }
@@ -408,7 +408,7 @@ class ElementsSessionJsonParserTest {
         val parser = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
                 clientSecret = "secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             apiKey = "test",
         )
@@ -424,7 +424,7 @@ class ElementsSessionJsonParserTest {
         val parser = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
                 clientSecret = "secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             apiKey = "test",
         )
@@ -440,7 +440,7 @@ class ElementsSessionJsonParserTest {
         val parser = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
                 clientSecret = "secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             apiKey = "test",
         )
@@ -490,7 +490,7 @@ class ElementsSessionJsonParserTest {
             ElementsSessionParams.PaymentIntentType(
                 clientSecret = "secret",
                 customerSessionClientSecret = "customer_session_client_secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             apiKey = "test",
         )
@@ -545,7 +545,7 @@ class ElementsSessionJsonParserTest {
         val parser = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
                 clientSecret = "secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             apiKey = "test"
         )

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -2409,7 +2409,7 @@ internal class StripeApiRepositoryTest {
         create().retrieveElementsSession(
             params = ElementsSessionParams.PaymentIntentType(
                 clientSecret = "client_secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             options = DEFAULT_OPTIONS,
         )
@@ -2510,7 +2510,7 @@ internal class StripeApiRepositoryTest {
             params = ElementsSessionParams.PaymentIntentType(
                 clientSecret = "client_secret",
                 customerSessionClientSecret = null,
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             options = DEFAULT_OPTIONS,
         )
@@ -2543,7 +2543,7 @@ internal class StripeApiRepositoryTest {
             params = ElementsSessionParams.PaymentIntentType(
                 clientSecret = "client_secret",
                 customerSessionClientSecret = "customer_session_client_secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             options = DEFAULT_OPTIONS,
         )
@@ -2575,7 +2575,7 @@ internal class StripeApiRepositoryTest {
         create().retrieveElementsSession(
             params = ElementsSessionParams.SetupIntentType(
                 clientSecret = "client_secret",
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             options = DEFAULT_OPTIONS,
         )
@@ -2618,7 +2618,7 @@ internal class StripeApiRepositoryTest {
                     paymentMethodConfigurationId = "pmc_234",
                     onBehalfOf = null,
                 ),
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ),
             options = DEFAULT_OPTIONS,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/common/analytics/AnalyticsKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/analytics/AnalyticsKtx.kt
@@ -68,7 +68,5 @@ internal fun List<CardBrand>.toAnalyticsValue(): String? {
 }
 
 internal fun PaymentSheet.Configuration.getExternalPaymentMethodsAnalyticsValue(): List<String>? {
-    return this.externalPaymentMethods.takeIf {
-        it?.isNotEmpty() ?: false
-    }?.take(PaymentSheetEvent.MAX_EXTERNAL_PAYMENT_METHODS)
+    return this.externalPaymentMethods.takeIf { it.isNotEmpty() }?.take(PaymentSheetEvent.MAX_EXTERNAL_PAYMENT_METHODS)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/configuration/ConfigurationDefaults.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/configuration/ConfigurationDefaults.kt
@@ -22,5 +22,5 @@ internal object ConfigurationDefaults {
     val primaryButtonColor: ColorStateList? = null
     val primaryButtonLabel: String? = null
     val shippingDetails: AddressDetails? = null
-    val externalPaymentMethods: List<String>? = null
+    val externalPaymentMethods: List<String> = emptyList()
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -117,7 +117,7 @@ internal class DefaultCustomerSheetLoader(
         return elementsSessionRepository.get(
             initializationMode,
             customer = null,
-            externalPaymentMethods = null,
+            externalPaymentMethods = emptyList(),
         ).map { elementsSession ->
             val billingDetailsCollectionConfig = configuration.billingDetailsCollectionConfiguration
             val sharedDataSpecs = lpmRepository.getSharedDataSpecs(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -444,7 +444,7 @@ class PaymentSheet internal constructor(
 
         internal val paymentMethodOrder: List<String> = ConfigurationDefaults.paymentMethodOrder,
 
-        internal val externalPaymentMethods: List<String>? = ConfigurationDefaults.externalPaymentMethods,
+        internal val externalPaymentMethods: List<String> = ConfigurationDefaults.externalPaymentMethods,
 
         internal val paymentMethodLayout: PaymentMethodLayout = PaymentMethodLayout.default,
     ) : Parcelable {
@@ -594,7 +594,7 @@ class PaymentSheet internal constructor(
             private var allowsRemovalOfLastSavedPaymentMethod: Boolean =
                 ConfigurationDefaults.allowsRemovalOfLastSavedPaymentMethod
             private var paymentMethodOrder: List<String> = ConfigurationDefaults.paymentMethodOrder
-            private var externalPaymentMethods: List<String>? = ConfigurationDefaults.externalPaymentMethods
+            private var externalPaymentMethods: List<String> = ConfigurationDefaults.externalPaymentMethods
             private var paymentMethodLayout: PaymentMethodLayout = PaymentMethodLayout.default
 
             fun merchantDisplayName(merchantDisplayName: String) =
@@ -671,7 +671,7 @@ class PaymentSheet internal constructor(
             }
 
             @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-            fun externalPaymentMethods(externalPaymentMethods: List<String>?): Builder = apply {
+            fun externalPaymentMethods(externalPaymentMethods: List<String>): Builder = apply {
                 this.externalPaymentMethods = externalPaymentMethods
             }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -21,7 +21,7 @@ internal interface ElementsSessionRepository {
     suspend fun get(
         initializationMode: PaymentSheet.InitializationMode,
         customer: PaymentSheet.CustomerConfiguration?,
-        externalPaymentMethods: List<String>?,
+        externalPaymentMethods: List<String>,
     ): Result<ElementsSession>
 }
 
@@ -45,7 +45,7 @@ internal class RealElementsSessionRepository @Inject constructor(
     override suspend fun get(
         initializationMode: PaymentSheet.InitializationMode,
         customer: PaymentSheet.CustomerConfiguration?,
-        externalPaymentMethods: List<String>?,
+        externalPaymentMethods: List<String>,
     ): Result<ElementsSession> {
         val params = initializationMode.toElementsSessionParams(
             customer = customer,
@@ -110,7 +110,7 @@ private fun StripeIntent.withoutWeChatPay(): StripeIntent {
 
 internal fun PaymentSheet.InitializationMode.toElementsSessionParams(
     customer: PaymentSheet.CustomerConfiguration?,
-    externalPaymentMethods: List<String>?,
+    externalPaymentMethods: List<String>,
 ): ElementsSessionParams {
     val customerSessionClientSecret = customer?.toElementSessionParam()
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -271,7 +271,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
     private suspend fun retrieveElementsSession(
         initializationMode: PaymentSheet.InitializationMode,
         customer: PaymentSheet.CustomerConfiguration?,
-        externalPaymentMethods: List<String>?,
+        externalPaymentMethods: List<String>,
     ): Result<ElementsSession> {
         return elementsSessionRepository.get(initializationMode, customer, externalPaymentMethods)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -226,7 +226,7 @@ class DefaultCustomerSheetLoaderTest {
         assertThat(loader.load(config).getOrThrow()).isNotNull()
         val params = elementsSessionRepository.lastParams?.initializationMode?.toElementsSessionParams(
             customer = null,
-            externalPaymentMethods = null
+            externalPaymentMethods = emptyList(),
         ) as ElementsSessionParams.DeferredIntentType
         assertThat(params.deferredIntentParams.paymentMethodTypes).containsExactly("card")
     }
@@ -259,7 +259,7 @@ class DefaultCustomerSheetLoaderTest {
         assertThat(loader.load(config).getOrThrow()).isNotNull()
         val params = elementsSessionRepository.lastParams?.initializationMode?.toElementsSessionParams(
             customer = null,
-            externalPaymentMethods = null
+            externalPaymentMethods = emptyList(),
         ) as ElementsSessionParams.DeferredIntentType
         assertThat(params.deferredIntentParams.paymentMethodTypes).containsExactly("card")
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
@@ -51,7 +51,7 @@ internal class ElementsSessionRepositoryTest {
                     clientSecret = "client_secret",
                 ),
                 customer = null,
-                externalPaymentMethods = null,
+                externalPaymentMethods = emptyList(),
             ).getOrThrow()
         }
 
@@ -79,7 +79,7 @@ internal class ElementsSessionRepositoryTest {
                         clientSecret = "client_secret",
                     ),
                     customer = null,
-                    externalPaymentMethods = null,
+                    externalPaymentMethods = emptyList(),
                 ).getOrThrow()
             }
 
@@ -104,7 +104,7 @@ internal class ElementsSessionRepositoryTest {
                         clientSecret = "client_secret",
                     ),
                     customer = null,
-                    externalPaymentMethods = null,
+                    externalPaymentMethods = emptyList(),
                 ).getOrThrow()
             }
 
@@ -135,7 +135,7 @@ internal class ElementsSessionRepositoryTest {
                 clientSecret = "client_secret",
             ),
             customer = null,
-            externalPaymentMethods = null,
+            externalPaymentMethods = emptyList(),
         ).getOrThrow()
 
         val argumentCaptor: KArgumentCaptor<ElementsSessionParams> = argumentCaptor()
@@ -171,7 +171,7 @@ internal class ElementsSessionRepositoryTest {
                 )
             ),
             customer = null,
-            externalPaymentMethods = null,
+            externalPaymentMethods = emptyList(),
         )
 
         assertThat(session.getOrNull()).isNull()
@@ -206,7 +206,7 @@ internal class ElementsSessionRepositoryTest {
                 id = "cus_1",
                 clientSecret = "customer_session_client_secret"
             ),
-            externalPaymentMethods = null,
+            externalPaymentMethods = emptyList(),
         )
 
         verify(stripeRepository).retrieveElementsSession(
@@ -214,7 +214,7 @@ internal class ElementsSessionRepositoryTest {
                 ElementsSessionParams.PaymentIntentType(
                     clientSecret = "client_secret",
                     customerSessionClientSecret = "customer_session_client_secret",
-                    externalPaymentMethods = null
+                    externalPaymentMethods = emptyList(),
                 )
             ),
             options = any()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -1298,7 +1298,7 @@ internal class DefaultPaymentSheetLoaderTest {
         }
 
     private suspend fun testExternalPaymentMethods(
-        requestedExternalPaymentMethods: List<String>?,
+        requestedExternalPaymentMethods: List<String>,
         externalPaymentMethodData: String?,
         expectedExternalPaymentMethods: List<String>?
     ) {

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
@@ -18,7 +18,7 @@ internal class FakeElementsSessionRepository(
     data class Params(
         val initializationMode: PaymentSheet.InitializationMode,
         val customer: PaymentSheet.CustomerConfiguration?,
-        val externalPaymentMethods: List<String>?,
+        val externalPaymentMethods: List<String>,
     )
 
     var lastParams: Params? = null
@@ -26,7 +26,7 @@ internal class FakeElementsSessionRepository(
     override suspend fun get(
         initializationMode: PaymentSheet.InitializationMode,
         customer: PaymentSheet.CustomerConfiguration?,
-        externalPaymentMethods: List<String>?,
+        externalPaymentMethods: List<String>,
     ): Result<ElementsSession> {
         lastParams = Params(
             initializationMode = initializationMode,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Change `externalPaymentMethods` config param type from List<String>? to List<String>

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Based on [API review](https://docs.google.com/document/d/1WTv3tGqjCSM3Bf6cfehoKqol0zCrnGwSGdNHqa33s10/edit?disco=AAABMQyEk2k), to be more consistent with other configuration fields with list types. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

No behavior changes, already pretty well-tested code paths.