### PR TITLE
Add `3DS2` & `US Bank Account` end-to-end tests for `CustomerSheet`

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCardInCustomerSheet.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCardInCustomerSheet.kt
@@ -15,6 +15,8 @@ import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
 import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillingAddress
 import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillingAddressSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.PaymentMethodMode
+import com.stripe.android.test.core.AuthorizeAction
+import com.stripe.android.test.core.FieldPopulator
 import com.stripe.android.test.core.TestParameters
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -65,6 +67,22 @@ internal class TestCardInCustomerSheet : BasePlaygroundTest() {
             populateCustomLpmFields = {
                 populateCardDetails()
             },
+        )
+    }
+
+    @Test
+    fun testCardWith3ds2() {
+        testDriver.savePaymentMethodInCustomerSheet(
+            testParameters.copyPlaygroundSettings { settings ->
+                settings[CountrySettingsDefinition] = Country.US
+                settings[CustomerSheetPaymentMethodModeDefinition] = PaymentMethodMode.SetupIntent
+            }.copy(
+                authorizationAction = AuthorizeAction.Authorize3ds2,
+            ),
+            populateCustomLpmFields = {
+                populateCardDetails()
+            },
+            values = FieldPopulator.Values(cardNumber = "4000000000003220")
         )
     }
 

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUsBankAccountInCustomerSheet.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUsBankAccountInCustomerSheet.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.lpm
+
+import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.paymentsheet.example.playground.settings.Country
+import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomerSheetPaymentMethodModeDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.PaymentMethodMode
+import com.stripe.android.test.core.AuthorizeAction
+import com.stripe.android.test.core.TestParameters
+import org.junit.Test
+
+internal class TestUsBankAccountInCustomerSheet : BasePlaygroundTest() {
+    private val testParameters = TestParameters.create(
+        paymentMethodCode = "us_bank_account",
+        executeInNightlyRun = true,
+        authorizationAction = null
+    ) { settings ->
+        settings[CountrySettingsDefinition] = Country.US
+        settings[CustomerSheetPaymentMethodModeDefinition] = PaymentMethodMode.SetupIntent
+    }
+
+    @Test
+    fun testUSBankAccount() {
+        testDriver.saveUsBankAccountInCustomerSheet(
+            testParameters = testParameters.copy(
+                authorizationAction = AuthorizeAction.Cancel,
+            )
+        )
+    }
+}


### PR DESCRIPTION
# Summary
Add `3DS2` & `US Bank Account` end-to-end tests for `CustomerSheet`.

# Motivation
Ensures `3DS2` & `US Bank Account` work as expected for `CustomerSheet`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
