### PR TITLE
Update payment selection when payment selection is an ExternalPaymentMethod

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -124,10 +124,13 @@ internal class PaymentOptionsViewModel @Inject constructor(
         )
     }
 
-    // Only used to determine if we should skip the list and go to the add card view.
-    // and how to populate that view.
-    override var newPaymentSelection: PaymentSelection.New? =
-        args.state.paymentSelection as? PaymentSelection.New
+    // Only used to determine if we should skip the list and go to the add card view and how to populate that view.
+    override var newPaymentSelection: NewOrExternalPaymentSelection? =
+        when (val selection = args.state.paymentSelection) {
+            is PaymentSelection.New -> NewOrExternalPaymentSelection.New(selection)
+            is PaymentSelection.ExternalPaymentMethod -> NewOrExternalPaymentSelection.External(selection)
+            else -> null
+        }
 
     override val primaryButtonUiState = primaryButtonUiStateMapper.forCustomFlow().stateIn(
         scope = viewModelScope,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -153,7 +153,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     internal val isProcessingPaymentIntent
         get() = args.initializationMode.isProcessingPayment
 
-    override var newPaymentSelection: PaymentSelection.New? = null
+    override var newPaymentSelection: NewOrExternalPaymentSelection? = null
 
     private var googlePayPaymentMethodLauncher: GooglePayPaymentMethodLauncher? = null
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -115,7 +115,7 @@ internal fun AddPaymentMethod(
                     stripeIntentId = stripeIntent?.id,
                     clientSecret = stripeIntent?.clientSecret,
                     shippingDetails = sheetViewModel.config.shippingDetails,
-                    draftPaymentSelection = sheetViewModel.newPaymentSelection,
+                    draftPaymentSelection = sheetViewModel.newPaymentSelection?.paymentSelection,
                     onMandateTextChanged = sheetViewModel::updateMandateText,
                     onConfirmUSBankAccount = sheetViewModel::handleConfirmUSBankAccount,
                     onCollectBankAccountResult = null,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -469,8 +469,8 @@ internal abstract class BaseSheetViewModel(
     fun updateSelection(selection: PaymentSelection?) {
         when (selection) {
             is PaymentSelection.New -> newPaymentSelection = NewOrExternalPaymentSelection.New(selection)
-            is PaymentSelection.ExternalPaymentMethod -> newPaymentSelection =
-                NewOrExternalPaymentSelection.External(selection)
+            is PaymentSelection.ExternalPaymentMethod ->
+                newPaymentSelection = NewOrExternalPaymentSelection.External(selection)
             else -> Unit
         }
 
@@ -825,7 +825,9 @@ internal abstract class BaseSheetViewModel(
 
     data class UserErrorMessage(val message: String)
 
-    sealed interface NewOrExternalPaymentSelection {
+    internal sealed interface NewOrExternalPaymentSelection {
+
+        val paymentSelection: PaymentSelection
 
         fun getPaymentMethodCode(): PaymentMethodCode
 
@@ -835,7 +837,7 @@ internal abstract class BaseSheetViewModel(
 
         fun getPaymentMethodExtraParams(): PaymentMethodExtraParams?
 
-        data class New(val paymentSelection: PaymentSelection.New): NewOrExternalPaymentSelection {
+        data class New(override val paymentSelection: PaymentSelection.New) : NewOrExternalPaymentSelection {
             override fun getPaymentMethodCode(): PaymentMethodCode {
                 return when (paymentSelection) {
                     is PaymentSelection.New.LinkInline -> PaymentMethod.Type.Card.code
@@ -846,11 +848,15 @@ internal abstract class BaseSheetViewModel(
             }
 
             override fun getType(): String = paymentSelection.paymentMethodCreateParams.typeCode
-            override fun getPaymentMethodCreateParams(): PaymentMethodCreateParams = paymentSelection.paymentMethodCreateParams
-            override fun getPaymentMethodExtraParams(): PaymentMethodExtraParams? = paymentSelection.paymentMethodExtraParams
+            override fun getPaymentMethodCreateParams(): PaymentMethodCreateParams =
+                paymentSelection.paymentMethodCreateParams
+
+            override fun getPaymentMethodExtraParams(): PaymentMethodExtraParams? =
+                paymentSelection.paymentMethodExtraParams
         }
 
-        data class External(val paymentSelection: PaymentSelection.ExternalPaymentMethod): NewOrExternalPaymentSelection {
+        data class External(override val paymentSelection: PaymentSelection.ExternalPaymentMethod) :
+            NewOrExternalPaymentSelection {
             override fun getPaymentMethodCode(): PaymentMethodCode = paymentSelection.type
 
             override fun getType(): String = paymentSelection.type
@@ -860,7 +866,6 @@ internal abstract class BaseSheetViewModel(
             override fun getPaymentMethodExtraParams(): PaymentMethodExtraParams? = null
         }
     }
-
 
     companion object {
         internal const val SAVED_CUSTOMER = "customer_info"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -838,6 +838,7 @@ internal abstract class BaseSheetViewModel(
         fun getPaymentMethodExtraParams(): PaymentMethodExtraParams?
 
         data class New(override val paymentSelection: PaymentSelection.New) : NewOrExternalPaymentSelection {
+
             override fun getPaymentMethodCode(): PaymentMethodCode {
                 return when (paymentSelection) {
                     is PaymentSelection.New.LinkInline -> PaymentMethod.Type.Card.code
@@ -848,6 +849,7 @@ internal abstract class BaseSheetViewModel(
             }
 
             override fun getType(): String = paymentSelection.paymentMethodCreateParams.typeCode
+
             override fun getPaymentMethodCreateParams(): PaymentMethodCreateParams =
                 paymentSelection.paymentMethodCreateParams
 
@@ -857,6 +859,7 @@ internal abstract class BaseSheetViewModel(
 
         data class External(override val paymentSelection: PaymentSelection.ExternalPaymentMethod) :
             NewOrExternalPaymentSelection {
+
             override fun getPaymentMethodCode(): PaymentMethodCode = paymentSelection.type
 
             override fun getType(): String = paymentSelection.type

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -36,6 +36,7 @@ import com.stripe.android.paymentsheet.ui.EditPaymentMethodViewAction
 import com.stripe.android.paymentsheet.ui.ModifiableEditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
@@ -383,7 +384,11 @@ internal class PaymentOptionsViewModelTest {
             assertThat(awaitItem()).isNull()
             viewModel.updateSelection(newSelection)
             assertThat(awaitItem()).isEqualTo(newSelection)
-            assertThat(viewModel.newPaymentSelection).isEqualTo(newSelection)
+            assertThat(viewModel.newPaymentSelection).isEqualTo(
+                BaseSheetViewModel.NewOrExternalPaymentSelection.New(
+                    newSelection
+                )
+            )
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -88,6 +88,7 @@ import com.stripe.android.paymentsheet.ui.EditPaymentMethodViewState
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.utils.FakeEditPaymentMethodInteractorFactory
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.SAVE_PROCESSING
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.UserErrorMessage
 import com.stripe.android.testing.FakeErrorReporter
@@ -1677,7 +1678,35 @@ internal class PaymentSheetViewModelTest {
             viewModel.updateSelection(newSelection)
             assertThat(awaitItem())
                 .isEqualTo(newSelection)
-            assertThat(viewModel.newPaymentSelection).isEqualTo(newSelection)
+            assertThat(viewModel.newPaymentSelection).isEqualTo(
+                BaseSheetViewModel.NewOrExternalPaymentSelection.New(
+                    newSelection
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `updateSelection with external payment method updates the current selection`() = runTest {
+        val viewModel = createViewModel(initialPaymentSelection = null)
+
+        viewModel.selection.test {
+            val newSelection = PaymentSelection.ExternalPaymentMethod(
+                type = "external_fawry",
+                billingDetails = null,
+                label = "Fawry",
+                iconResource = 0,
+                lightThemeIconUrl = "some_url",
+                darkThemeIconUrl = null,
+            )
+            assertThat(awaitItem()).isNull()
+            viewModel.updateSelection(newSelection)
+            assertThat(awaitItem()).isEqualTo(newSelection)
+            assertThat(viewModel.newPaymentSelection).isEqualTo(
+                BaseSheetViewModel.NewOrExternalPaymentSelection.External(
+                    newSelection
+                )
+            )
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update payment selection in `BaseSheetViewModel` when the `PaymentSelection` is an `ExternalPaymentMethod`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
If we don't do this, re-selecting a payment method in FlowController will show card as the current selection when you've previously selected an external payment method. See screen recordings.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screen recordings
Before: 

https://github.com/stripe/stripe-android/assets/160939932/a865a518-a9f5-4105-8cb0-bcb971f15f29

 After:

https://github.com/stripe/stripe-android/assets/160939932/0fe281b2-5690-4509-aab1-8de75c70be58
