### PR TITLE
Exit manage screen on done when 1 CBC card remaining

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
@@ -184,6 +184,68 @@ class DefaultManageScreenInteractorTest {
     }
 
     @Test
+    fun removeSecondToLastPaymentMethod_canRemoveLastPm_cbcEligible_doesNotNavBackWhenEditingFinishes() {
+        var backPressed = false
+        fun handleBackPressed() {
+            backPressed = true
+        }
+
+        val nonCbcCard = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        val cbcCard = PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD
+        val initialPaymentMethods = listOf(nonCbcCard, cbcCard)
+        runScenario(
+            initialPaymentMethods = initialPaymentMethods,
+            currentSelection = PaymentSelection.Saved(initialPaymentMethods[0]),
+            onSelectPaymentMethod = {},
+            isEditing = true,
+            allowsRemovalOfLastSavedPaymentMethod = true,
+            handleBackPressed = ::handleBackPressed,
+        ) {
+            assertThat(backPressed).isFalse()
+
+            paymentMethodsSource.value = listOf(nonCbcCard)
+
+            dispatcher.scheduler.advanceUntilIdle()
+            assertThat(backPressed).isFalse()
+
+            editingSource.value = false
+
+            dispatcher.scheduler.advanceUntilIdle()
+            assertThat(backPressed).isFalse()
+        }
+    }
+
+    @Test
+    fun removeThirdToLastPaymentMethod_doesNotNavBackWhenEditingFinishes() {
+        var backPressed = false
+        fun handleBackPressed() {
+            backPressed = true
+        }
+
+        val initialPaymentMethods = PaymentMethodFixtures.createCards(3)
+        runScenario(
+            initialPaymentMethods = initialPaymentMethods,
+            currentSelection = PaymentSelection.Saved(initialPaymentMethods[0]),
+            isEditing = true,
+            onSelectPaymentMethod = {},
+            allowsRemovalOfLastSavedPaymentMethod = false,
+            handleBackPressed = ::handleBackPressed,
+        ) {
+            assertThat(backPressed).isFalse()
+
+            paymentMethodsSource.value = initialPaymentMethods.minus(initialPaymentMethods[0])
+
+            dispatcher.scheduler.advanceUntilIdle()
+            assertThat(backPressed).isFalse()
+
+            editingSource.value = false
+
+            dispatcher.scheduler.advanceUntilIdle()
+            assertThat(backPressed).isFalse()
+        }
+    }
+
+    @Test
     fun removeSecondToLastPaymentMethod_canRemoveLastPm_doesntNavigateBackOrHideButtons() {
         var backPressed = false
         fun handleBackPressed() {
@@ -192,7 +254,7 @@ class DefaultManageScreenInteractorTest {
 
         val initialPaymentMethods = PaymentMethodFixtures.createCards(2)
         runScenario(
-            initialPaymentMethods = PaymentMethodFixtures.createCards(1),
+            initialPaymentMethods = initialPaymentMethods,
             currentSelection = PaymentSelection.Saved(initialPaymentMethods[0]),
             isEditing = true,
             allowsRemovalOfLastSavedPaymentMethod = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
@@ -6,6 +6,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -145,6 +146,44 @@ class DefaultManageScreenInteractorTest {
     }
 
     @Test
+    fun removeSecondToLastPaymentMethod_cantRemoveLastPm_cbcEligible_navsBackWhenEditingFinishes() {
+        var backPressed = false
+        fun handleBackPressed() {
+            backPressed = true
+        }
+
+        var selectedPaymentMethod: DisplayableSavedPaymentMethod? = null
+        fun onSelectPaymentMethod(savedPaymentMethod: DisplayableSavedPaymentMethod) {
+            selectedPaymentMethod = savedPaymentMethod
+        }
+
+        val nonCbcCard = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        val cbcCard = PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD
+        val initialPaymentMethods = listOf(nonCbcCard, cbcCard)
+        runScenario(
+            initialPaymentMethods = initialPaymentMethods,
+            currentSelection = PaymentSelection.Saved(initialPaymentMethods[0]),
+            onSelectPaymentMethod = ::onSelectPaymentMethod,
+            isEditing = true,
+            allowsRemovalOfLastSavedPaymentMethod = false,
+            handleBackPressed = ::handleBackPressed,
+        ) {
+            assertThat(backPressed).isFalse()
+
+            paymentMethodsSource.value = listOf(cbcCard)
+
+            dispatcher.scheduler.advanceUntilIdle()
+            assertThat(backPressed).isFalse()
+
+            editingSource.value = false
+
+            dispatcher.scheduler.advanceUntilIdle()
+            assertThat(backPressed).isTrue()
+            assertThat(selectedPaymentMethod?.paymentMethod).isEqualTo(cbcCard)
+        }
+    }
+
+    @Test
     fun removeSecondToLastPaymentMethod_canRemoveLastPm_doesntNavigateBackOrHideButtons() {
         var backPressed = false
         fun handleBackPressed() {
@@ -181,6 +220,7 @@ class DefaultManageScreenInteractorTest {
         currentSelection: PaymentSelection?,
         isEditing: Boolean = false,
         allowsRemovalOfLastSavedPaymentMethod: Boolean = true,
+        onSelectPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit = { notImplemented() },
         handleBackPressed: () -> Unit = { notImplemented() },
         testBlock: suspend TestParams.() -> Unit
     ) {
@@ -199,7 +239,7 @@ class DefaultManageScreenInteractorTest {
             editing = editing,
             allowsRemovalOfLastSavedPaymentMethod = allowsRemovalOfLastSavedPaymentMethod,
             providePaymentMethodName = { it ?: "Missing name" },
-            onSelectPaymentMethod = { notImplemented() },
+            onSelectPaymentMethod = onSelectPaymentMethod,
             onDeletePaymentMethod = { notImplemented() },
             onEditPaymentMethod = { notImplemented() },
             navigateBack = handleBackPressed,
@@ -209,6 +249,7 @@ class DefaultManageScreenInteractorTest {
         TestParams(
             interactor = interactor,
             paymentMethodsSource = paymentMethods,
+            editingSource = editing,
             dispatcher = dispatcher
         ).apply {
             runTest {
@@ -220,6 +261,7 @@ class DefaultManageScreenInteractorTest {
     private data class TestParams(
         val interactor: ManageScreenInteractor,
         val dispatcher: TestDispatcher,
-        val paymentMethodsSource: MutableStateFlow<List<PaymentMethod>?>
+        val paymentMethodsSource: MutableStateFlow<List<PaymentMethod>?>,
+        val editingSource: MutableStateFlow<Boolean>,
     )
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Exit manage screen when user clicks "done" when 1 CBC card remaining and `allowsRemovalOfLastSavedPaymentMethod` is false

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Design request for vertical mode: https://stripe.slack.com/archives/C06JTLU0K8E/p1718390567002709?thread_ts=1718386921.184159&cid=C06JTLU0K8E

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screen recording

https://github.com/stripe/stripe-android/assets/160939932/93792424-63e3-4209-ab43-d47093de6b2a

