### PR TITLE
Add the ability to select an LPM with no fields on the main screen.

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AffirmHeaderElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AffirmHeaderElement.kt
@@ -13,6 +13,8 @@ data class AffirmHeaderElement(
     override val identifier: IdentifierSpec,
     override val controller: Controller? = null
 ) : FormElement {
+    override val allowsUserInteraction: Boolean = false
+
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
         stateFlowOf(emptyList())
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement.kt
@@ -19,6 +19,8 @@ data class AfterpayClearpayHeaderElement(
     private val amount: Amount,
     override val controller: Controller? = null
 ) : FormElement {
+    override val allowsUserInteraction: Boolean = false
+
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
         stateFlowOf(emptyList())
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateTextElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateTextElement.kt
@@ -19,6 +19,8 @@ data class AuBecsDebitMandateTextElement(
     val merchantName: String?,
     override val controller: InputController? = null
 ) : FormElement {
+    override val allowsUserInteraction: Boolean = false
+
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
         stateFlowOf(emptyList())
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BlikElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BlikElement.kt
@@ -16,6 +16,7 @@ class BlikElement(
         textFieldConfig = BlikConfig()
     )
 ) : SectionSingleFieldElement(identifier = identifier) {
+    override val allowsUserInteraction: Boolean = true
 
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
         return controller.formFieldValue.mapAsStateFlow { entry ->

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbElement.kt
@@ -21,6 +21,7 @@ class BsbElement(
         get() = null
     override val identifier: IdentifierSpec
         get() = identifierSpec
+    override val allowsUserInteraction: Boolean = true
 
     internal val textElement: SimpleTextElement = SimpleTextElement(
         identifier = IdentifierSpec.Generic("au_becs_debit[bsb_number]"),

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
@@ -32,6 +32,8 @@ internal class CardDetailsElement(
 ) : SectionMultiFieldElement(identifier) {
     val isCardScanEnabled = controller.numberElement.controller.cardScanEnabled
 
+    override val allowsUserInteraction: Boolean = true
+
     override fun sectionFieldErrorController(): SectionFieldErrorController =
         controller
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElement.kt
@@ -22,6 +22,8 @@ class CardDetailsSectionElement(
         cbcEligibility = cbcEligibility,
     ),
 ) : FormElement {
+    override val allowsUserInteraction: Boolean = true
+
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
         controller.cardDetailsElement.getFormFieldValueFlow()
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberElement.kt
@@ -7,6 +7,8 @@ internal data class CardNumberElement(
     val _identifier: IdentifierSpec,
     override val controller: CardNumberController
 ) : SectionSingleFieldElement(_identifier) {
+    override val allowsUserInteraction: Boolean = true
+
     override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
         // Nothing from FormArguments to populate
     }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcElement.kt
@@ -9,6 +9,8 @@ data class CvcElement(
     val _identifier: IdentifierSpec,
     override val controller: CvcController
 ) : SectionSingleFieldElement(_identifier) {
+    override val allowsUserInteraction: Boolean = true
+
     override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
         // Nothing from FormArguments to populate
     }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/EmailElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/EmailElement.kt
@@ -15,4 +15,6 @@ data class EmailElement(
         EmailConfig(),
         initialValue = initialValue
     )
-) : SectionSingleFieldElement(identifier)
+) : SectionSingleFieldElement(identifier) {
+    override val allowsUserInteraction: Boolean = true
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/EmptyFormElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/EmptyFormElement.kt
@@ -13,6 +13,8 @@ data class EmptyFormElement(
     override val identifier: IdentifierSpec = IdentifierSpec.Generic("empty_form"),
     override val controller: Controller? = null
 ) : FormElement {
+    override val allowsUserInteraction: Boolean = false
+
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
         stateFlowOf(emptyList())
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IbanElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IbanElement.kt
@@ -7,4 +7,6 @@ import com.stripe.android.uicore.elements.TextFieldController
 internal data class IbanElement(
     override val identifier: IdentifierSpec,
     override val controller: TextFieldController
-) : SectionSingleFieldElement(identifier)
+) : SectionSingleFieldElement(identifier) {
+    override val allowsUserInteraction: Boolean = true
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextElement.kt
@@ -15,6 +15,7 @@ data class MandateTextElement(
     val args: List<String>,
     override val controller: InputController? = null
 ) : FormElement {
+    override val allowsUserInteraction: Boolean = false
 
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
         stateFlowOf(emptyList())

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseElement.kt
@@ -16,6 +16,8 @@ data class SaveForFutureUseElement(
     val initialValue: Boolean,
     val merchantName: String?
 ) : FormElement {
+    override val allowsUserInteraction: Boolean = true
+
     override val controller: SaveForFutureUseController = SaveForFutureUseController(
         initialValue
     )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SimpleDropdownElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SimpleDropdownElement.kt
@@ -9,4 +9,6 @@ import com.stripe.android.uicore.elements.SectionSingleFieldElement
 data class SimpleDropdownElement(
     override val identifier: IdentifierSpec,
     override val controller: DropdownFieldController
-) : SectionSingleFieldElement(identifier)
+) : SectionSingleFieldElement(identifier) {
+    override val allowsUserInteraction: Boolean = true
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/StaticTextElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/StaticTextElement.kt
@@ -19,6 +19,8 @@ data class StaticTextElement(
     val stringResId: Int,
     override val controller: InputController? = null
 ) : FormElement {
+    override val allowsUserInteraction: Boolean = false
+
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
         stateFlowOf(emptyList())
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/UpiElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/UpiElement.kt
@@ -12,5 +12,7 @@ class UpiElement(
         textFieldConfig = UpiConfig()
     )
 ) : SectionSingleFieldElement(identifier = IdentifierSpec.Vpa) {
+    override val allowsUserInteraction: Boolean = true
+
     override val identifier: IdentifierSpec = IdentifierSpec.Vpa
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -1,8 +1,14 @@
 package com.stripe.android.paymentsheet.verticalmode
 
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.analytics.code
+import com.stripe.android.paymentsheet.forms.FormFieldValues
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -14,48 +20,105 @@ internal interface PaymentMethodVerticalLayoutInteractor {
     data class State(
         val supportedPaymentMethods: List<SupportedPaymentMethod>,
         val isProcessing: Boolean,
+        val selectedPaymentMethodIndex: Int,
     )
 
     sealed interface ViewAction {
         data object TransitionToManageSavedPaymentMethods : ViewAction
-        data class TransitionToForm(val selectedPaymentMethodCode: String) : ViewAction
+        data class PaymentMethodSelected(val selectedPaymentMethodCode: String) : ViewAction
     }
 }
 
 internal class DefaultPaymentMethodVerticalLayoutInteractor(
-    private val viewModel: BaseSheetViewModel,
+    paymentMethodMetadata: PaymentMethodMetadata,
+    processing: StateFlow<Boolean>,
+    selection: StateFlow<PaymentSelection?>,
+    private val formElementsForCode: (code: String) -> List<FormElement>,
+    private val transitionTo: (screen: PaymentSheetScreen) -> Unit,
+    private val onFormFieldValuesChanged: (formValues: FormFieldValues, selectedPaymentMethodCode: String) -> Unit,
+    private val manageScreenFactory: () -> PaymentSheetScreen,
+    private val formScreenFactory: (selectedPaymentMethodCode: String) -> PaymentSheetScreen,
 ) : PaymentMethodVerticalLayoutInteractor {
+    constructor(viewModel: BaseSheetViewModel) : this(
+        paymentMethodMetadata = requireNotNull(viewModel.paymentMethodMetadata.value),
+        processing = viewModel.processing,
+        selection = viewModel.selection,
+        formElementsForCode = viewModel::formElementsForCode,
+        transitionTo = viewModel::transitionTo,
+        onFormFieldValuesChanged = viewModel::onFormFieldValuesChanged,
+        manageScreenFactory = {
+            PaymentSheetScreen.ManageSavedPaymentMethods(
+                interactor = DefaultManageScreenInteractor(
+                    viewModel
+                )
+            )
+        },
+        formScreenFactory = { selectedPaymentMethodCode ->
+            PaymentSheetScreen.Form(
+                DefaultVerticalModeFormInteractor(
+                    selectedPaymentMethodCode,
+                    viewModel
+                )
+            )
+        },
+    )
+
+    private val supportedPaymentMethods = paymentMethodMetadata.sortedSupportedPaymentMethods()
+
     override val state: StateFlow<PaymentMethodVerticalLayoutInteractor.State> = combineAsStateFlow(
-        viewModel.processing,
-        viewModel.paymentMethodMetadata,
-    ) { isProcessing, paymentMethodMetadata ->
+        processing,
+        selection,
+    ) { isProcessing, selection ->
         PaymentMethodVerticalLayoutInteractor.State(
-            supportedPaymentMethods = paymentMethodMetadata?.sortedSupportedPaymentMethods() ?: emptyList(),
+            supportedPaymentMethods = supportedPaymentMethods,
             isProcessing = isProcessing,
+            selectedPaymentMethodIndex = selectedPaymentMethodIndex(selection),
         )
+    }
+
+    private fun selectedPaymentMethodIndex(
+        selection: PaymentSelection?,
+    ): Int {
+        if (selection is PaymentSelection.Saved) {
+            return -1
+        }
+        val selectedPaymentMethodCode = selection.code()
+        return supportedPaymentMethods.indexOfFirst { it.code == selectedPaymentMethodCode }
     }
 
     override fun handleViewAction(viewAction: PaymentMethodVerticalLayoutInteractor.ViewAction) {
         when (viewAction) {
-            is PaymentMethodVerticalLayoutInteractor.ViewAction.TransitionToForm -> {
-                viewModel.transitionTo(
-                    PaymentSheetScreen.Form(
-                        DefaultVerticalModeFormInteractor(
-                            viewAction.selectedPaymentMethodCode,
-                            viewModel
-                        )
-                    )
-                )
+            is PaymentMethodVerticalLayoutInteractor.ViewAction.PaymentMethodSelected -> {
+                if (requiresFormScreen(viewAction.selectedPaymentMethodCode)) {
+                    transitionTo(formScreenFactory(viewAction.selectedPaymentMethodCode))
+                } else {
+                    updateSelectedPaymentMethod(viewAction.selectedPaymentMethodCode)
+                }
             }
             PaymentMethodVerticalLayoutInteractor.ViewAction.TransitionToManageSavedPaymentMethods -> {
-                viewModel.transitionTo(
-                    PaymentSheetScreen.ManageSavedPaymentMethods(
-                        interactor = DefaultManageScreenInteractor(
-                            viewModel
-                        )
-                    )
-                )
+                transitionTo(manageScreenFactory())
             }
         }
+    }
+
+    private fun requiresFormScreen(selectedPaymentMethodCode: String): Boolean {
+        val formElements = formElementsForCode(selectedPaymentMethodCode)
+        val userInteractionFormElements = formElements.filter {
+            it.allowsUserInteraction
+        }
+        return userInteractionFormElements.isNotEmpty() ||
+            selectedPaymentMethodCode == PaymentMethod.Type.USBankAccount.code ||
+            selectedPaymentMethodCode == PaymentMethod.Type.Link.code
+    }
+
+    private fun updateSelectedPaymentMethod(selectedPaymentMethodCode: String) {
+        onFormFieldValuesChanged(
+            FormFieldValues(
+                // userRequestedReuse only changes based on `SaveForFutureUse`, which won't ever hit this
+                // code path.
+                userRequestedReuse = PaymentSelection.CustomerRequestedSave.NoRequest
+            ),
+            selectedPaymentMethodCode,
+        )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
@@ -29,7 +29,7 @@ internal fun PaymentMethodVerticalLayoutUI(interactor: PaymentMethodVerticalLayo
 
     PaymentMethodVerticalLayoutUI(
         paymentMethods = state.supportedPaymentMethods,
-        selectedIndex = -1,
+        selectedIndex = state.selectedPaymentMethodIndex,
         isEnabled = !state.isProcessing,
         onViewMorePaymentMethods = {
             interactor.handleViewAction(
@@ -37,7 +37,7 @@ internal fun PaymentMethodVerticalLayoutUI(interactor: PaymentMethodVerticalLayo
             )
         },
         onItemSelectedListener = {
-            interactor.handleViewAction(PaymentMethodVerticalLayoutInteractor.ViewAction.TransitionToForm(it.code))
+            interactor.handleViewAction(PaymentMethodVerticalLayoutInteractor.ViewAction.PaymentMethodSelected(it.code))
         },
         imageLoader = imageLoader,
         modifier = Modifier.padding(horizontal = 20.dp)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -1,0 +1,228 @@
+package com.stripe.android.paymentsheet.verticalmode
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.forms.FormFieldValues
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
+import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor.ViewAction
+import com.stripe.android.ui.core.elements.SaveForFutureUseElement
+import com.stripe.android.uicore.elements.FormElement
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+class DefaultPaymentMethodVerticalLayoutInteractorTest {
+    @Test
+    fun state_updatesWhenProcessingUpdates() = runScenario {
+        interactor.state.test {
+            awaitItem().run {
+                assertThat(isProcessing).isFalse()
+            }
+            processingSource.value = true
+            awaitItem().run {
+                assertThat(isProcessing).isTrue()
+            }
+        }
+    }
+
+    @Test
+    fun state_updatesWhenSelectionUpdates() = runScenario(
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "cashapp")
+            )
+        )
+    ) {
+        interactor.state.test {
+            awaitItem().run {
+                assertThat(supportedPaymentMethods).isNotEmpty()
+                assertThat(selectedPaymentMethodIndex).isEqualTo(-1)
+            }
+            selectionSource.value = PaymentSelection.New.GenericPaymentMethod(
+                labelResource = "CashApp",
+                iconResource = 0,
+                lightThemeIconUrl = null,
+                darkThemeIconUrl = null,
+                paymentMethodCreateParams = PaymentMethodCreateParams.createCashAppPay(),
+                customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
+            )
+            awaitItem().run {
+                assertThat(supportedPaymentMethods).isNotEmpty()
+                assertThat(selectedPaymentMethodIndex).isEqualTo(1)
+            }
+        }
+    }
+
+    @Test
+    fun state_returnsCorrectSelectedPaymentMethodIndexWhenSelectionIsSaved() = runScenario {
+        interactor.state.test {
+            awaitItem().run {
+                assertThat(supportedPaymentMethods).isNotEmpty()
+                assertThat(selectedPaymentMethodIndex).isEqualTo(-1)
+            }
+            selectionSource.value = PaymentSelection.Saved(
+                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            )
+            // No value produced, since the state is the same.
+        }
+    }
+
+    @Test
+    fun handleViewAction_PaymentMethodSelected_transitionsToFormScreen_whenFieldsAllowUserInteraction() {
+        var calledFormScreenFactory = false
+        var calledTransitionTo = false
+        runScenario(
+            formElementsForCode = {
+                listOf(SaveForFutureUseElement(true, "Jay's Ski Shop"))
+            },
+            formScreenFactory = {
+                calledFormScreenFactory = true
+                mock()
+            },
+            transitionTo = {
+                calledTransitionTo = true
+            }
+        ) {
+            interactor.handleViewAction(ViewAction.PaymentMethodSelected("card"))
+            assertThat(calledFormScreenFactory).isTrue()
+            assertThat(calledTransitionTo).isTrue()
+        }
+    }
+
+    @Test
+    fun handleViewAction_PaymentMethodSelected_transitionsToFormScreen_whenSelectedIsUsBank() {
+        var calledFormScreenFactory = false
+        var calledTransitionTo = false
+        runScenario(
+            formElementsForCode = {
+                listOf()
+            },
+            formScreenFactory = {
+                calledFormScreenFactory = true
+                mock()
+            },
+            transitionTo = {
+                calledTransitionTo = true
+            }
+        ) {
+            interactor.handleViewAction(ViewAction.PaymentMethodSelected("us_bank_account"))
+            assertThat(calledFormScreenFactory).isTrue()
+            assertThat(calledTransitionTo).isTrue()
+        }
+    }
+
+    @Test
+    fun handleViewAction_PaymentMethodSelected_transitionsToFormScreen_whenSelectedIsInstantDebits() {
+        var calledFormScreenFactory = false
+        var calledTransitionTo = false
+        runScenario(
+            formElementsForCode = {
+                listOf()
+            },
+            formScreenFactory = {
+                calledFormScreenFactory = true
+                mock()
+            },
+            transitionTo = {
+                calledTransitionTo = true
+            }
+        ) {
+            interactor.handleViewAction(ViewAction.PaymentMethodSelected("link"))
+            assertThat(calledFormScreenFactory).isTrue()
+            assertThat(calledTransitionTo).isTrue()
+        }
+    }
+
+    @Test
+    fun handleViewAction_PaymentMethodSelected_updatesSelectedLPM() {
+        var onFormFieldValuesChangedCalled = false
+        runScenario(
+            formElementsForCode = {
+                listOf()
+            },
+            onFormFieldValuesChanged = { fieldValues, selectedPaymentMethodCode ->
+                fieldValues.run {
+                    assertThat(fieldValuePairs).isEmpty()
+                    assertThat(userRequestedReuse).isEqualTo(PaymentSelection.CustomerRequestedSave.NoRequest)
+                }
+                assertThat(selectedPaymentMethodCode).isEqualTo("cashapp")
+                onFormFieldValuesChangedCalled = true
+            }
+        ) {
+            interactor.handleViewAction(ViewAction.PaymentMethodSelected("cashapp"))
+            assertThat(onFormFieldValuesChangedCalled).isTrue()
+        }
+    }
+
+    @Test
+    fun handleViewAction_TransitionToManageSavedPaymentMethods_transitionsToManageScreen() {
+        var calledManageScreenFactory = false
+        var calledTransitionTo = false
+        runScenario(
+            manageScreenFactory = {
+                calledManageScreenFactory = true
+                mock()
+            },
+            transitionTo = {
+                calledTransitionTo = true
+            }
+        ) {
+            interactor.handleViewAction(ViewAction.TransitionToManageSavedPaymentMethods)
+            assertThat(calledManageScreenFactory).isTrue()
+            assertThat(calledTransitionTo).isTrue()
+        }
+    }
+
+    private val notImplemented: () -> Nothing = { throw AssertionError("Not implemented") }
+
+    private fun runScenario(
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        initialProcessing: Boolean = false,
+        initialSelection: PaymentSelection? = null,
+        formElementsForCode: (code: String) -> List<FormElement> = { notImplemented() },
+        transitionTo: (screen: PaymentSheetScreen) -> Unit = { notImplemented() },
+        onFormFieldValuesChanged: (formValues: FormFieldValues, selectedPaymentMethodCode: String) -> Unit = { _, _ ->
+            notImplemented()
+        },
+        manageScreenFactory: () -> PaymentSheetScreen = { notImplemented() },
+        formScreenFactory: (selectedPaymentMethodCode: String) -> PaymentSheetScreen = { notImplemented() },
+        testBlock: suspend TestParams.() -> Unit
+    ) {
+        val processing: MutableStateFlow<Boolean> = MutableStateFlow(initialProcessing)
+        val selection: MutableStateFlow<PaymentSelection?> = MutableStateFlow(initialSelection)
+
+        val interactor = DefaultPaymentMethodVerticalLayoutInteractor(
+            paymentMethodMetadata = paymentMethodMetadata,
+            processing = processing,
+            selection = selection,
+            formElementsForCode = formElementsForCode,
+            transitionTo = transitionTo,
+            onFormFieldValuesChanged = onFormFieldValuesChanged,
+            manageScreenFactory = manageScreenFactory,
+            formScreenFactory = formScreenFactory,
+        )
+
+        TestParams(
+            processingSource = processing,
+            selectionSource = selection,
+            interactor = interactor,
+        ).apply {
+            runTest {
+                testBlock()
+            }
+        }
+    }
+
+    private class TestParams(
+        val processingSource: MutableStateFlow<Boolean>,
+        val selectionSource: MutableStateFlow<PaymentSelection?>,
+        val interactor: PaymentMethodVerticalLayoutInteractor,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
@@ -1,6 +1,9 @@
 package com.stripe.android.paymentsheet.verticalmode
 
 import android.os.Build
+import androidx.compose.ui.test.assertAll
+import androidx.compose.ui.test.assertAny
+import androidx.compose.ui.test.isSelected
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
@@ -29,6 +32,7 @@ internal class PaymentMethodVerticalLayoutUITest {
         PaymentMethodVerticalLayoutInteractor.State(
             supportedPaymentMethods = emptyList(),
             isProcessing = false,
+            selectedPaymentMethodIndex = -1,
         )
     ) {
         assertThat(viewActionRecorder.viewActions).isEmpty()
@@ -46,11 +50,12 @@ internal class PaymentMethodVerticalLayoutUITest {
                 CardDefinition.uiDefinitionFactory().supportedPaymentMethod(CardDefinition, emptyList())!!,
             ),
             isProcessing = false,
+            selectedPaymentMethodIndex = -1,
         )
     ) {
         assertThat(viewActionRecorder.viewActions).isEmpty()
         composeRule.onNodeWithTag(TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON + "_card").performClick()
-        viewActionRecorder.consume(PaymentMethodVerticalLayoutInteractor.ViewAction.TransitionToForm("card"))
+        viewActionRecorder.consume(PaymentMethodVerticalLayoutInteractor.ViewAction.PaymentMethodSelected("card"))
         assertThat(viewActionRecorder.viewActions).isEmpty()
     }
 
@@ -63,6 +68,7 @@ internal class PaymentMethodVerticalLayoutUITest {
                 )
             ).sortedSupportedPaymentMethods(),
             isProcessing = false,
+            selectedPaymentMethodIndex = -1,
         )
     ) {
         assertThat(
@@ -73,6 +79,34 @@ internal class PaymentMethodVerticalLayoutUITest {
         composeRule.onNodeWithTag(TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON + "_card").assertExists()
         composeRule.onNodeWithTag(TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON + "_cashapp").assertExists()
         composeRule.onNodeWithTag(TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON + "_klarna").assertExists()
+    }
+
+    @Test
+    fun correctIndexIsSelected() = runScenario(
+        PaymentMethodVerticalLayoutInteractor.State(
+            supportedPaymentMethods = PaymentMethodMetadataFactory.create(
+                PaymentIntentFixtures.PI_WITH_PAYMENT_METHOD!!.copy(
+                    paymentMethodTypes = listOf("card", "cashapp", "klarna")
+                )
+            ).sortedSupportedPaymentMethods(),
+            isProcessing = false,
+            selectedPaymentMethodIndex = 1,
+        )
+    ) {
+        assertThat(
+            composeRule.onNodeWithTag(TEST_TAG_NEW_PAYMENT_METHOD_VERTICAL_LAYOUT_UI)
+                .onChildren().fetchSemanticsNodes().size
+        ).isEqualTo(3)
+
+        composeRule.onNodeWithTag(TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON + "_card")
+            .assertExists()
+            .onChildren().assertAll(isSelected().not())
+        composeRule.onNodeWithTag(TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON + "_cashapp")
+            .assertExists()
+            .onChildren().assertAny(isSelected())
+        composeRule.onNodeWithTag(TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON + "_klarna")
+            .assertExists()
+            .onChildren().assertAll(isSelected().not())
     }
 
     private fun runScenario(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
@@ -28,6 +28,8 @@ open class AddressElement constructor(
     private val hideCountry: Boolean = false,
 ) : SectionMultiFieldElement(_identifier) {
 
+    override val allowsUserInteraction: Boolean = true
+
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     val countryElement = CountryElement(
         IdentifierSpec.Country,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldElement.kt
@@ -8,6 +8,7 @@ class AddressTextFieldElement(
     config: TextFieldConfig,
     onNavigation: (() -> Unit)? = null
 ) : SectionSingleFieldElement(identifier) {
+    override val allowsUserInteraction: Boolean = true
 
     override val controller: AddressTextFieldController =
         AddressTextFieldController(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AdministrativeAreaElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AdministrativeAreaElement.kt
@@ -6,4 +6,6 @@ import androidx.annotation.RestrictTo
 data class AdministrativeAreaElement(
     override val identifier: IdentifierSpec,
     override val controller: DropdownFieldController
-) : SectionSingleFieldElement(identifier)
+) : SectionSingleFieldElement(identifier) {
+    override val allowsUserInteraction: Boolean = true
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CheckboxFieldElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CheckboxFieldElement.kt
@@ -9,6 +9,8 @@ class CheckboxFieldElement(
     override val identifier: IdentifierSpec,
     override val controller: CheckboxFieldController = CheckboxFieldController()
 ) : FormElement {
+    override val allowsUserInteraction: Boolean = true
+
     override fun getFormFieldValueFlow() = controller.isChecked.mapAsStateFlow { isChecked ->
         listOf(
             identifier to FormFieldEntry(isChecked.toString(), isChecked)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CountryElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CountryElement.kt
@@ -6,4 +6,6 @@ import androidx.annotation.RestrictTo
 data class CountryElement(
     override val identifier: IdentifierSpec,
     override val controller: DropdownFieldController
-) : SectionSingleFieldElement(identifier)
+) : SectionSingleFieldElement(identifier) {
+    override val allowsUserInteraction: Boolean = true
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/FormElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/FormElement.kt
@@ -14,6 +14,13 @@ interface FormElement {
     val identifier: IdentifierSpec
     val controller: Controller?
 
+    /**
+     * Whether the form element allows user interaction.
+     *
+     * This is used to determine if vertical mode needs to show the form screen.
+     */
+    val allowsUserInteraction: Boolean
+
     fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>>
     fun getTextFieldIdentifiers(): StateFlow<List<IdentifierSpec>> =
         stateFlowOf(emptyList())

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElement.kt
@@ -12,6 +12,8 @@ data class OTPElement(
     override val identifier: IdentifierSpec,
     override val controller: OTPController
 ) : FormElement {
+    override val allowsUserInteraction: Boolean = true
+
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
         return controller.fieldValue.mapAsStateFlow {
             listOf(identifier to FormFieldEntry(it, it.length == controller.otpLength))

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberElement.kt
@@ -6,4 +6,6 @@ import androidx.annotation.RestrictTo
 data class PhoneNumberElement(
     override val identifier: IdentifierSpec,
     override val controller: PhoneNumberController
-) : SectionSingleFieldElement(identifier)
+) : SectionSingleFieldElement(identifier) {
+    override val allowsUserInteraction: Boolean = true
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowElement.kt
@@ -11,6 +11,8 @@ class RowElement constructor(
     val fields: List<SectionSingleFieldElement>,
     val controller: RowController
 ) : SectionMultiFieldElement(_identifier) {
+    override val allowsUserInteraction: Boolean = fields.any { it.allowsUserInteraction }
+
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
         combineAsStateFlow(fields.map { it.getFormFieldValueFlow() }) {
             it.toList().flatten()

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingElement.kt
@@ -10,6 +10,8 @@ data class SameAsShippingElement(
     override val shouldRenderOutsideCard: Boolean
         get() = true
 
+    override val allowsUserInteraction: Boolean = true
+
     override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
         rawValuesMap[identifier]?.let {
             controller.onRawValueChange(it)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElement.kt
@@ -17,6 +17,8 @@ data class SectionElement(
         controller: SectionController
     ) : this(identifier, listOf(field), controller)
 
+    override val allowsUserInteraction: Boolean = fields.any { it.allowsUserInteraction }
+
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
         combineAsStateFlow(fields.map { it.getFormFieldValueFlow() }) {
             it.toList().flatten()

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionFieldElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionFieldElement.kt
@@ -10,6 +10,13 @@ interface SectionFieldElement {
     val shouldRenderOutsideCard: Boolean
         get() = false
 
+    /**
+     * Whether the field element allows user interaction.
+     *
+     * This is used to determine if vertical mode needs to show the form screen.
+     */
+    val allowsUserInteraction: Boolean
+
     fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>>
     fun sectionFieldErrorController(): SectionFieldErrorController
     fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SimpleTextElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SimpleTextElement.kt
@@ -6,4 +6,6 @@ import androidx.annotation.RestrictTo
 data class SimpleTextElement(
     override val identifier: IdentifierSpec,
     override val controller: TextFieldController
-) : SectionSingleFieldElement(identifier)
+) : SectionSingleFieldElement(identifier) {
+    override val allowsUserInteraction: Boolean = true
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Updated the main vertical mode screen to support a selected payment method index, and update the view model to select the payment method to allow for payment.

https://github.com/stripe/stripe-android/assets/116920913/47080690-8fb7-4dfa-886a-ca55fd6c7b96


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2145

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
