### PR TITLE
Add CVC Field Animation for PaymentSheet

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -351,7 +351,6 @@ private fun SavedPaymentMethodTab(
     }
 }
 
-@Suppress("MagicNumber")
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal fun CvcRecollectionField(cvcControllerFlow: StateFlow<CvcController>, isProcessing: Boolean) {
@@ -363,8 +362,6 @@ internal fun CvcRecollectionField(cvcControllerFlow: StateFlow<CvcController>, i
     val focusRequester = remember { FocusRequester() }
     var visible by remember { mutableStateOf(false) }
     val focusManager = LocalFocusManager.current
-    val animationDelay = 400
-    val animationDuration = 500
     LaunchedEffect(isProcessing) {
         // Clear focus once primary button is clicked
         if (isProcessing) {
@@ -373,12 +370,12 @@ internal fun CvcRecollectionField(cvcControllerFlow: StateFlow<CvcController>, i
     }
 
     LaunchedEffect(key1 = Unit) {
-        delay(animationDelay.toLong())
+        delay(ANIMATION_DELAY.toLong())
         visible = true
     }
     AnimatedVisibility(
         visible = visible,
-        enter = expandVertically(tween(animationDuration, animationDelay)) {
+        enter = expandVertically(tween(ANIMATION_DURATION, ANIMATION_DELAY)) {
             it
         }
     ) {
@@ -413,3 +410,5 @@ internal fun CvcRecollectionField(cvcControllerFlow: StateFlow<CvcController>, i
 @VisibleForTesting
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 const val SAVED_PAYMENT_OPTION_TEST_TAG = "PaymentSheetSavedPaymentOption"
+private const val ANIMATION_DELAY = 400
+private const val ANIMATION_DURATION = 500


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add animation to emphasize CVC recollection field
Remove autofocus on CVC Field to match iOS

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[Bug Bash](https://docs.google.com/document/d/1AiOPYq1QXP4UjC-7r9idd7OBCxGt7CAnYpnsGF4N-Ho/edit)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified


https://github.com/stripe/stripe-android/assets/163896025/217f4ec1-5288-439a-80eb-1227df146043



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
