### PR TITLE
Refactor ManageScreenInteractor to not require BaseSheetViewModel in its constructor

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
@@ -6,6 +6,7 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Test
 
 class DefaultManageScreenInteractorTest {
@@ -46,19 +47,29 @@ class DefaultManageScreenInteractorTest {
         assertThat(initialState.currentSelection).isNull()
     }
 
+    private val notImplemented: () -> Nothing = { throw AssertionError("Not implemented") }
+
     private fun createInitialState(
-        paymentMethods: List<PaymentMethod>?,
+        initialPaymentMethods: List<PaymentMethod>?,
         currentSelection: PaymentSelection?,
         isEditing: Boolean = false,
     ): ManageScreenInteractor.State {
-        return DefaultManageScreenInteractor.computeInitialState(
+        val paymentMethods = MutableStateFlow(initialPaymentMethods)
+        val selection = MutableStateFlow(currentSelection)
+        val editing = MutableStateFlow(isEditing)
+
+        return DefaultManageScreenInteractor(
             paymentMethods = paymentMethods,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
             ),
-            selection = currentSelection,
+            selection = selection,
+            editing = editing,
             providePaymentMethodName = { it ?: "Missing name" },
-            isEditing = isEditing,
-        )
+            onSelectPaymentMethod = { notImplemented() },
+            onDeletePaymentMethod = { notImplemented() },
+            onEditPaymentMethod = { notImplemented() },
+            navigateBack = { notImplemented() },
+        ).state.value
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Refactor ManageScreenInteractor to not require BaseSheetViewModel in its constructor

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Planning to make some updates to handle edge cases with zero or one saved PMs in a follow up. This refactor will make it easier to test those changes.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

no behavior changes