### PR TITLE
Ensure the image always fits within the viewfinder

### DIFF
--- a/camera-core/src/androidTest/java/com/stripe/android/camera/framework/util/LayoutTest.kt
+++ b/camera-core/src/androidTest/java/com/stripe/android/camera/framework/util/LayoutTest.kt
@@ -241,4 +241,23 @@ class LayoutTest {
     fun adjustSizeToAspectRatio_horizontalExpand() {
         assertEquals(Size(1800, 900), adjustSizeToAspectRatio(Size(1600, 900), 2F))
     }
+
+    @Test
+    @SmallTest
+    fun sizeUnion_mixed() {
+        assertEquals(Size(100, 200), Size(50, 200).union(Size(100, 100)))
+        assertEquals(Size(100, 200), Size(100, 100).union(Size(50, 200)))
+    }
+
+    @Test
+    @SmallTest
+    fun sizeUnion_smaller() {
+        assertEquals(Size(100, 200), Size(100, 200).union(Size(75, 150)))
+    }
+
+    @Test
+    @SmallTest
+    fun sizeUnion_larger() {
+        assertEquals(Size(100, 200), Size(75, 150).union(Size(100, 200)))
+    }
 }

--- a/camera-core/src/main/java/com/stripe/android/camera/framework/util/Layout.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/framework/util/Layout.kt
@@ -214,6 +214,13 @@ fun Size.centerOn(rect: Rect) = Rect(
     rect.centerY() + this.height / 2
 )
 
+@CheckResult
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun Size.union(size: Size) = Size(
+    max(this.width, size.width),
+    max(this.height, size.height)
+)
+
 /**
  * Scale a [Rect] to have a size equivalent to the [scaledSize]. This will also scale the position
  * of the [Rect].

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanFlow.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanFlow.kt
@@ -12,6 +12,7 @@ import com.stripe.android.camera.framework.ProcessBoundAnalyzerLoop
 import com.stripe.android.camera.framework.util.centerOn
 import com.stripe.android.camera.framework.util.minAspectRatioSurroundingSize
 import com.stripe.android.camera.framework.util.size
+import com.stripe.android.camera.framework.util.union
 import com.stripe.android.camera.scanui.ScanFlow
 import com.stripe.android.stripecardscan.cardscan.result.MainLoopAggregator
 import com.stripe.android.stripecardscan.cardscan.result.MainLoopState
@@ -87,7 +88,7 @@ internal abstract class CardScanFlow(
                         SSDOcr.cameraPreviewToInput(
                             cameraImage.image,
                             minAspectRatioSurroundingSize(
-                                cameraImage.viewBounds.size(),
+                                cameraImage.viewBounds.size().union(viewFinder.size()),
                                 cameraImage.image.width.toFloat() / cameraImage.image.height
                             ).centerOn(cameraImage.viewBounds),
                             viewFinder


### PR DESCRIPTION
# Summary
Include the viewfinder when calculating the crop of the image to process

# Motivation
https://github.com/stripe/stripe-android/issues/7915

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
[Fixed] #7915 by including the viewfinder in the crop calculation
