### PR TITLE
Add client-side validation for `CustomerSession` client secret

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
@@ -13,6 +13,9 @@ import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.StripeThemeDefaults
 import java.lang.IllegalArgumentException
 
+private const val EPHEMERAL_KEY_SECRET_PREFIX = "ek_"
+private const val CUSTOMER_SESSION_CLIENT_SECRET_KEY_PREFIX = "cuss_"
+
 internal fun PaymentSheet.Configuration.validate() {
     // These are not localized as they are not intended to be displayed to a user.
     when {
@@ -41,10 +44,22 @@ internal fun PaymentSheet.Configuration.validate() {
                 }
             }
             is PaymentSheet.CustomerAccessType.CustomerSession -> {
-                if (customerAccessType.customerSessionClientSecret.isBlank()) {
+                val customerSessionClientSecret = customerAccessType.customerSessionClientSecret
+
+                if (customerSessionClientSecret.isBlank()) {
                     throw IllegalArgumentException(
                         "When a CustomerConfiguration is passed to PaymentSheet, " +
                             "the customerSessionClientSecret cannot be an empty string."
+                    )
+                } else if (customerSessionClientSecret.startsWith(EPHEMERAL_KEY_SECRET_PREFIX)) {
+                    throw IllegalArgumentException(
+                        "Argument looks like an Ephemeral Key secret, but expecting a CustomerSession client " +
+                            "secret. See CustomerSession API: https://docs.stripe.com/api/customer_sessions/create"
+                    )
+                } else if (!customerSessionClientSecret.startsWith(CUSTOMER_SESSION_CLIENT_SECRET_KEY_PREFIX)) {
+                    throw IllegalArgumentException(
+                        "Argument does not look like a CustomerSession client secret. " +
+                            "See CustomerSession API: https://docs.stripe.com/api/customer_sessions/create"
                     )
                 }
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
@@ -129,6 +129,44 @@ class PaymentSheetConfigurationKtxTest {
         }
     }
 
+    @OptIn(ExperimentalCustomerSessionApi::class)
+    @Test
+    fun `'validate' should fail when provided argument has an ephemeral key secret format`() {
+        val configWithEphemeralKeySecretAsCustomerSessionClientSecret = configuration.copy(
+            customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
+                id = "cus_1",
+                clientSecret = "ek_12345"
+            ),
+        )
+
+        assertFailsWith(
+            IllegalArgumentException::class,
+            message = "Argument looks like an Ephemeral Key secret, but expecting a CustomerSession client " +
+                "secret. See CustomerSession API: https://docs.stripe.com/api/customer_sessions/create"
+        ) {
+            configWithEphemeralKeySecretAsCustomerSessionClientSecret.validate()
+        }
+    }
+
+    @OptIn(ExperimentalCustomerSessionApi::class)
+    @Test
+    fun `'validate' should fail when provided argument is not a recognized customer session client secret format`() {
+        val configWithInvalidCustomerSessionClientSecret = configuration.copy(
+            customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
+                id = "cus_1",
+                clientSecret = "total_12345"
+            ),
+        )
+
+        assertFailsWith(
+            IllegalArgumentException::class,
+            message = "Argument does not look like a CustomerSession client secret. " +
+                "See CustomerSession API: https://docs.stripe.com/api/customer_sessions/create"
+        ) {
+            configWithInvalidCustomerSessionClientSecret.validate()
+        }
+    }
+
     private companion object {
         val configuration = PaymentSheet.Configuration(
             merchantDisplayName = "Merchant, Inc.",


### PR DESCRIPTION
# Summary
Add client-side validation for `CustomerSession` client secret

# Motivation
Ensure merchants are informed if the provided secret does not work for the `CustomerSession` use case.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified