### PR TITLE
[RUN_LINK_PREFERENCE-241] Remove link_2024_rebrand_m1 flag

### DIFF
--- a/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
@@ -1250,7 +1250,6 @@ internal object ElementsSessionFixtures {
                     "enable_third_party_recurring_express_checkout_element": false,
                     "financial_connections_enable_deferred_intent_flow": true,
                     "legacy_confirmation_tokens": false,
-                    "link_2024_rebrand_m1": true,
                     "link_enable_card_brand_choice": true,
                     "link_purchase_protections_enabled": false,
                     "link_share_expand_payment_method": true,
@@ -1265,7 +1264,6 @@ internal object ElementsSessionFixtures {
                     "type": "shopping"
                 },
                 "link_settings": {
-                    "link_2024_rebrand_m1": true,
                     "link_authenticated_change_event_enabled": false,
                     "link_bank_incentives_enabled": false,
                     "link_bank_onboarding_enabled": false,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Removing unused flag `link_2024_rebrand_m1`. See [slack thread ](https://stripe.slack.com/archives/CJ0STL524/p1716565128566459)for more info

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[RUN_LINK_PREFERENCE-241](https://jira.corp.stripe.com/browse/RUN_LINK_PREFERENCE-241)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
