### PR TITLE
Add new deploy script which updates version numbers

### DIFF
--- a/scripts/deploy/deploy.rb
+++ b/scripts/deploy/deploy.rb
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+
+require 'colorize'
+require 'optparse'
+
+require_relative 'update_version_numbers'
+
+@step_index = 1
+
+def rputs(string)
+    puts string.red
+end
+
+def execute_steps(steps, step_index)
+  step_count = steps.length
+
+  if step_index > 1
+    steps = steps.drop(step_index - 1)
+    rputs "Continuing from step #{step_index}: #{steps.first.name}"
+  end
+
+  begin
+    steps.each do |step|
+      rputs "# #{step.name} (step #{step_index}/#{step_count})"
+      step.call
+      step_index += 1
+    end
+  rescue Exception => e
+    rputs "Restart with --continue-from #{step_index} to re-run from this step."
+    raise
+  end
+end
+
+OptionParser.new do |opts|
+  opts.on('--version VERSION',
+          'Version to release (e.g. 21.2.0)') do |t|
+    @version = t
+  end
+
+  opts.on('--continue-from NUMBER',
+          'Continue from a specified step') do |t|
+    @step_index = t.to_i
+  end
+end.parse!
+
+steps = [
+    method(:update_read_me),
+    method(:update_stripe_sdk_version),
+    method(:update_gradle_properties),
+]
+
+execute_steps(steps, @step_index)

--- a/scripts/deploy/update_version_numbers.rb
+++ b/scripts/deploy/update_version_numbers.rb
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+
+def replace_in_file(filename, pattern, replacement)
+  puts "> Updating #{filename}"
+  content = File.read(filename)
+  new_content = content.sub(pattern, replacement)
+  File.write(filename, new_content)
+end
+
+def update_read_me()
+  replace_in_file("README.md",
+      /implementation 'com.stripe:stripe-android:[.\d]+'/,
+      "implementation 'com.stripe:stripe-android:#{@version}'",
+  )
+ end
+
+def update_stripe_sdk_version()
+  replace_in_file("stripe-core/src/main/java/com/stripe/android/core/version/StripeSdkVersion.kt",
+      /const val VERSION_NAME = "[.\d]+"/,
+      %Q{const val VERSION_NAME = "#{@version}"},
+  )
+end
+
+def update_gradle_properties()
+  replace_in_file("gradle.properties",
+      /VERSION_NAME=[.\d]+/,
+      "VERSION_NAME=#{@version}",
+  )
+end


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add new deploy script which updates version numbers

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Updating release process. Going to start incrementally moving things from bindings to here. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Tested by running:
`bundle install && bundle exec ruby ./scripts/deploy/deploy.rb --version 20.50.2` (random version number) and verified that the files were updated with the specified version number. 

Also was able to verify that continuing after a failed step works properly, as there were failures while getting this set up :D 

Output:
<img width="849" alt="Screenshot 2024-07-12 at 4 28 48 PM" src="https://github.com/user-attachments/assets/969d251e-eea0-48e9-a53c-6a2fb41d28e0">
