### PR TITLE
Fix issue where removing a saved PM was ignored in vertical mode

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -181,6 +181,17 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         }
 
         coroutineScope.launch {
+            mostRecentlySelectedSavedPaymentMethod.collect { mostRecentlySelectedSavedPaymentMethod ->
+                if (
+                    mostRecentlySelectedSavedPaymentMethod == null &&
+                    verticalModeScreenSelection.value is PaymentSelection.Saved
+                ) {
+                    _verticalModeScreenSelection.value = null
+                }
+            }
+        }
+
+        coroutineScope.launch {
             isCurrentScreen.collect { isCurrentScreen ->
                 if (isCurrentScreen) {
                     updateSelection(verticalModeScreenSelection.value)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -241,6 +241,47 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
+    fun `removing multiple saved PMs leads to correct displayed saved PM`() {
+        val paymentMethods = PaymentMethodFixtures.createCards(5)
+        val displayedPM = paymentMethods[2]
+        runScenario(
+            initialPaymentMethods = paymentMethods,
+            initialMostRecentlySelectedSavedPaymentMethod = displayedPM,
+            updateSelection = {},
+        ) {
+            interactor.state.test {
+                awaitItem().run {
+                    assertThat(displayedSavedPaymentMethod).isNotNull()
+                    assertThat(displayedSavedPaymentMethod!!.paymentMethod).isEqualTo(displayedPM)
+                }
+            }
+
+            var updatedPaymentMethods = paymentMethods.subList(1, 4) // remove first and last PMs
+            paymentMethodsSource.value = updatedPaymentMethods
+            dispatcher.scheduler.advanceUntilIdle()
+
+            interactor.state.test {
+                awaitItem().run {
+                    assertThat(displayedSavedPaymentMethod).isNotNull()
+                    assertThat(displayedSavedPaymentMethod!!.paymentMethod).isEqualTo(displayedPM)
+                }
+            }
+
+            mostRecentlySelectedSavedPaymentMethodSource.value = null
+            updatedPaymentMethods = paymentMethods.minus(displayedPM)
+            paymentMethodsSource.value = updatedPaymentMethods
+            dispatcher.scheduler.advanceUntilIdle()
+
+            interactor.state.test {
+                awaitItem().run {
+                    assertThat(displayedSavedPaymentMethod).isNotNull()
+                    assertThat(displayedSavedPaymentMethod!!.paymentMethod).isEqualTo(updatedPaymentMethods[0])
+                }
+            }
+        }
+    }
+
+    @Test
     fun `state displays most recently selected PM if it exists`() {
         val displayedPM = PaymentMethodFixtures.CARD_PAYMENT_METHOD
         runScenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -91,6 +91,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
         )
         selectionSource.value = savedSelection
+        mostRecentlySelectedSavedPaymentMethodSource.value = PaymentMethodFixtures.CARD_PAYMENT_METHOD
 
         dispatcher.scheduler.advanceUntilIdle()
 
@@ -177,6 +178,63 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
                     assertThat(availableSavedPaymentMethodAction).isEqualTo(
                         PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE
                     )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `saved PM selection is removed if only saved pm is removed`() {
+        val displayedPM = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        runScenario(
+            initialPaymentMethods = listOf(displayedPM),
+            initialMostRecentlySelectedSavedPaymentMethod = displayedPM,
+            updateSelection = {},
+        ) {
+            interactor.state.test {
+                awaitItem().run {
+                    assertThat(displayedSavedPaymentMethod).isNotNull()
+                    assertThat(displayedSavedPaymentMethod!!.paymentMethod).isEqualTo(displayedPM)
+                }
+            }
+
+            mostRecentlySelectedSavedPaymentMethodSource.value = null
+            paymentMethodsSource.value = emptyList()
+            dispatcher.scheduler.advanceUntilIdle()
+
+            interactor.state.test {
+                awaitItem().run {
+                    assertThat(displayedSavedPaymentMethod).isNull()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `saved PM selection is updated if most recently selected saved pm is removed`() {
+        val paymentMethods = PaymentMethodFixtures.createCards(2)
+        val displayedPM = paymentMethods[0]
+        runScenario(
+            initialPaymentMethods = paymentMethods,
+            initialMostRecentlySelectedSavedPaymentMethod = displayedPM,
+            updateSelection = {},
+        ) {
+            interactor.state.test {
+                awaitItem().run {
+                    assertThat(displayedSavedPaymentMethod).isNotNull()
+                    assertThat(displayedSavedPaymentMethod!!.paymentMethod).isEqualTo(displayedPM)
+                }
+            }
+
+            mostRecentlySelectedSavedPaymentMethodSource.value = null
+            val updatedPaymentMethods = paymentMethods.minus(displayedPM)
+            paymentMethodsSource.value = updatedPaymentMethods
+            dispatcher.scheduler.advanceUntilIdle()
+
+            interactor.state.test {
+                awaitItem().run {
+                    assertThat(displayedSavedPaymentMethod).isNotNull()
+                    assertThat(displayedSavedPaymentMethod!!.paymentMethod).isEqualTo(updatedPaymentMethods[0])
                 }
             }
         }
@@ -732,11 +790,13 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         val initialPaymentSelection = PaymentSelection.Link
         runScenario(
             initialSelection = initialPaymentSelection,
+            initialPaymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
             updateSelection = {},
             formElementsForCode = { emptyList() }
         ) {
             val newSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
             selectionSource.value = newSelection
+            mostRecentlySelectedSavedPaymentMethodSource.value = newSelection.paymentMethod
 
             dispatcher.scheduler.advanceUntilIdle()
 
@@ -883,6 +943,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             selectionSource = selection,
             isCurrentScreenSource = isCurrentScreen,
             mostRecentlySelectedSavedPaymentMethodSource = mostRecentlySelectedSavedPaymentMethod,
+            paymentMethodsSource = paymentMethods,
             walletsState = walletsState,
             interactor = interactor,
             dispatcher = dispatcher,
@@ -898,6 +959,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         val selectionSource: MutableStateFlow<PaymentSelection?>,
         val isCurrentScreenSource: MutableStateFlow<Boolean>,
         val mostRecentlySelectedSavedPaymentMethodSource: MutableStateFlow<PaymentMethod?>,
+        val paymentMethodsSource: MutableStateFlow<List<PaymentMethod>?>,
         val walletsState: MutableStateFlow<WalletsState?>,
         val interactor: PaymentMethodVerticalLayoutInteractor,
         val dispatcher: TestDispatcher,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fix issue where removing a saved PM was ignored in vertical mode

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This bug was introduced [here](https://github.com/stripe/stripe-android/pull/8699/files#diff-c10926a315e7cbc11f1d02b5accf571e6a5badf047af137cfbbe33f2f03808a2R184-R187) and this PR fixes it. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified

We should also have integration tests for this because it relies on BSVM working properly. Added a note in our e2e tests [jira](https://jira.corp.stripe.com/browse/MOBILESDK-2152)