### PR TITLE
Remove screen out of wallet state calculation.

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -33,6 +33,7 @@
     <ID>LongMethod:PaymentOptionFactory.kt$PaymentOptionFactory$fun create(selection: PaymentSelection): PaymentOption</ID>
     <ID>LongMethod:PaymentSheetConfigurationKtx.kt$internal fun PaymentSheet.Appearance.parseAppearance()</ID>
     <ID>LongMethod:PaymentSheetLoader.kt$DefaultPaymentSheetLoader$private suspend fun create( elementsSession: ElementsSession, config: PaymentSheet.Configuration, metadata: PaymentMethodMetadata, ): PaymentSheetState.Full</ID>
+    <ID>LongMethod:PaymentSheetScreen.kt$@Composable private fun PaymentSheetContent( viewModel: BaseSheetViewModel, type: PaymentSheetFlowType, headerText: Int?, walletsState: WalletsState?, walletsProcessingState: WalletsProcessingState?, error: String?, currentScreen: PaymentSheetScreen, mandateText: MandateText?, )</ID>
     <ID>LongMethod:PlaceholderHelperTest.kt$PlaceholderHelperTest$@Test fun `Test correct placeholder is removed for placeholder spec`()</ID>
     <ID>LongMethod:USBankAccountEmitters.kt$@Composable internal fun USBankAccountEmitters( viewModel: USBankAccountFormViewModel, usBankAccountFormArgs: USBankAccountFormArguments, )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable internal fun BillingDetailsForm( instantDebits: Boolean, formArgs: FormArguments, isProcessing: Boolean, isPaymentFlow: Boolean, nameController: TextFieldController, emailController: TextFieldController, phoneController: PhoneNumberController, addressController: AddressController, lastTextFieldIdentifier: IdentifierSpec?, sameAsShippingElement: SameAsShippingElement?, )</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -103,8 +103,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
         linkEmailFlow,
         buttonsEnabled,
         supportedPaymentMethodsFlow,
-        backStack,
-    ) { isLinkAvailable, linkEmail, buttonsEnabled, paymentMethodTypes, stack ->
+    ) { isLinkAvailable, linkEmail, buttonsEnabled, paymentMethodTypes ->
         WalletsState.create(
             isLinkAvailable = isLinkAvailable,
             linkEmail = linkEmail,
@@ -113,8 +112,6 @@ internal class PaymentOptionsViewModel @Inject constructor(
             paymentMethodTypes = paymentMethodTypes,
             googlePayLauncherConfig = null,
             googlePayButtonType = GooglePayButtonType.Pay,
-            screen = stack.last(),
-            isCompleteFlow = false,
             onGooglePayPressed = {
                 error("Google Pay shouldn't be enabled in the custom flow.")
             },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -219,8 +219,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         googlePayState,
         buttonsEnabled,
         supportedPaymentMethodsFlow,
-        backStack,
-    ) { isLinkAvailable, linkEmail, googlePayState, buttonsEnabled, paymentMethodTypes, stack ->
+    ) { isLinkAvailable, linkEmail, googlePayState, buttonsEnabled, paymentMethodTypes ->
         WalletsState.create(
             isLinkAvailable = isLinkAvailable,
             linkEmail = linkEmail,
@@ -229,8 +228,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             paymentMethodTypes = paymentMethodTypes,
             googlePayLauncherConfig = googlePayLauncherConfig,
             googlePayButtonType = googlePayButtonType,
-            screen = stack.last(),
-            isCompleteFlow = true,
             onGooglePayPressed = this::checkoutWithGooglePay,
             onLinkPressed = linkHandler::launchLink,
             isSetupIntent = paymentMethodMetadata.value?.stripeIntent is SetupIntent

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/WalletsState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/WalletsState.kt
@@ -7,7 +7,6 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher.Billi
 import com.stripe.android.model.PaymentMethod.Type.Card
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.model.GooglePayButtonType
-import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 
 internal data class WalletsState(
     val link: Link?,
@@ -38,16 +37,10 @@ internal data class WalletsState(
             buttonsEnabled: Boolean,
             paymentMethodTypes: List<String>,
             googlePayLauncherConfig: GooglePayPaymentMethodLauncher.Config?,
-            screen: PaymentSheetScreen,
-            isCompleteFlow: Boolean,
             onGooglePayPressed: () -> Unit,
             onLinkPressed: () -> Unit,
             isSetupIntent: Boolean
         ): WalletsState? {
-            if (!screen.showsWalletsHeader(isCompleteFlow)) {
-                return null
-            }
-
             val link = Link(email = linkEmail).takeIf { isLinkAvailable == true }
 
             val googlePay = GooglePay(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -212,15 +212,17 @@ private fun PaymentSheetContent(
             )
         }
 
-        walletsState?.let { state ->
-            val bottomSpacing = WalletDividerSpacing - currentScreen.topContentPadding
-            Wallet(
-                state = state,
-                processingState = walletsProcessingState,
-                onGooglePayPressed = state.onGooglePayPressed,
-                onLinkPressed = state.onLinkPressed,
-                modifier = Modifier.padding(bottom = bottomSpacing),
-            )
+        if (currentScreen.showsWalletsHeader(type == Complete)) {
+            walletsState?.let { state ->
+                val bottomSpacing = WalletDividerSpacing - currentScreen.topContentPadding
+                Wallet(
+                    state = state,
+                    processingState = walletsProcessingState,
+                    onGooglePayPressed = state.onGooglePayPressed,
+                    onLinkPressed = state.onLinkPressed,
+                    modifier = Modifier.padding(bottom = bottomSpacing),
+                )
+            }
         }
 
         Column(modifier = Modifier.fillMaxWidth()) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I'd like to use this for some internal vertical mode calculations. And having it not controllable by the screen seems to defeat the purpose. 

This should be a pure refactor, with no behavior changes.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2099