### PR TITLE
Add default feature parameters to `CustomerEphemeralKeyRequest`.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCustomerModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCustomerModel.kt
@@ -11,6 +11,12 @@ class CustomerEphemeralKeyRequest private constructor(
     val customerKeyType: CustomerKeyType?,
     @SerialName("merchant_country_code")
     val merchantCountryCode: String?,
+    @SerialName("customer_session_payment_method_save")
+    val paymentMethodSaveFeature: FeatureState?,
+    @SerialName("customer_session_payment_method_remove")
+    val paymentMethodRemoveFeature: FeatureState?,
+    @SerialName("customer_session_payment_method_redisplay")
+    val paymentMethodRedisplayFeature: FeatureState?
 ) {
     @Serializable
     enum class CustomerKeyType {
@@ -19,6 +25,15 @@ class CustomerEphemeralKeyRequest private constructor(
 
         @SerialName("legacy")
         Legacy;
+    }
+
+    @Serializable
+    enum class FeatureState {
+        @SerialName("enabled")
+        Enabled,
+
+        @SerialName("disabled")
+        Disabled;
     }
 
     class Builder {
@@ -38,6 +53,9 @@ class CustomerEphemeralKeyRequest private constructor(
                 customerType = customerType,
                 customerKeyType = CustomerKeyType.Legacy,
                 merchantCountryCode = merchantCountryCode,
+                paymentMethodSaveFeature = FeatureState.Enabled,
+                paymentMethodRemoveFeature = FeatureState.Enabled,
+                paymentMethodRedisplayFeature = FeatureState.Enabled,
             )
         }
     }


### PR DESCRIPTION
# Summary
Add default feature parameters to `CustomerEphemeralKeyRequest`.

# Motivation
Following merging of this [PR](https://git.corp.stripe.com/stripe-internal/sandbox-apps/pull/679) on your example playground, save, remove, and redisplay features will be off by default. This PR sets them to enabled by default in our request until `CustomerSession` features are implemented.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
