### PR TITLE
Switch to editing via toggleEditing instead of clicking editing button in PaymentSheetActivityTest test

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -441,7 +441,7 @@ internal class PaymentSheetActivityTest {
                 PAYMENT_SHEET_EDIT_BUTTON_TEST_TAG,
             ).performClick()
 
-            composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.waitUntil(timeoutMillis = 15_000) {
                 composeTestRule.onAllNodes(hasTestTag(TEST_TAG_REMOVE_BADGE), useUnmergedTree = true)
                     .fetchSemanticsNodes().isNotEmpty()
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsSelected
-import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isSelected
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -58,7 +57,6 @@ import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSaved
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.WalletsProcessingState
 import com.stripe.android.paymentsheet.ui.GOOGLE_PAY_BUTTON_TEST_TAG
-import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_EDIT_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.SHEET_NAVIGATION_BUTTON_TAG
@@ -437,14 +435,7 @@ internal class PaymentSheetActivityTest {
         val scenario = activityScenario(viewModel)
 
         scenario.launch(intent).onActivity { activity ->
-            composeTestRule.onNodeWithTag(
-                PAYMENT_SHEET_EDIT_BUTTON_TEST_TAG,
-            ).performClick()
-
-            composeTestRule.waitUntil(timeoutMillis = 15_000) {
-                composeTestRule.onAllNodes(hasTestTag(TEST_TAG_REMOVE_BADGE), useUnmergedTree = true)
-                    .fetchSemanticsNodes().isNotEmpty()
-            }
+            viewModel.toggleEditing()
 
             composeTestRule.onNodeWithTag(
                 TEST_TAG_REMOVE_BADGE,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Switch to editing via toggleEditing instead of clicking editing button in PaymentSheetActivityTest test

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Test stability

I saw this flake because of this timeout and noticed that using `toggleEditing` seems a lot more stable (we don't seem to need a timeout at all if we do this?)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified
