### PR TITLE
Select saved payment method when it's clicked in vertical mode

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -28,7 +28,7 @@ internal interface PaymentMethodVerticalLayoutInteractor {
     sealed interface ViewAction {
         data object TransitionToManageSavedPaymentMethods : ViewAction
         data class PaymentMethodSelected(val selectedPaymentMethodCode: String) : ViewAction
-        data class SavedPaymentMethodSelected(val savedPaymentMethod: DisplayableSavedPaymentMethod) : ViewAction
+        data class SavedPaymentMethodSelected(val savedPaymentMethod: PaymentMethod) : ViewAction
     }
 }
 
@@ -44,7 +44,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     paymentMethods: StateFlow<List<PaymentMethod>?>,
     private val mostRecentlySelectedSavedPaymentMethod: StateFlow<PaymentMethod?>,
     private val providePaymentMethodName: (PaymentMethodCode?) -> String,
-    private val onSelectSavedPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
+    private val onSelectSavedPaymentMethod: (PaymentMethod) -> Unit,
 ) : PaymentMethodVerticalLayoutInteractor {
     constructor(viewModel: BaseSheetViewModel) : this(
         paymentMethodMetadata = requireNotNull(viewModel.paymentMethodMetadata.value),
@@ -72,7 +72,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         mostRecentlySelectedSavedPaymentMethod = viewModel.mostRecentlySelectedSavedPaymentMethod,
         providePaymentMethodName = viewModel::providePaymentMethodName,
         onSelectSavedPaymentMethod = {
-            viewModel.handlePaymentMethodSelected(PaymentSelection.Saved(it.paymentMethod))
+            viewModel.handlePaymentMethodSelected(PaymentSelection.Saved(it))
         }
     )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -28,6 +28,7 @@ internal interface PaymentMethodVerticalLayoutInteractor {
     sealed interface ViewAction {
         data object TransitionToManageSavedPaymentMethods : ViewAction
         data class PaymentMethodSelected(val selectedPaymentMethodCode: String) : ViewAction
+        data class SavedPaymentMethodSelected(val savedPaymentMethod: DisplayableSavedPaymentMethod) : ViewAction
     }
 }
 
@@ -43,6 +44,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     paymentMethods: StateFlow<List<PaymentMethod>?>,
     private val mostRecentlySelectedSavedPaymentMethod: StateFlow<PaymentMethod?>,
     private val providePaymentMethodName: (PaymentMethodCode?) -> String,
+    private val onSelectSavedPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
 ) : PaymentMethodVerticalLayoutInteractor {
     constructor(viewModel: BaseSheetViewModel) : this(
         paymentMethodMetadata = requireNotNull(viewModel.paymentMethodMetadata.value),
@@ -69,6 +71,9 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         paymentMethods = viewModel.paymentMethods,
         mostRecentlySelectedSavedPaymentMethod = viewModel.mostRecentlySelectedSavedPaymentMethod,
         providePaymentMethodName = viewModel::providePaymentMethodName,
+        onSelectSavedPaymentMethod = {
+            viewModel.handlePaymentMethodSelected(PaymentSelection.Saved(it.paymentMethod))
+        }
     )
 
     private val supportedPaymentMethods = paymentMethodMetadata.sortedSupportedPaymentMethods()
@@ -116,6 +121,9 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                 } else {
                     updateSelectedPaymentMethod(viewAction.selectedPaymentMethodCode)
                 }
+            }
+            is ViewAction.SavedPaymentMethodSelected -> {
+                onSelectSavedPaymentMethod(viewAction.savedPaymentMethod)
             }
             ViewAction.TransitionToManageSavedPaymentMethods -> {
                 transitionTo(manageScreenFactory())

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
@@ -50,6 +50,11 @@ internal fun PaymentMethodVerticalLayoutUI(interactor: PaymentMethodVerticalLayo
                 PaymentMethodVerticalLayoutInteractor.ViewAction.TransitionToManageSavedPaymentMethods
             )
         },
+        onSelectSavedPaymentMethod = {
+            interactor.handleViewAction(
+                PaymentMethodVerticalLayoutInteractor.ViewAction.SavedPaymentMethodSelected(it)
+            )
+        },
         imageLoader = imageLoader,
         modifier = Modifier.padding(horizontal = 20.dp)
     )
@@ -63,6 +68,7 @@ internal fun PaymentMethodVerticalLayoutUI(
     selection: PaymentSelection?,
     isEnabled: Boolean,
     onViewMorePaymentMethods: () -> Unit,
+    onSelectSavedPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
     imageLoader: StripeImageLoader,
     modifier: Modifier = Modifier,
 ) {
@@ -79,7 +85,8 @@ internal fun PaymentMethodVerticalLayoutUI(
                 isSelected = selection?.isSaved == true,
                 trailingContent = {
                     ViewMoreButton(onViewMorePaymentMethods = onViewMorePaymentMethods)
-                }
+                },
+                onClick = { onSelectSavedPaymentMethod(displayedSavedPaymentMethod) },
             )
             Text(stringResource(id = R.string.stripe_paymentsheet_new_pm), style = textStyle, color = textColor)
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
@@ -52,7 +52,7 @@ internal fun PaymentMethodVerticalLayoutUI(interactor: PaymentMethodVerticalLayo
         },
         onSelectSavedPaymentMethod = {
             interactor.handleViewAction(
-                PaymentMethodVerticalLayoutInteractor.ViewAction.SavedPaymentMethodSelected(it)
+                PaymentMethodVerticalLayoutInteractor.ViewAction.SavedPaymentMethodSelected(it.paymentMethod)
             )
         },
         imageLoader = imageLoader,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.analytics.code
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -314,6 +315,18 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         }
     }
 
+    @Test
+    fun handleViewAction_SelectSavedPaymentMethod_selectsSavedPm() {
+        val savedPaymentMethod = PaymentMethodFixtures.displayableCard()
+        var selectedSavedPaymentMethod: DisplayableSavedPaymentMethod? = null
+        runScenario(
+            onSelectSavedPaymentMethod = { selectedSavedPaymentMethod = it }
+        ) {
+            interactor.handleViewAction(ViewAction.SavedPaymentMethodSelected(savedPaymentMethod))
+            assertThat(selectedSavedPaymentMethod).isEqualTo(savedPaymentMethod)
+        }
+    }
+
     private val notImplemented: () -> Nothing = { throw AssertionError("Not implemented") }
 
     private fun runScenario(
@@ -329,6 +342,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         formScreenFactory: (selectedPaymentMethodCode: String) -> PaymentSheetScreen = { notImplemented() },
         initialPaymentMethods: List<PaymentMethod>? = null,
         initialMostRecentlySelectedSavedPaymentMethod: PaymentMethod? = null,
+        onSelectSavedPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit = { notImplemented() },
         testBlock: suspend TestParams.() -> Unit
     ) {
         val processing: MutableStateFlow<Boolean> = MutableStateFlow(initialProcessing)
@@ -348,7 +362,8 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             formScreenFactory = formScreenFactory,
             paymentMethods = paymentMethods,
             mostRecentlySelectedSavedPaymentMethod = mostRecentlySelectedSavedPaymentMethod,
-            providePaymentMethodName = { it!! }
+            providePaymentMethodName = { it!! },
+            onSelectSavedPaymentMethod = onSelectSavedPaymentMethod,
         )
 
         TestParams(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -9,7 +9,6 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
-import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.analytics.code
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -318,12 +317,12 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     @Test
     fun handleViewAction_SelectSavedPaymentMethod_selectsSavedPm() {
         val savedPaymentMethod = PaymentMethodFixtures.displayableCard()
-        var selectedSavedPaymentMethod: DisplayableSavedPaymentMethod? = null
+        var selectedSavedPaymentMethod: PaymentMethod? = null
         runScenario(
             onSelectSavedPaymentMethod = { selectedSavedPaymentMethod = it }
         ) {
-            interactor.handleViewAction(ViewAction.SavedPaymentMethodSelected(savedPaymentMethod))
-            assertThat(selectedSavedPaymentMethod).isEqualTo(savedPaymentMethod)
+            interactor.handleViewAction(ViewAction.SavedPaymentMethodSelected(savedPaymentMethod.paymentMethod))
+            assertThat(selectedSavedPaymentMethod).isEqualTo(savedPaymentMethod.paymentMethod)
         }
     }
 
@@ -342,7 +341,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         formScreenFactory: (selectedPaymentMethodCode: String) -> PaymentSheetScreen = { notImplemented() },
         initialPaymentMethods: List<PaymentMethod>? = null,
         initialMostRecentlySelectedSavedPaymentMethod: PaymentMethod? = null,
-        onSelectSavedPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit = { notImplemented() },
+        onSelectSavedPaymentMethod: (PaymentMethod) -> Unit = { notImplemented() },
         testBlock: suspend TestParams.() -> Unit
     ) {
         val processing: MutableStateFlow<Boolean> = MutableStateFlow(initialProcessing)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUIScreenshotTest.kt
@@ -28,6 +28,7 @@ internal class PaymentMethodVerticalLayoutUIScreenshotTest {
                 selection = PaymentSelection.Saved(savedPaymentMethod.paymentMethod),
                 isEnabled = true,
                 onViewMorePaymentMethods = {},
+                onSelectSavedPaymentMethod = {},
                 imageLoader = mock(),
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
@@ -87,7 +87,7 @@ internal class PaymentMethodVerticalLayoutUITest {
             ).performClick()
             viewActionRecorder.consume(
                 PaymentMethodVerticalLayoutInteractor.ViewAction.SavedPaymentMethodSelected(
-                    savedPaymentMethod
+                    savedPaymentMethod.paymentMethod
                 )
             )
             assertThat(viewActionRecorder.viewActions).isEmpty()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
@@ -71,6 +71,30 @@ internal class PaymentMethodVerticalLayoutUITest {
     }
 
     @Test
+    fun clickingSavedPaymentMethod_callsSelectSavedPaymentMethod() {
+        val savedPaymentMethod = PaymentMethodFixtures.displayableCard()
+        runScenario(
+            PaymentMethodVerticalLayoutInteractor.State(
+                displayablePaymentMethods = emptyList(),
+                isProcessing = false,
+                selection = null,
+                displayedSavedPaymentMethod = savedPaymentMethod,
+            )
+        ) {
+            assertThat(viewActionRecorder.viewActions).isEmpty()
+            composeRule.onNodeWithTag(
+                TEST_TAG_SAVED_PAYMENT_METHOD_ROW_BUTTON + "_${savedPaymentMethod.paymentMethod.id}"
+            ).performClick()
+            viewActionRecorder.consume(
+                PaymentMethodVerticalLayoutInteractor.ViewAction.SavedPaymentMethodSelected(
+                    savedPaymentMethod
+                )
+            )
+            assertThat(viewActionRecorder.viewActions).isEmpty()
+        }
+    }
+
+    @Test
     fun allPaymentMethodsAreShown() = runScenario(
         PaymentMethodVerticalLayoutInteractor.State(
             displayablePaymentMethods = PaymentMethodMetadataFactory.create(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Select saved payment method when it's clicked in vertical mode

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This is the expected behavior

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screen recording

https://github.com/stripe/stripe-android/assets/160939932/49114e29-ff71-405a-9474-a26389b0e699

The issue with the saved PM not being selected anymore after viewing a form is being tracked in this ticket: https://jira.corp.stripe.com/browse/MOBILESDK-2177
