### PR TITLE
Filter payment methods from `CustomerSession` by supported saved payment method types.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
@@ -28,7 +28,8 @@ internal data class CustomerState(
          * @return [CustomerState] instance using [ElementsSession.Customer] data
          */
         internal fun createForCustomerSession(
-            customer: ElementsSession.Customer
+            customer: ElementsSession.Customer,
+            supportedSavedPaymentMethodTypes: List<PaymentMethod.Type>,
         ): CustomerState {
             val canRemovePaymentMethods = when (
                 val paymentSheetComponent = customer.session.components.paymentSheet
@@ -41,7 +42,9 @@ internal data class CustomerState(
             return CustomerState(
                 id = customer.session.customerId,
                 ephemeralKeySecret = customer.session.apiKey,
-                paymentMethods = customer.paymentMethods,
+                paymentMethods = customer.paymentMethods.filter {
+                    supportedSavedPaymentMethodTypes.contains(it.type)
+                },
                 permissions = Permissions(
                     canRemovePaymentMethods = canRemovePaymentMethods,
                     // Should always remove duplicates when using `customer_session`

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -218,7 +218,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         val customerState = when (val accessType = customerConfig?.accessType) {
             is PaymentSheet.CustomerAccessType.CustomerSession -> {
                 elementsSession.customer?.let { customer ->
-                    CustomerState.createForCustomerSession(customer)
+                    CustomerState.createForCustomerSession(customer, metadata.supportedSavedPaymentMethodTypes())
                 } ?: run {
                     val exception = IllegalStateException(
                         "Excepted 'customer' attribute as part of 'elements_session' response!"

--- a/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
@@ -85,6 +85,16 @@ internal object PaymentMethodFixtures {
         customerId = "cus_AQsHpvKfKwJDrF",
         code = "paypal"
     )
+
+    val LINK_PAYMENT_METHOD = PaymentMethod(
+        id = "pm_123456789",
+        created = 1550757934255L,
+        liveMode = true,
+        type = PaymentMethod.Type.Link,
+        billingDetails = BILLING_DETAILS,
+        customerId = "cus_AQsHpvKfKwJDrF",
+        code = "link"
+    )
 //
 //    val AU_BECS_DEBIT_PAYMENT_METHOD = PaymentMethod(
 //        id = "pm_1GJ4cUABjb",


### PR DESCRIPTION
# Summary
Filter payment methods from `CustomerSession` by supported saved payment method types.

# Motivation
Prevents an issue with non-supported saved payment methods being provided as displayable when they are not, resulting in out-of-sync UI and presentation state.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
