### PR TITLE
Add leak canary to PaymentSheet instrumentation tests.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -44,7 +44,7 @@ ext.versions = [
         kotlinSerialization         : '1.6.2',
         kotlinSerializationConverter: '1.0.0',
         ktlint                      : '0.48.2',
-        leakCanary                  : '2.13',
+        leakCanary                  : '2.14',
         material                    : '1.11.0',
         mockito                     : '5.10.0',
         mockitoInline               : '5.2.0',
@@ -218,6 +218,7 @@ ext.testLibs = [
                 junit      : "org.jetbrains.kotlin:kotlin-test-junit:${versions.kotlin}",
                 test       : "org.jetbrains.kotlin:kotlin-test:${versions.kotlin}",
         ],
+        leakCanaryInstrumentation : "com.squareup.leakcanary:leakcanary-android-instrumentation:${versions.leakCanary}",
         mockito              : [
                 android: "org.mockito:mockito-android:${versions.mockito}",
                 core   : "org.mockito:mockito-core:${versions.mockito}",

--- a/payments-core-testing/build.gradle
+++ b/payments-core-testing/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation libs.kotlin.coroutinesAndroid
     implementation testLibs.junit
     implementation testLibs.kotlin.coroutines
+    implementation testLibs.leakCanaryInstrumentation
 
     androidTestImplementation project(':stripe-ui-core') // Resources defined here, but used in payments-core.
 }

--- a/payments-core-testing/dependencies/dependencies.txt
+++ b/payments-core-testing/dependencies/dependencies.txt
@@ -736,10 +736,51 @@
 +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)
 +--- junit:junit:4.13.2
 |    \--- org.hamcrest:hamcrest-core:1.3
-\--- org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3
-     \--- org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm:1.7.3
-          +--- org.jetbrains:annotations:23.0.0
-          +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
-          +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
-          +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
-          \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22 (*)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3
+|    \--- org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm:1.7.3
+|         +--- org.jetbrains:annotations:23.0.0
+|         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
+|         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
+|         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22 (*)
+\--- com.squareup.leakcanary:leakcanary-android-instrumentation:2.14
+     +--- com.squareup.leakcanary:leakcanary-android-core:2.14
+     |    +--- com.squareup.leakcanary:shark-android:2.14
+     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 -> 1.9.22 (*)
+     |    |    \--- com.squareup.leakcanary:shark:2.14
+     |    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 -> 1.9.22 (*)
+     |    |         +--- com.squareup.okio:okio:2.2.2
+     |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.2.60 -> 1.9.22 (*)
+     |    |         \--- com.squareup.leakcanary:shark-graph:2.14
+     |    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 -> 1.9.22 (*)
+     |    |              +--- com.squareup.okio:okio:2.2.2 (*)
+     |    |              \--- com.squareup.leakcanary:shark-hprof:2.14
+     |    |                   +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 -> 1.9.22 (*)
+     |    |                   \--- com.squareup.leakcanary:shark-log:2.14
+     |    |                        \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 -> 1.9.22 (*)
+     |    +--- com.squareup.leakcanary:leakcanary-object-watcher-android-core:2.14
+     |    |    +--- com.squareup.leakcanary:leakcanary-object-watcher:2.14
+     |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 -> 1.9.22 (*)
+     |    |    |    \--- com.squareup.leakcanary:shark-log:2.14 (*)
+     |    |    +--- com.squareup.leakcanary:leakcanary-android-utils:2.14
+     |    |    |    +--- com.squareup.leakcanary:shark-log:2.14 (*)
+     |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 -> 1.9.22 (*)
+     |    |    +--- com.squareup.curtains:curtains:1.2.4
+     |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.21 -> 1.9.22 (*)
+     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 -> 1.9.22 (*)
+     |    +--- com.squareup.leakcanary:leakcanary-object-watcher-android-androidx:2.14
+     |    |    +--- com.squareup.leakcanary:leakcanary-object-watcher-android-core:2.14 (*)
+     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 -> 1.9.22 (*)
+     |    +--- com.squareup.leakcanary:leakcanary-object-watcher-android-support-fragments:2.14
+     |    |    +--- com.squareup.leakcanary:leakcanary-object-watcher-android-core:2.14 (*)
+     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 -> 1.9.22 (*)
+     |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 -> 1.9.22 (*)
+     +--- androidx.test:runner:1.4.0
+     |    +--- androidx.annotation:annotation:1.0.0 -> 1.7.1 (*)
+     |    +--- androidx.test:monitor:1.4.0
+     |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.7.1 (*)
+     |    +--- androidx.test.services:storage:1.4.0
+     |    |    +--- androidx.test:monitor:1.4.0 (*)
+     |    |    \--- com.google.code.findbugs:jsr305:2.0.1
+     |    \--- junit:junit:4.12 -> 4.13.2 (*)
+     \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 -> 1.9.22 (*)

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/RetryRule.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/RetryRule.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.testing
 
 import android.util.Log
+import leakcanary.NoLeakAssertionFailedError
 import org.junit.AssumptionViolatedException
 import org.junit.rules.TestRule
 import org.junit.runner.Description
@@ -19,7 +20,7 @@ class RetryRule(private val attempts: Int) : TestRule {
                     }.onSuccess {
                         return
                     }.onFailure { error ->
-                        if (isLast || error is AssumptionViolatedException) {
+                        if (isLast || error is AssumptionViolatedException || error is NoLeakAssertionFailedError) {
                             throw error
                         }
                         Log.d(logTag, "Failed attempt $attempt out of $attempts with error")

--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     androidTestImplementation testLibs.espresso.core
     androidTestImplementation testLibs.espresso.intents
     androidTestImplementation testLibs.espresso.web
+    androidTestImplementation testLibs.leakCanaryInstrumentation
     androidTestImplementation testLibs.truth
 }
 

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -1038,6 +1038,7 @@ internal class PlaygroundTestDriver(
 
     internal fun teardown() {
         application?.unregisterActivityLifecycleCallbacks(activityLifecycleCallbacks)
+        currentActivity[0] = null
     }
 
     private fun isSelectPaymentMethodScreen(): Boolean {

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/TestRules.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/TestRules.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import com.stripe.android.paymentsheet.example.BuildConfig
 import com.stripe.android.test.core.INDIVIDUAL_TEST_TIMEOUT_SECONDS
 import com.stripe.android.testing.RetryRule
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.rules.RuleChain
 import org.junit.rules.TestRule
 import org.junit.rules.Timeout
@@ -34,6 +35,7 @@ class TestRules private constructor(
             val composeTestRule = createEmptyComposeRule()
 
             val chain = RuleChain.emptyRuleChain()
+                .around(DetectLeaksAfterTestSuccess())
                 .around(composeTestRule)
                 .let { chain ->
                     if (disableAnimations) {

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -100,6 +100,8 @@ dependencies {
     androidTestImplementation testLibs.mockito.core
     androidTestImplementation testLibs.mockito.inline
     androidTestImplementation testLibs.mockito.kotlin
+    androidTestImplementation libs.leakCanary
+    androidTestImplementation testLibs.leakCanaryInstrumentation
     androidTestImplementation testLibs.testParameterInjector
     androidTestImplementation testLibs.truth
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
@@ -26,6 +26,7 @@ import com.stripe.android.paymentsheet.utils.IntegrationTypeProvider
 import com.stripe.android.paymentsheet.utils.PrefsTestStore
 import com.stripe.android.paymentsheet.utils.runCustomerSheetTest
 import com.stripe.android.testing.RetryRule
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -40,6 +41,7 @@ internal class CustomerSheetTest {
 
     @get:Rule
     val chain: RuleChain = RuleChain.emptyRuleChain()
+        .around(DetectLeaksAfterTestSuccess())
         .around(composeTestRule)
         .around(retryRule)
         .around(networkRule)

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.paymentsheet.utils.assertCompleted
 import com.stripe.android.paymentsheet.utils.assertFailed
 import com.stripe.android.paymentsheet.utils.runFlowControllerTest
 import com.stripe.android.testing.RetryRule
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -36,6 +37,7 @@ internal class FlowControllerTest {
 
     @get:Rule
     val chain: RuleChain = RuleChain.emptyRuleChain()
+        .around(DetectLeaksAfterTestSuccess())
         .around(composeTestRule)
         .around(retryRule)
         .around(networkRule)

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
@@ -23,6 +23,7 @@ import com.stripe.android.paymentsheet.utils.LinkIntegrationTypeProvider
 import com.stripe.android.paymentsheet.utils.assertCompleted
 import com.stripe.android.paymentsheet.utils.runLinkTest
 import com.stripe.android.testing.RetryRule
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -41,6 +42,7 @@ internal class LinkTest {
 
     @get:Rule
     val chain: RuleChain = RuleChain.emptyRuleChain()
+        .around(DetectLeaksAfterTestSuccess())
         .around(composeTestRule)
         .around(retryRule)
         .around(networkRule)

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.paymentsheet.utils.assertCompleted
 import com.stripe.android.paymentsheet.utils.runFlowControllerTest
 import com.stripe.android.paymentsheet.utils.runPaymentSheetTest
 import com.stripe.android.testing.RetryRule
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -40,6 +41,7 @@ internal class PaymentSheetAnalyticsTest {
 
     @get:Rule
     val chain: RuleChain = RuleChain.emptyRuleChain()
+        .around(DetectLeaksAfterTestSuccess())
         .around(composeTestRule)
         .around(retryRule)
         .around(networkRule)

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetBillingConfigurationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetBillingConfigurationTest.kt
@@ -15,21 +15,25 @@ import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.utils.IntegrationType
 import com.stripe.android.paymentsheet.utils.assertCompleted
 import com.stripe.android.paymentsheet.utils.runPaymentSheetTest
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 internal class PaymentSheetBillingConfigurationTest {
-    @get:Rule
-    val composeTestRule = createAndroidComposeRule<MainActivity>()
-
+    private val composeTestRule = createAndroidComposeRule<MainActivity>()
+    private val networkRule = NetworkRule()
     private val page: PaymentSheetPage = PaymentSheetPage(composeTestRule)
 
     @get:Rule
-    val networkRule = NetworkRule()
+    val chain: RuleChain = RuleChain.emptyRuleChain()
+        .around(DetectLeaksAfterTestSuccess())
+        .around(composeTestRule)
+        .around(networkRule)
 
     @Test
     fun testPayloadWithDefaultsAndOverrides() {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -18,6 +18,7 @@ import com.stripe.android.paymentsheet.utils.assertFailed
 import com.stripe.android.paymentsheet.utils.expectNoResult
 import com.stripe.android.paymentsheet.utils.runPaymentSheetTest
 import com.stripe.android.testing.RetryRule
+import leakcanary.DetectLeaksAfterTestSuccess
 import okhttp3.mockwebserver.SocketPolicy
 import org.junit.Rule
 import org.junit.Test
@@ -32,6 +33,7 @@ internal class PaymentSheetTest {
 
     @get:Rule
     val chain: RuleChain = RuleChain.emptyRuleChain()
+        .around(DetectLeaksAfterTestSuccess())
         .around(composeTestRule)
         .around(retryRule)
         .around(networkRule)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I tested that it'll fail when leaks occur by adding a leak to PaymentSheetActivity where I had a global var set to the activities instance.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
The hope for this is to prevent occurrences of issues like https://github.com/stripe/stripe-android/pull/8513
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3194

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
