### PR TITLE
Correctly filter out saved PMs that we do not display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 20XX-XX-XX
 
+### PaymentSheet
+* [FIXED][8553](https://github.com/stripe/stripe-android/pull/8553) Issue where "Select your payment method" screen would be displayed with no saved payment methods to select
+
 ## 20.44.1 - 2024-05-28
 
 ### PaymentSheet

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -130,7 +130,6 @@ internal abstract class BaseSheetViewModel(
                     PaymentMethod.Type.Card, PaymentMethod.Type.SepaDebit, PaymentMethod.Type.USBankAccount -> it
                     else -> null
                 }
-
             }
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -125,7 +125,13 @@ internal abstract class BaseSheetViewModel(
     internal val paymentMethods: StateFlow<List<PaymentMethod>?> = savedStateHandle
         .getStateFlow<CustomerState?>(SAVED_CUSTOMER, null)
         .mapAsStateFlow { state ->
-            state?.paymentMethods
+            state?.paymentMethods?.mapNotNull {
+                when (it.type) {
+                    PaymentMethod.Type.Card, PaymentMethod.Type.SepaDebit, PaymentMethod.Type.USBankAccount -> it
+                    else -> null
+                }
+
+            }
         }
 
     protected val backStack = MutableStateFlow<List<PaymentSheetScreen>>(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Filter out saved payment methods that we don't display in the view model, rather than at the UI layer

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
The current behavior introduces a few bugs if the user has saved link PMs but no other saved PMs, specifically:
- you can remove the last PM even if `allowsRemovalOfLastSavedPM` is false
- the select your payment method screen will be displayed with no saved payment method tabs

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screen recordings
Before:


https://github.com/stripe/stripe-android/assets/160939932/597be1b8-12e1-4dd8-b565-8cc995bff20c



After:

https://github.com/stripe/stripe-android/assets/160939932/e75b40d8-b728-443a-815a-3d89dac5c2a3



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
- [FIXED] Issue where "Select your payment method" screen would be displayed with no saved payment methods to select
