### PR TITLE
[FC][Example] Fix Redirection URI Override Issue in debug mode

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetRedirectActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetRedirectActivity.kt
@@ -20,9 +20,10 @@ class FinancialConnectionsSheetRedirectActivity : AppCompatActivity() {
          */
         intent.data
             ?.let { uri ->
-                uri.overrideWithDebugConfiguration().toIntent()
+                val uriWithDebugConfiguration = uri.overrideWithDebugConfiguration()
+                uriWithDebugConfiguration.toIntent()
                     ?.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                    ?.also { it.data = intent.data }
+                    ?.also { it.data = uriWithDebugConfiguration }
                     ?.let { startActivity(it) }
             }
         finish()


### PR DESCRIPTION
# Summary
- When overriding deeplinks on the playground app, we were not properly setting the overriden url as intent data before launching the corresponding activity.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
