### PR TITLE
Move CompositionLocalProvider up so it's shared between all screens.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -223,8 +223,3 @@ internal sealed interface PaymentSheetScreen {
         }
     }
 }
-
-@Composable
-internal fun PaymentSheetScreen.Content(viewModel: BaseSheetViewModel) {
-    Content(viewModel, modifier = Modifier)
-}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -1,10 +1,7 @@
 package com.stripe.android.paymentsheet.ui
 
 import android.content.Context
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -26,9 +23,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.FieldValuesToParamsMapConverter
-import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventReporter
 import com.stripe.android.uicore.elements.IdentifierSpec
-import com.stripe.android.uicore.elements.LocalAutofillEventReporter
 
 @Composable
 internal fun AddPaymentMethod(
@@ -54,46 +49,40 @@ internal fun AddPaymentMethod(
         sheetViewModel.clearErrorMessages()
     }
 
-    Column(modifier = modifier.fillMaxWidth()) {
-        CompositionLocalProvider(
-            LocalAutofillEventReporter provides sheetViewModel::reportAutofillEvent,
-            LocalCardNumberCompletedEventReporter provides sheetViewModel::reportCardNumberCompleted,
-        ) {
-            val processing by sheetViewModel.processing.collectAsState()
-            val formElements = remember(selectedPaymentMethodCode) {
-                sheetViewModel.formElementsForCode(selectedPaymentMethodCode)
-            }
-            val usBankAccountFormArguments = remember(selectedPaymentMethodCode) {
-                USBankAccountFormArguments.create(sheetViewModel, selectedPaymentMethodCode)
-            }
-
-            PaymentElement(
-                enabled = !processing,
-                supportedPaymentMethods = supportedPaymentMethods,
-                selectedItemCode = selectedPaymentMethodCode,
-                formElements = formElements,
-                linkSignupMode = linkInlineSignupMode,
-                linkConfigurationCoordinator = sheetViewModel.linkConfigurationCoordinator,
-                onItemSelectedListener = { selectedLpm ->
-                    if (selectedPaymentMethodCode != selectedLpm.code) {
-                        selectedPaymentMethodCode = selectedLpm.code
-                        sheetViewModel.reportPaymentMethodTypeSelected(selectedLpm.code)
-                    }
-                },
-                onLinkSignupStateChanged = { _, inlineSignupViewState ->
-                    sheetViewModel.onLinkSignUpStateUpdated(inlineSignupViewState)
-                },
-                formArguments = arguments,
-                usBankAccountFormArguments = usBankAccountFormArguments,
-                onFormFieldValuesChanged = { formValues ->
-                    sheetViewModel.onFormFieldValuesChanged(formValues, selectedPaymentMethodCode)
-                },
-                onInteractionEvent = {
-                    sheetViewModel.reportFieldInteraction(selectedPaymentMethodCode)
-                }
-            )
-        }
+    val processing by sheetViewModel.processing.collectAsState()
+    val formElements = remember(selectedPaymentMethodCode) {
+        sheetViewModel.formElementsForCode(selectedPaymentMethodCode)
     }
+    val usBankAccountFormArguments = remember(selectedPaymentMethodCode) {
+        USBankAccountFormArguments.create(sheetViewModel, selectedPaymentMethodCode)
+    }
+
+    PaymentElement(
+        enabled = !processing,
+        supportedPaymentMethods = supportedPaymentMethods,
+        selectedItemCode = selectedPaymentMethodCode,
+        formElements = formElements,
+        linkSignupMode = linkInlineSignupMode,
+        linkConfigurationCoordinator = sheetViewModel.linkConfigurationCoordinator,
+        onItemSelectedListener = { selectedLpm ->
+            if (selectedPaymentMethodCode != selectedLpm.code) {
+                selectedPaymentMethodCode = selectedLpm.code
+                sheetViewModel.reportPaymentMethodTypeSelected(selectedLpm.code)
+            }
+        },
+        onLinkSignupStateChanged = { _, inlineSignupViewState ->
+            sheetViewModel.onLinkSignUpStateUpdated(inlineSignupViewState)
+        },
+        formArguments = arguments,
+        usBankAccountFormArguments = usBankAccountFormArguments,
+        onFormFieldValuesChanged = { formValues ->
+            sheetViewModel.onFormFieldValuesChanged(formValues, selectedPaymentMethodCode)
+        },
+        modifier = modifier,
+        onInteractionEvent = {
+            sheetViewModel.reportFieldInteraction(selectedPaymentMethodCode)
+        },
+    )
 }
 
 internal fun FormFieldValues.transformToPaymentMethodCreateParams(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
@@ -48,6 +48,7 @@ internal fun PaymentElement(
     formArguments: FormArguments,
     usBankAccountFormArguments: USBankAccountFormArguments,
     onFormFieldValuesChanged: (FormFieldValues?) -> Unit,
+    modifier: Modifier = Modifier,
     onInteractionEvent: () -> Unit = {},
 ) {
     val context = LocalContext.current
@@ -66,7 +67,7 @@ internal fun PaymentElement(
         supportedPaymentMethods[selectedIndex]
     }
 
-    Column(modifier = Modifier.fillMaxWidth()) {
+    Column(modifier = modifier.fillMaxWidth()) {
         if (supportedPaymentMethods.size > 1) {
             NewPaymentMethodTabLayoutUI(
                 selectedIndex = selectedIndex,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -56,6 +57,8 @@ import com.stripe.android.paymentsheet.utils.PaymentSheetContentPadding
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.CircularProgressIndicator
 import com.stripe.android.ui.core.elements.H4Text
+import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventReporter
+import com.stripe.android.uicore.elements.LocalAutofillEventReporter
 import com.stripe.android.uicore.strings.resolve
 import kotlinx.coroutines.delay
 
@@ -220,10 +223,17 @@ private fun PaymentSheetContent(
             )
         }
 
-        currentScreen.Content(
-            viewModel = viewModel,
-            modifier = Modifier.padding(bottom = 8.dp),
-        )
+        Column(modifier = Modifier.fillMaxWidth()) {
+            CompositionLocalProvider(
+                LocalAutofillEventReporter provides viewModel::reportAutofillEvent,
+                LocalCardNumberCompletedEventReporter provides viewModel::reportCardNumberCompleted,
+            ) {
+                currentScreen.Content(
+                    viewModel = viewModel,
+                    modifier = Modifier.padding(bottom = 8.dp),
+                )
+            }
+        }
 
         if (mandateText?.showAbovePrimaryButton == true) {
             Mandate(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This is used throughout many screen for reporting autofill and interaction events. Moving this up the stack a layer allows this to work for both tabs and vertical mode.
