### PR TITLE
Fix Samsung memory leak in screenshot tests

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.screenshot
 
 import android.graphics.Color
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -87,7 +86,6 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
     @After
     fun resetAppearanceStore() {
         AppearanceStore.reset()
-        forceLightMode()
     }
 
     @Test
@@ -107,18 +105,18 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
 
     @Test
     fun testPaymentSheetNewCustomerDark() {
-        forceDarkMode()
         testDriver.screenshotRegression(
-            testParams
+            darkMode = true,
+            testParameters = testParams,
         )
     }
 
     @Test
     fun testPaymentSheetNewCustomerDarkAppearance() {
         AppearanceStore.state = appearance
-        forceDarkMode()
         testDriver.screenshotRegression(
-            testParams
+            darkMode = true,
+            testParameters = testParams,
         )
     }
 
@@ -143,22 +141,22 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
 
     @Test
     fun testPaymentSheetReturningCustomerDark() {
-        forceDarkMode()
         testDriver.screenshotRegression(
-            testParams.copyPlaygroundSettings { settings ->
+            darkMode = true,
+            testParameters = testParams.copyPlaygroundSettings { settings ->
                 settings[CustomerSettingsDefinition] = CustomerType.RETURNING
-            }
+            },
         )
     }
 
     @Test
     fun testPaymentSheetReturningCustomerDarkAppearance() {
         AppearanceStore.state = appearance
-        forceDarkMode()
         testDriver.screenshotRegression(
-            testParams.copyPlaygroundSettings { settings ->
+            darkMode = true,
+            testParameters = testParams.copyPlaygroundSettings { settings ->
                 settings[CustomerSettingsDefinition] = CustomerType.RETURNING
-            }
+            },
         )
     }
 
@@ -190,8 +188,8 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
 
     @Test
     fun testPaymentSheetEditPaymentMethodsDark() {
-        forceDarkMode()
         testDriver.screenshotRegression(
+            darkMode = true,
             testParameters = testParams
                 .copyPlaygroundSettings { settings ->
                     settings[CustomerSettingsDefinition] = CustomerType.RETURNING
@@ -204,8 +202,8 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
 
     @Test
     fun testPaymentSheetEditPaymentMethodsDarkAppearance() {
-        forceDarkMode()
         testDriver.screenshotRegression(
+            darkMode = true,
             testParameters = testParams.copyPlaygroundSettings { settings ->
                 settings[CustomerSettingsDefinition] = CustomerType.RETURNING
             },
@@ -230,9 +228,9 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
         AppearanceStore.state = PaymentSheet.Appearance(
             primaryButton = primaryButton
         )
-        forceDarkMode()
         testDriver.screenshotRegression(
-            testParams
+            darkMode = true,
+            testParameters = testParams,
         )
     }
 
@@ -258,19 +256,5 @@ internal class TestPaymentSheetScreenshots : BasePlaygroundTest(disableAnimation
                 testDriver.scrollToBottom()
             }
         )
-    }
-
-    private fun forceDarkMode() {
-        AppearanceStore.forceDarkMode = true
-        rules.compose.runOnUiThread {
-            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
-        }
-    }
-
-    private fun forceLightMode() {
-        AppearanceStore.forceDarkMode = false
-        rules.compose.runOnUiThread {
-            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
-        }
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -503,7 +503,7 @@ private fun PlaygroundTheme(
     content: @Composable ColumnScope.() -> Unit,
     bottomBarContent: @Composable ColumnScope.() -> Unit,
 ) {
-    val colors = if (isSystemInDarkTheme() || AppearanceStore.forceDarkMode) {
+    val colors = if (isSystemInDarkTheme()) {
         darkColors()
     } else {
         lightColors()

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
@@ -291,7 +291,9 @@ internal class PaymentSheetPlaygroundViewModel(
 
         val statusMessage = when (paymentResult) {
             is PaymentSheetResult.Canceled -> {
-                "Canceled"
+                // We don't show the toast in tests so that we don't
+                // pollute the screenshots with those overlays.
+                "Canceled".takeUnless { runningInTest }
             }
 
             is PaymentSheetResult.Completed -> {
@@ -503,6 +505,9 @@ internal class PaymentSheetPlaygroundViewModel(
             return PaymentSheetPlaygroundViewModel(applicationSupplier(), uriSupplier()) as T
         }
     }
+
+    private val runningInTest: Boolean
+        get() = runCatching { Class.forName("androidx.test.espresso.Espresso") }.isSuccess
 }
 
 class ConfirmIntentEndpointException : Exception()

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/AppearanceStore.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/AppearanceStore.kt
@@ -7,10 +7,8 @@ import com.stripe.android.paymentsheet.PaymentSheet
 
 internal object AppearanceStore {
     var state by mutableStateOf(PaymentSheet.Appearance())
-    var forceDarkMode by mutableStateOf(false)
 
     fun reset() {
         state = PaymentSheet.Appearance()
-        forceDarkMode = false
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes a memory leak in `TestPaymentSheetScreenshots` that’s happening on some Samsung devices.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
