### PR TITLE
[Identity] upload as doc front when captured image is not expected type

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
@@ -473,7 +473,12 @@ internal class IdentityViewModel constructor(
 
             else -> {
                 Log.e(TAG, "incorrect category: ${legacyOutput.category}")
-                throw IllegalStateException("incorrect targetScanType: ${legacyOutput.category}")
+                isFront = true
+                targetScanType = IdentityScanState.ScanType.DOC_FRONT
+                logError(
+                    IllegalStateException("incorrect legacy targetScanType: ${legacyOutput.category}, " +
+                        "upload as DOC_FRONT")
+                )
             }
         }
 
@@ -529,7 +534,12 @@ internal class IdentityViewModel constructor(
 
             else -> {
                 Log.e(TAG, "incorrect category: ${modernOutput.category}")
-                throw IllegalStateException("incorrect targetScanType: ${modernOutput.category}")
+                isFront = true
+                targetScanType = IdentityScanState.ScanType.DOC_FRONT
+                logError(
+                    IllegalStateException("incorrect modern targetScanType: ${modernOutput.category}, " +
+                        "upload as DOC_FRONT")
+                )
             }
         }
 
@@ -949,13 +959,13 @@ internal class IdentityViewModel constructor(
                             "sessionID: ${verificationArgs.verificationSessionId} and ephemeralKey: " +
                                 verificationArgs.ephemeralKeySecret
                             ).let { msg ->
-                            _verificationPage.postValue(
-                                Resource.error(
-                                    msg,
-                                    IllegalStateException(msg, it)
+                                _verificationPage.postValue(
+                                    Resource.error(
+                                        msg,
+                                        IllegalStateException(msg, it)
+                                    )
                                 )
-                            )
-                        }
+                            }
                 }
             )
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Upload as doc front when captured image is not expected type, this would trigger a retry instead of a crash

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix crash

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
