### PR TITLE
Replace `DefaultCardAccountRangeStore` with `InMemoryCardAccountRangeStore`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactory.kt
@@ -33,10 +33,10 @@ class DefaultCardAccountRangeRepositoryFactory(
 
     @Throws(IllegalStateException::class)
     override fun create(): CardAccountRangeRepository {
-        val store = DefaultCardAccountRangeStore(appContext)
+        val store = InMemoryCardAccountRangeStore()
         return DefaultCardAccountRangeRepository(
             inMemorySource = InMemoryCardAccountRangeSource(store),
-            remoteSource = createRemoteCardAccountRangeSource(),
+            remoteSource = createRemoteCardAccountRangeSource(store),
             staticSource = StaticCardAccountRangeSource(),
             store = store
         )
@@ -46,7 +46,7 @@ class DefaultCardAccountRangeRepositoryFactory(
         stripeRepository: StripeRepository,
         publishableKey: String
     ): CardAccountRangeRepository {
-        val store = DefaultCardAccountRangeStore(appContext)
+        val store = InMemoryCardAccountRangeStore()
         return DefaultCardAccountRangeRepository(
             inMemorySource = InMemoryCardAccountRangeSource(store),
             remoteSource = RemoteCardAccountRangeSource(
@@ -54,7 +54,7 @@ class DefaultCardAccountRangeRepositoryFactory(
                 ApiRequest.Options(
                     publishableKey
                 ),
-                DefaultCardAccountRangeStore(appContext),
+                store,
                 DefaultAnalyticsRequestExecutor(),
                 PaymentAnalyticsRequestFactory(appContext, publishableKey)
             ),
@@ -63,7 +63,9 @@ class DefaultCardAccountRangeRepositoryFactory(
         )
     }
 
-    private fun createRemoteCardAccountRangeSource(): CardAccountRangeSource {
+    private fun createRemoteCardAccountRangeSource(
+        store: CardAccountRangeStore
+    ): CardAccountRangeSource {
         return runCatching {
             PaymentConfiguration.getInstance(
                 appContext
@@ -88,7 +90,7 @@ class DefaultCardAccountRangeRepositoryFactory(
                     ApiRequest.Options(
                         publishableKey
                     ),
-                    DefaultCardAccountRangeStore(appContext),
+                    store,
                     DefaultAnalyticsRequestExecutor(),
                     PaymentAnalyticsRequestFactory(appContext, publishableKey)
                 )

--- a/payments-core/src/main/java/com/stripe/android/cards/InMemoryCardAccountRangeStore.kt
+++ b/payments-core/src/main/java/com/stripe/android/cards/InMemoryCardAccountRangeStore.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.cards
+
+import com.stripe.android.model.AccountRange
+
+internal class InMemoryCardAccountRangeStore : CardAccountRangeStore {
+    private val store = mutableMapOf<Bin, List<AccountRange>>()
+
+    override suspend fun get(bin: Bin): List<AccountRange> {
+        return store.getOrElse(bin) {
+            emptyList()
+        }
+    }
+
+    override fun save(bin: Bin, accountRanges: List<AccountRange>) {
+        store[bin] = accountRanges
+    }
+
+    override suspend fun contains(bin: Bin): Boolean {
+        return store.contains(bin)
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/cards/InMemoryCardAccountRangeStoreTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/cards/InMemoryCardAccountRangeStoreTest.kt
@@ -1,0 +1,36 @@
+package com.stripe.android.cards
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.BinFixtures
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class InMemoryCardAccountRangeStoreTest {
+    @Test
+    fun `should be able to retrieve saved account ranges for BIN`() = runTest {
+        val store = InMemoryCardAccountRangeStore()
+
+        store.save(BinFixtures.VISA, listOf(AccountRangeFixtures.VISA))
+
+        assertThat(
+            store.get(BinFixtures.VISA)
+        ).containsExactly(AccountRangeFixtures.VISA)
+    }
+
+    @Test
+    fun `two instances of 'InMemoryCardAccountRangeStore' should maintain their own data`() = runTest {
+        val store1 = InMemoryCardAccountRangeStore()
+        val store2 = InMemoryCardAccountRangeStore()
+
+        store1.save(BinFixtures.VISA, listOf(AccountRangeFixtures.VISA))
+        store2.save(BinFixtures.VISA, listOf(AccountRangeFixtures.UNIONPAY16))
+
+        assertThat(
+            store1.get(BinFixtures.VISA)
+        ).containsExactly(AccountRangeFixtures.VISA)
+
+        assertThat(
+            store2.get(BinFixtures.VISA)
+        ).containsExactly(AccountRangeFixtures.UNIONPAY16)
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
@@ -30,6 +30,23 @@ internal class PaymentSheetPage(
         }
     }
 
+    fun clearCard() {
+        Espresso.onIdle()
+        composeTestRule.waitForIdle()
+
+        waitForText("4242 4242 4242 4242")
+
+        replaceText("4242 4242 4242 4242", "")
+    }
+
+    fun fillCard() {
+        Espresso.onIdle()
+        composeTestRule.waitForIdle()
+
+        waitForText("Card number")
+        replaceText("Card number", "4242424242424242")
+    }
+
     fun fillOutLink() {
         Espresso.onIdle()
         composeTestRule.waitForIdle()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -420,4 +420,52 @@ internal class PaymentSheetTest {
             )
         }
     }
+
+    @Test
+    fun testCardMetadataQueryExecutedOncePerCardSessionForBin() {
+        repeat(2) {
+            runPaymentSheetTest(
+                networkRule = networkRule,
+                integrationType = integrationType,
+                resultCallback = ::assertCompleted,
+            ) { testContext ->
+                networkRule.enqueue(
+                    host("api.stripe.com"),
+                    method("GET"),
+                    path("/v1/elements/sessions"),
+                ) { response ->
+                    response.testBodyFromFile("elements-sessions-requires_payment_method_with_cbc.json")
+                }
+
+                testContext.presentPaymentSheet {
+                    presentWithPaymentIntent(
+                        paymentIntentClientSecret = "pi_example_secret_example",
+                        configuration = null,
+                    )
+                }
+
+                networkRule.enqueue(
+                    method("GET"),
+                    path("edge-internal/card-metadata")
+                ) { response ->
+                    response.testBodyFromFile("card-metadata-get.json")
+                }
+
+                page.fillOutCardDetails()
+                page.clearCard()
+                page.fillCard()
+                page.clearCard()
+                page.fillCard()
+
+                networkRule.enqueue(
+                    method("POST"),
+                    path("/v1/payment_intents/pi_example/confirm")
+                ) { response ->
+                    response.testBodyFromFile("payment-intent-confirm.json")
+                }
+
+                page.clickPrimaryButton()
+            }
+        }
+    }
 }

--- a/paymentsheet/src/androidTest/resources/card-metadata-get.json
+++ b/paymentsheet/src/androidTest/resources/card-metadata-get.json
@@ -1,0 +1,11 @@
+{
+  "data": [
+    {
+      "account_range_high": "4242999999999999",
+      "account_range_low": "4242420000000000",
+      "pan_length": 16,
+      "brand": "VISA",
+      "country": "US"
+    }
+  ]
+}


### PR DESCRIPTION
# Summary
Replace `DefaultCardAccountRangeStore` with `InMemoryCardAccountRangeStore`

# Motivation
Fixes issue with invalid BIN ranges being persisted in disk.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified