### PR TITLE
Extract analytics notifications into its own type.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -46,7 +46,7 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
         }
 
         if (!applicationIsTaskOwner()) {
-            viewModel.cannotProperlyReturnFromLinkAndOtherLPMs()
+            viewModel.analyticsListener.cannotProperlyReturnFromLinkAndOtherLPMs()
         }
 
         setContent {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -86,7 +86,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
         customPrimaryButtonUiStateFlow = customPrimaryButtonUiState,
         cvcCompleteFlow = cvcRecollectionCompleteFlow,
         onClick = {
-            reportConfirmButtonPressed()
+            eventReporter.onPressConfirmButton(selection.value)
             onUserSelection()
         },
     )
@@ -229,7 +229,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     }
 
     override fun onUserCancel() {
-        reportDismiss()
+        eventReporter.onDismiss()
         _paymentOptionResult.tryEmit(
             PaymentOptionResult.Canceled(
                 mostRecentError = mostRecentError,
@@ -299,7 +299,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
 
     override fun handleConfirmUSBankAccount(paymentSelection: PaymentSelection.New.USBankAccount) {
         updateSelection(paymentSelection)
-        reportConfirmButtonPressed()
+        eventReporter.onPressConfirmButton(selection.value)
         onUserSelection()
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -60,7 +60,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
         )
 
         if (!applicationIsTaskOwner()) {
-            viewModel.cannotProperlyReturnFromLinkAndOtherLPMs()
+            viewModel.analyticsListener.cannotProperlyReturnFromLinkAndOtherLPMs()
         }
 
         setContent {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -137,7 +137,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         customPrimaryButtonUiStateFlow = customPrimaryButtonUiState,
         cvcCompleteFlow = cvcRecollectionCompleteFlow,
         onClick = {
-            reportConfirmButtonPressed()
+            eventReporter.onPressConfirmButton(selection.value)
             checkout()
         },
     )
@@ -540,7 +540,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     override fun handleConfirmUSBankAccount(paymentSelection: PaymentSelection.New.USBankAccount) {
         updateSelection(paymentSelection)
-        reportConfirmButtonPressed()
+        eventReporter.onPressConfirmButton(selection.value)
         checkout()
     }
 
@@ -820,7 +820,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     override fun onUserCancel() {
-        reportDismiss()
+        eventReporter.onDismiss()
         _paymentSheetResult.tryEmit(PaymentSheetResult.Canceled)
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsListener.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsListener.kt
@@ -63,19 +63,6 @@ internal class PaymentSheetAnalyticsListener(
         }
     }
 
-    fun reportPaymentMethodTypeSelected(code: PaymentMethodCode) {
-        eventReporter.onSelectPaymentMethod(code)
-        reportFormShown(code)
-    }
-
-    fun reportAutofillEvent(type: String) {
-        eventReporter.onAutofill(type)
-    }
-
-    fun reportCardNumberCompleted() {
-        eventReporter.onCardNumberCompleted()
-    }
-
     private fun reportPaymentSheetShown(currentScreen: PaymentSheetScreen) {
         when (currentScreen) {
             is PaymentSheetScreen.Loading,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsListener.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsListener.kt
@@ -1,0 +1,130 @@
+package com.stripe.android.paymentsheet.analytics
+
+import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddAnotherPaymentMethod
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddFirstPaymentMethod
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+internal class PaymentSheetAnalyticsListener(
+    private val savedStateHandle: SavedStateHandle,
+    private val eventReporter: EventReporter,
+    currentScreen: Flow<PaymentSheetScreen>,
+    coroutineScope: CoroutineScope,
+    private val currentPaymentMethodTypeProvider: () -> String
+) {
+    private var previouslySentDeepLinkEvent: Boolean
+        get() = savedStateHandle[PREVIOUSLY_SENT_DEEP_LINK_EVENT] ?: false
+        set(value) {
+            savedStateHandle[PREVIOUSLY_SENT_DEEP_LINK_EVENT] = value
+        }
+
+    private var previouslyShownForm: PaymentMethodCode?
+        get() = savedStateHandle[PREVIOUSLY_SHOWN_PAYMENT_FORM]
+        set(value) {
+            savedStateHandle[PREVIOUSLY_SHOWN_PAYMENT_FORM] = value
+        }
+
+    private var previouslyInteractedForm: PaymentMethodCode?
+        get() = savedStateHandle[PREVIOUSLY_INTERACTION_PAYMENT_FORM]
+        set(value) {
+            savedStateHandle[PREVIOUSLY_INTERACTION_PAYMENT_FORM] = value
+        }
+
+    init {
+        coroutineScope.launch {
+            currentScreen.collectLatest { screen ->
+                reportPaymentSheetShown(screen)
+            }
+        }
+    }
+
+    fun cannotProperlyReturnFromLinkAndOtherLPMs() {
+        if (!previouslySentDeepLinkEvent) {
+            eventReporter.onCannotProperlyReturnFromLinkAndOtherLPMs()
+
+            previouslySentDeepLinkEvent = true
+        }
+    }
+
+    fun reportFieldInteraction(code: PaymentMethodCode) {
+        /*
+         * Prevents this event from being reported multiple times on field interactions
+         * on the same payment form. We should have one field interaction event for
+         * every form shown event triggered.
+         */
+        if (previouslyInteractedForm != code) {
+            eventReporter.onPaymentMethodFormInteraction(code)
+            previouslyInteractedForm = code
+        }
+    }
+
+    fun reportPaymentMethodTypeSelected(code: PaymentMethodCode) {
+        eventReporter.onSelectPaymentMethod(code)
+        reportFormShown(code)
+    }
+
+    fun reportAutofillEvent(type: String) {
+        eventReporter.onAutofill(type)
+    }
+
+    fun reportCardNumberCompleted() {
+        eventReporter.onCardNumberCompleted()
+    }
+
+    private fun reportPaymentSheetShown(currentScreen: PaymentSheetScreen) {
+        when (currentScreen) {
+            is PaymentSheetScreen.Loading,
+            is PaymentSheetScreen.Form,
+            is PaymentSheetScreen.ManageOneSavedPaymentMethod,
+            is PaymentSheetScreen.ManageSavedPaymentMethods -> {
+                // Nothing to do here
+            }
+            is PaymentSheetScreen.EditPaymentMethod -> {
+                eventReporter.onShowEditablePaymentOption()
+            }
+            is PaymentSheetScreen.SelectSavedPaymentMethods -> {
+                eventReporter.onShowExistingPaymentOptions()
+                previouslyShownForm = null
+                previouslyInteractedForm = null
+            }
+            is AddFirstPaymentMethod, is AddAnotherPaymentMethod, is PaymentSheetScreen.VerticalMode -> {
+                reportFormShown(currentPaymentMethodTypeProvider())
+                eventReporter.onShowNewPaymentOptionForm()
+            }
+        }
+    }
+
+    fun reportPaymentSheetHidden(hiddenScreen: PaymentSheetScreen) {
+        when (hiddenScreen) {
+            is PaymentSheetScreen.EditPaymentMethod -> {
+                eventReporter.onHideEditablePaymentOption()
+            }
+            else -> {
+                // Events for hiding other screens not supported
+            }
+        }
+    }
+
+    private fun reportFormShown(code: String) {
+        /*
+         * Prevents this event from being reported multiple times on the same payment form after process death. We
+         * should only trigger a form shown event when initially shown in the add payment method screen or the user
+         * navigates to a different form.
+         */
+        if (previouslyShownForm != code) {
+            eventReporter.onPaymentMethodFormShown(code)
+            previouslyShownForm = code
+        }
+    }
+
+    companion object {
+        internal const val PREVIOUSLY_SHOWN_PAYMENT_FORM = "previously_shown_payment_form"
+        internal const val PREVIOUSLY_INTERACTION_PAYMENT_FORM = "previously_interacted_payment_form"
+        internal const val PREVIOUSLY_SENT_DEEP_LINK_EVENT = "previously_sent_deep_link_event"
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodInteractor.kt
@@ -83,9 +83,9 @@ internal class DefaultAddPaymentMethodInteractor(
         formElementsForCode = sheetViewModel::formElementsForCode,
         clearErrorMessages = sheetViewModel::clearErrorMessages,
         onLinkSignUpStateUpdated = sheetViewModel::onLinkSignUpStateUpdated,
-        reportFieldInteraction = sheetViewModel::reportFieldInteraction,
+        reportFieldInteraction = sheetViewModel.analyticsListener::reportFieldInteraction,
         onFormFieldValuesChanged = sheetViewModel::onFormFieldValuesChanged,
-        reportPaymentMethodTypeSelected = sheetViewModel::reportPaymentMethodTypeSelected,
+        reportPaymentMethodTypeSelected = sheetViewModel.analyticsListener::reportPaymentMethodTypeSelected,
         createUSBankAccountFormArguments = {
             USBankAccountFormArguments.create(
                 viewModel = sheetViewModel,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodInteractor.kt
@@ -85,7 +85,7 @@ internal class DefaultAddPaymentMethodInteractor(
         onLinkSignUpStateUpdated = sheetViewModel::onLinkSignUpStateUpdated,
         reportFieldInteraction = sheetViewModel.analyticsListener::reportFieldInteraction,
         onFormFieldValuesChanged = sheetViewModel::onFormFieldValuesChanged,
-        reportPaymentMethodTypeSelected = sheetViewModel.analyticsListener::reportPaymentMethodTypeSelected,
+        reportPaymentMethodTypeSelected = sheetViewModel.eventReporter::onSelectPaymentMethod,
         createUSBankAccountFormArguments = {
             USBankAccountFormArguments.create(
                 viewModel = sheetViewModel,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -232,8 +232,8 @@ private fun PaymentSheetContent(
 
         Column(modifier = Modifier.fillMaxWidth()) {
             CompositionLocalProvider(
-                LocalAutofillEventReporter provides viewModel::reportAutofillEvent,
-                LocalCardNumberCompletedEventReporter provides viewModel::reportCardNumberCompleted,
+                LocalAutofillEventReporter provides viewModel.analyticsListener::reportAutofillEvent,
+                LocalCardNumberCompletedEventReporter provides viewModel.analyticsListener::reportCardNumberCompleted,
             ) {
                 currentScreen.Content(
                     viewModel = viewModel,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -232,8 +232,8 @@ private fun PaymentSheetContent(
 
         Column(modifier = Modifier.fillMaxWidth()) {
             CompositionLocalProvider(
-                LocalAutofillEventReporter provides viewModel.analyticsListener::reportAutofillEvent,
-                LocalCardNumberCompletedEventReporter provides viewModel.analyticsListener::reportCardNumberCompleted,
+                LocalAutofillEventReporter provides viewModel.eventReporter::onAutofill,
+                LocalCardNumberCompletedEventReporter provides viewModel.eventReporter::onCardNumberCompleted,
             ) {
                 currentScreen.Content(
                     viewModel = viewModel,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
@@ -70,7 +70,7 @@ internal class DefaultVerticalModeFormInteractor(
     override fun handleViewAction(viewAction: VerticalModeFormInteractor.ViewAction) {
         when (viewAction) {
             VerticalModeFormInteractor.ViewAction.FieldInteraction -> {
-                viewModel.reportFieldInteraction(selectedPaymentMethodCode)
+                viewModel.analyticsListener.reportFieldInteraction(selectedPaymentMethodCode)
             }
             is VerticalModeFormInteractor.ViewAction.FormFieldValuesChanged -> {
                 viewModel.onFormFieldValuesChanged(viewAction.formValues, selectedPaymentMethodCode)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -53,7 +53,6 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
@@ -775,18 +774,6 @@ internal class PaymentOptionsViewModelTest {
             assertThat(state?.link).isEqualTo(WalletsState.Link(email = null))
             assertThat(state?.googlePay).isNull()
         }
-    }
-
-    @Test
-    fun `on cannot properly return from link or other lpms, should report event at maximum once`() = runTest {
-        val viewModel = createViewModel()
-
-        viewModel.cannotProperlyReturnFromLinkAndOtherLPMs()
-        viewModel.cannotProperlyReturnFromLinkAndOtherLPMs()
-        viewModel.cannotProperlyReturnFromLinkAndOtherLPMs()
-        viewModel.cannotProperlyReturnFromLinkAndOtherLPMs()
-
-        verify(eventReporter, times(1)).onCannotProperlyReturnFromLinkAndOtherLPMs()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -2606,18 +2606,6 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `on cannot properly return from link or other lpms, should report event at maximum once`() = runTest {
-        val viewModel = createViewModel()
-
-        viewModel.cannotProperlyReturnFromLinkAndOtherLPMs()
-        viewModel.cannotProperlyReturnFromLinkAndOtherLPMs()
-        viewModel.cannotProperlyReturnFromLinkAndOtherLPMs()
-        viewModel.cannotProperlyReturnFromLinkAndOtherLPMs()
-
-        verify(eventReporter, times(1)).onCannotProperlyReturnFromLinkAndOtherLPMs()
-    }
-
-    @Test
     fun `on navigate to AddPaymentMethod screen, should report form shown event`() = runTest {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP,
@@ -2628,34 +2616,6 @@ internal class PaymentSheetViewModelTest {
         viewModel.transitionToAddPaymentScreen()
 
         verify(eventReporter).onPaymentMethodFormShown("card")
-    }
-
-    @Test
-    fun `on payment form changed, should report form shown event`() = runTest {
-        val viewModel = createViewModel(
-            isGooglePayReady = true,
-            stripeIntent = SETUP_INTENT,
-            customer = EMPTY_CUSTOMER_STATE,
-        )
-
-        viewModel.reportPaymentMethodTypeSelected("us_bank_account")
-
-        verify(eventReporter).onPaymentMethodFormShown("us_bank_account")
-    }
-
-    @Test
-    fun `on form changed to same value, should report form shown event only once`() = runTest {
-        val viewModel = createViewModel(
-            isGooglePayReady = true,
-            stripeIntent = SETUP_INTENT,
-            customer = EMPTY_CUSTOMER_STATE,
-        )
-
-        viewModel.reportPaymentMethodTypeSelected("us_bank_account")
-        viewModel.reportPaymentMethodTypeSelected("us_bank_account")
-        viewModel.reportPaymentMethodTypeSelected("us_bank_account")
-
-        verify(eventReporter, times(1)).onPaymentMethodFormShown("us_bank_account")
     }
 
     @Test
@@ -2671,47 +2631,6 @@ internal class PaymentSheetViewModelTest {
         viewModel.transitionToAddPaymentScreen()
 
         verify(eventReporter, times(2)).onPaymentMethodFormShown("card")
-    }
-
-    @Test
-    fun `on field interaction, should report event`() = runTest {
-        val viewModel = createViewModel(
-            args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP,
-            isGooglePayReady = true,
-            stripeIntent = SETUP_INTENT,
-        )
-
-        viewModel.reportFieldInteraction("card")
-
-        verify(eventReporter).onPaymentMethodFormInteraction("card")
-    }
-
-    @Test
-    fun `on multiple field interactions with same payment form, should report event only once`() = runTest {
-        val viewModel = createViewModel(
-            args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP,
-            isGooglePayReady = true,
-            stripeIntent = SETUP_INTENT,
-        )
-
-        viewModel.reportFieldInteraction("card")
-        viewModel.reportFieldInteraction("card")
-        viewModel.reportFieldInteraction("card")
-
-        verify(eventReporter, times(1)).onPaymentMethodFormInteraction("card")
-    }
-
-    @Test
-    fun `on card number completed event, should report event`() = runTest {
-        val viewModel = createViewModel(
-            args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP,
-            isGooglePayReady = true,
-            stripeIntent = SETUP_INTENT,
-        )
-
-        viewModel.reportCardNumberCompleted()
-
-        verify(eventReporter).onCardNumberCompleted()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsListenerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsListenerTest.kt
@@ -1,0 +1,186 @@
+package com.stripe.android.paymentsheet.analytics
+
+import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.runTest
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.clearInvocations
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
+import kotlin.test.Test
+
+class PaymentSheetAnalyticsListenerTest {
+    @Test
+    fun `cannotProperlyReturnFromLinkAndOtherLPMs should report event at maximum once`() = runScenario {
+        analyticsListener.cannotProperlyReturnFromLinkAndOtherLPMs()
+        analyticsListener.cannotProperlyReturnFromLinkAndOtherLPMs()
+        analyticsListener.cannotProperlyReturnFromLinkAndOtherLPMs()
+        analyticsListener.cannotProperlyReturnFromLinkAndOtherLPMs()
+
+        verify(eventReporter, times(1)).onCannotProperlyReturnFromLinkAndOtherLPMs()
+    }
+
+    @Test
+    fun `reportPaymentMethodTypeSelected should report form shown event only once`() = runScenario {
+        analyticsListener.reportPaymentMethodTypeSelected("us_bank_account")
+        analyticsListener.reportPaymentMethodTypeSelected("us_bank_account")
+        analyticsListener.reportPaymentMethodTypeSelected("us_bank_account")
+
+        verify(eventReporter, times(1)).onPaymentMethodFormShown("us_bank_account")
+        verify(eventReporter, times(3)).onSelectPaymentMethod("us_bank_account")
+    }
+
+    @Test
+    fun `reportPaymentMethodTypeSelected should report changes in form shown event`() = runScenario {
+        analyticsListener.reportPaymentMethodTypeSelected("us_bank_account")
+        verify(eventReporter).onPaymentMethodFormShown("us_bank_account")
+        verify(eventReporter).onSelectPaymentMethod("us_bank_account")
+        analyticsListener.reportPaymentMethodTypeSelected("card")
+        verify(eventReporter).onPaymentMethodFormShown("card")
+        verify(eventReporter).onSelectPaymentMethod("card")
+        analyticsListener.reportPaymentMethodTypeSelected("cashapp")
+        verify(eventReporter).onPaymentMethodFormShown("cashapp")
+        verify(eventReporter).onSelectPaymentMethod("cashapp")
+    }
+
+    @Test
+    fun `on field interaction, should report event`() = runScenario {
+        analyticsListener.reportFieldInteraction("card")
+
+        verify(eventReporter).onPaymentMethodFormInteraction("card")
+    }
+
+    @Test
+    fun `on multiple field interactions with same payment form, should report event only once`() = runScenario {
+        analyticsListener.reportFieldInteraction("card")
+        analyticsListener.reportFieldInteraction("card")
+        analyticsListener.reportFieldInteraction("card")
+
+        verify(eventReporter, times(1)).onPaymentMethodFormInteraction("card")
+    }
+
+    @Test
+    fun `reportAutofillEvent, should report event`() = runScenario {
+        analyticsListener.reportAutofillEvent("autofill_type")
+
+        verify(eventReporter).onAutofill(eq("autofill_type"))
+    }
+
+    @Test
+    fun `on card number completed event, should report event`() = runScenario {
+        analyticsListener.reportCardNumberCompleted()
+
+        verify(eventReporter).onCardNumberCompleted()
+    }
+
+    @Test
+    fun `reportPaymentSheetHidden reports for Edit`() = runScenario {
+        analyticsListener.reportPaymentSheetHidden(mock<PaymentSheetScreen.EditPaymentMethod>())
+
+        verify(eventReporter).onHideEditablePaymentOption()
+    }
+
+    @Test
+    fun `reportPaymentSheetHidden does not report for non edit screens`() = runScenario {
+        analyticsListener.reportPaymentSheetHidden(PaymentSheetScreen.Loading)
+
+        verifyNoInteractions(eventReporter)
+    }
+
+    @Test
+    fun `onShowEditablePaymentOption is called when screen updates to EditPaymentMethod`() = runScenario {
+        verifyNoInteractions(eventReporter)
+        currentScreen.value = mock<PaymentSheetScreen.EditPaymentMethod>()
+        testScheduler.advanceUntilIdle()
+        verify(eventReporter).onShowEditablePaymentOption()
+    }
+
+    @Test
+    fun `onShowExistingPaymentOptions is called when screen updates to SelectSavedPaymentMethods`() = runScenario {
+        currentScreen.value = mock<PaymentSheetScreen.SelectSavedPaymentMethods>()
+        testScheduler.advanceUntilIdle()
+        verify(eventReporter).onShowExistingPaymentOptions()
+    }
+
+    @Test
+    fun `form events are emitted when screen changes to one with a form`() = runScenario {
+        val screenTypes = listOf(
+            PaymentSheetScreen.AddFirstPaymentMethod::class,
+            PaymentSheetScreen.AddAnotherPaymentMethod::class,
+            PaymentSheetScreen.VerticalMode::class,
+        )
+        screenTypes.forEach { screenType ->
+            currentScreen.value = mock(screenType.java)
+            testScheduler.advanceUntilIdle()
+        }
+
+        verify(eventReporter, times(screenTypes.size)).onShowNewPaymentOptionForm()
+        // Only once since it didn't change.
+        verify(eventReporter).onPaymentMethodFormShown(eq("card"))
+    }
+
+    @Test
+    fun `debounced analytics are re-emitted after navigating to SelectSavedPaymentMethods`() = runScenario {
+        currentScreen.value = mock<PaymentSheetScreen.AddAnotherPaymentMethod>()
+        testScheduler.advanceUntilIdle()
+        verify(eventReporter).onShowNewPaymentOptionForm()
+        verify(eventReporter).onPaymentMethodFormShown(eq("card"))
+        analyticsListener.reportFieldInteraction("card")
+        verify(eventReporter).onPaymentMethodFormInteraction(eq("card"))
+        verifyNoMoreInteractions(eventReporter)
+        clearInvocations(eventReporter)
+
+        currentScreen.value = mock<PaymentSheetScreen.SelectSavedPaymentMethods>()
+        testScheduler.advanceUntilIdle()
+        verify(eventReporter).onShowExistingPaymentOptions()
+        verifyNoMoreInteractions(eventReporter)
+        clearInvocations(eventReporter)
+
+        currentScreen.value = mock<PaymentSheetScreen.AddAnotherPaymentMethod>()
+        testScheduler.advanceUntilIdle()
+        verify(eventReporter).onShowNewPaymentOptionForm()
+        verify(eventReporter).onPaymentMethodFormShown(eq("card"))
+        analyticsListener.reportFieldInteraction("card")
+        verify(eventReporter).onPaymentMethodFormInteraction(eq("card"))
+    }
+
+    private fun runScenario(block: Scenario.() -> Unit) {
+        runTest {
+            val eventReporter = mock<EventReporter>()
+            val currentScreen = MutableStateFlow<PaymentSheetScreen>(PaymentSheetScreen.Loading)
+            val currentPaymentMethodTypeProvider = { "card" }
+            val coroutineScope = CoroutineScope(coroutineContext + SupervisorJob())
+            val analyticsListener = PaymentSheetAnalyticsListener(
+                savedStateHandle = SavedStateHandle(),
+                eventReporter = eventReporter,
+                currentScreen = currentScreen,
+                coroutineScope = coroutineScope,
+                currentPaymentMethodTypeProvider = currentPaymentMethodTypeProvider
+            )
+            Scenario(
+                analyticsListener = analyticsListener,
+                eventReporter = eventReporter,
+                currentScreen = currentScreen,
+                testScheduler = testScheduler,
+            ).apply(block)
+            testScheduler.advanceUntilIdle()
+            coroutineScope.cancel()
+            verifyNoMoreInteractions(eventReporter)
+        }
+    }
+
+    private class Scenario(
+        val analyticsListener: PaymentSheetAnalyticsListener,
+        val eventReporter: EventReporter,
+        val currentScreen: MutableStateFlow<PaymentSheetScreen>,
+        val testScheduler: TestCoroutineScheduler,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsListenerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsListenerTest.kt
@@ -29,29 +29,6 @@ class PaymentSheetAnalyticsListenerTest {
     }
 
     @Test
-    fun `reportPaymentMethodTypeSelected should report form shown event only once`() = runScenario {
-        analyticsListener.reportPaymentMethodTypeSelected("us_bank_account")
-        analyticsListener.reportPaymentMethodTypeSelected("us_bank_account")
-        analyticsListener.reportPaymentMethodTypeSelected("us_bank_account")
-
-        verify(eventReporter, times(1)).onPaymentMethodFormShown("us_bank_account")
-        verify(eventReporter, times(3)).onSelectPaymentMethod("us_bank_account")
-    }
-
-    @Test
-    fun `reportPaymentMethodTypeSelected should report changes in form shown event`() = runScenario {
-        analyticsListener.reportPaymentMethodTypeSelected("us_bank_account")
-        verify(eventReporter).onPaymentMethodFormShown("us_bank_account")
-        verify(eventReporter).onSelectPaymentMethod("us_bank_account")
-        analyticsListener.reportPaymentMethodTypeSelected("card")
-        verify(eventReporter).onPaymentMethodFormShown("card")
-        verify(eventReporter).onSelectPaymentMethod("card")
-        analyticsListener.reportPaymentMethodTypeSelected("cashapp")
-        verify(eventReporter).onPaymentMethodFormShown("cashapp")
-        verify(eventReporter).onSelectPaymentMethod("cashapp")
-    }
-
-    @Test
     fun `on field interaction, should report event`() = runScenario {
         analyticsListener.reportFieldInteraction("card")
 
@@ -65,20 +42,6 @@ class PaymentSheetAnalyticsListenerTest {
         analyticsListener.reportFieldInteraction("card")
 
         verify(eventReporter, times(1)).onPaymentMethodFormInteraction("card")
-    }
-
-    @Test
-    fun `reportAutofillEvent, should report event`() = runScenario {
-        analyticsListener.reportAutofillEvent("autofill_type")
-
-        verify(eventReporter).onAutofill(eq("autofill_type"))
-    }
-
-    @Test
-    fun `on card number completed event, should report event`() = runScenario {
-        analyticsListener.reportCardNumberCompleted()
-
-        verify(eventReporter).onCardNumberCompleted()
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Moving the reading of screen transitions and analytics event coordination out of BaseSheetViewModel.
