### PR TITLE
[Android] Unsupportability: Initial institution is erased when navigating from LinkAccountPicker to PartnerAuth


### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
@@ -112,9 +112,7 @@ internal class PartnerAuthViewModel @AssistedInject constructor(
         // auth session in the manifest.
         // if coming from a process kill, we'll fetch the current manifest from network,
         // that should contain the active auth session.
-        val sync: SynchronizeSessionResponse = getOrFetchSync(
-            refetchCondition = IfMissingActiveAuthSession
-        )
+        val sync: SynchronizeSessionResponse = getOrFetchSync()
         val manifest = sync.manifest
         val authSession = manifest.activeAuthSession ?: createAuthorizationSession(
             institution = requireNotNull(manifest.activeInstitution),


### PR DESCRIPTION
# Summary
- On the unsupportability flow, LinkAccountPicker sets an `activeInstitution` locally and navigates to partner auth
- Since [this PR](https://github.com/stripe/stripe-android/pull/8317), we're fetching the manifest if there's no active auth session, erasing the cached institution, and making the flow fail.
- We should be fine not refetching the manifest if it already exists, regardless of wether an active auth session is present, so this PR removes that refetch condition.

# Motivation
:notebook_with_decorative_cover: &nbsp;**[Android] Unsupportability: Initial institution is erased when navigating from LinkAccountPicker to PartnerAuth**
:globe_with_meridians: &nbsp;[BANKCON-11421](https://jira.corp.stripe.com/browse/BANKCON-11421)

https://github.com/stripe/stripe-android/assets/99293320/98c5a5be-ca51-4f48-84d6-7f0b1fe7a5c2

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->