### PR TITLE
Fix issue where `FlowController` shows an empty saved payment method screen when `Google Pay` is enabled.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageOneSavedPaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageOneSavedPaymentMethodInteractor.kt
@@ -29,7 +29,7 @@ internal class DefaultManageOneSavedPaymentMethodInteractor(
 ) : ManageOneSavedPaymentMethodInteractor {
 
     constructor(sheetViewModel: BaseSheetViewModel) : this(
-        paymentMethod = sheetViewModel.paymentMethods.value!!.first(),
+        paymentMethod = sheetViewModel.paymentMethods.value.first(),
         paymentMethodMetadata = sheetViewModel.paymentMethodMetadata.value!!,
         providePaymentMethodName = sheetViewModel::providePaymentMethodName,
         onDeletePaymentMethod = { sheetViewModel.removePaymentMethod(it) },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
@@ -5,7 +5,7 @@ import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 
 internal object VerticalModeInitialScreenFactory {
     fun create(viewModel: BaseSheetViewModel): PaymentSheetScreen {
-        val savedPaymentMethods = viewModel.paymentMethods.value ?: emptyList()
+        val savedPaymentMethods = viewModel.paymentMethods.value
         if (viewModel.supportedPaymentMethods.size == 1 && savedPaymentMethods.isEmpty()) {
             return PaymentSheetScreen.Form(
                 interactor = DefaultVerticalModeFormInteractor(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -127,10 +127,10 @@ internal abstract class BaseSheetViewModel(
      * The list of saved payment methods for the current customer.
      * Value is null until it's loaded, and non-null (could be empty) after that.
      */
-    internal val paymentMethods: StateFlow<List<PaymentMethod>?> = savedStateHandle
+    internal val paymentMethods: StateFlow<List<PaymentMethod>> = savedStateHandle
         .getStateFlow<CustomerState?>(SAVED_CUSTOMER, null)
         .mapAsStateFlow { state ->
-            state?.paymentMethods
+            state?.paymentMethods ?: emptyList()
         }
 
     protected val backStack = MutableStateFlow<List<PaymentSheetScreen>>(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsStateMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsStateMapper.kt
@@ -10,7 +10,7 @@ import com.stripe.android.uicore.utils.combineAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 internal class PaymentOptionsStateMapper(
-    private val paymentMethods: StateFlow<List<PaymentMethod>?>,
+    private val paymentMethods: StateFlow<List<PaymentMethod>>,
     private val googlePayState: StateFlow<GooglePayState>,
     private val isLinkEnabled: StateFlow<Boolean?>,
     private val currentSelection: StateFlow<PaymentSelection?>,
@@ -39,13 +39,12 @@ internal class PaymentOptionsStateMapper(
 
     @Suppress("ReturnCount")
     private fun createPaymentOptionsState(
-        paymentMethods: List<PaymentMethod>?,
+        paymentMethods: List<PaymentMethod>,
         currentSelection: PaymentSelection?,
         isLinkEnabled: Boolean?,
         canRemovePaymentMethods: Boolean?,
         googlePayState: GooglePayState,
     ): PaymentOptionsState? {
-        if (paymentMethods == null) return null
         if (isLinkEnabled == null) return null
 
         return PaymentOptionsStateFactory.create(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -830,6 +830,24 @@ internal class PaymentOptionsViewModelTest {
             )
         }
 
+    @Test
+    fun `paymentMethods is not null when loading is complete`() = runTest {
+        val args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(
+            isGooglePayReady = true,
+        ).run {
+            copy(state = state.copy(customer = null))
+        }
+
+        val viewModel = createViewModel(args = args)
+
+        viewModel.currentScreen.test {
+            assertThat(awaitItem()).isInstanceOf(SelectSavedPaymentMethods::class.java)
+        }
+        viewModel.paymentMethods.test {
+            assertThat(awaitItem()).isEmpty()
+        }
+    }
+
     private fun createLinkViewModel(): PaymentOptionsViewModel {
         val linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(
             attachNewCardToAccountResult = Result.success(LinkTestUtils.LINK_NEW_PAYMENT_DETAILS),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1455,15 +1455,6 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `paymentMethods is null if payment sheet state is not loaded`() = runTest {
-        val viewModel = createViewModel(delay = Duration.INFINITE)
-
-        viewModel.paymentMethods.test {
-            assertThat(awaitItem()).isNull()
-        }
-    }
-
-    @Test
     fun `handleBackPressed is consumed when processing is true`() = runTest {
         val viewModel = createViewModel(customer = EMPTY_CUSTOMER_STATE)
         viewModel.savedStateHandle[SAVE_PROCESSING] = true

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsStateMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsStateMapperTest.kt
@@ -20,7 +20,7 @@ class PaymentOptionsStateMapperTest {
     @get:Rule
     val instantTaskExecutorRule = InstantTaskExecutorRule()
 
-    private val paymentMethodsFlow = MutableStateFlow<List<PaymentMethod>?>(null)
+    private val paymentMethodsFlow = MutableStateFlow<List<PaymentMethod>>(emptyList())
     private val currentSelectionFlow = MutableStateFlow<PaymentSelection?>(null)
     private val googlePayStateFlow = MutableStateFlow<GooglePayState>(GooglePayState.Indeterminate)
     private val isLinkEnabledFlow = MutableStateFlow<Boolean?>(null)


### PR DESCRIPTION
# Summary
Fix issue where `FlowController` shows an empty saved payment method screen when `Google Pay` is enabled.

# Motivation
Fix issue where `FlowController` shows an empty saved payment method screen when `Google Pay` is enabled.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
