### PR TITLE
Decouple `AuthorizeAction` from `CheckoutMode`

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -34,8 +34,6 @@ import com.stripe.android.paymentsheet.example.playground.PaymentSheetPlayground
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 import com.stripe.android.paymentsheet.example.playground.SUCCESS_RESULT
 import com.stripe.android.paymentsheet.example.playground.activity.FawryActivity
-import com.stripe.android.paymentsheet.example.playground.settings.CheckoutMode
-import com.stripe.android.paymentsheet.example.playground.settings.CheckoutModeSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundConfigurationData
@@ -923,8 +921,6 @@ internal class PlaygroundTestDriver(
 
     private fun doAuthorization() {
         selectors.apply {
-            val checkoutMode =
-                testParameters.playgroundSettingsSnapshot[CheckoutModeSettingsDefinition]
             if (testParameters.authorizationAction != null) {
                 if (testParameters.authorizationAction?.requiresBrowser == true) {
                     // If a specific browser is requested we will use it, otherwise, we will
@@ -939,9 +935,7 @@ internal class PlaygroundTestDriver(
 
                     assertThat(browserWindow(selectedBrowser)?.exists()).isTrue()
 
-                    blockUntilAuthorizationPageLoaded(
-                        isSetup = checkoutMode == CheckoutMode.SETUP
-                    )
+                    blockUntilAuthorizationPageLoaded(isSetup = testParameters.isSetupMode)
                 }
 
                 if (authorizeAction != null) {
@@ -951,7 +945,7 @@ internal class PlaygroundTestDriver(
                         // Buttons aren't showing the same way each time in the web page.
                         object : UiAutomatorText(
                             label = requireNotNull(testParameters.authorizationAction)
-                                .text(checkoutMode),
+                                .text(testParameters.isSetupMode),
                             className = "android.widget.TextView",
                             device = device
                         ) {}.click()
@@ -961,7 +955,7 @@ internal class PlaygroundTestDriver(
 
                 when (val authAction = testParameters.authorizationAction) {
                     is AuthorizeAction.DisplayQrCode -> {
-                        if (checkoutMode != CheckoutMode.SETUP) {
+                        if (!testParameters.isSetupMode) {
                             closeButton.wait(5000)
                             onView(withText("CLOSE")).perform(click())
                         }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
@@ -2,6 +2,7 @@ package com.stripe.android.test.core
 
 import com.stripe.android.paymentsheet.example.playground.settings.AutomaticPaymentMethodsSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CheckoutMode
+import com.stripe.android.paymentsheet.example.playground.settings.CheckoutModeSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.Currency
@@ -25,6 +26,10 @@ internal data class TestParameters(
     val executeInNightlyRun: Boolean = false,
     val playgroundSettingsSnapshot: PlaygroundSettings.Snapshot = playgroundSettings().snapshot(),
 ) {
+    val isSetupMode: Boolean =
+        playgroundSettingsSnapshot.configurationData.integrationType.isCustomerFlow() ||
+            playgroundSettingsSnapshot[CheckoutModeSettingsDefinition] == CheckoutMode.SETUP
+
     fun copyPlaygroundSettings(block: (PlaygroundSettings) -> Unit): TestParameters {
         val playgroundSettings = playgroundSettingsSnapshot.playgroundSettings()
         block(playgroundSettings)
@@ -78,13 +83,13 @@ enum class Browser {
  */
 internal sealed interface AuthorizeAction {
 
-    fun text(checkoutMode: CheckoutMode): String
+    fun text(isSetup: Boolean): String
 
     val requiresBrowser: Boolean
     val isConsideredDone: Boolean
 
     data object PollingSucceedsAfterDelay : AuthorizeAction {
-        override fun text(checkoutMode: CheckoutMode): String = "POLLING SUCCEEDS AFTER DELAY"
+        override fun text(isSetup: Boolean): String = "POLLING SUCCEEDS AFTER DELAY"
 
         override val requiresBrowser: Boolean = false
         override val isConsideredDone: Boolean = true
@@ -93,7 +98,7 @@ internal sealed interface AuthorizeAction {
     data object Authorize3ds2 : AuthorizeAction {
         override val requiresBrowser: Boolean = false
 
-        override fun text(checkoutMode: CheckoutMode): String {
+        override fun text(isSetup: Boolean): String {
             return "COMPLETE"
         }
         override val isConsideredDone: Boolean = true
@@ -102,8 +107,8 @@ internal sealed interface AuthorizeAction {
     data class AuthorizePayment(
         override val requiresBrowser: Boolean = true,
     ) : AuthorizeAction {
-        override fun text(checkoutMode: CheckoutMode): String {
-            return if (checkoutMode == CheckoutMode.SETUP) {
+        override fun text(isSetup: Boolean): String {
+            return if (isSetup) {
                 "AUTHORIZE TEST SETUP"
             } else {
                 "AUTHORIZE TEST PAYMENT"
@@ -113,34 +118,34 @@ internal sealed interface AuthorizeAction {
     }
 
     data object DisplayQrCode : AuthorizeAction {
-        override fun text(checkoutMode: CheckoutMode): String = "Display QR code"
+        override fun text(isSetup: Boolean): String = "Display QR code"
 
         override val requiresBrowser: Boolean = false
         override val isConsideredDone: Boolean = true
     }
 
     data class Fail(val expectedError: String) : AuthorizeAction {
-        override fun text(checkoutMode: CheckoutMode): String = "FAIL TEST PAYMENT"
+        override fun text(isSetup: Boolean): String = "FAIL TEST PAYMENT"
 
         override val requiresBrowser: Boolean = true
         override val isConsideredDone: Boolean = false
     }
 
     data object Cancel : AuthorizeAction {
-        override fun text(checkoutMode: CheckoutMode): String = ""
+        override fun text(isSetup: Boolean): String = ""
         override val requiresBrowser: Boolean = true
         override val isConsideredDone: Boolean = false
     }
 
     sealed interface Bacs : AuthorizeAction {
         data object Confirm : Bacs {
-            override fun text(checkoutMode: CheckoutMode): String = "Confirm"
+            override fun text(isSetup: Boolean): String = "Confirm"
             override val requiresBrowser: Boolean = false
             override val isConsideredDone: Boolean = false
         }
 
         data object ModifyDetails : Bacs {
-            override fun text(checkoutMode: CheckoutMode): String = "Modify details"
+            override fun text(isSetup: Boolean): String = "Modify details"
             override val requiresBrowser: Boolean = false
             override val isConsideredDone: Boolean = false
         }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -22,7 +22,6 @@ import com.stripe.android.model.PaymentMethod.Type.Blik
 import com.stripe.android.model.PaymentMethod.Type.CashAppPay
 import com.stripe.android.paymentsheet.example.playground.RELOAD_TEST_TAG
 import com.stripe.android.paymentsheet.example.playground.activity.FawryActivity
-import com.stripe.android.paymentsheet.example.playground.settings.CheckoutModeSettingsDefinition
 import com.stripe.android.paymentsheet.example.samples.ui.shared.CHECKOUT_TEST_TAG
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PAYMENT_METHOD_SELECTOR_TEST_TAG
 import com.stripe.android.test.core.AuthorizeAction
@@ -155,14 +154,11 @@ internal class Selectors(
         .packageManager
         .getInstalledApplications(PackageManager.GET_META_DATA)
 
-    private val checkoutMode =
-        testParameters.playgroundSettingsSnapshot[CheckoutModeSettingsDefinition]
-
     @OptIn(ExperimentalTestApi::class)
     val authorizeAction = when (testParameters.authorizationAction) {
         is AuthorizeAction.AuthorizePayment -> {
             object : UiAutomatorText(
-                label = testParameters.authorizationAction.text(checkoutMode),
+                label = testParameters.authorizationAction.text(testParameters.isSetupMode),
                 className = "android.widget.Button",
                 device = device
             ) {
@@ -182,7 +178,7 @@ internal class Selectors(
 
         is AuthorizeAction.Cancel -> {
             object : UiAutomatorText(
-                label = testParameters.authorizationAction.text(checkoutMode),
+                label = testParameters.authorizationAction.text(testParameters.isSetupMode),
                 className = "android.widget.Button",
                 device = device
             ) {
@@ -194,7 +190,7 @@ internal class Selectors(
 
         is AuthorizeAction.Fail -> {
             object : UiAutomatorText(
-                label = testParameters.authorizationAction.text(checkoutMode),
+                label = testParameters.authorizationAction.text(testParameters.isSetupMode),
                 className = "android.widget.Button",
                 device = device
             ) {}
@@ -202,7 +198,7 @@ internal class Selectors(
 
         is AuthorizeAction.Bacs.Confirm -> {
             object : UiAutomatorText(
-                label = testParameters.authorizationAction.text(checkoutMode),
+                label = testParameters.authorizationAction.text(testParameters.isSetupMode),
                 className = "android.widget.Button",
                 device = device
             ) {
@@ -224,7 +220,7 @@ internal class Selectors(
 
         is AuthorizeAction.Bacs.ModifyDetails -> {
             object : UiAutomatorText(
-                label = testParameters.authorizationAction.text(checkoutMode),
+                label = testParameters.authorizationAction.text(testParameters.isSetupMode),
                 className = "android.widget.Button",
                 device = device
             ) {


### PR DESCRIPTION
# Summary
Decouple `AuthorizeAction` from `CheckoutMode`

# Motivation
Allows for testing authorization actions in `CustomerSheet` where `CheckoutMode` is inapplicable.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
