### PR TITLE
Fix issue with enter address manually button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 20XX-XX-XX
 
+### AddressElement
+* [FIXED][8596](https://github.com/stripe/stripe-android/pull/8596) Fixed issue where "Enter address manually" button only worked the first time it was clicked.
+
 ## 20.44.2 - 2024-06-03
 
 ### Identity

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementNavigator.kt
@@ -41,4 +41,8 @@ internal class AddressElementNavigator @Inject constructor() {
             }
         }
     }
+
+    companion object {
+        internal const val FORCE_EXPANDED_FORM_KEY = "force_expanded_form"
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.addresselement.AddressElementNavigator.Companion.FORCE_EXPANDED_FORM_KEY
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
 import com.stripe.android.paymentsheet.injection.AutocompleteViewModelSubcomponent
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
@@ -150,6 +151,7 @@ internal class AutocompleteViewModel @Inject constructor(
     }
 
     fun onEnterAddressManually() {
+        navigator.setResult(FORCE_EXPANDED_FORM_KEY, true)
         setResultAndGoBack(
             AddressDetails(
                 address = PaymentSheet.Address(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -77,7 +77,11 @@ internal class InputAddressViewModel @Inject constructor(
                     .stripeIntent(null)
                     .merchantName("")
                     .shippingValues(null)
-                    .formSpec(buildFormSpec(!forceExpandedForm && addressDetails?.address?.line1 == null))
+                    .formSpec(
+                        buildFormSpec(
+                            condensedForm = !forceExpandedForm && addressDetails?.address?.line1 == null
+                        )
+                    )
                     .initialValues(initialValues)
                     .build().formController
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -79,7 +79,7 @@ class InputAddressViewModelTest {
     fun `autocomplete address passed is collected to start`() = runTest(UnconfinedTestDispatcher()) {
         val expectedAddress = AddressDetails(name = "skyler", address = PaymentSheet.Address(country = "US"))
         val flow = MutableStateFlow<AddressDetails?>(expectedAddress)
-        whenever(navigator.getResultFlow<AddressDetails?>(any())).thenReturn(flow)
+        whenever(navigator.getResultFlow<AddressDetails?>(AddressDetails.KEY)).thenReturn(flow)
 
         val viewModel = createViewModel()
         assertThat(viewModel.collectedAddress.value).isEqualTo(expectedAddress)
@@ -89,7 +89,7 @@ class InputAddressViewModelTest {
     fun `takes only fields in new address`() = runTest(UnconfinedTestDispatcher()) {
         val usAddress = AddressDetails(name = "skyler", address = PaymentSheet.Address(country = "US"))
         val flow = MutableStateFlow<AddressDetails?>(usAddress)
-        whenever(navigator.getResultFlow<AddressDetails?>(any())).thenReturn(flow)
+        whenever(navigator.getResultFlow<AddressDetails?>(AddressDetails.KEY)).thenReturn(flow)
 
         val viewModel = createViewModel()
         assertThat(viewModel.collectedAddress.value).isEqualTo(usAddress)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Set a "forceExpandedForm" field on InputAddressScreen after "Enter address manually" has been clicked to force displaying the expanded form 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix issue with enter address manually button

https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3247

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screen recordings
Before:


https://github.com/stripe/stripe-android/assets/160939932/06abd9a6-e3bb-4a0c-9c4d-6f530bc15504

After:


https://github.com/stripe/stripe-android/assets/160939932/722112ae-846d-4f33-a413-a9463f29a67d

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
* [FIXED][8596](https://github.com/stripe/stripe-android/pull/8596) Fixed issue where "Enter address manually" button only worked the first time it was clicked.