### PR TITLE
Fix initial payment method option not being first from `payment_method_order` in `CustomerSheet`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -788,6 +788,7 @@ internal class CustomerSheetViewModel(
         cbcEligibility: CardBrandChoiceEligibility = viewState.value.cbcEligibility,
     ) {
         val paymentMethodCode = previouslySelectedPaymentMethod?.code
+            ?: paymentMethodMetadata?.supportedPaymentMethodTypes()?.firstOrNull()
             ?: PaymentMethod.Type.Card.code
 
         val formArguments = FormArgumentsFactory.create(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -1871,6 +1871,30 @@ class CustomerSheetViewModelTest {
     }
 
     @Test
+    fun `When 'paymentMethodOrder' is defined, initial shown payment method should be first from 'paymentMethodOrder'`() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel(
+                workContext = testDispatcher,
+                customerSheetLoader = FakeCustomerSheetLoader(
+                    customerPaymentMethods = listOf(),
+                    isGooglePayAvailable = false,
+                    stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD_WITH_US_BANK_ACCOUNT,
+                    financialConnectionsAvailable = true,
+                ),
+                configuration = CustomerSheet.Configuration(
+                    merchantDisplayName = "Merchant, Inc.",
+                    paymentMethodOrder = listOf("us_bank_account", "card")
+                )
+            )
+
+            viewModel.viewState.test {
+                val viewState = awaitViewState<AddPaymentMethod>()
+
+                assertThat(viewState.paymentMethodCode).isEqualTo("us_bank_account")
+            }
+        }
+
+    @Test
     fun `The custom primary button can be updated`() = runTest(testDispatcher) {
         val viewModel = createViewModel(
             workContext = testDispatcher,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
@@ -28,6 +28,7 @@ internal class FakeCustomerSheetLoader(
     private val isGooglePayAvailable: Boolean = false,
     private val delay: Duration = Duration.ZERO,
     private val cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
+    private val financialConnectionsAvailable: Boolean = false,
 ) : CustomerSheetLoader {
 
     override suspend fun load(configuration: CustomerSheet.Configuration): Result<CustomerSheetState.Full> {
@@ -41,6 +42,8 @@ internal class FakeCustomerSheetLoader(
                     PaymentMethodMetadataFactory.create(
                         stripeIntent = stripeIntent,
                         cbcEligibility = cbcEligibility,
+                        financialConnectionsAvailable = financialConnectionsAvailable,
+                        paymentMethodOrder = configuration.paymentMethodOrder
                     ),
                     supportedPaymentMethods = supportedPaymentMethods,
                     customerPaymentMethods = customerPaymentMethods,

--- a/paymentsheet/src/test/java/com/stripe/android/model/SetupIntentFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/SetupIntentFixtures.kt
@@ -278,6 +278,37 @@ internal object SetupIntentFixtures {
         )
     )
 
+    internal val SI_REQUIRES_PAYMENT_METHOD_WITH_US_BANK_ACCOUNT = requireNotNull(
+        PARSER.parse(
+            JSONObject(
+                """
+        {
+            "id": "seti_1GSmaFCRMbs",
+            "object": "setup_intent",
+            "cancellation_reason": null,
+            "client_secret": "seti_1GSmaFCRMbs6FrXfmjThcHan_secret_H0oC2iSB4FtW4d",
+            "created": 1585670699,
+            "description": null,
+            "last_setup_error": null,
+            "livemode": false,
+            "payment_method": null,
+            "payment_method_types": [
+                "card",
+                "us_bank_account"
+            ],
+            "payment_method_options": {
+                "us_bank_account": {
+                    "verification_method": "automatic"
+                }
+            },
+            "status": "requires_payment_method",
+            "usage": "off_session"
+        }
+                """.trimIndent()
+            )
+        )
+    )
+
     internal val EXPANDED_PAYMENT_METHOD = JSONObject(
         """
         {


### PR DESCRIPTION
# Summary
Fix initial payment method option not being first from `payment_method_order` in `CustomerSheet`

# Motivation
Ensures users will be shown the first payment option from `paymentMethodOrder` when adding a payment method if the merchant has it configured.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Video
https://github.com/stripe/stripe-android/assets/141707240/85b23dab-5a2d-42cf-9073-7bc941873953