### PR TITLE
Safely observe `StateFlow` in elements with Compose.

### DIFF
--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
@@ -21,7 +21,6 @@ import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -241,7 +240,7 @@ internal fun LinkFields(
 ) {
     var didShowAllFields by rememberSaveable { mutableStateOf(false) }
 
-    val sectionError by sectionController.error.collectAsState()
+    val sectionError by sectionController.error.collectAsStateSafely()
 
     AnimatedVisibility(visible = expanded) {
         Column(

--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
@@ -58,6 +58,7 @@ import com.stripe.android.uicore.elements.menu.Checkbox
 import com.stripe.android.uicore.getBorderStroke
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.stripeShapes
+import com.stripe.android.uicore.utils.collectAsStateSafely
 import kotlinx.coroutines.launch
 
 internal const val ProgressIndicatorTestTag = "CircularProgressIndicator"
@@ -74,8 +75,8 @@ fun LinkInlineSignup(
             factory = InlineSignupViewModel.Factory(component)
         )
 
-        val viewState by viewModel.viewState.collectAsState()
-        val errorMessage by viewModel.errorMessage.collectAsState()
+        val viewState by viewModel.viewState.collectAsStateSafely()
+        val errorMessage by viewModel.errorMessage.collectAsStateSafely()
 
         LaunchedEffect(viewState) {
             onStateChanged(component.configuration, viewState)

--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkOptionalInlineSignup.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkOptionalInlineSignup.kt
@@ -16,7 +16,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -54,6 +53,7 @@ import com.stripe.android.uicore.elements.TextField
 import com.stripe.android.uicore.elements.TextFieldController
 import com.stripe.android.uicore.shouldUseDarkDynamicColor
 import com.stripe.android.uicore.stripeColors
+import com.stripe.android.uicore.utils.collectAsStateSafely
 import kotlinx.coroutines.job
 
 @Composable
@@ -68,8 +68,8 @@ fun LinkOptionalInlineSignup(
             factory = InlineSignupViewModel.Factory(component)
         )
 
-        val viewState by viewModel.viewState.collectAsState()
-        val errorMessage by viewModel.errorMessage.collectAsState()
+        val viewState by viewModel.viewState.collectAsStateSafely()
+        val errorMessage by viewModel.errorMessage.collectAsStateSafely()
 
         LaunchedEffect(viewState) {
             onStateChanged(component.configuration, viewState)
@@ -122,7 +122,7 @@ internal fun LinkOptionalInlineSignup(
         val nameFocusRequester = remember { FocusRequester() }
 
         var didShowAllFields by rememberSaveable { mutableStateOf(false) }
-        val sectionError by sectionController.error.collectAsState()
+        val sectionError by sectionController.error.collectAsStateSafely()
 
         if (signUpState == SignUpState.InputtingRemainingFields) {
             LaunchedEffect(signUpState) {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
@@ -4,7 +4,6 @@ import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.stripe.android.ui.core.elements.AffirmElementUI
@@ -32,6 +31,7 @@ import com.stripe.android.uicore.elements.OTPElement
 import com.stripe.android.uicore.elements.OTPElementUI
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SectionElementUI
+import com.stripe.android.uicore.utils.collectAsStateSafely
 import kotlinx.coroutines.flow.StateFlow
 
 @Composable
@@ -43,10 +43,10 @@ fun FormUI(
     lastTextFieldIdentifierFlow: StateFlow<IdentifierSpec?>,
     modifier: Modifier = Modifier
 ) {
-    val hiddenIdentifiers by hiddenIdentifiersFlow.collectAsState()
-    val enabled by enabledFlow.collectAsState()
-    val elements by elementsFlow.collectAsState()
-    val lastTextFieldIdentifier by lastTextFieldIdentifierFlow.collectAsState()
+    val hiddenIdentifiers by hiddenIdentifiersFlow.collectAsStateSafely()
+    val enabled by enabledFlow.collectAsStateSafely()
+    val elements by elementsFlow.collectAsStateSafely()
+    val lastTextFieldIdentifier by lastTextFieldIdentifierFlow.collectAsStateSafely()
 
     FormUI(
         hiddenIdentifiers = hiddenIdentifiers,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbElementUI.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -13,6 +12,7 @@ import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.Section
 import com.stripe.android.uicore.elements.TextField
 import com.stripe.android.uicore.stripeColors
+import com.stripe.android.uicore.utils.collectAsStateSafely
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -21,8 +21,8 @@ fun BsbElementUI(
     element: BsbElement,
     lastTextFieldIdentifier: IdentifierSpec?
 ) {
-    val error by element.textElement.controller.error.collectAsState()
-    val bankName by element.bankName.collectAsState()
+    val error by element.textElement.controller.error.collectAsStateSafely()
+    val bankName by element.bankName.collectAsStateSafely()
     val sectionErrorString = error?.let {
         it.formatArgs?.let { args ->
             stringResource(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseElementUI.kt
@@ -2,11 +2,11 @@ package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import com.stripe.android.uicore.elements.CheckboxElementUI
+import com.stripe.android.uicore.utils.collectAsStateSafely
 
 const val SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG = "SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG"
 
@@ -18,8 +18,8 @@ fun SaveForFutureUseElementUI(
     modifier: Modifier = Modifier,
 ) {
     val controller = element.controller
-    val checked by controller.saveForFutureUse.collectAsState()
-    val label by controller.label.collectAsState()
+    val checked by controller.saveForFutureUse.collectAsStateSafely()
+    val label by controller.label.collectAsStateSafely()
     val resources = LocalContext.current.resources
 
     CheckboxElementUI(

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetBillingConfigurationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetBillingConfigurationTest.kt
@@ -12,6 +12,9 @@ import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.not
 import com.stripe.android.networktesting.RequestMatchers.path
 import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.paymentsheet.utils.IntegrationType
+import com.stripe.android.paymentsheet.utils.assertCompleted
+import com.stripe.android.paymentsheet.utils.runPaymentSheetTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -167,5 +170,53 @@ internal class PaymentSheetBillingConfigurationTest {
         page.clickPrimaryButton()
 
         assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
+    }
+
+    @Test
+    fun testAddressInputNotReset() = runPaymentSheetTest(
+        networkRule = networkRule,
+        integrationType = IntegrationType.Compose,
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
+        networkRule.enqueue(
+            method("GET"),
+            path("/v1/elements/sessions"),
+        ) { response ->
+            response.testBodyFromFile("elements-sessions-requires_payment_method.json")
+        }
+
+        testContext.presentPaymentSheet {
+            presentWithPaymentIntent(
+                paymentIntentClientSecret = "pi_example_secret_example",
+                configuration = PaymentSheet.Configuration(
+                    merchantDisplayName = "Merchant, Inc.",
+                    defaultBillingDetails = PaymentSheet.BillingDetails(
+                        name = "Jenny Rosen",
+                        email = "foo@bar.com",
+                        phone = "+13105551234",
+                        address = PaymentSheet.Address(
+                            postalCode = "94111",
+                            country = "US",
+                            state = "CA",
+                            city = "South San Francisco",
+                            line1 = "123 Main Street",
+                            line2 = null,
+                        ),
+                    ),
+                    billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                        address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                        attachDefaultsToPaymentMethod = false,
+                    ),
+                ),
+            )
+        }
+
+        page.replaceText("123 Main Street", "123 Main Road")
+        page.replaceText("MM / YY", "12/34")
+
+        // Check that line 1 was not reset to default value
+        page.waitForText("123 Main Road")
+
+        testContext.markTestSucceeded()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.navigation
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
@@ -13,6 +12,7 @@ import com.stripe.android.paymentsheet.ui.EditPaymentMethod
 import com.stripe.android.paymentsheet.ui.ModifiableEditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.ui.PaymentOptions
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.uicore.utils.collectAsStateSafely
 import java.io.Closeable
 
 internal val PaymentSheetScreen.topContentPadding: Dp
@@ -68,9 +68,9 @@ internal sealed interface PaymentSheetScreen {
 
         @Composable
         override fun Content(viewModel: BaseSheetViewModel, modifier: Modifier) {
-            val state by viewModel.paymentOptionsState.collectAsState()
-            val isEditing by viewModel.editing.collectAsState()
-            val isProcessing by viewModel.processing.collectAsState()
+            val state by viewModel.paymentOptionsState.collectAsStateSafely()
+            val isEditing by viewModel.editing.collectAsStateSafely()
+            val isProcessing by viewModel.processing.collectAsStateSafely()
 
             PaymentOptions(
                 state = state,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountEmitters.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountEmitters.kt
@@ -4,9 +4,9 @@ import androidx.activity.compose.LocalActivityResultRegistryOwner
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
+import com.stripe.android.uicore.utils.collectAsStateSafely
 import kotlinx.coroutines.flow.filterNot
 
 @Composable
@@ -15,8 +15,8 @@ internal fun USBankAccountEmitters(
     usBankAccountFormArgs: USBankAccountFormArguments,
 ) {
     val context = LocalContext.current
-    val screenState by viewModel.currentScreenState.collectAsState()
-    val hasRequiredFields by viewModel.requiredFields.collectAsState()
+    val screenState by viewModel.currentScreenState.collectAsStateSafely()
+    val hasRequiredFields by viewModel.requiredFields.collectAsStateSafely()
     val activityResultRegistryOwner = LocalActivityResultRegistryOwner.current
 
     LaunchedEffect(Unit) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -47,6 +46,7 @@ import com.stripe.android.uicore.elements.SectionCard
 import com.stripe.android.uicore.elements.TextFieldController
 import com.stripe.android.uicore.elements.TextFieldSection
 import com.stripe.android.uicore.stripeColors
+import com.stripe.android.uicore.utils.collectAsStateSafely
 import com.stripe.android.R as StripeR
 import com.stripe.android.ui.core.R as PaymentsUiCoreR
 
@@ -73,8 +73,8 @@ internal fun USBankAccountForm(
         },
     )
 
-    val currentScreenState by viewModel.currentScreenState.collectAsState()
-    val lastTextFieldIdentifier by viewModel.lastTextFieldIdentifier.collectAsState()
+    val currentScreenState by viewModel.currentScreenState.collectAsStateSafely()
+    val lastTextFieldIdentifier by viewModel.lastTextFieldIdentifier.collectAsStateSafely()
 
     USBankAccountEmitters(
         viewModel = viewModel,
@@ -320,7 +320,7 @@ private fun PhoneSection(
     phoneController: PhoneNumberController,
     imeAction: ImeAction,
 ) {
-    val error by phoneController.error.collectAsState()
+    val error by phoneController.error.collectAsStateSafely()
 
     val sectionErrorString = error?.let {
         it.formatArgs?.let { args ->
@@ -355,7 +355,7 @@ private fun AddressSection(
     lastTextFieldIdentifier: IdentifierSpec?,
     sameAsShippingElement: SameAsShippingElement?,
 ) {
-    val error by addressController.error.collectAsState()
+    val error by addressController.error.collectAsStateSafely()
 
     val sectionErrorString = error?.let {
         it.formatArgs?.let { args ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationForm.kt
@@ -15,7 +15,6 @@ import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -39,6 +38,7 @@ import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.stripeTypography
 import com.stripe.android.uicore.text.Html
+import com.stripe.android.uicore.utils.collectAsStateSafely
 import com.stripe.android.R as PaymentsCoreR
 import com.stripe.android.ui.core.R as PaymentsUiCoreR
 import com.stripe.android.uicore.R as StripeUiCoreR
@@ -47,7 +47,7 @@ import com.stripe.android.uicore.R as StripeUiCoreR
 internal fun BacsMandateConfirmationFormScreen(
     viewModel: BacsMandateConfirmationViewModel = viewModel()
 ) {
-    val viewState by viewModel.viewState.collectAsState()
+    val viewState by viewModel.viewState.collectAsStateSafely()
 
     BacsMandateConfirmationFormView(viewState, viewModel::handleViewAction)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -34,6 +33,7 @@ import com.stripe.android.ui.core.FieldValuesToParamsMapConverter
 import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventReporter
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.LocalAutofillEventReporter
+import com.stripe.android.uicore.utils.collectAsStateSafely
 
 @Composable
 internal fun AddPaymentMethod(
@@ -48,9 +48,9 @@ internal fun AddPaymentMethod(
         sheetViewModel.createFormArguments(selectedPaymentMethodCode)
     }
 
-    val paymentSelection by sheetViewModel.selection.collectAsState()
+    val paymentSelection by sheetViewModel.selection.collectAsStateSafely()
 
-    val linkSignupMode by sheetViewModel.linkSignupMode.collectAsState()
+    val linkSignupMode by sheetViewModel.linkSignupMode.collectAsStateSafely()
     val linkInlineSignupMode = remember(linkSignupMode, selectedPaymentMethodCode) {
         linkSignupMode.takeIf { selectedPaymentMethodCode == PaymentMethod.Type.Card.code }
     }
@@ -70,9 +70,9 @@ internal fun AddPaymentMethod(
             val onBehalfOf = (initializationMode as? PaymentSheet.InitializationMode.DeferredIntent)
                 ?.intentConfiguration
                 ?.onBehalfOf
-            val processing by sheetViewModel.processing.collectAsState()
+            val processing by sheetViewModel.processing.collectAsStateSafely()
             val context = LocalContext.current
-            val paymentMethodMetadata by sheetViewModel.paymentMethodMetadata.collectAsState()
+            val paymentMethodMetadata by sheetViewModel.paymentMethodMetadata.collectAsStateSafely()
             val stripeIntent = paymentMethodMetadata?.stripeIntent
             val formElements = remember(selectedPaymentMethodCode) {
                 sheetViewModel.formElementsForCode(selectedPaymentMethodCode)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditPaymentMethod.kt
@@ -28,7 +28,6 @@ import androidx.compose.material.ripple.RippleAlpha
 import androidx.compose.material.ripple.RippleTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -61,6 +60,7 @@ import com.stripe.android.uicore.getComposeTextStyle
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.stripeShapes
+import com.stripe.android.uicore.utils.collectAsStateSafely
 import com.stripe.android.R as PaymentsCoreR
 import com.stripe.android.R as StripeR
 import com.stripe.android.uicore.R as UiCoreR
@@ -70,7 +70,7 @@ internal fun EditPaymentMethod(
     interactor: EditPaymentMethodViewInteractor,
     modifier: Modifier = Modifier
 ) {
-    val viewState by interactor.viewState.collectAsState()
+    val viewState by interactor.viewState.collectAsStateSafely()
 
     EditPaymentMethodUi(
         modifier = modifier,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -13,6 +12,7 @@ import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.ui.core.FormUI
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.utils.collectAsStateSafely
 import kotlinx.coroutines.flow.Flow
 
 @Composable
@@ -33,8 +33,8 @@ internal fun PaymentMethodForm(
     )
 
     val elements = formViewModel.elements
-    val hiddenIdentifiers by formViewModel.hiddenIdentifiers.collectAsState()
-    val lastTextFieldIdentifier by formViewModel.lastTextFieldIdentifier.collectAsState(null)
+    val hiddenIdentifiers by formViewModel.hiddenIdentifiers.collectAsStateSafely()
+    val lastTextFieldIdentifier by formViewModel.lastTextFieldIdentifier.collectAsStateSafely()
 
     PaymentMethodForm(
         paymentMethodCode = args.paymentMethodCode,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -57,6 +56,7 @@ import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.CircularProgressIndicator
 import com.stripe.android.ui.core.elements.H4Text
 import com.stripe.android.uicore.strings.resolve
+import com.stripe.android.uicore.utils.collectAsStateSafely
 import kotlinx.coroutines.delay
 
 @Composable
@@ -65,11 +65,11 @@ internal fun PaymentSheetScreen(
     type: PaymentSheetFlowType,
     modifier: Modifier = Modifier,
 ) {
-    val contentVisible by viewModel.contentVisible.collectAsState()
-    val processing by viewModel.processing.collectAsState()
+    val contentVisible by viewModel.contentVisible.collectAsStateSafely()
+    val processing by viewModel.processing.collectAsStateSafely()
 
-    val topBarState by viewModel.topBarState.collectAsState()
-    val walletsProcessingState by viewModel.walletsProcessingState.collectAsState()
+    val topBarState by viewModel.topBarState.collectAsStateSafely()
+    val walletsProcessingState by viewModel.walletsProcessingState.collectAsStateSafely()
 
     val density = LocalDensity.current
     var contentHeight by remember { mutableStateOf(0.dp) }
@@ -131,12 +131,12 @@ internal fun PaymentSheetScreenContent(
     type: PaymentSheetFlowType,
     modifier: Modifier = Modifier,
 ) {
-    val headerText by viewModel.headerText.collectAsState()
-    val walletsState by viewModel.walletsState.collectAsState()
-    val walletsProcessingState by viewModel.walletsProcessingState.collectAsState()
-    val error by viewModel.error.collectAsState()
-    val currentScreen by viewModel.currentScreen.collectAsState()
-    val mandateText by viewModel.mandateText.collectAsState()
+    val headerText by viewModel.headerText.collectAsStateSafely()
+    val walletsState by viewModel.walletsState.collectAsStateSafely()
+    val walletsProcessingState by viewModel.walletsProcessingState.collectAsStateSafely()
+    val error by viewModel.error.collectAsStateSafely()
+    val currentScreen by viewModel.currentScreen.collectAsStateSafely()
+    val mandateText by viewModel.mandateText.collectAsStateSafely()
 
     Column(modifier) {
         PaymentSheetContent(
@@ -309,7 +309,7 @@ internal fun Wallet(
 
 @Composable
 private fun PrimaryButton(viewModel: BaseSheetViewModel, type: PaymentSheetFlowType) {
-    val uiState = viewModel.primaryButtonUiState.collectAsState()
+    val uiState = viewModel.primaryButtonUiState.collectAsStateSafely()
 
     val modifier = Modifier
         .testTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElementUI.kt
@@ -6,12 +6,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.stripeShapes
+import com.stripe.android.uicore.utils.collectAsStateSafely
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -21,11 +21,11 @@ fun AddressElementUI(
     hiddenIdentifiers: Set<IdentifierSpec>,
     lastTextFieldIdentifier: IdentifierSpec?
 ) {
-    val fields by controller.fieldsFlowable.collectAsState(null)
+    val fields by controller.fieldsFlowable.collectAsStateSafely()
 
     // The last rendered field is not always the last field in the list.
     // So we need to pre filter so we know when to stop drawing dividers.
-    fields?.filterNot { hiddenIdentifiers.contains(it.identifier) }?.let { fieldList ->
+    fields.filterNot { hiddenIdentifiers.contains(it.identifier) }.let { fieldList ->
         Column {
             fieldList.forEachIndexed { index, field ->
                 SectionFieldElementUI(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CheckboxFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CheckboxFieldUI.kt
@@ -15,7 +15,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -32,6 +31,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.stripeColors
+import com.stripe.android.uicore.utils.collectAsStateSafely
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -40,8 +40,8 @@ fun CheckboxFieldUI(
     controller: CheckboxFieldController,
     enabled: Boolean = true
 ) {
-    val isChecked by controller.isChecked.collectAsState()
-    val error by controller.error.collectAsState()
+    val isChecked by controller.isChecked.collectAsStateSafely()
+    val error by controller.error.collectAsStateSafely()
 
     CheckboxFieldUIView(
         modifier = modifier,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldUI.kt
@@ -23,7 +23,6 @@ import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -40,6 +39,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.stripeColors
+import com.stripe.android.uicore.utils.collectAsStateSafely
 
 @Preview
 @Composable
@@ -82,8 +82,8 @@ fun DropDown(
     modifier: Modifier = Modifier,
     showChevron: Boolean = true
 ) {
-    val label by controller.label.collectAsState()
-    val selectedIndex by controller.selectedIndex.collectAsState()
+    val label by controller.label.collectAsStateSafely()
+    val selectedIndex by controller.selectedIndex.collectAsStateSafely()
     val items = controller.displayItems
     val shouldDisableDropdownWithSingleItem =
         items.count() == 1 && controller.disableDropdownWithSingleElement

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElementUI.kt
@@ -21,7 +21,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
@@ -60,6 +59,7 @@ import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.getBorderStrokeWidth
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.text.autofill
+import com.stripe.android.uicore.utils.collectAsStateSafely
 
 @Composable
 @Preview(backgroundColor = 0xFFFFFFFF, showBackground = true)
@@ -137,7 +137,7 @@ fun OTPElementUI(
                     }
                 )
             ) {
-                val value by element.controller.fieldValues[index].collectAsState()
+                val value by element.controller.fieldValues[index].collectAsStateSafely()
 
                 var textFieldModifier = Modifier
                     .height(56.dp)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberElementUI.kt
@@ -15,7 +15,6 @@ import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -39,6 +38,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.text.autofill
+import com.stripe.android.uicore.utils.collectAsStateSafely
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 
@@ -68,7 +68,7 @@ fun PhoneNumberCollectionSection(
     focusRequester: FocusRequester = remember { FocusRequester() },
     imeAction: ImeAction = ImeAction.Done
 ) {
-    val error by phoneNumberController.error.collectAsState()
+    val error by phoneNumberController.error.collectAsStateSafely()
 
     val sectionErrorString = error?.let {
         it.formatArgs?.let { args ->
@@ -116,12 +116,12 @@ fun PhoneNumberElementUI(
     val bringIntoViewRequester = remember { BringIntoViewRequester() }
     val focusManager = LocalFocusManager.current
 
-    val value by controller.fieldValue.collectAsState()
-    val isComplete by controller.isComplete.collectAsState()
-    val shouldShowError by controller.error.collectAsState()
-    val label by controller.label.collectAsState()
-    val placeholder by controller.placeholder.collectAsState()
-    val visualTransformation by controller.visualTransformation.collectAsState()
+    val value by controller.fieldValue.collectAsStateSafely()
+    val isComplete by controller.isComplete.collectAsStateSafely()
+    val shouldShowError by controller.error.collectAsStateSafely()
+    val label by controller.label.collectAsStateSafely()
+    val placeholder by controller.placeholder.collectAsStateSafely()
+    val visualTransformation by controller.visualTransformation.collectAsStateSafely()
     val colors = TextFieldColors(shouldShowError != null)
     var hasFocus by rememberSaveable { mutableStateOf(false) }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingElementUI.kt
@@ -2,9 +2,9 @@ package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.res.stringResource
+import com.stripe.android.uicore.utils.collectAsStateSafely
 
 const val SAME_AS_SHIPPING_CHECKBOX_TEST_TAG = "SAME_AS_SHIPPING_CHECKBOX_TEST_TAG"
 
@@ -13,8 +13,8 @@ const val SAME_AS_SHIPPING_CHECKBOX_TEST_TAG = "SAME_AS_SHIPPING_CHECKBOX_TEST_T
 fun SameAsShippingElementUI(
     controller: SameAsShippingController
 ) {
-    val checked by controller.value.collectAsState()
-    val label by controller.label.collectAsState()
+    val checked by controller.value.collectAsStateSafely()
+    val label by controller.label.collectAsStateSafely()
 
     CheckboxElementUI(
         automationTestTag = SAME_AS_SHIPPING_CHECKBOX_TEST_TAG,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElementUI.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
@@ -15,6 +14,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.stripeShapes
+import com.stripe.android.uicore.utils.collectAsStateSafely
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -29,7 +29,7 @@ fun SectionElementUI(
     if (!hiddenIdentifiers.contains(element.identifier)) {
         val controller = element.controller
 
-        val error by controller.error.collectAsState(null)
+        val error by controller.error.collectAsStateSafely()
         val sectionErrorString = error?.let {
             it.formatArgs?.let { args ->
                 stringResource(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
@@ -149,9 +148,7 @@ fun TextField(
 
     val hasFocus = rememberSaveable { mutableStateOf(false) }
 
-    val fieldState by textFieldController.fieldState.collectAsState(
-        TextFieldStateConstants.Error.Blank
-    )
+    val fieldState by textFieldController.fieldState.collectAsStateSafely()
     val label by textFieldController.label.collectAsStateSafely()
 
     LaunchedEffect(fieldState) {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
@@ -66,6 +66,7 @@ import com.stripe.android.uicore.R
 import com.stripe.android.uicore.elements.compat.CompatTextField
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.text.autofill
+import com.stripe.android.uicore.utils.collectAsStateSafely
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -95,7 +96,7 @@ fun TextFieldSection(
     @StringRes sectionTitle: Int? = null,
     onTextStateChanged: (TextFieldState?) -> Unit = {}
 ) {
-    val error by textFieldController.error.collectAsState()
+    val error by textFieldController.error.collectAsStateSafely()
 
     val sectionErrorString = error?.let {
         it.formatArgs?.let { args ->
@@ -139,19 +140,19 @@ fun TextField(
     focusRequester: FocusRequester = remember { FocusRequester() },
 ) {
     val focusManager = LocalFocusManager.current
-    val value by textFieldController.fieldValue.collectAsState()
-    val trailingIcon by textFieldController.trailingIcon.collectAsState()
-    val shouldShowError by textFieldController.visibleError.collectAsState()
-    val loading by textFieldController.loading.collectAsState()
-    val contentDescription by textFieldController.contentDescription.collectAsState()
-    val placeHolder by textFieldController.placeHolder.collectAsState()
+    val value by textFieldController.fieldValue.collectAsStateSafely()
+    val trailingIcon by textFieldController.trailingIcon.collectAsStateSafely()
+    val shouldShowError by textFieldController.visibleError.collectAsStateSafely()
+    val loading by textFieldController.loading.collectAsStateSafely()
+    val contentDescription by textFieldController.contentDescription.collectAsStateSafely()
+    val placeHolder by textFieldController.placeHolder.collectAsStateSafely()
 
     val hasFocus = rememberSaveable { mutableStateOf(false) }
 
     val fieldState by textFieldController.fieldState.collectAsState(
         TextFieldStateConstants.Error.Blank
     )
-    val label by textFieldController.label.collectAsState()
+    val label by textFieldController.label.collectAsStateSafely()
 
     LaunchedEffect(fieldState) {
         // When field is in focus and full, move to next field so the user can keep typing

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/text/Html.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/text/Html.kt
@@ -26,7 +26,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -56,6 +55,7 @@ import androidx.core.text.HtmlCompat
 import com.stripe.android.uicore.image.StripeImage
 import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.uicore.image.isSupportedImageUrl
+import com.stripe.android.uicore.utils.collectAsStateSafely
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -199,7 +199,7 @@ private fun rememberRemoteImages(
         }
     }
 
-    return remoteImages.collectAsState()
+    return remoteImages.collectAsStateSafely()
 }
 
 /**

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/utils/StateFlowsCompose.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/utils/StateFlowsCompose.kt
@@ -10,9 +10,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.EmptyCoroutineContext
 
 private class DefaultProduceStateScope<T>(
     state: MutableState<T>,
@@ -42,17 +40,9 @@ private fun <T> produceState(
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Composable
-fun <T> StateFlow<T>.collectAsStateSafely(
-    context: CoroutineContext = EmptyCoroutineContext
-): State<T> = produceState(
+fun <T> StateFlow<T>.collectAsStateSafely(): State<T> = produceState(
     produceInitialValue = remember { { value } },
     key = this
 ) {
-    if (context == EmptyCoroutineContext) {
-        collect { value = it }
-    } else {
-        withContext(context) {
-            collect { value = it }
-        }
-    }
+    collect { value = it }
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/utils/StateFlowsCompose.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/utils/StateFlowsCompose.kt
@@ -1,0 +1,58 @@
+package com.stripe.android.uicore.utils
+
+import androidx.annotation.RestrictTo
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.ProduceStateScope
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+private class DefaultProduceStateScope<T>(
+    state: MutableState<T>,
+    override val coroutineContext: CoroutineContext
+) : ProduceStateScope<T>, MutableState<T> by state {
+    override suspend fun awaitDispose(onDispose: () -> Unit): Nothing {
+        try {
+            suspendCancellableCoroutine<Nothing> { }
+        } finally {
+            onDispose()
+        }
+    }
+}
+
+@Composable
+private fun <T> produceState(
+    produceInitialValue: () -> T,
+    key: Any?,
+    producer: suspend ProduceStateScope<T>.() -> Unit
+): State<T> {
+    val result = remember { mutableStateOf(produceInitialValue()) }
+    LaunchedEffect(key) {
+        DefaultProduceStateScope(result, coroutineContext).producer()
+    }
+    return result
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Composable
+fun <T> StateFlow<T>.collectAsStateSafely(
+    context: CoroutineContext = EmptyCoroutineContext
+): State<T> = produceState(
+    produceInitialValue = remember { { value } },
+    key = this
+) {
+    if (context == EmptyCoroutineContext) {
+        collect { value = it }
+    } else {
+        withContext(context) {
+            collect { value = it }
+        }
+    }
+}

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressElementUiTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressElementUiTest.kt
@@ -1,0 +1,70 @@
+package com.stripe.android.uicore.elements
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTextReplacement
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.stripe.android.uicore.utils.collectAsStateSafely
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AddressElementUiTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    /*
+     * This test ensures that there is no regression to 'AddressElement' behavior in which
+     * input is reset when the user is typing.
+     */
+    @Test
+    fun `On input updated, input is not reset in 'AddressElement' when observed`() {
+        val element = AddressElement(
+            _identifier = IdentifierSpec.BillingAddress,
+            rawValuesMap = mapOf(
+                IdentifierSpec.Line1 to "123 Main Street",
+                IdentifierSpec.Line2 to "456",
+                IdentifierSpec.City to "San Francisco",
+                IdentifierSpec.State to "CA",
+                IdentifierSpec.Country to "US",
+                IdentifierSpec.PostalCode to "94111",
+            ),
+            countryCodes = setOf("US"),
+            sameAsShippingElement = SameAsShippingElement(
+                IdentifierSpec.SameAsShipping,
+                SameAsShippingController(false)
+            ),
+            shippingValuesMap = mapOf(
+                IdentifierSpec.Country to "US"
+            ),
+        )
+
+        val formValues = element.getFormFieldValueFlow()
+
+        composeTestRule.setContent {
+            val formValuesState by formValues.collectAsStateSafely()
+
+            Text(formValuesState.toString())
+
+            AddressElementUI(
+                enabled = true,
+                controller = element.controller,
+                hiddenIdentifiers = setOf(),
+                lastTextFieldIdentifier = null,
+            )
+        }
+
+        composeTestRule.onNodeWithText("123 Main Street")
+            .performTextReplacement("123 Main ")
+
+        composeTestRule.onNodeWithText("123 Main ")
+            .performTextInput("Road")
+
+        composeTestRule.onNodeWithText("123 Main Road").assertExists()
+        composeTestRule.onNodeWithText("123 Main Street").assertDoesNotExist()
+    }
+}

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/utils/StateFlowsComposeTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/utils/StateFlowsComposeTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.uicore.utils
 
 import androidx.compose.material.Text
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -45,7 +46,9 @@ class StateFlowsComposeTest {
 
             val testState by testStateFlow.collectAsStateSafely()
 
-            recompositionCount++
+            SideEffect {
+                recompositionCount++
+            }
 
             Text(textState)
             Text(recompositionCount.toString())

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/utils/StateFlowsComposeTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/utils/StateFlowsComposeTest.kt
@@ -1,0 +1,93 @@
+package com.stripe.android.uicore.utils
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@OptIn(ExperimentalTestApi::class)
+@RunWith(AndroidJUnit4::class)
+class StateFlowsComposeTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `'collectAsStateSafely' only produces initial value on initial composition`() {
+        val stateFlow = MutableStateFlow(2)
+        var initialValueProducedCount = 0
+
+        val testStateFlow = object : StateFlow<Int> by stateFlow {
+            override val value: Int
+                get() {
+                    initialValueProducedCount++
+
+                    return stateFlow.value
+                }
+        }
+
+        val text = mutableStateOf("Hello")
+        var recompositionCount = 0
+
+        composeTestRule.setContent {
+            val textState by remember {
+                text
+            }
+
+            val testState by testStateFlow.collectAsStateSafely()
+
+            recompositionCount++
+
+            Text(textState)
+            Text(recompositionCount.toString())
+            Text(testState.toString())
+        }
+
+        text.value = "my"
+        composeTestRule.waitUntilExactlyOneExists(hasText("my"))
+
+        text.value = "name"
+        composeTestRule.waitUntilExactlyOneExists(hasText("name"))
+
+        text.value = "is"
+        composeTestRule.waitUntilExactlyOneExists(hasText("is"))
+
+        text.value = "John"
+        composeTestRule.waitUntilExactlyOneExists(hasText("John"))
+
+        assertThat(recompositionCount).isEqualTo(5)
+        assertThat(initialValueProducedCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `'collectAsStateSafely' recomposes on state updates`() {
+        val testStateFlow = MutableStateFlow("Hello")
+
+        composeTestRule.setContent {
+            val testState by testStateFlow.collectAsStateSafely()
+
+            Text(testState)
+        }
+
+        testStateFlow.value = "my"
+        composeTestRule.waitUntilExactlyOneExists(hasText("my"))
+
+        testStateFlow.value = "name"
+        composeTestRule.waitUntilExactlyOneExists(hasText("name"))
+
+        testStateFlow.value = "is"
+        composeTestRule.waitUntilExactlyOneExists(hasText("is"))
+
+        testStateFlow.value = "John"
+        composeTestRule.waitUntilExactlyOneExists(hasText("John"))
+    }
+}


### PR DESCRIPTION
# Summary
Adds a new function called `collectAsStateSafely` which produces the initial value using a lambda rather than using `value` directly.

Replaces multiple usages of `collectAsState` in `PaymentSheet` elements.

# Motivation
We are currently using `collectAsState` from the Compose Runtime library. This works well with the default implementation of `StateFlow` but makes the assumption that `value` is a stored property and not a getter property. There is a lint error for using `StateFlow.value` in composition but for a different reason.

```kotlin
/**
 * 
 * StateFlow.value should not be called within composition
 *
 * Inspection info: Calling StateFlow.value within composition will not observe changes to the StateFlow, so changes might
 * not be reflected within the composition. Instead you should use stateFlow.collectAsState() to observe changes to the.
 * StateFlow, and recompose when it changes.
 */
@Suppress("StateFlowValueCalledInComposition")
@Composable
fun <T> StateFlow<T>.collectAsState(
    context: CoroutineContext = EmptyCoroutineContext
): State<T> = collectAsState(value, context)
```

Since we introduced `mapAsStateFlow`, we've been using it pretty aggressively across the repository. Unfortunately, the internal `FlowToStateFlow` class makes `value` a getter property. 
https://github.com/stripe/stripe-android/blob/f8f76a01629a89817399cbdb98e8663e95ba2788/stripe-ui-core/src/main/java/com/stripe/android/uicore/utils/StateFlows.kt#L30-L40
This means on every recomposition, we are rebuilding the value from `FlowtoStateFlow`. This can be especially problematic if multiple `mapAsStateFlow` calls are chained together (such as `AddressElement` fields).