### PR TITLE
Added `supported_payment_method_types` to `TestSunbit`

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSunbit.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSunbit.kt
@@ -2,10 +2,12 @@ package com.stripe.android.lpm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
 import com.stripe.android.test.core.TestParameters
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -17,6 +19,10 @@ internal class TestSunbit : BasePlaygroundTest() {
     ) { settings ->
         settings[CountrySettingsDefinition] = Country.US
         settings[CurrencySettingsDefinition] = Currency.USD
+        settings[SupportedPaymentMethodsSettingsDefinition] = listOf(
+            PaymentMethod.Type.Card,
+            PaymentMethod.Type.Sunbit
+        ).joinToString(",")
     }
 
     @Test


### PR DESCRIPTION
# Summary
Added `supported_payment_method_types` to `TestSunbit`

# Motivation
Loads `Sunbit` properly in `PaymentSheet` tests.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified
