### PR TITLE
Only call refresh endpoint once.

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
@@ -42,6 +42,16 @@ object PaymentMethodFactory {
         )
     }
 
+    fun swish(): PaymentMethod {
+        return PaymentMethod(
+            id = "pm_1234",
+            created = 123456789L,
+            liveMode = false,
+            type = PaymentMethod.Type.Swish,
+            code = PaymentMethod.Type.Swish.code,
+        )
+    }
+
     fun usBankAccount(): PaymentMethod {
         return PaymentMethod(
             id = "pm_1234",

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -3362,6 +3362,30 @@ public final class com/stripe/android/model/PaymentMethod : com/stripe/android/c
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
+public final class com/stripe/android/model/PaymentMethod$AfterRedirectAction$None$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$AfterRedirectAction$None;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethod$AfterRedirectAction$None;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethod$AfterRedirectAction$Poll$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$AfterRedirectAction$Poll;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethod$AfterRedirectAction$Poll;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethod$AfterRedirectAction$Refresh$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethod$AfterRedirectAction$Refresh;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethod$AfterRedirectAction$Refresh;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/model/PaymentMethod$AllowRedisplay : java/lang/Enum, com/stripe/android/core/model/StripeModel {
 	public static final field ALWAYS Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;
 	public static final field CREATOR Landroid/os/Parcelable$Creator;

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -5,6 +5,7 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.model.parsers.PaymentMethodJsonParser
 import com.stripe.android.model.wallets.Wallet
+import com.stripe.android.payments.PaymentFlowResultProcessor.Companion.MAX_RETRIES
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
@@ -176,7 +177,7 @@ constructor(
         @JvmField val isVoucher: Boolean,
         @JvmField val requiresMandate: Boolean,
         private val hasDelayedSettlement: Boolean,
-        internal val shouldRefreshIfIntentRequiresAction: Boolean,
+        internal val afterRedirectAction: AfterRedirectAction = AfterRedirectAction.None,
     ) : Parcelable {
         Link(
             "link",
@@ -184,7 +185,6 @@ constructor(
             isVoucher = false,
             requiresMandate = true,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         Card(
             "card",
@@ -192,7 +192,6 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         CardPresent(
             "card_present",
@@ -200,7 +199,6 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         Fpx(
             "fpx",
@@ -208,7 +206,6 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         Ideal(
             "ideal",
@@ -216,7 +213,6 @@ constructor(
             isVoucher = false,
             requiresMandate = true,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         SepaDebit(
             "sepa_debit",
@@ -224,7 +220,6 @@ constructor(
             isVoucher = false,
             requiresMandate = true,
             hasDelayedSettlement = true,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         AuBecsDebit(
             "au_becs_debit",
@@ -232,7 +227,6 @@ constructor(
             isVoucher = false,
             requiresMandate = true,
             hasDelayedSettlement = true,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         BacsDebit(
             "bacs_debit",
@@ -240,7 +234,6 @@ constructor(
             isVoucher = false,
             requiresMandate = true,
             hasDelayedSettlement = true,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         Sofort(
             "sofort",
@@ -248,7 +241,6 @@ constructor(
             isVoucher = false,
             requiresMandate = true,
             hasDelayedSettlement = true,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         Upi(
             "upi",
@@ -256,7 +248,7 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
+            afterRedirectAction = AfterRedirectAction.Refresh(),
         ),
         P24(
             "p24",
@@ -264,7 +256,6 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         Bancontact(
             "bancontact",
@@ -272,7 +263,6 @@ constructor(
             isVoucher = false,
             requiresMandate = true,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         Giropay(
             "giropay",
@@ -280,7 +270,6 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         Eps(
             "eps",
@@ -288,7 +277,6 @@ constructor(
             isVoucher = false,
             requiresMandate = true,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         Oxxo(
             "oxxo",
@@ -296,7 +284,6 @@ constructor(
             isVoucher = true,
             requiresMandate = false,
             hasDelayedSettlement = true,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         Alipay(
             "alipay",
@@ -304,7 +291,6 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         GrabPay(
             "grabpay",
@@ -312,7 +298,6 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         PayPal(
             "paypal",
@@ -320,7 +305,6 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         AfterpayClearpay(
             "afterpay_clearpay",
@@ -328,7 +312,6 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         Netbanking(
             "netbanking",
@@ -336,7 +319,6 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         Blik(
             "blik",
@@ -344,7 +326,6 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         WeChatPay(
             "wechat_pay",
@@ -352,7 +333,7 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = true,
+            afterRedirectAction = AfterRedirectAction.Refresh(retryCount = MAX_RETRIES),
         ),
         Klarna(
             "klarna",
@@ -360,7 +341,6 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         Affirm(
             "affirm",
@@ -368,7 +348,6 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         RevolutPay(
             "revolut_pay",
@@ -376,7 +355,6 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         Sunbit(
             "sunbit",
@@ -384,7 +362,6 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         Billie(
             "billie",
@@ -392,7 +369,6 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         Satispay(
             "satispay",
@@ -400,7 +376,6 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         AmazonPay(
             "amazon_pay",
@@ -408,7 +383,6 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = true,
         ),
         Alma(
             "alma",
@@ -416,7 +390,6 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         MobilePay(
             "mobilepay",
@@ -424,7 +397,6 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         Multibanco(
             "multibanco",
@@ -432,7 +404,6 @@ constructor(
             isVoucher = true,
             requiresMandate = false,
             hasDelayedSettlement = true,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         Zip(
             "zip",
@@ -440,7 +411,6 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         USBankAccount(
             code = "us_bank_account",
@@ -448,7 +418,6 @@ constructor(
             isVoucher = false,
             requiresMandate = true,
             hasDelayedSettlement = true,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         CashAppPay(
             code = "cashapp",
@@ -456,7 +425,7 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
-            shouldRefreshIfIntentRequiresAction = true,
+            afterRedirectAction = AfterRedirectAction.Refresh(),
         ),
         Boleto(
             code = "boleto",
@@ -464,7 +433,6 @@ constructor(
             isVoucher = true,
             requiresMandate = false,
             hasDelayedSettlement = true,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         Konbini(
             code = "konbini",
@@ -472,7 +440,6 @@ constructor(
             isVoucher = true,
             requiresMandate = false,
             hasDelayedSettlement = true,
-            shouldRefreshIfIntentRequiresAction = false,
         ),
         Swish(
             code = "swish",
@@ -484,7 +451,7 @@ constructor(
             // About 50% of the time, the intent is still in `requires_action` status
             // after redirecting following a successful payment.
             // This allows time for the intent to transition to its terminal state.
-            shouldRefreshIfIntentRequiresAction = true,
+            afterRedirectAction = AfterRedirectAction.Poll(),
         ),
         Twint(
             code = "twint",
@@ -496,7 +463,7 @@ constructor(
             // About 50% of the time, the intent is still in `requires_action` status
             // after redirecting following a successful payment.
             // This allows time for the intent to transition to its terminal state.
-            shouldRefreshIfIntentRequiresAction = true,
+            afterRedirectAction = AfterRedirectAction.Poll(),
         );
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet
@@ -513,6 +480,32 @@ constructor(
             fun fromCode(code: String?): Type? {
                 return entries.firstOrNull { it.code == code }
             }
+        }
+    }
+
+    internal sealed interface AfterRedirectAction : Parcelable {
+        val shouldRefresh: Boolean
+        val retryCount: Int
+
+        @Parcelize
+        data object None : AfterRedirectAction {
+            @IgnoredOnParcel
+            override val shouldRefresh: Boolean = false
+
+            @IgnoredOnParcel
+            override val retryCount: Int = MAX_RETRIES
+        }
+
+        @Parcelize
+        data class Poll(override val retryCount: Int = MAX_RETRIES) : AfterRedirectAction {
+            @IgnoredOnParcel
+            override val shouldRefresh: Boolean = true
+        }
+
+        @Parcelize
+        data class Refresh(override val retryCount: Int = 1) : AfterRedirectAction {
+            @IgnoredOnParcel
+            override val shouldRefresh: Boolean = true
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -211,7 +211,7 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
         var remainingRetries = MAX_RETRIES
 
         var stripeIntentResult = if (shouldCallRefreshIntent(originalIntent)) {
-            refreshStripeIntent(
+            return refreshStripeIntent(
                 clientSecret = clientSecret,
                 requestOptions = requestOptions,
                 expandFields = EXPAND_PAYMENT_METHOD
@@ -231,7 +231,7 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
             )
             delay(delayDuration)
             stripeIntentResult = if (shouldCallRefreshIntent(originalIntent)) {
-                refreshStripeIntent(
+                return refreshStripeIntent(
                     clientSecret = clientSecret,
                     requestOptions = requestOptions,
                     expandFields = EXPAND_PAYMENT_METHOD

--- a/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
@@ -343,7 +343,8 @@ internal class PaymentIntentFlowResultProcessorTest {
             val expectedResult = PaymentIntentResult(
                 intent = requiresActionIntent,
                 outcomeFromFlow = StripeIntentResult.Outcome.UNKNOWN,
-                failureMessage = "We are unable to authenticate your payment method. Please choose a different payment method and try again.",
+                failureMessage = "We are unable to authenticate your payment method." +
+                    " Please choose a different payment method and try again.",
             )
 
             assertThat(result).isEqualTo(expectedResult)

--- a/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.payments.PaymentFlowResultProcessor.Companion.MAX_RETRIES
 import com.stripe.android.testing.PaymentMethodFactory
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -176,8 +177,78 @@ internal class SetupIntentFlowResultProcessorTest {
                 )
         }
 
+
     @Test
-    fun `Keeps refreshing when encountering a CashAppPay setup that still requires action`() =
+    fun `Stops polling after max retries when encountering a Swish payment that still requires action`() =
+        runTest(testDispatcher) {
+            val requiresActionIntent = SetupIntentFixtures.SI_SUCCEEDED.copy(
+                status = StripeIntent.Status.RequiresAction,
+                paymentMethod = PaymentMethodFactory.swish(),
+                paymentMethodTypes = listOf("card", "swish"),
+            )
+
+            whenever(mockStripeRepository.retrieveSetupIntent(any(), any(), any())).thenReturn(
+                Result.success(requiresActionIntent),
+            )
+
+            val clientSecret = requireNotNull(requiresActionIntent.clientSecret)
+
+            val result = processor.processResult(
+                PaymentFlowResult.Unvalidated(
+                    clientSecret = clientSecret,
+                    flowOutcome = StripeIntentResult.Outcome.UNKNOWN,
+                )
+            ).getOrThrow()
+
+            val expectedResult = SetupIntentResult(
+                intent = requiresActionIntent,
+                outcomeFromFlow = StripeIntentResult.Outcome.UNKNOWN,
+                failureMessage = null,
+            )
+
+            assertThat(result).isEqualTo(expectedResult)
+
+            // We need to retrieve the first time, before we start retries.
+            verify(mockStripeRepository, times(MAX_RETRIES + 1)).retrieveSetupIntent(any(), any(), any())
+        }
+
+    @Test
+    fun `Keeps retrying when encountering a Swish payment that still requires action`() =
+        runTest(testDispatcher) {
+            val requiresActionIntent = SetupIntentFixtures.SI_SUCCEEDED.copy(
+                status = StripeIntent.Status.RequiresAction,
+                paymentMethod = PaymentMethodFactory.swish(),
+                paymentMethodTypes = listOf("card", "swish"),
+            )
+
+            val succeededIntent = requiresActionIntent.copy(status = StripeIntent.Status.Succeeded)
+
+            whenever(mockStripeRepository.retrieveSetupIntent(any(), any(), any())).thenReturn(
+                Result.success(requiresActionIntent),
+                Result.success(requiresActionIntent),
+                Result.success(succeededIntent),
+            )
+
+            val clientSecret = requireNotNull(requiresActionIntent.clientSecret)
+
+            val result = processor.processResult(
+                PaymentFlowResult.Unvalidated(
+                    clientSecret = clientSecret,
+                    flowOutcome = StripeIntentResult.Outcome.UNKNOWN,
+                )
+            ).getOrThrow()
+
+            val expectedResult = SetupIntentResult(
+                intent = succeededIntent,
+                outcomeFromFlow = StripeIntentResult.Outcome.SUCCEEDED,
+                failureMessage = null,
+            )
+
+            assertThat(result).isEqualTo(expectedResult)
+        }
+
+    @Test
+    fun `Calls refresh endpoint when encountering a CashAppPay setup that still requires action`() =
         runTest(testDispatcher) {
             val requiresActionIntent = SetupIntentFixtures.SI_SUCCEEDED.copy(
                 status = StripeIntent.Status.RequiresAction,
@@ -192,7 +263,6 @@ internal class SetupIntentFlowResultProcessorTest {
             )
 
             whenever(mockStripeRepository.refreshSetupIntent(any(), any())).thenReturn(
-                Result.success(requiresActionIntent),
                 Result.success(succeededIntent),
             )
 

--- a/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
@@ -177,7 +177,6 @@ internal class SetupIntentFlowResultProcessorTest {
                 )
         }
 
-
     @Test
     fun `Stops polling after max retries when encountering a Swish payment that still requires action`() =
         runTest(testDispatcher) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Follow up to #8552 

The refresh endpoint only needs to be called once.

This was a bug from when we added polling initially.
