### PR TITLE
Remove ASCS in ConsumerSession

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
@@ -83,7 +83,6 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
         consumersApiService.startConsumerVerification(
             consumerSessionClientSecret = consumerSessionClientSecret,
             locale = locale ?: Locale.getDefault(),
-            authSessionCookie = null,
             connectionsMerchantName = connectionsMerchantName,
             requestSurface = CONSUMER_SURFACE,
             type = type,
@@ -101,7 +100,6 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
     ): ConsumerSession = mutex.withLock {
         return consumersApiService.confirmConsumerVerification(
             consumerSessionClientSecret = consumerSessionClientSecret,
-            authSessionCookie = null,
             verificationCode = verificationCode,
             type = type,
             requestSurface = CONSUMER_SURFACE,

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/ApiKeyFixtures.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/ApiKeyFixtures.kt
@@ -133,7 +133,6 @@ internal object ApiKeyFixtures {
         redactedPhoneNumber = "+1********12",
         redactedFormattedPhoneNumber = "(***) *** **12",
         verificationSessions = emptyList(),
-        authSessionClientSecret = null,
         publishableKey = null
     )
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepositoryImplTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepositoryImplTest.kt
@@ -90,7 +90,6 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
             consumersApiService.startConsumerVerification(
                 consumerSessionClientSecret = eq(consumerSessionClientSecret),
                 locale = eq(locale),
-                authSessionCookie = anyOrNull(),
                 requestSurface = eq("android_connections"),
                 type = eq(type),
                 connectionsMerchantName = anyOrNull(),
@@ -113,7 +112,6 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
         verify(consumersApiService).startConsumerVerification(
             consumerSessionClientSecret = consumerSessionClientSecret,
             locale = locale,
-            authSessionCookie = null,
             requestSurface = "android_connections",
             type = type,
             connectionsMerchantName = connectionsMerchantName,
@@ -137,7 +135,6 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
             consumersApiService.confirmConsumerVerification(
                 consumerSessionClientSecret = eq(consumerSessionClientSecret),
                 verificationCode = eq(verificationCode),
-                authSessionCookie = anyOrNull(),
                 requestSurface = eq("android_connections"),
                 type = eq(type),
                 requestOptions = eq(apiOptions)
@@ -156,7 +153,6 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
         verify(consumersApiService).confirmConsumerVerification(
             consumerSessionClientSecret = consumerSessionClientSecret,
             verificationCode = verificationCode,
-            authSessionCookie = null,
             "android_connections",
             type,
             apiOptions

--- a/link/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/link/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -35,10 +35,6 @@ internal class LinkAccountManager @Inject constructor(
     private val _linkAccount = MutableStateFlow<LinkAccount?>(null)
     val linkAccount: StateFlow<LinkAccount?> = _linkAccount
 
-    @Volatile
-    @VisibleForTesting
-    var authSessionCookie: String? = null
-
     /**
      * The publishable key for the signed in Link account.
      */
@@ -61,7 +57,7 @@ internal class LinkAccountManager @Inject constructor(
         email: String,
         startSession: Boolean = true,
     ): Result<LinkAccount?> =
-        linkRepository.lookupConsumer(email, authSessionCookie)
+        linkRepository.lookupConsumer(email)
             .onFailure { error ->
                 linkEventsReporter.onAccountLookupFailure(error)
             }.map { consumerSessionLookup ->
@@ -173,7 +169,7 @@ internal class LinkAccountManager @Inject constructor(
         name: String?,
         consentAction: SignUpConsentAction
     ): Result<LinkAccount> =
-        linkRepository.consumerSignUp(email, phone, country, name, authSessionCookie, consentAction.consumerAction)
+        linkRepository.consumerSignUp(email, phone, country, name, consentAction.consumerAction)
             .map { consumerSession ->
                 setAccount(consumerSession)
             }
@@ -224,7 +220,6 @@ internal class LinkAccountManager @Inject constructor(
         maybeUpdateConsumerPublishableKey(consumerSession)
         val newAccount = LinkAccount(consumerSession)
         _linkAccount.value = newAccount
-        authSessionCookie = newAccount.getAuthSessionCookie()
         return newAccount
     }
 

--- a/link/src/main/java/com/stripe/android/link/model/LinkAccount.kt
+++ b/link/src/main/java/com/stripe/android/link/model/LinkAccount.kt
@@ -28,8 +28,6 @@ internal class LinkAccount(private val consumerSession: ConsumerSession) {
         }
     }
 
-    fun getAuthSessionCookie() = consumerSession.authSessionClientSecret
-
     private fun ConsumerSession.containsSMSSessionStarted() = verificationSessions.find {
         it.type == ConsumerSession.VerificationSession.SessionType.Sms &&
             it.state == ConsumerSession.VerificationSession.SessionState.Started

--- a/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -39,14 +39,12 @@ internal class LinkApiRepository @Inject constructor(
 ) : LinkRepository {
 
     override suspend fun lookupConsumer(
-        email: String?,
-        authSessionCookie: String?
+        email: String,
     ): Result<ConsumerSessionLookup> = withContext(workContext) {
         runCatching {
             requireNotNull(
                 consumersApiService.lookupConsumerSession(
                     email = email,
-                    authSessionCookie = authSessionCookie,
                     requestSurface = REQUEST_SURFACE,
                     requestOptions = buildRequestOptions(),
                 )
@@ -59,7 +57,6 @@ internal class LinkApiRepository @Inject constructor(
         phone: String,
         country: String,
         name: String?,
-        authSessionCookie: String?,
         consentAction: ConsumerSignUpConsentAction
     ): Result<ConsumerSession> = withContext(workContext) {
         stripeRepository.consumerSignUp(
@@ -68,7 +65,6 @@ internal class LinkApiRepository @Inject constructor(
             country = country,
             name = name,
             locale = locale,
-            authSessionCookie = authSessionCookie,
             consentAction = consentAction,
             requestOptions = buildRequestOptions(),
         )

--- a/link/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/link/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -16,8 +16,7 @@ internal interface LinkRepository {
      * Check if the email already has a link account.
      */
     suspend fun lookupConsumer(
-        email: String?,
-        authSessionCookie: String?
+        email: String,
     ): Result<ConsumerSessionLookup>
 
     /**
@@ -28,7 +27,6 @@ internal interface LinkRepository {
         phone: String,
         country: String,
         name: String?,
-        authSessionCookie: String?,
         consentAction: ConsumerSignUpConsentAction
     ): Result<ConsumerSession>
 

--- a/link/src/test/java/com/stripe/android/link/account/LinkAccountManagerTest.kt
+++ b/link/src/test/java/com/stripe/android/link/account/LinkAccountManagerTest.kt
@@ -49,10 +49,7 @@ class LinkAccountManagerTest {
     @Test
     fun `When cookie exists and network call fails then account status is Error`() = runSuspendTest {
         val accountManager = accountManager(EMAIL)
-        accountManager.authSessionCookie = "cookie"
-        whenever(linkRepository.lookupConsumer(anyOrNull(), anyOrNull()))
-            .thenReturn(Result.failure(Exception()))
-
+        whenever(linkRepository.lookupConsumer(anyOrNull())).thenReturn(Result.failure(Exception()))
         assertThat(accountManager.accountStatus.first()).isEqualTo(AccountStatus.Error)
     }
 
@@ -60,12 +57,12 @@ class LinkAccountManagerTest {
     fun `When customerEmail is set in arguments then it is looked up`() = runSuspendTest {
         assertThat(accountManager(EMAIL).accountStatus.first()).isEqualTo(AccountStatus.Verified)
 
-        verify(linkRepository).lookupConsumer(EMAIL, null)
+        verify(linkRepository).lookupConsumer(EMAIL)
     }
 
     @Test
     fun `When customerEmail is set and network call fails then account status is Error`() = runSuspendTest {
-        whenever(linkRepository.lookupConsumer(anyOrNull(), anyOrNull()))
+        whenever(linkRepository.lookupConsumer(anyOrNull()))
             .thenReturn(Result.failure(Exception()))
 
         assertThat(accountManager(EMAIL).accountStatus.first()).isEqualTo(AccountStatus.Error)
@@ -113,7 +110,7 @@ class LinkAccountManagerTest {
 
     @Test
     fun `lookupConsumer sends analytics event when call fails`() = runSuspendTest {
-        whenever(linkRepository.lookupConsumer(anyOrNull(), anyOrNull()))
+        whenever(linkRepository.lookupConsumer(anyOrNull()))
             .thenReturn(Result.failure(Exception()))
 
         accountManager().lookupConsumer(EMAIL, false)
@@ -128,7 +125,7 @@ class LinkAccountManagerTest {
 
             accountManager.signInWithUserInput(UserInput.SignIn(EMAIL))
 
-            verify(linkRepository).lookupConsumer(eq(EMAIL), anyOrNull())
+            verify(linkRepository).lookupConsumer(eq(EMAIL))
             assertThat(accountManager.linkAccount.value).isNotNull()
         }
 
@@ -155,7 +152,6 @@ class LinkAccountManagerTest {
                 phone = eq(phone),
                 country = eq(country),
                 name = eq(name),
-                authSessionCookie = anyOrNull(),
                 consentAction = eq(ConsumerSignUpConsentAction.Checkbox)
             )
             assertThat(accountManager.linkAccount.value).isNotNull()
@@ -281,7 +277,6 @@ class LinkAccountManagerTest {
                     phone = anyOrNull(),
                     country = anyOrNull(),
                     name = anyOrNull(),
-                    authSessionCookie = anyOrNull(),
                     consentAction = anyOrNull()
                 )
             ).thenReturn(Result.failure(Exception()))
@@ -330,7 +325,7 @@ class LinkAccountManagerTest {
                     anyOrNull(),
                     anyOrNull(),
                 )
-            verify(linkRepository, times(0)).lookupConsumer(anyOrNull(), anyOrNull())
+            verify(linkRepository, times(0)).lookupConsumer(anyOrNull())
         }
 
     @Test
@@ -395,7 +390,7 @@ class LinkAccountManagerTest {
         val consumerSessionLookup = mock<ConsumerSessionLookup>().apply {
             whenever(consumerSession).thenReturn(mockConsumerSession)
         }
-        whenever(linkRepository.lookupConsumer(anyOrNull(), anyOrNull()))
+        whenever(linkRepository.lookupConsumer(anyOrNull()))
             .thenReturn(Result.success(consumerSessionLookup))
         whenever(
             linkRepository.consumerSignUp(
@@ -403,7 +398,6 @@ class LinkAccountManagerTest {
                 phone = anyOrNull(),
                 country = anyOrNull(),
                 name = anyOrNull(),
-                authSessionCookie = anyOrNull(),
                 consentAction = any()
             )
         ).thenReturn(Result.success(mockConsumerSession))
@@ -471,7 +465,6 @@ class LinkAccountManagerTest {
             phone = any(),
             country = any(),
             name = anyOrNull(),
-            authSessionCookie = anyOrNull(),
             consentAction = eq(consumerAction)
         )
     }

--- a/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -62,12 +62,10 @@ class LinkApiRepositoryTest {
     @Test
     fun `lookupConsumer sends correct parameters`() = runTest {
         val email = "email@example.com"
-        val cookie = "cookie1"
-        linkRepository.lookupConsumer(email, cookie)
+        linkRepository.lookupConsumer(email)
 
         verify(consumersApiService).lookupConsumerSession(
             eq(email),
-            eq(cookie),
             eq(CONSUMER_SURFACE),
             eq(ApiRequest.Options(PUBLISHABLE_KEY, STRIPE_ACCOUNT_ID))
         )
@@ -81,12 +79,11 @@ class LinkApiRepositoryTest {
                 any(),
                 any(),
                 any(),
-                any()
             )
         )
             .thenReturn(consumerSessionLookup)
 
-        val result = linkRepository.lookupConsumer("email", "cookie")
+        val result = linkRepository.lookupConsumer("email")
 
         assertThat(result.isSuccess).isTrue()
         assertThat(result.getOrNull()).isEqualTo(consumerSessionLookup)
@@ -99,12 +96,11 @@ class LinkApiRepositoryTest {
                 any(),
                 any(),
                 any(),
-                any()
             )
         )
             .thenThrow(RuntimeException("error"))
 
-        val result = linkRepository.lookupConsumer("email", "cookie")
+        val result = linkRepository.lookupConsumer("email")
 
         assertThat(result.isFailure).isTrue()
     }
@@ -115,13 +111,11 @@ class LinkApiRepositoryTest {
         val phone = "phone"
         val country = "US"
         val name = "name"
-        val cookie = "cookie2"
         linkRepository.consumerSignUp(
             email,
             phone,
             country,
             name,
-            cookie,
             ConsumerSignUpConsentAction.Checkbox
         )
 
@@ -131,7 +125,6 @@ class LinkApiRepositoryTest {
             eq(country),
             eq(name),
             eq(Locale.US),
-            eq(cookie),
             eq(ConsumerSignUpConsentAction.Checkbox),
             eq(ApiRequest.Options(PUBLISHABLE_KEY, STRIPE_ACCOUNT_ID))
         )
@@ -147,7 +140,6 @@ class LinkApiRepositoryTest {
                 country = any(),
                 name = anyOrNull(),
                 locale = anyOrNull(),
-                authSessionCookie = anyOrNull(),
                 consentAction = any(),
                 requestOptions = any()
             )
@@ -158,7 +150,6 @@ class LinkApiRepositoryTest {
             "phone",
             "country",
             "name",
-            "cookie",
             ConsumerSignUpConsentAction.Checkbox
         )
 
@@ -175,7 +166,6 @@ class LinkApiRepositoryTest {
                 country = any(),
                 name = anyOrNull(),
                 locale = anyOrNull(),
-                authSessionCookie = anyOrNull(),
                 consentAction = any(),
                 requestOptions = any()
             )
@@ -186,7 +176,6 @@ class LinkApiRepositoryTest {
             "phone",
             "country",
             "name",
-            "cookie",
             ConsumerSignUpConsentAction.Implied
         )
 

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -294,7 +294,6 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         country: String,
         name: String?,
         locale: Locale?,
-        authSessionCookie: String?,
         consentAction: ConsumerSignUpConsentAction,
         requestOptions: ApiRequest.Options
     ): Result<ConsumerSession> {

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1043,7 +1043,6 @@ class StripeApiRepository @JvmOverloads internal constructor(
         country: String,
         name: String?,
         locale: Locale?,
-        authSessionCookie: String?,
         consentAction: ConsumerSignUpConsentAction,
         requestOptions: ApiRequest.Options
     ): Result<ConsumerSession> {
@@ -1058,13 +1057,6 @@ class StripeApiRepository @JvmOverloads internal constructor(
                     "phone_number" to phoneNumber,
                     "country" to country,
                     "consent_action" to consentAction.value
-                ).plus(
-                    authSessionCookie?.let {
-                        mapOf(
-                            "cookies" to
-                                mapOf("verification_session_client_secrets" to listOf(it))
-                        )
-                    } ?: emptyMap()
                 ).plus(
                     locale?.let {
                         mapOf("locale" to it.toLanguageTag())

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -271,7 +271,6 @@ interface StripeRepository {
         country: String,
         name: String?,
         locale: Locale?,
-        authSessionCookie: String?,
         consentAction: ConsumerSignUpConsentAction,
         requestOptions: ApiRequest.Options
     ): Result<ConsumerSession>

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -1728,7 +1728,6 @@ internal class StripeApiRepositoryTest {
             val country = "US"
             val name = "name"
             val locale = Locale.US
-            val cookie = "cookie1"
             val consentAction = ConsumerSignUpConsentAction.Implied
             create().consumerSignUp(
                 email,
@@ -1736,7 +1735,6 @@ internal class StripeApiRepositoryTest {
                 country,
                 name,
                 locale,
-                cookie,
                 consentAction,
                 DEFAULT_OPTIONS
             )
@@ -1751,9 +1749,6 @@ internal class StripeApiRepositoryTest {
                 assertThat(this["legal_name"]).isEqualTo(name)
                 assertThat(this["locale"]).isEqualTo(locale.toLanguageTag())
                 assertThat(this["consent_action"]).isEqualTo("implied_consent_withspm_mobile_v0")
-                withNestedParams("cookies") {
-                    assertThat(this["verification_session_client_secrets"]).isEqualTo(listOf(cookie))
-                }
             }
         }
 

--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerSession.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerSession.kt
@@ -24,8 +24,6 @@ data class ConsumerSession(
     val redactedPhoneNumber: String,
     @SerialName("verification_sessions")
     val verificationSessions: List<VerificationSession> = emptyList(),
-    @SerialName("auth_session_client_secret")
-    val authSessionClientSecret: String? = null,
     @SerialName("publishable_key")
     val publishableKey: String? = null
 ) : StripeModel {

--- a/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerSessionJsonParser.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerSessionJsonParser.kt
@@ -25,7 +25,6 @@ class ConsumerSessionJsonParser : ModelJsonParser<ConsumerSession> {
             redactedFormattedPhoneNumber = consumerSessionJson.getString(FIELD_CONSUMER_SESSION_FORMATTED_PHONE),
             redactedPhoneNumber = consumerSessionJson.getString(FIELD_CONSUMER_SESSION_PHONE),
             verificationSessions = verificationSession,
-            authSessionClientSecret = optString(json, FIELD_CONSUMER_SESSION_AUTH_SESSION_SECRET),
             publishableKey = optString(json, FIELD_PUBLISHABLE_KEY)
         )
     }
@@ -49,7 +48,6 @@ class ConsumerSessionJsonParser : ModelJsonParser<ConsumerSession> {
         private const val FIELD_CONSUMER_SESSION_PHONE = "redacted_phone_number"
         private const val FIELD_CONSUMER_SESSION_FORMATTED_PHONE = "redacted_formatted_phone_number"
         private const val FIELD_CONSUMER_SESSION_VERIFICATION_SESSIONS = "verification_sessions"
-        private const val FIELD_CONSUMER_SESSION_AUTH_SESSION_SECRET = "auth_session_client_secret"
 
         private const val FIELD_VERIFICATION_SESSION_TYPE = "type"
         private const val FIELD_VERIFICATION_SESSION_STATE = "state"

--- a/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
+++ b/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
@@ -19,8 +19,7 @@ import java.util.Locale
 interface ConsumersApiService {
 
     suspend fun lookupConsumerSession(
-        email: String?,
-        authSessionCookie: String?,
+        email: String,
         requestSurface: String,
         requestOptions: ApiRequest.Options
     ): ConsumerSessionLookup
@@ -28,7 +27,6 @@ interface ConsumersApiService {
     suspend fun startConsumerVerification(
         consumerSessionClientSecret: String,
         locale: Locale,
-        authSessionCookie: String?,
         requestSurface: String,
         type: VerificationType,
         customEmailType: CustomEmailType?,
@@ -39,7 +37,6 @@ interface ConsumersApiService {
     suspend fun confirmConsumerVerification(
         consumerSessionClientSecret: String,
         verificationCode: String,
-        authSessionCookie: String?,
         requestSurface: String,
         type: VerificationType,
         requestOptions: ApiRequest.Options
@@ -66,8 +63,7 @@ class ConsumersApiServiceImpl(
      * Retrieves the ConsumerSession if the given email is associated with a Link account.
      */
     override suspend fun lookupConsumerSession(
-        email: String?,
-        authSessionCookie: String?,
+        email: String,
         requestSurface: String,
         requestOptions: ApiRequest.Options
     ): ConsumerSessionLookup {
@@ -78,20 +74,8 @@ class ConsumersApiServiceImpl(
                 consumerSessionLookupUrl,
                 requestOptions,
                 mapOf(
-                    "request_surface" to requestSurface
-                ).plus(
-                    email?.let {
-                        mapOf(
-                            "email_address" to it.lowercase()
-                        )
-                    } ?: emptyMap()
-                ).plus(
-                    authSessionCookie?.let {
-                        mapOf(
-                            "cookies" to
-                                mapOf("verification_session_client_secrets" to listOf(it))
-                        )
-                    } ?: emptyMap()
+                    "request_surface" to requestSurface,
+                    "email_address" to email.lowercase()
                 )
             ),
             responseJsonParser = ConsumerSessionLookupJsonParser()
@@ -104,7 +88,6 @@ class ConsumersApiServiceImpl(
     override suspend fun startConsumerVerification(
         consumerSessionClientSecret: String,
         locale: Locale,
-        authSessionCookie: String?,
         requestSurface: String,
         type: VerificationType,
         customEmailType: CustomEmailType?,
@@ -126,16 +109,7 @@ class ConsumersApiServiceImpl(
                     "custom_email_type" to customEmailType?.value,
                     "connections_merchant_name" to connectionsMerchantName,
                     "locale" to locale.toLanguageTag()
-                )
-                    .filterValues { it != null }
-                    .plus(
-                        authSessionCookie?.let {
-                            mapOf(
-                                "cookies" to
-                                    mapOf("verification_session_client_secrets" to listOf(it))
-                            )
-                        } ?: emptyMap()
-                    )
+                ).filterValues { it != null }
             ),
             responseJsonParser = ConsumerSessionJsonParser()
         )
@@ -147,7 +121,6 @@ class ConsumersApiServiceImpl(
     override suspend fun confirmConsumerVerification(
         consumerSessionClientSecret: String,
         verificationCode: String,
-        authSessionCookie: String?,
         requestSurface: String,
         type: VerificationType,
         requestOptions: ApiRequest.Options
@@ -164,13 +137,6 @@ class ConsumersApiServiceImpl(
                 ),
                 "type" to type.value,
                 "code" to verificationCode
-            ).plus(
-                authSessionCookie?.let {
-                    mapOf(
-                        "cookies" to
-                            mapOf("verification_session_client_secrets" to listOf(it))
-                    )
-                } ?: emptyMap()
             )
         ),
         responseJsonParser = ConsumerSessionJsonParser()

--- a/payments-model/src/test/java/com/stripe/android/model/parsers/ConsumerSessionJsonParserTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/model/parsers/ConsumerSessionJsonParserTest.kt
@@ -23,7 +23,6 @@ class ConsumerSessionJsonParserTest {
                         state = ConsumerSession.VerificationSession.SessionState.Started
                     )
                 ),
-                authSessionClientSecret = "21yKkFYNnhMVTlXbXdBQUFJRmEaJDNmZDE1",
                 publishableKey = "asdfg123"
             )
         )
@@ -45,7 +44,6 @@ class ConsumerSessionJsonParserTest {
                         state = ConsumerSession.VerificationSession.SessionState.Verified
                     )
                 ),
-                authSessionClientSecret = null,
                 publishableKey = null
             )
         )
@@ -67,7 +65,6 @@ class ConsumerSessionJsonParserTest {
                         state = ConsumerSession.VerificationSession.SessionState.Started
                     )
                 ),
-                authSessionClientSecret = null,
                 publishableKey = null
             )
         )

--- a/payments-model/src/test/java/com/stripe/android/model/parsers/ConsumerSessionLookupJsonParserTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/model/parsers/ConsumerSessionLookupJsonParserTest.kt
@@ -32,7 +32,6 @@ class ConsumerSessionLookupJsonParserTest {
                     redactedPhoneNumber = "+1********68",
                     redactedFormattedPhoneNumber = "(***) *** **68",
                     verificationSessions = emptyList(),
-                    authSessionClientSecret = null,
                     publishableKey = null
                 ),
                 errorMessage = null


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request removes the ASCS from `ConsumerSession`. There’s no need for it on Mobile and we’re not actually using it, as it’s still `null` when we pass it to network requests.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
