### PR TITLE
Fix payment_user_agent in the share endpoint.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1143,7 +1143,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
                         "consumer_session_client_secret" to consumerSessionClientSecret
                     ),
                     "id" to id,
-                    PAYMENT_USER_AGENT to buildPaymentUserAgentPair()
+                    buildPaymentUserAgentPair(),
                 )
             ),
             jsonParser = ConsumerPaymentDetailsShareJsonParser,

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -1959,6 +1959,7 @@ internal class StripeApiRepositoryTest {
                     assertThat(this["consumer_session_client_secret"]).isEqualTo(clientSecret)
                 }
                 assertThat(this["id"]).isEqualTo(id)
+                assertThat(this["payment_user_agent"].toString()).startsWith("stripe-android/")
             }
         }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We weren't sending the correct payment_user_agent when calling the `v1/consumers/payment_details/share` endpoint.

