### PR TITLE
Add UserFacingLogger and use it to when log external PMs are missing from elements/session response

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -11,6 +11,8 @@ import com.stripe.android.core.networking.NetworkTypeDetector
 import com.stripe.android.core.utils.ContextUtils.packageInfo
 import com.stripe.android.core.utils.DefaultDurationProvider
 import com.stripe.android.core.utils.DurationProvider
+import com.stripe.android.core.utils.RealUserFacingLogger
+import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.RealLinkConfigurationCoordinator
 import com.stripe.android.link.injection.LinkAnalyticsComponent
@@ -74,6 +76,9 @@ internal abstract class PaymentSheetCommonModule {
 
     @Binds
     abstract fun bindsPaymentSheetLoader(impl: DefaultPaymentSheetLoader): PaymentSheetLoader
+
+    @Binds
+    abstract fun bindsUserFacingLogger(impl: RealUserFacingLogger): UserFacingLogger
 
     @Binds
     abstract fun bindsLinkAccountStatusProvider(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -474,7 +474,10 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
                 )
             ) {
                 userFacingLogger.logWarningWithoutPii(
-                    "Requested external payment method $requestedExternalPaymentMethod is not supported."
+                    "Requested external payment method $requestedExternalPaymentMethod is not supported. View all " +
+                        "available external payment methods here: " +
+                        "https://docs.stripe.com/payments/external-payment-methods?platform=android#" +
+                        "available-external-payment-methods"
                 )
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.state
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
+import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.link.LinkConfiguration
@@ -74,6 +75,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
     private val accountStatusProvider: LinkAccountStatusProvider,
     private val linkStore: LinkStore,
     private val externalPaymentMethodsRepository: ExternalPaymentMethodsRepository,
+    private val userFacingLogger: UserFacingLogger,
 ) : PaymentSheetLoader {
 
     override suspend fun load(
@@ -471,7 +473,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
                     requestedExternalPaymentMethod
                 )
             ) {
-                logger.warning(
+                userFacingLogger.logWarningWithoutPii(
                     "Requested external payment method $requestedExternalPaymentMethod is not supported."
                 )
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -1035,7 +1035,9 @@ internal class DefaultPaymentSheetLoaderTest {
             externalPaymentMethodData = null,
             expectedExternalPaymentMethods = emptyList(),
             expectedLogMessages = listOf(
-                "Requested external payment method external_paypal is not supported."
+                "Requested external payment method external_paypal is not supported. View all available external " +
+                    "payment methods here: https://docs.stripe.com/payments/external-payment-methods?" +
+                    "platform=android#available-external-payment-methods"
             ),
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -4,7 +4,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.model.CountryCode
-import com.stripe.android.core.utils.FakeUserFacingLogger
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.account.LinkStore
@@ -33,6 +32,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException.PaymentIntentInTerminalState
+import com.stripe.android.paymentsheet.utils.FakeUserFacingLogger
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.ui.core.elements.ExternalPaymentMethodsRepository

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/FakeUserFacingLogger.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/FakeUserFacingLogger.kt
@@ -1,0 +1,16 @@
+package com.stripe.android.paymentsheet.utils
+
+import com.stripe.android.core.utils.UserFacingLogger
+
+class FakeUserFacingLogger : UserFacingLogger {
+
+    private val loggedMessages: MutableList<String> = mutableListOf()
+
+    override fun logWarningWithoutPii(message: String) {
+        loggedMessages.add(message)
+    }
+
+    fun getLoggedMessages(): List<String> {
+        return loggedMessages.toList()
+    }
+}

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/UserFacingLogger.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/UserFacingLogger.kt
@@ -24,17 +24,3 @@ class RealUserFacingLogger @Inject constructor(context: Context) : UserFacingLog
         logger.warning(message)
     }
 }
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class FakeUserFacingLogger : UserFacingLogger {
-
-    private val loggedMessages: MutableList<String> = mutableListOf()
-
-    override fun logWarningWithoutPii(message: String) {
-        loggedMessages.add(message)
-    }
-
-    fun getLoggedMessages(): List<String> {
-        return loggedMessages.toList()
-    }
-}

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/UserFacingLogger.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/UserFacingLogger.kt
@@ -29,6 +29,7 @@ class RealUserFacingLogger @Inject constructor(context: Context) : UserFacingLog
 class FakeUserFacingLogger : UserFacingLogger {
 
     private val loggedMessages: MutableList<String> = mutableListOf()
+
     override fun logWarningWithoutPii(message: String) {
         loggedMessages.add(message)
     }

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/UserFacingLogger.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/UserFacingLogger.kt
@@ -1,0 +1,39 @@
+package com.stripe.android.core.utils
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import androidx.annotation.RestrictTo
+import com.stripe.android.core.BuildConfig
+import com.stripe.android.core.Logger
+import javax.inject.Inject
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+interface UserFacingLogger {
+    fun logWarningWithoutPii(message: String)
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class RealUserFacingLogger @Inject constructor(context: Context) : UserFacingLogger {
+
+    private val isDebuggable = 0 != context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE
+    private val isDebugBuild = BuildConfig.DEBUG
+
+    private val logger = Logger.getInstance(enableLogging = isDebuggable || isDebugBuild)
+
+    override fun logWarningWithoutPii(message: String) {
+        logger.warning(message)
+    }
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class FakeUserFacingLogger : UserFacingLogger {
+
+    private val loggedMessages: MutableList<String> = mutableListOf()
+    override fun logWarningWithoutPii(message: String) {
+        loggedMessages.add(message)
+    }
+
+    fun getLoggedMessages(): List<String> {
+        return loggedMessages.toList()
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add UserFacingLogger and use it to when log external PMs are missing from elements/session response

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2107
https://jira.corp.stripe.com/browse/MOBILESDK-2108

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified