### PR TITLE
Refresh twint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # CHANGELOG
 
 ## XX.XX.XX - 20XX-XX-XX
+* [FIXED][8746](https://github.com/stripe/stripe-android/pull/8746) Fixed an issue where successful TWINT payments were sometimes incorrectly considered 'canceled'.
 
 ## 20.48.0 - 2024-07-01
 
 ### PaymentSheet
-* [Fixed][8710](https://github.com/stripe/stripe-android/pull/8710) Fixed issue where no payment method was selected after navigating back to the select saved payment method screen.
+* [FIXED][8710](https://github.com/stripe/stripe-android/pull/8710) Fixed issue where no payment method was selected after navigating back to the select saved payment method screen.
 * [ADDED][8717](https://github.com/stripe/stripe-android/pull/8717) Add CVC Recollection functionality to `PaymentSheet` and `PaymentSheet.FlowController`
 
 ## 20.47.4 - 2024-06-27

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -492,6 +492,10 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
+            // We are intentionally polling for Twint even though it uses the redirect trampoline.
+            // About 50% of the time, the intent is still in `requires_action` status
+            // after redirecting following a successful payment.
+            // This allows time for the intent to transition to its terminal state.
             shouldRefreshIfIntentRequiresAction = true,
         );
 

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -170,7 +170,7 @@ constructor(
         }
 
     @Parcelize
-    enum class Type constructor(
+    enum class Type(
         @JvmField val code: String,
         @JvmField val isReusable: Boolean,
         @JvmField val isVoucher: Boolean,
@@ -492,7 +492,7 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
+            shouldRefreshIfIntentRequiresAction = true,
         );
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Twint doesn't transition to success right away, so adding polling to ensure the correct state is reflected in PaymentSheet.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://stripe.slack.com/archives/C01CY476ESJ/p1720179429423349

