### PR TITLE
Add `detachPaymentMethodAndDuplicates` extension function.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryKtx.kt
@@ -1,0 +1,73 @@
+package com.stripe.android.paymentsheet.repositories
+
+import com.stripe.android.model.PaymentMethod
+
+/**
+ * Removes the provided saved payment method alongside any duplicate stored payment methods. This function should be
+ * deleted once an endpoint is stood up to handle detaching and removing duplicates.
+ *
+ * @param customerInfo authentication information that can perform detaching operations.
+ * @param paymentMethodId the id of the payment method to remove and to compare with for stored duplicates
+ *
+ * @return a list of removal results that identify the payment methods that were successfully removed and the payment
+ * methods that failed to be removed.
+ */
+internal suspend fun CustomerRepository.detachPaymentMethodAndDuplicates(
+    customerInfo: CustomerRepository.CustomerInfo,
+    paymentMethodId: String
+): List<PaymentMethodRemovalResult> {
+    val paymentMethods = getPaymentMethods(
+        customerInfo = customerInfo,
+        // We only support removing duplicate cards.
+        types = listOf(PaymentMethod.Type.Card),
+        silentlyFail = false,
+    ).getOrElse {
+        return listOf(
+            PaymentMethodRemovalResult(
+                paymentMethodId = paymentMethodId,
+                result = Result.failure(it)
+            )
+        )
+    }
+
+    val requestedPaymentMethodToRemove = paymentMethods.find { paymentMethod ->
+        paymentMethod.id == paymentMethodId
+    } ?: return listOf()
+
+    val paymentMethodRemovalResults = mutableListOf<PaymentMethodRemovalResult>()
+
+    val paymentMethodsToRemove = paymentMethods.filter { paymentMethod ->
+        paymentMethod.type == PaymentMethod.Type.Card &&
+            paymentMethod.card?.fingerprint == requestedPaymentMethodToRemove.card?.fingerprint
+    }
+
+    paymentMethodsToRemove.forEach { paymentMethod ->
+        val paymentMethodIdToRemove = paymentMethod.id!!
+
+        detachPaymentMethod(
+            customerInfo = customerInfo,
+            paymentMethodId = paymentMethodIdToRemove
+        ).onSuccess { removedPaymentMethod ->
+            paymentMethodRemovalResults.add(
+                PaymentMethodRemovalResult(
+                    paymentMethodId = paymentMethodIdToRemove,
+                    result = Result.success(removedPaymentMethod),
+                )
+            )
+        }.onFailure {
+            paymentMethodRemovalResults.add(
+                PaymentMethodRemovalResult(
+                    paymentMethodId = paymentMethodIdToRemove,
+                    result = Result.failure(it),
+                )
+            )
+        }
+    }
+
+    return paymentMethodRemovalResults
+}
+
+internal data class PaymentMethodRemovalResult(
+    val paymentMethodId: String,
+    val result: Result<PaymentMethod>,
+)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryKtxTest.kt
@@ -1,0 +1,206 @@
+package com.stripe.android.paymentsheet.repositories
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.testing.PaymentMethodFactory
+import com.stripe.android.utils.FakeCustomerRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.Mockito.spy
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+
+class CustomerRepositoryKtxTest {
+    @Test
+    fun `'detachPaymentMethodAndDuplicates' attempts to remove all duplicate cards with matching fingerprints`() =
+        runTest {
+            val fingerprint = "4343434343"
+            val differentFingerprint = "5454545454"
+
+            val cards = PaymentMethodFactory.cards(size = 5)
+            val cardsWithFingerprints = cards.mapIndexed { index, paymentMethod ->
+                if (index < 3) {
+                    paymentMethod.copy(
+                        card = paymentMethod.card?.copy(
+                            fingerprint = fingerprint
+                        )
+                    )
+                } else {
+                    paymentMethod.copy(
+                        card = paymentMethod.card?.copy(
+                            fingerprint = differentFingerprint
+                        )
+                    )
+                }
+            }
+
+            val repository = spy(
+                FakeCustomerRepository(
+                    paymentMethods = cardsWithFingerprints,
+                    onDetachPaymentMethod = {
+                        Result.success(cards.first())
+                    }
+                )
+            )
+
+            repository.detachPaymentMethodAndDuplicates(
+                customerInfo = CustomerRepository.CustomerInfo(
+                    id = "cus_1",
+                    ephemeralKeySecret = "ephemeral_key_secret",
+                ),
+                paymentMethodId = cards[0].id!!
+            )
+
+            verify(repository).detachPaymentMethod(any(), eq(cards[0].id!!))
+            verify(repository).detachPaymentMethod(any(), eq(cards[1].id!!))
+            verify(repository).detachPaymentMethod(any(), eq(cards[2].id!!))
+        }
+
+    @Test
+    fun `'detachPaymentMethodAndDuplicates' returns both successful and failed removals`() =
+        runTest {
+            val cards = PaymentMethodFactory.cards(size = 5).map { paymentMethod ->
+                paymentMethod.copy(
+                    card = paymentMethod.card?.copy(
+                        fingerprint = "4343434343"
+                    )
+                )
+            }
+
+            val repository = FakeCustomerRepository(
+                paymentMethods = cards,
+                onDetachPaymentMethod = { paymentMethodId ->
+                    if (paymentMethodId == cards[3].id || paymentMethodId == cards[4].id) {
+                        Result.failure(TestException("Failed!"))
+                    } else {
+                        val card = cards.find { paymentMethod ->
+                            paymentMethodId == paymentMethod.id
+                        }!!
+
+                        Result.success(card)
+                    }
+                }
+            )
+
+            val results = repository.detachPaymentMethodAndDuplicates(
+                customerInfo = CustomerRepository.CustomerInfo(
+                    id = "cus_1",
+                    ephemeralKeySecret = "ephemeral_key_secret",
+                ),
+                paymentMethodId = cards.first().id!!
+            )
+
+            assertThat(results).containsExactly(
+                PaymentMethodRemovalResult(
+                    paymentMethodId = cards[0].id!!,
+                    result = Result.success(cards[0])
+                ),
+                PaymentMethodRemovalResult(
+                    paymentMethodId = cards[1].id!!,
+                    result = Result.success(cards[1])
+                ),
+                PaymentMethodRemovalResult(
+                    paymentMethodId = cards[2].id!!,
+                    result = Result.success(cards[2])
+                ),
+                PaymentMethodRemovalResult(
+                    paymentMethodId = cards[3].id!!,
+                    result = Result.failure(TestException("Failed!"))
+                ),
+                PaymentMethodRemovalResult(
+                    paymentMethodId = cards[4].id!!,
+                    result = Result.failure(TestException("Failed!"))
+                )
+            )
+        }
+
+    @Test
+    fun `'detachPaymentMethodAndDuplicates' returns payment method object received from removal operation`() =
+        runTest {
+            val cards = PaymentMethodFactory.cards(size = 2).map { paymentMethod ->
+                paymentMethod.copy(
+                    customerId = "cus_111",
+                    card = paymentMethod.card?.copy(fingerprint = "4343434343"),
+                )
+            }
+
+            val repository = FakeCustomerRepository(
+                paymentMethods = cards,
+                onDetachPaymentMethod = { paymentMethodId ->
+                    Result.success(
+                        cards.find { paymentMethod ->
+                            paymentMethod.id == paymentMethodId
+                        }!!.copy(
+                            customerId = null
+                        )
+                    )
+                }
+            )
+
+            val results = repository.detachPaymentMethodAndDuplicates(
+                customerInfo = CustomerRepository.CustomerInfo(
+                    id = "cus_1",
+                    ephemeralKeySecret = "ephemeral_key_secret",
+                ),
+                paymentMethodId = cards.first().id!!
+            )
+
+            assertThat(results).containsExactly(
+                PaymentMethodRemovalResult(
+                    paymentMethodId = cards.first().id!!,
+                    result = Result.success(cards.first().copy(customerId = null))
+                ),
+                PaymentMethodRemovalResult(
+                    paymentMethodId = cards.last().id!!,
+                    result = Result.success(cards.last().copy(customerId = null))
+                )
+            )
+        }
+
+    @Test
+    fun `'detachPaymentMethodAndDuplicates' returns single removal failure if fails to fetch payment methods`() =
+        runTest {
+            val cards = PaymentMethodFactory.cards(size = 2)
+            val repository = FakeCustomerRepository(
+                paymentMethods = cards,
+                onGetPaymentMethods = {
+                    Result.failure(TestException("Failed!"))
+                },
+            )
+
+            val results = repository.detachPaymentMethodAndDuplicates(
+                customerInfo = CustomerRepository.CustomerInfo(
+                    id = "cus_1",
+                    ephemeralKeySecret = "ephemeral_key_secret",
+                ),
+                paymentMethodId = cards.first().id!!
+            )
+
+            assertThat(results).containsExactly(
+                PaymentMethodRemovalResult(
+                    paymentMethodId = cards.first().id!!,
+                    result = Result.failure(TestException("Failed!"))
+                ),
+            )
+        }
+
+    @Test
+    fun `'detachPaymentMethodAndDuplicates' returns success with no removals if no payment methods were found`() =
+        runTest {
+            val repository = FakeCustomerRepository(
+                paymentMethods = listOf(),
+            )
+
+            val results = repository.detachPaymentMethodAndDuplicates(
+                customerInfo = CustomerRepository.CustomerInfo(
+                    id = "cus_1",
+                    ephemeralKeySecret = "ephemeral_key_secret",
+                ),
+                paymentMethodId = "pm_1"
+            )
+
+            assertThat(results).isEmpty()
+        }
+
+    private data class TestException(override val message: String?) : Exception()
+}

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
@@ -14,7 +14,7 @@ internal open class FakeCustomerRepository(
     private val onGetPaymentMethods: () -> Result<List<PaymentMethod>> = {
         Result.success(paymentMethods)
     },
-    private val onDetachPaymentMethod: () -> Result<PaymentMethod> = {
+    private val onDetachPaymentMethod: (paymentMethodId: String) -> Result<PaymentMethod> = {
         Result.failure(NotImplementedError())
     },
     private val onAttachPaymentMethod: () -> Result<PaymentMethod> = {
@@ -39,7 +39,7 @@ internal open class FakeCustomerRepository(
     override suspend fun detachPaymentMethod(
         customerInfo: CustomerRepository.CustomerInfo,
         paymentMethodId: String
-    ): Result<PaymentMethod> = onDetachPaymentMethod()
+    ): Result<PaymentMethod> = onDetachPaymentMethod(paymentMethodId)
 
     override suspend fun attachPaymentMethod(
         customerInfo: CustomerRepository.CustomerInfo,

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
@@ -24,6 +24,9 @@ internal open class FakeCustomerRepository(
         Result.failure(NotImplementedError())
     }
 ) : CustomerRepository {
+    private val _detachRequests = mutableListOf<DetachRequest>()
+    val detachRequests: List<DetachRequest> = _detachRequests
+
     var error: Throwable? = null
 
     override suspend fun retrieveCustomer(
@@ -39,7 +42,16 @@ internal open class FakeCustomerRepository(
     override suspend fun detachPaymentMethod(
         customerInfo: CustomerRepository.CustomerInfo,
         paymentMethodId: String
-    ): Result<PaymentMethod> = onDetachPaymentMethod(paymentMethodId)
+    ): Result<PaymentMethod> {
+        _detachRequests.add(
+            DetachRequest(
+                paymentMethodId = paymentMethodId,
+                customerInfo = customerInfo
+            )
+        )
+
+        return onDetachPaymentMethod(paymentMethodId)
+    }
 
     override suspend fun attachPaymentMethod(
         customerInfo: CustomerRepository.CustomerInfo,
@@ -51,4 +63,9 @@ internal open class FakeCustomerRepository(
         paymentMethodId: String,
         params: PaymentMethodUpdateParams
     ): Result<PaymentMethod> = onUpdatePaymentMethod()
+
+    data class DetachRequest(
+        val paymentMethodId: String,
+        val customerInfo: CustomerRepository.CustomerInfo,
+    )
 }


### PR DESCRIPTION
# Summary
Add `detachPaymentMethodAndDuplicates` extension function.

# Motivation
Helps ensure when using `CustomerSession`, any Stripe payment methods that are effectively duplicates are removed from the Stripe API since `CustomerSession` dedupes these payment methods. I chose to build it out this way to ensure we know exactly what payment methods were successfully removed and see if we need to swap in a duplicate payment method that failed to detach in place of the originally selected payment method we wanted to remove which was removed successfully.

In the future, this will be replaced by a `detach` endpoint that we can reference.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
