### PR TITLE
Prevent calling EPM confirm multiple times

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExternalPaymentMethodProxyActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExternalPaymentMethodProxyActivity.kt
@@ -16,15 +16,19 @@ import com.stripe.android.model.PaymentMethod
  */
 internal class ExternalPaymentMethodProxyActivity : AppCompatActivity() {
 
+    private var hasConfirmStarted: Boolean = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        savedInstanceState?.getBoolean(HAS_CONFIRM_STARTED_KEY)?.let { hasConfirmStarted = it }
 
         val type = intent.getStringExtra(EXTRA_EXTERNAL_PAYMENT_METHOD_TYPE)
 
         @Suppress("DEPRECATION")
         val billingDetails = intent.getParcelableExtra<PaymentMethod.BillingDetails>(EXTRA_BILLING_DETAILS)
 
-        if (type != null) {
+        if (type != null && !hasConfirmStarted) {
+            hasConfirmStarted = true
             ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler?.confirmExternalPaymentMethod(
                 type,
                 billingDetails ?: PaymentMethod.BillingDetails()
@@ -68,8 +72,16 @@ internal class ExternalPaymentMethodProxyActivity : AppCompatActivity() {
         }
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putBoolean(HAS_CONFIRM_STARTED_KEY, hasConfirmStarted)
+
+        super.onSaveInstanceState(outState)
+    }
+
     internal companion object {
         const val EXTRA_EXTERNAL_PAYMENT_METHOD_TYPE = "external_payment_method_type"
         const val EXTRA_BILLING_DETAILS = "external_payment_method_billing_details"
+
+        const val HAS_CONFIRM_STARTED_KEY = "has_confirm_started"
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Ensure `ExternalPaymentMethodProxyActivity` only calls `onExternalPaymentMethodConfirm` once.

Also cleaned up `ExternalPaymentMethodProxyActivityTest` a bit while adding the new test

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
To avoid an issue where EPM confirm would be called twice when the `ExternalPaymentMethodProxyActivity` is recreated.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screen recordings
Before:

https://github.com/stripe/stripe-android/assets/160939932/2189067a-b2f8-4edb-9ae8-cceb196961ca


After:


https://github.com/stripe/stripe-android/assets/160939932/a7a2bca6-da2d-4e36-81a6-c52e71bbf0a0

