### PR TITLE
Update external payment methods playground setting to use enum of options

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestExternalPaymentMethod.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestExternalPaymentMethod.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.example.playground.settings.ExternalPaymentMethodSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.ExternalPaymentMethodType
 import com.stripe.android.paymentsheet.example.playground.settings.PaymentMethodOrderSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
 import com.stripe.android.test.core.TestParameters
@@ -18,7 +19,7 @@ internal class TestExternalPaymentMethod : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = externalFawryCode,
     ) { settings ->
-        settings[ExternalPaymentMethodSettingsDefinition] = externalFawryCode
+        settings[ExternalPaymentMethodSettingsDefinition] = ExternalPaymentMethodType.Fawry
         settings[PaymentMethodOrderSettingsDefinition] = externalFawryCode
         settings[SupportedPaymentMethodsSettingsDefinition] = listOf(
             PaymentMethod.Type.Card,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/ExternalPaymentMethodSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/ExternalPaymentMethodSettingsDefinition.kt
@@ -4,26 +4,119 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 
 internal object ExternalPaymentMethodSettingsDefinition :
-    PlaygroundSettingDefinition<String>,
-    PlaygroundSettingDefinition.Saveable<String>,
-    PlaygroundSettingDefinition.Displayable<String> {
-    override val key: String = "externalPaymentMethods"
+    PlaygroundSettingDefinition<ExternalPaymentMethodType>,
+    PlaygroundSettingDefinition.Saveable<ExternalPaymentMethodType> by EnumSaveable(
+        key = "externalPaymentMethods",
+        values = ExternalPaymentMethodType.entries.toTypedArray(),
+        defaultValue = ExternalPaymentMethodType.Off,
+    ),
+    PlaygroundSettingDefinition.Displayable<ExternalPaymentMethodType> {
     override val displayName: String = "External payment methods"
-    override val options: List<PlaygroundSettingDefinition.Displayable.Option<String>> = emptyList()
-    override val defaultValue: String = ""
+    override val options: List<PlaygroundSettingDefinition.Displayable.Option<ExternalPaymentMethodType>> =
+        ExternalPaymentMethodType.entries.map {
+            option(it.displayName, it)
+        }
 
-    override fun convertToValue(value: String): String = value
+    override fun convertToValue(value: String): ExternalPaymentMethodType {
+        val possibleExternalPaymentMethods = value.split(",")
 
-    override fun convertToString(value: String): String = value
+        return ExternalPaymentMethodType.entries.find { it.externalPaymentMethods == possibleExternalPaymentMethods }
+            ?: ExternalPaymentMethodType.Off
+    }
+
+    override fun convertToString(value: ExternalPaymentMethodType): String = value.value
 
     override fun configure(
-        value: String,
+        value: ExternalPaymentMethodType,
         configurationBuilder: PaymentSheet.Configuration.Builder,
         playgroundState: PlaygroundState,
         configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData
     ) {
-        if (value.isNotEmpty()) {
-            configurationBuilder.externalPaymentMethods(value.split(",").map { it.trim() })
+        when (value) {
+            ExternalPaymentMethodType.Off -> Unit
+            ExternalPaymentMethodType.Fawry,
+            ExternalPaymentMethodType.PayPalAndVenmo,
+            ExternalPaymentMethodType.All ->
+                configurationBuilder.externalPaymentMethods(value.externalPaymentMethods)
         }
     }
 }
+
+enum class ExternalPaymentMethodType(val externalPaymentMethods: List<String>, val displayName: String) : ValueEnum {
+    All(externalPaymentMethods = allExternalPaymentMethods, displayName = "All"),
+    Fawry(externalPaymentMethods = listOf("external_fawry"), displayName = "Fawry"),
+    PayPalAndVenmo(
+        externalPaymentMethods = listOf("external_paypal", "external_venmo"),
+        displayName = "PayPal and Venmo"
+    ),
+    Off(externalPaymentMethods = emptyList(), displayName = "Off"),
+    ;
+
+    override val value: String
+        get() = this.externalPaymentMethods.joinToString(",")
+}
+
+val allExternalPaymentMethods = listOf(
+    "external_aplazame",
+    "external_atone",
+    "external_au_easy_payment",
+    "external_au_pay",
+    "external_azupay",
+    "external_bank_pay",
+    "external_benefit",
+    "external_billie",
+    "external_bitcash",
+    "external_bizum",
+    "external_catch",
+    "external_dapp",
+    "external_dbarai",
+    "external_divido",
+    "external_famipay",
+    "external_fawry",
+    "external_fonix",
+    "external_gcash",
+    "external_grabpay_later",
+    "external_interac",
+    "external_iwocapay",
+    "external_kbc",
+    "external_knet",
+    "external_kriya",
+    "external_laybuy",
+    "external_line_pay",
+    "external_merpay",
+    "external_momo",
+    "external_mondu",
+    "external_net_cash",
+    "external_nexi_pay",
+    "external_octopus",
+    "external_oney",
+    "external_paidy",
+    "external_pay_easy",
+    "external_payconiq",
+    "external_paypal",
+    "external_paypay",
+    "external_paypo",
+    "external_paysafecard",
+    "external_picpay",
+    "external_planpay",
+    "external_pledg",
+    "external_postepay",
+    "external_postfinance",
+    "external_rakuten_pay",
+    "external_samsung_pay",
+    "external_satispay",
+    "external_scalapay",
+    "external_sequra",
+    "external_sezzle",
+    "external_shopback_paylater",
+    "external_softbank_carrier_payment",
+    "external_tabby",
+    "external_tng_ewallet",
+    "external_toss_pay",
+    "external_truelayer",
+    "external_twint",
+    "external_venmo",
+    "external_walley",
+    "external_webmoney",
+    "external_younited_pay",
+)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/ExternalPaymentMethodSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/ExternalPaymentMethodSettingsDefinition.kt
@@ -56,7 +56,7 @@ enum class ExternalPaymentMethodType(val externalPaymentMethods: List<String>, v
         get() = this.externalPaymentMethods.joinToString(",")
 }
 
-val allExternalPaymentMethods = listOf(
+private val allExternalPaymentMethods = listOf(
     "external_aplazame",
     "external_atone",
     "external_au_easy_payment",


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update external payment methods playground setting to use enum of options

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
- Make it easier and less error prone to test EPMs during the bug bash and going forward.
- Consistency with iOS

The one downside that I see to this approach is that it's now harder to test just one specific EPM. But we can mitigate this by selecting "All" and then using payment method order to make the EPM we're interested in testing show up early in the list.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified