### PR TITLE
Wait for link button to not be enabled before asserting

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -4,12 +4,15 @@ import android.content.Context
 import android.os.Build
 import androidx.activity.result.ActivityResultLauncher
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertAny
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isNotEnabled
 import androidx.compose.ui.test.isSelected
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onChildren
@@ -188,6 +191,7 @@ internal class PaymentSheetActivityTest {
         }
     }
 
+    @OptIn(ExperimentalTestApi::class)
     @Test
     fun `link button should not be enabled when editing`() {
         val viewModel = createViewModel(isLinkAvailable = true)
@@ -199,6 +203,10 @@ internal class PaymentSheetActivityTest {
                 .assertIsEnabled()
 
             viewModel.toggleEditing()
+            composeTestRule.waitUntilAtLeastOneExists(
+                hasTestTag(LinkButtonTestTag).and(isNotEnabled()),
+                timeoutMillis = 5_000
+            )
 
             composeTestRule
                 .onNodeWithTag(LinkButtonTestTag)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Wait for link button to not be enabled in test before asserting

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix flaky test

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
