### PR TITLE
Remove dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Dependabot can't generate PRs that we can merge. We're very deliberate when we update dependencies. From now on we'll do this manually.