### PR TITLE
Add `CustomerSheet` playground UI

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/CustomerSheetState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/CustomerSheetState.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.paymentsheet.example.playground
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.painter.Painter
+import com.stripe.android.paymentsheet.model.PaymentOption
+
+internal data class CustomerSheetState(
+    val selectedPaymentOption: PaymentOption? = null,
+    val shouldFetchPaymentOption: Boolean = true
+)
+
+internal fun CustomerSheetState?.paymentMethodLabel(): String {
+    return this?.selectedPaymentOption?.label ?: "Select"
+}
+
+@Composable
+internal fun CustomerSheetState?.paymentMethodPainter(): Painter? {
+    return this?.selectedPaymentOption?.iconPainter
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.customersheet.CustomerSheetResult
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.customersheet.rememberCustomerSheet
 import com.stripe.android.model.PaymentMethod
@@ -55,9 +57,12 @@ import com.stripe.android.paymentsheet.example.playground.settings.SettingsUi
 import com.stripe.android.paymentsheet.example.samples.ui.shared.BuyButton
 import com.stripe.android.paymentsheet.example.samples.ui.shared.CHECKOUT_TEST_TAG
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentMethodSelector
+import com.stripe.android.paymentsheet.model.PaymentOption
 import com.stripe.android.paymentsheet.rememberPaymentSheet
 import com.stripe.android.paymentsheet.rememberPaymentSheetFlowController
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.withContext
 
 internal class PaymentSheetPlaygroundActivity : AppCompatActivity(), ExternalPaymentMethodConfirmHandler {
     companion object {
@@ -76,6 +81,7 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity(), ExternalPay
         )
     }
 
+    @OptIn(ExperimentalCustomerSheetApi::class)
     @Suppress("LongMethod")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -100,6 +106,14 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity(), ExternalPay
             val localPlaygroundSettings = playgroundSettings ?: return@setContent
 
             val playgroundState by viewModel.state.collectAsState()
+
+            val customerSheet = playgroundState?.asCustomerState()?.let { customerPlaygroundState ->
+                rememberCustomerSheet(
+                    configuration = customerPlaygroundState.customerSheetConfiguration(),
+                    customerAdapter = customerPlaygroundState.adapter,
+                    callback = viewModel::onCustomerSheetCallback
+                )
+            }
 
             PlaygroundTheme(
                 content = {
@@ -130,6 +144,7 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity(), ExternalPay
                                 playgroundState = playgroundState,
                                 paymentSheet = paymentSheet,
                                 flowController = flowController,
+                                customerSheet = customerSheet,
                                 addressLauncher = addressLauncher,
                             )
                         }
@@ -208,11 +223,13 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity(), ExternalPay
         }
     }
 
+    @OptIn(ExperimentalCustomerSheetApi::class)
     @Composable
     private fun PlaygroundStateUi(
         playgroundState: PlaygroundState?,
         paymentSheet: PaymentSheet,
         flowController: PaymentSheet.FlowController,
+        customerSheet: CustomerSheet?,
         addressLauncher: AddressLauncher
     ) {
         if (playgroundState == null) {
@@ -243,15 +260,8 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity(), ExternalPay
                     else -> Unit
                 }
             }
-            is PlaygroundState.Customer -> {
-                val customerSheetState by viewModel.customerSheetState.collectAsState()
-
-                customerSheetState?.let { state ->
-                    CustomerSheetUi(
-                        customerSheetState = state,
-                        playgroundState = playgroundState
-                    )
-                }
+            is PlaygroundState.Customer -> customerSheet?.run {
+                CustomerSheetUi(customerSheet = this)
             }
         }
     }
@@ -318,29 +328,41 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity(), ExternalPay
     @OptIn(ExperimentalCustomerSheetApi::class)
     @Composable
     fun CustomerSheetUi(
-        playgroundState: PlaygroundState.Customer,
-        customerSheetState: CustomerSheetState,
+        customerSheet: CustomerSheet,
     ) {
-        val customerSheet = rememberCustomerSheet(
-            configuration = playgroundState.customerSheetConfiguration(),
-            customerAdapter = playgroundState.adapter,
-            callback = viewModel::onCustomerSheetCallback
-        )
+        val customerSheetState by viewModel.customerSheetState.collectAsState()
 
-        LaunchedEffect(customerSheet) {
-            viewModel.fetchOption(customerSheet)
+        customerSheetState?.let { state ->
+            LaunchedEffect(state) {
+                if (state.shouldFetchPaymentOption) {
+                    fetchOption(customerSheet).onSuccess { option ->
+                        viewModel.customerSheetState.emit(
+                            CustomerSheetState(
+                                selectedPaymentOption = option,
+                                shouldFetchPaymentOption = false
+                            )
+                        )
+                    }.onFailure { exception ->
+                        viewModel.status.emit(
+                            StatusMessage(
+                                message = "Failed to retrieve payment options:\n${exception.message}"
+                            )
+                        )
+                    }
+                }
+            }
+
+            if (state.shouldFetchPaymentOption) {
+                return
+            }
+
+            PaymentMethodSelector(
+                isEnabled = true,
+                paymentMethodLabel = customerSheetState.paymentMethodLabel(),
+                paymentMethodPainter = customerSheetState.paymentMethodPainter(),
+                onClick = customerSheet::present
+            )
         }
-
-        if (customerSheetState.shouldFetchPaymentOption) {
-            return
-        }
-
-        PaymentMethodSelector(
-            isEnabled = true,
-            paymentMethodLabel = customerSheetState.paymentMethodLabel(),
-            paymentMethodPainter = customerSheetState.paymentMethodPainter(),
-            onClick = customerSheet::present
-        )
     }
 
     @Composable
@@ -416,6 +438,17 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity(), ExternalPay
                 configuration = playgroundState.paymentSheetConfiguration(),
                 callback = viewModel::onFlowControllerConfigured,
             )
+        }
+    }
+
+    @OptIn(ExperimentalCustomerSheetApi::class)
+    private suspend fun fetchOption(
+        customerSheet: CustomerSheet
+    ): Result<PaymentOption?> = withContext(Dispatchers.IO) {
+        when (val result = customerSheet.retrievePaymentOptionSelection()) {
+            is CustomerSheetResult.Selected -> Result.success(result.selection?.paymentOption)
+            is CustomerSheetResult.Failed -> Result.failure(result.exception)
+            is CustomerSheetResult.Canceled -> Result.success(null)
         }
     }
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
@@ -13,7 +13,6 @@ import com.github.kittinunf.result.Result
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.CustomerEphemeralKey
-import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetResult
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.model.PaymentMethod
@@ -302,42 +301,6 @@ internal class PaymentSheetPlaygroundViewModel(
         }
 
         status.value = StatusMessage(statusMessage)
-    }
-
-    @OptIn(ExperimentalCustomerSheetApi::class)
-    fun fetchOption(customerSheet: CustomerSheet) {
-        viewModelScope.launch(Dispatchers.IO) {
-            when (val result = customerSheet.retrievePaymentOptionSelection()) {
-                is CustomerSheetResult.Selected -> {
-                    customerSheetState.update { existingState ->
-                        existingState?.copy(
-                            selectedPaymentOption = result.selection?.paymentOption,
-                            shouldFetchPaymentOption = false,
-                        )
-                    }
-                }
-                is CustomerSheetResult.Failed -> {
-                    customerSheetState.update { existingState ->
-                        existingState?.copy(
-                            shouldFetchPaymentOption = false,
-                        )
-                    }
-
-                    status.emit(
-                        StatusMessage(
-                            message = "Failed to retrieve payment options:\n${result.exception.message}"
-                        )
-                    )
-                }
-                is CustomerSheetResult.Canceled -> {
-                    customerSheetState.update { existingState ->
-                        existingState?.copy(
-                            shouldFetchPaymentOption = false,
-                        )
-                    }
-                }
-            }
-        }
     }
 
     @OptIn(ExperimentalCustomerSheetApi::class)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
@@ -13,6 +13,8 @@ import com.github.kittinunf.result.Result
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.CustomerEphemeralKey
+import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.customersheet.CustomerSheetResult
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.CreateIntentResult
@@ -59,6 +61,7 @@ internal class PaymentSheetPlaygroundViewModel(
     val status = MutableStateFlow<StatusMessage?>(null)
     val state = MutableStateFlow<PlaygroundState?>(null)
     val flowControllerState = MutableStateFlow<FlowControllerState?>(null)
+    val customerSheetState = MutableStateFlow<CustomerSheetState?>(null)
 
     init {
         viewModelScope.launch(Dispatchers.IO) {
@@ -73,6 +76,7 @@ internal class PaymentSheetPlaygroundViewModel(
     ) {
         state.value = null
         flowControllerState.value = null
+        customerSheetState.value = null
 
         if (playgroundSettings.configurationData.value.integrationType.isPaymentFlow()) {
             prepareCheckout(playgroundSettings)
@@ -162,6 +166,7 @@ internal class PaymentSheetPlaygroundViewModel(
                     }
                 )
             )
+            customerSheetState.value = CustomerSheetState()
         }
     }
 
@@ -297,6 +302,66 @@ internal class PaymentSheetPlaygroundViewModel(
         }
 
         status.value = StatusMessage(statusMessage)
+    }
+
+    @OptIn(ExperimentalCustomerSheetApi::class)
+    fun fetchOption(customerSheet: CustomerSheet) {
+        viewModelScope.launch(Dispatchers.IO) {
+            when (val result = customerSheet.retrievePaymentOptionSelection()) {
+                is CustomerSheetResult.Selected -> {
+                    customerSheetState.update { existingState ->
+                        existingState?.copy(
+                            selectedPaymentOption = result.selection?.paymentOption,
+                            shouldFetchPaymentOption = false,
+                        )
+                    }
+                }
+                is CustomerSheetResult.Failed -> {
+                    customerSheetState.update { existingState ->
+                        existingState?.copy(
+                            shouldFetchPaymentOption = false,
+                        )
+                    }
+
+                    status.emit(
+                        StatusMessage(
+                            message = "Failed to retrieve payment options:\n${result.exception.message}"
+                        )
+                    )
+                }
+                is CustomerSheetResult.Canceled -> {
+                    customerSheetState.update { existingState ->
+                        existingState?.copy(
+                            shouldFetchPaymentOption = false,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @OptIn(ExperimentalCustomerSheetApi::class)
+    fun onCustomerSheetCallback(result: CustomerSheetResult) {
+        val statusMessage = when (result) {
+            is CustomerSheetResult.Selected -> {
+                customerSheetState.update { existingState ->
+                    existingState?.copy(
+                        selectedPaymentOption = result.selection?.paymentOption,
+                        shouldFetchPaymentOption = false
+                    )
+                }
+
+                null
+            }
+            is CustomerSheetResult.Failed -> "An error occurred: ${result.exception.message}"
+            is CustomerSheetResult.Canceled -> "Canceled"
+        }
+
+        statusMessage?.let { message ->
+            viewModelScope.launch {
+                status.emit(StatusMessage(message))
+            }
+        }
     }
 
     private fun createIntent(clientSecret: String): CreateIntentResult {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PlaygroundState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PlaygroundState.kt
@@ -64,6 +64,10 @@ internal sealed interface PlaygroundState {
         return this as? Payment
     }
 
+    fun asCustomerState(): Customer? {
+        return this as? Customer
+    }
+
     companion object {
         fun CheckoutResponse.asPlaygroundState(
             snapshot: PlaygroundSettings.Snapshot,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CountrySettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CountrySettingsDefinition.kt
@@ -15,8 +15,8 @@ internal object CountrySettingsDefinition :
     PlaygroundSettingDefinition.Displayable<Country> {
     private val supportedPaymentFlowCountries = Country.entries.map { it.value }.toSet()
     private val supportedCustomerFlowCountries = setOf(
-        Country.US,
-        Country.FR,
+        Country.US.value,
+        Country.FR.value,
     )
 
     override val displayName: String = "Merchant"

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
@@ -117,6 +117,10 @@ private fun IntegrationTypeConfigurableSetting(
                 name = "Flow Controller",
                 value = PlaygroundConfigurationData.IntegrationType.FlowController
             ),
+            PlaygroundSettingDefinition.Displayable.Option(
+                name = "Customer Sheet",
+                value = PlaygroundConfigurationData.IntegrationType.CustomerSheet
+            ),
         ),
         value = configurationData.integrationType
     ) { integrationType ->


### PR DESCRIPTION
# Summary
Add `CustomerSheet` playground UI to complete `CustomerSheet` integration in the playground.

# Motivation
Allows for showing `CustomerSheet` integration in playground.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Videos
| 1 | 2 |
| -- | --- |
| <video src="https://github.com/stripe/stripe-android/assets/141707240/54802d9d-61d7-48de-852f-639379a94a19" /> | <video src="https://github.com/stripe/stripe-android/assets/141707240/22017d52-03df-4bf8-9090-83fd6615ef6b" /> |

<video src="https://github.com/stripe/stripe-android/assets/141707240/a06c5929-df1c-4231-9701-a5a894a580a5" />

