### PR TITLE
Reduce recompositions in FC top app bar

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.semantics
@@ -59,7 +60,7 @@ internal fun FinancialConnectionsTopAppBar(
     state: TopAppBarState,
     onCloseClick: () -> Unit
 ) {
-    val elevation by animateDpAsState(
+    val elevation = animateDpAsState(
         targetValue = if (state.isElevated) AppBarDefaults.TopAppBarElevation else 0.dp,
         label = "TopAppBarElevation",
     )
@@ -77,9 +78,10 @@ internal fun FinancialConnectionsTopAppBar(
 private fun FinancialConnectionsTopAppBar(
     hideStripeLogo: Boolean,
     testMode: Boolean,
-    elevation: Dp,
+    elevation: State<Dp>,
     allowBackNavigation: Boolean,
-    onCloseClick: () -> Unit
+    onCloseClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current
     val localBackPressed = onBackPressedDispatcher?.onBackPressedDispatcher
@@ -97,7 +99,7 @@ private fun FinancialConnectionsTopAppBar(
                 testmode = testMode
             )
         },
-        elevation = elevation,
+        elevation = 0.dp,
         navigationIcon = if (canShowBackIcon && allowBackNavigation) {
             {
                 BackButton(
@@ -117,7 +119,10 @@ private fun FinancialConnectionsTopAppBar(
             )
         },
         backgroundColor = FinancialConnectionsTheme.colors.textWhite,
-        contentColor = FinancialConnectionsTheme.colors.textBrand
+        contentColor = FinancialConnectionsTheme.colors.textBrand,
+        modifier = modifier.graphicsLayer {
+            shadowElevation = elevation.value.toPx()
+        }
     )
 }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request uses `Modifier.graphicsLayer { shadowElevation = … }` to animate the top app bar elevation, instead of updating the `elevation` parameter. The latter resulted in more recompositions than necessary. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
