### PR TITLE
Run FC Maestro tests on every push

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -34,6 +34,8 @@ stages:
       - run-paymentsheet-instrumentation-tests: { }
       - run-example-instrumentation-tests: { }
       - run-financial-connections-instrumentation-tests: { }
+      - run-connections-e2e-payments-tests-on-push: { }
+      - run-connections-e2e-data-tests-on-push: { }
       - run-cardscan-instrumentation-tests: { }
       - run-paymentsheet-end-to-end-tests: { }
       - run-paymentsheet-screenshot-tests: { }
@@ -111,6 +113,18 @@ workflows:
     envs:
       - MAESTRO_TAGS: testmode-data
     before_run:
+      - _run-connections-e2e-tests
+  run-connections-e2e-payments-tests-on-push:
+    envs:
+      - MAESTRO_TAGS: testmode-payments
+    before_run:
+      - _build-connections
+      - _run-connections-e2e-tests
+  run-connections-e2e-data-tests-on-push:
+    envs:
+      - MAESTRO_TAGS: testmode-data
+    before_run:
+      - _build-connections
       - _run-connections-e2e-tests
   run-connections-e2e-livemode-tests:
     envs:

--- a/financial-connections/src/androidTest/java/com/stripe/android/financialconnections/FinancialConnectionsSheetRedirectActivityTest.kt
+++ b/financial-connections/src/androidTest/java/com/stripe/android/financialconnections/FinancialConnectionsSheetRedirectActivityTest.kt
@@ -14,8 +14,8 @@ import androidx.test.espresso.intent.Intents.intending
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
-import junit.framework.Assert.assertEquals
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request makes our FC Maestro tests run on every push, so that we learn about broken tests before merging a change.

The tests run in about the same time as the PaymentSheet tests, so we’re not adding any delays.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
