### PR TITLE
Move `CustomerState` logic to factory methods.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
@@ -21,38 +21,33 @@ internal data class CustomerState(
 
     internal companion object {
         /**
-         * Creates a [CustomerState] instance using an [ElementsSession] response. It's expected that the
-         * [ElementsSession.customer] field is available when creating the state. If the field is null, throws
-         * [IllegalStateException].
+         * Creates a [CustomerState] instance using an [ElementsSession.Customer] response.
          *
-         * @param elementsSession session response object with customer information
+         * @param customer elements session customer data
          *
-         * @return [CustomerState] instance using [ElementsSession.customer] data
-         * @throws IllegalStateException if [ElementsSession.customer] field is null
+         * @return [CustomerState] instance using [ElementsSession.Customer] data
          */
         internal fun createForCustomerSession(
-            elementsSession: ElementsSession
+            customer: ElementsSession.Customer
         ): CustomerState {
-            return elementsSession.customer?.let { customer ->
-                val canRemovePaymentMethods = when (
-                    val paymentSheetComponent = customer.session.components.paymentSheet
-                ) {
-                    is ElementsSession.Customer.Components.PaymentSheet.Enabled ->
-                        paymentSheetComponent.isPaymentMethodRemoveEnabled
-                    is ElementsSession.Customer.Components.PaymentSheet.Disabled -> false
-                }
+            val canRemovePaymentMethods = when (
+                val paymentSheetComponent = customer.session.components.paymentSheet
+            ) {
+                is ElementsSession.Customer.Components.PaymentSheet.Enabled ->
+                    paymentSheetComponent.isPaymentMethodRemoveEnabled
+                is ElementsSession.Customer.Components.PaymentSheet.Disabled -> false
+            }
 
-                CustomerState(
-                    id = customer.session.customerId,
-                    ephemeralKeySecret = customer.session.apiKey,
-                    paymentMethods = customer.paymentMethods,
-                    permissions = Permissions(
-                        canRemovePaymentMethods = canRemovePaymentMethods,
-                        // Should always remove duplicates when using `customer_session`
-                        canRemoveDuplicates = true,
-                    )
+            return CustomerState(
+                id = customer.session.customerId,
+                ephemeralKeySecret = customer.session.apiKey,
+                paymentMethods = customer.paymentMethods,
+                permissions = Permissions(
+                    canRemovePaymentMethods = canRemovePaymentMethods,
+                    // Should always remove duplicates when using `customer_session`
+                    canRemoveDuplicates = true,
                 )
-            } ?: throw IllegalStateException("Excepted 'customer' attribute as part of 'elements_session' response!")
+            )
         }
 
         /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
@@ -1,7 +1,9 @@
 package com.stripe.android.paymentsheet.state
 
 import android.os.Parcelable
+import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -16,4 +18,74 @@ internal data class CustomerState(
         val canRemovePaymentMethods: Boolean,
         val canRemoveDuplicates: Boolean,
     ) : Parcelable
+
+    internal companion object {
+        /**
+         * Creates a [CustomerState] instance using an [ElementsSession] response. It's expected that the
+         * [ElementsSession.customer] field is available when creating the state. If the field is null, throws
+         * [IllegalStateException].
+         *
+         * @param elementsSession session response object with customer information
+         *
+         * @return [CustomerState] instance using [ElementsSession.customer] data
+         * @throws IllegalStateException if [ElementsSession.customer] field is null
+         */
+        internal fun createForCustomerSession(
+            elementsSession: ElementsSession
+        ): CustomerState {
+            return elementsSession.customer?.let { customer ->
+                val canRemovePaymentMethods = when (
+                    val paymentSheetComponent = customer.session.components.paymentSheet
+                ) {
+                    is ElementsSession.Customer.Components.PaymentSheet.Enabled ->
+                        paymentSheetComponent.isPaymentMethodRemoveEnabled
+                    is ElementsSession.Customer.Components.PaymentSheet.Disabled -> false
+                }
+
+                CustomerState(
+                    id = customer.session.customerId,
+                    ephemeralKeySecret = customer.session.apiKey,
+                    paymentMethods = customer.paymentMethods,
+                    permissions = Permissions(
+                        canRemovePaymentMethods = canRemovePaymentMethods,
+                        // Should always remove duplicates when using `customer_session`
+                        canRemoveDuplicates = true,
+                    )
+                )
+            } ?: throw IllegalStateException("Excepted 'customer' attribute as part of 'elements_session' response!")
+        }
+
+        /**
+         * Creates a [CustomerState] instance with un-scoped legacy ephemeral key information.
+         *
+         * @param customerId identifier for a customer
+         * @param accessType legacy ephemeral key secret access type
+         * @param paymentMethods list of payment methods belonging to the customer
+         *
+         * @return [CustomerState] instance with legacy ephemeral key secrets
+         */
+        internal fun createForLegacyEphemeralKey(
+            customerId: String,
+            accessType: PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey,
+            paymentMethods: List<PaymentMethod>,
+        ): CustomerState {
+            return CustomerState(
+                id = customerId,
+                ephemeralKeySecret = accessType.ephemeralKeySecret,
+                paymentMethods = paymentMethods,
+                permissions = Permissions(
+                    /*
+                     * Un-scoped legacy ephemeral keys have full permissions to remove/save/modify. This should
+                     * always be set to true.
+                     */
+                    canRemovePaymentMethods = true,
+                    /*
+                     * Removing duplicates is not applicable here since we don't filter out duplicates for for
+                     * un-scoped ephemeral keys.
+                     */
+                    canRemoveDuplicates = false,
+                )
+            )
+        }
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -317,9 +317,13 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
 
         val customerState = when (val accessType = customerConfig?.accessType) {
             is PaymentSheet.CustomerAccessType.CustomerSession -> {
-                try {
-                    CustomerState.createForCustomerSession(elementsSession)
-                } catch (exception: IllegalStateException) {
+                elementsSession.customer?.let { customer ->
+                    CustomerState.createForCustomerSession(customer)
+                } ?: run {
+                    val exception = IllegalStateException(
+                        "Excepted 'customer' attribute as part of 'elements_session' response!"
+                    )
+
                     errorReporter.report(
                         ErrorReporter.UnexpectedErrorEvent.PAYMENT_SHEET_LOADER_ELEMENTS_SESSION_CUSTOMER_NOT_FOUND,
                         StripeException.create(exception)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
@@ -1,0 +1,175 @@
+package com.stripe.android.paymentsheet.state
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.testing.PaymentMethodFactory
+import org.junit.Test
+import kotlin.test.assertFailsWith
+
+class CustomerStateTest {
+    @Test
+    fun `Should create 'CustomerState' for customer session properly with permissions disabled`() {
+        val paymentMethods = PaymentMethodFactory.cards(4)
+        val elementsSession = createElementsSession(
+            customerId = "cus_1",
+            ephemeralKeySecret = "ek_1",
+            paymentMethods = paymentMethods,
+            paymentSheetComponent = ElementsSession.Customer.Components.PaymentSheet.Disabled
+        )
+
+        val customerState = CustomerState.createForCustomerSession(elementsSession)
+
+        assertThat(customerState).isEqualTo(
+            CustomerState(
+                id = "cus_1",
+                ephemeralKeySecret = "ek_1",
+                paymentMethods = paymentMethods,
+                permissions = CustomerState.Permissions(
+                    canRemovePaymentMethods = false,
+                    // Always true for `customer_session`
+                    canRemoveDuplicates = true,
+                ),
+            )
+        )
+    }
+
+    @Test
+    fun `Should create 'CustomerState' for customer session properly with remove permissions enabled`() {
+        val paymentMethods = PaymentMethodFactory.cards(4)
+        val elementsSession = createElementsSession(
+            customerId = "cus_1",
+            ephemeralKeySecret = "ek_1",
+            paymentMethods = paymentMethods,
+            paymentSheetComponent = ElementsSession.Customer.Components.PaymentSheet.Enabled(
+                isPaymentMethodSaveEnabled = false,
+                isPaymentMethodRemoveEnabled = true,
+            ),
+        )
+
+        val customerState = CustomerState.createForCustomerSession(elementsSession)
+
+        assertThat(customerState).isEqualTo(
+            CustomerState(
+                id = "cus_1",
+                ephemeralKeySecret = "ek_1",
+                paymentMethods = paymentMethods,
+                permissions = CustomerState.Permissions(
+                    canRemovePaymentMethods = true,
+                    // Always true for `customer_session`
+                    canRemoveDuplicates = true,
+                ),
+            )
+        )
+    }
+
+    @Test
+    fun `Should create 'CustomerState' for customer session properly with remove permissions disabled`() {
+        val paymentMethods = PaymentMethodFactory.cards(3)
+        val elementsSession = createElementsSession(
+            customerId = "cus_3",
+            ephemeralKeySecret = "ek_3",
+            paymentMethods = paymentMethods,
+            paymentSheetComponent = ElementsSession.Customer.Components.PaymentSheet.Enabled(
+                isPaymentMethodSaveEnabled = false,
+                isPaymentMethodRemoveEnabled = false,
+            ),
+        )
+
+        val customerState = CustomerState.createForCustomerSession(elementsSession)
+
+        assertThat(customerState).isEqualTo(
+            CustomerState(
+                id = "cus_3",
+                ephemeralKeySecret = "ek_3",
+                paymentMethods = paymentMethods,
+                permissions = CustomerState.Permissions(
+                    canRemovePaymentMethods = false,
+                    // Always true for `customer_session`
+                    canRemoveDuplicates = true,
+                ),
+            )
+        )
+    }
+
+    @Test
+    fun `Should throw 'IllegalStateException' for customer session if 'customer' field is null`() {
+        val elementsSession = ElementsSession(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            customer = null,
+            linkSettings = null,
+            externalPaymentMethodData = null,
+            paymentMethodSpecs = null,
+            isEligibleForCardBrandChoice = false,
+            isGooglePayEnabled = false,
+            merchantCountry = null,
+        )
+
+        val exception = assertFailsWith<IllegalStateException> {
+            CustomerState.createForCustomerSession(elementsSession)
+        }
+
+        assertThat(exception.message)
+            .isEqualTo("Excepted 'customer' attribute as part of 'elements_session' response!")
+    }
+
+    @Test
+    fun `Should create 'CustomerState' for legacy ephemeral keys properly`() {
+        val paymentMethods = PaymentMethodFactory.cards(7)
+        val customerState = CustomerState.createForLegacyEphemeralKey(
+            customerId = "cus_1",
+            accessType = PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey(
+                ephemeralKeySecret = "ek_1",
+            ),
+            paymentMethods = paymentMethods,
+        )
+
+        assertThat(customerState).isEqualTo(
+            CustomerState(
+                id = "cus_1",
+                ephemeralKeySecret = "ek_1",
+                paymentMethods = paymentMethods,
+                permissions = CustomerState.Permissions(
+                    // Always true for legacy ephemeral keys since un-scoped
+                    canRemovePaymentMethods = true,
+                    // Always 'false' for legacy ephemeral keys
+                    canRemoveDuplicates = false,
+                ),
+            )
+        )
+    }
+
+    private fun createElementsSession(
+        customerId: String,
+        ephemeralKeySecret: String,
+        paymentMethods: List<PaymentMethod>,
+        paymentSheetComponent: ElementsSession.Customer.Components.PaymentSheet
+    ): ElementsSession {
+        return ElementsSession(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            customer = ElementsSession.Customer(
+                paymentMethods = paymentMethods,
+                defaultPaymentMethod = null,
+                session = ElementsSession.Customer.Session(
+                    id = "cuss_1",
+                    customerId = customerId,
+                    apiKey = ephemeralKeySecret,
+                    apiKeyExpiry = 999999999,
+                    liveMode = false,
+                    components = ElementsSession.Customer.Components(
+                        customerSheet = ElementsSession.Customer.Components.CustomerSheet.Disabled,
+                        paymentSheet = paymentSheetComponent
+                    )
+                ),
+            ),
+            linkSettings = null,
+            externalPaymentMethodData = null,
+            paymentMethodSpecs = null,
+            isEligibleForCardBrandChoice = false,
+            isGooglePayEnabled = false,
+            merchantCountry = null
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
@@ -2,25 +2,23 @@ package com.stripe.android.paymentsheet.state
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.ElementsSession
-import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.testing.PaymentMethodFactory
 import org.junit.Test
-import kotlin.test.assertFailsWith
 
 class CustomerStateTest {
     @Test
     fun `Should create 'CustomerState' for customer session properly with permissions disabled`() {
         val paymentMethods = PaymentMethodFactory.cards(4)
-        val elementsSession = createElementsSession(
+        val customer = createElementsSessionCustomer(
             customerId = "cus_1",
             ephemeralKeySecret = "ek_1",
             paymentMethods = paymentMethods,
             paymentSheetComponent = ElementsSession.Customer.Components.PaymentSheet.Disabled
         )
 
-        val customerState = CustomerState.createForCustomerSession(elementsSession)
+        val customerState = CustomerState.createForCustomerSession(customer)
 
         assertThat(customerState).isEqualTo(
             CustomerState(
@@ -39,7 +37,7 @@ class CustomerStateTest {
     @Test
     fun `Should create 'CustomerState' for customer session properly with remove permissions enabled`() {
         val paymentMethods = PaymentMethodFactory.cards(4)
-        val elementsSession = createElementsSession(
+        val customer = createElementsSessionCustomer(
             customerId = "cus_1",
             ephemeralKeySecret = "ek_1",
             paymentMethods = paymentMethods,
@@ -49,7 +47,7 @@ class CustomerStateTest {
             ),
         )
 
-        val customerState = CustomerState.createForCustomerSession(elementsSession)
+        val customerState = CustomerState.createForCustomerSession(customer)
 
         assertThat(customerState).isEqualTo(
             CustomerState(
@@ -68,7 +66,7 @@ class CustomerStateTest {
     @Test
     fun `Should create 'CustomerState' for customer session properly with remove permissions disabled`() {
         val paymentMethods = PaymentMethodFactory.cards(3)
-        val elementsSession = createElementsSession(
+        val customer = createElementsSessionCustomer(
             customerId = "cus_3",
             ephemeralKeySecret = "ek_3",
             paymentMethods = paymentMethods,
@@ -78,7 +76,7 @@ class CustomerStateTest {
             ),
         )
 
-        val customerState = CustomerState.createForCustomerSession(elementsSession)
+        val customerState = CustomerState.createForCustomerSession(customer)
 
         assertThat(customerState).isEqualTo(
             CustomerState(
@@ -92,27 +90,6 @@ class CustomerStateTest {
                 ),
             )
         )
-    }
-
-    @Test
-    fun `Should throw 'IllegalStateException' for customer session if 'customer' field is null`() {
-        val elementsSession = ElementsSession(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-            customer = null,
-            linkSettings = null,
-            externalPaymentMethodData = null,
-            paymentMethodSpecs = null,
-            isEligibleForCardBrandChoice = false,
-            isGooglePayEnabled = false,
-            merchantCountry = null,
-        )
-
-        val exception = assertFailsWith<IllegalStateException> {
-            CustomerState.createForCustomerSession(elementsSession)
-        }
-
-        assertThat(exception.message)
-            .isEqualTo("Excepted 'customer' attribute as part of 'elements_session' response!")
     }
 
     @Test
@@ -141,35 +118,26 @@ class CustomerStateTest {
         )
     }
 
-    private fun createElementsSession(
+    private fun createElementsSessionCustomer(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethods: List<PaymentMethod>,
         paymentSheetComponent: ElementsSession.Customer.Components.PaymentSheet
-    ): ElementsSession {
-        return ElementsSession(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-            customer = ElementsSession.Customer(
-                paymentMethods = paymentMethods,
-                defaultPaymentMethod = null,
-                session = ElementsSession.Customer.Session(
-                    id = "cuss_1",
-                    customerId = customerId,
-                    apiKey = ephemeralKeySecret,
-                    apiKeyExpiry = 999999999,
-                    liveMode = false,
-                    components = ElementsSession.Customer.Components(
-                        customerSheet = ElementsSession.Customer.Components.CustomerSheet.Disabled,
-                        paymentSheet = paymentSheetComponent
-                    )
-                ),
+    ): ElementsSession.Customer {
+        return ElementsSession.Customer(
+            paymentMethods = paymentMethods,
+            defaultPaymentMethod = null,
+            session = ElementsSession.Customer.Session(
+                id = "cuss_1",
+                customerId = customerId,
+                apiKey = ephemeralKeySecret,
+                apiKeyExpiry = 999999999,
+                liveMode = false,
+                components = ElementsSession.Customer.Components(
+                    customerSheet = ElementsSession.Customer.Components.CustomerSheet.Disabled,
+                    paymentSheet = paymentSheetComponent
+                )
             ),
-            linkSettings = null,
-            externalPaymentMethodData = null,
-            paymentMethodSpecs = null,
-            isEligibleForCardBrandChoice = false,
-            isGooglePayEnabled = false,
-            merchantCountry = null
         )
     }
 }


### PR DESCRIPTION
# Summary
Move `CustomerState` logic to factory methods.

# Motivation
Cleans up `PaymentSheetLoader` logic & secludes `CustomerState` logic inside class as well as easier to read tests.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
