### PR TITLE
Revert "[Identity] Add support for http logoUri (#4851)"

### DIFF
--- a/identity/src/main/AndroidManifest.xml
+++ b/identity/src/main/AndroidManifest.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.CAMERA" />
 
-    <application
-        android:usesCleartextTraffic="true"
-        tools:targetApi="m">
+    <application>
         <activity
             android:name=".IdentityActivity"
             android:screenOrientation="portrait"


### PR DESCRIPTION
This reverts commit 435facbb7ae3ab56ab32f9c9e08eac416b7ba81b.

Fixes https://github.com/stripe/stripe-android/issues/8666

# Summary
<!-- Simple summary of what was changed. -->
The reason this was introduced is no longer in use, so it's not needed.

