### PR TITLE
[Identity]avoid crash and log when status is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 20XX-XX-XX
 
+### Identity
+* [FIXED][8566](https://github.com/stripe/stripe-android/pull/8566) Fixed a crash when scan finishes and states is cleared.
+
 ## 20.44.1 - 2024-05-28
 
 ### PaymentSheet

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityScanViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityScanViewModel.kt
@@ -141,8 +141,12 @@ internal abstract class IdentityScanViewModel(
     }
 
     fun stopScan(lifecycleOwner: LifecycleOwner) {
-        requireNotNull(identityScanFlow).resetFlow()
-        cameraManager.cameraAdapter?.unbindFromLifecycle(lifecycleOwner)
+        runCatching {
+            requireNotNull(identityScanFlow).resetFlow()
+            cameraManager.requireCameraAdapter().unbindFromLifecycle(lifecycleOwner)
+        }.onFailure {
+            identityAnalyticsRequestFactory.genericError("required object is null", it.stackTraceToString())
+        }
     }
 
     /**


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Don't crash but instead log a generic error when either `identityScanFlow` or `cameraManager.cameraAdatper` is null when stop scanning

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Avoid runtime crash

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
