### PR TITLE
Don't throw max retries exception after refreshing stripe intent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 20XX-XX-XX
 
+### Identity
+* [FIXED][8566](https://github.com/stripe/stripe-android/pull/8566) Fixed a crash when scan finishes and states is cleared.
+
 ### Payments
 * [FIXED][8590](https://github.com/stripe/stripe-android/pull/8590) Fix an issue where cancelling payment for Amazon Pay and Cash App Pay would show an error
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,6 @@
 ### Identity
 * [FIXED][8566](https://github.com/stripe/stripe-android/pull/8566) Fixed a crash when scan finishes and states is cleared.
 
-### Payments
-* [FIXED][8590](https://github.com/stripe/stripe-android/pull/8590) Fix an issue where cancelling payment for Amazon Pay and Cash App Pay would show an error
-
-## 20.44.2 - 2024-06-03
-
-### Identity
-* [FIXED][8566](https://github.com/stripe/stripe-android/pull/8566) Fixed a crash when scan finishes and states is cleared.
-
 ## 20.44.1 - 2024-05-28
 
 ### PaymentSheet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## XX.XX.XX - 20XX-XX-XX
 
+### Payments
+* [FIXED][8590](https://github.com/stripe/stripe-android/pull/8590) Fix an issue where cancelling payment for Amazon Pay and Cash App Pay would show an error
+
+## 20.44.2 - 2024-06-03
+
 ### Identity
 * [FIXED][8566](https://github.com/stripe/stripe-android/pull/8566) Fixed a crash when scan finishes and states is cleared.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 20XX-XX-XX
 
+### Payments
+* [FIXED][8590](https://github.com/stripe/stripe-android/pull/8590) Fix an issue where cancelling payment for Amazon Pay and Cash App Pay would show an error
+
 ## 20.44.2 - 2024-06-03
 
 ### Identity

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -245,11 +245,7 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
             remainingRetries--
         }
 
-        return if (shouldThrowException(stripeIntentResult)) {
-            Result.failure(MaxRetryReachedException())
-        } else {
-            stripeIntentResult
-        }
+        return stripeIntentResult
     }
 
     /**
@@ -274,13 +270,6 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
         val isCardPaymentProcessing = stripeIntent.status == StripeIntent.Status.Processing &&
             stripeIntent.paymentMethod?.type == PaymentMethod.Type.Card
         return requiresAction || isCardPaymentProcessing
-    }
-
-    private fun shouldThrowException(stripeIntentResult: Result<StripeIntent>): Boolean {
-        val stripeIntent = stripeIntentResult.getOrNull() ?: return true
-        val requiresAction = stripeIntent.requiresAction()
-        val is3ds2 = stripeIntent.nextActionData is StripeIntent.NextActionData.SdkData.Use3DS2
-        return requiresAction && !is3ds2
     }
 
     internal companion object {

--- a/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
@@ -7,7 +7,6 @@ import com.stripe.android.PaymentIntentResult
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.APIConnectionException
-import com.stripe.android.core.exception.MaxRetryReachedException
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
@@ -171,14 +170,12 @@ internal class PaymentIntentFlowResultProcessorTest {
             val clientSecret = "pi_3JkCxKBNJ02ErVOj0kNqBMAZ_secret_bC6oXqo976LFM06Z9rlhmzUQq"
             val requestOptions = ApiRequest.Options(apiKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
 
-            val result = processor.processResult(
+            processor.processResult(
                 PaymentFlowResult.Unvalidated(
                     clientSecret = clientSecret,
                     flowOutcome = StripeIntentResult.Outcome.SUCCEEDED
                 )
             )
-
-            assertThat(result.exceptionOrNull()).isInstanceOf(MaxRetryReachedException::class.java)
 
             verify(mockStripeRepository).retrievePaymentIntent(
                 eq(clientSecret),

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCashApp.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCashApp.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.lpm
 
+import androidx.compose.ui.test.hasTestTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
 import com.stripe.android.model.PaymentMethod
@@ -10,6 +11,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.CountrySettin
 import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
+import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_ERROR_TEXT_TEST_TAG
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.TestParameters
 import org.junit.Test
@@ -54,6 +56,10 @@ internal class TestCashApp : BasePlaygroundTest() {
             testParameters = testParameters.copy(
                 authorizationAction = AuthorizeAction.Cancel,
             ),
+            afterAuthorization = {
+                it.composeTestRule.onNode(hasTestTag(PAYMENT_SHEET_ERROR_TEXT_TEST_TAG))
+                    .assertDoesNotExist()
+            }
         )
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Don't throw max retries exception after refreshing stripe intent

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fixes a bug where cancelling payment shows an error for LPMs (CAP, Amazon Pay) which require refreshing 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [X] Manually verified

# Screen recordings
Before:


https://github.com/stripe/stripe-android/assets/160939932/c9d3fa7f-aa18-4c01-80cd-565d27983081


After:


https://github.com/stripe/stripe-android/assets/160939932/bba1be84-3ce8-4e2d-9e3e-83e608047843





# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

* [FIXED][8590](https://github.com/stripe/stripe-android/pull/8590) Fix an issue where cancelling payment for Amazon Pay and Cash App Pay would show an error
