### PR TITLE
Uppercase UK post codes

### DIFF
--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
@@ -74,7 +74,6 @@ class PostalCodeConfigTest {
             Truth.assertThat(determineStateForInput("").isFull()).isFalse()
             Truth.assertThat(determineStateForInput("1M1AA").isValid()).isFalse()
             Truth.assertThat(determineStateForInput("1M 1AA").isValid()).isFalse()
-            Truth.assertThat(determineStateForInput("EC1A 1BBB").isValid()).isFalse()
             Truth.assertThat(determineStateForInput("M11AA").isValid()).isTrue()
             Truth.assertThat(determineStateForInput("B2 3DF").isValid()).isTrue()
             Truth.assertThat(determineStateForInput("CR26XH").isValid()).isTrue()
@@ -125,9 +124,8 @@ class PostalCodeConfigTest {
             Truth.assertThat(determineStateForInput("").getError()).isNull()
             Truth.assertThat(determineStateForInput("N18E").getError()).isNotNull()
             Truth.assertThat(determineStateForInput("4C1A 1BB").getError()).isNotNull()
-            Truth.assertThat(determineStateForInput("EC1  1BB").getError()).isNotNull()
-            Truth.assertThat(determineStateForInput("EC1 1BB ").getError()).isNotNull()
-            Truth.assertThat(determineStateForInput("DN55 1PTT").getError()).isNotNull()
+            Truth.assertThat(determineStateForInput("12345").getError()).isNull()
+            Truth.assertThat(determineStateForInput("141124").getError()).isNotNull()
         }
     }
 

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
@@ -124,7 +124,7 @@ class PostalCodeConfigTest {
             Truth.assertThat(determineStateForInput("").getError()).isNull()
             Truth.assertThat(determineStateForInput("N18E").getError()).isNotNull()
             Truth.assertThat(determineStateForInput("4C1A 1BB").getError()).isNotNull()
-            Truth.assertThat(determineStateForInput("12345").getError()).isNull()
+            Truth.assertThat(determineStateForInput("12345").getError()).isNotNull()
             Truth.assertThat(determineStateForInput("141124").getError()).isNotNull()
         }
     }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
@@ -26,8 +26,16 @@ class PostalCodeConfigTest {
     }
 
     @Test
+    fun `verify GB config uses proper keyboard capitalization & keyboard type`() {
+        with(createConfigForCountry("GB")) {
+            Truth.assertThat(capitalization).isEqualTo(KeyboardCapitalization.Characters)
+            Truth.assertThat(keyboard).isEqualTo(KeyboardType.Text)
+        }
+    }
+
+    @Test
     fun `verify Other config uses proper keyboard capitalization & keyboard type`() {
-        with(createConfigForCountry("UK")) {
+        with(createConfigForCountry("IN")) {
             Truth.assertThat(capitalization).isEqualTo(KeyboardCapitalization.Characters)
             Truth.assertThat(keyboard).isEqualTo(KeyboardType.Text)
         }
@@ -60,8 +68,26 @@ class PostalCodeConfigTest {
     }
 
     @Test
+    fun `verify GB postal codes`() {
+        with(createConfigForCountry("GB")) {
+            Truth.assertThat(determineStateForInput("").isValid()).isFalse()
+            Truth.assertThat(determineStateForInput("").isFull()).isFalse()
+            Truth.assertThat(determineStateForInput("1M1AA").isValid()).isFalse()
+            Truth.assertThat(determineStateForInput("1M 1AA").isValid()).isFalse()
+            Truth.assertThat(determineStateForInput("EC1A 1BBB").isValid()).isFalse()
+            Truth.assertThat(determineStateForInput("M11AA").isValid()).isTrue()
+            Truth.assertThat(determineStateForInput("B2 3DF").isValid()).isTrue()
+            Truth.assertThat(determineStateForInput("CR26XH").isValid()).isTrue()
+            Truth.assertThat(determineStateForInput("M60 1NW").isValid()).isTrue()
+            Truth.assertThat(determineStateForInput("DN551PT").isValid()).isTrue()
+            Truth.assertThat(determineStateForInput("EC1A 1BB").isValid()).isTrue()
+            Truth.assertThat(determineStateForInput("EC1A 1BB").isFull()).isTrue()
+        }
+    }
+
+    @Test
     fun `verify other postal codes`() {
-        with(createConfigForCountry("UK")) {
+        with(createConfigForCountry("IN")) {
             Truth.assertThat(determineStateForInput("").isValid()).isFalse()
             Truth.assertThat(determineStateForInput("").isFull()).isFalse()
             Truth.assertThat(determineStateForInput(" ").isValid()).isFalse()
@@ -90,6 +116,18 @@ class PostalCodeConfigTest {
             Truth.assertThat(determineStateForInput("").getError()).isNull()
             Truth.assertThat(determineStateForInput("1N8E8R").getError()).isNotNull()
             Truth.assertThat(determineStateForInput("141124").getError()).isNotNull()
+        }
+    }
+
+    @Test
+    fun `invalid GB postal codes emit error`() {
+        with(createConfigForCountry("GB")) {
+            Truth.assertThat(determineStateForInput("").getError()).isNull()
+            Truth.assertThat(determineStateForInput("N18E").getError()).isNotNull()
+            Truth.assertThat(determineStateForInput("4C1A 1BB").getError()).isNotNull()
+            Truth.assertThat(determineStateForInput("EC1  1BB").getError()).isNotNull()
+            Truth.assertThat(determineStateForInput("EC1 1BB ").getError()).isNotNull()
+            Truth.assertThat(determineStateForInput("DN55 1PTT").getError()).isNotNull()
         }
     }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PostalCodeConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PostalCodeConfig.kt
@@ -19,12 +19,14 @@ class PostalCodeConfig(
     override val capitalization: KeyboardCapitalization = when (format) {
         CountryPostalFormat.US -> KeyboardCapitalization.None
         CountryPostalFormat.CA,
+        CountryPostalFormat.GB,
         CountryPostalFormat.Other -> KeyboardCapitalization.Characters
     }
 
     override val keyboard: KeyboardType = when (format) {
         CountryPostalFormat.US -> KeyboardType.NumberPassword
         CountryPostalFormat.CA,
+        CountryPostalFormat.GB,
         CountryPostalFormat.Other -> KeyboardType.Text
     }
 
@@ -67,6 +69,9 @@ class PostalCodeConfig(
         return when (format) {
             CountryPostalFormat.US -> userTyped.filter { it.isDigit() }
             CountryPostalFormat.CA -> userTyped.filter { it.isLetterOrDigit() }.uppercase()
+            CountryPostalFormat.GB -> userTyped.filter {
+                it.isLetterOrDigit() || it.isWhitespace()
+            }.uppercase()
             CountryPostalFormat.Other -> userTyped
         }.take(format.maximumLength)
     }
@@ -90,6 +95,13 @@ class PostalCodeConfig(
         )
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        object GB : CountryPostalFormat(
+            minimumLength = 5,
+            maximumLength = 8,
+            regexPattern = Regex("^[A-Za-z][A-Za-z0-9]*(?: [A-Za-z0-9]*)?\$")
+        )
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         object US : CountryPostalFormat(
             minimumLength = 5,
             maximumLength = 5,
@@ -109,6 +121,7 @@ class PostalCodeConfig(
                 return when (country) {
                     "US" -> US
                     "CA" -> CA
+                    "GB" -> GB
                     else -> Other
                 }
             }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PostalCodeConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PostalCodeConfig.kt
@@ -68,10 +68,8 @@ class PostalCodeConfig(
     override fun filter(userTyped: String): String {
         return when (format) {
             CountryPostalFormat.US -> userTyped.filter { it.isDigit() }
-            CountryPostalFormat.CA -> userTyped.filter { it.isLetterOrDigit() }.uppercase()
-            CountryPostalFormat.GB -> userTyped.filter {
-                it.isLetterOrDigit() || it.isWhitespace()
-            }.uppercase()
+            CountryPostalFormat.CA,
+            CountryPostalFormat.GB -> userTyped.filter { it.isLetterOrDigit() }.uppercase()
             CountryPostalFormat.Other -> userTyped
         }.take(format.maximumLength)
     }
@@ -97,7 +95,7 @@ class PostalCodeConfig(
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         object GB : CountryPostalFormat(
             minimumLength = 5,
-            maximumLength = 8,
+            maximumLength = 7,
             regexPattern = Regex("^[A-Za-z][A-Za-z0-9]*(?: [A-Za-z0-9]*)?\$")
         )
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This pulls in a public PR from #7256 

Update PostalCodeConfig for GB (United Kingdom).

Only allow letters, digits, and spaces
Capitalize letters


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
GB postal codes should be uppercase. Lowercase postal codes are considered invalid by some United Kingdom card providers.

UK Government advice on postcode format:
https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/611951/Appendix_C_ILR_2017_to_2018_v1_Published_28April17.pdf

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

