### PR TITLE
Isolate payment sheet navigation behavior.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -61,7 +61,7 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
                     viewModel.paymentOptionResult.filterNotNull().collect { sheetResult ->
                         setActivityResult(sheetResult)
                         bottomSheetState.hide()
-                        viewModel.closeScreens()
+                        viewModel.navigationHandler.closeScreens()
                         finish()
                     }
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -79,7 +79,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     private val primaryButtonUiStateMapper = PrimaryButtonUiStateMapper(
         config = config,
         isProcessingPayment = args.state.stripeIntent is PaymentIntent,
-        currentScreenFlow = currentScreen,
+        currentScreenFlow = navigationHandler.currentScreen,
         buttonsEnabledFlow = buttonsEnabled,
         amountFlow = paymentMethodMetadata.mapAsStateFlow { it?.amount() },
         selectionFlow = selection,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -75,7 +75,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
                     viewModel.paymentSheetResult.filterNotNull().collect { sheetResult ->
                         setActivityResult(sheetResult)
                         bottomSheetState.hide()
-                        viewModel.closeScreens()
+                        viewModel.navigationHandler.closeScreens()
                         finish()
                     }
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -130,7 +130,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     private val primaryButtonUiStateMapper = PrimaryButtonUiStateMapper(
         config = config,
         isProcessingPayment = isProcessingPaymentIntent,
-        currentScreenFlow = currentScreen,
+        currentScreenFlow = navigationHandler.currentScreen,
         buttonsEnabledFlow = buttonsEnabled,
         amountFlow = paymentMethodMetadata.mapAsStateFlow { it?.amount() },
         selectionFlow = selection,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/NavigationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/NavigationHandler.kt
@@ -1,0 +1,62 @@
+package com.stripe.android.paymentsheet.navigation
+
+import com.stripe.android.uicore.utils.mapAsStateFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.io.Closeable
+
+internal class NavigationHandler {
+    private val backStack = MutableStateFlow<List<PaymentSheetScreen>>(
+        value = listOf(PaymentSheetScreen.Loading),
+    )
+
+    val currentScreen: StateFlow<PaymentSheetScreen> = backStack
+        .mapAsStateFlow { it.last() }
+
+    val canGoBack: Boolean
+        get() = backStack.value.size > 1
+
+    fun transitionTo(target: PaymentSheetScreen) {
+        backStack.update { (it - PaymentSheetScreen.Loading) + target }
+    }
+
+    fun resetTo(screens: List<PaymentSheetScreen>) {
+        val previousBackStack = backStack.value
+
+        backStack.value = screens
+
+        previousBackStack.forEach { oldScreen ->
+            if (oldScreen !in screens) {
+                oldScreen.onClose()
+            }
+        }
+    }
+
+    fun pop(poppedScreenHandler: (PaymentSheetScreen) -> Unit) {
+        backStack.update { screens ->
+            val modifiableScreens = screens.toMutableList()
+
+            val lastScreen = modifiableScreens.removeLast()
+
+            lastScreen.onClose()
+
+            poppedScreenHandler(lastScreen)
+
+            modifiableScreens.toList()
+        }
+    }
+
+    fun closeScreens() {
+        backStack.value.forEach {
+            it.onClose()
+        }
+    }
+
+    private fun PaymentSheetScreen.onClose() {
+        when (this) {
+            is Closeable -> close()
+            else -> Unit
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -146,7 +146,7 @@ internal fun PaymentSheetScreenContent(
     val walletsState by viewModel.walletsState.collectAsState()
     val walletsProcessingState by viewModel.walletsProcessingState.collectAsState()
     val error by viewModel.error.collectAsState()
-    val currentScreen by viewModel.currentScreen.collectAsState()
+    val currentScreen by viewModel.navigationHandler.currentScreen.collectAsState()
     val mandateText by viewModel.mandateText.collectAsState()
     val showsWalletsHeader by currentScreen.showsWalletsHeader(type == Complete).collectAsState()
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -119,7 +119,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         walletsState = viewModel.walletsState,
         isFlowController = viewModel is PaymentOptionsViewModel,
         updateSelection = viewModel::updateSelection,
-        isCurrentScreen = viewModel.currentScreen.mapAsStateFlow {
+        isCurrentScreen = viewModel.navigationHandler.currentScreen.mapAsStateFlow {
             it is PaymentSheetScreen.VerticalMode
         },
         onMandateTextUpdated = {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -174,7 +174,7 @@ internal class PaymentOptionsViewModelTest {
             args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(paymentSelection = null)
         )
 
-        viewModel.currentScreen.test {
+        viewModel.navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isInstanceOf<SelectSavedPaymentMethods>()
         }
     }
@@ -190,7 +190,7 @@ internal class PaymentOptionsViewModelTest {
             )
         )
 
-        viewModel.currentScreen.test {
+        viewModel.navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isInstanceOf<PaymentSheetScreen.AddAnotherPaymentMethod>()
 
             verify(eventReporter).onShowNewPaymentOptionForm()
@@ -320,7 +320,7 @@ internal class PaymentOptionsViewModelTest {
             )
         )
 
-        viewModel.currentScreen.test {
+        viewModel.navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isInstanceOf<AddFirstPaymentMethod>()
         }
     }
@@ -336,7 +336,7 @@ internal class PaymentOptionsViewModelTest {
                 )
             )
 
-            viewModel.currentScreen.test {
+            viewModel.navigationHandler.currentScreen.test {
                 assertThat(awaitItem()).isInstanceOf<SelectSavedPaymentMethods>()
 
                 verify(eventReporter).onShowExistingPaymentOptions()
@@ -360,7 +360,7 @@ internal class PaymentOptionsViewModelTest {
                 )
             )
 
-            viewModel.currentScreen.test {
+            viewModel.navigationHandler.currentScreen.test {
                 assertThat(awaitItem()).isInstanceOf<PaymentSheetScreen.Form>()
             }
         }
@@ -382,7 +382,7 @@ internal class PaymentOptionsViewModelTest {
                 )
             )
 
-            viewModel.currentScreen.test {
+            viewModel.navigationHandler.currentScreen.test {
                 assertThat(awaitItem()).isInstanceOf<PaymentSheetScreen.VerticalMode>()
             }
         }
@@ -404,7 +404,7 @@ internal class PaymentOptionsViewModelTest {
                 )
             )
 
-            viewModel.currentScreen.test {
+            viewModel.navigationHandler.currentScreen.test {
                 assertThat(awaitItem()).isInstanceOf<PaymentSheetScreen.VerticalMode>()
             }
         }
@@ -684,7 +684,7 @@ internal class PaymentOptionsViewModelTest {
         )
 
         turbineScope {
-            val screenTurbine = viewModel.currentScreen.testIn(this)
+            val screenTurbine = viewModel.navigationHandler.currentScreen.testIn(this)
             val paymentMethodsTurbine = viewModel.paymentMethods.testIn(this)
 
             assertThat(screenTurbine.awaitItem()).isInstanceOf<SelectSavedPaymentMethods>()
@@ -736,7 +736,7 @@ internal class PaymentOptionsViewModelTest {
         )
 
         turbineScope {
-            val screenTurbine = viewModel.currentScreen.testIn(this)
+            val screenTurbine = viewModel.navigationHandler.currentScreen.testIn(this)
             val paymentMethodsTurbine = viewModel.paymentMethods.testIn(this)
 
             assertThat(screenTurbine.awaitItem()).isInstanceOf<SelectSavedPaymentMethods>()
@@ -841,7 +841,7 @@ internal class PaymentOptionsViewModelTest {
 
         val viewModel = createViewModel(args = args)
 
-        viewModel.currentScreen.test {
+        viewModel.navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isInstanceOf<SelectSavedPaymentMethods>()
         }
         viewModel.paymentMethods.test {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -446,7 +446,8 @@ internal class PaymentSheetActivityTest {
 
             composeTestRule.waitForIdle()
 
-            assertThat(viewModel.currentScreen.value).isInstanceOf(PaymentSheetScreen.AddFirstPaymentMethod::class.java)
+            assertThat(viewModel.navigationHandler.currentScreen.value)
+                .isInstanceOf(PaymentSheetScreen.AddFirstPaymentMethod::class.java)
 
             composeTestRule.onNodeWithTag(
                 TEST_TAG_LIST + "card",
@@ -534,7 +535,7 @@ internal class PaymentSheetActivityTest {
         val viewModel = createViewModel(paymentMethods = paymentMethods)
         val scenario = activityScenario(viewModel)
 
-        viewModel.currentScreen.test {
+        viewModel.navigationHandler.currentScreen.test {
             scenario.launch(intent)
             assertThat(awaitItem()).isInstanceOf<SelectSavedPaymentMethods>()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -213,7 +213,7 @@ internal class PaymentSheetViewModelTest {
             customer = EMPTY_CUSTOMER_STATE.copy(paymentMethods = paymentMethods)
         )
 
-        viewModel.currentScreen.test {
+        viewModel.navigationHandler.currentScreen.test {
             awaitItem()
 
             viewModel.modifyPaymentMethod(CARD_WITH_NETWORKS_PAYMENT_METHOD)
@@ -245,7 +245,7 @@ internal class PaymentSheetViewModelTest {
             customer = EMPTY_CUSTOMER_STATE.copy(paymentMethods = paymentMethods)
         )
 
-        viewModel.currentScreen.test {
+        viewModel.navigationHandler.currentScreen.test {
             awaitItem()
 
             viewModel.modifyPaymentMethod(CARD_WITH_NETWORKS_PAYMENT_METHOD)
@@ -326,7 +326,7 @@ internal class PaymentSheetViewModelTest {
             customer = EMPTY_CUSTOMER_STATE.copy(paymentMethods = paymentMethods)
         )
 
-        viewModel.currentScreen.test {
+        viewModel.navigationHandler.currentScreen.test {
             awaitItem()
 
             viewModel.modifyPaymentMethod(CARD_WITH_NETWORKS_PAYMENT_METHOD)
@@ -384,7 +384,7 @@ internal class PaymentSheetViewModelTest {
             customerRepository = customerRepository
         )
 
-        viewModel.currentScreen.test {
+        viewModel.navigationHandler.currentScreen.test {
             awaitItem()
 
             viewModel.modifyPaymentMethod(paymentMethods.first())
@@ -450,7 +450,7 @@ internal class PaymentSheetViewModelTest {
             customerRepository = customerRepository
         )
 
-        viewModel.currentScreen.test {
+        viewModel.navigationHandler.currentScreen.test {
             awaitItem()
 
             viewModel.modifyPaymentMethod(firstPaymentMethod)
@@ -520,7 +520,7 @@ internal class PaymentSheetViewModelTest {
             customerRepository = customerRepository
         )
 
-        viewModel.currentScreen.test {
+        viewModel.navigationHandler.currentScreen.test {
             awaitItem()
 
             viewModel.modifyPaymentMethod(firstPaymentMethod)
@@ -1475,7 +1475,7 @@ internal class PaymentSheetViewModelTest {
     fun `handleBackPressed is consumed when processing is true`() = runTest {
         val viewModel = createViewModel(customer = EMPTY_CUSTOMER_STATE)
         viewModel.savedStateHandle[SAVE_PROCESSING] = true
-        viewModel.currentScreen.test {
+        viewModel.navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isInstanceOf<AddFirstPaymentMethod>()
             viewModel.handleBackPressed()
         }
@@ -1484,7 +1484,7 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `handleBackPressed delivers cancelled when pressing back on last screen`() = runTest {
         val viewModel = createViewModel(customer = EMPTY_CUSTOMER_STATE)
-        viewModel.currentScreen.test {
+        viewModel.navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isInstanceOf<AddFirstPaymentMethod>()
             viewModel.paymentSheetResult.test {
                 viewModel.handleBackPressed()
@@ -1501,7 +1501,7 @@ internal class PaymentSheetViewModelTest {
             )
         )
         viewModel.transitionToAddPaymentScreen()
-        viewModel.currentScreen.test {
+        viewModel.navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isInstanceOf<AddAnotherPaymentMethod>()
             viewModel.handleBackPressed()
             assertThat(awaitItem()).isInstanceOf<SelectSavedPaymentMethods>()
@@ -1512,7 +1512,7 @@ internal class PaymentSheetViewModelTest {
     fun `current screen is AddFirstPaymentMethod if payment methods is empty`() = runTest {
         val viewModel = createViewModel(customer = EMPTY_CUSTOMER_STATE)
 
-        viewModel.currentScreen.test {
+        viewModel.navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isInstanceOf<AddFirstPaymentMethod>()
         }
     }
@@ -1525,7 +1525,7 @@ internal class PaymentSheetViewModelTest {
             )
         )
 
-        viewModel.currentScreen.test {
+        viewModel.navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isInstanceOf<SelectSavedPaymentMethods>()
         }
     }
@@ -1560,7 +1560,7 @@ internal class PaymentSheetViewModelTest {
         )
 
         turbineScope {
-            val receiver = viewModel.currentScreen.testIn(this)
+            val receiver = viewModel.navigationHandler.currentScreen.testIn(this)
 
             verify(eventReporter).onShowNewPaymentOptionForm()
 
@@ -1581,7 +1581,7 @@ internal class PaymentSheetViewModelTest {
         )
 
         turbineScope {
-            val receiver = viewModel.currentScreen.testIn(this)
+            val receiver = viewModel.navigationHandler.currentScreen.testIn(this)
 
             verify(eventReporter).onShowNewPaymentOptionForm()
 
@@ -1602,7 +1602,7 @@ internal class PaymentSheetViewModelTest {
         )
 
         turbineScope {
-            val receiver = viewModel.currentScreen.testIn(this)
+            val receiver = viewModel.navigationHandler.currentScreen.testIn(this)
 
             verify(eventReporter).onShowNewPaymentOptionForm()
 
@@ -1741,7 +1741,7 @@ internal class PaymentSheetViewModelTest {
             customer = EMPTY_CUSTOMER_STATE.copy(paymentMethods = paymentMethods)
         )
 
-        viewModel.currentScreen.test {
+        viewModel.navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isInstanceOf<SelectSavedPaymentMethods>()
             viewModel.removePaymentMethod(paymentMethods.single())
             assertThat(awaitItem()).isInstanceOf<AddFirstPaymentMethod>()
@@ -2740,7 +2740,7 @@ internal class PaymentSheetViewModelTest {
             customerRepository = customerRepository,
         )
 
-        viewModel.currentScreen.test {
+        viewModel.navigationHandler.currentScreen.test {
             awaitItem()
 
             viewModel.modifyPaymentMethod(CARD_WITH_NETWORKS_PAYMENT_METHOD)
@@ -2807,7 +2807,7 @@ internal class PaymentSheetViewModelTest {
             ),
             stripeIntent = stripeIntent
         )
-        viewModel.currentScreen.test {
+        viewModel.navigationHandler.currentScreen.test {
             val screen = awaitItem()
             assertThat(screen).isInstanceOf<SelectSavedPaymentMethods>()
             assertThat(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/NavigationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/NavigationHandlerTest.kt
@@ -1,0 +1,172 @@
+package com.stripe.android.paymentsheet.navigation
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import java.io.Closeable
+
+internal class NavigationHandlerTest {
+    @Test
+    fun `currentScreen is initialized to Loading`() = runTest {
+        val navigationHandler = NavigationHandler()
+        navigationHandler.currentScreen.test {
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
+            assertThat(navigationHandler.canGoBack).isFalse()
+        }
+    }
+
+    @Test
+    fun `transitionTo removes Loading`() = runTest {
+        val navigationHandler = NavigationHandler()
+        navigationHandler.currentScreen.test {
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
+            val newScreen = mock<PaymentSheetScreen>()
+            navigationHandler.transitionTo(newScreen)
+            assertThat(awaitItem()).isEqualTo(newScreen)
+            assertThat(navigationHandler.canGoBack).isFalse()
+        }
+    }
+
+    @Test
+    fun `transitionTo keeps backstack`() = runTest {
+        val navigationHandler = NavigationHandler()
+        navigationHandler.currentScreen.test {
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
+            val screenOne = mock<PaymentSheetScreen>()
+            navigationHandler.transitionTo(screenOne)
+            assertThat(awaitItem()).isEqualTo(screenOne)
+            val screenTwo = mock<PaymentSheetScreen>()
+            navigationHandler.transitionTo(screenTwo)
+            assertThat(awaitItem()).isEqualTo(screenTwo)
+            assertThat(navigationHandler.canGoBack).isTrue()
+        }
+    }
+
+    @Test
+    fun `resetTo resets backstack`() = runTest {
+        val navigationHandler = NavigationHandler()
+        navigationHandler.currentScreen.test {
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
+            val screenOne = mock<PaymentSheetScreen>()
+            navigationHandler.transitionTo(screenOne)
+            assertThat(awaitItem()).isEqualTo(screenOne)
+            val screenTwo = mock<PaymentSheetScreen>()
+            navigationHandler.transitionTo(screenTwo)
+            assertThat(awaitItem()).isEqualTo(screenTwo)
+            assertThat(navigationHandler.canGoBack).isTrue()
+            val screenThree = mock<PaymentSheetScreen>()
+            navigationHandler.resetTo(listOf(screenThree))
+            assertThat(awaitItem()).isEqualTo(screenThree)
+            assertThat(navigationHandler.canGoBack).isFalse()
+        }
+    }
+
+    @Test
+    fun `resetTo calls close on removed screens`() = runTest {
+        val navigationHandler = NavigationHandler()
+        navigationHandler.currentScreen.test {
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
+            val screenOne = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
+            navigationHandler.transitionTo(screenOne)
+            assertThat(awaitItem()).isEqualTo(screenOne)
+            val screenTwo = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
+            navigationHandler.transitionTo(screenTwo)
+            assertThat(awaitItem()).isEqualTo(screenTwo)
+            assertThat(navigationHandler.canGoBack).isTrue()
+            val screenThree = mock<PaymentSheetScreen>()
+            navigationHandler.resetTo(listOf(screenThree))
+            assertThat(awaitItem()).isEqualTo(screenThree)
+            assertThat(navigationHandler.canGoBack).isFalse()
+            verify(screenOne as Closeable).close()
+            verify(screenTwo as Closeable).close()
+        }
+    }
+
+    @Test
+    fun `resetTo only calls close on removed screens`() = runTest {
+        val navigationHandler = NavigationHandler()
+        navigationHandler.currentScreen.test {
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
+            val screenOne = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
+            navigationHandler.transitionTo(screenOne)
+            assertThat(awaitItem()).isEqualTo(screenOne)
+            val screenTwo = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
+            navigationHandler.transitionTo(screenTwo)
+            assertThat(awaitItem()).isEqualTo(screenTwo)
+            assertThat(navigationHandler.canGoBack).isTrue()
+            val screenThree = mock<PaymentSheetScreen>()
+            navigationHandler.resetTo(listOf(screenTwo, screenThree))
+            assertThat(awaitItem()).isEqualTo(screenThree)
+            verify(screenOne as Closeable).close()
+            verify(screenTwo as Closeable, never()).close()
+        }
+    }
+
+    @Test
+    fun `pop removes the top screen from the backstack`() = runTest {
+        val navigationHandler = NavigationHandler()
+        navigationHandler.currentScreen.test {
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
+            val screenOne = mock<PaymentSheetScreen>()
+            navigationHandler.transitionTo(screenOne)
+            assertThat(awaitItem()).isEqualTo(screenOne)
+            val screenTwo = mock<PaymentSheetScreen>()
+            navigationHandler.transitionTo(screenTwo)
+            assertThat(awaitItem()).isEqualTo(screenTwo)
+            assertThat(navigationHandler.canGoBack).isTrue()
+            var calledPopHandler = false
+            navigationHandler.pop {
+                calledPopHandler = true
+                assertThat(it).isEqualTo(screenTwo)
+            }
+            assertThat(calledPopHandler).isTrue()
+            assertThat(awaitItem()).isEqualTo(screenOne)
+            assertThat(navigationHandler.canGoBack).isFalse()
+        }
+    }
+
+    @Test
+    fun `pop removes the top screen from the backstack and calls close`() = runTest {
+        val navigationHandler = NavigationHandler()
+        navigationHandler.currentScreen.test {
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
+            val screenOne = mock<PaymentSheetScreen>()
+            navigationHandler.transitionTo(screenOne)
+            assertThat(awaitItem()).isEqualTo(screenOne)
+            val screenTwo = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
+            navigationHandler.transitionTo(screenTwo)
+            assertThat(awaitItem()).isEqualTo(screenTwo)
+            assertThat(navigationHandler.canGoBack).isTrue()
+            var calledPopHandler = false
+            navigationHandler.pop {
+                calledPopHandler = true
+                assertThat(it).isEqualTo(screenTwo)
+            }
+            assertThat(calledPopHandler).isTrue()
+            assertThat(awaitItem()).isEqualTo(screenOne)
+            assertThat(navigationHandler.canGoBack).isFalse()
+            verify(screenTwo as Closeable).close()
+        }
+    }
+
+    @Test
+    fun `closeScreens calls close on all closable screens in the backstack`() = runTest {
+        val navigationHandler = NavigationHandler()
+        navigationHandler.currentScreen.test {
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
+            val screenOne = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
+            navigationHandler.transitionTo(screenOne)
+            assertThat(awaitItem()).isEqualTo(screenOne)
+            val screenTwo = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
+            navigationHandler.transitionTo(screenTwo)
+            assertThat(awaitItem()).isEqualTo(screenTwo)
+            navigationHandler.closeScreens()
+            verify(screenOne as Closeable).close()
+            verify(screenTwo as Closeable).close()
+        }
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
The goal is to chip away at the state/behavior in BaseSheetViewModel.

This was an easy win.
