### PR TITLE
Fix soft keyboard covering 'Enter address manually' button on autocomplete screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## XX.XX.XX - 20XX-XX-XX
 * [ADDED][8466](https://github.com/stripe/stripe-android/pull/8466) Added support for [external payment methods](https://docs.stripe.com/payments/external-payment-methods?platform=android).
+* [FIXED][8486](https://github.com/stripe/stripe-android/pull/8486) Prevent soft keyboard from covering "Enter address manually" button for Address Autocomplete
 
 ## 20.43.0 - 2024-05-13
 

--- a/paymentsheet/src/main/AndroidManifest.xml
+++ b/paymentsheet/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
         <activity
             android:name=".addresselement.AddressElementActivity"
             android:theme="@style/StripePaymentSheetDefaultTheme"
+            android:windowSoftInputMode="adjustResize"
             android:exported="false" />
         <activity
             android:name=".paymentdatacollection.bacs.BacsMandateConfirmationActivity"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Adds `android:windowSoftInputMode="adjustResize"` to `AndroidManifest.xml`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[RUN_MOBILESDK-3187](https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3187)
[Github Issue #7742](https://github.com/stripe/stripe-android/issues/7742)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified


https://github.com/stripe/stripe-android/assets/163896025/6c1f961f-562c-4745-b204-b584ecb31b30



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
