### PR TITLE
Fold `Google Pay` confirm errors into a single error type

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -154,9 +154,6 @@ interface ErrorReporter {
         LINK_INVALID_SESSION_STATE(
             partialEventName = "link.signup.failure.invalidSessionState"
         ),
-        GOOGLE_PAY_UNEXPECTED_RESULT_CODE(
-            partialEventName = "google_pay.confirm.unexpected_result_code"
-        ),
         GOOGLE_PAY_UNEXPECTED_CONFIRM_RESULT(
             partialEventName = "google_pay.confirm.unexpected_result"
         ),


### PR DESCRIPTION
# Summary
Fold `Google Pay` confirm errors into a single error type.

# Motivation
#ir-concur-march

Rather than separate these errors locally, we are going to separate them out in Splunk based on the status code and message.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified