### PR TITLE
Handle one saved PM edge cases on vertical mode screen

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -2024,7 +2024,9 @@ public final class com/stripe/android/paymentsheet/ui/SepaMandateResult$Canceled
 public final class com/stripe/android/paymentsheet/verticalmode/ComposableSingletons$PaymentMethodVerticalLayoutUIKt {
 	public static final field INSTANCE Lcom/stripe/android/paymentsheet/verticalmode/ComposableSingletons$PaymentMethodVerticalLayoutUIKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function3;
 	public fun <init> ()V
 	public final fun getLambda-1$paymentsheet_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$paymentsheet_release ()Lkotlin/jvm/functions/Function3;
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -137,12 +137,27 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
             return PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE
         }
 
-        return if (paymentMethods.size > 1) {
-            return PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL
-        } else if (paymentMethods.size == 1 && allowsRemovalOfLastSavedPaymentMethod) {
-            return PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ONE
-        } else if (paymentMethods.size == 1 && savedPaymentMethod.isModifiable()) {
-            return PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.EDIT_CARD_BRAND
+        return when (paymentMethods.size) {
+            0 -> PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE
+            1 -> {
+                getSavedPaymentMethodActionForOnePaymentMethod(
+                    savedPaymentMethod,
+                    allowsRemovalOfLastSavedPaymentMethod
+                )
+            }
+            else ->
+                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL
+        }
+    }
+
+    private fun getSavedPaymentMethodActionForOnePaymentMethod(
+        paymentMethod: DisplayableSavedPaymentMethod,
+        allowsRemovalOfLastSavedPaymentMethod: Boolean
+    ): PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction {
+        return if (allowsRemovalOfLastSavedPaymentMethod) {
+            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ONE
+        } else if (paymentMethod.isModifiable()) {
+            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.EDIT_CARD_BRAND
         } else {
             PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -149,6 +149,27 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     }
 
     override fun handleViewAction(viewAction: ViewAction) {
+    private fun getAvailableSavedPaymentMethodAction(
+        paymentMethods: List<PaymentMethod>?,
+        savedPaymentMethod: DisplayableSavedPaymentMethod?,
+        allowsRemovalOfLastSavedPaymentMethod: Boolean,
+    ): PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction {
+        if (paymentMethods == null || savedPaymentMethod == null) {
+            return PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE
+        }
+
+        return if (paymentMethods.size > 1) {
+            return PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL
+        } else if (paymentMethods.size == 1 && allowsRemovalOfLastSavedPaymentMethod) {
+            return PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ONE
+        } else if (paymentMethods.size == 1 && savedPaymentMethod.isModifiable()) {
+            return PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.EDIT_CARD_BRAND
+        } else {
+            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE
+        }
+    }
+
+    override fun handleViewAction(viewAction: PaymentMethodVerticalLayoutInteractor.ViewAction) {
         when (viewAction) {
             is ViewAction.PaymentMethodSelected -> {
                 if (requiresFormScreen(viewAction.selectedPaymentMethodCode)) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -149,27 +149,6 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     }
 
     override fun handleViewAction(viewAction: ViewAction) {
-    private fun getAvailableSavedPaymentMethodAction(
-        paymentMethods: List<PaymentMethod>?,
-        savedPaymentMethod: DisplayableSavedPaymentMethod?,
-        allowsRemovalOfLastSavedPaymentMethod: Boolean,
-    ): PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction {
-        if (paymentMethods == null || savedPaymentMethod == null) {
-            return PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE
-        }
-
-        return if (paymentMethods.size > 1) {
-            return PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL
-        } else if (paymentMethods.size == 1 && allowsRemovalOfLastSavedPaymentMethod) {
-            return PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ONE
-        } else if (paymentMethods.size == 1 && savedPaymentMethod.isModifiable()) {
-            return PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.EDIT_CARD_BRAND
-        } else {
-            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE
-        }
-    }
-
-    override fun handleViewAction(viewAction: PaymentMethodVerticalLayoutInteractor.ViewAction) {
         when (viewAction) {
             is ViewAction.PaymentMethodSelected -> {
                 if (requiresFormScreen(viewAction.selectedPaymentMethodCode)) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.verticalmode
 
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
@@ -7,7 +8,6 @@ import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
-import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor.ViewAction
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.utils.combineAsStateFlow
@@ -19,7 +19,7 @@ internal interface PaymentMethodVerticalLayoutInteractor {
     fun handleViewAction(viewAction: ViewAction)
 
     data class State(
-        val displayablePaymentMethods: List<DisplayablePaymentMethod>,
+        val supportedPaymentMethods: List<SupportedPaymentMethod>,
         val isProcessing: Boolean,
         val selection: PaymentSelection?,
         val displayedSavedPaymentMethod: DisplayableSavedPaymentMethod?,
@@ -99,7 +99,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         )
 
         PaymentMethodVerticalLayoutInteractor.State(
-            displayablePaymentMethods = getDisplayablePaymentMethods(),
+            supportedPaymentMethods = supportedPaymentMethods,
             isProcessing = isProcessing,
             selection = selection,
             displayedSavedPaymentMethod = displayedSavedPaymentMethod,
@@ -109,14 +109,6 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                 allowsRemovalOfLastSavedPaymentMethod
             )
         )
-    }
-
-    private fun getDisplayablePaymentMethods(): List<DisplayablePaymentMethod> {
-        return supportedPaymentMethods.map { supportedPaymentMethod ->
-            supportedPaymentMethod.asDisplayablePaymentMethod {
-                handleViewAction(ViewAction.PaymentMethodSelected(supportedPaymentMethod.code))
-            }
-        }
     }
 
     private fun getDisplayedSavedPaymentMethod(
@@ -148,19 +140,19 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         }
     }
 
-    override fun handleViewAction(viewAction: ViewAction) {
+    override fun handleViewAction(viewAction: PaymentMethodVerticalLayoutInteractor.ViewAction) {
         when (viewAction) {
-            is ViewAction.PaymentMethodSelected -> {
+            is PaymentMethodVerticalLayoutInteractor.ViewAction.PaymentMethodSelected -> {
                 if (requiresFormScreen(viewAction.selectedPaymentMethodCode)) {
                     transitionTo(formScreenFactory(viewAction.selectedPaymentMethodCode))
                 } else {
                     updateSelectedPaymentMethod(viewAction.selectedPaymentMethodCode)
                 }
             }
-            ViewAction.TransitionToManageSavedPaymentMethods -> {
+            PaymentMethodVerticalLayoutInteractor.ViewAction.TransitionToManageSavedPaymentMethods -> {
                 transitionTo(manageScreenFactory())
             }
-            is ViewAction.EditPaymentMethod -> {
+            is PaymentMethodVerticalLayoutInteractor.ViewAction.EditPaymentMethod -> {
                 onEditPaymentMethod(viewAction.savedPaymentMethod)
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -83,7 +83,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         mostRecentlySelectedSavedPaymentMethod = viewModel.mostRecentlySelectedSavedPaymentMethod,
         providePaymentMethodName = viewModel::providePaymentMethodName,
         allowsRemovalOfLastSavedPaymentMethod = viewModel.config.allowsRemovalOfLastSavedPaymentMethod,
-        onEditPaymentMethod = { viewModel.modifyPaymentMethod(it.paymentMethod) }
+        onEditPaymentMethod = { viewModel.modifyPaymentMethod(it.paymentMethod) },
         onSelectSavedPaymentMethod = {
             viewModel.handlePaymentMethodSelected(PaymentSelection.Saved(it))
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.verticalmode
 
-import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
@@ -8,6 +7,7 @@ import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
+import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor.ViewAction
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.utils.combineAsStateFlow
@@ -19,7 +19,7 @@ internal interface PaymentMethodVerticalLayoutInteractor {
     fun handleViewAction(viewAction: ViewAction)
 
     data class State(
-        val supportedPaymentMethods: List<SupportedPaymentMethod>,
+        val displayablePaymentMethods: List<DisplayablePaymentMethod>,
         val isProcessing: Boolean,
         val selection: PaymentSelection?,
         val displayedSavedPaymentMethod: DisplayableSavedPaymentMethod?,
@@ -99,7 +99,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         )
 
         PaymentMethodVerticalLayoutInteractor.State(
-            supportedPaymentMethods = supportedPaymentMethods,
+            displayablePaymentMethods = getDisplayablePaymentMethods(),
             isProcessing = isProcessing,
             selection = selection,
             displayedSavedPaymentMethod = displayedSavedPaymentMethod,
@@ -109,6 +109,14 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                 allowsRemovalOfLastSavedPaymentMethod
             )
         )
+    }
+
+    private fun getDisplayablePaymentMethods(): List<DisplayablePaymentMethod> {
+        return supportedPaymentMethods.map { supportedPaymentMethod ->
+            supportedPaymentMethod.asDisplayablePaymentMethod {
+                handleViewAction(ViewAction.PaymentMethodSelected(supportedPaymentMethod.code))
+            }
+        }
     }
 
     private fun getDisplayedSavedPaymentMethod(
@@ -140,19 +148,19 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         }
     }
 
-    override fun handleViewAction(viewAction: PaymentMethodVerticalLayoutInteractor.ViewAction) {
+    override fun handleViewAction(viewAction: ViewAction) {
         when (viewAction) {
-            is PaymentMethodVerticalLayoutInteractor.ViewAction.PaymentMethodSelected -> {
+            is ViewAction.PaymentMethodSelected -> {
                 if (requiresFormScreen(viewAction.selectedPaymentMethodCode)) {
                     transitionTo(formScreenFactory(viewAction.selectedPaymentMethodCode))
                 } else {
                     updateSelectedPaymentMethod(viewAction.selectedPaymentMethodCode)
                 }
             }
-            PaymentMethodVerticalLayoutInteractor.ViewAction.TransitionToManageSavedPaymentMethods -> {
+            ViewAction.TransitionToManageSavedPaymentMethods -> {
                 transitionTo(manageScreenFactory())
             }
-            is PaymentMethodVerticalLayoutInteractor.ViewAction.EditPaymentMethod -> {
+            is ViewAction.EditPaymentMethod -> {
                 onEditPaymentMethod(viewAction.savedPaymentMethod)
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.analytics.code
@@ -43,7 +42,7 @@ internal fun PaymentMethodVerticalLayoutUI(interactor: PaymentMethodVerticalLayo
     val state by interactor.state.collectAsState()
 
     PaymentMethodVerticalLayoutUI(
-        paymentMethods = state.supportedPaymentMethods,
+        paymentMethods = state.displayablePaymentMethods,
         displayedSavedPaymentMethod = state.displayedSavedPaymentMethod,
         savedPaymentMethodAction = state.availableSavedPaymentMethodAction,
         selection = state.selection,
@@ -58,9 +57,6 @@ internal fun PaymentMethodVerticalLayoutUI(interactor: PaymentMethodVerticalLayo
                 PaymentMethodVerticalLayoutInteractor.ViewAction.EditPaymentMethod(it)
             )
         },
-        onItemSelectedListener = {
-            interactor.handleViewAction(PaymentMethodVerticalLayoutInteractor.ViewAction.PaymentMethodSelected(it.code))
-        },
         imageLoader = imageLoader,
         modifier = Modifier.padding(horizontal = 20.dp)
     )
@@ -69,14 +65,13 @@ internal fun PaymentMethodVerticalLayoutUI(interactor: PaymentMethodVerticalLayo
 @VisibleForTesting
 @Composable
 internal fun PaymentMethodVerticalLayoutUI(
-    paymentMethods: List<SupportedPaymentMethod>,
+    paymentMethods: List<DisplayablePaymentMethod>,
     displayedSavedPaymentMethod: DisplayableSavedPaymentMethod?,
     savedPaymentMethodAction: PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction,
     selection: PaymentSelection?,
     isEnabled: Boolean,
     onViewMorePaymentMethods: () -> Unit,
     onEditPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
-    onItemSelectedListener: (SupportedPaymentMethod) -> Unit,
     imageLoader: StripeImageLoader,
     modifier: Modifier = Modifier,
 ) {
@@ -116,7 +111,6 @@ internal fun PaymentMethodVerticalLayoutUI(
             paymentMethods = paymentMethods,
             selectedIndex = selectedIndex,
             isEnabled = isEnabled,
-            onItemSelectedListener = onItemSelectedListener,
             imageLoader = imageLoader
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
@@ -55,6 +55,8 @@ internal fun PaymentMethodVerticalLayoutUI(interactor: PaymentMethodVerticalLayo
         onEditPaymentMethod = {
             interactor.handleViewAction(
                 PaymentMethodVerticalLayoutInteractor.ViewAction.EditPaymentMethod(it)
+            )
+        },
         onSelectSavedPaymentMethod = {
             interactor.handleViewAction(
                 PaymentMethodVerticalLayoutInteractor.ViewAction.SavedPaymentMethodSelected(it.paymentMethod)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.analytics.code
@@ -42,7 +43,7 @@ internal fun PaymentMethodVerticalLayoutUI(interactor: PaymentMethodVerticalLayo
     val state by interactor.state.collectAsState()
 
     PaymentMethodVerticalLayoutUI(
-        paymentMethods = state.displayablePaymentMethods,
+        paymentMethods = state.supportedPaymentMethods,
         displayedSavedPaymentMethod = state.displayedSavedPaymentMethod,
         savedPaymentMethodAction = state.availableSavedPaymentMethodAction,
         selection = state.selection,
@@ -57,6 +58,9 @@ internal fun PaymentMethodVerticalLayoutUI(interactor: PaymentMethodVerticalLayo
                 PaymentMethodVerticalLayoutInteractor.ViewAction.EditPaymentMethod(it)
             )
         },
+        onItemSelectedListener = {
+            interactor.handleViewAction(PaymentMethodVerticalLayoutInteractor.ViewAction.PaymentMethodSelected(it.code))
+        },
         imageLoader = imageLoader,
         modifier = Modifier.padding(horizontal = 20.dp)
     )
@@ -65,13 +69,14 @@ internal fun PaymentMethodVerticalLayoutUI(interactor: PaymentMethodVerticalLayo
 @VisibleForTesting
 @Composable
 internal fun PaymentMethodVerticalLayoutUI(
-    paymentMethods: List<DisplayablePaymentMethod>,
+    paymentMethods: List<SupportedPaymentMethod>,
     displayedSavedPaymentMethod: DisplayableSavedPaymentMethod?,
     savedPaymentMethodAction: PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction,
     selection: PaymentSelection?,
     isEnabled: Boolean,
     onViewMorePaymentMethods: () -> Unit,
     onEditPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
+    onItemSelectedListener: (SupportedPaymentMethod) -> Unit,
     imageLoader: StripeImageLoader,
     modifier: Modifier = Modifier,
 ) {
@@ -111,6 +116,7 @@ internal fun PaymentMethodVerticalLayoutUI(
             paymentMethods = paymentMethods,
             selectedIndex = selectedIndex,
             isEnabled = isEnabled,
+            onItemSelectedListener = onItemSelectedListener,
             imageLoader = imageLoader
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -605,6 +605,14 @@ internal abstract class BaseSheetViewModel(
             }
         )
 
+        if (mostRecentlySelectedSavedPaymentMethod.value?.id == paymentMethodId) {
+            savedStateHandle[SAVED_PM_SELECTION] = null
+        }
+
+        if ((selection.value as? PaymentSelection.Saved)?.paymentMethod?.id == paymentMethodId) {
+            savedStateHandle[SAVE_SELECTION] = null
+        }
+
         val shouldResetToAddPaymentMethodForm = paymentMethods.value.isNullOrEmpty() &&
             currentScreen.value is PaymentSheetScreen.SelectSavedPaymentMethods
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -99,7 +99,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
-    fun `state has manage_one saved payment method action when one modifiable saved PM and allowsRemovalOfLast is true`() {
+    fun `state has manage_one SPM action when one modifiable saved PM and allowsRemovalOfLast is true`() {
         runScenario(
             initialPaymentMethods = listOf(PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD),
             allowsRemovalOfLastSavedPaymentMethod = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -99,7 +99,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
-    fun `state has manage_one saved payment method action when one modifiable saved PM and allowsRemovalOfLast is true`() {
+    fun `state has manage_one saved PM action when one modifiable saved PM and allowsRemovalOfLast is true`() {
         runScenario(
             initialPaymentMethods = listOf(PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD),
             allowsRemovalOfLastSavedPaymentMethod = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -99,7 +99,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
-    fun `state has manage_one SPM action when one modifiable saved PM and allowsRemovalOfLast is true`() {
+    fun `state has manage_one saved payment method action when one modifiable saved PM and allowsRemovalOfLast is true`() {
         runScenario(
             initialPaymentMethods = listOf(PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD),
             allowsRemovalOfLastSavedPaymentMethod = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -9,11 +9,13 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.analytics.code
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor.ViewAction
+import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.uicore.elements.FormElement
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -76,6 +78,86 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             awaitItem().run {
                 assertThat(displayablePaymentMethods).isNotEmpty()
                 assertThat(selection).isEqualTo(savedSelection)
+            }
+        }
+    }
+
+    @Test
+    fun `state has manage_all saved payment method action when multiple saved PMs are available`() {
+        runScenario(
+            initialPaymentMethods = PaymentMethodFixtures.createCards(3),
+            allowsRemovalOfLastSavedPaymentMethod = false,
+        ) {
+            interactor.state.test {
+                awaitItem().run {
+                    assertThat(availableSavedPaymentMethodAction).isEqualTo(
+                        PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `state has manage_one saved payment method action when one modifiable saved PM and allowsRemovalOfLast is true`() {
+        runScenario(
+            initialPaymentMethods = listOf(PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD),
+            allowsRemovalOfLastSavedPaymentMethod = true,
+        ) {
+            interactor.state.test {
+                awaitItem().run {
+                    assertThat(availableSavedPaymentMethodAction).isEqualTo(
+                        PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ONE
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `state has manage_one saved payment method action when one saved PM and allowsRemovalOfLast is true`() {
+        runScenario(
+            initialPaymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            allowsRemovalOfLastSavedPaymentMethod = true,
+        ) {
+            interactor.state.test {
+                awaitItem().run {
+                    assertThat(availableSavedPaymentMethodAction).isEqualTo(
+                        PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ONE
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `state has edit card brand saved payment method action when one saved PM and allowsRemovalOfLast is false`() {
+        runScenario(
+            initialPaymentMethods = listOf(PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD),
+            allowsRemovalOfLastSavedPaymentMethod = false,
+        ) {
+            interactor.state.test {
+                awaitItem().run {
+                    assertThat(availableSavedPaymentMethodAction).isEqualTo(
+                        PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.EDIT_CARD_BRAND
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `state has no saved payment method action when one unmodifiable saved PM and allowsRemovalOfLast is false`() {
+        runScenario(
+            initialPaymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            allowsRemovalOfLastSavedPaymentMethod = false,
+        ) {
+            interactor.state.test {
+                awaitItem().run {
+                    assertThat(availableSavedPaymentMethodAction).isEqualTo(
+                        PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE
+                    )
+                }
             }
         }
     }
@@ -317,7 +399,12 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     private val notImplemented: () -> Nothing = { throw AssertionError("Not implemented") }
 
     private fun runScenario(
-        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            cbcEligibility = CardBrandChoiceEligibility.create(
+                isEligible = true,
+                preferredNetworks = emptyList()
+            )
+        ),
         initialProcessing: Boolean = false,
         initialSelection: PaymentSelection? = null,
         formElementsForCode: (code: String) -> List<FormElement> = { notImplemented() },
@@ -329,6 +416,8 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         formScreenFactory: (selectedPaymentMethodCode: String) -> PaymentSheetScreen = { notImplemented() },
         initialPaymentMethods: List<PaymentMethod>? = null,
         initialMostRecentlySelectedSavedPaymentMethod: PaymentMethod? = null,
+        allowsRemovalOfLastSavedPaymentMethod: Boolean = true,
+        onEditPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit = { notImplemented() },
         testBlock: suspend TestParams.() -> Unit
     ) {
         val processing: MutableStateFlow<Boolean> = MutableStateFlow(initialProcessing)
@@ -348,7 +437,9 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             formScreenFactory = formScreenFactory,
             paymentMethods = paymentMethods,
             mostRecentlySelectedSavedPaymentMethod = mostRecentlySelectedSavedPaymentMethod,
-            providePaymentMethodName = { it!! }
+            providePaymentMethodName = { it!! },
+            allowsRemovalOfLastSavedPaymentMethod = allowsRemovalOfLastSavedPaymentMethod,
+            onEditPaymentMethod = onEditPaymentMethod,
         )
 
         TestParams(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUIScreenshotTest.kt
@@ -25,8 +25,11 @@ internal class PaymentMethodVerticalLayoutUIScreenshotTest {
             PaymentMethodVerticalLayoutUI(
                 paymentMethods = paymentMethods,
                 displayedSavedPaymentMethod = savedPaymentMethod,
+                savedPaymentMethodAction =
+                    PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
                 selection = PaymentSelection.Saved(savedPaymentMethod.paymentMethod),
                 isEnabled = true,
+                onEditPaymentMethod = {},
                 onViewMorePaymentMethods = {},
                 imageLoader = mock(),
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUIScreenshotTest.kt
@@ -26,7 +26,7 @@ internal class PaymentMethodVerticalLayoutUIScreenshotTest {
                 paymentMethods = paymentMethods,
                 displayedSavedPaymentMethod = savedPaymentMethod,
                 savedPaymentMethodAction =
-                    PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
+                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
                 selection = PaymentSelection.Saved(savedPaymentMethod.paymentMethod),
                 isEnabled = true,
                 onEditPaymentMethod = {},

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUIScreenshotTest.kt
@@ -26,7 +26,7 @@ internal class PaymentMethodVerticalLayoutUIScreenshotTest {
                 paymentMethods = paymentMethods,
                 displayedSavedPaymentMethod = savedPaymentMethod,
                 savedPaymentMethodAction =
-                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
+                    PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
                 selection = PaymentSelection.Saved(savedPaymentMethod.paymentMethod),
                 isEnabled = true,
                 onEditPaymentMethod = {},

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
@@ -35,7 +35,7 @@ internal class PaymentMethodVerticalLayoutUITest {
     @Test
     fun clickingOnViewMore_transitionsToManageScreen() = runScenario(
         PaymentMethodVerticalLayoutInteractor.State(
-            supportedPaymentMethods = emptyList(),
+            displayablePaymentMethods = emptyList(),
             isProcessing = false,
             selection = null,
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
@@ -111,31 +111,34 @@ internal class PaymentMethodVerticalLayoutUITest {
     }
 
     @Test
-    fun clickingOnNewPaymentMethod_transitionsToForm() = runScenario(
-        PaymentMethodVerticalLayoutInteractor.State(
-            supportedPaymentMethods = listOf(
-                CardDefinition.uiDefinitionFactory().supportedPaymentMethod(CardDefinition, emptyList())!!,
-            ),
-            isProcessing = false,
-            selection = null,
-            displayedSavedPaymentMethod = null,
-            availableSavedPaymentMethodAction = PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE,
-        )
-    ) {
-        assertThat(viewActionRecorder.viewActions).isEmpty()
-        composeRule.onNodeWithTag(TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON + "_card").performClick()
-        viewActionRecorder.consume(PaymentMethodVerticalLayoutInteractor.ViewAction.PaymentMethodSelected("card"))
-        assertThat(viewActionRecorder.viewActions).isEmpty()
+    fun clickingOnNewPaymentMethod_callsOnClick() {
+        var onClickCalled = false
+        runScenario(
+            PaymentMethodVerticalLayoutInteractor.State(
+                displayablePaymentMethods = listOf(
+                    CardDefinition.uiDefinitionFactory().supportedPaymentMethod(CardDefinition, emptyList())!!
+                        .asDisplayablePaymentMethod { onClickCalled = true },
+                ),
+                isProcessing = false,
+                selection = null,
+                displayedSavedPaymentMethod = null,
+            )
+        ) {
+            assertThat(onClickCalled).isFalse()
+            composeRule.onNodeWithTag(TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON + "_card").performClick()
+            assertThat(onClickCalled).isTrue()
+            assertThat(viewActionRecorder.viewActions).isEmpty()
+        }
     }
 
     @Test
     fun allPaymentMethodsAreShown() = runScenario(
         PaymentMethodVerticalLayoutInteractor.State(
-            supportedPaymentMethods = PaymentMethodMetadataFactory.create(
+            displayablePaymentMethods = PaymentMethodMetadataFactory.create(
                 PaymentIntentFixtures.PI_WITH_PAYMENT_METHOD!!.copy(
                     paymentMethodTypes = listOf("card", "cashapp", "klarna")
                 )
-            ).sortedSupportedPaymentMethods(),
+            ).sortedSupportedPaymentMethods().map { it.asDisplayablePaymentMethod { } },
             isProcessing = false,
             selection = null,
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
@@ -160,11 +163,11 @@ internal class PaymentMethodVerticalLayoutUITest {
     @Test
     fun savedPaymentMethodIsSelected_whenSelectionIsSavedPm() = runScenario(
         PaymentMethodVerticalLayoutInteractor.State(
-            supportedPaymentMethods = PaymentMethodMetadataFactory.create(
+            displayablePaymentMethods = PaymentMethodMetadataFactory.create(
                 PaymentIntentFixtures.PI_WITH_PAYMENT_METHOD!!.copy(
                     paymentMethodTypes = listOf("card", "cashapp", "klarna")
                 )
-            ).sortedSupportedPaymentMethods(),
+            ).sortedSupportedPaymentMethods().map { it.asDisplayablePaymentMethod { } },
             isProcessing = false,
             selection = PaymentSelection.Saved(PaymentMethodFixtures.displayableCard().paymentMethod),
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
@@ -205,7 +208,7 @@ internal class PaymentMethodVerticalLayoutUITest {
         )
         runScenario(
             PaymentMethodVerticalLayoutInteractor.State(
-                supportedPaymentMethods = supportedPaymentMethods,
+                displayablePaymentMethods = supportedPaymentMethods.map { it.asDisplayablePaymentMethod { } },
                 isProcessing = false,
                 selection = selection,
                 displayedSavedPaymentMethod = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
@@ -40,7 +40,7 @@ internal class PaymentMethodVerticalLayoutUITest {
             selection = null,
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
             availableSavedPaymentMethodAction =
-                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
+            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
         )
     ) {
         assertThat(viewActionRecorder.viewActions).isEmpty()
@@ -54,12 +54,12 @@ internal class PaymentMethodVerticalLayoutUITest {
     @Test
     fun oneSavedPm_canBeRemoved_buttonIsEdit_transitionsToManageScreen() = runScenario(
         PaymentMethodVerticalLayoutInteractor.State(
-            supportedPaymentMethods = emptyList(),
+            displayablePaymentMethods = emptyList(),
             isProcessing = false,
             selection = null,
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
             availableSavedPaymentMethodAction =
-                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ONE,
+            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ONE,
         )
     ) {
         assertThat(viewActionRecorder.viewActions).isEmpty()
@@ -73,12 +73,12 @@ internal class PaymentMethodVerticalLayoutUITest {
     @Test
     fun oneSavedPm_canBeModified_buttonIsEdit_editsPaymentMethod() = runScenario(
         PaymentMethodVerticalLayoutInteractor.State(
-            supportedPaymentMethods = emptyList(),
+            displayablePaymentMethods = emptyList(),
             isProcessing = false,
             selection = null,
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
             availableSavedPaymentMethodAction =
-                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.EDIT_CARD_BRAND,
+            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.EDIT_CARD_BRAND,
         )
     ) {
         assertThat(viewActionRecorder.viewActions).isEmpty()
@@ -94,12 +94,12 @@ internal class PaymentMethodVerticalLayoutUITest {
     @Test
     fun oneSavedPm_cannotBeEdited_noSavedPaymentMethodButton() = runScenario(
         PaymentMethodVerticalLayoutInteractor.State(
-            supportedPaymentMethods = emptyList(),
+            displayablePaymentMethods = emptyList(),
             isProcessing = false,
             selection = null,
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
             availableSavedPaymentMethodAction =
-                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE,
+            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE,
         )
     ) {
         composeRule.onNodeWithTag(
@@ -122,6 +122,7 @@ internal class PaymentMethodVerticalLayoutUITest {
                 isProcessing = false,
                 selection = null,
                 displayedSavedPaymentMethod = null,
+                availableSavedPaymentMethodAction = PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
             )
         ) {
             assertThat(onClickCalled).isFalse()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
@@ -59,7 +59,7 @@ internal class PaymentMethodVerticalLayoutUITest {
             selection = null,
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
             availableSavedPaymentMethodAction =
-            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ONE,
+                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ONE,
         )
     ) {
         assertThat(viewActionRecorder.viewActions).isEmpty()
@@ -78,7 +78,7 @@ internal class PaymentMethodVerticalLayoutUITest {
             selection = null,
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
             availableSavedPaymentMethodAction =
-            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.EDIT_CARD_BRAND,
+                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.EDIT_CARD_BRAND,
         )
     ) {
         assertThat(viewActionRecorder.viewActions).isEmpty()
@@ -99,7 +99,7 @@ internal class PaymentMethodVerticalLayoutUITest {
             selection = null,
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
             availableSavedPaymentMethodAction =
-            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE,
+                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE,
         )
     ) {
         composeRule.onNodeWithTag(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
@@ -142,6 +142,7 @@ internal class PaymentMethodVerticalLayoutUITest {
                 isProcessing = false,
                 selection = null,
                 displayedSavedPaymentMethod = savedPaymentMethod,
+                availableSavedPaymentMethodAction = PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE,
             )
         ) {
             assertThat(viewActionRecorder.viewActions).isEmpty()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
@@ -122,7 +122,8 @@ internal class PaymentMethodVerticalLayoutUITest {
                 isProcessing = false,
                 selection = null,
                 displayedSavedPaymentMethod = null,
-                availableSavedPaymentMethodAction = PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
+                availableSavedPaymentMethodAction =
+                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
             )
         ) {
             assertThat(onClickCalled).isFalse()
@@ -143,7 +144,8 @@ internal class PaymentMethodVerticalLayoutUITest {
             isProcessing = false,
             selection = null,
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
-            availableSavedPaymentMethodAction = PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
+            availableSavedPaymentMethodAction =
+            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
         )
     ) {
         assertThat(
@@ -171,7 +173,8 @@ internal class PaymentMethodVerticalLayoutUITest {
             isProcessing = false,
             selection = PaymentSelection.Saved(PaymentMethodFixtures.displayableCard().paymentMethod),
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
-            availableSavedPaymentMethodAction = PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
+            availableSavedPaymentMethodAction =
+            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
         )
     ) {
         composeRule.onNodeWithTag(
@@ -211,7 +214,8 @@ internal class PaymentMethodVerticalLayoutUITest {
                 isProcessing = false,
                 selection = selection,
                 displayedSavedPaymentMethod = null,
-                availableSavedPaymentMethodAction = PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
+                availableSavedPaymentMethodAction =
+                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
             )
         ) {
             assertThat(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
@@ -40,7 +40,7 @@ internal class PaymentMethodVerticalLayoutUITest {
             selection = null,
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
             availableSavedPaymentMethodAction =
-                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
+            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
         )
     ) {
         assertThat(viewActionRecorder.viewActions).isEmpty()
@@ -59,7 +59,7 @@ internal class PaymentMethodVerticalLayoutUITest {
             selection = null,
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
             availableSavedPaymentMethodAction =
-                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ONE,
+            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ONE,
         )
     ) {
         assertThat(viewActionRecorder.viewActions).isEmpty()
@@ -78,7 +78,7 @@ internal class PaymentMethodVerticalLayoutUITest {
             selection = null,
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
             availableSavedPaymentMethodAction =
-                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.EDIT_CARD_BRAND,
+            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.EDIT_CARD_BRAND,
         )
     ) {
         assertThat(viewActionRecorder.viewActions).isEmpty()
@@ -99,7 +99,7 @@ internal class PaymentMethodVerticalLayoutUITest {
             selection = null,
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
             availableSavedPaymentMethodAction =
-                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE,
+            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE,
         )
     ) {
         composeRule.onNodeWithTag(
@@ -139,7 +139,8 @@ internal class PaymentMethodVerticalLayoutUITest {
             isProcessing = false,
             selection = null,
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
-            availableSavedPaymentMethodAction = PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
+            availableSavedPaymentMethodAction =
+            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
         )
     ) {
         assertThat(
@@ -167,7 +168,8 @@ internal class PaymentMethodVerticalLayoutUITest {
             isProcessing = false,
             selection = PaymentSelection.Saved(PaymentMethodFixtures.displayableCard().paymentMethod),
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
-            availableSavedPaymentMethodAction = PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
+            availableSavedPaymentMethodAction =
+            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
         )
     ) {
         composeRule.onNodeWithTag(
@@ -207,7 +209,8 @@ internal class PaymentMethodVerticalLayoutUITest {
                 isProcessing = false,
                 selection = selection,
                 displayedSavedPaymentMethod = null,
-                availableSavedPaymentMethodAction = PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
+                availableSavedPaymentMethodAction =
+                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
             )
         ) {
             assertThat(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
@@ -35,12 +35,12 @@ internal class PaymentMethodVerticalLayoutUITest {
     @Test
     fun clickingOnViewMore_transitionsToManageScreen() = runScenario(
         PaymentMethodVerticalLayoutInteractor.State(
-            displayablePaymentMethods = emptyList(),
+            supportedPaymentMethods = emptyList(),
             isProcessing = false,
             selection = null,
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
             availableSavedPaymentMethodAction =
-            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
+                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
         )
     ) {
         assertThat(viewActionRecorder.viewActions).isEmpty()
@@ -52,26 +52,6 @@ internal class PaymentMethodVerticalLayoutUITest {
     }
 
     @Test
-    fun clickingOnNewPaymentMethod_callsOnClick() {
-        var onClickCalled = false
-        runScenario(
-            PaymentMethodVerticalLayoutInteractor.State(
-                displayablePaymentMethods = listOf(
-                    CardDefinition.uiDefinitionFactory().supportedPaymentMethod(CardDefinition, emptyList())!!
-                        .asDisplayablePaymentMethod { onClickCalled = true },
-                ),
-                isProcessing = false,
-                selection = null,
-                displayedSavedPaymentMethod = null,
-            )
-        ) {
-            assertThat(onClickCalled).isFalse()
-            composeRule.onNodeWithTag(TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON + "_card").performClick()
-            assertThat(onClickCalled).isTrue()
-            assertThat(viewActionRecorder.viewActions).isEmpty()
-        }
-
-        @Test
     fun oneSavedPm_canBeRemoved_buttonIsEdit_transitionsToManageScreen() = runScenario(
         PaymentMethodVerticalLayoutInteractor.State(
             supportedPaymentMethods = emptyList(),
@@ -131,98 +111,35 @@ internal class PaymentMethodVerticalLayoutUITest {
     }
 
     @Test
-    fun oneSavedPm_canBeRemoved_buttonIsEdit_transitionsToManageScreen() = runScenario(
+    fun clickingOnNewPaymentMethod_transitionsToForm() = runScenario(
         PaymentMethodVerticalLayoutInteractor.State(
-            supportedPaymentMethods = emptyList(),
+            supportedPaymentMethods = listOf(
+                CardDefinition.uiDefinitionFactory().supportedPaymentMethod(CardDefinition, emptyList())!!,
+            ),
             isProcessing = false,
             selection = null,
-            displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
-            availableSavedPaymentMethodAction =
-                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ONE,
+            displayedSavedPaymentMethod = null,
+            availableSavedPaymentMethodAction = PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE,
         )
     ) {
         assertThat(viewActionRecorder.viewActions).isEmpty()
-        composeRule.onNodeWithTag(TEST_TAG_EDIT_SAVED_CARD).performClick()
-        viewActionRecorder.consume(
-            PaymentMethodVerticalLayoutInteractor.ViewAction.TransitionToManageSavedPaymentMethods
-        )
+        composeRule.onNodeWithTag(TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON + "_card").performClick()
+        viewActionRecorder.consume(PaymentMethodVerticalLayoutInteractor.ViewAction.PaymentMethodSelected("card"))
         assertThat(viewActionRecorder.viewActions).isEmpty()
-    }
-
-    @Test
-    fun oneSavedPm_canBeModified_buttonIsEdit_editsPaymentMethod() = runScenario(
-        PaymentMethodVerticalLayoutInteractor.State(
-            supportedPaymentMethods = emptyList(),
-            isProcessing = false,
-            selection = null,
-            displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
-            availableSavedPaymentMethodAction =
-                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.EDIT_CARD_BRAND,
-        )
-    ) {
-        assertThat(viewActionRecorder.viewActions).isEmpty()
-        composeRule.onNodeWithTag(TEST_TAG_EDIT_SAVED_CARD).performClick()
-        viewActionRecorder.consume(
-            PaymentMethodVerticalLayoutInteractor.ViewAction.EditPaymentMethod(
-                PaymentMethodFixtures.displayableCard()
-            )
-        )
-        assertThat(viewActionRecorder.viewActions).isEmpty()
-    }
-
-    @Test
-    fun oneSavedPm_cannotBeEdited_noSavedPaymentMethodButton() = runScenario(
-        PaymentMethodVerticalLayoutInteractor.State(
-            supportedPaymentMethods = emptyList(),
-            isProcessing = false,
-            selection = null,
-            displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
-            availableSavedPaymentMethodAction =
-                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE,
-        )
-    ) {
-        composeRule.onNodeWithTag(
-            TEST_TAG_SAVED_PAYMENT_METHOD_ROW_BUTTON + "_${PaymentMethodFixtures.displayableCard().paymentMethod.id}"
-        ).assertExists()
-
-        composeRule.onNodeWithTag(TEST_TAG_EDIT_SAVED_CARD).assertDoesNotExist()
-        composeRule.onNodeWithTag(TEST_TAG_VIEW_MORE).assertDoesNotExist()
-    }
-
-    @Test
-    fun clickingOnNewPaymentMethod_callsOnClick() {
-        var onClickCalled = false
-        runScenario(
-            PaymentMethodVerticalLayoutInteractor.State(
-                displayablePaymentMethods = listOf(
-                    CardDefinition.uiDefinitionFactory().supportedPaymentMethod(CardDefinition, emptyList())!!
-                        .asDisplayablePaymentMethod { onClickCalled = true },
-                ),
-                isProcessing = false,
-                selection = null,
-                displayedSavedPaymentMethod = null,
-            )
-        ) {
-            assertThat(onClickCalled).isFalse()
-            composeRule.onNodeWithTag(TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON + "_card").performClick()
-            assertThat(onClickCalled).isTrue()
-            assertThat(viewActionRecorder.viewActions).isEmpty()
-        }
     }
 
     @Test
     fun allPaymentMethodsAreShown() = runScenario(
         PaymentMethodVerticalLayoutInteractor.State(
-            displayablePaymentMethods = PaymentMethodMetadataFactory.create(
+            supportedPaymentMethods = PaymentMethodMetadataFactory.create(
                 PaymentIntentFixtures.PI_WITH_PAYMENT_METHOD!!.copy(
                     paymentMethodTypes = listOf("card", "cashapp", "klarna")
                 )
-            ).sortedSupportedPaymentMethods().map { it.asDisplayablePaymentMethod { } },
+            ).sortedSupportedPaymentMethods(),
             isProcessing = false,
             selection = null,
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
-            availableSavedPaymentMethodAction =
-            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
+            availableSavedPaymentMethodAction = PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
         )
     ) {
         assertThat(
@@ -242,11 +159,11 @@ internal class PaymentMethodVerticalLayoutUITest {
     @Test
     fun savedPaymentMethodIsSelected_whenSelectionIsSavedPm() = runScenario(
         PaymentMethodVerticalLayoutInteractor.State(
-            displayablePaymentMethods = PaymentMethodMetadataFactory.create(
+            supportedPaymentMethods = PaymentMethodMetadataFactory.create(
                 PaymentIntentFixtures.PI_WITH_PAYMENT_METHOD!!.copy(
                     paymentMethodTypes = listOf("card", "cashapp", "klarna")
                 )
-            ).sortedSupportedPaymentMethods().map { it.asDisplayablePaymentMethod { } },
+            ).sortedSupportedPaymentMethods(),
             isProcessing = false,
             selection = PaymentSelection.Saved(PaymentMethodFixtures.displayableCard().paymentMethod),
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
@@ -286,12 +203,11 @@ internal class PaymentMethodVerticalLayoutUITest {
         )
         runScenario(
             PaymentMethodVerticalLayoutInteractor.State(
-                displayablePaymentMethods = supportedPaymentMethods.map { it.asDisplayablePaymentMethod { } },
+                supportedPaymentMethods = supportedPaymentMethods,
                 isProcessing = false,
                 selection = selection,
                 displayedSavedPaymentMethod = null,
-                availableSavedPaymentMethodAction =
-                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
+                availableSavedPaymentMethodAction = PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
             )
         ) {
             assertThat(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
@@ -131,6 +131,65 @@ internal class PaymentMethodVerticalLayoutUITest {
     }
 
     @Test
+    fun oneSavedPm_canBeRemoved_buttonIsEdit_transitionsToManageScreen() = runScenario(
+        PaymentMethodVerticalLayoutInteractor.State(
+            supportedPaymentMethods = emptyList(),
+            isProcessing = false,
+            selection = null,
+            displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
+            availableSavedPaymentMethodAction =
+                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ONE,
+        )
+    ) {
+        assertThat(viewActionRecorder.viewActions).isEmpty()
+        composeRule.onNodeWithTag(TEST_TAG_EDIT_SAVED_CARD).performClick()
+        viewActionRecorder.consume(
+            PaymentMethodVerticalLayoutInteractor.ViewAction.TransitionToManageSavedPaymentMethods
+        )
+        assertThat(viewActionRecorder.viewActions).isEmpty()
+    }
+
+    @Test
+    fun oneSavedPm_canBeModified_buttonIsEdit_editsPaymentMethod() = runScenario(
+        PaymentMethodVerticalLayoutInteractor.State(
+            supportedPaymentMethods = emptyList(),
+            isProcessing = false,
+            selection = null,
+            displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
+            availableSavedPaymentMethodAction =
+                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.EDIT_CARD_BRAND,
+        )
+    ) {
+        assertThat(viewActionRecorder.viewActions).isEmpty()
+        composeRule.onNodeWithTag(TEST_TAG_EDIT_SAVED_CARD).performClick()
+        viewActionRecorder.consume(
+            PaymentMethodVerticalLayoutInteractor.ViewAction.EditPaymentMethod(
+                PaymentMethodFixtures.displayableCard()
+            )
+        )
+        assertThat(viewActionRecorder.viewActions).isEmpty()
+    }
+
+    @Test
+    fun oneSavedPm_cannotBeEdited_noSavedPaymentMethodButton() = runScenario(
+        PaymentMethodVerticalLayoutInteractor.State(
+            supportedPaymentMethods = emptyList(),
+            isProcessing = false,
+            selection = null,
+            displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
+            availableSavedPaymentMethodAction =
+                PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE,
+        )
+    ) {
+        composeRule.onNodeWithTag(
+            TEST_TAG_SAVED_PAYMENT_METHOD_ROW_BUTTON + "_${PaymentMethodFixtures.displayableCard().paymentMethod.id}"
+        ).assertExists()
+
+        composeRule.onNodeWithTag(TEST_TAG_EDIT_SAVED_CARD).assertDoesNotExist()
+        composeRule.onNodeWithTag(TEST_TAG_VIEW_MORE).assertDoesNotExist()
+    }
+
+    @Test
     fun clickingOnNewPaymentMethod_callsOnClick() {
         var onClickCalled = false
         runScenario(
@@ -191,8 +250,7 @@ internal class PaymentMethodVerticalLayoutUITest {
             isProcessing = false,
             selection = PaymentSelection.Saved(PaymentMethodFixtures.displayableCard().paymentMethod),
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
-            availableSavedPaymentMethodAction =
-            PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
+            availableSavedPaymentMethodAction = PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
         )
     ) {
         composeRule.onNodeWithTag(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
@@ -35,7 +35,7 @@ internal class PaymentMethodVerticalLayoutUITest {
     @Test
     fun clickingOnViewMore_transitionsToManageScreen() = runScenario(
         PaymentMethodVerticalLayoutInteractor.State(
-            supportedPaymentMethods = emptyList(),
+            displayablePaymentMethods = emptyList(),
             isProcessing = false,
             selection = null,
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
@@ -111,31 +111,34 @@ internal class PaymentMethodVerticalLayoutUITest {
     }
 
     @Test
-    fun clickingOnNewPaymentMethod_transitionsToForm() = runScenario(
-        PaymentMethodVerticalLayoutInteractor.State(
-            supportedPaymentMethods = listOf(
-                CardDefinition.uiDefinitionFactory().supportedPaymentMethod(CardDefinition, emptyList())!!,
-            ),
-            isProcessing = false,
-            selection = null,
-            displayedSavedPaymentMethod = null,
-            availableSavedPaymentMethodAction = PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE,
-        )
-    ) {
-        assertThat(viewActionRecorder.viewActions).isEmpty()
-        composeRule.onNodeWithTag(TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON + "_card").performClick()
-        viewActionRecorder.consume(PaymentMethodVerticalLayoutInteractor.ViewAction.PaymentMethodSelected("card"))
-        assertThat(viewActionRecorder.viewActions).isEmpty()
+    fun clickingOnNewPaymentMethod_callsOnClick() {
+        var onClickCalled = false
+        runScenario(
+            PaymentMethodVerticalLayoutInteractor.State(
+                displayablePaymentMethods = listOf(
+                    CardDefinition.uiDefinitionFactory().supportedPaymentMethod(CardDefinition, emptyList())!!
+                        .asDisplayablePaymentMethod { onClickCalled = true },
+                ),
+                isProcessing = false,
+                selection = null,
+                displayedSavedPaymentMethod = null,
+            )
+        ) {
+            assertThat(onClickCalled).isFalse()
+            composeRule.onNodeWithTag(TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON + "_card").performClick()
+            assertThat(onClickCalled).isTrue()
+            assertThat(viewActionRecorder.viewActions).isEmpty()
+        }
     }
 
     @Test
     fun allPaymentMethodsAreShown() = runScenario(
         PaymentMethodVerticalLayoutInteractor.State(
-            supportedPaymentMethods = PaymentMethodMetadataFactory.create(
+            displayablePaymentMethods = PaymentMethodMetadataFactory.create(
                 PaymentIntentFixtures.PI_WITH_PAYMENT_METHOD!!.copy(
                     paymentMethodTypes = listOf("card", "cashapp", "klarna")
                 )
-            ).sortedSupportedPaymentMethods(),
+            ).sortedSupportedPaymentMethods().map { it.asDisplayablePaymentMethod { } },
             isProcessing = false,
             selection = null,
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
@@ -159,11 +162,11 @@ internal class PaymentMethodVerticalLayoutUITest {
     @Test
     fun savedPaymentMethodIsSelected_whenSelectionIsSavedPm() = runScenario(
         PaymentMethodVerticalLayoutInteractor.State(
-            supportedPaymentMethods = PaymentMethodMetadataFactory.create(
+            displayablePaymentMethods = PaymentMethodMetadataFactory.create(
                 PaymentIntentFixtures.PI_WITH_PAYMENT_METHOD!!.copy(
                     paymentMethodTypes = listOf("card", "cashapp", "klarna")
                 )
-            ).sortedSupportedPaymentMethods(),
+            ).sortedSupportedPaymentMethods().map { it.asDisplayablePaymentMethod { } },
             isProcessing = false,
             selection = PaymentSelection.Saved(PaymentMethodFixtures.displayableCard().paymentMethod),
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
@@ -203,7 +206,7 @@ internal class PaymentMethodVerticalLayoutUITest {
         )
         runScenario(
             PaymentMethodVerticalLayoutInteractor.State(
-                supportedPaymentMethods = supportedPaymentMethods,
+                displayablePaymentMethods = supportedPaymentMethods.map { it.asDisplayablePaymentMethod { } },
                 isProcessing = false,
                 selection = selection,
                 displayedSavedPaymentMethod = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
@@ -52,6 +52,26 @@ internal class PaymentMethodVerticalLayoutUITest {
     }
 
     @Test
+    fun clickingOnNewPaymentMethod_callsOnClick() {
+        var onClickCalled = false
+        runScenario(
+            PaymentMethodVerticalLayoutInteractor.State(
+                displayablePaymentMethods = listOf(
+                    CardDefinition.uiDefinitionFactory().supportedPaymentMethod(CardDefinition, emptyList())!!
+                        .asDisplayablePaymentMethod { onClickCalled = true },
+                ),
+                isProcessing = false,
+                selection = null,
+                displayedSavedPaymentMethod = null,
+            )
+        ) {
+            assertThat(onClickCalled).isFalse()
+            composeRule.onNodeWithTag(TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON + "_card").performClick()
+            assertThat(onClickCalled).isTrue()
+            assertThat(viewActionRecorder.viewActions).isEmpty()
+        }
+
+        @Test
     fun oneSavedPm_canBeRemoved_buttonIsEdit_transitionsToManageScreen() = runScenario(
         PaymentMethodVerticalLayoutInteractor.State(
             supportedPaymentMethods = emptyList(),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Handle one saved PM edge cases on vertical mode screen

Specifically:
- if there's one saved PM that cannot be edited, no button is displayed

https://github.com/stripe/stripe-android/assets/160939932/dbfbcd2c-d3a0-4011-a5a7-50a009e2b971


- if there's one saved PM that cannot be removed but is CBC eligible, we should display an "edit" button and open directly to the edit payment method screen


https://github.com/stripe/stripe-android/assets/160939932/114043dc-dc58-4a78-a6d6-874ce0fc4d11



- if there's one saved PM that can be removed, we should display an "edit" button that opens to the manage screen. The manage screen should also open in edit mode -- I will do that in a follow up 

https://github.com/stripe/stripe-android/assets/160939932/c81d4c2c-09f8-4a63-bdfb-426105385030

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

https://jira.corp.stripe.com/browse/MOBILESDK-2166
https://jira.corp.stripe.com/browse/MOBILESDK-2165

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified