### PR TITLE
Fix updating `CustomerSheet` state when removing payment methods from edit screen

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -471,7 +471,7 @@ internal class CustomerSheetViewModel(
             val result = removePaymentMethod(paymentMethod)
 
             result.fold(
-                onSuccess = ::handlePaymentMethodRemoved,
+                onSuccess = ::removePaymentMethodFromState,
                 onFailure = { _, displayMessage -> handleFailureToRemovePaymentMethod(displayMessage) }
             )
         }
@@ -518,42 +518,10 @@ internal class CustomerSheetViewModel(
         }
     }
 
-    private fun handlePaymentMethodRemoved(paymentMethod: PaymentMethod) {
-        val currentViewState = viewState.value
-        val newSavedPaymentMethods = currentViewState.savedPaymentMethods.filter { it.id != paymentMethod.id!! }
-
-        if (currentViewState is CustomerSheetViewState.SelectPaymentMethod) {
-            updateViewState<CustomerSheetViewState.SelectPaymentMethod> { viewState ->
-                val originalSelection = originalPaymentSelection
-
-                val didRemoveCurrentSelection = viewState.paymentSelection is PaymentSelection.Saved &&
-                    viewState.paymentSelection.paymentMethod.id == paymentMethod.id
-
-                val didRemoveOriginalSelection = viewState.paymentSelection is PaymentSelection.Saved &&
-                    originalSelection is PaymentSelection.Saved &&
-                    viewState.paymentSelection.paymentMethod.id == originalSelection.paymentMethod.id
-
-                if (didRemoveOriginalSelection) {
-                    originalPaymentSelection = null
-                }
-
-                val updatedStateCanUpdate = canEdit(
-                    viewState.allowsRemovalOfLastSavedPaymentMethod,
-                    newSavedPaymentMethods,
-                    viewState.cbcEligibility
-                )
-                viewState.copy(
-                    savedPaymentMethods = newSavedPaymentMethods,
-                    paymentSelection = viewState.paymentSelection.takeUnless {
-                        didRemoveCurrentSelection
-                    } ?: originalPaymentSelection,
-                    isEditing = viewState.isEditing && updatedStateCanUpdate
-                )
-            }
-        }
-
-        if (newSavedPaymentMethods.isEmpty() && !isGooglePayReadyAndEnabled) {
-            transitionToAddPaymentMethod(isFirstPaymentMethod = true)
+    private fun handlePaymentMethodRemovedFromEditScreen(paymentMethod: PaymentMethod) {
+        viewModelScope.launch(workContext) {
+            delay(PaymentMethodRemovalDelayMillis)
+            removePaymentMethodFromState(paymentMethod)
         }
     }
 
@@ -603,7 +571,7 @@ internal class CustomerSheetViewModel(
                     removeExecutor = { pm ->
                         removePaymentMethod(pm).onSuccess {
                             onBackPressed()
-                            removePaymentMethodFromState(pm)
+                            handlePaymentMethodRemovedFromEditScreen(pm)
                         }.failureOrNull()?.cause
                     },
                     updateExecutor = { method, brand ->
@@ -623,18 +591,42 @@ internal class CustomerSheetViewModel(
     }
 
     private fun removePaymentMethodFromState(paymentMethod: PaymentMethod) {
-        viewModelScope.launch(workContext) {
-            delay(PaymentMethodRemovalDelayMillis)
+        val currentViewState = viewState.value
+        val newSavedPaymentMethods = currentViewState.savedPaymentMethods.filter { it.id != paymentMethod.id!! }
 
-            val newSavedPaymentMethods = viewState.value.savedPaymentMethods - paymentMethod
+        if (currentViewState is CustomerSheetViewState.SelectPaymentMethod) {
+            updateViewState<CustomerSheetViewState.SelectPaymentMethod> { viewState ->
+                val originalSelection = originalPaymentSelection
 
-            if (newSavedPaymentMethods.isEmpty() && !isGooglePayReadyAndEnabled) {
-                transitionToAddPaymentMethod(isFirstPaymentMethod = true)
-            } else {
-                updateViewState<CustomerSheetViewState.SelectPaymentMethod> {
-                    it.copy(savedPaymentMethods = newSavedPaymentMethods)
+                val didRemoveCurrentSelection = viewState.paymentSelection is PaymentSelection.Saved &&
+                    viewState.paymentSelection.paymentMethod.id == paymentMethod.id
+
+                val didRemoveOriginalSelection = viewState.paymentSelection is PaymentSelection.Saved &&
+                    originalSelection is PaymentSelection.Saved &&
+                    viewState.paymentSelection.paymentMethod.id == originalSelection.paymentMethod.id
+
+                if (didRemoveOriginalSelection) {
+                    originalPaymentSelection = null
                 }
+
+                val updatedStateCanUpdate = canEdit(
+                    viewState.allowsRemovalOfLastSavedPaymentMethod,
+                    newSavedPaymentMethods,
+                    viewState.cbcEligibility
+                )
+
+                viewState.copy(
+                    savedPaymentMethods = newSavedPaymentMethods,
+                    paymentSelection = viewState.paymentSelection.takeUnless {
+                        didRemoveCurrentSelection
+                    } ?: originalPaymentSelection,
+                    isEditing = viewState.isEditing && updatedStateCanUpdate
+                )
             }
+        }
+
+        if (newSavedPaymentMethods.isEmpty() && !isGooglePayReadyAndEnabled) {
+            transitionToAddPaymentMethod(isFirstPaymentMethod = true)
         }
     }
 


### PR DESCRIPTION
# Summary
Fix updating `CustomerSheet` view state when removing payment methods from edit screen. `canEdit` will now be properly evaluated. The original selection and current payment selection will be removed if they are the same as the removed payment method.

# Motivation
Ensures payment method removal from the edit screen is properly propagated to the select saved payment methods screen.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Video
https://github.com/stripe/stripe-android/assets/141707240/b13036b0-3a6b-40ad-a6d2-fe3d8c8339b8