### PR TITLE
Improve pane transitions in bank auth flow

### DIFF
--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -2049,13 +2049,13 @@ public final class com/stripe/android/financialconnections/ui/components/Composa
 	public static final field INSTANCE Lcom/stripe/android/financialconnections/ui/components/ComposableSingletons$TopAppBarKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;
 	public static field lambda-2 Lkotlin/jvm/functions/Function2;
-	public static field lambda-3 Lkotlin/jvm/functions/Function2;
+	public static field lambda-3 Lkotlin/jvm/functions/Function3;
 	public static field lambda-4 Lkotlin/jvm/functions/Function2;
 	public static field lambda-5 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-4$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-5$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
@@ -63,11 +63,14 @@ import com.stripe.android.financialconnections.utils.error
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import java.util.Date
 import javax.inject.Named
 import com.stripe.android.financialconnections.features.partnerauth.SharedPartnerAuthState.AuthenticationStatus as Status
+
+private val NavigationDelayMillis = 500L
 
 internal class PartnerAuthViewModel @AssistedInject constructor(
     private val completeAuthorizationSession: CompleteAuthorizationSession,
@@ -410,6 +413,7 @@ internal class PartnerAuthViewModel @AssistedInject constructor(
                 AccountPicker(referrer = PANE)
             }
             FinancialConnections.emitEvent(Name.INSTITUTION_AUTHORIZED)
+            delay(NavigationDelayMillis)
             navigationManager.tryNavigateTo(nextPane)
         }.onFailure {
             eventTracker.logError(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/Destination.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/Destination.kt
@@ -52,6 +52,7 @@ internal sealed class Destination(
     val closeWithoutConfirmation: Boolean,
     val logPaneLaunched: Boolean,
     extraArgs: List<NamedNavArgument> = emptyList(),
+    val fadeOnlyTransition: Boolean,
     protected val composable: @Composable (NavBackStackEntry) -> Unit
 ) {
 
@@ -96,6 +97,7 @@ internal sealed class Destination(
         route = Pane.INSTITUTION_PICKER.value,
         closeWithoutConfirmation = false,
         logPaneLaunched = true,
+        fadeOnlyTransition = false,
         composable = { InstitutionPickerScreen(it) },
     )
 
@@ -103,6 +105,7 @@ internal sealed class Destination(
         route = Pane.CONSENT.value,
         closeWithoutConfirmation = true,
         logPaneLaunched = true,
+        fadeOnlyTransition = false,
         composable = { ConsentScreen() }
     )
 
@@ -110,6 +113,7 @@ internal sealed class Destination(
         route = Pane.PARTNER_AUTH_DRAWER.value,
         closeWithoutConfirmation = false,
         logPaneLaunched = true,
+        fadeOnlyTransition = false,
         composable = { PartnerAuthScreen(inModal = true) }
     )
 
@@ -117,6 +121,7 @@ internal sealed class Destination(
         route = Pane.PARTNER_AUTH.value,
         closeWithoutConfirmation = false,
         logPaneLaunched = true,
+        fadeOnlyTransition = false,
         composable = { PartnerAuthScreen(inModal = false) }
     )
 
@@ -124,6 +129,7 @@ internal sealed class Destination(
         route = Pane.ACCOUNT_PICKER.value,
         closeWithoutConfirmation = false,
         logPaneLaunched = true,
+        fadeOnlyTransition = false,
         composable = { AccountPickerScreen() }
     )
 
@@ -131,6 +137,7 @@ internal sealed class Destination(
         route = Pane.SUCCESS.value,
         closeWithoutConfirmation = true,
         logPaneLaunched = true,
+        fadeOnlyTransition = false,
         composable = { SuccessScreen() }
     )
 
@@ -138,6 +145,7 @@ internal sealed class Destination(
         route = Pane.MANUAL_ENTRY.value,
         closeWithoutConfirmation = false,
         logPaneLaunched = true,
+        fadeOnlyTransition = false,
         composable = { ManualEntryScreen() }
     )
 
@@ -145,6 +153,7 @@ internal sealed class Destination(
         route = Pane.ATTACH_LINKED_PAYMENT_ACCOUNT.value,
         closeWithoutConfirmation = false,
         logPaneLaunched = true,
+        fadeOnlyTransition = true,
         composable = { AttachPaymentScreen() }
     )
 
@@ -152,6 +161,7 @@ internal sealed class Destination(
         route = Pane.NETWORKING_LINK_SIGNUP_PANE.value,
         closeWithoutConfirmation = false,
         logPaneLaunched = true,
+        fadeOnlyTransition = false,
         composable = { NetworkingLinkSignupScreen() }
     )
 
@@ -165,6 +175,7 @@ internal sealed class Destination(
         ),
         closeWithoutConfirmation = false,
         logPaneLaunched = true,
+        fadeOnlyTransition = false,
         composable = { NetworkingLinkLoginWarmupScreen(it) }
     )
 
@@ -172,6 +183,7 @@ internal sealed class Destination(
         route = Pane.NETWORKING_LINK_VERIFICATION.value,
         closeWithoutConfirmation = false,
         logPaneLaunched = true,
+        fadeOnlyTransition = false,
         composable = { NetworkingLinkVerificationScreen() }
     )
 
@@ -179,6 +191,7 @@ internal sealed class Destination(
         route = Pane.NETWORKING_SAVE_TO_LINK_VERIFICATION.value,
         closeWithoutConfirmation = false,
         logPaneLaunched = true,
+        fadeOnlyTransition = false,
         composable = { NetworkingSaveToLinkVerificationScreen() }
     )
 
@@ -186,6 +199,7 @@ internal sealed class Destination(
         route = Pane.LINK_ACCOUNT_PICKER.value,
         closeWithoutConfirmation = false,
         logPaneLaunched = true,
+        fadeOnlyTransition = false,
         composable = { LinkAccountPickerScreen() },
     )
 
@@ -193,6 +207,7 @@ internal sealed class Destination(
         route = Pane.LINK_STEP_UP_VERIFICATION.value,
         closeWithoutConfirmation = false,
         logPaneLaunched = true,
+        fadeOnlyTransition = false,
         composable = { LinkStepUpVerificationScreen() }
     )
 
@@ -200,6 +215,7 @@ internal sealed class Destination(
         route = Pane.RESET.value,
         closeWithoutConfirmation = false,
         logPaneLaunched = true,
+        fadeOnlyTransition = false,
         composable = { ResetScreen() }
     )
 
@@ -207,6 +223,7 @@ internal sealed class Destination(
         route = Pane.EXIT.value,
         closeWithoutConfirmation = false,
         logPaneLaunched = false,
+        fadeOnlyTransition = false,
         composable = { ExitModal(it) }
     )
 
@@ -214,6 +231,7 @@ internal sealed class Destination(
         route = Pane.NOTICE.value,
         closeWithoutConfirmation = false,
         logPaneLaunched = false,
+        fadeOnlyTransition = false,
         composable = { NoticeSheet(it) },
     )
 
@@ -221,6 +239,7 @@ internal sealed class Destination(
         route = Pane.ACCOUNT_UPDATE_REQUIRED.value,
         closeWithoutConfirmation = false,
         logPaneLaunched = false,
+        fadeOnlyTransition = false,
         composable = { AccountUpdateRequiredModal(it) },
     )
 
@@ -228,6 +247,7 @@ internal sealed class Destination(
         route = Pane.UNEXPECTED_ERROR.value,
         closeWithoutConfirmation = false,
         logPaneLaunched = false,
+        fadeOnlyTransition = false,
         composable = { ErrorScreen() }
     )
 
@@ -235,6 +255,7 @@ internal sealed class Destination(
         route = Pane.BANK_AUTH_REPAIR.value,
         closeWithoutConfirmation = false,
         logPaneLaunched = true,
+        fadeOnlyTransition = false,
         composable = { BankAuthRepairScreen() }
     )
 
@@ -242,6 +263,7 @@ internal sealed class Destination(
         route = Pane.MANUAL_ENTRY_SUCCESS.value,
         closeWithoutConfirmation = true,
         logPaneLaunched = true,
+        fadeOnlyTransition = false,
         composable = { ManualEntrySuccessScreen() }
     )
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/DestinationMappers.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/DestinationMappers.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.navigation
 
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDestination
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 
@@ -35,5 +36,11 @@ internal val Pane.destination: Destination
 internal val NavDestination.pane: Pane
     get() = paneToDestination.entries
         .firstOrNull { (_, destination) -> destination.fullRoute == route }
+        ?.key
+        ?: throw IllegalArgumentException("No corresponding destination for $this")
+
+internal val NavBackStackEntry.pane: Pane
+    get() = paneToDestination.entries
+        .firstOrNull { (_, destination) -> destination.fullRoute == this.destination.route }
         ?.key
         ?: throw IllegalArgumentException("No corresponding destination for $this")

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -204,6 +204,10 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity() {
                     NavHost(
                         navController = navController,
                         startDestination = initialDestination.fullRoute,
+                        enterTransition = enterTransition(),
+                        exitTransition = pauseTransition(),
+                        popEnterTransition = resumeTransition(),
+                        popExitTransition = exitTransition(),
                     ) {
                         composable(Destination.Consent)
                         composable(Destination.ManualEntry)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/Transitions.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/Transitions.kt
@@ -1,0 +1,91 @@
+package com.stripe.android.financialconnections.ui
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.navigation.NavBackStackEntry
+import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane.ATTACH_LINKED_PAYMENT_ACCOUNT
+import com.stripe.android.financialconnections.navigation.pane
+
+private const val TransitionDurationMillis = 300
+
+private val FADE_IN_TRANSITION = fadeIn(
+    animationSpec = tween(TransitionDurationMillis)
+)
+
+private val FADE_OUT_TRANSITION = fadeOut(
+    animationSpec = tween(TransitionDurationMillis)
+)
+
+internal fun enterTransition(): AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition {
+    return {
+        if (initialState.skipTransition) {
+            FADE_IN_TRANSITION
+        } else {
+            FADE_IN_TRANSITION + slideInHorizontally(
+                animationSpec = tween(TransitionDurationMillis),
+                initialOffsetX = { fullWidth ->
+                    fullWidth / 2
+                },
+            )
+        }
+    }
+}
+
+internal fun resumeTransition(): AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition {
+    return {
+        if (initialState.skipTransition) {
+            FADE_IN_TRANSITION
+        } else {
+            FADE_IN_TRANSITION + slideInHorizontally(
+                animationSpec = tween(TransitionDurationMillis),
+                initialOffsetX = { fullWidth ->
+                    -fullWidth / 2
+                },
+            )
+        }
+    }
+}
+
+internal fun pauseTransition(): AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition {
+    return {
+        if (initialState.skipTransition) {
+            FADE_OUT_TRANSITION
+        } else {
+            FADE_OUT_TRANSITION + slideOutHorizontally(
+                animationSpec = tween(TransitionDurationMillis),
+                targetOffsetX = { fullWidth ->
+                    -fullWidth / 2
+                },
+            )
+        }
+    }
+}
+
+internal fun exitTransition(): AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition {
+    return {
+        if (initialState.skipTransition) {
+            FADE_OUT_TRANSITION
+        } else {
+            FADE_OUT_TRANSITION + slideOutHorizontally(
+                animationSpec = tween(TransitionDurationMillis),
+                targetOffsetX = { fullWidth ->
+                    fullWidth / 2
+                },
+            )
+        }
+    }
+}
+
+/**
+ * We want to skip the transition for some screens and use a simple fade instead. This currently only applies
+ * to transitions starting from the attach linked payment account screen, which only ever shows a loading indicator.
+ * We wouldn't want to show a slide transition from one loading indicator to another, therefore we use a fade.
+ */
+private val NavBackStackEntry.skipTransition: Boolean
+    get() = destination.pane == ATTACH_LINKED_PAYMENT_ACCOUNT

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/Transitions.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/Transitions.kt
@@ -9,7 +9,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.navigation.NavBackStackEntry
-import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane.ATTACH_LINKED_PAYMENT_ACCOUNT
+import com.stripe.android.financialconnections.navigation.destination
 import com.stripe.android.financialconnections.navigation.pane
 
 private const val TransitionDurationMillis = 300
@@ -24,7 +24,7 @@ private val FADE_OUT_TRANSITION = fadeOut(
 
 internal fun enterTransition(): AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition {
     return {
-        if (initialState.skipTransition) {
+        if (initialState.pane.destination.fadeOnlyTransition) {
             FADE_IN_TRANSITION
         } else {
             FADE_IN_TRANSITION + slideInHorizontally(
@@ -39,7 +39,7 @@ internal fun enterTransition(): AnimatedContentTransitionScope<NavBackStackEntry
 
 internal fun resumeTransition(): AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition {
     return {
-        if (initialState.skipTransition) {
+        if (initialState.pane.destination.fadeOnlyTransition) {
             FADE_IN_TRANSITION
         } else {
             FADE_IN_TRANSITION + slideInHorizontally(
@@ -54,7 +54,7 @@ internal fun resumeTransition(): AnimatedContentTransitionScope<NavBackStackEntr
 
 internal fun pauseTransition(): AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition {
     return {
-        if (initialState.skipTransition) {
+        if (initialState.pane.destination.fadeOnlyTransition) {
             FADE_OUT_TRANSITION
         } else {
             FADE_OUT_TRANSITION + slideOutHorizontally(
@@ -69,7 +69,7 @@ internal fun pauseTransition(): AnimatedContentTransitionScope<NavBackStackEntry
 
 internal fun exitTransition(): AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition {
     return {
-        if (initialState.skipTransition) {
+        if (initialState.pane.destination.fadeOnlyTransition) {
             FADE_OUT_TRANSITION
         } else {
             FADE_OUT_TRANSITION + slideOutHorizontally(
@@ -81,11 +81,3 @@ internal fun exitTransition(): AnimatedContentTransitionScope<NavBackStackEntry>
         }
     }
 }
-
-/**
- * We want to skip the transition for some screens and use a simple fade instead. This currently only applies
- * to transitions starting from the attach linked payment account screen, which only ever shows a loading indicator.
- * We wouldn't want to show a slide transition from one loading indicator to another, therefore we use a fade.
- */
-private val NavBackStackEntry.skipTransition: Boolean
-    get() = destination.pane == ATTACH_LINKED_PAYMENT_ACCOUNT

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
@@ -197,7 +197,7 @@ private fun Title(
             enter = fadeIn(animationSpec = tween()),
             exit = fadeOut(animationSpec = tween()),
         ) {
-            Icon(
+            Image(
                 modifier = Modifier.size(width = LOGO_WIDTH, height = LOGO_HEIGHT),
                 painter = painterResource(id = theme.icon),
                 contentDescription = null // decorative element

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
@@ -2,7 +2,11 @@ package com.stripe.android.financialconnections.ui.components
 
 import androidx.activity.OnBackPressedDispatcher
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -188,13 +192,18 @@ private fun Title(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        if (hideStripeLogo.not()) {
-            Image(
+        AnimatedVisibility(
+            visible = !hideStripeLogo,
+            enter = fadeIn(animationSpec = tween()),
+            exit = fadeOut(animationSpec = tween()),
+        ) {
+            Icon(
                 modifier = Modifier.size(width = LOGO_WIDTH, height = LOGO_HEIGHT),
                 painter = painterResource(id = theme.icon),
                 contentDescription = null // decorative element
             )
         }
+
         // show a test mode pill if in test mode
         if (testmode) {
             Text(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds proper pane slide transitions in the bank auth flow, and a fade effect for the Stripe logo in the top bar.

We exclude the attach-payment screen from the slide transitions, as it would just cause a slide from one loading indicator to another (we use a fade instead).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screen recordings

<details><summary>Before</summary>
<p>

https://github.com/stripe/stripe-android/assets/110940675/660fb0e7-742f-4a44-946a-9774c0d133d7

</p>
</details>

<details><summary>After</summary>
<p>

https://github.com/stripe/stripe-android/assets/110940675/fcd53593-3b8f-429f-92dc-295216985f0c

</p>
</details>

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
