### PR TITLE
Revert `Maestro` support for Google Pay.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -473,7 +473,7 @@ class GooglePayJsonFactory constructor(
 
         private val ALLOWED_AUTH_METHODS = listOf("PAN_ONLY", "CRYPTOGRAM_3DS")
         private val DEFAULT_CARD_NETWORKS =
-            listOf("AMEX", "DISCOVER", "MASTERCARD", "VISA", "MAESTRO")
+            listOf("AMEX", "DISCOVER", "MASTERCARD", "VISA")
         private const val JCB_CARD_NETWORK = "JCB"
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
@@ -30,7 +30,7 @@ class GooglePayJsonFactoryTest {
                     "type": "CARD",
                     "parameters": {
                         "allowedAuthMethods": ["PAN_ONLY", "CRYPTOGRAM_3DS"],
-                        "allowedCardNetworks": ["AMEX", "DISCOVER", "MASTERCARD", "VISA", "MAESTRO"]
+                        "allowedCardNetworks": ["AMEX", "DISCOVER", "MASTERCARD", "VISA"]
                     },
                     "tokenizationSpecification": {
                         "type": "PAYMENT_GATEWAY",
@@ -66,7 +66,7 @@ class GooglePayJsonFactoryTest {
                     "type": "CARD",
                     "parameters": {
                         "allowedAuthMethods": ["PAN_ONLY", "CRYPTOGRAM_3DS"],
-                        "allowedCardNetworks": ["AMEX", "DISCOVER", "MASTERCARD", "VISA", "MAESTRO"],
+                        "allowedCardNetworks": ["AMEX", "DISCOVER", "MASTERCARD", "VISA"],
                         "billingAddressRequired": true,
                         "billingAddressParameters": {
                             "phoneNumberRequired": true,
@@ -102,7 +102,7 @@ class GooglePayJsonFactoryTest {
                     "type": "CARD",
                     "parameters": {
                         "allowedAuthMethods": ["PAN_ONLY", "CRYPTOGRAM_3DS"],
-                        "allowedCardNetworks": ["AMEX", "DISCOVER", "MASTERCARD", "VISA", "MAESTRO"],
+                        "allowedCardNetworks": ["AMEX", "DISCOVER", "MASTERCARD", "VISA"],
                         "billingAddressRequired": true,
                         "billingAddressParameters": {
                             "phoneNumberRequired": true,
@@ -238,7 +238,7 @@ class GooglePayJsonFactoryTest {
             }
 
         assertThat(allowedCardNetworks)
-            .isEqualTo(listOf("AMEX", "DISCOVER", "MASTERCARD", "VISA", "MAESTRO"))
+            .isEqualTo(listOf("AMEX", "DISCOVER", "MASTERCARD", "VISA"))
     }
 
     @Test
@@ -255,7 +255,7 @@ class GooglePayJsonFactoryTest {
                 }
 
         assertThat(allowedCardNetworks)
-            .isEqualTo(listOf("AMEX", "DISCOVER", "MASTERCARD", "VISA", "MAESTRO", "JCB"))
+            .isEqualTo(listOf("AMEX", "DISCOVER", "MASTERCARD", "VISA", "JCB"))
     }
 
     @Test


### PR DESCRIPTION
# Summary
Revert `Maestro` support for Google Pay.

# Motivation
Revert `Maestro` support for Google Pay.
#ir-oval-component

