### PR TITLE
Add `PaymentMethodSaveConsentBehavior` and update `SaveForFutureUseHelper`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelper.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.lpmfoundations.luxe
 
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.SetupIntent
@@ -9,19 +10,25 @@ internal fun isSaveForFutureUseValueChangeable(
     code: PaymentMethodCode,
     metadata: PaymentMethodMetadata,
 ): Boolean {
-    return when (metadata.stripeIntent) {
-        is PaymentIntent -> {
-            val isSetupFutureUsageSet = metadata.stripeIntent.isSetupFutureUsageSet(code)
+    return when (metadata.paymentMethodSaveConsentBehavior) {
+        PaymentMethodSaveConsentBehavior.Disabled -> false
+        PaymentMethodSaveConsentBehavior.Enabled -> metadata.hasCustomerConfiguration
+        PaymentMethodSaveConsentBehavior.Legacy -> {
+            when (metadata.stripeIntent) {
+                is PaymentIntent -> {
+                    val isSetupFutureUsageSet = metadata.stripeIntent.isSetupFutureUsageSet(code)
 
-            if (isSetupFutureUsageSet) {
-                false
-            } else {
-                metadata.hasCustomerConfiguration
+                    if (isSetupFutureUsageSet) {
+                        false
+                    } else {
+                        metadata.hasCustomerConfiguration
+                    }
+                }
+
+                is SetupIntent -> {
+                    false
+                }
             }
-        }
-
-        is SetupIntent -> {
-            false
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -41,6 +41,7 @@ internal data class PaymentMethodMetadata(
     val externalPaymentMethodSpecs: List<ExternalPaymentMethodSpec>,
     val hasCustomerConfiguration: Boolean,
     val isGooglePayReady: Boolean,
+    val paymentMethodSaveConsentBehavior: PaymentMethodSaveConsentBehavior,
     val financialConnectionsAvailable: Boolean = DefaultIsFinancialConnectionsAvailable(),
 ) : Parcelable {
     fun hasIntentToSetup(): Boolean {
@@ -217,6 +218,7 @@ internal data class PaymentMethodMetadata(
                 hasCustomerConfiguration = configuration.customer != null,
                 sharedDataSpecs = sharedDataSpecs,
                 externalPaymentMethodSpecs = externalPaymentMethodSpecs,
+                paymentMethodSaveConsentBehavior = elementsSession.toPaymentSheetSaveConsentBehavior(),
                 isGooglePayReady = isGooglePayReady,
             )
         }
@@ -246,6 +248,7 @@ internal data class PaymentMethodMetadata(
                 sharedDataSpecs = sharedDataSpecs,
                 isGooglePayReady = isGooglePayReady,
                 financialConnectionsAvailable = isFinancialConnectionsAvailable(),
+                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
                 externalPaymentMethodSpecs = emptyList(),
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataKtx.kt
@@ -1,0 +1,18 @@
+package com.stripe.android.lpmfoundations.paymentmethod
+
+import com.stripe.android.model.ElementsSession
+
+internal fun ElementsSession.toPaymentSheetSaveConsentBehavior(): PaymentMethodSaveConsentBehavior {
+    return when (val paymentSheetComponent = customer?.session?.components?.paymentSheet) {
+        is ElementsSession.Customer.Components.PaymentSheet.Enabled -> {
+            if (paymentSheetComponent.isPaymentMethodSaveEnabled) {
+                PaymentMethodSaveConsentBehavior.Enabled
+            } else {
+                PaymentMethodSaveConsentBehavior.Disabled
+            }
+        }
+        // Unless the merchant explicitly defines the consent behavior, always use the legacy behavior
+        is ElementsSession.Customer.Components.PaymentSheet.Disabled,
+        null -> PaymentMethodSaveConsentBehavior.Legacy
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodSaveConsentBehavior.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodSaveConsentBehavior.kt
@@ -1,0 +1,23 @@
+package com.stripe.android.lpmfoundations.paymentmethod
+
+/**
+ * [PaymentMethodSaveConsentBehavior] defines the behavior to use when saving a payment method. This controls
+ * whether or not the "Save for future use" checkbox should be shown.
+ */
+internal enum class PaymentMethodSaveConsentBehavior {
+    /**
+     * Default behavior for saving a payment method which shows a "Save for future use" checkbox when
+     * in PI mode and has a customer to save the payment method to. PI w/SFU & SI modes do not show a checkbox.
+     */
+    Legacy,
+
+    /**
+     * Behavior in which "Save for future use" is shown for all transaction modes (PI, PI w/SFU, and SI).
+     */
+    Enabled,
+
+    /**
+     * Behavior in which "Save for future use" is shown for none of the transaction modes (PI, PI w/SFU, and SI).
+     */
+    Disabled,
+}

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelperKtTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelperKtTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.lpmfoundations.luxe
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntentFixtures
@@ -10,54 +11,106 @@ import kotlin.test.Test
 
 class SaveForFutureUseHelperKtTest {
     @Test
-    fun `isSaveForFutureUseValueChangeable returns false for SetupIntents`() {
+    fun `isSaveForFutureUseValueChangeable returns false for SI if behavior is Legacy`() {
         val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
             code = PaymentMethod.Type.Card.code,
             metadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
-            ),
-        )
-        assertThat(isSaveForFutureUseValueChangeable).isFalse()
-    }
-
-    @Test
-    fun `isSaveForFutureUseValueChangeable returns false for PaymentIntents with SFU and null customerConfig`() {
-        val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
-            code = PaymentMethod.Type.Card.code,
-            metadata = PaymentMethodMetadataFactory.create(
-                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                    setupFutureUsage = StripeIntent.Usage.OnSession,
-                ),
-            ),
-        )
-        assertThat(isSaveForFutureUseValueChangeable).isFalse()
-    }
-
-    @Test
-    fun `isSaveForFutureUseValueChangeable returns false for PaymentIntents with SFU and valid customerConfig`() {
-        val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
-            code = PaymentMethod.Type.Card.code,
-            metadata = PaymentMethodMetadataFactory.create(
-                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                    setupFutureUsage = StripeIntent.Usage.OnSession,
-                ),
+                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
                 hasCustomerConfiguration = true,
             ),
         )
+
         assertThat(isSaveForFutureUseValueChangeable).isFalse()
     }
 
     @Test
-    fun `isSaveForFutureUseValueChangeable returns true for PaymentIntents without SFU and valid customerConfig`() {
+    fun `isSaveForFutureUseValueChangeable returns false for PI with SFU and no customer if behavior is Legacy`() {
+        val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
+            code = PaymentMethod.Type.Card.code,
+            metadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    setupFutureUsage = StripeIntent.Usage.OnSession,
+                ),
+                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+                hasCustomerConfiguration = false,
+            ),
+        )
+
+        assertThat(isSaveForFutureUseValueChangeable).isFalse()
+    }
+
+    @Test
+    fun `isSaveForFutureUseValueChangeable returns false for PI with SFU and has customer if behavior is Legacy`() {
+        val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
+            code = PaymentMethod.Type.Card.code,
+            metadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    setupFutureUsage = StripeIntent.Usage.OnSession,
+                ),
+                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+                hasCustomerConfiguration = true,
+            ),
+        )
+
+        assertThat(isSaveForFutureUseValueChangeable).isFalse()
+    }
+
+    @Test
+    fun `isSaveForFutureUseValueChangeable returns true for PI without SFU and has customer if behavior is Legacy`() {
         val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
             code = PaymentMethod.Type.Card.code,
             metadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
                     setupFutureUsage = null,
                 ),
+                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
                 hasCustomerConfiguration = true,
             ),
         )
+
         assertThat(isSaveForFutureUseValueChangeable).isTrue()
+    }
+
+    @Test
+    fun `isSaveForFutureUseValueChangeable returns true if consent behavior is Enabled and has customer`() {
+        val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
+            code = PaymentMethod.Type.Card.code,
+            metadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+                hasCustomerConfiguration = true,
+                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Enabled,
+            ),
+        )
+
+        assertThat(isSaveForFutureUseValueChangeable).isTrue()
+    }
+
+    @Test
+    fun `isSaveForFutureUseValueChangeable returns false if consent behavior is Enabled and no customer`() {
+        val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
+            code = PaymentMethod.Type.Card.code,
+            metadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+                hasCustomerConfiguration = false,
+                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Enabled,
+            ),
+        )
+
+        assertThat(isSaveForFutureUseValueChangeable).isFalse()
+    }
+
+    @Test
+    fun `isSaveForFutureUseValueChangeable returns false if consent behavior is Disabled`() {
+        val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
+            code = PaymentMethod.Type.Card.code,
+            metadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+                hasCustomerConfiguration = true,
+                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Disabled,
+            ),
+        )
+
+        assertThat(isSaveForFutureUseValueChangeable).isFalse()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -25,6 +25,7 @@ internal object PaymentMethodMetadataFactory {
         sharedDataSpecs: List<SharedDataSpec> = createSharedDataSpecs(),
         externalPaymentMethodSpecs: List<ExternalPaymentMethodSpec> = emptyList(),
         isGooglePayReady: Boolean = false,
+        paymentMethodSaveConsentBehavior: PaymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,
@@ -39,6 +40,7 @@ internal object PaymentMethodMetadataFactory {
             shippingDetails = shippingDetails,
             hasCustomerConfiguration = hasCustomerConfiguration,
             sharedDataSpecs = sharedDataSpecs,
+            paymentMethodSaveConsentBehavior = paymentMethodSaveConsentBehavior,
             externalPaymentMethodSpecs = externalPaymentMethodSpecs,
             isGooglePayReady = isGooglePayReady,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -14,6 +14,7 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.R
@@ -772,6 +773,7 @@ internal class PaymentMethodMetadataTest {
                 sharedDataSpecs = listOf(SharedDataSpec("card")),
                 externalPaymentMethodSpecs = listOf(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC),
                 hasCustomerConfiguration = true,
+                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
                 isGooglePayReady = false,
             )
         )
@@ -829,21 +831,95 @@ internal class PaymentMethodMetadataTest {
                 externalPaymentMethodSpecs = listOf(),
                 hasCustomerConfiguration = true,
                 isGooglePayReady = true,
+                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
                 financialConnectionsAvailable = false,
             )
         )
     }
 
+    @Test
+    fun `consent behavior should be Always for Payment Sheet is customer session save is enabled`() {
+        val metadata = createPaymentMethodMetadataForPaymentSheet(
+            paymentSheetComponent = ElementsSession.Customer.Components.PaymentSheet.Enabled(
+                isPaymentMethodSaveEnabled = true,
+                isPaymentMethodRemoveEnabled = true,
+            )
+        )
+
+        assertThat(metadata.paymentMethodSaveConsentBehavior).isEqualTo(PaymentMethodSaveConsentBehavior.Enabled)
+    }
+
+    @Test
+    fun `consent behavior should be Disabled for Payment Sheet is customer session save is disabled`() {
+        val metadata = createPaymentMethodMetadataForPaymentSheet(
+            paymentSheetComponent = ElementsSession.Customer.Components.PaymentSheet.Enabled(
+                isPaymentMethodSaveEnabled = false,
+                isPaymentMethodRemoveEnabled = true,
+            ),
+        )
+
+        assertThat(metadata.paymentMethodSaveConsentBehavior).isEqualTo(PaymentMethodSaveConsentBehavior.Disabled)
+    }
+
+    @Test
+    fun `consent behavior should be Legacy for Payment Sheet if payment sheet component is disabled`() {
+        val metadata = createPaymentMethodMetadataForPaymentSheet(
+            paymentSheetComponent = ElementsSession.Customer.Components.PaymentSheet.Disabled,
+        )
+
+        assertThat(metadata.paymentMethodSaveConsentBehavior).isEqualTo(PaymentMethodSaveConsentBehavior.Legacy)
+    }
+
+    @Test
+    fun `consent behavior should be Legacy for Payment Sheet if no customer session provided`() {
+        val metadata = createPaymentMethodMetadataForPaymentSheet(
+            paymentSheetComponent = null,
+        )
+
+        assertThat(metadata.paymentMethodSaveConsentBehavior).isEqualTo(PaymentMethodSaveConsentBehavior.Legacy)
+    }
+
+    private fun createPaymentMethodMetadataForPaymentSheet(
+        paymentSheetComponent: ElementsSession.Customer.Components.PaymentSheet?,
+    ): PaymentMethodMetadata {
+        return PaymentMethodMetadata.create(
+            elementsSession = createElementsSession(
+                paymentSheetComponent = paymentSheetComponent
+            ),
+            configuration = PaymentSheetFixtures.CONFIG_CUSTOMER,
+            sharedDataSpecs = listOf(),
+            externalPaymentMethodSpecs = listOf(),
+            isGooglePayReady = false,
+        )
+    }
+
     private fun createElementsSession(
-        intent: StripeIntent,
-        isEligibleForCardBrandChoice: Boolean,
+        intent: StripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+        isEligibleForCardBrandChoice: Boolean = true,
+        paymentSheetComponent: ElementsSession.Customer.Components.PaymentSheet? = null
     ): ElementsSession {
         return ElementsSession(
             stripeIntent = intent,
             isEligibleForCardBrandChoice = isEligibleForCardBrandChoice,
             merchantCountry = null,
             isGooglePayEnabled = false,
-            customer = null,
+            customer = paymentSheetComponent?.let { component ->
+                ElementsSession.Customer(
+                    paymentMethods = listOf(),
+                    session = ElementsSession.Customer.Session(
+                        id = "cuss_123",
+                        customerId = "cus_123",
+                        liveMode = false,
+                        apiKey = "123",
+                        apiKeyExpiry = 999999999,
+                        components = ElementsSession.Customer.Components(
+                            paymentSheet = component,
+                            customerSheet = ElementsSession.Customer.Components.CustomerSheet.Disabled,
+                        )
+                    ),
+                    defaultPaymentMethod = null,
+                )
+            },
             linkSettings = null,
             externalPaymentMethodData = null,
             paymentMethodSpecs = null,


### PR DESCRIPTION
# Summary
Add `PaymentMethodSaveConsentBehavior` and update `SaveForFutureUseHelper` to use the consent behavior when deciding if the checkbox should be shown.

# Motivation
With `CustomerSession`, merchants have the ability to define when the checkbox is shown for saving payment methods. The introduced `PaymentMethodSaveConsentBehavior` enables this to be defined through `PaymentMethodMetadata`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
