### PR TITLE
Move `create` function into `load` in `PaymentSheetLoader`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -85,7 +85,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         paymentSheetConfiguration: PaymentSheet.Configuration,
         isReloadingAfterProcessDeath: Boolean,
         initializedViaCompose: Boolean,
-    ): Result<PaymentSheetState.Full> = withTask(::reportFailedLoad) {
+    ): Result<PaymentSheetState.Full> = withContextCatching(::reportFailedLoad) {
         eventReporter.onLoadStarted(initializedViaCompose)
 
         val savedPaymentMethodSelection = retrieveSavedPaymentMethodSelection(paymentSheetConfiguration)
@@ -163,7 +163,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             isGooglePaySupported = isGooglePaySupported(),
         )
 
-        return@withTask state
+        return@withContextCatching state
     }
 
     private suspend fun isGooglePayReady(
@@ -632,7 +632,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
      * it. If a failure occurs, we can also run the 'onFailure' logic inside the outer work coroutine rather than the
      * caller's coroutine.
      */
-    private suspend fun <T> withTask(
+    private suspend fun <T> withContextCatching(
         onFailure: (error: Throwable) -> Unit,
         task: suspend CoroutineScope.() -> T
     ): Result<T> {


### PR DESCRIPTION
# Summary
Move logic in `create` function into the primary `load` function in `PaymentSheetLoader`

# Motivation
Makes loading process easier to read at a high level without needing to read through the file.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
