### PR TITLE
Allow testing Instant Debits flow in FC playground

### DIFF
--- a/financial-connections-example/detekt-baseline.xml
+++ b/financial-connections-example/detekt-baseline.xml
@@ -1,5 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <SmellBaseline>
   <ManuallySuppressedIssues/>
-  <CurrentIssues/>
+  <CurrentIssues>
+    <ID>LongMethod:FinancialConnectionsPlaygroundActivity.kt$FinancialConnectionsPlaygroundActivity$@Composable private fun FinancialConnectionsScreen()</ID>
+  </CurrentIssues>
 </SmellBaseline>

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -75,10 +75,18 @@ internal class FinancialConnectionsPlaygroundViewModel(
             "Starting session with settings: ${asJsonString()}"
         )
         saveToSharedPreferences(getApplication())
-        when (state.value.flow) {
-            Flow.Data -> startForData(this)
-            Flow.Token -> startForToken(this)
-            Flow.PaymentIntent -> startWithPaymentIntent(this)
+
+        when (state.value.experience) {
+            Experience.FinancialConnections -> {
+                when (state.value.flow) {
+                    Flow.Data -> startForData(this)
+                    Flow.Token -> startForToken(this)
+                    Flow.PaymentIntent -> startWithPaymentIntent(this)
+                }
+            }
+            Experience.InstantDebits -> {
+                startWithPaymentIntent(this)
+            }
         }
     }
 

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/ConfirmIntentSetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/ConfirmIntentSetting.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.example.settings
 
+import com.stripe.android.financialconnections.example.Experience
 import com.stripe.android.financialconnections.example.Flow
 import com.stripe.android.financialconnections.example.Merchant
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
@@ -28,8 +29,12 @@ data class ConfirmIntentSetting(
         return replace(currentSettings, this.copy(selectedOption = value))
     }
 
-    override fun shouldDisplay(merchant: Merchant, flow: Flow): Boolean {
-        return flow == Flow.PaymentIntent
+    override fun shouldDisplay(
+        merchant: Merchant,
+        flow: Flow,
+        experience: Experience,
+    ): Boolean {
+        return experience == Experience.InstantDebits || flow == Flow.PaymentIntent
     }
 
     override fun convertToValue(value: String): Boolean = value.toBoolean()

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/ExperienceSetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/ExperienceSetting.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.financialconnections.example.settings
+
+import com.stripe.android.financialconnections.example.Experience
+import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
+import com.stripe.android.financialconnections.example.data.model.PaymentIntentBody
+
+data class ExperienceSetting(
+    override val selectedOption: Experience = Experience.FinancialConnections,
+    override val key: String = "experience",
+) : Saveable<Experience>, SingleChoiceSetting<Experience>(
+    displayName = "Experience",
+    options = Experience.entries.map { Option(it.displayName, it) },
+    selectedOption = selectedOption,
+) {
+    override fun lasRequest(body: LinkAccountSessionBody): LinkAccountSessionBody = body
+
+    override fun paymentIntentRequest(body: PaymentIntentBody): PaymentIntentBody = body
+
+    override fun convertToString(value: Experience): String {
+        return value.name
+    }
+
+    override fun convertToValue(value: String): Experience {
+        return Experience.entries.find { it.name == value } ?: Experience.FinancialConnections
+    }
+
+    override fun valueUpdated(currentSettings: List<Setting<*>>, value: Experience): List<Setting<*>> {
+        return replace(currentSettings, this.copy(selectedOption = value))
+    }
+}

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/FlowSetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/FlowSetting.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.financialconnections.example.settings
 
+import com.stripe.android.financialconnections.example.Experience
 import com.stripe.android.financialconnections.example.Flow
+import com.stripe.android.financialconnections.example.Merchant
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
 import com.stripe.android.financialconnections.example.data.model.PaymentIntentBody
 
@@ -15,6 +17,10 @@ data class FlowSetting(
     override fun lasRequest(body: LinkAccountSessionBody): LinkAccountSessionBody = body
 
     override fun paymentIntentRequest(body: PaymentIntentBody): PaymentIntentBody = body
+
+    override fun shouldDisplay(merchant: Merchant, flow: Flow, experience: Experience): Boolean {
+        return experience != Experience.InstantDebits
+    }
 
     override fun convertToString(value: Flow): String {
         return value.apiValue

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PlaygroundSettings.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PlaygroundSettings.kt
@@ -153,6 +153,7 @@ internal data class PlaygroundSettings(
         }
 
         private val allSettings: List<Setting<*>> = listOf(
+            ExperienceSetting(),
             MerchantSetting(),
             PublicKeySetting(),
             PrivateKeySetting(),

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PlaygroundSettings.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PlaygroundSettings.kt
@@ -20,10 +20,12 @@ internal data class PlaygroundSettings(
     val displayableSettings: List<Setting<*>> by lazy {
         val merchant = get<MerchantSetting>()
         val flow = get<FlowSetting>()
+        val experience = get<ExperienceSetting>()
         settings.filter {
             it.shouldDisplay(
                 merchant = merchant.selectedOption,
                 flow = flow.selectedOption,
+                experience = experience.selectedOption,
             )
         }
     }

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PrivateKeySetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PrivateKeySetting.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.example.settings
 
+import com.stripe.android.financialconnections.example.Experience
 import com.stripe.android.financialconnections.example.Flow
 import com.stripe.android.financialconnections.example.Merchant
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
@@ -28,7 +29,11 @@ internal data class PrivateKeySetting(
         return replace(currentSettings, this.copy(selectedOption = value))
     }
 
-    override fun shouldDisplay(merchant: Merchant, flow: Flow): Boolean {
+    override fun shouldDisplay(
+        merchant: Merchant,
+        flow: Flow,
+        experience: Experience,
+    ): Boolean {
         return merchant == Merchant.Custom
     }
 

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PublicKeySetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PublicKeySetting.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.example.settings
 
+import com.stripe.android.financialconnections.example.Experience
 import com.stripe.android.financialconnections.example.Flow
 import com.stripe.android.financialconnections.example.Merchant
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
@@ -29,7 +30,11 @@ internal data class PublicKeySetting(
         return replace(currentSettings, this.copy(selectedOption = value))
     }
 
-    override fun shouldDisplay(merchant: Merchant, flow: Flow): Boolean {
+    override fun shouldDisplay(
+        merchant: Merchant,
+        flow: Flow,
+        experience: Experience,
+    ): Boolean {
         return merchant == Merchant.Custom
     }
 

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/Setting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/Setting.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.example.settings
 
+import com.stripe.android.financialconnections.example.Experience
 import com.stripe.android.financialconnections.example.Flow
 import com.stripe.android.financialconnections.example.Merchant
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
@@ -21,7 +22,11 @@ sealed class Setting<T> {
         return this as? Saveable<T>?
     }
 
-    open fun shouldDisplay(merchant: Merchant, flow: Flow): Boolean = true
+    open fun shouldDisplay(
+        merchant: Merchant,
+        flow: Flow,
+        experience: Experience,
+    ): Boolean = true
 
     abstract val displayName: String
     abstract val selectedOption: T

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/TestModeSetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/TestModeSetting.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.example.settings
 
+import com.stripe.android.financialconnections.example.Experience
 import com.stripe.android.financialconnections.example.Flow
 import com.stripe.android.financialconnections.example.Merchant
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
@@ -28,7 +29,11 @@ data class TestModeSetting(
         return replace(currentSettings, this.copy(selectedOption = value))
     }
 
-    override fun shouldDisplay(merchant: Merchant, flow: Flow): Boolean {
+    override fun shouldDisplay(
+        merchant: Merchant,
+        flow: Flow,
+        experience: Experience,
+    ): Boolean {
         return merchant != Merchant.Custom && merchant.canSwitchBetweenTestAndLive
     }
 

--- a/maestro/financial-connections/Livemode-Data-Finbank.yaml
+++ b/maestro/financial-connections/Livemode-Data-Finbank.yaml
@@ -5,7 +5,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/livemode-data-finbank-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?flow=Data&financial_connections_override_native=native&merchant=live_testing&financial_connections_test_mode=false
+- openLink: stripeconnectionsexample://playground?experience=FinancialConnections&flow=Data&financial_connections_override_native=native&merchant=live_testing&financial_connections_test_mode=false
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible

--- a/maestro/financial-connections/Livemode-Data-MXBank.yaml
+++ b/maestro/financial-connections/Livemode-Data-MXBank.yaml
@@ -5,7 +5,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/livemode-data-mxbank-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?flow=Data&financial_connections_override_native=native&merchant=live_testing&financial_connections_test_mode=false
+- openLink: stripeconnectionsexample://playground?experience=FinancialConnections&flow=Data&financial_connections_override_native=native&merchant=live_testing&financial_connections_test_mode=false
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible

--- a/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
+++ b/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
@@ -6,7 +6,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/testmode-data-testoauthinstitution-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?flow=Data&financial_connections_override_native=native&merchant=testmode&financial_connections_test_mode=true
+- openLink: stripeconnectionsexample://playground?experience=FinancialConnections&flow=Data&financial_connections_override_native=native&merchant=testmode&financial_connections_test_mode=true
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking.yaml
@@ -6,7 +6,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-networking-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?flow=PaymentIntent&financial_connections_override_native=native&merchant=networking&financial_connections_test_mode=true&permissions=transactions,payment_method&financial_connections_confirm_intent=true
+- openLink: stripeconnectionsexample://playground?experience=FinancialConnections&flow=PaymentIntent&financial_connections_override_native=native&merchant=networking&financial_connections_test_mode=true&permissions=transactions,payment_method&financial_connections_confirm_intent=true
 - tapOn:
     id: "Customer email setting"
 - inputRandomEmail

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
@@ -6,7 +6,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-networking-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?flow=PaymentIntent&financial_connections_override_native=native&financial_connections_test_mode=true&merchant=testmode&permissions=payment_method
+- openLink: stripeconnectionsexample://playground?experience=FinancialConnections&flow=PaymentIntent&financial_connections_override_native=native&financial_connections_test_mode=true&merchant=testmode&permissions=payment_method
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
@@ -4,9 +4,9 @@ tags:
   - edge
   - testmode-payments
 ---
-- startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-' + new Date().getTime()}
+#- startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?flow=PaymentIntent&financial_connections_override_native=native&merchant=testmode&permissions=payment_method&financial_connections_test_mode=true&financial_connections_confirm_intent=true
+- openLink: stripeconnectionsexample://playground?experience=FinancialConnections&flow=PaymentIntent&financial_connections_override_native=native&merchant=testmode&permissions=payment_method&financial_connections_test_mode=true&financial_connections_confirm_intent=true
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible
@@ -41,4 +41,4 @@ tags:
 - scrollUntilVisible:
     element:
       text: ".*Intent Confirmed!.*"
-- stopRecording
+#- stopRecording

--- a/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
+++ b/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
@@ -6,7 +6,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/testmode-token_manualentry-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?flow=Token&financial_connections_override_native=native&financial_connections_test_mode=true&merchant=testmode&permissions=balances,payment_method
+- openLink: stripeconnectionsexample://playground?experience=FinancialConnections&flow=Token&financial_connections_override_native=native&financial_connections_test_mode=true&merchant=testmode&permissions=balances,payment_method
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible

--- a/maestro/financial-connections/disabled/Web-Testmode-Data-TestOauthInstitution.yaml
+++ b/maestro/financial-connections/disabled/Web-Testmode-Data-TestOauthInstitution.yaml
@@ -7,7 +7,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/web-testmode-data-testoauthinstitution-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?flow=Data&financial_connections_override_native=web&merchant=testmode&financial_connections_test_mode=true
+- openLink: stripeconnectionsexample://playground?experience=FinancialConnections&flow=Data&financial_connections_override_native=web&merchant=testmode&financial_connections_test_mode=true
 - tapOn:
     id: "connect_accounts"
 - extendedWaitUntil:


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request extends the Financial Connections playground and allows to launch the Instant Debits flow in addition to the standard auth flow.

(cc @mats-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
