### PR TITLE
Make more interactors private, and don't treat them as data classes.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -78,8 +78,8 @@ internal sealed interface PaymentSheetScreen {
         }
     }
 
-    data class SelectSavedPaymentMethods constructor(
-        val selectSavedPaymentMethodsInteractor: SelectSavedPaymentMethodsInteractor,
+    class SelectSavedPaymentMethods(
+        private val selectSavedPaymentMethodsInteractor: SelectSavedPaymentMethodsInteractor,
         val cvcRecollectionState: CvcRecollectionState = CvcRecollectionState.NotRequired,
     ) : PaymentSheetScreen, Closeable {
 
@@ -148,8 +148,8 @@ internal sealed interface PaymentSheetScreen {
         }
     }
 
-    data class AddAnotherPaymentMethod(
-        val interactor: AddPaymentMethodInteractor,
+    class AddAnotherPaymentMethod(
+        private val interactor: AddPaymentMethodInteractor,
     ) : PaymentSheetScreen, Closeable {
 
         override val showsBuyButton: Boolean = true
@@ -171,8 +171,8 @@ internal sealed interface PaymentSheetScreen {
         }
     }
 
-    data class AddFirstPaymentMethod(
-        val interactor: AddPaymentMethodInteractor,
+    class AddFirstPaymentMethod(
+        private val interactor: AddPaymentMethodInteractor,
     ) : PaymentSheetScreen, Closeable {
 
         override val showsBuyButton: Boolean = true
@@ -194,7 +194,7 @@ internal sealed interface PaymentSheetScreen {
         }
     }
 
-    data class EditPaymentMethod(
+    class EditPaymentMethod(
         val interactor: ModifiableEditPaymentMethodViewInteractor,
     ) : PaymentSheetScreen, Closeable {
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
These are intended to be implementation details, and interactors don't act like data classes, so marking the screens as data classes doesn't make sense.