### PR TITLE
Don't unbind if cameraAdapter is null when stopScanning

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/camera/IdentityCameraManager.kt
+++ b/identity/src/main/java/com/stripe/android/identity/camera/IdentityCameraManager.kt
@@ -12,7 +12,7 @@ import com.stripe.android.camera.scanui.CameraView
  */
 internal abstract class IdentityCameraManager {
     private var cameraView: CameraView? = null
-    private var cameraAdapter: CameraAdapter<CameraPreviewImage<Bitmap>>? = null
+    var cameraAdapter: CameraAdapter<CameraPreviewImage<Bitmap>>? = null
 
     /**
      * Callback from Jetpack Compose when a AndroidView is updated, might be called multiple times

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityScanViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityScanViewModel.kt
@@ -142,7 +142,7 @@ internal abstract class IdentityScanViewModel(
 
     fun stopScan(lifecycleOwner: LifecycleOwner) {
         requireNotNull(identityScanFlow).resetFlow()
-        cameraManager.requireCameraAdapter().unbindFromLifecycle(lifecycleOwner)
+        cameraManager.cameraAdapter?.unbindFromLifecycle(lifecycleOwner)
     }
 
     /**


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When stopScanning is called, only unbind if cameraAdapter is not null

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix a crash when cameraManager is reset during stopScanning

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
