### PR TITLE
Send a canceled() confirm result in FawryActivity#onDestroy

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/FawryActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/FawryActivity.kt
@@ -50,6 +50,12 @@ class FawryActivity : AppCompatActivity() {
         }
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+
+        ExternalPaymentMethodResultHandler.onExternalPaymentMethodResult(this, ExternalPaymentMethodResult.canceled())
+    }
+
     private fun onExternalPaymentMethodResult(
         context: Context,
         externalPaymentMethodResult: ExternalPaymentMethodResult


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Send a canceled() confirm result in FawryActivity#onDestroy

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Properly handle the case where a user presses "back" to exit the FawryActivity

We could also handle this by trying to detect if `ExternalPaymentMethodProxyActivity` has been restarted, but any solution there seems pretty fragile and likely to have unintended impacts on a merchant's EPM implementation. 

# Screen recordings
Before:
You need to press back twice to get back into PS, and FlowController just totally freezes

https://github.com/stripe/stripe-android/assets/160939932/f2ec08e0-8477-4e16-898d-83139da0da66

After: 
You press back from the FawryActivity and wait ~.5 second for state to be restored

https://github.com/stripe/stripe-android/assets/160939932/33c9c68c-1812-43c5-956b-0856168f993d


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified