### PR TITLE
Add PaymentSheetEventTest for external PMs success/failure events

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -498,6 +498,87 @@ class PaymentSheetEventTest {
     }
 
     @Test
+    fun `External payment method event should return expected event`() {
+        val newPMEvent = PaymentSheetEvent.Payment(
+            mode = EventReporter.Mode.Complete,
+            paymentSelection = PaymentSelection.ExternalPaymentMethod(
+                type = "external_fawry",
+                billingDetails = null,
+                label = "Fawry",
+                iconResource = 0,
+                lightThemeIconUrl = "some_url",
+                darkThemeIconUrl = null,
+            ),
+            duration = 1.milliseconds,
+            result = PaymentSheetEvent.Payment.Result.Success,
+            currency = "usd",
+            isDeferred = false,
+            linkEnabled = false,
+            googlePaySupported = false,
+            deferredIntentConfirmationType = null,
+        )
+        assertThat(
+            newPMEvent.eventName
+        ).isEqualTo(
+            "mc_complete_payment_unknown_success"
+        )
+        assertThat(
+            newPMEvent.params
+        ).isEqualTo(
+            mapOf(
+                "currency" to "usd",
+                "duration" to 0.001F,
+                "is_decoupled" to false,
+                "link_enabled" to false,
+                "google_pay_enabled" to false,
+                "selected_lpm" to "external_fawry",
+            )
+        )
+    }
+
+    @Test
+    fun `External payment method failure event should return expected event`() {
+        val newPMEvent = PaymentSheetEvent.Payment(
+            mode = EventReporter.Mode.Complete,
+            paymentSelection = PaymentSelection.ExternalPaymentMethod(
+                type = "external_fawry",
+                billingDetails = null,
+                label = "Fawry",
+                iconResource = 0,
+                lightThemeIconUrl = "some_url",
+                darkThemeIconUrl = null,
+            ),
+            duration = 1.milliseconds,
+            result = PaymentSheetEvent.Payment.Result.Failure(
+                error = PaymentSheetConfirmationError.ExternalPaymentMethod,
+            ),
+            currency = "usd",
+            isDeferred = false,
+            linkEnabled = false,
+            googlePaySupported = false,
+            deferredIntentConfirmationType = null,
+        )
+        assertThat(
+            newPMEvent.eventName
+        ).isEqualTo(
+            "mc_complete_payment_unknown_failure"
+        )
+        assertThat(
+            newPMEvent.params
+        ).isEqualTo(
+            mapOf(
+                "currency" to "usd",
+                "duration" to 0.001F,
+                "is_decoupled" to false,
+                "link_enabled" to false,
+                "google_pay_enabled" to false,
+                "selected_lpm" to "external_fawry",
+                "error_message" to "externalPaymentMethodError",
+            )
+        )
+    }
+
+    @Test
     fun `New payment method failure event should return expected event`() {
         val newPMEvent = PaymentSheetEvent.Payment(
             mode = EventReporter.Mode.Complete,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add PaymentSheetEventTest for external PMs success/failure events

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Improve testing, make it easier to see what analytic events we send for EPMs

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified