### PR TITLE
Add permissions to `CustomerState`

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1872,6 +1872,14 @@ public final class com/stripe/android/paymentsheet/state/CustomerState$Creator :
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentsheet/state/CustomerState$Permissions$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/state/CustomerState$Permissions;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/state/CustomerState$Permissions;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/paymentsheet/state/GooglePayState$Available$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/state/GooglePayState$Available;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
@@ -9,4 +9,11 @@ internal data class CustomerState(
     val id: String,
     val ephemeralKeySecret: String,
     val paymentMethods: List<PaymentMethod>,
-) : Parcelable
+    val permissions: Permissions,
+) : Parcelable {
+    @Parcelize
+    data class Permissions(
+        val canRemovePaymentMethods: Boolean,
+        val canRemoveDuplicates: Boolean,
+    ) : Parcelable
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -89,7 +89,11 @@ internal object PaymentSheetFixtures {
     internal val EMPTY_CUSTOMER_STATE = CustomerState(
         id = defaultCustomerConfig.id,
         ephemeralKeySecret = defaultCustomerConfig.ephemeralKeySecret,
-        paymentMethods = listOf()
+        paymentMethods = listOf(),
+        permissions = CustomerState.Permissions(
+            canRemovePaymentMethods = true,
+            canRemoveDuplicates = false,
+        )
     )
 
     internal val CONFIG_GOOGLEPAY
@@ -149,6 +153,10 @@ internal object PaymentSheetFixtures {
                     id = config.customer?.id ?: "cus_1",
                     ephemeralKeySecret = config.customer?.ephemeralKeySecret ?: "client_secret",
                     paymentMethods = paymentMethods,
+                    permissions = CustomerState.Permissions(
+                        canRemovePaymentMethods = true,
+                        canRemoveDuplicates = false,
+                    )
                 ),
                 isGooglePayReady = isGooglePayReady,
                 config = config,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -299,7 +299,11 @@ internal class PaymentSheetViewModelTest {
             customer = CustomerState(
                 id = "cus_2",
                 ephemeralKeySecret = "ephemeral_key_2",
-                paymentMethods = paymentMethods
+                paymentMethods = paymentMethods,
+                permissions = CustomerState.Permissions(
+                    canRemovePaymentMethods = true,
+                    canRemoveDuplicates = false,
+                ),
             ),
             customerRepository = customerRepository
         )
@@ -378,7 +382,11 @@ internal class PaymentSheetViewModelTest {
             customer = CustomerState(
                 id = "cus_2",
                 ephemeralKeySecret = "ephemeral_key_2",
-                paymentMethods = paymentMethods
+                paymentMethods = paymentMethods,
+                permissions = CustomerState.Permissions(
+                    canRemovePaymentMethods = true,
+                    canRemoveDuplicates = false,
+                ),
             ),
             customerRepository = customerRepository
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -114,7 +114,11 @@ internal class DefaultPaymentSheetLoaderTest {
                 customer = CustomerState(
                     id = config.customer!!.id,
                     ephemeralKeySecret = config.customer!!.ephemeralKeySecret,
-                    paymentMethods = PAYMENT_METHODS
+                    paymentMethods = PAYMENT_METHODS,
+                    permissions = CustomerState.Permissions(
+                        canRemovePaymentMethods = true,
+                        canRemoveDuplicates = false,
+                    ),
                 ),
                 isGooglePayReady = true,
                 paymentSelection = PaymentSelection.Saved(
@@ -1143,6 +1147,154 @@ internal class DefaultPaymentSheetLoaderTest {
                     id = "cus_1",
                     ephemeralKeySecret = "ek_123",
                     paymentMethods = cards,
+                    permissions = CustomerState.Permissions(
+                        canRemovePaymentMethods = false,
+                        canRemoveDuplicates = true,
+                    ),
+                )
+            )
+        }
+
+    @OptIn(ExperimentalCustomerSessionApi::class)
+    @Test
+    fun `When 'elements_session' has remove permissions enabled, should enable remove permissions in customer state`() =
+        runTest {
+            val loader = createPaymentSheetLoader(
+                customer = ElementsSession.Customer(
+                    paymentMethods = PaymentMethodFactory.cards(4),
+                    session = createElementsSessionCustomerSession(
+                        ElementsSession.Customer.Components.PaymentSheet.Enabled(
+                            isPaymentMethodRemoveEnabled = true,
+                            isPaymentMethodSaveEnabled = false,
+                        )
+                    ),
+                    defaultPaymentMethod = null,
+                )
+            )
+
+            val state = loader.load(
+                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                    clientSecret = "client_secret"
+                ),
+                paymentSheetConfiguration = PaymentSheet.Configuration(
+                    merchantDisplayName = "Merchant, Inc.",
+                    customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
+                        id = "cus_1",
+                        clientSecret = "customer_client_secret",
+                    ),
+                ),
+                initializedViaCompose = false,
+            ).getOrThrow()
+
+            assertThat(state.customer?.permissions).isEqualTo(
+                CustomerState.Permissions(
+                    canRemovePaymentMethods = true,
+                    canRemoveDuplicates = true,
+                )
+            )
+        }
+
+    @OptIn(ExperimentalCustomerSessionApi::class)
+    @Test
+    fun `When 'elements_session' has remove permissions disabled, should disable remove permissions in customer state`() =
+        runTest {
+            val loader = createPaymentSheetLoader(
+                customer = ElementsSession.Customer(
+                    paymentMethods = PaymentMethodFactory.cards(4),
+                    session = createElementsSessionCustomerSession(
+                        ElementsSession.Customer.Components.PaymentSheet.Enabled(
+                            isPaymentMethodRemoveEnabled = false,
+                            isPaymentMethodSaveEnabled = false,
+                        )
+                    ),
+                    defaultPaymentMethod = null,
+                )
+            )
+
+            val state = loader.load(
+                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                    clientSecret = "client_secret"
+                ),
+                paymentSheetConfiguration = PaymentSheet.Configuration(
+                    merchantDisplayName = "Merchant, Inc.",
+                    customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
+                        id = "cus_1",
+                        clientSecret = "customer_client_secret",
+                    ),
+                ),
+                initializedViaCompose = false,
+            ).getOrThrow()
+
+            assertThat(state.customer?.permissions).isEqualTo(
+                CustomerState.Permissions(
+                    canRemovePaymentMethods = false,
+                    canRemoveDuplicates = true,
+                )
+            )
+        }
+
+    @OptIn(ExperimentalCustomerSessionApi::class)
+    @Test
+    fun `When 'elements_session' has Payment Sheet component disabled, should disable permissions in customer state`() =
+        runTest {
+            val loader = createPaymentSheetLoader(
+                customer = ElementsSession.Customer(
+                    paymentMethods = PaymentMethodFactory.cards(4),
+                    session = createElementsSessionCustomerSession(
+                        ElementsSession.Customer.Components.PaymentSheet.Enabled(
+                            isPaymentMethodRemoveEnabled = false,
+                            isPaymentMethodSaveEnabled = false,
+                        )
+                    ),
+                    defaultPaymentMethod = null,
+                )
+            )
+
+            val state = loader.load(
+                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                    clientSecret = "client_secret"
+                ),
+                paymentSheetConfiguration = PaymentSheet.Configuration(
+                    merchantDisplayName = "Merchant, Inc.",
+                    customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
+                        id = "cus_1",
+                        clientSecret = "customer_client_secret",
+                    ),
+                ),
+                initializedViaCompose = false,
+            ).getOrThrow()
+
+            assertThat(state.customer?.permissions).isEqualTo(
+                CustomerState.Permissions(
+                    canRemovePaymentMethods = false,
+                    canRemoveDuplicates = true,
+                )
+            )
+        }
+
+    @Test
+    fun `When 'LegacyEphemeralKey' config is provided, permissions should always be enabled and remove duplicates should be disabled`() =
+        runTest {
+            val loader = createPaymentSheetLoader()
+
+            val state = loader.load(
+                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                    clientSecret = "client_secret"
+                ),
+                paymentSheetConfiguration = PaymentSheet.Configuration(
+                    merchantDisplayName = "Merchant, Inc.",
+                    customer = PaymentSheet.CustomerConfiguration(
+                        id = "cus_1",
+                        ephemeralKeySecret = "ephemeral_key",
+                    ),
+                ),
+                initializedViaCompose = false,
+            ).getOrThrow()
+
+            assertThat(state.customer?.permissions).isEqualTo(
+                CustomerState.Permissions(
+                    canRemovePaymentMethods = true,
+                    canRemoveDuplicates = false,
                 )
             )
         }
@@ -1263,6 +1415,10 @@ internal class DefaultPaymentSheetLoaderTest {
                     id = "cus_1",
                     ephemeralKeySecret = "ephemeral_key_secret",
                     paymentMethods = cards,
+                    permissions = CustomerState.Permissions(
+                        canRemovePaymentMethods = true,
+                        canRemoveDuplicates = false,
+                    ),
                 )
             )
         }
@@ -1510,6 +1666,22 @@ internal class DefaultPaymentSheetLoaderTest {
             linkEnabled = true,
             googlePaySupported = true,
             currency = "usd",
+        )
+    }
+
+    private fun createElementsSessionCustomerSession(
+        paymentSheetComponent: ElementsSession.Customer.Components.PaymentSheet,
+    ): ElementsSession.Customer.Session {
+        return ElementsSession.Customer.Session(
+            id = "cuss_1",
+            customerId = "cus_1",
+            liveMode = false,
+            apiKey = "ek_123",
+            apiKeyExpiry = 555555555,
+            components = ElementsSession.Customer.Components(
+                paymentSheet = paymentSheetComponent,
+                customerSheet = ElementsSession.Customer.Components.CustomerSheet.Disabled,
+            ),
         )
     }
 


### PR DESCRIPTION
# Summary
Add permissions to `CustomerState`

# Motivation
Allows for permission control of features within `PaymentSheet` & `FlowController`. Starting with removal and duplicate removal.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
