### PR TITLE
Increase timeout and retries for browserstack.

### DIFF
--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -9,7 +9,7 @@ jobs:
   browserstack-instrumentation-tests:
     name: Browserstack Instrumentation tests
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 240
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
@@ -20,11 +20,11 @@ jobs:
         run: pip install requests_toolbelt requests
 
       - name: 'Run BrowserStack tests'
-        timeout-minutes: 120
+        timeout-minutes: 180
         env:
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-        run: python scripts/browserstack.py --test --apk paymentsheet-example/build/outputs/apk/debug/paymentsheet-example-debug.apk --espresso paymentsheet-example/build/outputs/apk/androidTest/debug/paymentsheet-example-debug-androidTest.apk --is-nightly --num-retries 3
+        run: python scripts/browserstack.py --test --apk paymentsheet-example/build/outputs/apk/debug/paymentsheet-example-debug.apk --espresso paymentsheet-example/build/outputs/apk/androidTest/debug/paymentsheet-example-debug-androidTest.apk --is-nightly --num-retries 5
 
       - name: Notify failure endpoint
         id: notifyFailureEndpoint


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We've had some extra failures. One due to a timeout, another due to too many failed tests.
