### PR TITLE
Move metadata creation in `PaymentSheetLoader` to a factory method.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import com.stripe.android.lpmfoundations.FormHeaderInformation
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.ExternalPaymentMethodUiDefinitionFactory
+import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
@@ -38,6 +39,29 @@ internal data class PaymentMethodMetadata(
     val hasCustomerConfiguration: Boolean,
     val financialConnectionsAvailable: Boolean = DefaultIsFinancialConnectionsAvailable(),
 ) : Parcelable {
+    constructor(
+        elementsSession: ElementsSession,
+        configuration: PaymentSheet.Configuration,
+        sharedDataSpecs: List<SharedDataSpec>,
+        externalPaymentMethodSpecs: List<ExternalPaymentMethodSpec>,
+    ) : this(
+        stripeIntent = elementsSession.stripeIntent,
+        billingDetailsCollectionConfiguration = configuration.billingDetailsCollectionConfiguration,
+        allowsDelayedPaymentMethods = configuration.allowsDelayedPaymentMethods,
+        allowsPaymentMethodsRequiringShippingAddress = configuration.allowsPaymentMethodsRequiringShippingAddress,
+        paymentMethodOrder = configuration.paymentMethodOrder,
+        cbcEligibility = CardBrandChoiceEligibility.create(
+            isEligible = elementsSession.isEligibleForCardBrandChoice,
+            preferredNetworks = configuration.preferredNetworks,
+        ),
+        merchantName = configuration.merchantDisplayName,
+        defaultBillingDetails = configuration.defaultBillingDetails,
+        shippingDetails = configuration.shippingDetails,
+        hasCustomerConfiguration = configuration.customer != null,
+        sharedDataSpecs = sharedDataSpecs,
+        externalPaymentMethodSpecs = externalPaymentMethodSpecs
+    )
+
     fun hasIntentToSetup(): Boolean {
         return when (stripeIntent) {
             is PaymentIntent -> stripeIntent.setupFutureUsage != null

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -39,29 +39,6 @@ internal data class PaymentMethodMetadata(
     val hasCustomerConfiguration: Boolean,
     val financialConnectionsAvailable: Boolean = DefaultIsFinancialConnectionsAvailable(),
 ) : Parcelable {
-    constructor(
-        elementsSession: ElementsSession,
-        configuration: PaymentSheet.Configuration,
-        sharedDataSpecs: List<SharedDataSpec>,
-        externalPaymentMethodSpecs: List<ExternalPaymentMethodSpec>,
-    ) : this(
-        stripeIntent = elementsSession.stripeIntent,
-        billingDetailsCollectionConfiguration = configuration.billingDetailsCollectionConfiguration,
-        allowsDelayedPaymentMethods = configuration.allowsDelayedPaymentMethods,
-        allowsPaymentMethodsRequiringShippingAddress = configuration.allowsPaymentMethodsRequiringShippingAddress,
-        paymentMethodOrder = configuration.paymentMethodOrder,
-        cbcEligibility = CardBrandChoiceEligibility.create(
-            isEligible = elementsSession.isEligibleForCardBrandChoice,
-            preferredNetworks = configuration.preferredNetworks,
-        ),
-        merchantName = configuration.merchantDisplayName,
-        defaultBillingDetails = configuration.defaultBillingDetails,
-        shippingDetails = configuration.shippingDetails,
-        hasCustomerConfiguration = configuration.customer != null,
-        sharedDataSpecs = sharedDataSpecs,
-        externalPaymentMethodSpecs = externalPaymentMethodSpecs
-    )
-
     fun hasIntentToSetup(): Boolean {
         return when (stripeIntent) {
             is PaymentIntent -> stripeIntent.setupFutureUsage != null
@@ -207,6 +184,34 @@ internal data class PaymentMethodMetadata(
                     metadata = this,
                     requiresMandate = definition.requiresMandate(this),
                 ),
+            )
+        }
+    }
+
+    internal companion object {
+        internal fun create(
+            elementsSession: ElementsSession,
+            configuration: PaymentSheet.Configuration,
+            sharedDataSpecs: List<SharedDataSpec>,
+            externalPaymentMethodSpecs: List<ExternalPaymentMethodSpec>,
+        ): PaymentMethodMetadata {
+            return PaymentMethodMetadata(
+                stripeIntent = elementsSession.stripeIntent,
+                billingDetailsCollectionConfiguration = configuration.billingDetailsCollectionConfiguration,
+                allowsDelayedPaymentMethods = configuration.allowsDelayedPaymentMethods,
+                allowsPaymentMethodsRequiringShippingAddress = configuration
+                    .allowsPaymentMethodsRequiringShippingAddress,
+                paymentMethodOrder = configuration.paymentMethodOrder,
+                cbcEligibility = CardBrandChoiceEligibility.create(
+                    isEligible = elementsSession.isEligibleForCardBrandChoice,
+                    preferredNetworks = configuration.preferredNetworks,
+                ),
+                merchantName = configuration.merchantDisplayName,
+                defaultBillingDetails = configuration.defaultBillingDetails,
+                shippingDetails = configuration.shippingDetails,
+                hasCustomerConfiguration = configuration.customer != null,
+                sharedDataSpecs = sharedDataSpecs,
+                externalPaymentMethodSpecs = externalPaymentMethodSpecs
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -28,7 +28,6 @@ import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.paymentsheet.model.validate
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
-import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.ExternalPaymentMethodSpec
 import com.stripe.android.ui.core.elements.ExternalPaymentMethodsRepository
 import kotlinx.coroutines.CoroutineScope
@@ -282,46 +281,30 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         paymentSheetConfiguration: PaymentSheet.Configuration,
         elementsSession: ElementsSession,
     ): PaymentMethodMetadata {
-        val billingDetailsCollectionConfig =
-            paymentSheetConfiguration.billingDetailsCollectionConfiguration
-
-        val cbcEligibility = CardBrandChoiceEligibility.create(
-            isEligible = elementsSession.isEligibleForCardBrandChoice,
-            preferredNetworks = paymentSheetConfiguration.preferredNetworks,
-        )
-
         val sharedDataSpecsResult = lpmRepository.getSharedDataSpecs(
             stripeIntent = elementsSession.stripeIntent,
             serverLpmSpecs = elementsSession.paymentMethodSpecs,
-        )
-        val externalPaymentMethodSpecs = externalPaymentMethodsRepository.getExternalPaymentMethodSpecs(
-            elementsSession.externalPaymentMethodData
-        )
-        logIfMissingExternalPaymentMethods(
-            requestedExternalPaymentMethods = paymentSheetConfiguration.externalPaymentMethods,
-            actualExternalPaymentMethods = externalPaymentMethodSpecs
-        )
-        val metadata = PaymentMethodMetadata(
-            stripeIntent = elementsSession.stripeIntent,
-            billingDetailsCollectionConfiguration = billingDetailsCollectionConfig,
-            allowsDelayedPaymentMethods = paymentSheetConfiguration.allowsDelayedPaymentMethods,
-            allowsPaymentMethodsRequiringShippingAddress = paymentSheetConfiguration
-                .allowsPaymentMethodsRequiringShippingAddress,
-            paymentMethodOrder = paymentSheetConfiguration.paymentMethodOrder,
-            cbcEligibility = cbcEligibility,
-            merchantName = paymentSheetConfiguration.merchantDisplayName,
-            defaultBillingDetails = paymentSheetConfiguration.defaultBillingDetails,
-            shippingDetails = paymentSheetConfiguration.shippingDetails,
-            hasCustomerConfiguration = paymentSheetConfiguration.customer != null,
-            sharedDataSpecs = sharedDataSpecsResult.sharedDataSpecs,
-            externalPaymentMethodSpecs = externalPaymentMethodSpecs
         )
 
         if (sharedDataSpecsResult.failedToParseServerResponse) {
             eventReporter.onLpmSpecFailure(sharedDataSpecsResult.failedToParseServerErrorMessage)
         }
 
-        return metadata
+        val externalPaymentMethodSpecs = externalPaymentMethodsRepository.getExternalPaymentMethodSpecs(
+            elementsSession.externalPaymentMethodData
+        )
+
+        logIfMissingExternalPaymentMethods(
+            requestedExternalPaymentMethods = paymentSheetConfiguration.externalPaymentMethods,
+            actualExternalPaymentMethods = externalPaymentMethodSpecs
+        )
+
+        return PaymentMethodMetadata(
+            elementsSession = elementsSession,
+            configuration = paymentSheetConfiguration,
+            sharedDataSpecs = sharedDataSpecsResult.sharedDataSpecs,
+            externalPaymentMethodSpecs = externalPaymentMethodSpecs
+        )
     }
 
     private suspend fun createCustomerState(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -299,7 +299,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             actualExternalPaymentMethods = externalPaymentMethodSpecs
         )
 
-        return PaymentMethodMetadata(
+        return PaymentMethodMetadata.create(
             elementsSession = elementsSession,
             configuration = paymentSheetConfiguration,
             sharedDataSpecs = sharedDataSpecsResult.sharedDataSpecs,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -713,7 +713,7 @@ internal class PaymentMethodMetadataTest {
     }
 
     @Test
-    fun `should construct metadata properly with elements session response, configuration, and data specs`() {
+    fun `should create metadata properly with elements session response, configuration, and data specs`() {
         val billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
             name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
             phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
@@ -730,7 +730,7 @@ internal class PaymentMethodMetadataTest {
             address = PaymentSheet.Address(line1 = "123 Pear Street")
         )
 
-        val metadata = PaymentMethodMetadata(
+        val metadata = PaymentMethodMetadata.create(
             elementsSession = createElementsSession(
                 intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 isEligibleForCardBrandChoice = true,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -4,14 +4,18 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.AffirmDefinition
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.R
+import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.EmailElement
 import com.stripe.android.ui.core.elements.SharedDataSpec
 import com.stripe.android.uicore.elements.AddressElement
@@ -706,5 +710,82 @@ internal class PaymentMethodMetadataTest {
         )
 
         assertThat(metadata.isExternalPaymentMethod("card")).isFalse()
+    }
+
+    @Test
+    fun `should construct metadata properly with elements session response, configuration, and data specs`() {
+        val billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+            name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+            email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+            address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+            attachDefaultsToPaymentMethod = true,
+        )
+
+        val defaultBillingDetails = PaymentSheet.BillingDetails(
+            address = PaymentSheet.Address(line1 = "123 Apple Street")
+        )
+
+        val shippingDetails = AddressDetails(
+            address = PaymentSheet.Address(line1 = "123 Pear Street")
+        )
+
+        val metadata = PaymentMethodMetadata(
+            elementsSession = createElementsSession(
+                intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+                isEligibleForCardBrandChoice = true,
+            ),
+            configuration = PaymentSheet.Configuration(
+                merchantDisplayName = "Merchant Inc.",
+                allowsDelayedPaymentMethods = true,
+                allowsPaymentMethodsRequiringShippingAddress = false,
+                paymentMethodOrder = listOf("us_bank_account", "card", "sepa_debit"),
+                billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
+                customer = PaymentSheet.CustomerConfiguration(
+                    id = "cus_1",
+                    ephemeralKeySecret = "ek_1"
+                ),
+                defaultBillingDetails = defaultBillingDetails,
+                shippingDetails = shippingDetails,
+                preferredNetworks = listOf(CardBrand.CartesBancaires, CardBrand.Visa),
+            ),
+            sharedDataSpecs = listOf(SharedDataSpec("card")),
+            externalPaymentMethodSpecs = listOf(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC),
+        )
+
+        assertThat(metadata).isEqualTo(
+            PaymentMethodMetadata(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+                billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
+                allowsDelayedPaymentMethods = true,
+                allowsPaymentMethodsRequiringShippingAddress = false,
+                paymentMethodOrder = listOf("us_bank_account", "card", "sepa_debit"),
+                cbcEligibility = CardBrandChoiceEligibility.Eligible(
+                    preferredNetworks = listOf(CardBrand.CartesBancaires, CardBrand.Visa)
+                ),
+                merchantName = "Merchant Inc.",
+                defaultBillingDetails = defaultBillingDetails,
+                shippingDetails = shippingDetails,
+                sharedDataSpecs = listOf(SharedDataSpec("card")),
+                externalPaymentMethodSpecs = listOf(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC),
+                hasCustomerConfiguration = true,
+            )
+        )
+    }
+
+    private fun createElementsSession(
+        intent: StripeIntent,
+        isEligibleForCardBrandChoice: Boolean,
+    ): ElementsSession {
+        return ElementsSession(
+            stripeIntent = intent,
+            isEligibleForCardBrandChoice = isEligibleForCardBrandChoice,
+            merchantCountry = null,
+            isGooglePayEnabled = false,
+            customer = null,
+            linkSettings = null,
+            externalPaymentMethodData = null,
+            paymentMethodSpecs = null,
+        )
     }
 }


### PR DESCRIPTION
# Summary
Move metadata creation in `PaymentSheetLoader` to a factory method.

# Motivation
Simplifies logic in `PaymentSheetLoader`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified