### PR TITLE
Remove specific java version from lint build.gradle

### DIFF
--- a/lint/build.gradle
+++ b/lint/build.gradle
@@ -7,11 +7,6 @@ apply from: rootProject.file('build-configuration/ktlint.gradle')
 
 check.dependsOn('ktlint')
 
-java {
-    sourceCompatibility JavaVersion.VERSION_17
-    targetCompatibility JavaVersion.VERSION_17
-}
-
 dependencies {
     compileOnly libs.lint
     compileOnly libs.lintChecks


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove specific java version from lint build.gradle

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
I don't think we need this and it makes it so I can't run lint checks locally, since I have java 21 on my computer

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

Manually verified that this fixes my inability to run lint checks locally. CI checks that everything else still works.