### PR TITLE
Move types out of BaseSheetViewModel.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormHelper.kt
@@ -12,7 +12,6 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
-import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.NewOrExternalPaymentSelection
 import com.stripe.android.uicore.elements.FormElement
 
 internal class FormHelper(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/NewOrExternalPaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/NewOrExternalPaymentSelection.kt
@@ -1,0 +1,52 @@
+package com.stripe.android.paymentsheet
+
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodExtraParams
+import com.stripe.android.paymentsheet.model.PaymentSelection
+
+internal sealed interface NewOrExternalPaymentSelection {
+
+    val paymentSelection: PaymentSelection
+
+    fun getPaymentMethodCode(): PaymentMethodCode
+
+    fun getType(): String
+
+    fun getPaymentMethodCreateParams(): PaymentMethodCreateParams?
+
+    fun getPaymentMethodExtraParams(): PaymentMethodExtraParams?
+
+    data class New(override val paymentSelection: PaymentSelection.New) : NewOrExternalPaymentSelection {
+
+        override fun getPaymentMethodCode(): PaymentMethodCode {
+            return when (paymentSelection) {
+                is PaymentSelection.New.LinkInline -> PaymentMethod.Type.Card.code
+                is PaymentSelection.New.Card,
+                is PaymentSelection.New.USBankAccount,
+                is PaymentSelection.New.GenericPaymentMethod -> paymentSelection.paymentMethodCreateParams.typeCode
+            }
+        }
+
+        override fun getType(): String = paymentSelection.paymentMethodCreateParams.typeCode
+
+        override fun getPaymentMethodCreateParams(): PaymentMethodCreateParams =
+            paymentSelection.paymentMethodCreateParams
+
+        override fun getPaymentMethodExtraParams(): PaymentMethodExtraParams? =
+            paymentSelection.paymentMethodExtraParams
+    }
+
+    data class External(override val paymentSelection: PaymentSelection.ExternalPaymentMethod) :
+        NewOrExternalPaymentSelection {
+
+        override fun getPaymentMethodCode(): PaymentMethodCode = paymentSelection.type
+
+        override fun getType(): String = paymentSelection.type
+
+        override fun getPaymentMethodCreateParams(): PaymentMethodCreateParams? = null
+
+        override fun getPaymentMethodExtraParams(): PaymentMethodExtraParams? = null
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -413,7 +413,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     private fun resetViewState(userErrorMessage: String? = null) {
         viewState.value =
-            PaymentSheetViewState.Reset(userErrorMessage?.let { UserErrorMessage(it) })
+            PaymentSheetViewState.Reset(userErrorMessage?.let { PaymentSheetViewState.UserErrorMessage(it) })
         savedStateHandle[SAVE_PROCESSING] = false
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSheetViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSheetViewState.kt
@@ -1,16 +1,15 @@
 package com.stripe.android.paymentsheet.model
 
 import com.stripe.android.paymentsheet.PaymentSheetActivity
-import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 
 /**
  * This will show the state of the [PaymentSheetActivity] as it does work.  The states always
  * progress as follows: Ready -> StartProcessing -> FinishProcessing -> ProcessResult
  */
 internal sealed class PaymentSheetViewState(
-    val errorMessage: BaseSheetViewModel.UserErrorMessage? = null
+    val errorMessage: UserErrorMessage? = null
 ) {
-    data class Reset(private val message: BaseSheetViewModel.UserErrorMessage? = null) :
+    data class Reset(private val message: UserErrorMessage? = null) :
         PaymentSheetViewState(message)
 
     data object StartProcessing : PaymentSheetViewState(null)
@@ -18,4 +17,6 @@ internal sealed class PaymentSheetViewState(
     data class FinishProcessing(
         val onComplete: () -> Unit
     ) : PaymentSheetViewState()
+
+    data class UserErrorMessage(val message: String)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -15,12 +15,11 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
-import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.LinkHandler
+import com.stripe.android.paymentsheet.NewOrExternalPaymentSelection
 import com.stripe.android.paymentsheet.PaymentOptionsItem
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -678,53 +677,6 @@ internal abstract class BaseSheetViewModel(
     abstract fun onError(@StringRes error: Int? = null)
 
     abstract fun onError(error: String? = null)
-
-    data class UserErrorMessage(val message: String)
-
-    internal sealed interface NewOrExternalPaymentSelection {
-
-        val paymentSelection: PaymentSelection
-
-        fun getPaymentMethodCode(): PaymentMethodCode
-
-        fun getType(): String
-
-        fun getPaymentMethodCreateParams(): PaymentMethodCreateParams?
-
-        fun getPaymentMethodExtraParams(): PaymentMethodExtraParams?
-
-        data class New(override val paymentSelection: PaymentSelection.New) : NewOrExternalPaymentSelection {
-
-            override fun getPaymentMethodCode(): PaymentMethodCode {
-                return when (paymentSelection) {
-                    is PaymentSelection.New.LinkInline -> PaymentMethod.Type.Card.code
-                    is PaymentSelection.New.Card,
-                    is PaymentSelection.New.USBankAccount,
-                    is PaymentSelection.New.GenericPaymentMethod -> paymentSelection.paymentMethodCreateParams.typeCode
-                }
-            }
-
-            override fun getType(): String = paymentSelection.paymentMethodCreateParams.typeCode
-
-            override fun getPaymentMethodCreateParams(): PaymentMethodCreateParams =
-                paymentSelection.paymentMethodCreateParams
-
-            override fun getPaymentMethodExtraParams(): PaymentMethodExtraParams? =
-                paymentSelection.paymentMethodExtraParams
-        }
-
-        data class External(override val paymentSelection: PaymentSelection.ExternalPaymentMethod) :
-            NewOrExternalPaymentSelection {
-
-            override fun getPaymentMethodCode(): PaymentMethodCode = paymentSelection.type
-
-            override fun getType(): String = paymentSelection.type
-
-            override fun getPaymentMethodCreateParams(): PaymentMethodCreateParams? = null
-
-            override fun getPaymentMethodExtraParams(): PaymentMethodExtraParams? = null
-        }
-    }
 
     companion object {
         internal const val SAVED_CUSTOMER = "customer_info"

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
@@ -12,7 +12,6 @@ import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParams.Companion.getNameFromParams
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.NewOrExternalPaymentSelection
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -37,7 +37,6 @@ import com.stripe.android.paymentsheet.ui.EditPaymentMethodViewAction
 import com.stripe.android.paymentsheet.ui.ModifiableEditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
-import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
@@ -451,7 +450,7 @@ internal class PaymentOptionsViewModelTest {
             viewModel.updateSelection(newSelection)
             assertThat(awaitItem()).isEqualTo(newSelection)
             assertThat(viewModel.newPaymentSelection).isEqualTo(
-                BaseSheetViewModel.NewOrExternalPaymentSelection.New(
+                NewOrExternalPaymentSelection.New(
                     newSelection
                 )
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -62,7 +62,6 @@ import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.SHEET_NAVIGATION_BUTTON_TAG
 import com.stripe.android.paymentsheet.ui.TEST_TAG_LIST
 import com.stripe.android.paymentsheet.ui.TEST_TAG_REMOVE_BADGE
-import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.ui.core.elements.TEST_TAG_DIALOG_CONFIRM_BUTTON
 import com.stripe.android.uicore.elements.bottomsheet.BottomSheetContentTestTag
@@ -772,7 +771,7 @@ internal class PaymentSheetActivityTest {
 
             viewModel.checkoutIdentifier = CheckoutIdentifier.SheetTopWallet
             viewModel.viewState.value =
-                PaymentSheetViewState.Reset(BaseSheetViewModel.UserErrorMessage(errorMessage))
+                PaymentSheetViewState.Reset(PaymentSheetViewState.UserErrorMessage(errorMessage))
 
             composeTestRule
                 .onNodeWithText(errorMessage)
@@ -792,7 +791,7 @@ internal class PaymentSheetActivityTest {
                 .assertDoesNotExist()
 
             viewModel.viewState.value =
-                PaymentSheetViewState.Reset(BaseSheetViewModel.UserErrorMessage(errorMessage))
+                PaymentSheetViewState.Reset(PaymentSheetViewState.UserErrorMessage(errorMessage))
 
             composeTestRule
                 .onNodeWithText(errorMessage)
@@ -806,7 +805,7 @@ internal class PaymentSheetActivityTest {
 
             viewModel.checkoutIdentifier = CheckoutIdentifier.SheetTopWallet
             viewModel.viewState.value =
-                PaymentSheetViewState.Reset(BaseSheetViewModel.UserErrorMessage(errorMessage))
+                PaymentSheetViewState.Reset(PaymentSheetViewState.UserErrorMessage(errorMessage))
 
             composeTestRule
                 .onNodeWithText(errorMessage)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -66,6 +66,7 @@ import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
 import com.stripe.android.paymentsheet.model.GooglePayButtonType
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
+import com.stripe.android.paymentsheet.model.PaymentSheetViewState.UserErrorMessage
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddAnotherPaymentMethod
@@ -90,9 +91,7 @@ import com.stripe.android.paymentsheet.ui.EditPaymentMethodViewState
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.utils.FakeEditPaymentMethodInteractorFactory
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
-import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.SAVE_PROCESSING
-import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.UserErrorMessage
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
@@ -1688,7 +1687,7 @@ internal class PaymentSheetViewModelTest {
             assertThat(awaitItem())
                 .isEqualTo(newSelection)
             assertThat(viewModel.newPaymentSelection).isEqualTo(
-                BaseSheetViewModel.NewOrExternalPaymentSelection.New(
+                NewOrExternalPaymentSelection.New(
                     newSelection
                 )
             )
@@ -1712,7 +1711,7 @@ internal class PaymentSheetViewModelTest {
             viewModel.updateSelection(newSelection)
             assertThat(awaitItem()).isEqualTo(newSelection)
             assertThat(viewModel.newPaymentSelection).isEqualTo(
-                BaseSheetViewModel.NewOrExternalPaymentSelection.External(
+                NewOrExternalPaymentSelection.External(
                     newSelection
                 )
             )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Move some types that are used outside of BaseSheetViewModel to their own files.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Trying to make BaseSheetViewModel smaller/simpler.
