### PR TITLE
Add `CustomerSheetDataRepository` interface

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataRepository.kt
@@ -10,7 +10,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
 @OptIn(ExperimentalCustomerSheetApi::class)

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataRepository.kt
@@ -1,0 +1,116 @@
+package com.stripe.android.customersheet.data
+
+import com.stripe.android.core.injection.IOContext
+import com.stripe.android.customersheet.CustomerAdapter
+import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodUpdateParams
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+internal class CustomerAdapterDataRepository(
+    @IOContext private val workContext: CoroutineContext,
+    private val adapter: CustomerAdapter,
+    private val elementsSessionRepository: ElementsSessionRepository,
+) : CustomerSheetDataRepository {
+    override val canCreateSetupIntents: Boolean = adapter.canCreateSetupIntents
+
+    override val paymentMethodTypes: List<String> = adapter.paymentMethodTypes ?: emptyList()
+
+    override suspend fun retrievePaymentMethods(): Result<List<PaymentMethod>> {
+        return adapter.retrievePaymentMethods().toResult()
+    }
+
+    override suspend fun loadCustomerSheetSession(): Result<CustomerSheetSession> = withContext(workContext) {
+        runCatching {
+            val elementsSession = async {
+                retrieveElementsSession()
+            }
+
+            val paymentMethods = async {
+                retrievePaymentMethods()
+            }
+
+            CustomerSheetSession(
+                elementsSession = elementsSession.await().getOrThrow(),
+                paymentMethods = paymentMethods.await().getOrThrow(),
+            )
+        }
+    }
+
+    override suspend fun attachPaymentMethod(paymentMethodId: String) = withContext(workContext) {
+        adapter.attachPaymentMethod(paymentMethodId).toResult()
+    }
+
+    override suspend fun updatePaymentMethod(
+        paymentMethodId: String,
+        params: PaymentMethodUpdateParams
+    ) = withContext(workContext) {
+        adapter.updatePaymentMethod(paymentMethodId, params).toResult()
+    }
+
+    override suspend fun detachPaymentMethod(paymentMethodId: String) = withContext(workContext) {
+        adapter.detachPaymentMethod(paymentMethodId).toResult()
+    }
+
+    override suspend fun retrieveSelectedPaymentOption() = withContext(workContext) {
+        adapter.retrieveSelectedPaymentOption().toResult().map { option ->
+            when (option) {
+                is CustomerAdapter.PaymentOption.GooglePay -> CustomerPaymentOption.GooglePay
+                is CustomerAdapter.PaymentOption.Link -> CustomerPaymentOption.Link
+                is CustomerAdapter.PaymentOption.StripeId -> CustomerPaymentOption.Saved(option.id)
+                null -> CustomerPaymentOption.None
+            }
+        }
+    }
+
+    override suspend fun setSelectedPaymentOption(paymentOption: CustomerPaymentOption) = withContext(workContext) {
+        val adapterOption = when (paymentOption) {
+            is CustomerPaymentOption.GooglePay -> CustomerAdapter.PaymentOption.GooglePay
+            is CustomerPaymentOption.Link -> CustomerAdapter.PaymentOption.Link
+            is CustomerPaymentOption.Saved -> CustomerAdapter.PaymentOption.StripeId(paymentOption.id)
+            is CustomerPaymentOption.None -> null
+        }
+
+        adapter.setSelectedPaymentOption(adapterOption).toResult()
+    }
+
+    override suspend fun retrieveSetupIntentClientSecret() = withContext(workContext) {
+        adapter.setupIntentClientSecretForCustomerAttach().toResult()
+    }
+
+    private suspend fun retrieveElementsSession(): Result<ElementsSession> {
+        val paymentMethodTypes = if (adapter.canCreateSetupIntents) {
+            adapter.paymentMethodTypes ?: emptyList()
+        } else {
+            // We only support cards if `canCreateSetupIntents` is false.
+            listOf("card")
+        }
+
+        val initializationMode = PaymentSheet.InitializationMode.DeferredIntent(
+            PaymentSheet.IntentConfiguration(
+                mode = PaymentSheet.IntentConfiguration.Mode.Setup(),
+                paymentMethodTypes = paymentMethodTypes,
+            )
+        )
+
+        return elementsSessionRepository.get(
+            initializationMode = initializationMode,
+            customer = null,
+            externalPaymentMethods = listOf()
+        )
+    }
+
+    private fun <T> CustomerAdapter.Result<T>.toResult(): Result<T> {
+        return when (this) {
+            is CustomerAdapter.Result.Success -> Result.success(value)
+            is CustomerAdapter.Result.Failure -> Result.failure(cause)
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerPaymentOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerPaymentOption.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.customersheet.data
+
+internal sealed interface CustomerPaymentOption {
+    data object GooglePay : CustomerPaymentOption
+
+    data object Link : CustomerPaymentOption
+
+    data class Saved(val id: String) : CustomerPaymentOption
+
+    data object None : CustomerPaymentOption
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetDataRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetDataRepository.kt
@@ -1,0 +1,87 @@
+package com.stripe.android.customersheet.data
+
+import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodUpdateParams
+
+@ExperimentalCustomerSheetApi
+internal interface CustomerSheetDataRepository {
+    /**
+     * Defines if this repository can create [com.stripe.android.model.SetupIntent] objects. Use this
+     * to determine if [retrieveSetupIntentClientSecret] can be used.
+     */
+    val canCreateSetupIntents: Boolean
+
+    /**
+     * Defines the list of payment method types that can be displayed  to the customer.
+     */
+    val paymentMethodTypes: List<String>
+
+    /**
+     * Retrieves a list of payment methods attached to a customer.
+     *
+     * @return a list of [PaymentMethod] objects
+     */
+    suspend fun retrievePaymentMethods(): Result<List<PaymentMethod>>
+
+    /**
+     * Loads session for [com.stripe.android.customersheet.CustomerSheet]
+     *
+     * @return a [CustomerSheetSession] instance
+     */
+    suspend fun loadCustomerSheetSession(): Result<CustomerSheetSession>
+
+    /**
+     * Attaches a payment method to a customer.
+     *
+     * @param paymentMethodId identifier of the payment method to attach to a customer
+     *
+     * @return the modified [PaymentMethod]
+     */
+    suspend fun attachPaymentMethod(paymentMethodId: String): Result<PaymentMethod>
+
+    /**
+     * Updates a payment method.
+     *
+     * @param paymentMethodId identifier of the payment method to update
+     * @param params The [PaymentMethodUpdateParams] with payment method values to update
+     *
+     * @return The updated [PaymentMethod]
+     */
+    suspend fun updatePaymentMethod(
+        paymentMethodId: String,
+        params: PaymentMethodUpdateParams
+    ): Result<PaymentMethod>
+
+    /**
+     * Detaches the given payment method from a customer.
+     *
+     * @param paymentMethodId, identifier of the payment method to detach from a customer
+     *
+     * @return the detached [PaymentMethod]
+     */
+    suspend fun detachPaymentMethod(paymentMethodId: String): Result<PaymentMethod>
+
+    /**
+     * Retrieve the saved payment method option from a data store.
+     *
+     * @return the saved [CustomerPaymentOption]
+     */
+    suspend fun retrieveSelectedPaymentOption(): Result<CustomerPaymentOption>
+
+    /**
+     * Saves the payment option to a data store.
+     *
+     * @param paymentOption the [CustomerPaymentOption] to save to the data store
+     *
+     * @return success if the [CustomerPaymentOption] was persisted, failure otherwise
+     */
+    suspend fun setSelectedPaymentOption(paymentOption: CustomerPaymentOption): Result<Unit>
+
+    /**
+     * Returns a [com.stripe.android.model.SetupIntent] client secret.
+     *
+     * @return the client secret for the [com.stripe.android.model.SetupIntent].
+     */
+    suspend fun retrieveSetupIntentClientSecret(): Result<String>
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetSession.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.customersheet.data
+
+import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.PaymentMethod
+
+internal data class CustomerSheetSession(
+    val elementsSession: ElementsSession,
+    val paymentMethods: List<PaymentMethod>
+)

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterDataRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterDataRepositoryTest.kt
@@ -1,0 +1,251 @@
+package com.stripe.android.customersheet
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.customersheet.data.CustomerAdapterDataRepository
+import com.stripe.android.customersheet.data.CustomerPaymentOption
+import com.stripe.android.customersheet.data.CustomerSheetSession
+import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.PaymentMethodUpdateParams
+import com.stripe.android.model.SetupIntentFixtures
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
+import com.stripe.android.utils.FakeElementsSessionRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.coroutines.coroutineContext
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+class CustomerAdapterDataRepositoryTest {
+    @Test
+    fun `On 'loadCustomerSession', should call for elements session & payment methods`() = runTest {
+        var calledAdapter = false
+
+        val paymentMethodTypes = listOf("card")
+        val adapter = FakeCustomerAdapter(
+            paymentMethodTypes = paymentMethodTypes,
+            onRetrievePaymentMethods = {
+                calledAdapter = true
+                CustomerAdapter.Result.success(
+                    listOf(
+                        PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                        PaymentMethodFixtures.PAYPAL_PAYMENT_METHOD,
+                    )
+                )
+            },
+        )
+
+        val elementsSessionRepository = FakeElementsSessionRepository(
+            stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            error = null,
+            linkSettings = null,
+        )
+
+        val customerAdapterDataRepository = createCustomerAdapterDataRepository(
+            adapter = adapter,
+            elementsSessionRepository = elementsSessionRepository,
+        )
+
+        val result = customerAdapterDataRepository.loadCustomerSheetSession()
+
+        assertThat(calledAdapter).isTrue()
+        assertThat(elementsSessionRepository.lastParams?.initializationMode).isInstanceOf(
+            PaymentSheet.InitializationMode.DeferredIntent::class.java
+        )
+        assertThat(result.getOrNull()).isEqualTo(
+            CustomerSheetSession(
+                elementsSession = ElementsSession(
+                    stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+                    linkSettings = null,
+                    customer = null,
+                    externalPaymentMethodData = null,
+                    paymentMethodSpecs = null,
+                    merchantCountry = null,
+                    isGooglePayEnabled = true,
+                    isEligibleForCardBrandChoice = false,
+                ),
+                paymentMethods = listOf(
+                    PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                    PaymentMethodFixtures.PAYPAL_PAYMENT_METHOD,
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `On 'retrievePaymentMethods', should call 'CustomerAdapter' for payment methods`() = runTest {
+        var called = false
+
+        val adapter = FakeCustomerAdapter(
+            onRetrievePaymentMethods = {
+                called = true
+                CustomerAdapter.Result.success(
+                    listOf(
+                        PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                        PaymentMethodFixtures.PAYPAL_PAYMENT_METHOD,
+                    )
+                )
+            },
+        )
+
+        val customerAdapterDataRepository = createCustomerAdapterDataRepository(adapter)
+
+        val result = customerAdapterDataRepository.retrievePaymentMethods()
+
+        assertThat(called).isTrue()
+        assertThat(result.getOrNull()).containsExactly(
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            PaymentMethodFixtures.PAYPAL_PAYMENT_METHOD,
+        )
+    }
+
+    @Test
+    fun `On 'attachPaymentMethod', should call 'CustomerAdapter' to attach payment method`() = runTest {
+        var called = false
+        val attachingId = "pm_12341234"
+        val attachedPaymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = attachingId)
+
+        val adapter = FakeCustomerAdapter(
+            onAttachPaymentMethod = {
+                called = true
+                CustomerAdapter.Result.success(attachedPaymentMethod)
+            },
+        )
+
+        val customerAdapterDataRepository = createCustomerAdapterDataRepository(adapter)
+
+        val result = customerAdapterDataRepository.attachPaymentMethod(attachingId)
+
+        assertThat(called).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(attachedPaymentMethod)
+    }
+
+    @Test
+    fun `On 'detachPaymentMethod', should call 'CustomerAdapter' to detach payment method`() = runTest {
+        var called = false
+        val removingId = "pm_12341234"
+        val removedPaymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = removingId)
+
+        val adapter = FakeCustomerAdapter(
+            onDetachPaymentMethod = {
+                called = true
+                CustomerAdapter.Result.success(removedPaymentMethod)
+            },
+        )
+
+        val customerAdapterDataRepository = createCustomerAdapterDataRepository(adapter)
+
+        val result = customerAdapterDataRepository.detachPaymentMethod(removingId)
+
+        assertThat(called).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(removedPaymentMethod)
+    }
+
+    @Test
+    fun `On 'updatePaymentMethod', should call 'CustomerAdapter' to update payment method`() = runTest {
+        var called = false
+        val updatingId = "pm_12341234"
+        val originalPaymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = updatingId)
+        val updatedPaymentMethod = originalPaymentMethod.copy(
+            card = originalPaymentMethod.card?.copy(
+                expiryMonth = 2,
+                expiryYear = 2031,
+            ),
+        )
+
+        val adapter = FakeCustomerAdapter(
+            onUpdatePaymentMethod = { _, _ ->
+                called = true
+                CustomerAdapter.Result.success(updatedPaymentMethod)
+            },
+        )
+
+        val customerAdapterDataRepository = createCustomerAdapterDataRepository(adapter)
+
+        val result = customerAdapterDataRepository.updatePaymentMethod(
+            updatingId,
+            PaymentMethodUpdateParams.createCard(
+                expiryMonth = 2,
+                expiryYear = 2031,
+            ),
+        )
+
+        assertThat(called).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(updatedPaymentMethod)
+    }
+
+    @Test
+    fun `On 'setSelectedPaymentOption', should call 'CustomerAdapter' to set selected payment option`() = runTest {
+        var called = false
+
+        val adapter = FakeCustomerAdapter(
+            onSetSelectedPaymentOption = {
+                called = true
+                CustomerAdapter.Result.success(Unit)
+            },
+        )
+
+        val customerAdapterDataRepository = createCustomerAdapterDataRepository(adapter)
+
+        val result = customerAdapterDataRepository.setSelectedPaymentOption(
+            CustomerPaymentOption.GooglePay
+        )
+
+        assertThat(called).isTrue()
+        assertThat(result.isSuccess).isTrue()
+    }
+
+    @Test
+    fun `On 'retrieveSelectedPaymentOption', should call 'CustomerAdapter' for selected payment option`() = runTest {
+        var called = false
+
+        val adapter = FakeCustomerAdapter(
+            onGetSelectedPaymentOption = {
+                called = true
+                CustomerAdapter.Result.success(CustomerAdapter.PaymentOption.GooglePay)
+            },
+        )
+
+        val customerAdapterDataRepository = createCustomerAdapterDataRepository(adapter)
+
+        val result = customerAdapterDataRepository.retrieveSelectedPaymentOption()
+
+        assertThat(called).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(CustomerPaymentOption.GooglePay)
+    }
+
+    @Test
+    fun `On 'retrieveSetupIntentClientSecret', should call 'CustomerAdapter' to for client secret`() = runTest {
+        var called = false
+        val setupIntentId = "seti_123"
+
+        val adapter = FakeCustomerAdapter(
+            onSetupIntentClientSecretForCustomerAttach = {
+                called = true
+                CustomerAdapter.Result.success(setupIntentId)
+            },
+        )
+
+        val customerAdapterDataRepository = createCustomerAdapterDataRepository(adapter)
+
+        val result = customerAdapterDataRepository.retrieveSetupIntentClientSecret()
+
+        assertThat(called).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(setupIntentId)
+    }
+
+    private suspend fun createCustomerAdapterDataRepository(
+        adapter: CustomerAdapter,
+        elementsSessionRepository: ElementsSessionRepository = FakeElementsSessionRepository(
+            stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            linkSettings = null,
+            error = null,
+        ),
+    ): CustomerAdapterDataRepository {
+        return CustomerAdapterDataRepository(
+            workContext = coroutineContext,
+            adapter = adapter,
+            elementsSessionRepository = elementsSessionRepository,
+        )
+    }
+}


### PR DESCRIPTION
# Summary
Add `CustomerSheetDataRepository` interface.

# Motivation
Will be used to implement wrap `CustomerAdapter` and introduce a `CustomerSession` implementation then used in `CustomerSheet` instead of `CustomerAdapter` directly.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
