### PR TITLE
Share `customerId` across integration types in playground

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -70,7 +70,21 @@ internal class PlaygroundSettings private constructor(
                 return@forEach
             }
 
-            if (!values.contains(settings[definition]?.value)) {
+            val value = settings[definition]?.value
+
+            /*
+             * Keeps the existing customer ID if the country value can be shared between integration types
+             */
+            if (definition == CustomerSettingsDefinition && value is CustomerType.Existing) {
+                val countryOptions = CountrySettingsDefinition.createOptions(configurationData)
+                val country = settings[CountrySettingsDefinition]?.value
+
+                if (countryOptions.any { it.value == country }) {
+                    return@forEach
+                }
+            }
+
+            if (!values.contains(value)) {
                 settings[definition]?.value = values.firstOrNull()
             }
         }


### PR DESCRIPTION
# Summary
Share `customerId` across integration types in playground.

# Motivation
Allows for features to be tested using a new customer ID across all the integration types

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Video
https://github.com/stripe/stripe-android/assets/141707240/20d606ae-b894-4fa5-a3c9-99ac2581d746