### PR TITLE
Enforce HTTPs for all network requests.

### DIFF
--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
@@ -93,7 +93,7 @@ private class NetworkStatement(
         override fun open(
             request: StripeRequest,
             callback: HttpURLConnection.(request: StripeRequest) -> Unit
-        ): HttpURLConnection {
+        ): HttpsURLConnection {
             val requestHost = request.url.hostFromUrl()
             if (!hostsToTrack.contains(requestHost)) {
                 throw RequestNotFoundException(
@@ -109,10 +109,8 @@ private class NetworkStatement(
                     mockWebServer.baseUrl.toString().removeSuffix("/")
                 )
             )
-            return (URL(delegatingRequest.url).openConnection() as HttpURLConnection).apply {
-                if (this is HttpsURLConnection) {
-                    sslSocketFactory = mockWebServer.clientSocketFactory()
-                }
+            return (URL(delegatingRequest.url).openConnection() as HttpsURLConnection).apply {
+                sslSocketFactory = mockWebServer.clientSocketFactory()
                 callback(delegatingRequest)
             }
         }

--- a/stripe-core/build.gradle
+++ b/stripe-core/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 
     ksp libs.daggerCompiler
 
+    testImplementation project(':network-testing')
     testImplementation testLibs.androidx.archCore
     testImplementation testLibs.androidx.core
     testImplementation testLibs.androidx.fragment

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/ConnectionFactory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/ConnectionFactory.kt
@@ -7,9 +7,10 @@ import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URL
 import java.util.concurrent.TimeUnit
+import javax.net.ssl.HttpsURLConnection
 
 /**
- * Factory to create [StripeConnection], which encapsulates an [HttpURLConnection], triggers the
+ * Factory to create [StripeConnection], which encapsulates an [HttpsURLConnection], triggers the
  * request and parses the response with different body type as [StripeResponse].
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -31,15 +32,15 @@ interface ConnectionFactory {
         fun open(
             request: StripeRequest,
             callback: HttpURLConnection.(request: StripeRequest) -> Unit
-        ): HttpURLConnection
+        ): HttpsURLConnection
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         object Default : ConnectionOpener {
             override fun open(
                 request: StripeRequest,
                 callback: HttpURLConnection.(request: StripeRequest) -> Unit
-            ): HttpURLConnection {
-                return (URL(request.url).openConnection() as HttpURLConnection).apply {
+            ): HttpsURLConnection {
+                return (URL(request.url).openConnection() as HttpsURLConnection).apply {
                     callback(request)
                 }
             }
@@ -69,7 +70,7 @@ interface ConnectionFactory {
 
         private fun openConnectionAndApplyFields(
             originalRequest: StripeRequest
-        ): HttpURLConnection {
+        ): HttpsURLConnection {
             return connectionOpener.open(originalRequest) { request ->
                 connectTimeout = CONNECT_TIMEOUT
                 readTimeout = READ_TIMEOUT

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/StripeConnection.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/StripeConnection.kt
@@ -9,6 +9,7 @@ import java.io.InputStream
 import java.net.HttpURLConnection
 import java.nio.charset.StandardCharsets
 import java.util.Scanner
+import javax.net.ssl.HttpsURLConnection
 
 /**
  * A wrapper for accessing a [HttpURLConnection]. Implements [Closeable] to simplify closing related
@@ -22,7 +23,7 @@ interface StripeConnection<ResponseBodyType> : Closeable {
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     abstract class AbstractConnection<ResponseBodyType>(
-        private val conn: HttpURLConnection
+        private val conn: HttpsURLConnection
     ) : StripeConnection<ResponseBodyType> {
         override val responseCode: Int
             @JvmSynthetic
@@ -67,7 +68,7 @@ interface StripeConnection<ResponseBodyType> : Closeable {
      * Default [StripeConnection] that converts the ResponseStream to a String.
      */
     class Default internal constructor(
-        conn: HttpURLConnection
+        conn: HttpsURLConnection
     ) : AbstractConnection<String>(conn = conn) {
 
         /**
@@ -95,7 +96,7 @@ interface StripeConnection<ResponseBodyType> : Closeable {
      * [StripeConnection] that writes the ResponseStream to a File.
      */
     class FileConnection internal constructor(
-        conn: HttpURLConnection,
+        conn: HttpsURLConnection,
         private val outputFile: File
     ) : AbstractConnection<File>(conn = conn) {
 

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/FakeStripeRequest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/FakeStripeRequest.kt
@@ -1,0 +1,18 @@
+package com.stripe.android.core.networking
+
+const val TEST_HOST = "https://test.host.com"
+
+const val TEST_RETRY_CODES_START = 401
+const val TEST_RETRY_CODES_END = 456
+
+// [HTTP_TOO_MANY_REQUESTS] is included in this range
+private val TEST_RETRY_CODES: Iterable<Int> = TEST_RETRY_CODES_START..TEST_RETRY_CODES_END
+
+internal class FakeStripeRequest(
+    override val url: String = TEST_HOST,
+    override val shouldCache: Boolean = false,
+    override val method: Method = Method.POST,
+    override val mimeType: MimeType = MimeType.Form,
+    override val headers: Map<String, String> = emptyMap(),
+    override val retryResponseCodes: Iterable<Int> = TEST_RETRY_CODES
+) : StripeRequest()

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/NetworkCachingTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/NetworkCachingTest.kt
@@ -1,0 +1,81 @@
+package com.stripe.android.core.networking
+
+import android.net.http.HttpResponseCache
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.RequestMatchers.method
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import java.net.CacheRequest
+import java.net.CacheResponse
+import java.net.ResponseCache
+import java.net.URI
+import java.net.URLConnection
+import kotlin.test.Test
+
+internal class NetworkCachingTest {
+    @get:Rule
+    val networkRule = NetworkRule()
+
+    @Test
+    fun `request that should cache creates a connection that uses cache`() = runTest {
+        networkRule.enqueue(method("GET")) { response ->
+            response.setBody("response1")
+        }
+        networkRule.enqueue(method("GET")) { response ->
+            response.setBody("response2")
+        }
+        networkRule.enqueue(method("GET")) { response ->
+            response.setBody("response3")
+        }
+
+        var getCacheCount = 0
+        var putCacheCount = 0
+        HttpResponseCache.setDefault(object : ResponseCache() {
+            override fun get(
+                uri: URI?,
+                rqstMethod: String?,
+                rqstHeaders: MutableMap<String, MutableList<String>>?
+            ): CacheResponse? {
+                getCacheCount++
+                return null
+            }
+
+            override fun put(uri: URI?, conn: URLConnection?): CacheRequest? {
+                putCacheCount++
+                return null
+            }
+        })
+
+        val executor = DefaultStripeNetworkClient(
+            workContext = testScheduler,
+            connectionFactory = ConnectionFactory.Default
+        )
+
+        val url = ApiRequest.API_HOST
+
+        val requestWithCache = FakeStripeRequest(
+            shouldCache = true,
+            method = StripeRequest.Method.GET,
+            url = url
+        )
+
+        val requestWithoutCache = FakeStripeRequest(
+            shouldCache = false,
+            method = StripeRequest.Method.GET,
+            url = url
+        )
+
+        executor.executeRequest(requestWithCache)
+        assertThat(getCacheCount).isEqualTo(1)
+        assertThat(putCacheCount).isEqualTo(1)
+
+        executor.executeRequest(requestWithCache)
+        assertThat(getCacheCount).isEqualTo(2)
+        assertThat(putCacheCount).isEqualTo(2)
+
+        executor.executeRequest(requestWithoutCache)
+        assertThat(getCacheCount).isEqualTo(2)
+        assertThat(putCacheCount).isEqualTo(2)
+    }
+}


### PR DESCRIPTION
This is more or less a manual revert of #4851.

# Summary
<!-- Simple summary of what was changed. -->
This functionality is no longer needed, as the reason it was introduced has since changed.
