### PR TITLE
Move pop listening to the constructor.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/NavigationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/NavigationHandler.kt
@@ -6,7 +6,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import java.io.Closeable
 
-internal class NavigationHandler {
+internal class NavigationHandler(
+    private val poppedScreenHandler: (PaymentSheetScreen) -> Unit,
+) {
     private val backStack = MutableStateFlow<List<PaymentSheetScreen>>(
         value = listOf(PaymentSheetScreen.Loading),
     )
@@ -33,7 +35,7 @@ internal class NavigationHandler {
         }
     }
 
-    fun pop(poppedScreenHandler: (PaymentSheetScreen) -> Unit) {
+    fun pop() {
         backStack.update { screens ->
             val modifiableScreens = screens.toMutableList()
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -121,7 +121,9 @@ internal abstract class BaseSheetViewModel(
             state?.paymentMethods ?: emptyList()
         }
 
-    val navigationHandler: NavigationHandler = NavigationHandler()
+    val navigationHandler: NavigationHandler = NavigationHandler { poppedScreen ->
+        analyticsListener.reportPaymentSheetHidden(poppedScreen)
+    }
 
     abstract val walletsState: StateFlow<WalletsState?>
     abstract val walletsProcessingState: StateFlow<WalletsProcessingState?>
@@ -561,7 +563,7 @@ internal abstract class BaseSheetViewModel(
 
         if (result.isSuccess) {
             viewModelScope.launch(workContext) {
-                onUserBack()
+                navigationHandler.pop()
                 delay(PaymentMethodRemovalDelayMillis)
                 removeDeletedPaymentMethodFromState(paymentMethodId = paymentMethodId)
             }
@@ -656,19 +658,13 @@ internal abstract class BaseSheetViewModel(
             return
         }
         if (navigationHandler.canGoBack) {
-            onUserBack()
+            navigationHandler.pop()
         } else {
             onUserCancel()
         }
     }
 
     abstract fun onUserCancel()
-
-    private fun onUserBack() {
-        navigationHandler.pop { poppedScreen ->
-            analyticsListener.reportPaymentSheetHidden(poppedScreen)
-        }
-    }
 
     abstract fun onPaymentResult(paymentResult: PaymentResult)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/NavigationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/NavigationHandlerTest.kt
@@ -12,7 +12,7 @@ import java.io.Closeable
 internal class NavigationHandlerTest {
     @Test
     fun `currentScreen is initialized to Loading`() = runTest {
-        val navigationHandler = NavigationHandler()
+        val navigationHandler = NavigationHandler {}
         navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
             assertThat(navigationHandler.canGoBack).isFalse()
@@ -21,7 +21,7 @@ internal class NavigationHandlerTest {
 
     @Test
     fun `transitionTo removes Loading`() = runTest {
-        val navigationHandler = NavigationHandler()
+        val navigationHandler = NavigationHandler {}
         navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
             val newScreen = mock<PaymentSheetScreen>()
@@ -33,7 +33,7 @@ internal class NavigationHandlerTest {
 
     @Test
     fun `transitionTo keeps backstack`() = runTest {
-        val navigationHandler = NavigationHandler()
+        val navigationHandler = NavigationHandler {}
         navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
             val screenOne = mock<PaymentSheetScreen>()
@@ -48,7 +48,7 @@ internal class NavigationHandlerTest {
 
     @Test
     fun `resetTo resets backstack`() = runTest {
-        val navigationHandler = NavigationHandler()
+        val navigationHandler = NavigationHandler {}
         navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
             val screenOne = mock<PaymentSheetScreen>()
@@ -67,7 +67,7 @@ internal class NavigationHandlerTest {
 
     @Test
     fun `resetTo calls close on removed screens`() = runTest {
-        val navigationHandler = NavigationHandler()
+        val navigationHandler = NavigationHandler {}
         navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
             val screenOne = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
@@ -88,7 +88,7 @@ internal class NavigationHandlerTest {
 
     @Test
     fun `resetTo only calls close on removed screens`() = runTest {
-        val navigationHandler = NavigationHandler()
+        val navigationHandler = NavigationHandler {}
         navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
             val screenOne = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
@@ -108,21 +108,26 @@ internal class NavigationHandlerTest {
 
     @Test
     fun `pop removes the top screen from the backstack`() = runTest {
-        val navigationHandler = NavigationHandler()
+        var calledPopHandler = false
+        val screenOne = mock<PaymentSheetScreen>()
+        val screenTwo = mock<PaymentSheetScreen>()
+
+        val navigationHandler = NavigationHandler {
+            calledPopHandler = true
+            assertThat(it).isEqualTo(screenTwo)
+        }
+
         navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
-            val screenOne = mock<PaymentSheetScreen>()
+
             navigationHandler.transitionTo(screenOne)
             assertThat(awaitItem()).isEqualTo(screenOne)
-            val screenTwo = mock<PaymentSheetScreen>()
+
             navigationHandler.transitionTo(screenTwo)
             assertThat(awaitItem()).isEqualTo(screenTwo)
             assertThat(navigationHandler.canGoBack).isTrue()
-            var calledPopHandler = false
-            navigationHandler.pop {
-                calledPopHandler = true
-                assertThat(it).isEqualTo(screenTwo)
-            }
+
+            navigationHandler.pop()
             assertThat(calledPopHandler).isTrue()
             assertThat(awaitItem()).isEqualTo(screenOne)
             assertThat(navigationHandler.canGoBack).isFalse()
@@ -131,21 +136,27 @@ internal class NavigationHandlerTest {
 
     @Test
     fun `pop removes the top screen from the backstack and calls close`() = runTest {
-        val navigationHandler = NavigationHandler()
+        var calledPopHandler = false
+
+        val screenOne = mock<PaymentSheetScreen>()
+        val screenTwo = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
+
+        val navigationHandler = NavigationHandler {
+            calledPopHandler = true
+            assertThat(it).isEqualTo(screenTwo)
+        }
+
         navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
-            val screenOne = mock<PaymentSheetScreen>()
+
             navigationHandler.transitionTo(screenOne)
             assertThat(awaitItem()).isEqualTo(screenOne)
-            val screenTwo = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
+
             navigationHandler.transitionTo(screenTwo)
             assertThat(awaitItem()).isEqualTo(screenTwo)
             assertThat(navigationHandler.canGoBack).isTrue()
-            var calledPopHandler = false
-            navigationHandler.pop {
-                calledPopHandler = true
-                assertThat(it).isEqualTo(screenTwo)
-            }
+
+            navigationHandler.pop()
             assertThat(calledPopHandler).isTrue()
             assertThat(awaitItem()).isEqualTo(screenOne)
             assertThat(navigationHandler.canGoBack).isFalse()
@@ -155,7 +166,7 @@ internal class NavigationHandlerTest {
 
     @Test
     fun `closeScreens calls close on all closable screens in the backstack`() = runTest {
-        val navigationHandler = NavigationHandler()
+        val navigationHandler = NavigationHandler {}
         navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
             val screenOne = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I'm trying to refactor some stuff out of BaseSheetViewModel, and I realized we want to always track pop, and it should just be a part of the constructor.