### PR TITLE
Add logic to show form as initial screen in vertical mode.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -30,7 +30,7 @@ import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.paymentsheet.ui.HeaderTextFactory
 import com.stripe.android.paymentsheet.ui.ModifiableEditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.ui.PrimaryButton
-import com.stripe.android.paymentsheet.verticalmode.DefaultPaymentMethodVerticalLayoutInteractor
+import com.stripe.android.paymentsheet.verticalmode.VerticalModeInitialScreenFactory
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.PrimaryButtonUiStateMapper
 import com.stripe.android.uicore.utils.combineAsStateFlow
@@ -326,7 +326,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
 
     override fun determineInitialBackStack(): List<PaymentSheetScreen> {
         if (config.paymentMethodLayout == PaymentSheet.PaymentMethodLayout.Vertical) {
-            return listOf(PaymentSheetScreen.VerticalMode(DefaultPaymentMethodVerticalLayoutInteractor(this)))
+            return listOf(VerticalModeInitialScreenFactory.create(this))
         }
         val target = if (args.state.showSavedPaymentMethods) {
             SelectSavedPaymentMethods

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -62,7 +62,7 @@ import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.paymentsheet.ui.HeaderTextFactory
 import com.stripe.android.paymentsheet.ui.ModifiableEditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.utils.canSave
-import com.stripe.android.paymentsheet.verticalmode.DefaultPaymentMethodVerticalLayoutInteractor
+import com.stripe.android.paymentsheet.verticalmode.VerticalModeInitialScreenFactory
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.PrimaryButtonUiStateMapper
 import com.stripe.android.uicore.utils.combineAsStateFlow
@@ -814,7 +814,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     override fun determineInitialBackStack(): List<PaymentSheetScreen> {
         if (config.paymentMethodLayout == PaymentSheet.PaymentMethodLayout.Vertical) {
-            return listOf(PaymentSheetScreen.VerticalMode(DefaultPaymentMethodVerticalLayoutInteractor(this)))
+            return listOf(VerticalModeInitialScreenFactory.create(this))
         }
         val hasPaymentMethods = !paymentMethods.value.isNullOrEmpty()
         val target = if (hasPaymentMethods) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -163,14 +163,17 @@ internal sealed interface PaymentSheetScreen {
         }
     }
 
-    class Form(private val interactor: VerticalModeFormInteractor) : PaymentSheetScreen {
+    class Form(
+        private val interactor: VerticalModeFormInteractor,
+        private val showsWalletHeader: Boolean = false,
+    ) : PaymentSheetScreen {
 
         override val showsBuyButton: Boolean = true
         override val showsContinueButton: Boolean = true
         override val canNavigateBack: Boolean = true
 
         override fun showsWalletsHeader(isCompleteFlow: Boolean): Boolean {
-            return false
+            return showsWalletHeader
         }
 
         @Composable

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.paymentsheet.verticalmode
+
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+
+internal object VerticalModeInitialScreenFactory {
+    fun create(viewModel: BaseSheetViewModel): PaymentSheetScreen {
+        val savedPaymentMethods = viewModel.paymentMethods.value ?: emptyList()
+        if (viewModel.supportedPaymentMethods.size == 1 && savedPaymentMethods.isEmpty()) {
+            return PaymentSheetScreen.Form(
+                interactor = DefaultVerticalModeFormInteractor(
+                    selectedPaymentMethodCode = viewModel.supportedPaymentMethods.first().code,
+                    viewModel = viewModel,
+                ),
+                showsWalletHeader = true,
+            )
+        }
+        return PaymentSheetScreen.VerticalMode(DefaultPaymentMethodVerticalLayoutInteractor(viewModel))
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -343,6 +343,72 @@ internal class PaymentOptionsViewModelTest {
         }
 
     @Test
+    fun `currentScreen is Form if payment methods is empty and supportedPaymentMethods contains one`() =
+        runTest {
+            val viewModel = createViewModel(
+                args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(
+                    config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY.copy(
+                        paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+                    ),
+                    paymentMethods = listOf(),
+                    isGooglePayReady = false,
+                    linkState = null,
+                    stripeIntent = PaymentIntentFixtures.PI_WITH_PAYMENT_METHOD!!.copy(
+                        paymentMethodTypes = listOf("card")
+                    ),
+                )
+            )
+
+            viewModel.currentScreen.test {
+                assertThat(awaitItem()).isInstanceOf(PaymentSheetScreen.Form::class.java)
+            }
+        }
+
+    @Test
+    fun `currentScreen is VerticalMode if payment methods is not empty`() =
+        runTest {
+            val viewModel = createViewModel(
+                args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(
+                    config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY.copy(
+                        paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+                    ),
+                    paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+                    isGooglePayReady = false,
+                    linkState = null,
+                    stripeIntent = PaymentIntentFixtures.PI_WITH_PAYMENT_METHOD!!.copy(
+                        paymentMethodTypes = listOf("card")
+                    ),
+                )
+            )
+
+            viewModel.currentScreen.test {
+                assertThat(awaitItem()).isInstanceOf(PaymentSheetScreen.VerticalMode::class.java)
+            }
+        }
+
+    @Test
+    fun `currentScreen is VerticalMode if supportedPaymentMethods is greater than 1`() =
+        runTest {
+            val viewModel = createViewModel(
+                args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(
+                    config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY.copy(
+                        paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+                    ),
+                    paymentMethods = listOf(),
+                    isGooglePayReady = false,
+                    linkState = null,
+                    stripeIntent = PaymentIntentFixtures.PI_WITH_PAYMENT_METHOD!!.copy(
+                        paymentMethodTypes = listOf("card", "cashapp")
+                    ),
+                )
+            )
+
+            viewModel.currentScreen.test {
+                assertThat(awaitItem()).isInstanceOf(PaymentSheetScreen.VerticalMode::class.java)
+            }
+        }
+
+    @Test
     fun `onError updates error`() = runTest {
         val viewModel = createViewModel()
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This changes initial navigation to optimize for the case where the user has no saved payment methods, and only a single LPM available.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2144

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
