### PR TITLE
Fix a memory leak in EPMs and deferred intents.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
@@ -28,6 +28,7 @@ internal class DefaultPaymentSheetLauncher(
             object : DefaultLifecycleObserver {
                 override fun onDestroy(owner: LifecycleOwner) {
                     IntentConfirmationInterceptor.createIntentCallback = null
+                    ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler = null
                     super.onDestroy(owner)
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExternalPaymentMethodConfirmHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExternalPaymentMethodConfirmHandler.kt
@@ -8,7 +8,7 @@ import com.stripe.android.model.PaymentMethod
  * To learn more about external payment methods, see
  * https://docs.stripe.com/payments/external-payment-methods?platform=android.
  */
-interface ExternalPaymentMethodConfirmHandler {
+fun interface ExternalPaymentMethodConfirmHandler {
 
     /**
      * Called when a user confirms payment or setup with an external payment method.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -205,6 +205,8 @@ internal class DefaultFlowController @Inject internal constructor(
                     paymentLauncher = null
                     linkLauncher.unregister()
                     PaymentSheet.FlowController.linkHandler = null
+                    IntentConfirmationInterceptor.createIntentCallback = null
+                    ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler = null
                 }
             }
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncherTest.kt
@@ -107,6 +107,33 @@ class DefaultPaymentSheetLauncherTest {
         assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
+    @Test
+    fun `Clears out externalPaymentMethodConfirmHandler when lifecycle owner is destroyed`() {
+        ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler =
+            ExternalPaymentMethodConfirmHandler { _, _ ->
+                error("I’m alive")
+            }
+
+        val lifecycleOwner = TestLifecycleOwner()
+
+        DefaultPaymentSheetLauncher(
+            activityResultLauncher = mock(),
+            activity = mock(),
+            lifecycleOwner = lifecycleOwner,
+            application = ApplicationProvider.getApplicationContext(),
+            callback = mock(),
+        )
+
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+        assertThat(ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler).isNotNull()
+
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+        assertThat(ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler).isNotNull()
+
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        assertThat(ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler).isNull()
+    }
+
     private class FakeActivityResultRegistry(
         private val result: PaymentSheetResult? = null,
         private val error: Throwable? = null

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -45,7 +45,9 @@ import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.DelicatePaymentSheetApi
+import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
 import com.stripe.android.paymentsheet.ExternalPaymentMethodContract
+import com.stripe.android.paymentsheet.ExternalPaymentMethodInterceptor
 import com.stripe.android.paymentsheet.FakePrefsRepository
 import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.PaymentOptionCallback
@@ -147,7 +149,7 @@ internal class DefaultFlowControllerTest {
 
     private val prefsRepository = FakePrefsRepository()
 
-    private val lifeCycleOwner = TestLifecycleOwner()
+    private val lifecycleOwner = TestLifecycleOwner()
 
     private val testDispatcher = UnconfinedTestDispatcher()
     private val testScope = TestScope(testDispatcher)
@@ -236,7 +238,7 @@ internal class DefaultFlowControllerTest {
         whenever(paymentLauncherAssistedFactory.create(any(), any(), anyOrNull(), any(), any()))
             .thenReturn(paymentLauncher)
 
-        lifeCycleOwner.currentState = Lifecycle.State.RESUMED
+        lifecycleOwner.currentState = Lifecycle.State.RESUMED
     }
 
     @AfterTest
@@ -446,7 +448,7 @@ internal class DefaultFlowControllerTest {
         flowController.configureExpectingSuccess(
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
         )
-        lifeCycleOwner.currentState = Lifecycle.State.DESTROYED
+        lifecycleOwner.currentState = Lifecycle.State.DESTROYED
         whenever(paymentOptionActivityLauncher.launch(any(), any())).thenThrow(IllegalStateException("Boom"))
         verifyNoInteractions(paymentResultCallback)
 
@@ -1831,6 +1833,43 @@ internal class DefaultFlowControllerTest {
         assertThat(isPhoneRequired).isFalse()
     }
 
+    @Test
+    fun `Clears out CreateIntentCallback when lifecycle owner is destroyed`() {
+        IntentConfirmationInterceptor.createIntentCallback = CreateIntentCallback { _, _ ->
+            error("I’m alive")
+        }
+
+        createFlowController()
+
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNotNull()
+
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNotNull()
+
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
+    }
+
+    @Test
+    fun `Clears out externalPaymentMethodConfirmHandler when lifecycle owner is destroyed`() {
+        ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler =
+            ExternalPaymentMethodConfirmHandler { _, _ ->
+                error("I’m alive")
+            }
+
+        createFlowController()
+
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+        assertThat(ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler).isNotNull()
+
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+        assertThat(ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler).isNotNull()
+
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        assertThat(ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler).isNull()
+    }
+
     private suspend fun selectionSavedTest(
         customerRequestedSave: PaymentSelection.CustomerRequestedSave =
             PaymentSelection.CustomerRequestedSave.NoRequest,
@@ -1929,7 +1968,7 @@ internal class DefaultFlowControllerTest {
         bacsMandateConfirmationLauncherFactory: BacsMandateConfirmationLauncherFactory = mock()
     ) = DefaultFlowController(
         viewModelScope = testScope,
-        lifecycleOwner = lifeCycleOwner,
+        lifecycleOwner = lifecycleOwner,
         activityResultRegistryOwner = activityResultRegistryOwner,
         statusBarColor = { STATUS_BAR_COLOR },
         paymentOptionFactory = PaymentOptionFactory(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We statically reference a few handlers (to allow passing between activity boundaries). This is mostly fine if we clean up after ourselves (although still not ideal).

We had accounted for this in payment sheet with deferred intents, but not in flow controller.
We recently added external payment methods, which has a similar pattern, and we didn't clean up the reference. This made it clear that we probably had a memory leak in flow controller (for both!) as well.

