### PR TITLE
Add mandate for vertical mode.

### DIFF
--- a/payments-ui-core/detekt-baseline.xml
+++ b/payments-ui-core/detekt-baseline.xml
@@ -53,6 +53,7 @@
     <ID>MaxLineLength:CardNumberConfigTest.kt$CardNumberConfigTest$val state = cardNumberConfig.determineState(CardBrand.Visa, "4242424242424243", CardBrand.Visa.getMaxLengthForCardNumber("4242424242424243"))</ID>
     <ID>MaxLineLength:CardNumberControllerTest.kt$CardNumberControllerTest$fun</ID>
     <ID>SpreadOperator:BsbElementUI.kt$( it.errorMessage, *args )</ID>
+    <ID>SpreadOperator:MandateTextElement.kt$MandateTextElement$(stringResId, *args.toTypedArray())</ID>
     <ID>SpreadOperator:MandateTextUI.kt$(element.stringResId, *element.args.toTypedArray())</ID>
     <ID>TooGenericExceptionCaught:PlacesClientProxy.kt$DefaultPlacesClientProxy$e: Exception</ID>
     <ID>UtilityClassWithPublicConstructor:FieldValuesToParamsMapConverter.kt$FieldValuesToParamsMapConverter</ID>

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AffirmHeaderElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AffirmHeaderElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.elements.Controller
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -14,6 +15,7 @@ data class AffirmHeaderElement(
     override val controller: Controller? = null
 ) : FormElement {
     override val allowsUserInteraction: Boolean = false
+    override val mandateText: ResolvableString? = null
 
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
         stateFlowOf(emptyList())

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement.kt
@@ -3,6 +3,7 @@ package com.stripe.android.ui.core.elements
 import android.content.res.Resources
 import androidx.annotation.RestrictTo
 import androidx.compose.ui.text.intl.Locale
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.Controller
@@ -20,6 +21,7 @@ data class AfterpayClearpayHeaderElement(
     override val controller: Controller? = null
 ) : FormElement {
     override val allowsUserInteraction: Boolean = false
+    override val mandateText: ResolvableString? = null
 
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
         stateFlowOf(emptyList())

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateTextElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateTextElement.kt
@@ -1,6 +1,9 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.R
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.InputController
@@ -20,6 +23,8 @@ data class AuBecsDebitMandateTextElement(
     override val controller: InputController? = null
 ) : FormElement {
     override val allowsUserInteraction: Boolean = false
+    override val mandateText: ResolvableString =
+        resolvableString(id = R.string.stripe_au_becs_mandate, merchantName ?: "")
 
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
         stateFlowOf(emptyList())

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BlikElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BlikElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.InputController
 import com.stripe.android.uicore.elements.SectionSingleFieldElement
@@ -17,6 +18,7 @@ class BlikElement(
     )
 ) : SectionSingleFieldElement(identifier = identifier) {
     override val allowsUserInteraction: Boolean = true
+    override val mandateText: ResolvableString? = null
 
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
         return controller.formFieldValue.mapAsStateFlow { entry ->

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.elements.Controller
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -22,6 +23,7 @@ class BsbElement(
     override val identifier: IdentifierSpec
         get() = identifierSpec
     override val allowsUserInteraction: Boolean = true
+    override val mandateText: ResolvableString? = null
 
     internal val textElement: SimpleTextElement = SimpleTextElement(
         identifier = IdentifierSpec.Generic("au_becs_debit[bsb_number]"),

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import com.stripe.android.cards.CardAccountRangeRepository
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.model.CardBrand
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -33,6 +34,7 @@ internal class CardDetailsElement(
     val isCardScanEnabled = controller.numberElement.controller.cardScanEnabled
 
     override val allowsUserInteraction: Boolean = true
+    override val mandateText: ResolvableString? = null
 
     override fun sectionFieldErrorController(): SectionFieldErrorController =
         controller

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElement.kt
@@ -2,6 +2,7 @@ package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.cards.CardAccountRangeRepository
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -23,6 +24,7 @@ class CardDetailsSectionElement(
     ),
 ) : FormElement {
     override val allowsUserInteraction: Boolean = true
+    override val mandateText: ResolvableString? = null
 
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
         controller.cardDetailsElement.getFormFieldValueFlow()

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberElement.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.ui.core.elements
 
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionSingleFieldElement
 
@@ -8,6 +9,7 @@ internal data class CardNumberElement(
     override val controller: CardNumberController
 ) : SectionSingleFieldElement(_identifier) {
     override val allowsUserInteraction: Boolean = true
+    override val mandateText: ResolvableString? = null
 
     override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
         // Nothing from FormArguments to populate

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionSingleFieldElement
 
@@ -10,6 +11,7 @@ data class CvcElement(
     override val controller: CvcController
 ) : SectionSingleFieldElement(_identifier) {
     override val allowsUserInteraction: Boolean = true
+    override val mandateText: ResolvableString? = null
 
     override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
         // Nothing from FormArguments to populate

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/EmailElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/EmailElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.elements.EmailConfig
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionSingleFieldElement
@@ -17,4 +18,5 @@ data class EmailElement(
     )
 ) : SectionSingleFieldElement(identifier) {
     override val allowsUserInteraction: Boolean = true
+    override val mandateText: ResolvableString? = null
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/EmptyFormElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/EmptyFormElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.elements.Controller
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -14,6 +15,7 @@ data class EmptyFormElement(
     override val controller: Controller? = null
 ) : FormElement {
     override val allowsUserInteraction: Boolean = false
+    override val mandateText: ResolvableString? = null
 
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
         stateFlowOf(emptyList())

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IbanElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IbanElement.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.ui.core.elements
 
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionSingleFieldElement
 import com.stripe.android.uicore.elements.TextFieldController
@@ -9,4 +10,5 @@ internal data class IbanElement(
     override val controller: TextFieldController
 ) : SectionSingleFieldElement(identifier) {
     override val allowsUserInteraction: Boolean = true
+    override val mandateText: ResolvableString? = null
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextElement.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.InputController
@@ -16,6 +18,7 @@ data class MandateTextElement(
     override val controller: InputController? = null
 ) : FormElement {
     override val allowsUserInteraction: Boolean = false
+    override val mandateText: ResolvableString = resolvableString(stringResId, *args.toTypedArray())
 
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
         stateFlowOf(emptyList())

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry
@@ -17,6 +18,7 @@ data class SaveForFutureUseElement(
     val merchantName: String?
 ) : FormElement {
     override val allowsUserInteraction: Boolean = true
+    override val mandateText: ResolvableString? = null
 
     override val controller: SaveForFutureUseController = SaveForFutureUseController(
         initialValue

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SimpleDropdownElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SimpleDropdownElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionSingleFieldElement
@@ -11,4 +12,5 @@ data class SimpleDropdownElement(
     override val controller: DropdownFieldController
 ) : SectionSingleFieldElement(identifier) {
     override val allowsUserInteraction: Boolean = true
+    override val mandateText: ResolvableString? = null
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/StaticTextElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/StaticTextElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.InputController
@@ -20,6 +21,7 @@ data class StaticTextElement(
     override val controller: InputController? = null
 ) : FormElement {
     override val allowsUserInteraction: Boolean = false
+    override val mandateText: ResolvableString? = null
 
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
         stateFlowOf(emptyList())

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/UpiElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/UpiElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.InputController
 import com.stripe.android.uicore.elements.SectionSingleFieldElement
@@ -13,6 +14,7 @@ class UpiElement(
     )
 ) : SectionSingleFieldElement(identifier = IdentifierSpec.Vpa) {
     override val allowsUserInteraction: Boolean = true
+    override val mandateText: ResolvableString? = null
 
     override val identifier: IdentifierSpec = IdentifierSpec.Vpa
 }

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -17,6 +17,7 @@
     <ID>LargeClass:CustomerSheetViewModelTest.kt$CustomerSheetViewModelTest</ID>
     <ID>LargeClass:DefaultFlowController.kt$DefaultFlowController : FlowController</ID>
     <ID>LargeClass:DefaultFlowControllerTest.kt$DefaultFlowControllerTest</ID>
+    <ID>LargeClass:DefaultPaymentMethodVerticalLayoutInteractorTest.kt$DefaultPaymentMethodVerticalLayoutInteractorTest</ID>
     <ID>LargeClass:DefaultPaymentSheetLoaderTest.kt$DefaultPaymentSheetLoaderTest</ID>
     <ID>LargeClass:PaymentMethodMetadataTest.kt$PaymentMethodMetadataTest</ID>
     <ID>LargeClass:PaymentOptionsViewModelTest.kt$PaymentOptionsViewModelTest</ID>
@@ -33,7 +34,6 @@
     <ID>LongMethod:PaymentOptionFactory.kt$PaymentOptionFactory$fun create(selection: PaymentSelection): PaymentOption</ID>
     <ID>LongMethod:PaymentSheetConfigurationKtx.kt$internal fun PaymentSheet.Appearance.parseAppearance()</ID>
     <ID>LongMethod:PaymentSheetLoader.kt$DefaultPaymentSheetLoader$private suspend fun create( elementsSession: ElementsSession, config: PaymentSheet.Configuration, metadata: PaymentMethodMetadata, ): PaymentSheetState.Full</ID>
-    <ID>LongMethod:PaymentSheetScreen.kt$@Composable private fun PaymentSheetContent( viewModel: BaseSheetViewModel, type: PaymentSheetFlowType, headerText: Int?, walletsState: WalletsState?, walletsProcessingState: WalletsProcessingState?, error: String?, currentScreen: PaymentSheetScreen, mandateText: MandateText?, )</ID>
     <ID>LongMethod:PlaceholderHelperTest.kt$PlaceholderHelperTest$@Test fun `Test correct placeholder is removed for placeholder spec`()</ID>
     <ID>LongMethod:USBankAccountEmitters.kt$@Composable internal fun USBankAccountEmitters( viewModel: USBankAccountFormViewModel, usBankAccountFormArgs: USBankAccountFormArguments, )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable internal fun BillingDetailsForm( instantDebits: Boolean, formArgs: FormArguments, isProcessing: Boolean, isPaymentFlow: Boolean, nameController: TextFieldController, emailController: TextFieldController, phoneController: PhoneNumberController, addressController: AddressController, lastTextFieldIdentifier: IdentifierSpec?, sameAsShippingElement: SameAsShippingElement?, )</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -800,6 +800,8 @@ internal abstract class BaseSheetViewModel(
 
     private fun onUserBack() {
         clearErrorMessages()
+        _mandateText.value = null
+
         backStack.update { screens ->
             val modifiableScreens = screens.toMutableList()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -2,13 +2,17 @@ package com.stripe.android.paymentsheet.verticalmode
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.analytics.code
 import com.stripe.android.paymentsheet.forms.FormFieldValues
@@ -17,6 +21,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor.ViewAction
+import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.uicore.elements.FormElement
@@ -507,6 +512,49 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
+    fun handleViewAction_PaymentMethodSelected_updatesSelectedLPMAndMandate() {
+        var onFormFieldValuesChangedCalled = false
+        var mostRecentMandate: ResolvableString? = null
+        val paymentMethodTypes = listOf("card", "cashapp")
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = paymentMethodTypes
+            )
+        )
+        runScenario(
+            paymentMethodMetadata = paymentMethodMetadata,
+            formElementsForCode = {
+                val uiDefinitionFactoryArgumentsFactory = UiDefinitionFactory.Arguments.Factory.Default(
+                    cardAccountRangeRepositoryFactory = mock(),
+                    paymentMethodCreateParams = null,
+                    paymentMethodExtraParams = null,
+                )
+                paymentMethodMetadata.formElementsForCode(it, uiDefinitionFactoryArgumentsFactory)!!
+            },
+            onFormFieldValuesChanged = { fieldValues, selectedPaymentMethodCode ->
+                fieldValues.run {
+                    assertThat(fieldValuePairs).isEmpty()
+                    assertThat(userRequestedReuse).isEqualTo(PaymentSelection.CustomerRequestedSave.NoRequest)
+                }
+                assertThat(selectedPaymentMethodCode).isEqualTo("cashapp")
+                onFormFieldValuesChangedCalled = true
+            },
+            onMandateTextUpdated = { mostRecentMandate = it },
+        ) {
+            assertThat(mostRecentMandate).isNull()
+            interactor.handleViewAction(ViewAction.PaymentMethodSelected("cashapp"))
+            assertThat(onFormFieldValuesChangedCalled).isTrue()
+            assertThat(mostRecentMandate).isEqualTo(
+                resolvableString(
+                    R.string.stripe_cash_app_pay_mandate,
+                    paymentMethodMetadata.merchantName,
+                    paymentMethodMetadata.merchantName
+                )
+            )
+        }
+    }
+
+    @Test
     fun handleViewAction_PaymentMethodSelected_sameSavedPaymentMethodIsDisplayed() {
         val savedPaymentMethods = PaymentMethodFixtures.createCards(3)
         val displayedPaymentMethod = savedPaymentMethods[2]
@@ -612,6 +660,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         onSelectSavedPaymentMethod: (PaymentMethod) -> Unit = { notImplemented() },
         isFlowController: Boolean = false,
         onWalletSelected: (PaymentSelection) -> Unit = { notImplemented() },
+        onMandateTextUpdated: (ResolvableString?) -> Unit = { notImplemented() },
         testBlock: suspend TestParams.() -> Unit
     ) {
         val processing: MutableStateFlow<Boolean> = MutableStateFlow(initialProcessing)
@@ -640,6 +689,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             walletsState = walletsState,
             isFlowController = isFlowController,
             onWalletSelected = onWalletSelected,
+            onMandateTextUpdated = onMandateTextUpdated,
         )
 
         TestParams(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
@@ -2,6 +2,7 @@ package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.address.AddressSchemaRegistry
 import com.stripe.android.uicore.address.AutocompleteCapableAddressType
@@ -13,7 +14,7 @@ import kotlinx.coroutines.flow.StateFlow
 import com.stripe.android.core.R as CoreR
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-open class AddressElement constructor(
+open class AddressElement(
     _identifier: IdentifierSpec,
     private var rawValuesMap: Map<IdentifierSpec, String?> = emptyMap(),
     private val addressType: AddressType = AddressType.Normal(),
@@ -29,6 +30,7 @@ open class AddressElement constructor(
 ) : SectionMultiFieldElement(_identifier) {
 
     override val allowsUserInteraction: Boolean = true
+    override val mandateText: ResolvableString? = null
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     val countryElement = CountryElement(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AddressTextFieldElement(
@@ -9,6 +10,7 @@ class AddressTextFieldElement(
     onNavigation: (() -> Unit)? = null
 ) : SectionSingleFieldElement(identifier) {
     override val allowsUserInteraction: Boolean = true
+    override val mandateText: ResolvableString? = null
 
     override val controller: AddressTextFieldController =
         AddressTextFieldController(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AdministrativeAreaElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AdministrativeAreaElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class AdministrativeAreaElement(
@@ -8,4 +9,5 @@ data class AdministrativeAreaElement(
     override val controller: DropdownFieldController
 ) : SectionSingleFieldElement(identifier) {
     override val allowsUserInteraction: Boolean = true
+    override val mandateText: ResolvableString? = null
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CheckboxFieldElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CheckboxFieldElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.mapAsStateFlow
 
@@ -10,6 +11,7 @@ class CheckboxFieldElement(
     override val controller: CheckboxFieldController = CheckboxFieldController()
 ) : FormElement {
     override val allowsUserInteraction: Boolean = true
+    override val mandateText: ResolvableString? = null
 
     override fun getFormFieldValueFlow() = controller.isChecked.mapAsStateFlow { isChecked ->
         listOf(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CountryElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CountryElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class CountryElement(
@@ -8,4 +9,5 @@ data class CountryElement(
     override val controller: DropdownFieldController
 ) : SectionSingleFieldElement(identifier) {
     override val allowsUserInteraction: Boolean = true
+    override val mandateText: ResolvableString? = null
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/FormElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/FormElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
@@ -20,6 +21,13 @@ interface FormElement {
      * This is used to determine if vertical mode needs to show the form screen.
      */
     val allowsUserInteraction: Boolean
+
+    /**
+     * The mandate text, if any.
+     *
+     * This is used to determine if vertical mode needs to show mandates for LPMs with no fields, only a mandate.
+     */
+    val mandateText: ResolvableString?
 
     fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>>
     fun getTextFieldIdentifiers(): StateFlow<List<IdentifierSpec>> =

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.flow.Flow
@@ -13,6 +14,7 @@ data class OTPElement(
     override val controller: OTPController
 ) : FormElement {
     override val allowsUserInteraction: Boolean = true
+    override val mandateText: ResolvableString? = null
 
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
         return controller.fieldValue.mapAsStateFlow {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 data class PhoneNumberElement(
@@ -8,4 +9,5 @@ data class PhoneNumberElement(
     override val controller: PhoneNumberController
 ) : SectionSingleFieldElement(identifier) {
     override val allowsUserInteraction: Boolean = true
+    override val mandateText: ResolvableString? = null
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowElement.kt
@@ -1,17 +1,19 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class RowElement constructor(
+class RowElement(
     _identifier: IdentifierSpec,
     val fields: List<SectionSingleFieldElement>,
     val controller: RowController
 ) : SectionMultiFieldElement(_identifier) {
     override val allowsUserInteraction: Boolean = fields.any { it.allowsUserInteraction }
+    override val mandateText: ResolvableString? = null
 
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
         combineAsStateFlow(fields.map { it.getFormFieldValueFlow() }) {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class SameAsShippingElement(
@@ -11,6 +12,7 @@ data class SameAsShippingElement(
         get() = true
 
     override val allowsUserInteraction: Boolean = true
+    override val mandateText: ResolvableString? = null
 
     override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
         rawValuesMap[identifier]?.let {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -18,6 +19,8 @@ data class SectionElement(
     ) : this(identifier, listOf(field), controller)
 
     override val allowsUserInteraction: Boolean = fields.any { it.allowsUserInteraction }
+
+    override val mandateText: ResolvableString? = fields.firstNotNullOfOrNull { it.mandateText }
 
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
         combineAsStateFlow(fields.map { it.getFormFieldValueFlow() }) {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionFieldElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionFieldElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.flow.StateFlow
 
@@ -16,6 +17,13 @@ interface SectionFieldElement {
      * This is used to determine if vertical mode needs to show the form screen.
      */
     val allowsUserInteraction: Boolean
+
+    /**
+     * The mandate text, if any.
+     *
+     * This is used to determine if vertical mode needs to show mandates for LPMs with no fields, only a mandate.
+     */
+    val mandateText: ResolvableString?
 
     fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>>
     fun sectionFieldErrorController(): SectionFieldErrorController

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SimpleTextElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SimpleTextElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 data class SimpleTextElement(
@@ -8,4 +9,5 @@ data class SimpleTextElement(
     override val controller: TextFieldController
 ) : SectionSingleFieldElement(identifier) {
     override val allowsUserInteraction: Boolean = true
+    override val mandateText: ResolvableString? = null
 }

--- a/stripecardscan/detekt-baseline.xml
+++ b/stripecardscan/detekt-baseline.xml
@@ -24,8 +24,6 @@
     <ID>FunctionOnlyReturningConstant:AppDetails.kt$private fun getApplicationId(): String</ID>
     <ID>FunctionOnlyReturningConstant:Device.kt$@SuppressLint("HardwareIds") private fun getAndroidId()</ID>
     <ID>FunctionOnlyReturningConstant:Device.kt$internal fun getPlatform()</ID>
-    <ID>FunctionReturnTypeSpacing:StripeNetwork.kt$StripeNetwork$private suspend fun executeAndConvertToNetworkResult(request: StripeRequest): NetworkResult&lt;out String, out String></ID>
-    <ID>Indentation:CardImageVerificationDetails.kt$CardImageVerificationDetailsAcceptedImageConfigs$ </ID>
     <ID>LongMethod:Fetcher.kt$WebFetcher$override suspend fun fetchData(forImmediateUse: Boolean, isOptional: Boolean): FetchedData</ID>
     <ID>MagicNumber:BitmapExtensions.kt$100.0</ID>
     <ID>MagicNumber:CardExpiry.kt$100</ID>
@@ -63,7 +61,6 @@
     <ID>NestedBlockDepth:Network.kt$@Throws(IOException::class) private fun downloadFile( url: URL, outputFile: File )</ID>
     <ID>NestedBlockDepth:SSD.kt$internal fun rearrangeOCRArray( locations: Array&lt;FloatArray>, featureMapSizes: OcrFeatureMapSizes, numberOfPriors: Int, locationsPerPrior: Int ): Array&lt;FloatArray></ID>
     <ID>NestedBlockDepth:Yolo.kt$internal fun processYoloLayer( layer: Array&lt;Array&lt;FloatArray>>, anchors: Array&lt;Pair&lt;Int, Int>>, imageSize: Size, numClasses: Int, confidenceThreshold: Float ): List&lt;DetectionBox></ID>
-    <ID>NoSemicolons:CardImageVerificationDetails.kt$CardImageVerificationDetailsFormat.WEBP$;</ID>
     <ID>SwallowedException:Device.kt$t: Throwable</ID>
     <ID>SwallowedException:Fetcher.kt$FetchedData.Companion$t: Throwable</ID>
     <ID>SwallowedException:File.kt$t: Throwable</ID>
@@ -98,12 +95,5 @@
     <ID>UnusedPrivateMember:PaymentCardUtils.kt$@CheckResult private fun jaccardIndex(string1: String, string2: String): Double</ID>
     <ID>UnusedPrivateMember:PaymentCardUtils.kt$private fun String.isDigitsOnly()</ID>
     <ID>UnusedPrivateProperty:ScanActivity.kt$ScanActivity$private val permissionStat = Stats.trackTask("camera_permission")</ID>
-    <ID>Wrapping:CardImageVerificationDetails.kt$CardImageVerificationDetailsAcceptedImageConfigs$&lt; CardImageVerificationDetailsFormat, CardImageVerificationDetailsImageSettings?></ID>
-    <ID>Wrapping:CardImageVerificationDetails.kt$CardImageVerificationDetailsAcceptedImageConfigs$&lt;CardImageVerificationDetailsFormat, CardImageVerificationDetailsImageSettings?></ID>
-    <ID>Wrapping:CardImageVerificationFlow.kt$CardImageVerificationFlow$&lt; MainLoopAnalyzer.Input, MainLoopState, MainLoopAnalyzer.Prediction></ID>
-    <ID>Wrapping:CardScanFlow.kt$CardScanFlow$&lt; SSDOcr.Input, Any, SSDOcr.Prediction></ID>
-    <ID>Wrapping:CardScanFlow.kt$CardScanFlow$&lt; SSDOcr.Input, MainLoopState, SSDOcr.Prediction></ID>
-    <ID>Wrapping:MainLoopAnalyzer.kt$MainLoopAnalyzer.Factory$&lt; CardDetect.Input, Any, CardDetect.Prediction, out Analyzer&lt;CardDetect.Input, Any, CardDetect.Prediction>></ID>
-    <ID>Wrapping:MainLoopAnalyzer.kt$MainLoopAnalyzer.Factory$&lt; SSDOcr.Input, Any, SSDOcr.Prediction, out Analyzer&lt;SSDOcr.Input, Any, SSDOcr.Prediction>></ID>
   </CurrentIssues>
 </SmellBaseline>


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Adds mandates to the vertical mode list for new payment methods that require a mandate, but not other fields.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2114

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

https://github.com/stripe/stripe-android/assets/116920913/8aa89b88-9f0e-4307-8ec7-a5492d166f2a


