### PR TITLE
Add `CustomerSheet` integration type to Playground

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -236,6 +236,10 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity(), ExternalPay
                     playgroundState = playgroundState,
                 )
             }
+
+            PlaygroundConfigurationData.IntegrationType.CustomerSheet -> {
+                // TODO(samer-stripe): Implement Customer Sheet UI
+            }
         }
     }
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/AutomaticPaymentMethodsSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/AutomaticPaymentMethodsSettingsDefinition.kt
@@ -7,6 +7,10 @@ internal object AutomaticPaymentMethodsSettingsDefinition : BooleanSettingsDefin
     displayName = "Automatic Payment Methods",
     defaultValue = true,
 ) {
+    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
+        return configurationData.integrationType.isPaymentFlow()
+    }
+
     override fun configure(
         value: Boolean,
         checkoutRequestBuilder: CheckoutRequest.Builder,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CheckoutModeSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CheckoutModeSettingsDefinition.kt
@@ -23,6 +23,10 @@ internal object CheckoutModeSettingsDefinition :
         option("Setup", CheckoutMode.SETUP),
     )
 
+    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
+        return configurationData.integrationType.isPaymentFlow()
+    }
+
     override fun configure(value: CheckoutMode, checkoutRequestBuilder: CheckoutRequest.Builder) {
         checkoutRequestBuilder.mode(value.value)
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CountrySettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CountrySettingsDefinition.kt
@@ -12,17 +12,29 @@ internal object CountrySettingsDefinition :
         defaultValue = Country.US,
     ),
     PlaygroundSettingDefinition.Displayable<Country> {
-    private val supportedCountries = Country.entries.map { it.value }.toSet()
+    private val supportedPaymentFlowCountries = Country.entries.map { it.value }.toSet()
+    private val supportedCustomerFlowCountries = setOf(
+        Country.US,
+        Country.FR,
+    )
 
     override val displayName: String = "Merchant"
 
     override fun createOptions(
         configurationData: PlaygroundConfigurationData
-    ) = CountryUtils.getOrderedCountries(Locale.getDefault()).filter { country ->
-        country.code.value in supportedCountries
-    }.map { country ->
-        option(country.name, convertToValue(country.code.value))
-    }.toList()
+    ): List<PlaygroundSettingDefinition.Displayable.Option<Country>> {
+        val supportedCountries = if (configurationData.integrationType.isPaymentFlow()) {
+            supportedPaymentFlowCountries
+        } else {
+            supportedCustomerFlowCountries
+        }
+
+        return CountryUtils.getOrderedCountries(Locale.getDefault()).filter { country ->
+            country.code.value in supportedCountries
+        }.map { country ->
+            option(country.name, convertToValue(country.code.value))
+        }.toList()
+    }
 
     override fun configure(value: Country, checkoutRequestBuilder: CheckoutRequest.Builder) {
         checkoutRequestBuilder.merchantCountryCode(value.value)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CurrencySettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CurrencySettingsDefinition.kt
@@ -12,6 +12,10 @@ internal object CurrencySettingsDefinition :
     PlaygroundSettingDefinition.Displayable<Currency> {
     override val displayName: String = "Currency"
 
+    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
+        return configurationData.integrationType.isPaymentFlow()
+    }
+
     override fun createOptions(
         configurationData: PlaygroundConfigurationData
     ) = Currency.entries.map {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSettingsDefinition.kt
@@ -7,6 +7,10 @@ internal object CustomerSessionSettingsDefinition : BooleanSettingsDefinition(
     displayName = "Use Customer Session",
     key = "customer_session_enabled"
 ) {
+    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
+        return configurationData.integrationType.isPaymentFlow()
+    }
+
     override fun configure(value: Boolean, checkoutRequestBuilder: CheckoutRequest.Builder) {
         if (value) {
             checkoutRequestBuilder.customerKeyType(CheckoutRequest.CustomerKeyType.CustomerSession)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSettingsDefinition.kt
@@ -12,11 +12,18 @@ internal object CustomerSettingsDefinition :
 
     override fun createOptions(
         configurationData: PlaygroundConfigurationData
-    ) = listOf(
-        option("Guest", CustomerType.GUEST),
-        option("New", CustomerType.NEW),
-        option("Returning", CustomerType.RETURNING),
-    )
+    ): List<PlaygroundSettingDefinition.Displayable.Option<CustomerType>> {
+        val configurableOptions = if (configurationData.integrationType.isPaymentFlow()) {
+            listOf(option("Guest", CustomerType.GUEST))
+        } else {
+            listOf()
+        }
+
+        return configurableOptions + listOf(
+            option("New", CustomerType.NEW),
+            option("Returning", CustomerType.RETURNING),
+        )
+    }
 
     override fun configure(
         value: CustomerType,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/DefaultShippingAddressSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/DefaultShippingAddressSettingsDefinition.kt
@@ -7,6 +7,10 @@ internal object DefaultShippingAddressSettingsDefinition : BooleanSettingsDefini
     displayName = "Add Default Shipping Address",
     defaultValue = true,
 ) {
+    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
+        return configurationData.integrationType.isPaymentFlow()
+    }
+
     override fun configure(value: Boolean, checkoutRequestBuilder: CheckoutRequest.Builder) {
         checkoutRequestBuilder.setShippingAddress(value)
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/DelayedPaymentMethodsSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/DelayedPaymentMethodsSettingsDefinition.kt
@@ -8,6 +8,10 @@ internal object DelayedPaymentMethodsSettingsDefinition : BooleanSettingsDefinit
     displayName = "Delayed Payment Methods",
     defaultValue = true,
 ) {
+    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
+        return configurationData.integrationType.isPaymentFlow()
+    }
+
     override fun configure(
         value: Boolean,
         configurationBuilder: PaymentSheet.Configuration.Builder,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/ExternalPaymentMethodSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/ExternalPaymentMethodSettingsDefinition.kt
@@ -28,6 +28,10 @@ internal object ExternalPaymentMethodSettingsDefinition :
 
     override fun convertToString(value: ExternalPaymentMethodType): String = value.value
 
+    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
+        return configurationData.integrationType.isPaymentFlow()
+    }
+
     override fun configure(
         value: ExternalPaymentMethodType,
         configurationBuilder: PaymentSheet.Configuration.Builder,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/InitializationTypeSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/InitializationTypeSettingsDefinition.kt
@@ -22,6 +22,10 @@ internal object InitializationTypeSettingsDefinition :
         option("Deferred SSC + MP", InitializationType.DeferredMultiprocessor),
     )
 
+    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
+        return configurationData.integrationType.isPaymentFlow()
+    }
+
     override fun configure(
         value: InitializationType,
         checkoutRequestBuilder: CheckoutRequest.Builder

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LayoutSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LayoutSettingsDefinition.kt
@@ -9,6 +9,10 @@ internal object LayoutSettingsDefinition : BooleanSettingsDefinition(
     displayName = "Vertical Mode",
     defaultValue = false,
 ) {
+    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
+        return configurationData.integrationType.isPaymentFlow()
+    }
+
     @OptIn(ExperimentalPaymentMethodLayoutApi::class)
     override fun configure(
         value: Boolean,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkSettingsDefinition.kt
@@ -7,6 +7,10 @@ internal object LinkSettingsDefinition : BooleanSettingsDefinition(
     displayName = "Link",
     defaultValue = true,
 ) {
+    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
+        return configurationData.integrationType.isPaymentFlow()
+    }
+
     override fun configure(
         value: Boolean,
         checkoutRequestBuilder: CheckoutRequest.Builder,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PaymentMethodConfigurationSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PaymentMethodConfigurationSettingsDefinition.kt
@@ -17,6 +17,10 @@ internal object PaymentMethodConfigurationSettingsDefinition :
         configurationData: PlaygroundConfigurationData
     ) = emptyList<PlaygroundSettingDefinition.Displayable.Option<String>>()
 
+    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
+        return configurationData.integrationType.isPaymentFlow()
+    }
+
     override fun configure(
         value: String,
         checkoutRequestBuilder: CheckoutRequest.Builder,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundConfigurationData.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundConfigurationData.kt
@@ -14,5 +14,12 @@ data class PlaygroundConfigurationData(
 
         @SerialName("flowController")
         FlowController,
+
+        @SerialName("CustomerSheet")
+        CustomerSheet;
+
+        fun isPaymentFlow(): Boolean {
+            return this == PaymentSheet || this == FlowController
+        }
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PrimaryButtonLabelSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PrimaryButtonLabelSettingsDefinition.kt
@@ -18,6 +18,10 @@ internal object PrimaryButtonLabelSettingsDefinition :
         configurationData: PlaygroundConfigurationData
     ) = emptyList<PlaygroundSettingDefinition.Displayable.Option<String>>()
 
+    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
+        return configurationData.integrationType.isPaymentFlow()
+    }
+
     override fun configure(
         value: String,
         configurationBuilder: PaymentSheet.Configuration.Builder,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/ShippingAddressSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/ShippingAddressSettingsDefinition.kt
@@ -7,6 +7,10 @@ import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 internal object ShippingAddressSettingsDefinition : PlaygroundSettingDefinition<AddressDetails?> {
     override val defaultValue: AddressDetails? = null
 
+    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
+        return configurationData.integrationType.isPaymentFlow()
+    }
+
     override fun configure(
         value: AddressDetails?,
         configurationBuilder: PaymentSheet.Configuration.Builder,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SupportedPaymentMethodsSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SupportedPaymentMethodsSettingsDefinition.kt
@@ -21,6 +21,10 @@ internal object SupportedPaymentMethodsSettingsDefinition :
         configurationData: PlaygroundConfigurationData
     ) = emptyList<PlaygroundSettingDefinition.Displayable.Option<String>>()
 
+    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
+        return configurationData.integrationType.isPaymentFlow()
+    }
+
     override fun convertToString(value: String): String = value
     override fun convertToValue(value: String): String = value
 }


### PR DESCRIPTION
# Summary
Add `CustomerSheet` integration type to Playground

# Motivation
Helps allow `CustomerSheet` be shown in `Playground`.
