### PR TITLE
We don't need a property for merchant display name.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -200,7 +200,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                             GooglePayEnvironment.Test
                     },
                     merchantCountryCode = config.countryCode,
-                    merchantName = merchantName,
+                    merchantName = this.config.merchantDisplayName,
                     isEmailRequired = args.config.billingDetailsCollectionConfiguration.collectsEmail,
                     billingAddressConfig = args.config.billingDetailsCollectionConfiguration.toBillingAddressConfig(),
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -86,8 +86,6 @@ internal abstract class BaseSheetViewModel(
     private val editInteractorFactory: ModifiableEditPaymentMethodViewInteractor.Factory
 ) : AndroidViewModel(application) {
 
-    internal val merchantName = config.merchantDisplayName
-
     protected var mostRecentError: Throwable? = null
 
     internal val googlePayState: StateFlow<GooglePayState> = savedStateHandle
@@ -417,7 +415,7 @@ internal abstract class BaseSheetViewModel(
 
         val mandateText = selection?.mandateText(
             context = getApplication(),
-            merchantName = merchantName,
+            merchantName = config.merchantDisplayName,
             isSaveForFutureUseSelected = isRequestingReuse,
             isSetupFlow = paymentMethodMetadata.value?.stripeIntent is SetupIntent,
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We would have a billion properties if we always created a property for something we referenced that had two dots. So just inlining them.