### PR TITLE
Improve browserstack retries.

### DIFF
--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -215,7 +215,7 @@ def testShards(isNightly, testClassNames):
 
 
 # https://www.browserstack.com/docs/app-automate/api-reference/espresso/builds#execute-a-build
-def executeTests(appUrl, testUrl, isNightly, testClasses):
+def executeTestsWithJson(appUrl, testUrl, json):
     print(
         "RUNNING the tests (appUrl: {app}, testUrl: {test})...".format(
             app=appUrl, test=testUrl
@@ -223,38 +223,9 @@ def executeTests(appUrl, testUrl, isNightly, testClasses):
         end="",
     )
     url = "https://api-cloud.browserstack.com/app-automate/espresso/v2/build"
-    # firefox doesn't work on this samsung: Samsung Galaxy S9 Plus-9.0"]
-    shards = testShards(isNightly, testClasses)
-    runningAllTests = len(testClasses) == len(getAllTestClassNames())
-    devices = []
-    if isNightly:
-        devices = [
-            "Google Pixel 7-13.0",
-            "Samsung Galaxy S22-12.0",
-        ]
-    else:
-        devices = [
-            "Samsung Galaxy S22-12.0",
-        ]
     response = requests.post(
         url,
-        json={
-            "app": appUrl,
-            "devices": devices,
-            "testSuite": testUrl,
-            "networkLogs": True,
-            "deviceLogs": True,
-            "video": True,
-            "acceptInsecureCerts": True,
-            "locale": "en_US",
-            "enableSpoonFramework": False,
-            "project": PROJECT_NAME,
-            "shards": {
-                "numberOfShards": len(shards),
-                "mapping": shards,
-            },
-            "class": None if runningAllTests else testClasses,
-        },
+        json=json,
         auth=(user, authKey),
     )
     jsonResponse = response.json()
@@ -279,6 +250,51 @@ def executeTests(appUrl, testUrl, isNightly, testClasses):
         )
         return None
 
+def executeTests(appUrl, testUrl, isNightly, testClasses):
+    shards = testShards(isNightly, testClasses)
+    devices = []
+    if isNightly:
+        devices = [
+            "Google Pixel 7-13.0",
+            "Samsung Galaxy S22-12.0",
+        ]
+    else:
+        devices = [
+            "Samsung Galaxy S22-12.0",
+        ]
+    json = {
+        "app": appUrl,
+        "devices": devices,
+        "testSuite": testUrl,
+        "networkLogs": True,
+        "deviceLogs": True,
+        "video": True,
+        "acceptInsecureCerts": True,
+        "locale": "en_US",
+        "enableSpoonFramework": False,
+        "project": PROJECT_NAME,
+        "shards": {
+            "numberOfShards": len(shards),
+            "mapping": shards,
+        },
+    }
+    return executeTestsWithJson(appUrl, testUrl, json)
+
+def executeTestsForFailure(appUrl, testUrl, device, testClasses):
+    json = {
+        "app": appUrl,
+        "devices": [device],
+        "testSuite": testUrl,
+        "networkLogs": True,
+        "deviceLogs": True,
+        "video": True,
+        "acceptInsecureCerts": True,
+        "locale": "en_US",
+        "enableSpoonFramework": False,
+        "project": PROJECT_NAME,
+        "class": testClasses,
+    }
+    return executeTestsWithJson(appUrl, testUrl, json)
 
 # https://www.browserstack.com/docs/app-automate/api-reference/espresso/builds#get-build-status
 def get_build_status(buildId):
@@ -387,6 +403,15 @@ def runTests(appUrl, testUrl, isNightly, testClasses):
         deleteTestSuite(testUrl.replace("bs://", ""))
     return {"exitStatus": exitStatus, "buildId": buildId}
 
+def runTestsForFailure(appUrl, testUrl, device, testClasses):
+    print(f"RUNNING {str(len(testClasses))} test cases on {device}")
+    buildId = executeTestsForFailure(appUrl, testUrl, device, testClasses)
+    exitStatus = 1
+    if buildId != None:
+        exitStatus = waitForBuildComplete(buildId)
+    else:
+        deleteTestSuite(testUrl.replace("bs://", ""))
+    return {"exitStatus": exitStatus, "buildId": buildId}
 
 # https://www.browserstack.com/docs/app-automate/api-reference/espresso/sessions#get-session-details
 def getFailedTestClassesForSession(buildId, sessionId):
@@ -410,14 +435,13 @@ def getFailedTestClassesForSession(buildId, sessionId):
     return failedTestClasses
 
 
-def classNamesToFullyQualifiedClassNames(failedTestClassNames):
+def classNameToFullyQualifiedClassName(failedTestClassName):
     fullyQualifiedTestClassNames = getAllTestClassNames()
-    failedFullyQualifiedTestClassNames = []
     for fullyQualifiedTestClassName in fullyQualifiedTestClassNames:
         testClassName = fullyQualifiedTestClassName.split(".")[-1]
-        if testClassName in failedTestClassNames:
-            failedFullyQualifiedTestClassNames.append(fullyQualifiedTestClassName)
-    return failedFullyQualifiedTestClassNames
+        if testClassName == failedTestClassName:
+            return fullyQualifiedTestClassName
+    return None
 
 
 def getSessionIdsForBuild(buildId):
@@ -430,15 +454,29 @@ def getSessionIdsForBuild(buildId):
             sessionIds.append(session["id"])
     return sessionIds
 
+def getSessionIdsAndDeviceForBuild(buildId):
+    sessionIds = []
+    buildStatus = get_build_status(buildId)
+    devices = buildStatus.json()["devices"]
+    for device in devices:
+        sessions_on_device = device["sessions"]
+        for session in sessions_on_device:
+            deviceIdentifier = f"{device['device']}-{device['os_version']}"
+            sessionIds.append({"session_id": session["id"], "device": deviceIdentifier})
+    return sessionIds
+
 
 def getFailedTestsForBuild(buildId):
-    sessionIds = getSessionIdsForBuild(buildId)
-    failedClasses = []
-    for sessionId in sessionIds:
-        failedClassesInSession = getFailedTestClassesForSession(buildId, sessionId)
+    sessionIdsAndDevices = getSessionIdsAndDeviceForBuild(buildId)
+    devicesWithFailedClasses = {}
+    for item in sessionIdsAndDevices:
+        failedClassesInSession = getFailedTestClassesForSession(buildId, item["session_id"])
         for failedClass in failedClassesInSession:
-            failedClasses.append(failedClass)
-    return classNamesToFullyQualifiedClassNames(failedClasses)
+            if item["device"] not in devicesWithFailedClasses:
+                devicesWithFailedClasses[item["device"]] = []
+            devicesWithFailedClasses[item["device"]].append(classNameToFullyQualifiedClassName(failedClass))
+            print(f"Device failed: {item['device']} - {failedClass}")
+    return devicesWithFailedClasses
 
 
 if __name__ == "__main__":
@@ -524,19 +562,28 @@ if __name__ == "__main__":
 
             exitStatus = 1
             testClassesToRun = getAllTestClassNames()
-            while numRetries >= 0:
-                testResults = runTests(
-                    appUrl, testUrl, args.is_nightly, testClassesToRun
-                )
-                print("-----------------")
-                exitStatus = testResults["exitStatus"]
-                updateObservabilityWithResults(testResults["buildId"])
-                if exitStatus == 0:
-                    break
-                else:
+            testResults = runTests(
+                appUrl, testUrl, args.is_nightly, testClassesToRun
+            )
+            print("-----------------")
+            exitStatus = testResults["exitStatus"]
+            updateObservabilityWithResults(testResults["buildId"])
+            if exitStatus != 0 and numRetries > 0:
+                os.environ["BROWSERSTACK_RERUN"] = "true"
+                print(f"Getting failed tests for build {testResults['buildId']}")
+                failedTestsDictionary = getFailedTestsForBuild(testResults["buildId"])
+                while numRetries > 0:
+                    updatedFailedTestsDictionary = {}
                     numRetries -= 1
-                    testClassesToRun = getFailedTestsForBuild(testResults["buildId"])
-                    os.environ["BROWSERSTACK_RERUN"] = "true"
+                    for failedDevice in failedTestsDictionary:
+                        testResults = runTestsForFailure(appUrl, testUrl, failedDevice, failedTestsDictionary[failedDevice])
+                        exitStatus = testResults["exitStatus"]
+                        if exitStatus != 0 and numRetries > 0:
+                            updatedFailedTestsDictionary[failedDevice] = getFailedTestsForBuild(testResults["buildId"])[failedDevice]
+
+                    if len(updatedFailedTestsDictionary) == 0:
+                        break
+                    failedTestsDictionary = updatedFailedTestsDictionary
 
             os.environ["BROWSERSTACK_RERUN"] = "false"
             sys.exit(exitStatus)

--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -217,7 +217,7 @@ def testShards(isNightly, testClassNames):
 
 # https://www.browserstack.com/docs/app-automate/api-reference/espresso/builds#execute-a-build
 def executeTestsWithAddedParams(appUrl, testUrl, devices, addedParams):
-    json = {
+    baseParams = {
         "app": appUrl,
         "devices": devices,
         "testSuite": testUrl,
@@ -228,7 +228,8 @@ def executeTestsWithAddedParams(appUrl, testUrl, devices, addedParams):
         "locale": "en_US",
         "enableSpoonFramework": False,
         "project": PROJECT_NAME,
-    } | addedParams
+    }
+    json = {**baseParams, **addedParams}
     print(
         "RUNNING the tests (appUrl: {app}, testUrl: {test})...".format(
             app=appUrl, test=testUrl


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Runs that require multiple devices would run any failures on all devices.

Now retries only retry the failed tests on the device they failed on.

Example run (with reduced tests, but an added 50% chance of failure for address element test):
* https://app-automate.browserstack.com/dashboard/v2/builds/375810a2dcef2059d0bb5122ec95da78d68092ba
* https://app-automate.browserstack.com/dashboard/v2/builds/a0c9bf2eb87a4f373e133da9f07f9d588a9c44b9
* https://app-automate.browserstack.com/dashboard/v2/builds/ea580ec7d2eaf41507fc6ad428014821a651ef60
* https://app-automate.browserstack.com/dashboard/v2/builds/b999baa307094276f07825190e1f46cf9a737f26
* https://app-automate.browserstack.com/dashboard/v2/builds/412546a8a297e40293b0d518a602ee22299d1464
* https://app-automate.browserstack.com/dashboard/v2/builds/6b29d9f74ce0bf685030ec6fcbdbfc462911cf9f
* https://app-automate.browserstack.com/dashboard/v2/builds/1b9f04c2276e69cadb309fb1def36c34e404d0d8

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-1880

Precursor to https://github.com/stripe/stripe-android/pull/8560

