### PR TITLE
Provide only payment method ID when modifying or removing a payment method

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewAction.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewAction.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.customersheet
 
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResultInternal
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -16,8 +15,8 @@ internal sealed class CustomerSheetViewAction {
     object OnPrimaryButtonPressed : CustomerSheetViewAction()
     object OnCancelClose : CustomerSheetViewAction()
     class OnItemSelected(val selection: PaymentSelection?) : CustomerSheetViewAction()
-    class OnModifyItem(val paymentMethod: PaymentMethod) : CustomerSheetViewAction()
-    class OnItemRemoved(val paymentMethod: PaymentMethod) : CustomerSheetViewAction()
+    class OnModifyItem(val paymentMethodId: String?) : CustomerSheetViewAction()
+    class OnItemRemoved(val paymentMethodId: String?) : CustomerSheetViewAction()
     class OnAddPaymentMethodItemChanged(
         val paymentMethod: SupportedPaymentMethod,
     ) : CustomerSheetViewAction()

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -174,8 +174,8 @@ internal class CustomerSheetViewModel(
             is CustomerSheetViewAction.OnCardNumberInputCompleted -> onCardNumberInputCompleted()
             is CustomerSheetViewAction.OnBackPressed -> onBackPressed()
             is CustomerSheetViewAction.OnEditPressed -> onEditPressed()
-            is CustomerSheetViewAction.OnItemRemoved -> onItemRemoved(viewAction.paymentMethod)
-            is CustomerSheetViewAction.OnModifyItem -> onModifyItem(viewAction.paymentMethod)
+            is CustomerSheetViewAction.OnItemRemoved -> onItemRemoved(viewAction.paymentMethodId)
+            is CustomerSheetViewAction.OnModifyItem -> onModifyItem(viewAction.paymentMethodId)
             is CustomerSheetViewAction.OnItemSelected -> onItemSelected(viewAction.selection)
             is CustomerSheetViewAction.OnPrimaryButtonPressed -> onPrimaryButtonPressed()
             is CustomerSheetViewAction.OnAddPaymentMethodItemChanged ->
@@ -470,8 +470,19 @@ internal class CustomerSheetViewModel(
         }
     }
 
-    private fun onItemRemoved(paymentMethod: PaymentMethod) {
+    private fun onItemRemoved(paymentMethodId: String?) {
+        // TODO(samer-stripe): We should guarantee a payment method ID is available with data modeling updates to UI
+        if (paymentMethodId == null) {
+            return
+        }
+
         viewModelScope.launch(workContext) {
+            val currentViewState = viewState.value
+
+            val paymentMethod = currentViewState.savedPaymentMethods.find { paymentMethod ->
+                paymentMethod.id == paymentMethodId
+            } ?: return@launch
+
             val result = removePaymentMethod(paymentMethod)
 
             result.fold(
@@ -542,8 +553,17 @@ internal class CustomerSheetViewModel(
         }
     }
 
-    private fun onModifyItem(paymentMethod: PaymentMethod) {
+    private fun onModifyItem(paymentMethodId: String?) {
+        // TODO(samer-stripe): We should guarantee a payment method ID is available with data modeling updates to UI
+        if (paymentMethodId == null) {
+            return
+        }
+
         val currentViewState = viewState.value
+
+        val paymentMethod = currentViewState.savedPaymentMethods.find { paymentMethod ->
+            paymentMethod.id == paymentMethodId
+        } ?: return
 
         val canRemove = if (configuration.allowsRemovalOfLastSavedPaymentMethod) {
             true

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -75,8 +75,8 @@ internal fun SavedPaymentMethodTabLayoutUI(
     isProcessing: Boolean,
     onAddCardPressed: () -> Unit,
     onItemSelected: (PaymentSelection?) -> Unit,
-    onModifyItem: (PaymentMethod) -> Unit,
-    onItemRemoved: (PaymentMethod) -> Unit,
+    onModifyItem: (paymentMethodId: String?) -> Unit,
+    onItemRemoved: (paymentMethodId: String?) -> Unit,
     modifier: Modifier = Modifier,
     scrollState: LazyListState = rememberLazyListState(),
 ) {
@@ -184,8 +184,8 @@ private fun SavedPaymentMethodTab(
     isSelected: Boolean,
     onAddCardPressed: () -> Unit,
     onItemSelected: (PaymentSelection?) -> Unit,
-    onModifyItem: (PaymentMethod) -> Unit,
-    onItemRemoved: (PaymentMethod) -> Unit,
+    onModifyItem: (paymentMethodId: String?) -> Unit,
+    onItemRemoved: (paymentMethodId: String?) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     when (item) {
@@ -312,8 +312,8 @@ private fun SavedPaymentMethodTab(
     isRemovable: Boolean,
     isSelected: Boolean,
     onItemSelected: (PaymentSelection?) -> Unit,
-    onModifyItem: (PaymentMethod) -> Unit,
-    onItemRemoved: (PaymentMethod) -> Unit,
+    onModifyItem: (paymentMethodId: String?) -> Unit,
+    onItemRemoved: (paymentMethodId: String?) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -341,9 +341,9 @@ private fun SavedPaymentMethodTab(
             labelText = labelText,
             paymentMethod = paymentMethod.displayableSavedPaymentMethod,
             description = paymentMethod.displayableSavedPaymentMethod.getDescription(context.resources),
-            onModifyListener = { onModifyItem(paymentMethod.paymentMethod) },
+            onModifyListener = { onModifyItem(paymentMethod.paymentMethod.id) },
             onModifyAccessibilityDescription = paymentMethod.getModifyDescription(context.resources),
-            onRemoveListener = { onItemRemoved(paymentMethod.paymentMethod) },
+            onRemoveListener = { onItemRemoved(paymentMethod.paymentMethod.id) },
             onRemoveAccessibilityDescription = paymentMethod.getRemoveDescription(context.resources),
             onItemSelectedListener = { onItemSelected(paymentMethod.toPaymentSelection()) },
             modifier = modifier,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SelectSavedPaymentMethodsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SelectSavedPaymentMethodsInteractor.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.ui
 
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentOptionsState
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
@@ -32,8 +31,8 @@ internal interface SelectSavedPaymentMethodsInteractor {
 
         data class SelectPaymentMethod(val selection: PaymentSelection?) : ViewAction()
 
-        data class DeletePaymentMethod(val paymentMethod: PaymentMethod) : ViewAction()
-        data class EditPaymentMethod(val paymentMethod: PaymentMethod) : ViewAction()
+        data class DeletePaymentMethod(val paymentMethodId: String?) : ViewAction()
+        data class EditPaymentMethod(val paymentMethodId: String?) : ViewAction()
     }
 }
 
@@ -42,8 +41,8 @@ internal class DefaultSelectSavedPaymentMethodsInteractor(
     private val editing: StateFlow<Boolean>,
     private val isProcessing: StateFlow<Boolean>,
     private val onAddCardPressed: () -> Unit,
-    private val onEditPaymentMethod: (PaymentMethod) -> Unit,
-    private val onDeletePaymentMethod: (PaymentMethod) -> Unit,
+    private val onEditPaymentMethod: (paymentMethodId: String?) -> Unit,
+    private val onDeletePaymentMethod: (paymentMethodId: String?) -> Unit,
     private val onPaymentMethodSelected: (PaymentSelection?) -> Unit,
     dispatcher: CoroutineContext = Dispatchers.Default,
 ) : SelectSavedPaymentMethodsInteractor {
@@ -100,11 +99,11 @@ internal class DefaultSelectSavedPaymentMethodsInteractor(
     override fun handleViewAction(viewAction: SelectSavedPaymentMethodsInteractor.ViewAction) {
         when (viewAction) {
             is SelectSavedPaymentMethodsInteractor.ViewAction.DeletePaymentMethod -> onDeletePaymentMethod(
-                viewAction.paymentMethod
+                viewAction.paymentMethodId
             )
 
             is SelectSavedPaymentMethodsInteractor.ViewAction.EditPaymentMethod -> onEditPaymentMethod(
-                viewAction.paymentMethod
+                viewAction.paymentMethodId
             )
 
             is SelectSavedPaymentMethodsInteractor.ViewAction.SelectPaymentMethod -> onPaymentMethodSelected(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageOneSavedPaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageOneSavedPaymentMethodInteractor.kt
@@ -32,7 +32,7 @@ internal class DefaultManageOneSavedPaymentMethodInteractor(
         paymentMethod = sheetViewModel.paymentMethods.value.first(),
         paymentMethodMetadata = sheetViewModel.paymentMethodMetadata.value!!,
         providePaymentMethodName = sheetViewModel::providePaymentMethodName,
-        onDeletePaymentMethod = { sheetViewModel.removePaymentMethod(it) },
+        onDeletePaymentMethod = { sheetViewModel.removePaymentMethod(it.id) },
         navigateBack = sheetViewModel::handleBackPressed,
     )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
@@ -62,8 +62,8 @@ internal class DefaultManageScreenInteractor(
         allowsRemovalOfLastSavedPaymentMethod = viewModel.config.allowsRemovalOfLastSavedPaymentMethod,
         providePaymentMethodName = viewModel::providePaymentMethodName,
         onSelectPaymentMethod = { viewModel.handlePaymentMethodSelected(PaymentSelection.Saved(it.paymentMethod)) },
-        onDeletePaymentMethod = { viewModel.removePaymentMethod(it.paymentMethod) },
-        onEditPaymentMethod = { viewModel.modifyPaymentMethod(it.paymentMethod) },
+        onDeletePaymentMethod = { viewModel.removePaymentMethod(it.paymentMethod.id) },
+        onEditPaymentMethod = { viewModel.modifyPaymentMethod(it.paymentMethod.id) },
         navigateBack = viewModel::handleBackPressed
     )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -103,7 +103,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         mostRecentlySelectedSavedPaymentMethod = viewModel.mostRecentlySelectedSavedPaymentMethod,
         providePaymentMethodName = viewModel::providePaymentMethodName,
         allowsRemovalOfLastSavedPaymentMethod = viewModel.config.allowsRemovalOfLastSavedPaymentMethod,
-        onEditPaymentMethod = { viewModel.modifyPaymentMethod(it.paymentMethod) },
+        onEditPaymentMethod = { viewModel.modifyPaymentMethod(it.paymentMethod.id) },
         onSelectSavedPaymentMethod = {
             viewModel.handlePaymentMethodSelected(PaymentSelection.Saved(it))
         },

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -478,7 +478,8 @@ class CustomerSheetViewModelTest {
     @Test
     fun `When CustomerViewAction#OnEditPressed, view state isEditing should be updated`() = runTest(testDispatcher) {
         val viewModel = createViewModel(
-            workContext = testDispatcher
+            workContext = testDispatcher,
+            customerPaymentMethods = listOf(CARD_PAYMENT_METHOD),
         )
         viewModel.viewState.test {
             var viewState = awaitViewState<SelectPaymentMethod>()
@@ -491,7 +492,7 @@ class CustomerSheetViewModelTest {
             assertThat(viewState.isEditing).isTrue()
             assertThat(viewState.topBarState.showEditMenu).isTrue()
 
-            viewModel.handleViewAction(CustomerSheetViewAction.OnItemRemoved(CARD_PAYMENT_METHOD))
+            viewModel.handleViewAction(CustomerSheetViewAction.OnItemRemoved(CARD_PAYMENT_METHOD.id))
 
             viewState = awaitViewState()
             assertThat(viewState.isEditing).isFalse()
@@ -521,7 +522,7 @@ class CustomerSheetViewModelTest {
             assertThat(viewState.isEditing).isTrue()
             assertThat(viewState.topBarState.showEditMenu).isTrue()
 
-            viewModel.handleViewAction(CustomerSheetViewAction.OnItemRemoved(CARD_PAYMENT_METHOD))
+            viewModel.handleViewAction(CustomerSheetViewAction.OnItemRemoved(CARD_PAYMENT_METHOD.id))
 
             viewState = awaitViewState()
             assertThat(viewState.isEditing).isFalse()
@@ -550,7 +551,7 @@ class CustomerSheetViewModelTest {
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnItemRemoved(
-                    CARD_PAYMENT_METHOD
+                    CARD_PAYMENT_METHOD.id
                 )
             )
 
@@ -577,7 +578,7 @@ class CustomerSheetViewModelTest {
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnItemRemoved(
-                    CARD_PAYMENT_METHOD
+                    CARD_PAYMENT_METHOD.id
                 )
             )
 
@@ -611,7 +612,7 @@ class CustomerSheetViewModelTest {
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnItemRemoved(
-                    CARD_PAYMENT_METHOD
+                    CARD_PAYMENT_METHOD.id
                 )
             )
 
@@ -1050,7 +1051,7 @@ class CustomerSheetViewModelTest {
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnItemRemoved(
-                    CARD_PAYMENT_METHOD.copy(id = "pm_2")
+                    "pm_2"
                 )
             )
 
@@ -1131,7 +1132,7 @@ class CustomerSheetViewModelTest {
             assertThat(viewState.primaryButtonVisible).isFalse()
 
             viewModel.handleViewAction(
-                CustomerSheetViewAction.OnItemRemoved(CARD_PAYMENT_METHOD.copy(id = "pm_2"))
+                CustomerSheetViewAction.OnItemRemoved("pm_2")
             )
 
             viewState = awaitViewState()
@@ -1326,10 +1327,11 @@ class CustomerSheetViewModelTest {
         val viewModel = createViewModel(
             workContext = testDispatcher,
             eventReporter = eventReporter,
+            customerPaymentMethods = listOf(CARD_PAYMENT_METHOD),
         )
 
         viewModel.handleViewAction(
-            CustomerSheetViewAction.OnModifyItem(paymentMethod = CARD_PAYMENT_METHOD)
+            CustomerSheetViewAction.OnModifyItem(CARD_PAYMENT_METHOD.id)
         )
 
         verify(eventReporter).onScreenPresented(CustomerSheetEventReporter.Screen.EditPaymentMethod)
@@ -1342,10 +1344,11 @@ class CustomerSheetViewModelTest {
         val viewModel = createViewModel(
             workContext = testDispatcher,
             eventReporter = eventReporter,
+            customerPaymentMethods = listOf(CARD_PAYMENT_METHOD),
         )
 
         viewModel.handleViewAction(
-            CustomerSheetViewAction.OnModifyItem(paymentMethod = CARD_PAYMENT_METHOD)
+            CustomerSheetViewAction.OnModifyItem(CARD_PAYMENT_METHOD.id)
         )
 
         viewModel.handleViewAction(CustomerSheetViewAction.OnBackPressed)
@@ -1378,6 +1381,7 @@ class CustomerSheetViewModelTest {
         val viewModel = createViewModel(
             workContext = testDispatcher,
             customerAdapter = FakeCustomerAdapter(
+                paymentMethods = CustomerAdapter.Result.Success(listOf(CARD_PAYMENT_METHOD)),
                 onDetachPaymentMethod = {
                     CustomerAdapter.Result.success(CARD_PAYMENT_METHOD)
                 }
@@ -1388,7 +1392,7 @@ class CustomerSheetViewModelTest {
         viewModel.viewState.test {
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnItemRemoved(
-                    CARD_PAYMENT_METHOD
+                    CARD_PAYMENT_METHOD.id
                 )
             )
             verify(eventReporter).onRemovePaymentMethodSucceeded()
@@ -1410,13 +1414,14 @@ class CustomerSheetViewModelTest {
                     )
                 }
             ),
+            customerPaymentMethods = listOf(CARD_PAYMENT_METHOD),
             eventReporter = eventReporter,
         )
 
         viewModel.viewState.test {
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnItemRemoved(
-                    CARD_PAYMENT_METHOD
+                    CARD_PAYMENT_METHOD.id
                 )
             )
             verify(eventReporter).onRemovePaymentMethodFailed()
@@ -2656,7 +2661,7 @@ class CustomerSheetViewModelTest {
 
         viewModel.viewState.test {
             assertThat(awaitItem()).isInstanceOf(SelectPaymentMethod::class.java)
-            viewModel.handleViewAction(CustomerSheetViewAction.OnModifyItem(paymentMethods.single()))
+            viewModel.handleViewAction(CustomerSheetViewAction.OnModifyItem(paymentMethods.single().id))
 
             val editViewState = awaitViewState<CustomerSheetViewState.EditPaymentMethod>()
             editViewState.editPaymentMethodInteractor.handleViewAction(OnRemovePressed)
@@ -2694,7 +2699,7 @@ class CustomerSheetViewModelTest {
 
         viewModel.viewState.test {
             assertThat(awaitItem()).isInstanceOf(SelectPaymentMethod::class.java)
-            viewModel.handleViewAction(CustomerSheetViewAction.OnModifyItem(paymentMethods.first()))
+            viewModel.handleViewAction(CustomerSheetViewAction.OnModifyItem(paymentMethods.first().id))
 
             val editViewState = awaitViewState<CustomerSheetViewState.EditPaymentMethod>()
             editViewState.editPaymentMethodInteractor.handleViewAction(OnRemovePressed)
@@ -2756,7 +2761,7 @@ class CustomerSheetViewModelTest {
 
             viewModel.viewState.test {
                 assertThat(awaitItem()).isInstanceOf(SelectPaymentMethod::class.java)
-                viewModel.handleViewAction(CustomerSheetViewAction.OnModifyItem(firstMethod))
+                viewModel.handleViewAction(CustomerSheetViewAction.OnModifyItem(firstMethod.id))
 
                 val editViewState = awaitViewState<CustomerSheetViewState.EditPaymentMethod>()
                 editViewState.editPaymentMethodInteractor.handleViewAction(
@@ -2956,7 +2961,7 @@ class CustomerSheetViewModelTest {
 
         viewModel.viewState.test {
             assertThat(awaitItem()).isInstanceOf(SelectPaymentMethod::class.java)
-            viewModel.handleViewAction(CustomerSheetViewAction.OnModifyItem(firstMethod))
+            viewModel.handleViewAction(CustomerSheetViewAction.OnModifyItem(firstMethod.id))
 
             val editViewState = awaitViewState<CustomerSheetViewState.EditPaymentMethod>()
             editViewState.editPaymentMethodInteractor.handleViewAction(
@@ -2998,7 +3003,7 @@ class CustomerSheetViewModelTest {
 
         viewModel.viewState.test {
             assertThat(awaitItem()).isInstanceOf(SelectPaymentMethod::class.java)
-            viewModel.handleViewAction(CustomerSheetViewAction.OnModifyItem(paymentMethods.single()))
+            viewModel.handleViewAction(CustomerSheetViewAction.OnModifyItem(paymentMethods.single().id))
 
             val editViewState = awaitViewState<CustomerSheetViewState.EditPaymentMethod>()
             editViewState.editPaymentMethodInteractor.handleViewAction(
@@ -3030,7 +3035,7 @@ class CustomerSheetViewModelTest {
 
         viewModel.viewState.test {
             assertThat(awaitItem()).isInstanceOf(SelectPaymentMethod::class.java)
-            viewModel.handleViewAction(CustomerSheetViewAction.OnModifyItem(paymentMethods.single()))
+            viewModel.handleViewAction(CustomerSheetViewAction.OnModifyItem(paymentMethods.single().id))
 
             val editViewState = awaitViewState<CustomerSheetViewState.EditPaymentMethod>()
             editViewState.editPaymentMethodInteractor.handleViewAction(
@@ -3062,7 +3067,7 @@ class CustomerSheetViewModelTest {
 
         viewModel.viewState.test {
             assertThat(awaitItem()).isInstanceOf(SelectPaymentMethod::class.java)
-            viewModel.handleViewAction(CustomerSheetViewAction.OnModifyItem(paymentMethods.single()))
+            viewModel.handleViewAction(CustomerSheetViewAction.OnModifyItem(paymentMethods.single().id))
 
             val editViewState = awaitViewState<CustomerSheetViewState.EditPaymentMethod>()
             editViewState.editPaymentMethodInteractor.handleViewAction(
@@ -3096,7 +3101,7 @@ class CustomerSheetViewModelTest {
 
         viewModel.viewState.test {
             assertThat(awaitItem()).isInstanceOf(SelectPaymentMethod::class.java)
-            viewModel.handleViewAction(CustomerSheetViewAction.OnModifyItem(paymentMethods.single()))
+            viewModel.handleViewAction(CustomerSheetViewAction.OnModifyItem(paymentMethods.single().id))
 
             val editViewState = awaitViewState<CustomerSheetViewState.EditPaymentMethod>()
             editViewState.editPaymentMethodInteractor.handleViewAction(
@@ -3133,7 +3138,7 @@ class CustomerSheetViewModelTest {
             assertThat(initialViewState.paymentSelection)
                 .isEqualTo(PaymentSelection.Saved(CARD_PAYMENT_METHOD))
 
-            viewModel.handleViewAction(CustomerSheetViewAction.OnItemRemoved(CARD_PAYMENT_METHOD))
+            viewModel.handleViewAction(CustomerSheetViewAction.OnItemRemoved(CARD_PAYMENT_METHOD.id))
 
             val finalViewState = awaitViewState<SelectPaymentMethod>()
             assertThat(finalViewState.savedPaymentMethods).containsExactly(US_BANK_ACCOUNT).inOrder()
@@ -3296,7 +3301,7 @@ class CustomerSheetViewModelTest {
         viewState.test {
             assertThat(awaitItem()).isInstanceOf(SelectPaymentMethod::class.java)
 
-            handleViewAction(CustomerSheetViewAction.OnModifyItem(originalPaymentMethod))
+            handleViewAction(CustomerSheetViewAction.OnModifyItem(originalPaymentMethod.id))
 
             val editViewState = awaitViewState<CustomerSheetViewState.EditPaymentMethod>()
             editViewState.editPaymentMethodInteractor.handleViewAction(
@@ -3325,7 +3330,7 @@ class CustomerSheetViewModelTest {
         viewState.test {
             assertThat(awaitItem()).isInstanceOf(SelectPaymentMethod::class.java)
 
-            handleViewAction(CustomerSheetViewAction.OnModifyItem(paymentMethodToRemove))
+            handleViewAction(CustomerSheetViewAction.OnModifyItem(paymentMethodToRemove.id))
 
             val editViewState = awaitViewState<CustomerSheetViewState.EditPaymentMethod>()
             editViewState.editPaymentMethodInteractor.handleViewAction(OnRemoveConfirmed)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -206,7 +206,7 @@ internal class PaymentOptionsViewModelTest {
             args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(paymentMethods = cards)
         )
 
-        viewModel.removePaymentMethod(cards[1])
+        viewModel.removePaymentMethod(cards[1].id)
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(viewModel.paymentMethods.value)
@@ -224,7 +224,7 @@ internal class PaymentOptionsViewModelTest {
         viewModel.updateSelection(selection)
         assertThat(viewModel.selection.value).isEqualTo(selection)
 
-        viewModel.removePaymentMethod(selection.paymentMethod)
+        viewModel.removePaymentMethod(selection.paymentMethod.id)
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(viewModel.selection.value).isNull()
@@ -239,7 +239,7 @@ internal class PaymentOptionsViewModelTest {
             )
         )
 
-        viewModel.removePaymentMethod(paymentMethod)
+        viewModel.removePaymentMethod(paymentMethod.id)
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(viewModel.paymentMethods.value).isEmpty()
@@ -557,7 +557,7 @@ internal class PaymentOptionsViewModelTest {
 
         viewModel.paymentOptionResult.test {
             // Simulate user removing the selected payment method
-            viewModel.removePaymentMethod(selection.paymentMethod)
+            viewModel.removePaymentMethod(selection.paymentMethod.id)
             testDispatcher.scheduler.advanceUntilIdle()
 
             viewModel.onUserCancel()
@@ -690,7 +690,7 @@ internal class PaymentOptionsViewModelTest {
 
             assertThat(paymentMethodsTurbine.awaitItem()).containsExactlyElementsIn(cards).inOrder()
 
-            viewModel.modifyPaymentMethod(paymentMethodToRemove)
+            viewModel.modifyPaymentMethod(paymentMethodToRemove.id)
 
             val editViewState = screenTurbine.awaitItem() as PaymentSheetScreen.EditPaymentMethod
             editViewState.interactor.handleViewAction(EditPaymentMethodViewAction.OnRemovePressed)
@@ -742,7 +742,7 @@ internal class PaymentOptionsViewModelTest {
 
             assertThat(paymentMethodsTurbine.awaitItem()).containsExactlyElementsIn(cards).inOrder()
 
-            viewModel.modifyPaymentMethod(paymentMethodToRemove)
+            viewModel.modifyPaymentMethod(paymentMethodToRemove.id)
 
             val editViewState = screenTurbine.awaitItem() as PaymentSheetScreen.EditPaymentMethod
             editViewState.interactor.handleViewAction(EditPaymentMethodViewAction.OnRemovePressed)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -481,7 +481,7 @@ internal class PaymentSheetActivityTest {
             pressBack()
             assertThat(awaitItem()).isInstanceOf(SelectSavedPaymentMethods::class.java)
 
-            viewModel.modifyPaymentMethod(card)
+            viewModel.modifyPaymentMethod(card.id)
             assertThat(awaitItem()).isInstanceOf(PaymentSheetScreen.EditPaymentMethod::class.java)
 
             pressBack()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -204,11 +204,11 @@ internal class PaymentSheetViewModelTest {
             customerRepository = customerRepository
         )
 
-        viewModel.removePaymentMethod(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        viewModel.removePaymentMethod(CARD_PAYMENT_METHOD.id)
 
         verify(customerRepository).detachPaymentMethod(
             any(),
-            eq(PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!)
+            eq(CARD_PAYMENT_METHOD.id!!)
         )
     }
 
@@ -223,7 +223,7 @@ internal class PaymentSheetViewModelTest {
         viewModel.currentScreen.test {
             awaitItem()
 
-            viewModel.modifyPaymentMethod(CARD_WITH_NETWORKS_PAYMENT_METHOD)
+            viewModel.modifyPaymentMethod(CARD_WITH_NETWORKS_PAYMENT_METHOD.id)
 
             val currentScreen = awaitItem()
 
@@ -255,7 +255,7 @@ internal class PaymentSheetViewModelTest {
         viewModel.currentScreen.test {
             awaitItem()
 
-            viewModel.modifyPaymentMethod(CARD_WITH_NETWORKS_PAYMENT_METHOD)
+            viewModel.modifyPaymentMethod(CARD_WITH_NETWORKS_PAYMENT_METHOD.id)
 
             val currentScreen = awaitItem()
 
@@ -304,7 +304,7 @@ internal class PaymentSheetViewModelTest {
             customerRepository = customerRepository
         )
 
-        viewModel.removePaymentMethod(paymentMethods.first())
+        viewModel.removePaymentMethod(paymentMethods.first().id)
 
         val customerInfoCaptor = argumentCaptor<CustomerRepository.CustomerInfo>()
 
@@ -332,7 +332,7 @@ internal class PaymentSheetViewModelTest {
         viewModel.currentScreen.test {
             awaitItem()
 
-            viewModel.modifyPaymentMethod(CARD_WITH_NETWORKS_PAYMENT_METHOD)
+            viewModel.modifyPaymentMethod(CARD_WITH_NETWORKS_PAYMENT_METHOD.id)
 
             val currentScreen = awaitItem()
 
@@ -386,7 +386,7 @@ internal class PaymentSheetViewModelTest {
         viewModel.currentScreen.test {
             awaitItem()
 
-            viewModel.modifyPaymentMethod(paymentMethods.first())
+            viewModel.modifyPaymentMethod(paymentMethods.first().id)
 
             val currentScreen = awaitItem()
 
@@ -452,7 +452,7 @@ internal class PaymentSheetViewModelTest {
         viewModel.currentScreen.test {
             awaitItem()
 
-            viewModel.modifyPaymentMethod(firstPaymentMethod)
+            viewModel.modifyPaymentMethod(firstPaymentMethod.id)
 
             val currentScreen = awaitItem()
 
@@ -522,7 +522,7 @@ internal class PaymentSheetViewModelTest {
         viewModel.currentScreen.test {
             awaitItem()
 
-            viewModel.modifyPaymentMethod(firstPaymentMethod)
+            viewModel.modifyPaymentMethod(firstPaymentMethod.id)
 
             val currentScreen = awaitItem()
 
@@ -1618,7 +1618,7 @@ internal class PaymentSheetViewModelTest {
             customer = EMPTY_CUSTOMER_STATE.copy(paymentMethods = cards),
         )
 
-        viewModel.modifyPaymentMethod(CARD_WITH_NETWORKS_PAYMENT_METHOD)
+        viewModel.modifyPaymentMethod(CARD_WITH_NETWORKS_PAYMENT_METHOD.id)
 
         verify(eventReporter).onShowEditablePaymentOption()
     }
@@ -1632,7 +1632,7 @@ internal class PaymentSheetViewModelTest {
             customer = EMPTY_CUSTOMER_STATE.copy(paymentMethods = cards),
         )
 
-        viewModel.modifyPaymentMethod(CARD_WITH_NETWORKS_PAYMENT_METHOD)
+        viewModel.modifyPaymentMethod(CARD_WITH_NETWORKS_PAYMENT_METHOD.id)
         viewModel.handleBackPressed()
 
         verify(eventReporter).onHideEditablePaymentOption()
@@ -1651,7 +1651,7 @@ internal class PaymentSheetViewModelTest {
             viewModel.toggleEditing()
             assertThat(awaitItem()).isTrue()
 
-            viewModel.removePaymentMethod(customerPaymentMethods.single())
+            viewModel.removePaymentMethod(customerPaymentMethods.single().id)
             assertThat(awaitItem()).isFalse()
         }
     }
@@ -1742,7 +1742,7 @@ internal class PaymentSheetViewModelTest {
 
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isInstanceOf(SelectSavedPaymentMethods::class.java)
-            viewModel.removePaymentMethod(paymentMethods.single())
+            viewModel.removePaymentMethod(paymentMethods.single().id)
             assertThat(awaitItem()).isInstanceOf(AddFirstPaymentMethod::class.java)
         }
     }
@@ -2725,7 +2725,7 @@ internal class PaymentSheetViewModelTest {
             ),
         )
 
-        viewModel.removePaymentMethod(PAYMENT_METHODS.first())
+        viewModel.removePaymentMethod(PAYMENT_METHODS.first().id)
 
         verify(customerRepository, never()).detachPaymentMethod(any(), any())
     }
@@ -2742,23 +2742,11 @@ internal class PaymentSheetViewModelTest {
         viewModel.currentScreen.test {
             awaitItem()
 
-            viewModel.modifyPaymentMethod(CARD_WITH_NETWORKS_PAYMENT_METHOD)
+            viewModel.modifyPaymentMethod(CARD_WITH_NETWORKS_PAYMENT_METHOD.id)
 
-            val currentScreen = awaitItem()
+            verify(customerRepository, never()).updatePaymentMethod(any(), any(), any())
 
-            assertThat(currentScreen).isInstanceOf(PaymentSheetScreen.EditPaymentMethod::class.java)
-
-            if (currentScreen is PaymentSheetScreen.EditPaymentMethod) {
-                val interactor = currentScreen.interactor
-
-                interactor.handleViewAction(
-                    EditPaymentMethodViewAction.OnBrandChoiceChanged(
-                        EditPaymentMethodViewState.CardBrandChoice(CardBrand.Visa)
-                    )
-                )
-
-                verify(customerRepository, never()).updatePaymentMethod(any(), any(), any())
-            }
+            expectNoEvents()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultSelectSavedPaymentMethodsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultSelectSavedPaymentMethodsInteractorTest.kt
@@ -116,39 +116,39 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
 
     @Test
     fun handleViewAction_DeletePaymentMethod_deletesPaymentMethod() {
-        var deletedPaymentMethod: PaymentMethod? = null
-        fun onDeletePaymentMethod(paymentMethod: PaymentMethod) {
-            deletedPaymentMethod = paymentMethod
+        var deletedPaymentMethodId: String? = null
+        fun onDeletePaymentMethod(paymentMethodId: String?) {
+            deletedPaymentMethodId = paymentMethodId
         }
 
         runScenario(onDeletePaymentMethod = ::onDeletePaymentMethod) {
             val paymentMethodToDelete = PaymentMethodFixtures.CARD_PAYMENT_METHOD
             interactor.handleViewAction(
                 SelectSavedPaymentMethodsInteractor.ViewAction.DeletePaymentMethod(
-                    paymentMethodToDelete
+                    paymentMethodToDelete.id
                 )
             )
 
-            assertThat(deletedPaymentMethod).isEqualTo(paymentMethodToDelete)
+            assertThat(deletedPaymentMethodId).isEqualTo(paymentMethodToDelete.id)
         }
     }
 
     @Test
     fun handleViewAction_EditPaymentMethod_editsPaymentMethod() {
-        var editedPaymentMethod: PaymentMethod? = null
-        fun onEditPaymentMethod(paymentMethod: PaymentMethod) {
-            editedPaymentMethod = paymentMethod
+        var editedPaymentMethodId: String? = null
+        fun onEditPaymentMethod(paymentMethodId: String?) {
+            editedPaymentMethodId = paymentMethodId
         }
 
         runScenario(onEditPaymentMethod = ::onEditPaymentMethod) {
             val paymentMethodToEdit = PaymentMethodFixtures.CARD_PAYMENT_METHOD
             interactor.handleViewAction(
                 SelectSavedPaymentMethodsInteractor.ViewAction.EditPaymentMethod(
-                    paymentMethodToEdit
+                    paymentMethodToEdit.id
                 )
             )
 
-            assertThat(editedPaymentMethod).isEqualTo(paymentMethodToEdit)
+            assertThat(editedPaymentMethodId).isEqualTo(paymentMethodToEdit.id)
         }
     }
 
@@ -214,8 +214,8 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
         editing: StateFlow<Boolean> = MutableStateFlow(false),
         isProcessing: StateFlow<Boolean> = MutableStateFlow(false),
         onAddCardPressed: () -> Unit = { notImplemented() },
-        onEditPaymentMethod: (PaymentMethod) -> Unit = { notImplemented() },
-        onDeletePaymentMethod: (PaymentMethod) -> Unit = { notImplemented() },
+        onEditPaymentMethod: (String?) -> Unit = { notImplemented() },
+        onDeletePaymentMethod: (String?) -> Unit = { notImplemented() },
         onPaymentMethodSelected: (PaymentSelection?) -> Unit = { notImplemented() },
         testBlock: suspend TestParams.() -> Unit,
     ) {


### PR DESCRIPTION
# Summary
Provide only the payment method ID when modifying or removing a payment method

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
