### PR TITLE
Add `CustomerSheetPaymentMethodModeDefinition` for `CustomerSheet` in playground.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSheetPaymentMethodModeDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSheetPaymentMethodModeDefinition.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.paymentsheet.example.playground.settings
 
-internal object PaymentMethodModeDefinition :
+internal object CustomerSheetPaymentMethodModeDefinition :
     PlaygroundSettingDefinition<PaymentMethodMode>,
     PlaygroundSettingDefinition.Saveable<PaymentMethodMode> by EnumSaveable(
         key = "paymentMethodMode",

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PaymentMethodModeDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PaymentMethodModeDefinition.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+internal object PaymentMethodModeDefinition :
+    PlaygroundSettingDefinition<PaymentMethodMode>,
+    PlaygroundSettingDefinition.Saveable<PaymentMethodMode> by EnumSaveable(
+        key = "paymentMethodMode",
+        values = PaymentMethodMode.entries.toTypedArray(),
+        defaultValue = PaymentMethodMode.SetupIntent,
+    ),
+    PlaygroundSettingDefinition.Displayable<PaymentMethodMode> {
+    override val displayName: String = "Payment Method Mode"
+
+    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
+        return configurationData.integrationType.isCustomerFlow()
+    }
+
+    override fun createOptions(
+        configurationData: PlaygroundConfigurationData
+    ) = listOf(
+        option("Setup Intent", PaymentMethodMode.SetupIntent),
+        option("Create And Attach", PaymentMethodMode.CreateAndAttach),
+    )
+}
+
+enum class PaymentMethodMode(override val value: String) : ValueEnum {
+    SetupIntent("setup_intent"),
+    CreateAndAttach("create_and_attach")
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundConfigurationData.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundConfigurationData.kt
@@ -21,5 +21,9 @@ data class PlaygroundConfigurationData(
         fun isPaymentFlow(): Boolean {
             return this == PaymentSheet || this == FlowController
         }
+
+        fun isCustomerFlow(): Boolean {
+            return this == CustomerSheet
+        }
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -224,6 +224,7 @@ internal class PlaygroundSettings private constructor(
 
         private val uiSettingDefinitions: List<PlaygroundSettingDefinition.Displayable<*>> = listOf(
             InitializationTypeSettingsDefinition,
+            PaymentMethodModeDefinition,
             CustomerSessionSettingsDefinition,
             CustomerSettingsDefinition,
             CheckoutModeSettingsDefinition,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -224,7 +224,7 @@ internal class PlaygroundSettings private constructor(
 
         private val uiSettingDefinitions: List<PlaygroundSettingDefinition.Displayable<*>> = listOf(
             InitializationTypeSettingsDefinition,
-            PaymentMethodModeDefinition,
+            CustomerSheetPaymentMethodModeDefinition,
             CustomerSessionSettingsDefinition,
             CustomerSettingsDefinition,
             CheckoutModeSettingsDefinition,


### PR DESCRIPTION
# Summary
Add `CustomerSheetPaymentMethodModeDefinition` for `CustomerSheet` in playground.

# Motivation
Helps allow `CustomerSheet` to be shown in the playground.