### PR TITLE
Refactor PaymentSheetTopBarState to not require a PaymentSheetScreen object

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -187,9 +187,6 @@ interface ErrorReporter {
         CVC_RECOLLECTION_UNEXPECTED_PAYMENT_SELECTION(
             partialEventName = "payments.cvc_recollection_unexpected_payment_selection"
         ),
-        UNSUPPORTED_ADD_PAYMENT_METHOD_INTERACTOR_USED(
-            partialEventName = "add_payment_method_interactor.unsupported_implementation.used"
-        )
         ;
 
         override val eventName: String

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
@@ -10,14 +10,13 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAvailable
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
 import com.stripe.android.paymentsheet.ui.ModifiableEditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBarState
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBarStateFactory
 import com.stripe.android.paymentsheet.ui.PrimaryButton
-import com.stripe.android.paymentsheet.ui.UnsupportedAddPaymentMethodInteractor
+import com.stripe.android.paymentsheet.ui.SheetScreen
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.FormElement
 
@@ -26,7 +25,7 @@ internal sealed class CustomerSheetViewState(
     open val isLiveMode: Boolean,
     open val isProcessing: Boolean,
     open val isEditing: Boolean,
-    open val screen: PaymentSheetScreen,
+    open val screen: SheetScreen,
     open val cbcEligibility: CardBrandChoiceEligibility,
     open val allowsRemovalOfLastSavedPaymentMethod: Boolean,
     open val canRemovePaymentMethods: Boolean,
@@ -34,6 +33,7 @@ internal sealed class CustomerSheetViewState(
     val topBarState: PaymentSheetTopBarState
         get() = PaymentSheetTopBarStateFactory.create(
             screen = screen,
+            hasBackStack = false,
             isLiveMode = isLiveMode,
             isProcessing = isProcessing,
             isEditing = isEditing,
@@ -59,7 +59,7 @@ internal sealed class CustomerSheetViewState(
         isLiveMode = isLiveMode,
         isProcessing = false,
         isEditing = false,
-        screen = PaymentSheetScreen.Loading,
+        screen = SheetScreen.LOADING,
         cbcEligibility = CardBrandChoiceEligibility.Ineligible,
         allowsRemovalOfLastSavedPaymentMethod = true,
         canRemovePaymentMethods = false,
@@ -86,7 +86,7 @@ internal sealed class CustomerSheetViewState(
         isLiveMode = isLiveMode,
         isProcessing = isProcessing,
         isEditing = isEditing,
-        screen = PaymentSheetScreen.SelectSavedPaymentMethods(),
+        screen = SheetScreen.SELECT_SAVED_PAYMENT_METHODS,
         cbcEligibility = cbcEligibility,
         allowsRemovalOfLastSavedPaymentMethod = allowsRemovalOfLastSavedPaymentMethod,
         canRemovePaymentMethods = canRemovePaymentMethods,
@@ -123,11 +123,9 @@ internal sealed class CustomerSheetViewState(
         isProcessing = isProcessing,
         isEditing = false,
         screen = if (isFirstPaymentMethod) {
-            PaymentSheetScreen.AddFirstPaymentMethod(interactor = UnsupportedAddPaymentMethodInteractor(errorReporter))
+            SheetScreen.ADD_FIRST_PAYMENT_METHOD
         } else {
-            PaymentSheetScreen.AddAnotherPaymentMethod(
-                interactor = UnsupportedAddPaymentMethodInteractor(errorReporter)
-            )
+            SheetScreen.ADD_ANOTHER_PAYMENT_METHOD
         },
         cbcEligibility = cbcEligibility,
         allowsRemovalOfLastSavedPaymentMethod = true,
@@ -146,7 +144,7 @@ internal sealed class CustomerSheetViewState(
         isLiveMode = isLiveMode,
         isProcessing = false,
         isEditing = false,
-        screen = PaymentSheetScreen.EditPaymentMethod(editPaymentMethodInteractor),
+        screen = SheetScreen.EDIT_PAYMENT_METHOD,
         cbcEligibility = cbcEligibility,
         allowsRemovalOfLastSavedPaymentMethod = allowsRemovalOfLastSavedPaymentMethod,
         canRemovePaymentMethods = canRemovePaymentMethods,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
@@ -26,6 +26,7 @@ internal sealed class CustomerSheetViewState(
     open val isProcessing: Boolean,
     open val isEditing: Boolean,
     open val screen: SheetScreen,
+    open val canNavigateBack: Boolean,
     open val cbcEligibility: CardBrandChoiceEligibility,
     open val allowsRemovalOfLastSavedPaymentMethod: Boolean,
     open val canRemovePaymentMethods: Boolean,
@@ -33,7 +34,7 @@ internal sealed class CustomerSheetViewState(
     val topBarState: PaymentSheetTopBarState
         get() = PaymentSheetTopBarStateFactory.create(
             screen = screen,
-            hasBackStack = false,
+            hasBackStack = canNavigateBack,
             isLiveMode = isLiveMode,
             isProcessing = isProcessing,
             isEditing = isEditing,
@@ -60,6 +61,7 @@ internal sealed class CustomerSheetViewState(
         isProcessing = false,
         isEditing = false,
         screen = SheetScreen.LOADING,
+        canNavigateBack = false,
         cbcEligibility = CardBrandChoiceEligibility.Ineligible,
         allowsRemovalOfLastSavedPaymentMethod = true,
         canRemovePaymentMethods = false,
@@ -87,6 +89,7 @@ internal sealed class CustomerSheetViewState(
         isProcessing = isProcessing,
         isEditing = isEditing,
         screen = SheetScreen.SELECT_SAVED_PAYMENT_METHODS,
+        canNavigateBack = false,
         cbcEligibility = cbcEligibility,
         allowsRemovalOfLastSavedPaymentMethod = allowsRemovalOfLastSavedPaymentMethod,
         canRemovePaymentMethods = canRemovePaymentMethods,
@@ -127,6 +130,7 @@ internal sealed class CustomerSheetViewState(
         } else {
             SheetScreen.ADD_ANOTHER_PAYMENT_METHOD
         },
+        canNavigateBack = !isFirstPaymentMethod,
         cbcEligibility = cbcEligibility,
         allowsRemovalOfLastSavedPaymentMethod = true,
         canRemovePaymentMethods = false,
@@ -145,6 +149,7 @@ internal sealed class CustomerSheetViewState(
         isProcessing = false,
         isEditing = false,
         screen = SheetScreen.EDIT_PAYMENT_METHOD,
+        canNavigateBack = true,
         cbcEligibility = cbcEligibility,
         allowsRemovalOfLastSavedPaymentMethod = allowsRemovalOfLastSavedPaymentMethod,
         canRemovePaymentMethods = canRemovePaymentMethods,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -15,6 +15,7 @@ import com.stripe.android.paymentsheet.ui.EditPaymentMethod
 import com.stripe.android.paymentsheet.ui.ModifiableEditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.ui.SavedPaymentMethodTabLayoutUI
 import com.stripe.android.paymentsheet.ui.SavedPaymentMethodsTopContentPadding
+import com.stripe.android.paymentsheet.ui.SheetScreen
 import com.stripe.android.paymentsheet.verticalmode.ManageOneSavedPaymentMethodInteractor
 import com.stripe.android.paymentsheet.verticalmode.ManageOneSavedPaymentMethodUI
 import com.stripe.android.paymentsheet.verticalmode.ManageScreenInteractor
@@ -52,6 +53,7 @@ internal sealed interface PaymentSheetScreen {
     val showsBuyButton: Boolean
     val showsContinueButton: Boolean
     val canNavigateBack: Boolean
+    val sheetScreen: SheetScreen
 
     fun showsWalletsHeader(isCompleteFlow: Boolean): StateFlow<Boolean>
 
@@ -63,6 +65,7 @@ internal sealed interface PaymentSheetScreen {
         override val showsBuyButton: Boolean = false
         override val showsContinueButton: Boolean = false
         override val canNavigateBack: Boolean = false
+        override val sheetScreen: SheetScreen = SheetScreen.LOADING
 
         override fun showsWalletsHeader(isCompleteFlow: Boolean): StateFlow<Boolean> {
             return stateFlowOf(false)
@@ -86,6 +89,7 @@ internal sealed interface PaymentSheetScreen {
         override val showsBuyButton: Boolean = true
         override val showsContinueButton: Boolean = false
         override val canNavigateBack: Boolean = false
+        override val sheetScreen: SheetScreen = SheetScreen.SELECT_SAVED_PAYMENT_METHODS
 
         override fun showsWalletsHeader(isCompleteFlow: Boolean): StateFlow<Boolean> {
             return stateFlowOf(isCompleteFlow)
@@ -125,6 +129,7 @@ internal sealed interface PaymentSheetScreen {
         override val showsBuyButton: Boolean = true
         override val showsContinueButton: Boolean = true
         override val canNavigateBack: Boolean = true
+        override val sheetScreen: SheetScreen = SheetScreen.ADD_ANOTHER_PAYMENT_METHOD
 
         override fun showsWalletsHeader(isCompleteFlow: Boolean): StateFlow<Boolean> {
             return stateFlowOf(isCompleteFlow)
@@ -147,6 +152,7 @@ internal sealed interface PaymentSheetScreen {
         override val showsBuyButton: Boolean = true
         override val showsContinueButton: Boolean = true
         override val canNavigateBack: Boolean = false
+        override val sheetScreen: SheetScreen = SheetScreen.ADD_FIRST_PAYMENT_METHOD
 
         override fun showsWalletsHeader(isCompleteFlow: Boolean): StateFlow<Boolean> {
             return stateFlowOf(true)
@@ -169,6 +175,7 @@ internal sealed interface PaymentSheetScreen {
         override val showsBuyButton: Boolean = false
         override val showsContinueButton: Boolean = false
         override val canNavigateBack: Boolean = true
+        override val sheetScreen: SheetScreen = SheetScreen.EDIT_PAYMENT_METHOD
 
         override fun showsWalletsHeader(isCompleteFlow: Boolean): StateFlow<Boolean> {
             return stateFlowOf(false)
@@ -189,6 +196,7 @@ internal sealed interface PaymentSheetScreen {
         override val showsBuyButton: Boolean = true
         override val showsContinueButton: Boolean = true
         override val canNavigateBack: Boolean = false
+        override val sheetScreen: SheetScreen = SheetScreen.VERTICAL_MODE
 
         override fun showsWalletsHeader(isCompleteFlow: Boolean): StateFlow<Boolean> {
             return interactor.showsWalletsHeader
@@ -208,6 +216,7 @@ internal sealed interface PaymentSheetScreen {
         override val showsBuyButton: Boolean = true
         override val showsContinueButton: Boolean = true
         override val canNavigateBack: Boolean = true
+        override val sheetScreen: SheetScreen = SheetScreen.FORM
 
         override fun showsWalletsHeader(isCompleteFlow: Boolean): StateFlow<Boolean> {
             return stateFlowOf(showsWalletHeader)
@@ -223,6 +232,7 @@ internal sealed interface PaymentSheetScreen {
         override val showsBuyButton: Boolean = false
         override val showsContinueButton: Boolean = false
         override val canNavigateBack: Boolean = true
+        override val sheetScreen: SheetScreen = SheetScreen.MANAGE_SAVED_PAYMENT_METHODS
 
         override fun showsWalletsHeader(isCompleteFlow: Boolean): StateFlow<Boolean> = stateFlowOf(false)
 
@@ -241,6 +251,7 @@ internal sealed interface PaymentSheetScreen {
         override val showsBuyButton: Boolean = false
         override val showsContinueButton: Boolean = false
         override val canNavigateBack: Boolean = true
+        override val sheetScreen: SheetScreen = SheetScreen.MANAGE_ONE_SAVED_PAYMENT_METHOD
 
         override fun showsWalletsHeader(isCompleteFlow: Boolean): StateFlow<Boolean> = stateFlowOf(false)
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodInteractor.kt
@@ -6,7 +6,6 @@ import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
-import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
@@ -201,30 +200,5 @@ internal class DefaultAddPaymentMethodInteractor(
 
     private fun shouldHaveLinkInlineSignup(selectedPaymentMethodCode: PaymentMethodCode): Boolean {
         return selectedPaymentMethodCode == PaymentMethod.Type.Card.code
-    }
-}
-
-internal class UnsupportedAddPaymentMethodInteractor(private val errorReporter: ErrorReporter) :
-    AddPaymentMethodInteractor {
-
-    private val errorFieldFunctionAccessed = "function_accessed"
-
-    override val state: StateFlow<AddPaymentMethodInteractor.State>
-        get() {
-            throw UnsupportedOperationException("Attempting to use UnsupportedAddPaymentMethodInteractor")
-        }
-
-    override fun handleViewAction(viewAction: AddPaymentMethodInteractor.ViewAction) {
-        errorReporter.report(
-            ErrorReporter.UnexpectedErrorEvent.UNSUPPORTED_ADD_PAYMENT_METHOD_INTERACTOR_USED,
-            additionalNonPiiParams = mapOf(errorFieldFunctionAccessed to "handleViewAction_$viewAction")
-        )
-    }
-
-    override fun close() {
-        errorReporter.report(
-            ErrorReporter.UnexpectedErrorEvent.UNSUPPORTED_ADD_PAYMENT_METHOD_INTERACTOR_USED,
-            additionalNonPiiParams = mapOf(errorFieldFunctionAccessed to "close")
-        )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarState.kt
@@ -3,8 +3,6 @@ package com.stripe.android.paymentsheet.ui
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.stripe.android.paymentsheet.R
-import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
-import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods
 import com.stripe.android.R as StripeR
 import com.stripe.android.ui.core.R as StripeUiCoreR
 
@@ -20,14 +18,13 @@ internal data class PaymentSheetTopBarState(
 internal object PaymentSheetTopBarStateFactory {
 
     fun create(
-        screen: PaymentSheetScreen,
+        screen: SheetScreen,
+        hasBackStack: Boolean,
         isLiveMode: Boolean,
         isProcessing: Boolean,
         isEditing: Boolean,
         canEdit: Boolean,
     ): PaymentSheetTopBarState {
-        val hasBackStack = screen.canNavigateBack
-
         val icon = if (hasBackStack) {
             R.drawable.stripe_ic_paymentsheet_back
         } else {
@@ -46,8 +43,10 @@ internal object PaymentSheetTopBarStateFactory {
             StripeR.string.stripe_edit
         }
 
-        val showEditMenu =
-            (screen is SelectSavedPaymentMethods || screen is PaymentSheetScreen.ManageSavedPaymentMethods) && canEdit
+        val showEditMenu = (
+            screen == SheetScreen.SELECT_SAVED_PAYMENT_METHODS ||
+                screen == SheetScreen.MANAGE_SAVED_PAYMENT_METHODS
+            ) && canEdit
 
         return PaymentSheetTopBarState(
             icon = icon,
@@ -61,7 +60,8 @@ internal object PaymentSheetTopBarStateFactory {
 
     fun createDefault(): PaymentSheetTopBarState {
         return create(
-            screen = PaymentSheetScreen.Loading,
+            screen = SheetScreen.LOADING,
+            hasBackStack = false,
             canEdit = false,
             isLiveMode = true,
             isProcessing = false,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SheetScreen.kt
@@ -1,0 +1,13 @@
+package com.stripe.android.paymentsheet.ui
+
+internal enum class SheetScreen {
+    LOADING,
+    SELECT_SAVED_PAYMENT_METHODS,
+    ADD_ANOTHER_PAYMENT_METHOD,
+    ADD_FIRST_PAYMENT_METHOD,
+    EDIT_PAYMENT_METHOD,
+    VERTICAL_MODE,
+    FORM,
+    MANAGE_SAVED_PAYMENT_METHODS,
+    MANAGE_ONE_SAVED_PAYMENT_METHOD,
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -261,7 +261,8 @@ internal abstract class BaseSheetViewModel(
     }
 
     val topBarState: StateFlow<PaymentSheetTopBarState> = combineAsStateFlow(
-        currentScreen,
+        currentScreen.mapAsStateFlow { it.sheetScreen },
+        currentScreen.mapAsStateFlow { it.canNavigateBack },
         paymentMethodMetadata.mapAsStateFlow { it?.stripeIntent?.isLiveMode ?: true },
         processing,
         editing,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeAddPaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeAddPaymentMethodInteractor.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.paymentsheet.ui
+
+import kotlinx.coroutines.flow.StateFlow
+import org.mockito.Mockito
+
+internal object FakeAddPaymentMethodInteractor : AddPaymentMethodInteractor {
+    override val state: StateFlow<AddPaymentMethodInteractor.State>
+        get() = Mockito.mock()
+
+    override fun handleViewAction(viewAction: AddPaymentMethodInteractor.ViewAction) {
+        // Do nothing.
+    }
+
+    override fun close() {
+        // Do nothing.
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeAddPaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeAddPaymentMethodInteractor.kt
@@ -1,11 +1,12 @@
 package com.stripe.android.paymentsheet.ui
 
 import kotlinx.coroutines.flow.StateFlow
-import org.mockito.Mockito
 
 internal object FakeAddPaymentMethodInteractor : AddPaymentMethodInteractor {
     override val state: StateFlow<AddPaymentMethodInteractor.State>
-        get() = Mockito.mock()
+        get() = throw NotImplementedError(
+            "State has not been implemented for FakeAddPaymentMethodInteractor"
+        )
 
     override fun handleViewAction(viewAction: AddPaymentMethodInteractor.ViewAction) {
         // Do nothing.

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/HeaderTextFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/HeaderTextFactoryTest.kt
@@ -4,7 +4,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.verticalmode.FakeManageScreenInteractor
-import com.stripe.android.testing.FakeErrorReporter
 import org.junit.Test
 import org.mockito.Mockito.mock
 import com.stripe.android.R as StripeR
@@ -26,9 +25,7 @@ class HeaderTextFactoryTest {
     fun `Does not show a header on AddAnotherPaymentMethod screen`() {
         val resource = HeaderTextFactory(isCompleteFlow = true).create(
             screen = PaymentSheetScreen.AddAnotherPaymentMethod(
-                interactor = UnsupportedAddPaymentMethodInteractor(
-                    errorReporter = FakeErrorReporter()
-                )
+                interactor = FakeAddPaymentMethodInteractor
             ),
             isWalletEnabled = true,
             types = emptyList(),
@@ -54,9 +51,7 @@ class HeaderTextFactoryTest {
     fun `Shows the correct header if adding the first payment method in complete flow`() {
         val resource = HeaderTextFactory(isCompleteFlow = true).create(
             screen = PaymentSheetScreen.AddFirstPaymentMethod(
-                interactor = UnsupportedAddPaymentMethodInteractor(
-                    errorReporter = FakeErrorReporter()
-                )
+                interactor = FakeAddPaymentMethodInteractor
             ),
             isWalletEnabled = false,
             types = emptyList(),
@@ -69,9 +64,7 @@ class HeaderTextFactoryTest {
     fun `Does not show a header if adding the first payment method and wallets are available`() {
         val resource = HeaderTextFactory(isCompleteFlow = true).create(
             screen = PaymentSheetScreen.AddFirstPaymentMethod(
-                interactor = UnsupportedAddPaymentMethodInteractor(
-                    errorReporter = FakeErrorReporter()
-                )
+                interactor = FakeAddPaymentMethodInteractor
             ),
             isWalletEnabled = true,
             types = emptyList(),
@@ -95,9 +88,7 @@ class HeaderTextFactoryTest {
     fun `Shows the correct header when only credit card form is shown in custom flow`() {
         val resource = HeaderTextFactory(isCompleteFlow = false).create(
             screen = PaymentSheetScreen.AddFirstPaymentMethod(
-                interactor = UnsupportedAddPaymentMethodInteractor(
-                    errorReporter = FakeErrorReporter()
-                )
+                interactor = FakeAddPaymentMethodInteractor
             ),
             isWalletEnabled = false,
             types = listOf("card"),
@@ -123,9 +114,7 @@ class HeaderTextFactoryTest {
     fun `Shows the correct header when multiple LPMs are shown in custom flow`() {
         val resource = HeaderTextFactory(isCompleteFlow = false).create(
             screen = PaymentSheetScreen.AddFirstPaymentMethod(
-                interactor = UnsupportedAddPaymentMethodInteractor(
-                    errorReporter = FakeErrorReporter()
-                )
+                interactor = FakeAddPaymentMethodInteractor
             ),
             isWalletEnabled = false,
             types = listOf("card", "not_card"),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarStateFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarStateFactoryTest.kt
@@ -5,7 +5,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.verticalmode.FakeManageScreenInteractor
-import com.stripe.android.testing.FakeErrorReporter
 import org.junit.Test
 import org.junit.runner.RunWith
 import com.stripe.android.R as StripeR
@@ -43,9 +42,7 @@ class PaymentSheetTopBarStateFactoryTest {
     fun `AddFirstPaymentMethod shows correct navigation icon`() {
         val state = buildTopBarState(
             screen = PaymentSheetScreen.AddFirstPaymentMethod(
-                interactor = UnsupportedAddPaymentMethodInteractor(
-                    errorReporter = FakeErrorReporter()
-                )
+                interactor = FakeAddPaymentMethodInteractor
             ),
             canEdit = false,
             isLiveMode = false,
@@ -60,9 +57,7 @@ class PaymentSheetTopBarStateFactoryTest {
     fun `AddAnotherPaymentMethod shows correct navigation icon`() {
         val state = buildTopBarState(
             screen = PaymentSheetScreen.AddAnotherPaymentMethod(
-                interactor = UnsupportedAddPaymentMethodInteractor(
-                    errorReporter = FakeErrorReporter()
-                )
+                interactor = FakeAddPaymentMethodInteractor
             ),
             canEdit = false,
             isLiveMode = false,
@@ -77,9 +72,7 @@ class PaymentSheetTopBarStateFactoryTest {
     fun `Shows test mode badge if not running in live mode`() {
         val state = buildTopBarState(
             screen = PaymentSheetScreen.AddAnotherPaymentMethod(
-                interactor = UnsupportedAddPaymentMethodInteractor(
-                    errorReporter = FakeErrorReporter()
-                )
+                interactor = FakeAddPaymentMethodInteractor
             ),
             canEdit = false,
             isLiveMode = false,
@@ -94,9 +87,7 @@ class PaymentSheetTopBarStateFactoryTest {
     fun `Hide test mode badge if running in live mode`() {
         val state = buildTopBarState(
             screen = PaymentSheetScreen.AddAnotherPaymentMethod(
-                interactor = UnsupportedAddPaymentMethodInteractor(
-                    errorReporter = FakeErrorReporter()
-                )
+                interactor = FakeAddPaymentMethodInteractor
             ),
             canEdit = false,
             isLiveMode = true,
@@ -163,9 +154,7 @@ class PaymentSheetTopBarStateFactoryTest {
     fun `Hides edit menu if not on the saved payment methods screen`() {
         val state = buildTopBarState(
             screen = PaymentSheetScreen.AddAnotherPaymentMethod(
-                interactor = UnsupportedAddPaymentMethodInteractor(
-                    errorReporter = FakeErrorReporter()
-                )
+                interactor = FakeAddPaymentMethodInteractor
             ),
             canEdit = true,
             isLiveMode = false,
@@ -180,9 +169,7 @@ class PaymentSheetTopBarStateFactoryTest {
     fun `Shows correct edit menu label when not in editing mode`() {
         val state = buildTopBarState(
             screen = PaymentSheetScreen.AddAnotherPaymentMethod(
-                interactor = UnsupportedAddPaymentMethodInteractor(
-                    errorReporter = FakeErrorReporter()
-                )
+                interactor = FakeAddPaymentMethodInteractor
             ),
             canEdit = false,
             isLiveMode = false,
@@ -197,9 +184,7 @@ class PaymentSheetTopBarStateFactoryTest {
     fun `Shows correct edit menu label when in editing mode`() {
         val state = buildTopBarState(
             screen = PaymentSheetScreen.AddAnotherPaymentMethod(
-                interactor = UnsupportedAddPaymentMethodInteractor(
-                    errorReporter = FakeErrorReporter()
-                )
+                interactor = FakeAddPaymentMethodInteractor
             ),
             canEdit = false,
             isLiveMode = true,
@@ -227,9 +212,7 @@ class PaymentSheetTopBarStateFactoryTest {
     fun `Enables menu when not processing`() {
         val state = buildTopBarState(
             screen = PaymentSheetScreen.AddAnotherPaymentMethod(
-                interactor = UnsupportedAddPaymentMethodInteractor(
-                    errorReporter = FakeErrorReporter()
-                )
+                interactor = FakeAddPaymentMethodInteractor
             ),
             canEdit = false,
             isLiveMode = false,
@@ -244,9 +227,7 @@ class PaymentSheetTopBarStateFactoryTest {
     fun `Disables menu when processing`() {
         val state = buildTopBarState(
             screen = PaymentSheetScreen.AddAnotherPaymentMethod(
-                interactor = UnsupportedAddPaymentMethodInteractor(
-                    errorReporter = FakeErrorReporter()
-                )
+                interactor = FakeAddPaymentMethodInteractor
             ),
             canEdit = false,
             isLiveMode = false,
@@ -265,7 +246,8 @@ class PaymentSheetTopBarStateFactoryTest {
         canEdit: Boolean,
     ): PaymentSheetTopBarState {
         return PaymentSheetTopBarStateFactory.create(
-            screen = screen,
+            screen = screen.sheetScreen,
+            hasBackStack = screen.canNavigateBack,
             isLiveMode = isLiveMode,
             isProcessing = isProcessing,
             isEditing = isEditing,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Refactor PaymentSheetTopBarState to not require a PaymentSheetScreen object

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Makes it so that `CustomerSheetViewState` doesn't need to create instances of `PaymentSheetScreen`s which are not actually used as screens.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

There are existing unit tests for PaymentSheetTopBarState. No behavior changes in this PR.