### PR TITLE
Ignore `Giropay` tests

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestGiropay.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestGiropay.kt
@@ -3,6 +3,7 @@ package com.stripe.android.lpm
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
 import com.stripe.android.test.core.TestParameters
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -13,6 +14,7 @@ internal class TestGiropay : BasePlaygroundTest() {
     )
 
     @Test
+    @Ignore("Giropay is deprecated as of 2024-06-30")
     fun testGiropay() {
         testDriver.confirmNewOrGuestComplete(
             testParameters = testParameters,
@@ -20,6 +22,7 @@ internal class TestGiropay : BasePlaygroundTest() {
     }
 
     @Test
+    @Ignore("Giropay is deprecated as of 2024-06-30")
     fun testGiropayInCustomFlow() {
         testDriver.confirmCustom(
             testParameters = testParameters,


### PR DESCRIPTION
# Summary
Ignore `Giropay` tests.

# Motivation
`Giropay` is being deprecated on June 30th, 2024. These tests appear to begun failing now. This PR ignores them for now but we should validate and remove them as part of an overall `Giropay` removal for the SDK.

See #ir-awaken-students for more details

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified