### PR TITLE
Determine `allowRedisplay` from consent behavior & save for future usage value.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -271,22 +271,24 @@ data class PaymentMethodCreateParams internal constructor(
     }
 
     override fun toParamMap(): Map<String, Any> {
-        return overrideParamMap
+        val params = overrideParamMap
             ?: mapOf(
                 PARAM_TYPE to code
             ).plus(
                 billingDetails?.let {
                     mapOf(PARAM_BILLING_DETAILS to it.toParamMap())
                 }.orEmpty()
-            ).plus(
-                allowRedisplay?.let {
-                    mapOf(PARAM_ALLOW_REDISPLAY to allowRedisplay.value)
-                }.orEmpty()
             ).plus(typeParams).plus(
                 metadata?.let {
                     mapOf(PARAM_METADATA to it)
                 }.orEmpty()
             )
+
+        return params.plus(
+            allowRedisplay?.let {
+                mapOf(PARAM_ALLOW_REDISPLAY to allowRedisplay.value)
+            }.orEmpty()
+        )
     }
 
     private val typeParams: Map<String, Any>
@@ -1322,12 +1324,14 @@ data class PaymentMethodCreateParams internal constructor(
             billingDetails: PaymentMethod.BillingDetails?,
             requiresMandate: Boolean,
             overrideParamMap: Map<String, @RawValue Any>?,
-            productUsage: Set<String>
+            productUsage: Set<String>,
+            allowRedisplay: PaymentMethod.AllowRedisplay? = null,
         ): PaymentMethodCreateParams {
             return PaymentMethodCreateParams(
                 code = code,
                 billingDetails = billingDetails,
                 requiresMandate = requiresMandate,
+                allowRedisplay = allowRedisplay,
                 overrideParamMap = overrideParamMap,
                 productUsage = productUsage
             )

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -22,7 +22,8 @@ public final class com/stripe/android/ui/core/BuildConfig {
 }
 
 public final class com/stripe/android/ui/core/FieldValuesToParamsMapConverter$Companion {
-	public final fun transformToPaymentMethodCreateParams (Ljava/util/Map;Ljava/lang/String;Z)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun transformToPaymentMethodCreateParams (Ljava/util/Map;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod$AllowRedisplay;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun transformToPaymentMethodCreateParams$default (Lcom/stripe/android/ui/core/FieldValuesToParamsMapConverter$Companion;Ljava/util/Map;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod$AllowRedisplay;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 }
 
 public final class com/stripe/android/ui/core/cbc/CardBrandChoiceEligibility$Eligible$Creator : android/os/Parcelable$Creator {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
@@ -24,7 +24,8 @@ class FieldValuesToParamsMapConverter {
         fun transformToPaymentMethodCreateParams(
             fieldValuePairs: Map<IdentifierSpec, FormFieldEntry>,
             code: PaymentMethodCode,
-            requiresMandate: Boolean
+            requiresMandate: Boolean,
+            allowRedisplay: PaymentMethod.AllowRedisplay? = null,
         ): PaymentMethodCreateParams {
             val fieldValuePairsForCreateParams = fieldValuePairs.filter { entry ->
                 entry.key.destination == ParameterDestination.Api.Params
@@ -43,7 +44,8 @@ class FieldValuesToParamsMapConverter {
                         requiresMandate = requiresMandate,
                         billingDetails = createBillingDetails(fieldValuePairsForCreateParams),
                         overrideParamMap = this,
-                        productUsage = setOf("PaymentSheet")
+                        productUsage = setOf("PaymentSheet"),
+                        allowRedisplay = allowRedisplay,
                     )
                 }
         }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
@@ -407,4 +407,67 @@ class FieldValuesToParamsMapConverterTest {
 
         assertThat(paymentMethodParams).isNull()
     }
+
+    @Test
+    fun `allowRedisplay is set to UNSPECIFIED in param map`() {
+        val paymentMethodParams = FieldValuesToParamsMapConverter
+            .transformToPaymentMethodCreateParams(
+                fieldValuePairs = fieldValuePairs,
+                code = PaymentMethod.Type.Ideal.code,
+                requiresMandate = PaymentMethod.Type.Ideal.requiresMandate,
+                allowRedisplay = PaymentMethod.AllowRedisplay.UNSPECIFIED,
+            )
+
+        assertThat(paymentMethodParams.toParamMap().toString().replace("\\s".toRegex(), ""))
+            .isEqualTo(
+                """
+                    {type=ideal,ideal={bank=abn_amro},allow_redisplay=unspecified}
+                """.trimIndent()
+            )
+    }
+
+    @Test
+    fun `allowRedisplay is set to LIMITED in param map`() {
+        val paymentMethodParams = FieldValuesToParamsMapConverter
+            .transformToPaymentMethodCreateParams(
+                fieldValuePairs = fieldValuePairs,
+                code = PaymentMethod.Type.Ideal.code,
+                requiresMandate = PaymentMethod.Type.Ideal.requiresMandate,
+                PaymentMethod.AllowRedisplay.LIMITED,
+            )
+
+        assertThat(paymentMethodParams.toParamMap().toString().replace("\\s".toRegex(), ""))
+            .isEqualTo(
+                """
+                    {type=ideal,ideal={bank=abn_amro},allow_redisplay=limited}
+                """.trimIndent()
+            )
+    }
+
+    @Test
+    fun `allowRedisplay is set to ALWAYS in param map`() {
+        val paymentMethodParams = FieldValuesToParamsMapConverter
+            .transformToPaymentMethodCreateParams(
+                fieldValuePairs = fieldValuePairs,
+                code = PaymentMethod.Type.Ideal.code,
+                requiresMandate = PaymentMethod.Type.Ideal.requiresMandate,
+                PaymentMethod.AllowRedisplay.ALWAYS,
+            )
+
+        assertThat(paymentMethodParams.toParamMap().toString().replace("\\s".toRegex(), ""))
+            .isEqualTo(
+                """
+                    {type=ideal,ideal={bank=abn_amro},allow_redisplay=always}
+                """.trimIndent()
+            )
+    }
+
+    private companion object {
+        val fieldValuePairs = mapOf(
+            IdentifierSpec.Generic("ideal[bank]") to FormFieldEntry(
+                "abn_amro",
+                true
+            )
+        )
+    }
 }

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -15,7 +15,6 @@
     <ID>LargeClass:CustomerAdapterTest.kt$CustomerAdapterTest</ID>
     <ID>LargeClass:CustomerSheetViewModel.kt$CustomerSheetViewModel : ViewModel</ID>
     <ID>LargeClass:CustomerSheetViewModelTest.kt$CustomerSheetViewModelTest</ID>
-    <ID>LargeClass:DefaultFlowController.kt$DefaultFlowController : FlowController</ID>
     <ID>LargeClass:DefaultFlowControllerTest.kt$DefaultFlowControllerTest</ID>
     <ID>LargeClass:DefaultPaymentSheetLoaderTest.kt$DefaultPaymentSheetLoaderTest</ID>
     <ID>LargeClass:IntentConfirmationHandlerTest.kt$IntentConfirmationHandlerTest</ID>
@@ -73,6 +72,7 @@
     <ID>TooManyFunctions:DefaultEventReporter.kt$DefaultEventReporter : EventReporter</ID>
     <ID>TooManyFunctions:DefaultFlowController.kt$DefaultFlowController : FlowController</ID>
     <ID>TooManyFunctions:EventReporter.kt$EventReporter</ID>
+    <ID>TooManyFunctions:PaymentMethodMetadata.kt$PaymentMethodMetadata : Parcelable</ID>
     <ID>TooManyFunctions:PaymentOption.kt$DelegateDrawable : Drawable</ID>
     <ID>TooManyFunctions:PaymentSheetViewModel.kt$PaymentSheetViewModel : BaseSheetViewModel</ID>
     <ID>UnusedPrivateClass:PaymentOptionsViewModelTest.kt$PaymentOptionsViewModelTest$MyHostActivity : AppCompatActivity</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -197,6 +197,34 @@ internal data class PaymentMethodMetadata(
         }
     }
 
+    fun allowRedisplay(saveForFutureUse: Boolean?): PaymentMethod.AllowRedisplay {
+        return when (paymentMethodSaveConsentBehavior) {
+            PaymentMethodSaveConsentBehavior.Legacy -> PaymentMethod.AllowRedisplay.UNSPECIFIED
+            PaymentMethodSaveConsentBehavior.Disabled -> {
+                if (hasIntentToSetup()) {
+                    PaymentMethod.AllowRedisplay.LIMITED
+                } else {
+                    PaymentMethod.AllowRedisplay.UNSPECIFIED
+                }
+            }
+            PaymentMethodSaveConsentBehavior.Enabled -> {
+                if (hasIntentToSetup()) {
+                    if (saveForFutureUse == true) {
+                        PaymentMethod.AllowRedisplay.ALWAYS
+                    } else {
+                        PaymentMethod.AllowRedisplay.LIMITED
+                    }
+                } else {
+                    if (saveForFutureUse == true) {
+                        PaymentMethod.AllowRedisplay.ALWAYS
+                    } else {
+                        PaymentMethod.AllowRedisplay.UNSPECIFIED
+                    }
+                }
+            }
+        }
+    }
+
     internal companion object {
         internal fun create(
             elementsSession: ElementsSession,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -15,6 +15,7 @@ import com.stripe.android.payments.financialconnections.DefaultIsFinancialConnec
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAvailable
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.ExternalPaymentMethodSpec
@@ -197,29 +198,43 @@ internal data class PaymentMethodMetadata(
         }
     }
 
-    fun allowRedisplay(saveForFutureUse: Boolean?): PaymentMethod.AllowRedisplay {
+    fun allowRedisplay(
+        customerRequestedSave: PaymentSelection.CustomerRequestedSave,
+    ): PaymentMethod.AllowRedisplay {
+        return if (hasIntentToSetup()) {
+            allowRedisplayForSetupIntent(customerRequestedSave)
+        } else {
+            allowRedisplayForPaymentIntent(customerRequestedSave)
+        }
+    }
+
+    private fun allowRedisplayForSetupIntent(
+        customerRequestedSave: PaymentSelection.CustomerRequestedSave,
+    ): PaymentMethod.AllowRedisplay {
         return when (paymentMethodSaveConsentBehavior) {
             PaymentMethodSaveConsentBehavior.Legacy -> PaymentMethod.AllowRedisplay.UNSPECIFIED
-            PaymentMethodSaveConsentBehavior.Disabled -> {
-                if (hasIntentToSetup()) {
-                    PaymentMethod.AllowRedisplay.LIMITED
+            PaymentMethodSaveConsentBehavior.Disabled -> PaymentMethod.AllowRedisplay.LIMITED
+            PaymentMethodSaveConsentBehavior.Enabled -> {
+                if (customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse) {
+                    PaymentMethod.AllowRedisplay.ALWAYS
                 } else {
-                    PaymentMethod.AllowRedisplay.UNSPECIFIED
+                    PaymentMethod.AllowRedisplay.LIMITED
                 }
             }
+        }
+    }
+
+    private fun allowRedisplayForPaymentIntent(
+        customerRequestedSave: PaymentSelection.CustomerRequestedSave,
+    ): PaymentMethod.AllowRedisplay {
+        return when (paymentMethodSaveConsentBehavior) {
+            PaymentMethodSaveConsentBehavior.Legacy -> PaymentMethod.AllowRedisplay.UNSPECIFIED
+            PaymentMethodSaveConsentBehavior.Disabled -> PaymentMethod.AllowRedisplay.UNSPECIFIED
             PaymentMethodSaveConsentBehavior.Enabled -> {
-                if (hasIntentToSetup()) {
-                    if (saveForFutureUse == true) {
-                        PaymentMethod.AllowRedisplay.ALWAYS
-                    } else {
-                        PaymentMethod.AllowRedisplay.LIMITED
-                    }
+                if (customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse) {
+                    PaymentMethod.AllowRedisplay.ALWAYS
                 } else {
-                    if (saveForFutureUse == true) {
-                        PaymentMethod.AllowRedisplay.ALWAYS
-                    } else {
-                        PaymentMethod.AllowRedisplay.UNSPECIFIED
-                    }
+                    PaymentMethod.AllowRedisplay.UNSPECIFIED
                 }
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -68,10 +68,17 @@ internal fun FormFieldValues.transformToPaymentMethodCreateParams(
     paymentMethodCode: PaymentMethodCode,
     paymentMethodMetadata: PaymentMethodMetadata,
 ): PaymentMethodCreateParams {
+    val saveForFutureUse = when (userRequestedReuse) {
+        PaymentSelection.CustomerRequestedSave.RequestReuse -> true
+        PaymentSelection.CustomerRequestedSave.RequestNoReuse -> false
+        PaymentSelection.CustomerRequestedSave.NoRequest -> null
+    }
+
     return FieldValuesToParamsMapConverter.transformToPaymentMethodCreateParams(
         fieldValuePairs = fieldValuePairs,
         code = paymentMethodCode,
         requiresMandate = paymentMethodMetadata.requiresMandate(paymentMethodCode),
+        allowRedisplay = paymentMethodMetadata.allowRedisplay(saveForFutureUse),
     )
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -68,17 +68,11 @@ internal fun FormFieldValues.transformToPaymentMethodCreateParams(
     paymentMethodCode: PaymentMethodCode,
     paymentMethodMetadata: PaymentMethodMetadata,
 ): PaymentMethodCreateParams {
-    val saveForFutureUse = when (userRequestedReuse) {
-        PaymentSelection.CustomerRequestedSave.RequestReuse -> true
-        PaymentSelection.CustomerRequestedSave.RequestNoReuse -> false
-        PaymentSelection.CustomerRequestedSave.NoRequest -> null
-    }
-
     return FieldValuesToParamsMapConverter.transformToPaymentMethodCreateParams(
         fieldValuePairs = fieldValuePairs,
         code = paymentMethodCode,
         requiresMandate = paymentMethodMetadata.requiresMandate(paymentMethodCode),
-        allowRedisplay = paymentMethodMetadata.allowRedisplay(saveForFutureUse),
+        allowRedisplay = paymentMethodMetadata.allowRedisplay(userRequestedReuse),
     )
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
@@ -940,24 +941,34 @@ internal class PaymentMethodMetadataTest {
             paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy
         )
 
-        assertThat(metadataForPaymentIntent.allowRedisplay(saveForFutureUse = null))
-            .isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
-        assertThat(metadataForPaymentIntent.allowRedisplay(saveForFutureUse = true))
-            .isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
-        assertThat(metadataForPaymentIntent.allowRedisplay(saveForFutureUse = false))
-            .isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
+        assertThat(
+            metadataForPaymentIntent.allowRedisplay(PaymentSelection.CustomerRequestedSave.RequestReuse)
+        ).isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
+
+        assertThat(
+            metadataForPaymentIntent.allowRedisplay(PaymentSelection.CustomerRequestedSave.RequestNoReuse)
+        ).isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
+
+        assertThat(
+            metadataForPaymentIntent.allowRedisplay(PaymentSelection.CustomerRequestedSave.NoRequest)
+        ).isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
 
         val metadataForSetupIntent = PaymentMethodMetadataFactory.create(
             stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
             paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy
         )
 
-        assertThat(metadataForSetupIntent.allowRedisplay(saveForFutureUse = null))
-            .isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
-        assertThat(metadataForSetupIntent.allowRedisplay(saveForFutureUse = true))
-            .isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
-        assertThat(metadataForSetupIntent.allowRedisplay(saveForFutureUse = false))
-            .isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
+        assertThat(
+            metadataForSetupIntent.allowRedisplay(PaymentSelection.CustomerRequestedSave.RequestReuse)
+        ).isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
+
+        assertThat(
+            metadataForSetupIntent.allowRedisplay(PaymentSelection.CustomerRequestedSave.RequestNoReuse)
+        ).isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
+
+        assertThat(
+            metadataForSetupIntent.allowRedisplay(PaymentSelection.CustomerRequestedSave.NoRequest)
+        ).isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
 
         val metadataForPaymentIntentWithSfu = PaymentMethodMetadataFactory.create(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
@@ -966,12 +977,17 @@ internal class PaymentMethodMetadataTest {
             paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy
         )
 
-        assertThat(metadataForPaymentIntentWithSfu.allowRedisplay(saveForFutureUse = null))
-            .isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
-        assertThat(metadataForPaymentIntentWithSfu.allowRedisplay(saveForFutureUse = true))
-            .isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
-        assertThat(metadataForPaymentIntentWithSfu.allowRedisplay(saveForFutureUse = false))
-            .isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
+        assertThat(
+            metadataForPaymentIntentWithSfu.allowRedisplay(PaymentSelection.CustomerRequestedSave.RequestReuse)
+        ).isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
+
+        assertThat(
+            metadataForPaymentIntentWithSfu.allowRedisplay(PaymentSelection.CustomerRequestedSave.RequestNoReuse)
+        ).isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
+
+        assertThat(
+            metadataForPaymentIntentWithSfu.allowRedisplay(PaymentSelection.CustomerRequestedSave.NoRequest)
+        ).isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
     }
 
     @Test
@@ -982,8 +998,11 @@ internal class PaymentMethodMetadataTest {
                 paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Enabled
             )
 
-            assertThat(metadataForSetupIntent.allowRedisplay(saveForFutureUse = true))
-                .isEqualTo(PaymentMethod.AllowRedisplay.ALWAYS)
+            assertThat(
+                metadataForSetupIntent.allowRedisplay(
+                    customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
+                )
+            ).isEqualTo(PaymentMethod.AllowRedisplay.ALWAYS)
 
             val metadataForPaymentIntentWithSfu = PaymentMethodMetadataFactory.create(
                 stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
@@ -992,8 +1011,11 @@ internal class PaymentMethodMetadataTest {
                 paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Enabled
             )
 
-            assertThat(metadataForPaymentIntentWithSfu.allowRedisplay(saveForFutureUse = true))
-                .isEqualTo(PaymentMethod.AllowRedisplay.ALWAYS)
+            assertThat(
+                metadataForPaymentIntentWithSfu.allowRedisplay(
+                    customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
+                )
+            ).isEqualTo(PaymentMethod.AllowRedisplay.ALWAYS)
         }
 
     @Test
@@ -1004,10 +1026,17 @@ internal class PaymentMethodMetadataTest {
                 paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Enabled
             )
 
-            assertThat(metadataForSetupIntent.allowRedisplay(saveForFutureUse = null))
-                .isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
-            assertThat(metadataForSetupIntent.allowRedisplay(saveForFutureUse = false))
-                .isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
+            assertThat(
+                metadataForSetupIntent.allowRedisplay(
+                    customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
+                )
+            ).isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
+
+            assertThat(
+                metadataForSetupIntent.allowRedisplay(
+                    customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
+                )
+            ).isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
 
             val metadataForPaymentIntentWithSfu = PaymentMethodMetadataFactory.create(
                 stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
@@ -1016,10 +1045,17 @@ internal class PaymentMethodMetadataTest {
                 paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Enabled
             )
 
-            assertThat(metadataForPaymentIntentWithSfu.allowRedisplay(saveForFutureUse = null))
-                .isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
-            assertThat(metadataForPaymentIntentWithSfu.allowRedisplay(saveForFutureUse = false))
-                .isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
+            assertThat(
+                metadataForPaymentIntentWithSfu.allowRedisplay(
+                    customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
+                )
+            ).isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
+
+            assertThat(
+                metadataForPaymentIntentWithSfu.allowRedisplay(
+                    customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
+                )
+            ).isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
         }
 
     @Test
@@ -1030,8 +1066,11 @@ internal class PaymentMethodMetadataTest {
                 paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Enabled
             )
 
-            assertThat(metadata.allowRedisplay(saveForFutureUse = true))
-                .isEqualTo(PaymentMethod.AllowRedisplay.ALWAYS)
+            assertThat(
+                metadata.allowRedisplay(
+                    customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
+                )
+            ).isEqualTo(PaymentMethod.AllowRedisplay.ALWAYS)
         }
 
     @Test
@@ -1042,10 +1081,17 @@ internal class PaymentMethodMetadataTest {
                 paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Enabled
             )
 
-            assertThat(metadata.allowRedisplay(saveForFutureUse = null))
-                .isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
-            assertThat(metadata.allowRedisplay(saveForFutureUse = false))
-                .isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
+            assertThat(
+                metadata.allowRedisplay(
+                    customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
+                )
+            ).isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
+
+            assertThat(
+                metadata.allowRedisplay(
+                    customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
+                )
+            ).isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
         }
 
     @Test
@@ -1055,12 +1101,23 @@ internal class PaymentMethodMetadataTest {
             paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Disabled
         )
 
-        assertThat(metadata.allowRedisplay(saveForFutureUse = null))
-            .isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
-        assertThat(metadata.allowRedisplay(saveForFutureUse = false))
-            .isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
-        assertThat(metadata.allowRedisplay(saveForFutureUse = true))
-            .isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
+        assertThat(
+            metadata.allowRedisplay(
+                customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
+            )
+        ).isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
+
+        assertThat(
+            metadata.allowRedisplay(
+                customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
+            )
+        ).isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
+
+        assertThat(
+            metadata.allowRedisplay(
+                customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
+            )
+        ).isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
     }
 
     @Test
@@ -1070,12 +1127,23 @@ internal class PaymentMethodMetadataTest {
             paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Disabled
         )
 
-        assertThat(metadataForSetupIntent.allowRedisplay(saveForFutureUse = true))
-            .isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
-        assertThat(metadataForSetupIntent.allowRedisplay(saveForFutureUse = false))
-            .isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
-        assertThat(metadataForSetupIntent.allowRedisplay(saveForFutureUse = null))
-            .isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
+        assertThat(
+            metadataForSetupIntent.allowRedisplay(
+                customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
+            )
+        ).isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
+
+        assertThat(
+            metadataForSetupIntent.allowRedisplay(
+                customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
+            )
+        ).isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
+
+        assertThat(
+            metadataForSetupIntent.allowRedisplay(
+                customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
+            )
+        ).isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
 
         val metadataForPaymentIntentWithSfu = PaymentMethodMetadataFactory.create(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
@@ -1084,11 +1152,22 @@ internal class PaymentMethodMetadataTest {
             paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Disabled
         )
 
-        assertThat(metadataForPaymentIntentWithSfu.allowRedisplay(saveForFutureUse = true))
-            .isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
-        assertThat(metadataForPaymentIntentWithSfu.allowRedisplay(saveForFutureUse = false))
-            .isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
-        assertThat(metadataForPaymentIntentWithSfu.allowRedisplay(saveForFutureUse = null))
-            .isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
+        assertThat(
+            metadataForPaymentIntentWithSfu.allowRedisplay(
+                customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
+            )
+        ).isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
+
+        assertThat(
+            metadataForPaymentIntentWithSfu.allowRedisplay(
+                customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
+            )
+        ).isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
+
+        assertThat(
+            metadataForPaymentIntentWithSfu.allowRedisplay(
+                customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
+            )
+        ).isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
     }
 }


### PR DESCRIPTION
# Summary
Determines what value to use for `allowRedisplay` from the consent behavior and save for future usage value.

# Motivation
With `CustomerSession`, we are more explicitly defining if a payment method should be redisplayed for a customer. In the past, `SetupIntent` used to assume save consent when saving a payment method. With the changes in `CustomerSession`, this will no longer by the case. Customers may choose to have their payment method redisplayed in the saved payment method screen for all transaction types.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified
