### PR TITLE
Add `CustomerSession` params to `CheckoutRequest` & additional parameters to `CustomerEphemeralKeyRequest`

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -32,6 +32,14 @@ class CheckoutRequest private constructor(
     val paymentMethodConfigurationId: String?,
     @SerialName("require_cvc_recollection")
     val requireCvcRecollection: Boolean?,
+    @SerialName("customer_session_payment_method_save")
+    val paymentMethodSaveFeature: FeatureState?,
+    @SerialName("customer_session_payment_method_remove")
+    val paymentMethodRemoveFeature: FeatureState?,
+    @SerialName("customer_session_payment_method_redisplay")
+    val paymentMethodRedisplayFeature: FeatureState?,
+    @SerialName("customer_session_payment_method_allow_redisplay_filters")
+    val paymentMethodRedisplayFilters: List<AllowRedisplayFilter>?,
 ) {
     @Serializable
     enum class CustomerKeyType {
@@ -118,6 +126,14 @@ class CheckoutRequest private constructor(
                 supportedPaymentMethods = supportedPaymentMethods,
                 paymentMethodConfigurationId = paymentMethodConfigurationId,
                 requireCvcRecollection = requireCvcRecollection,
+                paymentMethodSaveFeature = FeatureState.Enabled,
+                paymentMethodRemoveFeature = FeatureState.Enabled,
+                paymentMethodRedisplayFeature = FeatureState.Enabled,
+                paymentMethodRedisplayFilters = listOf(
+                    AllowRedisplayFilter.Unspecified,
+                    AllowRedisplayFilter.Limited,
+                    AllowRedisplayFilter.Always,
+                )
             )
         }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCustomerModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCustomerModel.kt
@@ -16,7 +16,10 @@ class CustomerEphemeralKeyRequest private constructor(
     @SerialName("customer_session_payment_method_remove")
     val paymentMethodRemoveFeature: FeatureState?,
     @SerialName("customer_session_payment_method_redisplay")
-    val paymentMethodRedisplayFeature: FeatureState?
+    val paymentMethodRedisplayFeature: FeatureState?,
+    @SerialName("customer_session_payment_method_allow_redisplay_filters")
+    val paymentMethodRedisplayFilters: List<AllowRedisplayFilter>?,
+
 ) {
     @Serializable
     enum class CustomerKeyType {
@@ -25,15 +28,6 @@ class CustomerEphemeralKeyRequest private constructor(
 
         @SerialName("legacy")
         Legacy;
-    }
-
-    @Serializable
-    enum class FeatureState {
-        @SerialName("enabled")
-        Enabled,
-
-        @SerialName("disabled")
-        Disabled;
     }
 
     class Builder {
@@ -56,6 +50,11 @@ class CustomerEphemeralKeyRequest private constructor(
                 paymentMethodSaveFeature = FeatureState.Enabled,
                 paymentMethodRemoveFeature = FeatureState.Enabled,
                 paymentMethodRedisplayFeature = FeatureState.Enabled,
+                paymentMethodRedisplayFilters = listOf(
+                    AllowRedisplayFilter.Unspecified,
+                    AllowRedisplayFilter.Limited,
+                    AllowRedisplayFilter.Always,
+                )
             )
         }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundSharedModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundSharedModel.kt
@@ -1,0 +1,25 @@
+package com.stripe.android.paymentsheet.example.playground.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class FeatureState {
+    @SerialName("enabled")
+    Enabled,
+
+    @SerialName("disabled")
+    Disabled;
+}
+
+@Serializable
+enum class AllowRedisplayFilter {
+    @SerialName("unspecified")
+    Unspecified,
+
+    @SerialName("limited")
+    Limited,
+
+    @SerialName("always")
+    Always;
+}


### PR DESCRIPTION
# Summary
Add `CustomerSession` params to `CheckoutRequest` & additional `customer_session_payment_method_allow_redisplay_filters` parameter to `CustomerEphemeralKeyRequest`

# Motivation
Forgot to add these defaults to `CheckoutRequest`. Also new parameter being introduced [here](https://git.corp.stripe.com/stripe-internal/sandbox-apps/pull/682).

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
