### PR TITLE
Pass default payment method ID to `elements/sessions` when using `CustomerSession`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
@@ -14,6 +14,7 @@ sealed interface ElementsSessionParams : Parcelable {
     val customerSessionClientSecret: String?
     val locale: String?
     val expandFields: List<String>
+    val defaultPaymentMethodId: String?
     val externalPaymentMethods: List<String>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -22,6 +23,7 @@ sealed interface ElementsSessionParams : Parcelable {
         override val clientSecret: String,
         override val locale: String? = Locale.getDefault().toLanguageTag(),
         override val customerSessionClientSecret: String? = null,
+        override val defaultPaymentMethodId: String? = null,
         override val externalPaymentMethods: List<String>,
     ) : ElementsSessionParams {
 
@@ -38,6 +40,7 @@ sealed interface ElementsSessionParams : Parcelable {
         override val clientSecret: String,
         override val locale: String? = Locale.getDefault().toLanguageTag(),
         override val customerSessionClientSecret: String? = null,
+        override val defaultPaymentMethodId: String? = null,
         override val externalPaymentMethods: List<String>,
     ) : ElementsSessionParams {
 
@@ -54,6 +57,7 @@ sealed interface ElementsSessionParams : Parcelable {
         override val locale: String? = Locale.getDefault().toLanguageTag(),
         val deferredIntentParams: DeferredIntentParams,
         override val externalPaymentMethods: List<String>,
+        override val defaultPaymentMethodId: String? = null,
         override val customerSessionClientSecret: String? = null,
     ) : ElementsSessionParams {
 

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1487,6 +1487,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
             params.locale.let { this["locale"] = it }
             params.customerSessionClientSecret?.let { this["customer_session_client_secret"] = it }
             params.externalPaymentMethods.takeIf { it.isNotEmpty() }?.let { this["external_payment_methods"] = it }
+            params.defaultPaymentMethodId?.let { this["client_default_payment_method"] = it }
             (params as? ElementsSessionParams.DeferredIntentType)?.let { type ->
                 this.putAll(type.deferredIntentParams.toQueryParams())
             }

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -2591,6 +2591,72 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
+    fun `Verify 'client_default_payment_method' is in params when provided`() = runTest {
+        val stripeResponse = StripeResponse(
+            200,
+            ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_JSON.toString(),
+            emptyMap()
+        )
+
+        whenever(stripeNetworkClient.executeRequest(any<ApiRequest>())).thenReturn(stripeResponse)
+
+        create().retrieveElementsSession(
+            params = ElementsSessionParams.PaymentIntentType(
+                clientSecret = "client_secret",
+                externalPaymentMethods = emptyList(),
+                defaultPaymentMethodId = "pm_123",
+            ),
+            options = DEFAULT_OPTIONS,
+        )
+
+        verify(stripeNetworkClient).executeRequest(apiRequestArgumentCaptor.capture())
+
+        val request = apiRequestArgumentCaptor.firstValue
+        val params = requireNotNull(request.params)
+
+        assertThat(request.baseUrl).isEqualTo("https://api.stripe.com/v1/elements/sessions")
+
+        with(params) {
+            assertThat(this["type"]).isEqualTo("payment_intent")
+            assertThat(this["locale"]).isEqualTo("en-US")
+            assertThat(this["client_default_payment_method"]).isEqualTo("pm_123")
+        }
+    }
+
+    @Test
+    fun `Verify 'client_default_payment_method' not in params when not provided`() = runTest {
+        val stripeResponse = StripeResponse(
+            200,
+            ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_JSON.toString(),
+            emptyMap()
+        )
+
+        whenever(stripeNetworkClient.executeRequest(any<ApiRequest>())).thenReturn(stripeResponse)
+
+        create().retrieveElementsSession(
+            params = ElementsSessionParams.PaymentIntentType(
+                clientSecret = "client_secret",
+                defaultPaymentMethodId = null,
+                externalPaymentMethods = emptyList(),
+            ),
+            options = DEFAULT_OPTIONS,
+        )
+
+        verify(stripeNetworkClient).executeRequest(apiRequestArgumentCaptor.capture())
+
+        val request = apiRequestArgumentCaptor.firstValue
+        val params = requireNotNull(request.params)
+
+        assertThat(request.baseUrl).isEqualTo("https://api.stripe.com/v1/elements/sessions")
+
+        with(params) {
+            assertThat(this["type"]).isEqualTo("payment_intent")
+            assertThat(this["locale"]).isEqualTo("en-US")
+            assertThat(this["client_default_payment_method"]).isNull()
+        }
+    }
+
+    @Test
     fun `Verify that the elements session endpoint has the right query params for deferred intents`() = runTest {
         val stripeResponse = StripeResponse(
             200,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -118,6 +118,7 @@ internal class DefaultCustomerSheetLoader(
             initializationMode,
             customer = null,
             externalPaymentMethods = emptyList(),
+            defaultPaymentMethodId = null,
         ).map { elementsSession ->
             val billingDetailsCollectionConfig = configuration.billingDetailsCollectionConfiguration
             val sharedDataSpecs = lpmRepository.getSharedDataSpecs(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -22,6 +22,7 @@ internal interface ElementsSessionRepository {
         initializationMode: PaymentSheet.InitializationMode,
         customer: PaymentSheet.CustomerConfiguration?,
         externalPaymentMethods: List<String>,
+        defaultPaymentMethodId: String?
     ): Result<ElementsSession>
 }
 
@@ -46,10 +47,12 @@ internal class RealElementsSessionRepository @Inject constructor(
         initializationMode: PaymentSheet.InitializationMode,
         customer: PaymentSheet.CustomerConfiguration?,
         externalPaymentMethods: List<String>,
+        defaultPaymentMethodId: String?,
     ): Result<ElementsSession> {
         val params = initializationMode.toElementsSessionParams(
             customer = customer,
-            externalPaymentMethods = externalPaymentMethods
+            externalPaymentMethods = externalPaymentMethods,
+            defaultPaymentMethodId = defaultPaymentMethodId,
         )
 
         val elementsSession = stripeRepository.retrieveElementsSession(
@@ -111,6 +114,7 @@ private fun StripeIntent.withoutWeChatPay(): StripeIntent {
 internal fun PaymentSheet.InitializationMode.toElementsSessionParams(
     customer: PaymentSheet.CustomerConfiguration?,
     externalPaymentMethods: List<String>,
+    defaultPaymentMethodId: String?,
 ): ElementsSessionParams {
     val customerSessionClientSecret = customer?.toElementSessionParam()
 
@@ -120,6 +124,7 @@ internal fun PaymentSheet.InitializationMode.toElementsSessionParams(
                 clientSecret = clientSecret,
                 customerSessionClientSecret = customerSessionClientSecret,
                 externalPaymentMethods = externalPaymentMethods,
+                defaultPaymentMethodId = defaultPaymentMethodId,
             )
         }
 
@@ -128,6 +133,7 @@ internal fun PaymentSheet.InitializationMode.toElementsSessionParams(
                 clientSecret = clientSecret,
                 customerSessionClientSecret = customerSessionClientSecret,
                 externalPaymentMethods = externalPaymentMethods,
+                defaultPaymentMethodId = defaultPaymentMethodId,
             )
         }
 
@@ -136,6 +142,7 @@ internal fun PaymentSheet.InitializationMode.toElementsSessionParams(
                 deferredIntentParams = intentConfiguration.toDeferredIntentParams(),
                 externalPaymentMethods = externalPaymentMethods,
                 customerSessionClientSecret = customerSessionClientSecret,
+                defaultPaymentMethodId = defaultPaymentMethodId,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -84,51 +84,25 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
     ): Result<PaymentSheetState.Full> = withContext(workContext) {
         eventReporter.onLoadStarted(initializedViaCompose)
 
+        val savedPaymentMethodSelection = when (paymentSheetConfiguration.customer?.accessType) {
+            is PaymentSheet.CustomerAccessType.CustomerSession ->
+                retrieveSavedPaymentMethodSelection(paymentSheetConfiguration)
+            is PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey,
+            null -> null
+        }
+
         val elementsSessionResult = retrieveElementsSession(
             initializationMode = initializationMode,
             customer = paymentSheetConfiguration.customer,
             externalPaymentMethods = paymentSheetConfiguration.externalPaymentMethods,
+            defaultPaymentMethodId = savedPaymentMethodSelection?.id,
         )
 
         elementsSessionResult.mapCatching { elementsSession ->
-            val billingDetailsCollectionConfig =
-                paymentSheetConfiguration.billingDetailsCollectionConfiguration
-
-            val cbcEligibility = CardBrandChoiceEligibility.create(
-                isEligible = elementsSession.isEligibleForCardBrandChoice,
-                preferredNetworks = paymentSheetConfiguration.preferredNetworks,
+            val metadata = createPaymentMethodMetadata(
+                paymentSheetConfiguration = paymentSheetConfiguration,
+                elementsSession = elementsSession,
             )
-
-            val sharedDataSpecsResult = lpmRepository.getSharedDataSpecs(
-                stripeIntent = elementsSession.stripeIntent,
-                serverLpmSpecs = elementsSession.paymentMethodSpecs,
-            )
-            val externalPaymentMethodSpecs = externalPaymentMethodsRepository.getExternalPaymentMethodSpecs(
-                elementsSession.externalPaymentMethodData
-            )
-            logIfMissingExternalPaymentMethods(
-                requestedExternalPaymentMethods = paymentSheetConfiguration.externalPaymentMethods,
-                actualExternalPaymentMethods = externalPaymentMethodSpecs
-            )
-            val metadata = PaymentMethodMetadata(
-                stripeIntent = elementsSession.stripeIntent,
-                billingDetailsCollectionConfiguration = billingDetailsCollectionConfig,
-                allowsDelayedPaymentMethods = paymentSheetConfiguration.allowsDelayedPaymentMethods,
-                allowsPaymentMethodsRequiringShippingAddress = paymentSheetConfiguration
-                    .allowsPaymentMethodsRequiringShippingAddress,
-                paymentMethodOrder = paymentSheetConfiguration.paymentMethodOrder,
-                cbcEligibility = cbcEligibility,
-                merchantName = paymentSheetConfiguration.merchantDisplayName,
-                defaultBillingDetails = paymentSheetConfiguration.defaultBillingDetails,
-                shippingDetails = paymentSheetConfiguration.shippingDetails,
-                hasCustomerConfiguration = paymentSheetConfiguration.customer != null,
-                sharedDataSpecs = sharedDataSpecsResult.sharedDataSpecs,
-                externalPaymentMethodSpecs = externalPaymentMethodSpecs
-            )
-
-            if (sharedDataSpecsResult.failedToParseServerResponse) {
-                eventReporter.onLpmSpecFailure(sharedDataSpecsResult.failedToParseServerErrorMessage)
-            }
 
             create(
                 elementsSession = elementsSession,
@@ -274,8 +248,14 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         initializationMode: PaymentSheet.InitializationMode,
         customer: PaymentSheet.CustomerConfiguration?,
         externalPaymentMethods: List<String>,
+        defaultPaymentMethodId: String?,
     ): Result<ElementsSession> {
-        return elementsSessionRepository.get(initializationMode, customer, externalPaymentMethods)
+        return elementsSessionRepository.get(
+            initializationMode = initializationMode,
+            customer = customer,
+            externalPaymentMethods = externalPaymentMethods,
+            defaultPaymentMethodId = defaultPaymentMethodId
+        )
     }
 
     private suspend fun loadLinkState(
@@ -309,6 +289,52 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             configuration = linkConfig,
             loginState = loginState,
         )
+    }
+
+    private fun createPaymentMethodMetadata(
+        paymentSheetConfiguration: PaymentSheet.Configuration,
+        elementsSession: ElementsSession,
+    ): PaymentMethodMetadata {
+        val billingDetailsCollectionConfig =
+            paymentSheetConfiguration.billingDetailsCollectionConfiguration
+
+        val cbcEligibility = CardBrandChoiceEligibility.create(
+            isEligible = elementsSession.isEligibleForCardBrandChoice,
+            preferredNetworks = paymentSheetConfiguration.preferredNetworks,
+        )
+
+        val sharedDataSpecsResult = lpmRepository.getSharedDataSpecs(
+            stripeIntent = elementsSession.stripeIntent,
+            serverLpmSpecs = elementsSession.paymentMethodSpecs,
+        )
+        val externalPaymentMethodSpecs = externalPaymentMethodsRepository.getExternalPaymentMethodSpecs(
+            elementsSession.externalPaymentMethodData
+        )
+        logIfMissingExternalPaymentMethods(
+            requestedExternalPaymentMethods = paymentSheetConfiguration.externalPaymentMethods,
+            actualExternalPaymentMethods = externalPaymentMethodSpecs
+        )
+        val metadata = PaymentMethodMetadata(
+            stripeIntent = elementsSession.stripeIntent,
+            billingDetailsCollectionConfiguration = billingDetailsCollectionConfig,
+            allowsDelayedPaymentMethods = paymentSheetConfiguration.allowsDelayedPaymentMethods,
+            allowsPaymentMethodsRequiringShippingAddress = paymentSheetConfiguration
+                .allowsPaymentMethodsRequiringShippingAddress,
+            paymentMethodOrder = paymentSheetConfiguration.paymentMethodOrder,
+            cbcEligibility = cbcEligibility,
+            merchantName = paymentSheetConfiguration.merchantDisplayName,
+            defaultBillingDetails = paymentSheetConfiguration.defaultBillingDetails,
+            shippingDetails = paymentSheetConfiguration.shippingDetails,
+            hasCustomerConfiguration = paymentSheetConfiguration.customer != null,
+            sharedDataSpecs = sharedDataSpecsResult.sharedDataSpecs,
+            externalPaymentMethodSpecs = externalPaymentMethodSpecs
+        )
+
+        if (sharedDataSpecsResult.failedToParseServerResponse) {
+            eventReporter.onLpmSpecFailure(sharedDataSpecsResult.failedToParseServerErrorMessage)
+        }
+
+        return metadata
     }
 
     private suspend fun createLinkConfiguration(
@@ -397,12 +423,34 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         isGooglePayReady: Boolean,
         elementsSession: ElementsSession
     ): SavedSelection {
+        return retrieveSavedSelection(
+            config = config,
+            isGooglePayReady = isGooglePayReady,
+            isLinkAvailable = elementsSession.isLinkEnabled,
+        )
+    }
+
+    private suspend fun retrieveSavedPaymentMethodSelection(
+        config: PaymentSheet.Configuration,
+    ): SavedSelection.PaymentMethod? {
+        return retrieveSavedSelection(
+            config = config,
+            isGooglePayReady = false,
+            isLinkAvailable = false,
+        ) as? SavedSelection.PaymentMethod
+    }
+
+    private suspend fun retrieveSavedSelection(
+        config: PaymentSheet.Configuration,
+        isGooglePayReady: Boolean,
+        isLinkAvailable: Boolean,
+    ): SavedSelection {
         val customerConfig = config.customer
         val prefsRepository = prefsRepositoryFactory(customerConfig)
 
         return prefsRepository.getSavedSelection(
             isGooglePayAvailable = isGooglePayReady,
-            isLinkAvailable = elementsSession.isLinkEnabled,
+            isLinkAvailable = isLinkAvailable,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -434,8 +434,11 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         config: PaymentSheet.Configuration,
     ): SavedSelection.PaymentMethod? {
         /*
-         * We only care is the `SavedSelection` is a `PaymentMethod` type and not `Google Pay` or `Link`. Therefore
-         * we don't need to know if `Google Pay` or `Link` is ready and set them to `false`.
+         * For `CustomerSession`, `v1/elements/sessions` needs to know the client-side saved default payment method
+         * ID to ensure it is properly returned by the API when performing payment method deduping. We only care
+         * about the Stripe `payment_method` id when deduping since `Google Pay` and `Link` are locally defined
+         * LPMs and not recognized by the `v1/elements/sessions` API. We don't need to know if they are ready and
+         * can safely set them to `false`.
          */
         return retrieveSavedSelection(
             config = config,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -433,6 +433,10 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
     private suspend fun retrieveSavedPaymentMethodSelection(
         config: PaymentSheet.Configuration,
     ): SavedSelection.PaymentMethod? {
+        /*
+         * We only care is the `SavedSelection` is a `PaymentMethod` type and not `Google Pay` or `Link`. Therefore
+         * we don't need to know if `Google Pay` or `Link` is ready and set them to `false`.
+         */
         return retrieveSavedSelection(
             config = config,
             isGooglePayReady = false,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -227,6 +227,7 @@ class DefaultCustomerSheetLoaderTest {
         val params = elementsSessionRepository.lastParams?.initializationMode?.toElementsSessionParams(
             customer = null,
             externalPaymentMethods = emptyList(),
+            defaultPaymentMethodId = null,
         ) as ElementsSessionParams.DeferredIntentType
         assertThat(params.deferredIntentParams.paymentMethodTypes).containsExactly("card")
     }
@@ -260,6 +261,7 @@ class DefaultCustomerSheetLoaderTest {
         val params = elementsSessionRepository.lastParams?.initializationMode?.toElementsSessionParams(
             customer = null,
             externalPaymentMethods = emptyList(),
+            defaultPaymentMethodId = null,
         ) as ElementsSessionParams.DeferredIntentType
         assertThat(params.deferredIntentParams.paymentMethodTypes).containsExactly("card")
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
@@ -52,6 +52,7 @@ internal class ElementsSessionRepositoryTest {
                 ),
                 customer = null,
                 externalPaymentMethods = emptyList(),
+                defaultPaymentMethodId = null,
             ).getOrThrow()
         }
 
@@ -80,6 +81,7 @@ internal class ElementsSessionRepositoryTest {
                     ),
                     customer = null,
                     externalPaymentMethods = emptyList(),
+                    defaultPaymentMethodId = null,
                 ).getOrThrow()
             }
 
@@ -105,6 +107,7 @@ internal class ElementsSessionRepositoryTest {
                     ),
                     customer = null,
                     externalPaymentMethods = emptyList(),
+                    defaultPaymentMethodId = null,
                 ).getOrThrow()
             }
 
@@ -136,6 +139,7 @@ internal class ElementsSessionRepositoryTest {
             ),
             customer = null,
             externalPaymentMethods = emptyList(),
+            defaultPaymentMethodId = null,
         ).getOrThrow()
 
         val argumentCaptor: KArgumentCaptor<ElementsSessionParams> = argumentCaptor()
@@ -172,6 +176,7 @@ internal class ElementsSessionRepositoryTest {
             ),
             customer = null,
             externalPaymentMethods = emptyList(),
+            defaultPaymentMethodId = null,
         )
 
         assertThat(session.getOrNull()).isNull()
@@ -207,6 +212,7 @@ internal class ElementsSessionRepositoryTest {
                 clientSecret = "customer_session_client_secret"
             ),
             externalPaymentMethods = emptyList(),
+            defaultPaymentMethodId = null,
         )
 
         verify(stripeRepository).retrieveElementsSession(
@@ -215,6 +221,47 @@ internal class ElementsSessionRepositoryTest {
                     clientSecret = "client_secret",
                     customerSessionClientSecret = "customer_session_client_secret",
                     externalPaymentMethods = emptyList(),
+                    defaultPaymentMethodId = null,
+                )
+            ),
+            options = any()
+        )
+    }
+
+    @Test
+    fun `Verify default payment method id is passed to 'StripeRepository'`() = runTest {
+        whenever(
+            stripeRepository.retrieveElementsSession(any(), any())
+        ).thenReturn(
+            Result.success(
+                ElementsSession.createFromFallback(
+                    stripeIntent = PaymentIntentFixtures.PI_WITH_SHIPPING,
+                    sessionsError = null,
+                )
+            )
+        )
+
+        val repository = RealElementsSessionRepository(
+            stripeRepository,
+            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
+            testDispatcher,
+        )
+
+        repository.get(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = "client_secret"
+            ),
+            customer = null,
+            externalPaymentMethods = emptyList(),
+            defaultPaymentMethodId = "pm_123",
+        )
+
+        verify(stripeRepository).retrieveElementsSession(
+            params = eq(
+                ElementsSessionParams.PaymentIntentType(
+                    clientSecret = "client_secret",
+                    externalPaymentMethods = emptyList(),
+                    defaultPaymentMethodId = "pm_123",
                 )
             ),
             options = any()

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
@@ -19,6 +19,7 @@ internal class FakeElementsSessionRepository(
         val initializationMode: PaymentSheet.InitializationMode,
         val customer: PaymentSheet.CustomerConfiguration?,
         val externalPaymentMethods: List<String>,
+        val defaultPaymentMethodId: String?
     )
 
     var lastParams: Params? = null
@@ -27,11 +28,13 @@ internal class FakeElementsSessionRepository(
         initializationMode: PaymentSheet.InitializationMode,
         customer: PaymentSheet.CustomerConfiguration?,
         externalPaymentMethods: List<String>,
+        defaultPaymentMethodId: String?,
     ): Result<ElementsSession> {
         lastParams = Params(
             initializationMode = initializationMode,
             customer = customer,
-            externalPaymentMethods = externalPaymentMethods
+            externalPaymentMethods = externalPaymentMethods,
+            defaultPaymentMethodId = defaultPaymentMethodId,
         )
         return if (error != null) {
             Result.failure(error)


### PR DESCRIPTION
# Summary
Pass default payment method ID to `elements/sessions` when using `CustomerSession`

# Motivation
Ensures payment methods are properly deduped in `CustomerSession`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified