### PR TITLE
Add analytics param for has_instrumentation to cardscan error.

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/StripeCardScanProxy.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/StripeCardScanProxy.kt
@@ -53,12 +53,11 @@ internal interface StripeCardScanProxy {
             },
             isStripeCardScanAvailable: IsStripeCardScanAvailable = DefaultIsStripeCardScanAvailable(),
         ): StripeCardScanProxy {
-            return UnsupportedStripeCardScanProxy(errorReporter)
-//            return if (isStripeCardScanAvailable()) {
-//                provider()
-//            } else {
-//                UnsupportedStripeCardScanProxy(errorReporter)
-//            }
+            return if (isStripeCardScanAvailable()) {
+                provider()
+            } else {
+                UnsupportedStripeCardScanProxy(errorReporter)
+            }
         }
 
         fun removeCardScanFragment(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/StripeCardScanProxy.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/StripeCardScanProxy.kt
@@ -53,11 +53,12 @@ internal interface StripeCardScanProxy {
             },
             isStripeCardScanAvailable: IsStripeCardScanAvailable = DefaultIsStripeCardScanAvailable(),
         ): StripeCardScanProxy {
-            return if (isStripeCardScanAvailable()) {
-                provider()
-            } else {
-                UnsupportedStripeCardScanProxy(errorReporter)
-            }
+            return UnsupportedStripeCardScanProxy(errorReporter)
+//            return if (isStripeCardScanAvailable()) {
+//                provider()
+//            } else {
+//                UnsupportedStripeCardScanProxy(errorReporter)
+//            }
         }
 
         fun removeCardScanFragment(
@@ -96,9 +97,14 @@ internal class UnsupportedStripeCardScanProxy(private val errorReporter: ErrorRe
         if (BuildConfig.DEBUG) {
             throw illegalStateException
         } else {
+            // Instrumentation signals penetration testing.
+            val hasInstrumentation = runCatching {
+                Class.forName("androidx.test.InstrumentationRegistry")
+            }.isSuccess
             errorReporter.report(
                 ErrorReporter.UnexpectedErrorEvent.MISSING_CARDSCAN_DEPENDENCY,
-                StripeException.create(illegalStateException)
+                StripeException.create(illegalStateException),
+                additionalNonPiiParams = mapOf("has_instrumentation" to hasInstrumentation.toString()),
             )
         }
     }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanActivity.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanActivity.kt
@@ -14,19 +14,16 @@ internal class CardScanActivity : AppCompatActivity() {
         StripeActivityCardScanBinding.inflate(layoutInflater)
     }
 
-    private lateinit var stripeCardScanProxy: StripeCardScanProxy
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(viewBinding.root)
 
-        stripeCardScanProxy = StripeCardScanProxy.create(
+        StripeCardScanProxy.create(
             this,
             PaymentConfiguration.getInstance(this).publishableKey,
             this::onScanFinished,
             ErrorReporter.createFallbackInstance(applicationContext, setOf("CardScan"))
-        )
-        stripeCardScanProxy.present()
+        ).present()
     }
 
     private fun onScanFinished(result: CardScanSheetResult) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I'd like to be able to filter out our alerts based on the presence of people trying to penetration test apps.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3226
