### PR TITLE
Use viewModelScope for interactor coroutineScope.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -61,8 +61,10 @@ import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
 import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.utils.mapAsStateFlow
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -586,6 +588,7 @@ internal class CustomerSheetViewModel(
                         }
                     },
                     canRemove = canRemove,
+                    coroutineScope = CoroutineScope(viewModelScope.coroutineContext + SupervisorJob()),
                 ),
                 isLiveMode = currentViewState.isLiveMode,
                 cbcEligibility = currentViewState.cbcEligibility,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -61,7 +61,6 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
                     viewModel.paymentOptionResult.filterNotNull().collect { sheetResult ->
                         setActivityResult(sheetResult)
                         bottomSheetState.hide()
-                        viewModel.navigationHandler.closeScreens()
                         finish()
                     }
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -75,7 +75,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
                     viewModel.paymentSheetResult.filterNotNull().collect { sheetResult ->
                         setActivityResult(sheetResult)
                         bottomSheetState.hide()
-                        viewModel.navigationHandler.closeScreens()
                         finish()
                     }
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/NavigationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/NavigationHandler.kt
@@ -47,12 +47,6 @@ internal class NavigationHandler {
         }
     }
 
-    fun closeScreens() {
-        backStack.value.forEach {
-            it.onClose()
-        }
-    }
-
     private fun PaymentSheetScreen.onClose() {
         when (this) {
             is Closeable -> close()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodInteractor.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.ui
 
+import androidx.lifecycle.viewModelScope
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.ui.inline.InlineSignupViewState
 import com.stripe.android.link.ui.inline.LinkSignupMode
@@ -14,13 +15,11 @@ import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFo
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.uicore.elements.FormElement
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import kotlin.coroutines.CoroutineContext
 
 internal interface AddPaymentMethodInteractor {
     val state: StateFlow<State>
@@ -69,7 +68,7 @@ internal class DefaultAddPaymentMethodInteractor(
     private val onFormFieldValuesChanged: (FormFieldValues?, String) -> Unit,
     private val reportPaymentMethodTypeSelected: (PaymentMethodCode) -> Unit,
     private val createUSBankAccountFormArguments: (PaymentMethodCode) -> USBankAccountFormArguments,
-    dispatcher: CoroutineContext = Dispatchers.Default,
+    private val coroutineScope: CoroutineScope,
 ) : AddPaymentMethodInteractor {
 
     constructor(sheetViewModel: BaseSheetViewModel) : this(
@@ -92,10 +91,9 @@ internal class DefaultAddPaymentMethodInteractor(
                 hostedSurface = CollectBankAccountLauncher.HOSTED_SURFACE_PAYMENT_ELEMENT,
                 selectedPaymentMethodCode = it
             )
-        }
+        },
+        coroutineScope = CoroutineScope(sheetViewModel.viewModelScope.coroutineContext + SupervisorJob()),
     )
-
-    private val coroutineScope = CoroutineScope(dispatcher + SupervisorJob())
 
     private val _selectedPaymentMethodCode: MutableStateFlow<String> =
         MutableStateFlow(initiallySelectedPaymentMethodType)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SelectSavedPaymentMethodsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SelectSavedPaymentMethodsInteractor.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.ui
 
+import androidx.lifecycle.viewModelScope
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentOptionsItem
 import com.stripe.android.paymentsheet.PaymentOptionsStateFactory
@@ -7,14 +8,12 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
-import kotlin.coroutines.CoroutineContext
 
 internal interface SelectSavedPaymentMethodsInteractor {
 
@@ -51,7 +50,7 @@ internal class DefaultSelectSavedPaymentMethodsInteractor(
     private val onEditPaymentMethod: (PaymentMethod) -> Unit,
     private val onDeletePaymentMethod: (PaymentMethod) -> Unit,
     private val onPaymentMethodSelected: (PaymentSelection?) -> Unit,
-    dispatcher: CoroutineContext = Dispatchers.Default,
+    private val coroutineScope: CoroutineScope
 ) : SelectSavedPaymentMethodsInteractor {
     constructor(viewModel: BaseSheetViewModel) : this(
         paymentOptionsItems = viewModel.paymentOptionsItems,
@@ -63,9 +62,8 @@ internal class DefaultSelectSavedPaymentMethodsInteractor(
         onEditPaymentMethod = viewModel::modifyPaymentMethod,
         onDeletePaymentMethod = viewModel::removePaymentMethod,
         onPaymentMethodSelected = viewModel::handlePaymentMethodSelected,
+        coroutineScope = CoroutineScope(viewModel.viewModelScope.coroutineContext + SupervisorJob()),
     )
-
-    private val coroutineScope = CoroutineScope(dispatcher + SupervisorJob())
 
     private val _paymentOptionsRelevantSelection: MutableStateFlow<PaymentSelection?> = MutableStateFlow(null)
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.verticalmode
 
+import androidx.lifecycle.viewModelScope
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -19,12 +20,10 @@ import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import kotlin.coroutines.CoroutineContext
 import com.stripe.android.R as PaymentsCoreR
 
 internal interface PaymentMethodVerticalLayoutInteractor {
@@ -79,7 +78,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     private val onMandateTextUpdated: (ResolvableString?) -> Unit,
     private val updateSelection: (PaymentSelection?) -> Unit,
     private val isCurrentScreen: StateFlow<Boolean>,
-    dispatcher: CoroutineContext = Dispatchers.Default,
+    private val coroutineScope: CoroutineScope,
 ) : PaymentMethodVerticalLayoutInteractor {
     constructor(viewModel: BaseSheetViewModel) : this(
         paymentMethodMetadata = requireNotNull(viewModel.paymentMethodMetadata.value),
@@ -125,9 +124,8 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         onMandateTextUpdated = {
             viewModel.updateMandateText(it?.resolve(viewModel.getApplication()), true)
         },
+        coroutineScope = CoroutineScope(viewModel.viewModelScope.coroutineContext + SupervisorJob()),
     )
-
-    private val coroutineScope = CoroutineScope(dispatcher + SupervisorJob())
 
     private val _verticalModeScreenSelection = MutableStateFlow(selection.value)
     private val verticalModeScreenSelection = _verticalModeScreenSelection

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -63,7 +63,9 @@ import com.stripe.android.uicore.utils.combine
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -554,6 +556,7 @@ internal abstract class BaseSheetViewModel(
                         modifyCardPaymentMethod(method, brand)
                     },
                     canRemove = canRemove,
+                    coroutineScope = CoroutineScope(viewModelScope.coroutineContext + SupervisorJob()),
                 )
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/NavigationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/NavigationHandlerTest.kt
@@ -152,21 +152,4 @@ internal class NavigationHandlerTest {
             verify(screenTwo as Closeable).close()
         }
     }
-
-    @Test
-    fun `closeScreens calls close on all closable screens in the backstack`() = runTest {
-        val navigationHandler = NavigationHandler()
-        navigationHandler.currentScreen.test {
-            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
-            val screenOne = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
-            navigationHandler.transitionTo(screenOne)
-            assertThat(awaitItem()).isEqualTo(screenOne)
-            val screenTwo = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
-            navigationHandler.transitionTo(screenTwo)
-            assertThat(awaitItem()).isEqualTo(screenTwo)
-            navigationHandler.closeScreens()
-            verify(screenOne as Closeable).close()
-            verify(screenTwo as Closeable).close()
-        }
-    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I'm trying to simplify things, and make the system take care of things when we can.

This uses the cascading behavior of coroutine cancellation to cancel interactor coroutineScopes when the viewModel disappears. 
