### PR TITLE
Fix Compose state restoration in `CardInputWidget`.

### DIFF
--- a/example/AndroidManifest.xml
+++ b/example/AndroidManifest.xml
@@ -85,6 +85,7 @@
         <activity android:name=".activity.SwishExampleActivity"/>
         <activity android:name=".activity.MobilePayExampleActivity"/>
         <activity android:name=".activity.AlmaActivity"/>
+        <activity android:name=".activity.CardInputWidgetExampleActivity"/>
     </application>
 
 </manifest>

--- a/example/AndroidManifest.xml
+++ b/example/AndroidManifest.xml
@@ -85,7 +85,7 @@
         <activity android:name=".activity.SwishExampleActivity"/>
         <activity android:name=".activity.MobilePayExampleActivity"/>
         <activity android:name=".activity.AlmaActivity"/>
-        <activity android:name=".activity.CardInputWidgetExampleActivity"/>
+        <activity android:name=".activity.CardInputWidgetComposeExampleActivity"/>
     </application>
 
 </manifest>

--- a/example/src/main/java/com/stripe/example/activity/CardInputWidgetComposeExampleActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CardInputWidgetComposeExampleActivity.kt
@@ -32,7 +32,7 @@ import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.view.CardInputWidget
 import com.stripe.example.R
 
-class CardInputWidgetExampleActivity : AppCompatActivity() {
+class CardInputWidgetComposeExampleActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/example/src/main/java/com/stripe/example/activity/CardInputWidgetExampleActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CardInputWidgetExampleActivity.kt
@@ -1,0 +1,116 @@
+package com.stripe.example.activity
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Card
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Switch
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.SaveableStateHolder
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Alignment.Companion.CenterHorizontally
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.view.CardInputWidget
+import com.stripe.example.R
+
+class CardInputWidgetExampleActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            val stateHolder = rememberSaveableStateHolder()
+
+            var showCardInputWidget by remember {
+                mutableStateOf(true)
+            }
+
+            StripeTheme {
+                Scaffold(
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .padding(it)
+                            .padding(16.dp)
+                            .fillMaxSize(),
+                        horizontalAlignment = CenterHorizontally,
+                    ) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center
+                        ) {
+                            Text("Show Card Input Widget")
+                            Spacer(modifier = Modifier.width(16.dp))
+                            Switch(
+                                checked = showCardInputWidget,
+                                onCheckedChange = { checked ->
+                                    showCardInputWidget = checked
+                                }
+                            )
+                        }
+
+                        if (showCardInputWidget) {
+                            SaveableCardInputWidget(stateHolder)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun SaveableCardInputWidget(
+        stateHolder: SaveableStateHolder,
+    ) {
+        stateHolder.SaveableStateProvider("stripe_elements") {
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
+                Box {
+                    AndroidView(
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                        factory = { context ->
+                            CardInputWidget(context).apply {
+                                id = R.id.card_input_widget
+
+                                setCardValidCallback { isValid, fields ->
+                                    // Do something here
+                                }
+
+                                postalCodeRequired = true
+                            }
+                        },
+                        update = {
+                            // do nothing
+                        },
+                        onRelease = {
+                        },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
@@ -207,8 +207,8 @@ class LauncherActivity : AppCompatActivity() {
                 StripeImageActivity::class.java
             ),
             Item(
-                "Card Input Widget Example",
-                CardInputWidgetExampleActivity::class.java
+                "Card Input Widget Compose Example",
+                CardInputWidgetComposeExampleActivity::class.java
             )
         )
 

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
@@ -205,6 +205,10 @@ class LauncherActivity : AppCompatActivity() {
             Item(
                 "StripeImage Example",
                 StripeImageActivity::class.java
+            ),
+            Item(
+                "Card Input Widget Example",
+                CardInputWidgetExampleActivity::class.java
             )
         )
 

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -70,6 +70,7 @@ dependencies {
 
     androidTestImplementation project(':stripe-ui-core') // Resources defined here, but used in payments-core.
     androidTestImplementation project(':payments-core-testing')
+    androidTestImplementation testLibs.androidx.composeUi
     androidTestImplementation testLibs.androidx.coreKtx
     androidTestImplementation testLibs.androidx.testRules
     androidTestImplementation testLibs.androidx.testRunner

--- a/payments-core/src/androidTest/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/payments-core/src/androidTest/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -1,0 +1,103 @@
+package com.stripe.android.view
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withHint
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.R
+import org.junit.Rule
+import org.junit.Test
+
+class CardInputWidgetTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun restoresViewWidthsWhenUsingSaveableState() {
+        val cardInputWidgetState = mutableStateOf(value = State.Show)
+
+        composeTestRule.activity.setTheme(R.style.StripeDefaultTheme)
+
+        PaymentConfiguration.init(composeTestRule.activity, "publishable_key")
+
+        composeTestRule.setContent {
+            val stateHolder = rememberSaveableStateHolder()
+
+            val state by cardInputWidgetState
+
+            if (state == State.Show) {
+                stateHolder.SaveableStateProvider("stripe_elements") {
+                    AndroidView(
+                        modifier = Modifier.fillMaxWidth(),
+                        factory = { context ->
+                            CardInputWidget(context).apply {
+                                id = VIEW_ID
+                                postalCodeRequired = true
+                            }
+                        },
+                        update = {
+                            // do nothing
+                        },
+                        onRelease = {
+                        },
+                    )
+                }
+            }
+        }
+
+        Espresso.onIdle()
+        composeTestRule.waitForIdle()
+
+        onView(withHint("1234 1234 1234 1234")).perform(typeText("4242 4242 4242 4242"))
+        onView(withHint("MM/YY")).perform(typeText("04/25"))
+
+        Espresso.onIdle()
+
+        onView(withHint("CVC")).perform(typeText("404"))
+        onView(withHint("Postal code")).perform(typeText("A1B3C7"))
+
+        Espresso.onIdle()
+        composeTestRule.waitForIdle()
+
+        onView(withText("4242 4242 4242 4242")).check(matches(isDisplayed()))
+        onView(withText("04/25")).check(matches(isDisplayed()))
+        onView(withText("404")).check(matches(isDisplayed()))
+        onView(withText("A1B3C7")).check(matches(isDisplayed()))
+
+        cardInputWidgetState.value = State.Hide
+
+        Espresso.onIdle()
+        composeTestRule.waitForIdle()
+
+        cardInputWidgetState.value = State.Show
+
+        Espresso.onIdle()
+        composeTestRule.waitForIdle()
+
+        onView(withText("4242 4242 4242 4242")).check(matches(isDisplayed()))
+        onView(withText("04/25")).check(matches(isDisplayed()))
+        onView(withText("404")).check(matches(isDisplayed()))
+        onView(withText("A1B3C7")).check(matches(isDisplayed()))
+    }
+
+    private enum class State {
+        Show,
+        Hide,
+    }
+
+    private companion object {
+        const val VIEW_ID = 12345
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -26,6 +26,7 @@ import androidx.core.os.bundleOf
 import androidx.core.view.AccessibilityDelegateCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
+import androidx.core.view.doOnPreDraw
 import androidx.core.view.updateLayoutParams
 import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.ViewModelStoreOwner
@@ -592,48 +593,6 @@ class CardInputWidget @JvmOverloads constructor(
         if (state is Bundle) {
             postalCodeEnabled = state.getBoolean(STATE_POSTAL_CODE_ENABLED, true)
             isShowingFullCard = state.getBoolean(STATE_CARD_VIEWED, true)
-            updateSpaceSizes(isShowingFullCard)
-            placement.totalLengthInPixels = frameWidth
-            val cardStartMargin: Int
-            val dateStartMargin: Int
-            val cvcStartMargin: Int
-            val postalCodeStartMargin: Int
-            if (isShowingFullCard) {
-                cardStartMargin = 0
-                dateStartMargin = placement.getDateStartMargin(isFullCard = true)
-                cvcStartMargin = placement.getCvcStartMargin(isFullCard = true)
-                postalCodeStartMargin = placement.getPostalCodeStartMargin(isFullCard = true)
-            } else {
-                cardStartMargin = -1 * placement.hiddenCardWidth
-                dateStartMargin = placement.getDateStartMargin(isFullCard = false)
-                cvcStartMargin = placement.getCvcStartMargin(isFullCard = false)
-                postalCodeStartMargin = if (postalCodeEnabled) {
-                    placement.getPostalCodeStartMargin(isFullCard = false)
-                } else {
-                    placement.totalLengthInPixels
-                }
-            }
-
-            updateFieldLayout(
-                view = cardNumberTextInputLayout,
-                newWidth = placement.cardWidth,
-                newMarginStart = cardStartMargin
-            )
-            updateFieldLayout(
-                view = expiryDateTextInputLayout,
-                newWidth = placement.dateWidth,
-                newMarginStart = dateStartMargin
-            )
-            updateFieldLayout(
-                view = cvcNumberTextInputLayout,
-                newWidth = placement.cvcWidth,
-                newMarginStart = cvcStartMargin
-            )
-            updateFieldLayout(
-                view = postalCodeTextInputLayout,
-                newWidth = placement.postalCodeWidth,
-                newMarginStart = postalCodeStartMargin
-            )
 
             super.onRestoreInstanceState(state.getParcelable(STATE_SUPER_STATE))
         } else {
@@ -700,9 +659,11 @@ class CardInputWidget @JvmOverloads constructor(
         newWidth: Int,
         newMarginStart: Int
     ) {
-        view.updateLayoutParams<FrameLayout.LayoutParams> {
-            width = newWidth
-            marginStart = newMarginStart
+        view.doOnPreDraw {
+            it.updateLayoutParams<FrameLayout.LayoutParams> {
+                width = newWidth
+                marginStart = newMarginStart
+            }
         }
     }
 


### PR DESCRIPTION
# Summary
Fix Compose state restoration in `CardInputWidget`.

`CardinputWidget` does a lot of custom view width management for its internal `CardNumber`, `ExpiryDate`, `CVC`, and `Postal Code/Zip` fields. When initializing for the first time, the code in `master` works fine as the parent layout (being `CardInputWidget` is created first. Following that, its child fields are then created then everything is laid out on the screen. This also works fine when restoring instance state after the `Activity` or `Fragment` is destroyed.

This is not the case when restoring instance state with `SaveableStateProvider` with `CardInputWidget` having only been destroyed. `CardInputWidget` initially laid out using its initial parameters defined in the XML layout before using any programmatically set layout parameters. Due to setting the layout parameters initially in `onRestoreInstanceState`, this caused the all fields to have a `width` of 0.

The solution here is to remove the code from `onRestoreInstanceState` then before drawing, update the layout parameters so the views know the calculated width from `CardInputWidget`.

# Motivation
Allows users implementing `CardInputWidget` with Jetpack Compose to properly be able to restore the widget when using `SaveableStateProvider`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Video
https://github.com/stripe/stripe-android/assets/141707240/77b118ae-4bd8-43f2-a97f-e358cfcc9b2e