### PR TITLE
Remove CVC Feature Flag and RestrictTo annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 20XX-XX-XX
 
+### PaymentSheet
+* [ADDED][8717](https://github.com/stripe/stripe-android/pull/8717) Add CVC Recollection functionality to `PaymentSheet` and `PaymentSheet.FlowController`
+
 ## 20.47.4 - 2024-06-27
 
 ### PaymentSheet

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/RequireCvcRecollectionDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/RequireCvcRecollectionDefinition.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.example.playground.settings
 
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 
 internal object RequireCvcRecollectionDefinition : BooleanSettingsDefinition(
@@ -14,6 +13,5 @@ internal object RequireCvcRecollectionDefinition : BooleanSettingsDefinition(
 
     override fun configure(value: Boolean, checkoutRequestBuilder: CheckoutRequest.Builder) {
         checkoutRequestBuilder.requireCvcRecollection(value)
-        FeatureFlags.cvcRecollection.setEnabled(value)
     }
 }

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -248,7 +248,14 @@ public final class com/stripe/android/paymentsheet/CreateIntentResult$Success : 
 	public fun <init> (Ljava/lang/String;)V
 }
 
+public abstract interface class com/stripe/android/paymentsheet/CvcRecollectionEnabledCallback {
+	public abstract fun isCvcRecollectionRequired ()Z
+}
+
 public abstract interface annotation class com/stripe/android/paymentsheet/DelicatePaymentSheetApi : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class com/stripe/android/paymentsheet/ExperimentalCvcRecollectionApi : java/lang/annotation/Annotation {
 }
 
 public abstract interface annotation class com/stripe/android/paymentsheet/ExperimentalPaymentSheetDecouplingApi : java/lang/annotation/Annotation {
@@ -561,6 +568,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Builder {
 	public final fun build (Landroidx/compose/runtime/Composer;I)Lcom/stripe/android/paymentsheet/PaymentSheet;
 	public final fun build (Landroidx/fragment/app/Fragment;)Lcom/stripe/android/paymentsheet/PaymentSheet;
 	public final fun createIntentCallback (Lcom/stripe/android/paymentsheet/CreateIntentCallback;)Lcom/stripe/android/paymentsheet/PaymentSheet$Builder;
+	public final fun cvcRecollectionEnabledCallback (Lcom/stripe/android/paymentsheet/CvcRecollectionEnabledCallback;)Lcom/stripe/android/paymentsheet/PaymentSheet$Builder;
 	public final fun externalPaymentMethodConfirmHandler (Lcom/stripe/android/paymentsheet/ExternalPaymentMethodConfirmHandler;)Lcom/stripe/android/paymentsheet/PaymentSheet$Builder;
 }
 
@@ -681,6 +689,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration$Bu
 	public final fun externalPaymentMethods (Ljava/util/List;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun googlePay (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun merchantDisplayName (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
+	public final fun paymentMethodLayout (Lcom/stripe/android/paymentsheet/PaymentSheet$PaymentMethodLayout;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun paymentMethodOrder (Ljava/util/List;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun preferredNetworks (Ljava/util/List;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun primaryButtonColor (Landroid/content/res/ColorStateList;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
@@ -764,6 +773,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$FlowController$B
 	public final fun build (Landroidx/compose/runtime/Composer;I)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;
 	public final fun build (Landroidx/fragment/app/Fragment;)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;
 	public final fun createIntentCallback (Lcom/stripe/android/paymentsheet/CreateIntentCallback;)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController$Builder;
+	public final fun cvcRecollectionEnabledCallback (Lcom/stripe/android/paymentsheet/CvcRecollectionEnabledCallback;)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController$Builder;
 	public final fun externalPaymentMethodConfirmHandler (Lcom/stripe/android/paymentsheet/ExternalPaymentMethodConfirmHandler;)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController$Builder;
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CvcRecollectionEnabledCallback.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CvcRecollectionEnabledCallback.kt
@@ -1,12 +1,9 @@
 package com.stripe.android.paymentsheet
 
-import androidx.annotation.RestrictTo
-
 /**
  * Callback to be used when you use [PaymentSheet] or [PaymentSheet.FlowController] and intend to
  * create a [PaymentIntent] on your server and confirm on the client.
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @ExperimentalCvcRecollectionApi
 fun interface CvcRecollectionEnabledCallback {
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExperimentalCvcRecollectionApi.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExperimentalCvcRecollectionApi.kt
@@ -1,11 +1,8 @@
 package com.stripe.android.paymentsheet
 
-import androidx.annotation.RestrictTo
-
 @RequiresOptIn(
     level = RequiresOptIn.Level.ERROR,
     message = "This API is under construction. It can be changed or removed at any time (use at your own risk)"
 )
 @Retention(AnnotationRetention.BINARY)
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 annotation class ExperimentalCvcRecollectionApi

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -215,7 +215,6 @@ class PaymentSheet internal constructor(
          * CVC recollection field.
          *
          */
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @ExperimentalCvcRecollectionApi
         fun cvcRecollectionEnabledCallback(callback: CvcRecollectionEnabledCallback) = apply {
             cvcRecollectionEnabledCallback = callback
@@ -851,7 +850,6 @@ class PaymentSheet internal constructor(
                 this.externalPaymentMethods = externalPaymentMethods
             }
 
-            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             @ExperimentalPaymentMethodLayoutApi
             fun paymentMethodLayout(paymentMethodLayout: PaymentMethodLayout): Builder = apply {
                 this.paymentMethodLayout = paymentMethodLayout
@@ -1743,7 +1741,6 @@ class PaymentSheet internal constructor(
              * CVC recollection field.
              *
              */
-            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             @ExperimentalCvcRecollectionApi
             fun cvcRecollectionEnabledCallback(callback: CvcRecollectionEnabledCallback) = apply {
                 cvcRecollectionEnabledCallback = callback

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -19,7 +19,6 @@ import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.core.utils.requireApplication
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
@@ -880,12 +879,12 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         }
     }
 
-    internal fun isCvcRecollectionEnabled(): Boolean = FeatureFlags.cvcRecollection.isEnabled &&
+    internal fun isCvcRecollectionEnabled(): Boolean =
         ((paymentMethodMetadata.value?.stripeIntent as? PaymentIntent)?.requireCvcRecollection == true)
 
-    internal fun isCvcRecollectionEnabledForDeferred(): Boolean = FeatureFlags.cvcRecollection.isEnabled &&
+    internal fun isCvcRecollectionEnabledForDeferred(): Boolean =
         CvcRecollectionCallbackHandler.isCvcRecollectionEnabledForDeferredIntent() &&
-        args.initializationMode is PaymentSheet.InitializationMode.DeferredIntent
+            args.initializationMode is PaymentSheet.InitializationMode.DeferredIntent
 
     private fun mapViewStateToCheckoutIdentifier(
         viewState: PaymentSheetViewState?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -16,7 +16,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
@@ -413,8 +412,7 @@ internal class DefaultFlowController @Inject internal constructor(
     }
 
     private fun isCvcRecollectionEnabled(state: PaymentSheetState.Full): Boolean {
-        return FeatureFlags.cvcRecollection.isEnabled &&
-            (state.stripeIntent as? PaymentIntent)?.requireCvcRecollection == true ||
+        return (state.stripeIntent as? PaymentIntent)?.requireCvcRecollection == true ||
             (
                 CvcRecollectionCallbackHandler.isCvcRecollectionEnabledForDeferredIntent() &&
                     initializationMode is PaymentSheet.InitializationMode.DeferredIntent

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
@@ -7,7 +7,6 @@ import com.stripe.android.core.BuildConfig
 @Suppress("unused")
 object FeatureFlags {
     // Add any feature flags here
-    val cvcRecollection = FeatureFlag()
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove `FeatureFlags.cvcRecollectionEnabled`
Remove `RestrictTo` annotations on CVC related methods/classes

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [X] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
