### PR TITLE
Update `stripe:version` in `GooglePayConfig` to include Android SDK reference and version

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/GooglePayConfig.kt
+++ b/payments-core/src/main/java/com/stripe/android/GooglePayConfig.kt
@@ -2,7 +2,6 @@ package com.stripe.android
 
 import android.content.Context
 import com.stripe.android.core.ApiKeyValidator
-import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.version.StripeSdkVersion
 import org.json.JSONException
 import org.json.JSONObject
@@ -15,7 +14,7 @@ class GooglePayConfig @JvmOverloads constructor(
     private val connectedAccountId: String? = null
 ) {
     private val validPublishableKey: String = ApiKeyValidator.get().requireValid(publishableKey)
-    private val apiVersion: String = StripeSdkVersion.VERSION_NAME
+    private val sdkVersion: String = StripeSdkVersion.VERSION_NAME
 
     /**
      * @return a [JSONObject] representing a [Google Pay TokenizationSpecification](https://developers.google.com/pay/api/android/reference/object#gateway)
@@ -29,7 +28,7 @@ class GooglePayConfig @JvmOverloads constructor(
                 "parameters",
                 JSONObject()
                     .put("gateway", "stripe")
-                    .put("stripe:version", "$USER_AGENT/$apiVersion")
+                    .put("stripe:version", "$USER_AGENT/$sdkVersion")
                     .put("stripe:publishableKey", key)
             )
 
@@ -52,6 +51,6 @@ class GooglePayConfig @JvmOverloads constructor(
     )
 
     private companion object {
-        const val USER_AGENT = "StripeAndroid"
+        private const val USER_AGENT = "StripeAndroid"
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/GooglePayConfig.kt
+++ b/payments-core/src/main/java/com/stripe/android/GooglePayConfig.kt
@@ -3,6 +3,7 @@ package com.stripe.android
 import android.content.Context
 import com.stripe.android.core.ApiKeyValidator
 import com.stripe.android.core.ApiVersion
+import com.stripe.android.core.version.StripeSdkVersion
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -14,7 +15,7 @@ class GooglePayConfig @JvmOverloads constructor(
     private val connectedAccountId: String? = null
 ) {
     private val validPublishableKey: String = ApiKeyValidator.get().requireValid(publishableKey)
-    private val apiVersion: String = ApiVersion.get().code
+    private val apiVersion: String = StripeSdkVersion.VERSION_NAME
 
     /**
      * @return a [JSONObject] representing a [Google Pay TokenizationSpecification](https://developers.google.com/pay/api/android/reference/object#gateway)
@@ -28,7 +29,7 @@ class GooglePayConfig @JvmOverloads constructor(
                 "parameters",
                 JSONObject()
                     .put("gateway", "stripe")
-                    .put("stripe:version", apiVersion)
+                    .put("stripe:version", "$USER_AGENT/$apiVersion")
                     .put("stripe:publishableKey", key)
             )
 
@@ -49,4 +50,8 @@ class GooglePayConfig @JvmOverloads constructor(
         publishableKey = paymentConfiguration.publishableKey,
         connectedAccountId = paymentConfiguration.stripeAccountId
     )
+
+    private companion object {
+        const val USER_AGENT = "StripeAndroid"
+    }
 }

--- a/payments-core/src/test/java/com/stripe/android/GooglePayConfigTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/GooglePayConfigTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.ApiVersion
+import com.stripe.android.core.version.StripeSdkVersion
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -23,7 +24,7 @@ class GooglePayConfigTest {
         assertThat(params.getString("gateway"))
             .isEqualTo("stripe")
         assertThat(params.getString("stripe:version"))
-            .isEqualTo(ApiVersion.get().code)
+            .isEqualTo("StripeAndroid/${StripeSdkVersion.VERSION_NAME}")
         assertThat(params.getString("stripe:publishableKey"))
             .isEqualTo(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
     }
@@ -36,7 +37,7 @@ class GooglePayConfigTest {
         assertThat(params.getString("gateway"))
             .isEqualTo("stripe")
         assertThat(params.getString("stripe:version"))
-            .isEqualTo(ApiVersion.get().code)
+            .isEqualTo("StripeAndroid/${StripeSdkVersion.VERSION_NAME}")
         assertThat(params.getString("stripe:publishableKey"))
             .isEqualTo("pk_test_123/acct_1234")
     }

--- a/payments-core/src/test/java/com/stripe/android/GooglePayConfigTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/GooglePayConfigTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android
 
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.version.StripeSdkVersion
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner

--- a/payments-core/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.model.StripeJsonUtils
 import com.stripe.android.core.version.StripeSdkVersion
 import org.json.JSONException
@@ -78,7 +77,7 @@ class GooglePayJsonFactoryTest {
                         "type": "PAYMENT_GATEWAY",
                         "parameters": {
                             "gateway": "stripe",
-                            "stripe:version": "${ApiVersion.get().code}",
+                            "stripe:version": "StripeAndroid/${StripeSdkVersion.VERSION_NAME}",
                             "stripe:publishableKey": "${ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY}"
                         }
                     }
@@ -114,7 +113,7 @@ class GooglePayJsonFactoryTest {
                         "type": "PAYMENT_GATEWAY",
                         "parameters": {
                             "gateway": "stripe",
-                            "stripe:version": "${ApiVersion.get().code}",
+                            "stripe:version": "StripeAndroid/${StripeSdkVersion.VERSION_NAME}",
                             "stripe:publishableKey": "${ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY}"
                         }
                     }

--- a/payments-core/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.model.StripeJsonUtils
+import com.stripe.android.core.version.StripeSdkVersion
 import org.json.JSONException
 import org.json.JSONObject
 import org.junit.runner.RunWith
@@ -36,7 +37,7 @@ class GooglePayJsonFactoryTest {
                         "type": "PAYMENT_GATEWAY",
                         "parameters": {
                             "gateway": "stripe",
-                            "stripe:version": "${ApiVersion.get().code}",
+                            "stripe:version": "StripeAndroid/${StripeSdkVersion.VERSION_NAME}",
                             "stripe:publishableKey": "${ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY}"
                         }
                     }


### PR DESCRIPTION
# Summary
Update `stripe:version` in `GooglePayConfig` to include Android SDK reference and version

# Motivation
Allows us to more clearly track Google Pay PIV within the Android SDK

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified