### PR TITLE
Add `configure` method for building `CustomerEphemeralKeyRequest` in the playground.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CountrySettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CountrySettingsDefinition.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.example.playground.settings
 
 import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
+import com.stripe.android.paymentsheet.example.playground.model.CustomerEphemeralKeyRequest
 import java.util.Locale
 
 internal object CountrySettingsDefinition :
@@ -38,6 +39,13 @@ internal object CountrySettingsDefinition :
 
     override fun configure(value: Country, checkoutRequestBuilder: CheckoutRequest.Builder) {
         checkoutRequestBuilder.merchantCountryCode(value.value)
+    }
+
+    override fun configure(
+        value: Country,
+        customerEphemeralKeyRequestBuilder: CustomerEphemeralKeyRequest.Builder
+    ) {
+        customerEphemeralKeyRequestBuilder.merchantCountryCode(value.value)
     }
 
     override fun valueUpdated(value: Country, playgroundSettings: PlaygroundSettings) {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSettingsDefinition.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.example.playground.settings
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
+import com.stripe.android.paymentsheet.example.playground.model.CustomerEphemeralKeyRequest
 
 internal object CustomerSettingsDefinition :
     PlaygroundSettingDefinition<CustomerType>,
@@ -30,6 +31,13 @@ internal object CustomerSettingsDefinition :
         checkoutRequestBuilder: CheckoutRequest.Builder,
     ) {
         checkoutRequestBuilder.customer(value.value)
+    }
+
+    override fun configure(
+        value: CustomerType,
+        customerEphemeralKeyRequestBuilder: CustomerEphemeralKeyRequest.Builder
+    ) {
+        customerEphemeralKeyRequestBuilder.customerType(value.value)
     }
 
     override fun configure(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettingDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettingDefinition.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.example.playground.settings
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
+import com.stripe.android.paymentsheet.example.playground.model.CustomerEphemeralKeyRequest
 
 internal interface PlaygroundSettingDefinition<T> {
     val defaultValue: T
@@ -18,6 +19,12 @@ internal interface PlaygroundSettingDefinition<T> {
     fun configure(
         value: T,
         checkoutRequestBuilder: CheckoutRequest.Builder,
+    ) {
+    }
+
+    fun configure(
+        value: T,
+        customerEphemeralKeyRequestBuilder: CustomerEphemeralKeyRequest.Builder,
     ) {
     }
 


### PR DESCRIPTION
# Summary
Add `configure` for building `CustomerEphemeralKeyRequest` in the playground.

# Motivation
Helps enable `CustomerSheet` in the playground.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified