### PR TITLE
Update AutocompleteScreen button background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## XX.XX.XX - 20XX-XX-XX
+* [FIXED][8538](https://github.com/stripe/stripe-android/pull/8538) Change Autocomplete Screen "Enter address manually" button background to prevent unexpected changes to user set colors
 
 ## 20.44.0 - 2024-05-20
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -41,8 +42,8 @@ import com.stripe.android.common.ui.LoadingIndicator
 import com.stripe.android.paymentsheet.injection.AutocompleteViewModelSubcomponent
 import com.stripe.android.paymentsheet.ui.AddressOptionsAppBar
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
-import com.stripe.android.uicore.darken
 import com.stripe.android.uicore.elements.TextFieldSection
+import com.stripe.android.uicore.shouldUseDarkDynamicColor
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.text.annotatedStringResource
 import javax.inject.Provider
@@ -93,10 +94,10 @@ internal fun AutocompleteScreenUI(viewModel: AutocompleteViewModel) {
             }
         },
         bottomBar = {
-            val background = if (isSystemInDarkTheme()) {
-                MaterialTheme.stripeColors.component
+            val background = if (MaterialTheme.stripeColors.materialColors.surface.shouldUseDarkDynamicColor()) {
+                Color.Black.copy(alpha = 0.07f)
             } else {
-                MaterialTheme.stripeColors.materialColors.surface.darken(0.07f)
+                Color.White.copy(alpha = 0.07f)
             }
             Row(
                 verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Changes AutocompleteScreen "Enter address manually" button to us a 7% opacity background instead of darkening user set surface color

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[RUN_MOBILESDK-3206](https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3206)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| <img width="331" alt="image" src="https://github.com/stripe/stripe-android/assets/163896025/3ab8d6bc-a8ea-4bc6-b4ff-706eb33bb71f">  | ![Screenshot_1716500445](https://github.com/stripe/stripe-android/assets/163896025/b5eee4b9-ea47-4d43-aed8-6c59e6c9cacb) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
