### PR TITLE
Make all vertical mode mandates go above the primary button.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -27,6 +27,7 @@ import com.stripe.android.paymentsheet.PaymentOptionsItem
 import com.stripe.android.paymentsheet.PaymentOptionsState
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheet.PaymentMethodLayout
 import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -481,7 +482,14 @@ internal abstract class BaseSheetViewModel(
     }
 
     fun updateMandateText(mandateText: String?, showAbove: Boolean) {
-        _mandateText.value = if (mandateText != null) MandateText(mandateText, showAbove) else null
+        _mandateText.value = if (mandateText != null) {
+            MandateText(
+                text = mandateText,
+                showAbovePrimaryButton = showAbove || config.paymentMethodLayout == PaymentMethodLayout.Vertical
+            )
+        } else {
+            null
+        }
     }
 
     abstract fun handlePaymentMethodSelected(selection: PaymentSelection?)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -405,6 +405,35 @@ internal class PaymentOptionsActivityTest {
         }
     }
 
+    @Test
+    fun `mandate text is shown above primary button when in vertical mode`() {
+        val args = PAYMENT_OPTIONS_CONTRACT_ARGS.updateState(
+            paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            config = PAYMENT_OPTIONS_CONTRACT_ARGS.state.config.copy(
+                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+            )
+        )
+        runActivityScenario(args) { scenario ->
+            scenario.onActivity { activity ->
+                val viewModel = activity.viewModel
+                val text = "some text"
+                val mandateNode = composeTestRule.onNode(hasText(text))
+                val primaryButtonNode = composeTestRule
+                    .onNodeWithTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG)
+
+                viewModel.updateMandateText(text, false)
+                mandateNode.assertIsDisplayed()
+
+                val mandatePosition = mandateNode.fetchSemanticsNode().positionInRoot.y
+                val primaryButtonPosition = primaryButtonNode.fetchSemanticsNode().positionInRoot.y
+                assertThat(mandatePosition).isLessThan(primaryButtonPosition)
+
+                viewModel.updateMandateText(null, false)
+                mandateNode.assertDoesNotExist()
+            }
+        }
+    }
+
     private fun runActivityScenario(
         args: PaymentOptionContract.Args = PAYMENT_OPTIONS_CONTRACT_ARGS,
         block: (InjectableActivityScenario<PaymentOptionsActivity>) -> Unit,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -824,6 +824,34 @@ internal class PaymentSheetActivityTest {
     }
 
     @Test
+    fun `mandate text is shown above primary button when in vertical mode`() {
+        val args = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
+            config = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
+                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+            )
+        )
+        val viewModel = createViewModel(args = args)
+        val scenario = activityScenario(viewModel)
+
+        scenario.launch(intent).onActivity {
+            val text = "some text"
+            val mandateNode = composeTestRule.onNode(hasText(text))
+            val primaryButtonNode = composeTestRule
+                .onNodeWithTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG)
+
+            viewModel.updateMandateText(text, false)
+            mandateNode.assertIsDisplayed()
+
+            val mandatePosition = mandateNode.fetchSemanticsNode().positionInRoot.y
+            val primaryButtonPosition = primaryButtonNode.fetchSemanticsNode().positionInRoot.y
+            assertThat(mandatePosition).isLessThan(primaryButtonPosition)
+
+            viewModel.updateMandateText(null, false)
+            mandateNode.assertDoesNotExist()
+        }
+    }
+
+    @Test
     fun `Handles missing arguments correctly`() {
         val scenario = ActivityScenario.launchActivityForResult(PaymentSheetActivity::class.java)
 
@@ -986,6 +1014,7 @@ internal class PaymentSheetActivityTest {
         isGooglePayAvailable: Boolean = false,
         isLinkAvailable: Boolean = false,
         initialPaymentSelection: PaymentSelection? = paymentMethods.firstOrNull()?.let { PaymentSelection.Saved(it) },
+        args: PaymentSheetContractV2.Args = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY,
     ): PaymentSheetViewModel = runBlocking {
         TestViewModelFactory.create(
             linkConfigurationCoordinator = mock<LinkConfigurationCoordinator>().stub {
@@ -995,7 +1024,7 @@ internal class PaymentSheetActivityTest {
         ) { linkHandler, linkInteractor, savedStateHandle ->
             PaymentSheetViewModel(
                 application = ApplicationProvider.getApplicationContext(),
-                args = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY,
+                args = args,
                 eventReporter = eventReporter,
                 lazyPaymentConfig = { PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY) },
                 paymentSheetLoader = FakePaymentSheetLoader(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Updates vertical mode to always show the mandate on top.

This is important for saved payment methods, which previously would display both on top and bottom.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2114

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
