### PR TITLE
Use `rememberUpdatedState` instead of recreating objects

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
@@ -40,10 +40,9 @@ internal class DefaultPaymentSheetLauncher(
         callback: PaymentSheetResultCallback
     ) : this(
         activityResultLauncher = activity.registerForActivityResult(
-            PaymentSheetContractV2()
-        ) {
-            callback.onPaymentSheetResult(it)
-        },
+            PaymentSheetContractV2(),
+            callback::onPaymentSheetResult,
+        ),
         activity = activity,
         lifecycleOwner = activity,
         application = activity.application,
@@ -55,10 +54,9 @@ internal class DefaultPaymentSheetLauncher(
         callback: PaymentSheetResultCallback
     ) : this(
         activityResultLauncher = fragment.registerForActivityResult(
-            PaymentSheetContractV2()
-        ) {
-            callback.onPaymentSheetResult(it)
-        },
+            PaymentSheetContractV2(),
+            callback::onPaymentSheetResult,
+        ),
         activity = fragment.requireActivity(),
         lifecycleOwner = fragment,
         application = fragment.requireActivity().application,
@@ -73,10 +71,9 @@ internal class DefaultPaymentSheetLauncher(
     ) : this(
         activityResultLauncher = fragment.registerForActivityResult(
             PaymentSheetContractV2(),
-            registry
-        ) {
-            callback.onPaymentSheetResult(it)
-        },
+            registry,
+            callback::onPaymentSheetResult,
+        ),
         activity = fragment.requireActivity(),
         lifecycleOwner = fragment,
         application = fragment.requireActivity().application,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FlowControllerCompose.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FlowControllerCompose.kt
@@ -3,7 +3,9 @@ package com.stripe.android.paymentsheet
 import androidx.activity.compose.LocalActivityResultRegistryOwner
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import com.stripe.android.paymentsheet.flowcontroller.FlowControllerFactory
@@ -108,14 +110,17 @@ private fun internalRememberPaymentSheetFlowController(
         "PaymentSheet.FlowController must be created in the context of an Activity"
     }
 
-    return remember(paymentOptionCallback, paymentResultCallback) {
+    val currentPaymentOptionCallback by rememberUpdatedState(paymentOptionCallback::onPaymentOption)
+    val currentPaymentResultCallback by rememberUpdatedState(paymentResultCallback::onPaymentSheetResult)
+
+    return remember {
         FlowControllerFactory(
             viewModelStoreOwner = viewModelStoreOwner,
             lifecycleOwner = lifecycleOwner,
             activityResultRegistryOwner = activityResultRegistryOwner,
             statusBarColor = { activity.window?.statusBarColor },
-            paymentOptionCallback = paymentOptionCallback,
-            paymentResultCallback = paymentResultCallback,
+            paymentOptionCallback = currentPaymentOptionCallback,
+            paymentResultCallback = currentPaymentResultCallback,
         ).create()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetCompose.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetCompose.kt
@@ -22,7 +22,7 @@ import com.stripe.android.utils.rememberActivity
 fun rememberPaymentSheet(
     paymentResultCallback: PaymentSheetResultCallback,
 ): PaymentSheet {
-    val onResult by rememberUpdatedState(newValue = paymentResultCallback::onPaymentSheetResult)
+    val onResult by rememberUpdatedState(paymentResultCallback::onPaymentSheetResult)
 
     val activityResultLauncher = rememberLauncherForActivityResult(
         contract = PaymentSheetContractV2(),
@@ -36,13 +36,13 @@ fun rememberPaymentSheet(
         "PaymentSheet must be created in the context of an Activity"
     }
 
-    return remember(paymentResultCallback) {
+    return remember {
         val launcher = DefaultPaymentSheetLauncher(
             activityResultLauncher = activityResultLauncher,
             activity = activity,
             application = context.applicationContext as Application,
             lifecycleOwner = lifecycleOwner,
-            callback = paymentResultCallback,
+            callback = onResult,
         )
         PaymentSheet(launcher)
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request is a follow-up to https://github.com/stripe/stripe-android/pull/8480. Instead of creating a new `PaymentSheet` or `FlowController` whenever the provided callbacks change (and they really shouldn’t), we now just make sure that the most recent callback is used. That happens via `rememberUpdatedState`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
