### PR TITLE
Fix CBC eligibility not being enabled when navigating to 'SelectPaymentMethod' initially for `CustomerSheet`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -1229,7 +1229,7 @@ internal class CustomerSheetViewModel(
                 primaryButtonVisible = false,
                 primaryButtonLabel = resources.getString(R.string.stripe_paymentsheet_confirm),
                 errorMessage = null,
-                cbcEligibility = CardBrandChoiceEligibility.Ineligible,
+                cbcEligibility = paymentMethodMetadata?.cbcEligibility ?: CardBrandChoiceEligibility.Ineligible,
                 allowsRemovalOfLastSavedPaymentMethod = configuration.allowsRemovalOfLastSavedPaymentMethod,
             )
         )


### PR DESCRIPTION
# Summary
Fix CBC eligibility not being enabled when navigating to 'SelectPaymentMethod' initially for `CustomerSheet`

# Motivation
Ensures users can edit their initially added CBC-enabled card after attaching them.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Video
https://github.com/stripe/stripe-android/assets/141707240/09d33fdb-41f8-4562-a928-5fa7f30999bc