### PR TITLE
Fix disabled button in Instant Debits form

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -209,9 +209,16 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
             formFieldValues.all { it.second.isComplete }
         }
     ) { validName, validEmail, validPhone, validAddress ->
-        validName && validEmail &&
-            (validPhone || collectionConfiguration.phone != CollectionMode.Always) &&
+        val validBaseInfo = if (args.instantDebits) {
+            validEmail
+        } else {
+            validName && validEmail
+        }
+
+        val validAddressInfo = (validPhone || collectionConfiguration.phone != CollectionMode.Always) &&
             (validAddress || collectionConfiguration.address != AddressCollectionMode.Full)
+
+        validBaseInfo && validAddressInfo
     }
 
     @VisibleForTesting

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -97,6 +97,16 @@ class USBankAccountFormViewModelTest {
         }
 
     @Test
+    fun `when name is valid then required fields are filled for instant debits flow`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val viewModel = createViewModel(
+                args = defaultArgs.copy(instantDebits = true),
+            )
+
+            assertThat(viewModel.requiredFields.value).isTrue()
+        }
+
+    @Test
     fun `when email and name is invalid then required fields are not filled`() =
         runTest(UnconfinedTestDispatcher()) {
             val viewModel = createViewModel()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the `Continue` button stayed disabled even if the email field was filled out.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
