### PR TITLE
Update codeowners to improve auto assign.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,24 +2,24 @@
 * @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
 
 # Payments SDK
-/payment-method-messaging/ @android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
-/payments/ @android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
-/payments-core/ @android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
-/payments-core-testing/ @android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
-/payments-model/ @android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
-/payments-ui-core/ @android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
-/paymentsheet/ @android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
-/paymentsheet-example/ @android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/payment-method-messaging/ @stripe/android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/payments/ @stripe/android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/payments-core/ @stripe/android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/payments-core-testing/ @stripe/android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/payments-model/ @stripe/android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/payments-ui-core/ @stripe/android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/paymentsheet/ @stripe/android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/paymentsheet-example/ @stripe/android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
 
 # CardScan SDK
-/stripecardscan/ @android-cardscan-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
-/stripecardscan-example/ @android-cardscan-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
-/stripecardscan-tflite/ @android-cardscan-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/stripecardscan/ @stripe/android-cardscan-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/stripecardscan-example/ @stripe/android-cardscan-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/stripecardscan-tflite/ @stripe/android-cardscan-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
 
 # Identity SDK
-/identity/ @android-identity-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
-/identity-example/ @android-identity-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/identity/ @stripe/android-identity-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/identity-example/ @stripe/android-identity-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
 
 # Financial Connections SDK
-/financial-connections/ @android-connections-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
-/financial-connections-example/ @android-connections-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/financial-connections/ @stripe/android-connections-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/financial-connections-example/ @stripe/android-connections-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,25 @@
 # Automatically request reviews from @android-sdk-reviewers by default, allow reviews from @android-sdk-non-core-reviewers
 * @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+
+# Payments SDK
+/payment-method-messaging/ @android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/payments/ @android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/payments-core/ @android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/payments-core-testing/ @android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/payments-model/ @android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/payments-ui-core/ @android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/paymentsheet/ @android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/paymentsheet-example/ @android-payments-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+
+# CardScan SDK
+/stripecardscan/ @android-cardscan-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/stripecardscan-example/ @android-cardscan-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/stripecardscan-tflite/ @android-cardscan-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+
+# Identity SDK
+/identity/ @android-identity-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/identity-example/ @android-identity-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+
+# Financial Connections SDK
+/financial-connections/ @android-connections-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
+/financial-connections-example/ @android-connections-reviewers @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# Automatically request reviews from @android-sdk-reviewers by default, allow reviews from @android-sdk-non-core-reviewers
+# Require approvals from the android-sdk-reviewers team for all changes not in directories listed below.
 * @stripe/android-sdk-reviewers @stripe/android-sdk-non-core-reviewers
 
 # Payments SDK


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I turned auto assign off on the parent group (android-sdk-reviewers), and added it to the all the child groups that will hopefully be assigned first.
