### PR TITLE
Add screen for removing one payment method in vertical mode

### DIFF
--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -77,7 +77,7 @@
   <string name="stripe_paymentsheet_remove_card">Remove card</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Remove %s</string>
-  <!-- Title for a screen which allows you to delete your only saved payment method. -->
+  <!-- Title shown above a view containing a customer's payment method that they can delete -->
   <string name="stripe_paymentsheet_remove_pm_title">Remove payment method</string>
   <!-- A button used for saving a new payment method -->
   <string name="stripe_paymentsheet_save">Save</string>

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -77,6 +77,8 @@
   <string name="stripe_paymentsheet_remove_card">Remove card</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Remove %s</string>
+  <!-- Title for a screen which allows you to delete your only saved payment method. -->
+  <string name="stripe_paymentsheet_remove_pm_title">Remove payment method</string>
   <!-- A button used for saving a new payment method -->
   <string name="stripe_paymentsheet_save">Save</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -14,6 +14,8 @@ import com.stripe.android.paymentsheet.ui.EditPaymentMethod
 import com.stripe.android.paymentsheet.ui.ModifiableEditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.ui.SavedPaymentMethodTabLayoutUI
 import com.stripe.android.paymentsheet.ui.SavedPaymentMethodsTopContentPadding
+import com.stripe.android.paymentsheet.verticalmode.ManageOneSavedPaymentMethodInteractor
+import com.stripe.android.paymentsheet.verticalmode.ManageOneSavedPaymentMethodUI
 import com.stripe.android.paymentsheet.verticalmode.ManageScreenInteractor
 import com.stripe.android.paymentsheet.verticalmode.ManageScreenUI
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor
@@ -37,6 +39,7 @@ internal val PaymentSheetScreen.topContentPadding: Dp
         is PaymentSheetScreen.AddFirstPaymentMethod,
         is PaymentSheetScreen.AddAnotherPaymentMethod,
         is PaymentSheetScreen.ManageSavedPaymentMethods,
+        is PaymentSheetScreen.ManageOneSavedPaymentMethod,
         is PaymentSheetScreen.EditPaymentMethod -> {
             0.dp
         }
@@ -216,6 +219,20 @@ internal sealed interface PaymentSheetScreen {
 
         override fun close() {
             interactor.close()
+        }
+    }
+
+    class ManageOneSavedPaymentMethod(private val interactor: ManageOneSavedPaymentMethodInteractor) :
+        PaymentSheetScreen {
+        override val showsBuyButton: Boolean = false
+        override val showsContinueButton: Boolean = false
+        override val canNavigateBack: Boolean = true
+
+        override fun showsWalletsHeader(isCompleteFlow: Boolean): Boolean = false
+
+        @Composable
+        override fun Content(viewModel: BaseSheetViewModel, modifier: Modifier) {
+            ManageOneSavedPaymentMethodUI(interactor = interactor)
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/HeaderTextFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/HeaderTextFactory.kt
@@ -43,6 +43,7 @@ internal class HeaderTextFactory(
         is PaymentSheetScreen.EditPaymentMethod -> {
             StripeR.string.stripe_title_update_card
         }
+        is PaymentSheetScreen.ManageOneSavedPaymentMethod -> R.string.stripe_paymentsheet_remove_pm_title
         is PaymentSheetScreen.ManageSavedPaymentMethods -> getHeaderTextForManageScreen(isEditing)
         is PaymentSheetScreen.Loading,
         is PaymentSheetScreen.AddAnotherPaymentMethod,
@@ -64,6 +65,7 @@ internal class HeaderTextFactory(
         is PaymentSheetScreen.SelectSavedPaymentMethods -> {
             R.string.stripe_paymentsheet_select_payment_method
         }
+        is PaymentSheetScreen.ManageOneSavedPaymentMethod -> R.string.stripe_paymentsheet_remove_pm_title
         is PaymentSheetScreen.ManageSavedPaymentMethods -> getHeaderTextForManageScreen(isEditing)
         is PaymentSheetScreen.AddFirstPaymentMethod,
         is PaymentSheetScreen.AddAnotherPaymentMethod,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageOneSavedPaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageOneSavedPaymentMethodInteractor.kt
@@ -1,0 +1,54 @@
+package com.stripe.android.paymentsheet.verticalmode
+
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+
+internal interface ManageOneSavedPaymentMethodInteractor {
+    val state: State
+
+    fun handleViewAction(viewAction: ViewAction)
+
+    data class State(
+        val paymentMethod: DisplayableSavedPaymentMethod,
+    )
+
+    sealed class ViewAction {
+        data object DeletePaymentMethod : ViewAction()
+    }
+}
+
+internal class DefaultManageOneSavedPaymentMethodInteractor(
+    paymentMethod: PaymentMethod,
+    paymentMethodMetadata: PaymentMethodMetadata,
+    providePaymentMethodName: (PaymentMethodCode?) -> String,
+    private val onDeletePaymentMethod: (PaymentMethod) -> Unit,
+    private val navigateBack: () -> Unit,
+) : ManageOneSavedPaymentMethodInteractor {
+
+    constructor(sheetViewModel: BaseSheetViewModel) : this(
+        paymentMethod = sheetViewModel.paymentMethods.value!!.first(),
+        paymentMethodMetadata = sheetViewModel.paymentMethodMetadata.value!!,
+        providePaymentMethodName = sheetViewModel::providePaymentMethodName,
+        onDeletePaymentMethod = { sheetViewModel.removePaymentMethod(it) },
+        navigateBack = sheetViewModel::handleBackPressed,
+    )
+
+    override val state = ManageOneSavedPaymentMethodInteractor.State(
+        paymentMethod.toDisplayableSavedPaymentMethod(
+            providePaymentMethodName,
+            paymentMethodMetadata,
+        )
+    )
+
+    override fun handleViewAction(viewAction: ManageOneSavedPaymentMethodInteractor.ViewAction) {
+        when (viewAction) {
+            is ManageOneSavedPaymentMethodInteractor.ViewAction.DeletePaymentMethod -> {
+                onDeletePaymentMethod(state.paymentMethod.paymentMethod)
+                navigateBack()
+            }
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageOneSavedPaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageOneSavedPaymentMethodUI.kt
@@ -1,0 +1,43 @@
+package com.stripe.android.paymentsheet.verticalmode
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.unit.dp
+import com.stripe.android.paymentsheet.R
+
+@Composable
+internal fun ManageOneSavedPaymentMethodUI(interactor: ManageOneSavedPaymentMethodInteractor) {
+    val horizontalPadding = dimensionResource(
+        id = R.dimen.stripe_paymentsheet_outer_spacing_horizontal
+    )
+
+    val paymentMethod = interactor.state.paymentMethod
+
+    Column(
+        modifier = Modifier
+            .padding(horizontal = horizontalPadding),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        SavedPaymentMethodRowButton(
+            displayableSavedPaymentMethod = paymentMethod,
+            resources = LocalContext.current.resources,
+            isEnabled = true,
+            isSelected = true,
+            trailingContent = {
+                DeleteIcon(
+                    paymentMethod = paymentMethod,
+                    deletePaymentMethod = {
+                        interactor.handleViewAction(
+                            ManageOneSavedPaymentMethodInteractor.ViewAction.DeletePaymentMethod
+                        )
+                    }
+                )
+            }
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageOneSavedPaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageOneSavedPaymentMethodUI.kt
@@ -1,13 +1,10 @@
 package com.stripe.android.paymentsheet.verticalmode
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
-import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentsheet.R
 
 @Composable
@@ -18,26 +15,21 @@ internal fun ManageOneSavedPaymentMethodUI(interactor: ManageOneSavedPaymentMeth
 
     val paymentMethod = interactor.state.paymentMethod
 
-    Column(
-        modifier = Modifier
-            .padding(horizontal = horizontalPadding),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        SavedPaymentMethodRowButton(
-            displayableSavedPaymentMethod = paymentMethod,
-            resources = LocalContext.current.resources,
-            isEnabled = true,
-            isSelected = true,
-            trailingContent = {
-                DeleteIcon(
-                    paymentMethod = paymentMethod,
-                    deletePaymentMethod = {
-                        interactor.handleViewAction(
-                            ManageOneSavedPaymentMethodInteractor.ViewAction.DeletePaymentMethod
-                        )
-                    }
-                )
-            }
-        )
-    }
+    SavedPaymentMethodRowButton(
+        displayableSavedPaymentMethod = paymentMethod,
+        resources = LocalContext.current.resources,
+        isEnabled = true,
+        isSelected = true,
+        trailingContent = {
+            DeleteIcon(
+                paymentMethod = paymentMethod,
+                deletePaymentMethod = {
+                    interactor.handleViewAction(
+                        ManageOneSavedPaymentMethodInteractor.ViewAction.DeletePaymentMethod
+                    )
+                }
+            )
+        },
+        modifier = Modifier.padding(horizontal = horizontalPadding)
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenIcons.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenIcons.kt
@@ -1,0 +1,87 @@
+package com.stripe.android.paymentsheet.verticalmode
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Icon
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
+import com.stripe.android.paymentsheet.ui.RemovePaymentMethodDialogUI
+
+@Composable
+internal fun DeleteIcon(
+    paymentMethod: DisplayableSavedPaymentMethod,
+    deletePaymentMethod: (DisplayableSavedPaymentMethod) -> Unit
+) {
+    val openRemoveDialog = rememberSaveable { mutableStateOf(false) }
+    val paymentMethodId = paymentMethod.paymentMethod.id
+
+    TrailingIcon(
+        backgroundColor = Color.Red,
+        icon = Icons.Filled.Close,
+        modifier = Modifier.testTag("${TEST_TAG_MANAGE_SCREEN_DELETE_ICON}_$paymentMethodId"),
+        onClick = {
+            openRemoveDialog.value = true
+        },
+    )
+
+    if (openRemoveDialog.value) {
+        RemovePaymentMethodDialogUI(paymentMethod = paymentMethod, onConfirmListener = {
+            openRemoveDialog.value = false
+            deletePaymentMethod(paymentMethod)
+        }, onDismissListener = {
+            openRemoveDialog.value = false
+        })
+    }
+}
+
+@Composable
+internal fun EditIcon(
+    paymentMethod: DisplayableSavedPaymentMethod,
+    editPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
+) {
+    val paymentMethodId = paymentMethod.paymentMethod.id
+
+    TrailingIcon(
+        backgroundColor = Color.Gray,
+        icon = Icons.Filled.Edit,
+        modifier = Modifier.testTag("${TEST_TAG_MANAGE_SCREEN_EDIT_ICON}_$paymentMethodId"),
+        onClick = { editPaymentMethod(paymentMethod) }
+    )
+}
+
+@Composable
+private fun TrailingIcon(backgroundColor: Color, icon: ImageVector, onClick: () -> Unit, modifier: Modifier) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .clip(CircleShape)
+            .size(24.dp)
+            .background(backgroundColor)
+            .clickable(onClick = onClick),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = Color.White,
+            modifier = Modifier.size(12.dp),
+        )
+    }
+}
+
+internal const val TEST_TAG_MANAGE_SCREEN_EDIT_ICON = "manage_screen_edit_icon"
+internal const val TEST_TAG_MANAGE_SCREEN_DELETE_ICON = "manage_screen_delete_icon"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUI.kt
@@ -1,34 +1,18 @@
 package com.stripe.android.paymentsheet.verticalmode
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.Icon
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.R
-import com.stripe.android.paymentsheet.ui.RemovePaymentMethodDialogUI
 import com.stripe.android.paymentsheet.ui.SelectedBadge
 import com.stripe.android.uicore.utils.collectAsState
 
@@ -107,67 +91,4 @@ private fun TrailingContent(
     }
 }
 
-@Composable
-private fun DeleteIcon(
-    paymentMethod: DisplayableSavedPaymentMethod,
-    deletePaymentMethod: (DisplayableSavedPaymentMethod) -> Unit
-) {
-    val openRemoveDialog = rememberSaveable { mutableStateOf(false) }
-    val paymentMethodId = paymentMethod.paymentMethod.id
-
-    TrailingIcon(
-        backgroundColor = Color.Red,
-        icon = Icons.Filled.Close,
-        modifier = Modifier.testTag("${TEST_TAG_MANAGE_SCREEN_DELETE_ICON}_$paymentMethodId"),
-        onClick = {
-            openRemoveDialog.value = true
-        },
-    )
-
-    if (openRemoveDialog.value) {
-        RemovePaymentMethodDialogUI(paymentMethod = paymentMethod, onConfirmListener = {
-            openRemoveDialog.value = false
-            deletePaymentMethod(paymentMethod)
-        }, onDismissListener = {
-            openRemoveDialog.value = false
-        })
-    }
-}
-
-@Composable
-private fun EditIcon(
-    paymentMethod: DisplayableSavedPaymentMethod,
-    editPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
-) {
-    val paymentMethodId = paymentMethod.paymentMethod.id
-
-    TrailingIcon(
-        backgroundColor = Color.Gray,
-        icon = Icons.Filled.Edit,
-        modifier = Modifier.testTag("${TEST_TAG_MANAGE_SCREEN_EDIT_ICON}_$paymentMethodId"),
-        onClick = { editPaymentMethod(paymentMethod) }
-    )
-}
-
-@Composable
-private fun TrailingIcon(backgroundColor: Color, icon: ImageVector, onClick: () -> Unit, modifier: Modifier) {
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = modifier
-            .clip(CircleShape)
-            .size(24.dp)
-            .background(backgroundColor)
-            .clickable(onClick = onClick),
-    ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            tint = Color.White,
-            modifier = Modifier.size(12.dp),
-        )
-    }
-}
-
 internal const val TEST_TAG_MANAGE_SCREEN_SAVED_PMS_LIST = "manage_screen_saved_pms_list"
-internal const val TEST_TAG_MANAGE_SCREEN_EDIT_ICON = "manage_screen_edit_icon"
-internal const val TEST_TAG_MANAGE_SCREEN_DELETE_ICON = "manage_screen_delete_icon"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -28,6 +28,7 @@ internal interface PaymentMethodVerticalLayoutInteractor {
 
     sealed interface ViewAction {
         data object TransitionToManageSavedPaymentMethods : ViewAction
+        data object TransitionToManageOneSavedPaymentMethod : ViewAction
         data class PaymentMethodSelected(val selectedPaymentMethodCode: String) : ViewAction
         data class SavedPaymentMethodSelected(val savedPaymentMethod: PaymentMethod) : ViewAction
         data class EditPaymentMethod(val savedPaymentMethod: DisplayableSavedPaymentMethod) : ViewAction
@@ -49,6 +50,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     private val transitionTo: (screen: PaymentSheetScreen) -> Unit,
     private val onFormFieldValuesChanged: (formValues: FormFieldValues, selectedPaymentMethodCode: String) -> Unit,
     private val manageScreenFactory: () -> PaymentSheetScreen,
+    private val manageOneSavedPaymentMethodFactory: () -> PaymentSheetScreen,
     private val formScreenFactory: (selectedPaymentMethodCode: String) -> PaymentSheetScreen,
     paymentMethods: StateFlow<List<PaymentMethod>?>,
     private val mostRecentlySelectedSavedPaymentMethod: StateFlow<PaymentMethod?>,
@@ -69,6 +71,11 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                 interactor = DefaultManageScreenInteractor(
                     viewModel
                 )
+            )
+        },
+        manageOneSavedPaymentMethodFactory = {
+            PaymentSheetScreen.ManageOneSavedPaymentMethod(
+                interactor = DefaultManageOneSavedPaymentMethodInteractor(viewModel)
             )
         },
         formScreenFactory = { selectedPaymentMethodCode ->
@@ -182,6 +189,9 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
             }
             ViewAction.TransitionToManageSavedPaymentMethods -> {
                 transitionTo(manageScreenFactory())
+            }
+            ViewAction.TransitionToManageOneSavedPaymentMethod -> {
+                transitionTo(manageOneSavedPaymentMethodFactory())
             }
             is ViewAction.EditPaymentMethod -> {
                 onEditPaymentMethod(viewAction.savedPaymentMethod)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
@@ -62,6 +62,11 @@ internal fun PaymentMethodVerticalLayoutUI(interactor: PaymentMethodVerticalLayo
                 PaymentMethodVerticalLayoutInteractor.ViewAction.SavedPaymentMethodSelected(it.paymentMethod)
             )
         },
+        onManageOneSavedPaymentMethod = {
+            interactor.handleViewAction(
+                PaymentMethodVerticalLayoutInteractor.ViewAction.TransitionToManageOneSavedPaymentMethod
+            )
+        },
         imageLoader = imageLoader,
         modifier = Modifier.padding(horizontal = 20.dp)
     )
@@ -76,6 +81,7 @@ internal fun PaymentMethodVerticalLayoutUI(
     selection: PaymentSelection?,
     isEnabled: Boolean,
     onViewMorePaymentMethods: () -> Unit,
+    onManageOneSavedPaymentMethod: () -> Unit,
     onEditPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
     onSelectSavedPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
     imageLoader: StripeImageLoader,
@@ -97,7 +103,8 @@ internal fun PaymentMethodVerticalLayoutUI(
                         displayedSavedPaymentMethod = displayedSavedPaymentMethod,
                         savedPaymentMethodAction = savedPaymentMethodAction,
                         onViewMorePaymentMethods = onViewMorePaymentMethods,
-                        onEditPaymentMethod = onEditPaymentMethod
+                        onEditPaymentMethod = onEditPaymentMethod,
+                        onManageOneSavedPaymentMethod = onManageOneSavedPaymentMethod,
                     )
                 },
                 onClick = { onSelectSavedPaymentMethod(displayedSavedPaymentMethod) },
@@ -128,6 +135,7 @@ private fun SavedPaymentMethodTrailingContent(
     displayedSavedPaymentMethod: DisplayableSavedPaymentMethod,
     savedPaymentMethodAction: PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction,
     onViewMorePaymentMethods: () -> Unit,
+    onManageOneSavedPaymentMethod: () -> Unit,
     onEditPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
 ) {
     when (savedPaymentMethodAction) {
@@ -136,7 +144,7 @@ private fun SavedPaymentMethodTrailingContent(
             EditButton(onClick = { onEditPaymentMethod(displayedSavedPaymentMethod) })
         }
         PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ONE -> {
-            EditButton(onClick = onViewMorePaymentMethods)
+            EditButton(onClick = onManageOneSavedPaymentMethod)
         }
         PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL -> {
             ViewMoreButton(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -308,8 +308,9 @@ internal abstract class BaseSheetViewModel(
                         previouslyShownForm = null
                         previouslyInteractedForm = null
                     }
-                    is PaymentSheetScreen.Form, is PaymentSheetScreen.ManageSavedPaymentMethods -> {
-                    }
+                    is PaymentSheetScreen.Form,
+                    is PaymentSheetScreen.ManageSavedPaymentMethods,
+                    is PaymentSheetScreen.ManageOneSavedPaymentMethod -> {}
                 }
             }
         }
@@ -382,6 +383,7 @@ internal abstract class BaseSheetViewModel(
             is PaymentSheetScreen.Loading,
             is PaymentSheetScreen.EditPaymentMethod,
             is PaymentSheetScreen.Form,
+            is PaymentSheetScreen.ManageOneSavedPaymentMethod,
             is PaymentSheetScreen.ManageSavedPaymentMethods -> {
                 // Nothing to do here
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageOneSavedPaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageOneSavedPaymentMethodInteractorTest.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.paymentsheet.verticalmode
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodFixtures
+import kotlin.test.Test
+
+class DefaultManageOneSavedPaymentMethodInteractorTest {
+
+    @Test
+    fun handleViewAction_DeletePaymentMethod_deletesPmAndNavigatesBack() {
+        var deletedPm: PaymentMethod? = null
+        var hasNavigatedBack = false
+
+        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        val interactor = DefaultManageOneSavedPaymentMethodInteractor(
+            paymentMethod = paymentMethod,
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            providePaymentMethodName = { it!! },
+            onDeletePaymentMethod = { deletedPm = it },
+            navigateBack = { hasNavigatedBack = true }
+        )
+
+        interactor.handleViewAction(ManageOneSavedPaymentMethodInteractor.ViewAction.DeletePaymentMethod)
+
+        assertThat(deletedPm).isEqualTo(paymentMethod)
+        assertThat(hasNavigatedBack).isTrue()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -397,6 +397,25 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
+    fun handleViewAction_TransitionToManageOneSavedPaymentMethod_transitionsToManageOnSavedPMScreen() {
+        var calledManageOneSavedPaymentMethodScreenFactory = false
+        var calledTransitionTo = false
+        runScenario(
+            manageOneSavedPaymentMethodFactory = {
+                calledManageOneSavedPaymentMethodScreenFactory = true
+                mock()
+            },
+            transitionTo = {
+                calledTransitionTo = true
+            }
+        ) {
+            interactor.handleViewAction(ViewAction.TransitionToManageOneSavedPaymentMethod)
+            assertThat(calledManageOneSavedPaymentMethodScreenFactory).isTrue()
+            assertThat(calledTransitionTo).isTrue()
+        }
+    }
+
+    @Test
     fun handleViewAction_SelectSavedPaymentMethod_selectsSavedPm() {
         val savedPaymentMethod = PaymentMethodFixtures.displayableCard()
         var selectedSavedPaymentMethod: PaymentMethod? = null
@@ -425,6 +444,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             notImplemented()
         },
         manageScreenFactory: () -> PaymentSheetScreen = { notImplemented() },
+        manageOneSavedPaymentMethodFactory: () -> PaymentSheetScreen = { notImplemented() },
         formScreenFactory: (selectedPaymentMethodCode: String) -> PaymentSheetScreen = { notImplemented() },
         initialPaymentMethods: List<PaymentMethod>? = null,
         initialMostRecentlySelectedSavedPaymentMethod: PaymentMethod? = null,
@@ -447,6 +467,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             transitionTo = transitionTo,
             onFormFieldValuesChanged = onFormFieldValuesChanged,
             manageScreenFactory = manageScreenFactory,
+            manageOneSavedPaymentMethodFactory = manageOneSavedPaymentMethodFactory,
             formScreenFactory = formScreenFactory,
             paymentMethods = paymentMethods,
             mostRecentlySelectedSavedPaymentMethod = mostRecentlySelectedSavedPaymentMethod,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/ManageOneSavedPaymentMethodUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/ManageOneSavedPaymentMethodUITest.kt
@@ -1,0 +1,80 @@
+package com.stripe.android.paymentsheet.verticalmode
+
+import android.os.Build
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.PaymentMethodFixtures.toDisplayableSavedPaymentMethod
+import com.stripe.android.paymentsheet.ViewActionRecorder
+import com.stripe.android.ui.core.elements.TEST_TAG_DIALOG_CONFIRM_BUTTON
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.Test
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.Q])
+class ManageOneSavedPaymentMethodUITest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun savedPaymentMethod_isDisplayed() {
+        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        runScenario(paymentMethod) {
+            composeRule.onNodeWithTag(
+                TEST_TAG_SAVED_PAYMENT_METHOD_ROW_BUTTON + "_${paymentMethod.id}"
+            ).assertExists()
+        }
+    }
+
+    @Test
+    fun clickingDeleteIcon_callsDeletePaymentMethod() {
+        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        runScenario(paymentMethod) {
+            assertThat(viewActionRecorder.viewActions).isEmpty()
+
+            composeRule.onNodeWithTag(
+                TEST_TAG_MANAGE_SCREEN_DELETE_ICON + "_${paymentMethod.id}",
+                useUnmergedTree = true,
+            ).performClick()
+            composeRule.onNodeWithTag(TEST_TAG_DIALOG_CONFIRM_BUTTON).performClick()
+
+            viewActionRecorder.consume(
+                ManageOneSavedPaymentMethodInteractor.ViewAction.DeletePaymentMethod
+            )
+            assertThat(viewActionRecorder.viewActions).isEmpty()
+        }
+    }
+
+    private fun runScenario(
+        paymentMethod: PaymentMethod,
+        block: Scenario.() -> Unit
+    ) {
+        val viewActionRecorder = ViewActionRecorder<ManageOneSavedPaymentMethodInteractor.ViewAction>()
+
+        val manageScreenInteractor = object : ManageOneSavedPaymentMethodInteractor {
+            override val state: ManageOneSavedPaymentMethodInteractor.State
+                get() = ManageOneSavedPaymentMethodInteractor.State(paymentMethod.toDisplayableSavedPaymentMethod())
+
+            override fun handleViewAction(viewAction: ManageOneSavedPaymentMethodInteractor.ViewAction) {
+                viewActionRecorder.record(viewAction)
+            }
+        }
+
+        composeRule.setContent {
+            ManageOneSavedPaymentMethodUI(interactor = manageScreenInteractor)
+        }
+
+        Scenario(viewActionRecorder).apply(block)
+    }
+
+    private data class Scenario(
+        val viewActionRecorder: ViewActionRecorder<ManageOneSavedPaymentMethodInteractor.ViewAction>,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUIScreenshotTest.kt
@@ -32,6 +32,7 @@ internal class PaymentMethodVerticalLayoutUIScreenshotTest {
                 onEditPaymentMethod = {},
                 onViewMorePaymentMethods = {},
                 onSelectSavedPaymentMethod = {},
+                onManageOneSavedPaymentMethod = {},
                 imageLoader = mock(),
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
@@ -65,7 +65,7 @@ internal class PaymentMethodVerticalLayoutUITest {
         assertThat(viewActionRecorder.viewActions).isEmpty()
         composeRule.onNodeWithTag(TEST_TAG_EDIT_SAVED_CARD).performClick()
         viewActionRecorder.consume(
-            PaymentMethodVerticalLayoutInteractor.ViewAction.TransitionToManageSavedPaymentMethods
+            PaymentMethodVerticalLayoutInteractor.ViewAction.TransitionToManageOneSavedPaymentMethod
         )
         assertThat(viewActionRecorder.viewActions).isEmpty()
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add screen for removing one payment method in vertical mode

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Handling edge case of when a user has one saved PM and the merchant allows them to remove it, per [figma](https://www.figma.com/design/ysEUcRWOfdEH4C0jBA0EkH/MPE-LPM-Visibility?node-id=5623-69849&t=PseDPW4qmiKkzI1B-0).

https://jira.corp.stripe.com/browse/MOBILESDK-2170

I decided to add this as a new screen, because it's easier to understand how this screen and the existing manage screen work if they are separate. If we combine them, the edge cases around 1 saved PM are harder to manage/reason about.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified

# Screen recording

https://github.com/stripe/stripe-android/assets/160939932/272e5c58-c3b3-456a-a1c0-edeceb3a7985
