### PR TITLE
Display correct saved payment method selection after going back from add payment method screen

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -229,7 +229,14 @@ internal abstract class BaseSheetViewModel(
     private val paymentOptionsStateMapper: PaymentOptionsStateMapper by lazy {
         PaymentOptionsStateMapper(
             paymentMethods = paymentMethods,
-            currentSelection = selection,
+            currentSelection = mostRecentlySelectedSavedPaymentMethod
+                .mapAsStateFlow { paymentMethod ->
+                    paymentMethod?.let {
+                        PaymentSelection.Saved(
+                            it
+                        )
+                    }
+                },
             googlePayState = googlePayState,
             isLinkEnabled = linkHandler.isLinkEnabled,
             isNotPaymentFlow = this is PaymentOptionsViewModel,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsStateMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsStateMapper.kt
@@ -13,7 +13,7 @@ internal class PaymentOptionsStateMapper(
     private val paymentMethods: StateFlow<List<PaymentMethod>>,
     private val googlePayState: StateFlow<GooglePayState>,
     private val isLinkEnabled: StateFlow<Boolean?>,
-    private val currentSelection: StateFlow<PaymentSelection?>,
+    private val currentSelection: StateFlow<PaymentSelection.Saved?>,
     private val nameProvider: (PaymentMethodCode?) -> String,
     private val isNotPaymentFlow: Boolean,
     private val isCbcEligible: () -> Boolean


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Display correct saved payment method selection after going back from add payment method screen

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This is the intended behavior

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

No tests bc this logic is all in BaseSheetViewModel :( 

# Screen recordings
Before:


https://github.com/stripe/stripe-android/assets/160939932/6518285f-acdb-423c-941c-8947ed6c2f03



After:

https://github.com/stripe/stripe-android/assets/160939932/d8265dd1-794b-4ffc-b376-f37f19ec2255


