### PR TITLE
Move primary logic for intent confirmation into `IntentConfirmationHandler`

### DIFF
--- a/payments-core-testing/build.gradle
+++ b/payments-core-testing/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation libs.kotlin.coroutinesAndroid
     implementation testLibs.junit
     implementation testLibs.kotlin.coroutines
+    implementation testLibs.turbine
     implementation testLibs.leakCanaryInstrumentation
 
     androidTestImplementation project(':stripe-ui-core') // Resources defined here, but used in payments-core.

--- a/payments-core-testing/dependencies/dependencies.txt
+++ b/payments-core-testing/dependencies/dependencies.txt
@@ -743,6 +743,12 @@
 |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20 -> 1.9.10 (*)
 |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20 -> 1.9.22 (*)
++--- app.cash.turbine:turbine:1.0.0
+|    \--- app.cash.turbine:turbine-jvm:1.0.0
+|         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22 -> 1.9.10 (*)
+|         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1 -> 1.7.3 (*)
+|         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22 -> 1.9.22 (*)
+|         \--- org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.1 -> 1.7.3 (*)
 \--- com.squareup.leakcanary:leakcanary-android-instrumentation:2.14
      +--- com.squareup.leakcanary:leakcanary-android-core:2.14
      |    +--- com.squareup.leakcanary:shark-android:2.14

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/FakePaymentLauncher.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/FakePaymentLauncher.kt
@@ -1,0 +1,55 @@
+package com.stripe.android.testing
+
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
+import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.ConfirmSetupIntentParams
+import com.stripe.android.model.ConfirmStripeIntentParams
+import com.stripe.android.payments.paymentlauncher.PaymentLauncher
+
+class FakePaymentLauncher : PaymentLauncher {
+    private val _calls = Turbine<Call>()
+    val calls: ReceiveTurbine<Call> = _calls
+
+    override fun confirm(params: ConfirmPaymentIntentParams) {
+        _calls.add(Call.Confirm.PaymentIntent(params))
+    }
+
+    override fun confirm(params: ConfirmSetupIntentParams) {
+        _calls.add(Call.Confirm.SetupIntent(params))
+    }
+
+    override fun handleNextActionForPaymentIntent(clientSecret: String) {
+        _calls.add(Call.HandleNextAction.PaymentIntent(clientSecret))
+    }
+
+    override fun handleNextActionForSetupIntent(clientSecret: String) {
+        _calls.add(Call.HandleNextAction.SetupIntent(clientSecret))
+    }
+
+    sealed interface Call {
+        sealed interface Confirm<T : ConfirmStripeIntentParams> : Call {
+            val params: T
+
+            data class PaymentIntent(
+                override val params: ConfirmPaymentIntentParams
+            ) : Confirm<ConfirmPaymentIntentParams>
+
+            data class SetupIntent(
+                override val params: ConfirmSetupIntentParams
+            ) : Confirm<ConfirmSetupIntentParams>
+        }
+
+        sealed interface HandleNextAction : Call {
+            val clientSecret: String
+
+            data class PaymentIntent(
+                override val clientSecret: String
+            ) : HandleNextAction
+
+            data class SetupIntent(
+                override val clientSecret: String
+            ) : HandleNextAction
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationHandler.kt
@@ -1,0 +1,338 @@
+package com.stripe.android.paymentsheet
+
+import android.app.Activity
+import android.app.Application
+import android.content.Context
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.ConfirmSetupIntentParams
+import com.stripe.android.model.ConfirmStripeIntentParams
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
+import com.stripe.android.payments.paymentlauncher.PaymentLauncher
+import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
+import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Provider
+
+/**
+ * This interface handles the process of confirming a [StripeIntent]. This interface can only handle confirming one
+ * intent at a time.
+ */
+internal class IntentConfirmationHandler(
+    private val arguments: Args,
+    private val intentConfirmationInterceptor: IntentConfirmationInterceptor,
+    private val paymentLauncherFactory: (ActivityResultLauncher<PaymentLauncherContract.Args>) -> PaymentLauncher,
+    private val context: Context,
+    private val coroutineScope: CoroutineScope,
+    private val savedStateHandle: SavedStateHandle,
+) {
+    private var paymentLauncher: PaymentLauncher? = null
+    private var deferredIntentConfirmationType: DeferredIntentConfirmationType?
+        get() = savedStateHandle[DEFERRED_INTENT_CONFIRMATION_TYPE]
+        set(value) {
+            savedStateHandle[DEFERRED_INTENT_CONFIRMATION_TYPE] = value
+        }
+
+    private var completableResult: CompletableDeferred<Result>? = if (isAwaitingForPaymentResult()) {
+        CompletableDeferred()
+    } else {
+        null
+    }
+
+    /**
+     * Indicates if this handler has been reloaded from process death. This occurs if the handler was confirming
+     * an intent before did not complete the process before process death.
+     */
+    val hasReloadedFromProcessDeath = isAwaitingForPaymentResult()
+
+    /**
+     * Registers activities tied to confirmation process to the lifecycle.
+     *
+     * @param activityResultCaller a class that can call [Activity.startActivityForResult]-style APIs
+     * @param lifecycleOwner a class tied to an Android [Lifecycle]
+     */
+    fun register(activityResultCaller: ActivityResultCaller, lifecycleOwner: LifecycleOwner) {
+        paymentLauncher = paymentLauncherFactory(
+            activityResultCaller.registerForActivityResult(
+                PaymentLauncherContract(),
+                ::onPaymentResult
+            )
+        )
+
+        lifecycleOwner.lifecycle.addObserver(
+            object : DefaultLifecycleObserver {
+                override fun onDestroy(owner: LifecycleOwner) {
+                    paymentLauncher = null
+                    super.onDestroy(owner)
+                }
+            }
+        )
+    }
+
+    /**
+     * Starts the confirmation process with a given [StripeIntent] and [PaymentSelection] instance. Result from this
+     * method can be received from [awaitIntentResult]. This method cannot return a result since the confirmation
+     * process can be handed off to another [Activity] to handle after starting it.
+     *
+     * @param intent the Stripe intent to confirm
+     * @param paymentSelection the customer's payment selection to use for confirming the intent
+     */
+    fun start(
+        intent: StripeIntent,
+        paymentSelection: PaymentSelection?
+    ) {
+        if (completableResult?.isActive == true) {
+            return
+        }
+
+        completableResult = CompletableDeferred()
+
+        coroutineScope.launch {
+            val nextStep = intentConfirmationInterceptor.intercept(
+                initializationMode = arguments.initializationMode,
+                paymentSelection = paymentSelection,
+                shippingValues = arguments.shippingDetails?.toConfirmPaymentIntentShipping(),
+                context = context,
+            )
+
+            deferredIntentConfirmationType = nextStep.deferredIntentConfirmationType
+
+            when (nextStep) {
+                is IntentConfirmationInterceptor.NextStep.HandleNextAction -> {
+                    handleNextAction(
+                        clientSecret = nextStep.clientSecret,
+                        stripeIntent = intent,
+                    )
+                }
+                is IntentConfirmationInterceptor.NextStep.Confirm -> {
+                    confirmStripeIntent(nextStep.confirmParams)
+                }
+                is IntentConfirmationInterceptor.NextStep.Fail -> {
+                    onFailure(
+                        cause = nextStep.cause,
+                        message = nextStep.message,
+                        type = ErrorType.NextStep,
+                    )
+                }
+                is IntentConfirmationInterceptor.NextStep.Complete -> {
+                    onPaymentResult(InternalPaymentResult.Completed(intent))
+                }
+            }
+        }
+    }
+
+    /**
+     * Waits for an intent result to be returned following a call to start an intent confirmation process through the
+     * [start] method. If no such call has been made, will return null.
+     *
+     * @return result of intent confirmation process or null if not started.
+     */
+    suspend fun awaitIntentResult(): Result? {
+        return completableResult?.await()
+    }
+
+    private fun handleNextAction(
+        clientSecret: String,
+        stripeIntent: StripeIntent,
+    ) = withPaymentLauncher { launcher ->
+        /*
+         * In case of process death, we should store that we waiting for a payment result to return from a
+         * payment confirmation activity
+         */
+        storeIsAwaitingForPaymentResult()
+
+        when (stripeIntent) {
+            is PaymentIntent -> {
+                launcher.handleNextActionForPaymentIntent(clientSecret)
+            }
+            is SetupIntent -> {
+                launcher.handleNextActionForSetupIntent(clientSecret)
+            }
+        }
+    }
+
+    private fun confirmStripeIntent(
+        confirmStripeIntentParams: ConfirmStripeIntentParams
+    ) = withPaymentLauncher { launcher ->
+        /*
+         * In case of process death, we should store that we waiting for a payment result to return from a
+         * payment confirmation activity
+         */
+        storeIsAwaitingForPaymentResult()
+
+        when (confirmStripeIntentParams) {
+            is ConfirmPaymentIntentParams -> {
+                launcher.confirm(confirmStripeIntentParams)
+            }
+            is ConfirmSetupIntentParams -> {
+                launcher.confirm(confirmStripeIntentParams)
+            }
+        }
+    }
+
+    private fun onPaymentResult(result: InternalPaymentResult) {
+        val intentResult = when (result) {
+            is InternalPaymentResult.Completed -> Result.Succeeded(
+                intent = result.intent,
+                deferredIntentConfirmationType = deferredIntentConfirmationType
+            )
+            is InternalPaymentResult.Failed -> Result.Failed(
+                cause = result.throwable,
+                message = result.throwable.stripeErrorMessage(),
+                type = ErrorType.Payment,
+            )
+            is InternalPaymentResult.Canceled -> Result.Canceled
+        }
+
+        deferredIntentConfirmationType = null
+
+        completableResult?.complete(intentResult)
+
+        removeIsAwaitingForPaymentResult()
+    }
+
+    private fun onFailure(
+        cause: Throwable,
+        message: ResolvableString,
+        type: ErrorType,
+    ) {
+        completableResult?.complete(
+            Result.Failed(
+                cause = cause,
+                message = message,
+                type = type,
+            )
+        )
+    }
+
+    private fun withPaymentLauncher(action: (PaymentLauncher) -> Unit) {
+        paymentLauncher?.let(action) ?: run {
+            onFailure(
+                cause = IllegalArgumentException(
+                    "No 'PaymentLauncher' instance was created before starting confirmation. Did you call register?"
+                ),
+                message = resolvableString(R.string.stripe_something_went_wrong),
+                type = ErrorType.Fatal,
+            )
+        }
+    }
+
+    private fun storeIsAwaitingForPaymentResult() {
+        savedStateHandle[AWAITING_PAYMENT_RESULT_KEY] = true
+    }
+
+    private fun removeIsAwaitingForPaymentResult() {
+        savedStateHandle.remove<Boolean>(AWAITING_PAYMENT_RESULT_KEY)
+    }
+
+    private fun isAwaitingForPaymentResult(): Boolean {
+        return savedStateHandle.get<Boolean>(AWAITING_PAYMENT_RESULT_KEY) ?: false
+    }
+
+    internal data class Args(
+        val initializationMode: PaymentSheet.InitializationMode,
+        val shippingDetails: AddressDetails?,
+    )
+
+    /**
+     * Defines the result types that [IntentConfirmationHandler] can return after completing the confirmation process.
+     */
+    sealed interface Result {
+        /**
+         * Indicates that the confirmation process was canceled by the customer.
+         */
+        data object Canceled : Result
+
+        /**
+         * Indicates that the confirmation process has been successfully completed. A [StripeIntent] with an updated
+         * state is returned as part of the result as well.
+         */
+        data class Succeeded(
+            val intent: StripeIntent,
+            val deferredIntentConfirmationType: DeferredIntentConfirmationType?
+        ) : Result
+
+        /**
+         * Indicates that the confirmation process has failed. A cause and potentially a resolvable message are
+         * returned as part of the result.
+         */
+        data class Failed(
+            val cause: Throwable,
+            val message: ResolvableString,
+            val type: ErrorType,
+        ) : Result
+    }
+
+    /**
+     * Types of errors that can occur when confirming an intent.
+     */
+    enum class ErrorType {
+        /**
+         * Fatal confirmation error that occurred while confirming a payment. This should never happen.
+         */
+        Fatal,
+
+        /**
+         * Indicates an error when processing a payment during the confirmation process.
+         */
+        Payment,
+
+        /**
+         * Indicates an error occurred when determining the next step for the confirmation process.
+         */
+        NextStep,
+    }
+
+    class Factory(
+        private val paymentSheetArguments: PaymentSheetContractV2.Args,
+        private val intentConfirmationInterceptor: IntentConfirmationInterceptor,
+        private val paymentConfigurationProvider: Provider<PaymentConfiguration>,
+        private val stripePaymentLauncherAssistedFactory: StripePaymentLauncherAssistedFactory,
+        private val savedStateHandle: SavedStateHandle,
+        private val application: Application,
+    ) {
+        fun create(scope: CoroutineScope): IntentConfirmationHandler {
+            return IntentConfirmationHandler(
+                arguments = Args(
+                    initializationMode = paymentSheetArguments.initializationMode,
+                    shippingDetails = paymentSheetArguments.config.shippingDetails,
+                ),
+                paymentLauncherFactory = { hostActivityLauncher ->
+                    stripePaymentLauncherAssistedFactory.create(
+                        publishableKey = { paymentConfigurationProvider.get().publishableKey },
+                        stripeAccountId = { paymentConfigurationProvider.get().stripeAccountId },
+                        hostActivityLauncher = hostActivityLauncher,
+                        statusBarColor = paymentSheetArguments.statusBarColor,
+                        includePaymentSheetAuthenticators = true,
+                    )
+                },
+                intentConfirmationInterceptor = intentConfirmationInterceptor,
+                context = application,
+                coroutineScope = scope,
+                savedStateHandle = savedStateHandle,
+            )
+        }
+    }
+
+    internal companion object {
+        private const val AWAITING_PAYMENT_RESULT_KEY = "AwaitingPaymentResult"
+        private const val DEFERRED_INTENT_CONFIRMATION_TYPE = "DeferredIntentConfirmationType"
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -1,12 +1,19 @@
 package com.stripe.android.paymentsheet.injection
 
+import android.app.Application
 import android.content.Context
+import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.IOContext
+import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
+import com.stripe.android.paymentsheet.IntentConfirmationHandler
+import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.PaymentSheetContractV2
 import com.stripe.android.paymentsheet.PrefsRepository
 import dagger.Module
 import dagger.Provides
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 @Module
@@ -15,6 +22,24 @@ internal class PaymentSheetViewModelModule(private val starterArgs: PaymentSheet
     @Provides
     fun provideArgs(): PaymentSheetContractV2.Args {
         return starterArgs
+    }
+
+    @Provides
+    fun providesIntentConfirmationHandlerFactory(
+        application: Application,
+        savedStateHandle: SavedStateHandle,
+        paymentConfigurationProvider: Provider<PaymentConfiguration>,
+        stripePaymentLauncherAssistedFactory: StripePaymentLauncherAssistedFactory,
+        intentConfirmationInterceptor: IntentConfirmationInterceptor,
+    ): IntentConfirmationHandler.Factory {
+        return IntentConfirmationHandler.Factory(
+            paymentSheetArguments = starterArgs,
+            intentConfirmationInterceptor = intentConfirmationInterceptor,
+            paymentConfigurationProvider = paymentConfigurationProvider,
+            stripePaymentLauncherAssistedFactory = stripePaymentLauncherAssistedFactory,
+            application = application,
+            savedStateHandle = savedStateHandle,
+        )
     }
 
     @Provides

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
@@ -1,0 +1,574 @@
+package com.stripe.android.paymentsheet
+
+import androidx.activity.result.ActivityResultCallback
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.testing.TestLifecycleOwner
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.ConfirmSetupIntentParams
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.SetupIntentFixtures
+import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
+import com.stripe.android.payments.paymentlauncher.PaymentLauncher
+import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.testing.FakePaymentLauncher
+import com.stripe.android.utils.FakeIntentConfirmationInterceptor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+@RunWith(AndroidJUnit4::class)
+class IntentConfirmationHandlerTest {
+    @Test
+    fun `On 'start', should call interceptor properly`() = runTest {
+        val interceptor = FakeIntentConfirmationInterceptor()
+
+        val initializationMode = PaymentSheet.InitializationMode.PaymentIntent(clientSecret = "ci_123")
+        val shippingDetails = AddressDetails(
+            name = "John Doe",
+            address = PaymentSheet.Address(
+                city = "South San Francisco",
+                state = "CA",
+                country = "US"
+            )
+        )
+        val savedPaymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+
+        val intentConfirmationHandler = createIntentConfirmationHandler(
+            intentConfirmationInterceptor = interceptor,
+            arguments = IntentConfirmationHandler.Args(
+                initializationMode = initializationMode,
+                shippingDetails = shippingDetails,
+            )
+        )
+
+        intentConfirmationHandler.start(
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            paymentSelection = PaymentSelection.Saved(savedPaymentMethod),
+        )
+
+        val call = interceptor.calls.awaitItem()
+
+        assertThat(call).isEqualTo(
+            FakeIntentConfirmationInterceptor.InterceptCall.WithExistingPaymentMethod(
+                initializationMode = initializationMode,
+                shippingValues = shippingDetails.toConfirmPaymentIntentShipping(),
+                paymentMethod = savedPaymentMethod,
+                paymentMethodOptionsParams = null,
+            )
+        )
+    }
+
+    @Test
+    fun `On 'start' while handler is already confirming, should not do anything`() = runTest {
+        val interceptor = FakeIntentConfirmationInterceptor()
+        val intentConfirmationHandler = createIntentConfirmationHandler(
+            intentConfirmationInterceptor = interceptor
+        )
+
+        intentConfirmationHandler.start(
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+        )
+
+        interceptor.calls.skipItems(1)
+
+        intentConfirmationHandler.start(
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+        )
+
+        interceptor.calls.expectNoEvents()
+    }
+
+    @Test
+    fun `On intercepted intent complete, should receive 'Succeeded' result through 'awaitIntentResult'`() = runTest {
+        val interceptor = FakeIntentConfirmationInterceptor()
+
+        interceptor.enqueueCompleteStep()
+
+        val intentConfirmationHandler = createIntentConfirmationHandler(
+            intentConfirmationInterceptor = interceptor
+        )
+
+        intentConfirmationHandler.start(
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+        )
+
+        val result = intentConfirmationHandler.awaitIntentResult()
+
+        assertThat(result).isEqualTo(
+            IntentConfirmationHandler.Result.Succeeded(
+                intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+                deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+            )
+        )
+    }
+
+    @Test
+    fun `On intercepted intent next step failed, should be 'Failed' result through 'awaitIntentResult'`() = runTest {
+        val interceptor = FakeIntentConfirmationInterceptor()
+
+        val cause = IllegalStateException("An error occurred!")
+        val message = "Could not continue intent confirmation!"
+
+        interceptor.enqueueFailureStep(
+            cause = cause,
+            message = message,
+        )
+
+        val intentConfirmationHandler = createIntentConfirmationHandler(
+            intentConfirmationInterceptor = interceptor
+        )
+
+        intentConfirmationHandler.start(
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+        )
+
+        val result = intentConfirmationHandler.awaitIntentResult()
+
+        assertThat(result).isEqualTo(
+            IntentConfirmationHandler.Result.Failed(
+                cause = cause,
+                message = message.resolvableString,
+                type = IntentConfirmationHandler.ErrorType.NextStep,
+            )
+        )
+    }
+
+    @Test
+    fun `On confirmation attempt without registering callbacks, should return 'Failed' result`() =
+        runTest {
+            val interceptor = FakeIntentConfirmationInterceptor()
+            val paymentLauncher = FakePaymentLauncher()
+
+            interceptor.enqueueConfirmStep(ConfirmPaymentIntentParams.create(clientSecret = "pi_1234"))
+
+            val intentConfirmationHandler = createIntentConfirmationHandler(
+                intentConfirmationInterceptor = interceptor,
+                paymentLauncher = paymentLauncher,
+                shouldRegister = false,
+            )
+
+            intentConfirmationHandler.start(
+                intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+                paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            )
+
+            val result = intentConfirmationHandler.awaitIntentResult()
+
+            val failedResult = result.asFailed()
+
+            val message = "No 'PaymentLauncher' instance was created before starting confirmation. " +
+                "Did you call register?"
+
+            assertThat(failedResult.cause).isInstanceOf(IllegalArgumentException::class.java)
+            assertThat(failedResult.cause.message).isEqualTo(message)
+            assertThat(failedResult.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
+            assertThat(failedResult.type).isEqualTo(IntentConfirmationHandler.ErrorType.Fatal)
+        }
+
+    @Test
+    fun `On 'PaymentIntent' requires confirmation, should call 'PaymentLauncher' to handle confirmation`() = runTest {
+        val confirmParams = ConfirmPaymentIntentParams.create(clientSecret = "pi_1234")
+        val paymentLauncher = FakePaymentLauncher()
+        val interceptor = FakeIntentConfirmationInterceptor().apply {
+            enqueueConfirmStep(confirmParams)
+        }
+
+        val intentConfirmationHandler = createIntentConfirmationHandler(
+            intentConfirmationInterceptor = interceptor,
+            paymentLauncher = paymentLauncher,
+        )
+
+        intentConfirmationHandler.start(
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+        )
+
+        val call = paymentLauncher.calls.awaitItem()
+
+        assertThat(call).isEqualTo(
+            FakePaymentLauncher.Call.Confirm.PaymentIntent(
+                params = confirmParams
+            )
+        )
+    }
+
+    @Test
+    fun `On 'SetupIntent' requires confirmation, should call 'PaymentLauncher' to handle confirmation`() = runTest {
+        val confirmParams = ConfirmSetupIntentParams.create(
+            clientSecret = "pi_1234",
+            paymentMethodType = PaymentMethod.Type.Card
+        )
+        val paymentLauncher = FakePaymentLauncher()
+        val interceptor = FakeIntentConfirmationInterceptor().apply {
+            enqueueConfirmStep(confirmParams)
+        }
+
+        val intentConfirmationHandler = createIntentConfirmationHandler(
+            intentConfirmationInterceptor = interceptor,
+            paymentLauncher = paymentLauncher,
+        )
+
+        intentConfirmationHandler.start(
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+        )
+
+        val call = paymentLauncher.calls.awaitItem()
+
+        assertThat(call).isEqualTo(
+            FakePaymentLauncher.Call.Confirm.SetupIntent(
+                params = confirmParams
+            )
+        )
+    }
+
+    @Test
+    fun `On 'PaymentIntent' requires next action, should call 'PaymentLauncher' to handle next action`() = runTest {
+        val paymentLauncher = FakePaymentLauncher()
+        val clientSecret = "pi_1234"
+        val interceptor = FakeIntentConfirmationInterceptor().apply {
+            enqueueNextActionStep(clientSecret)
+        }
+
+        val intentConfirmationHandler = createIntentConfirmationHandler(
+            intentConfirmationInterceptor = interceptor,
+            paymentLauncher = paymentLauncher,
+        )
+
+        intentConfirmationHandler.start(
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+        )
+
+        val call = paymentLauncher.calls.awaitItem()
+
+        assertThat(call).isEqualTo(
+            FakePaymentLauncher.Call.HandleNextAction.PaymentIntent(
+                clientSecret = clientSecret
+            )
+        )
+    }
+
+    @Test
+    fun `On 'SetupIntent' requires next action, should call 'PaymentLauncher' to handle next action`() = runTest {
+        val paymentLauncher = FakePaymentLauncher()
+        val clientSecret = "pi_1234"
+        val interceptor = FakeIntentConfirmationInterceptor().apply {
+            enqueueNextActionStep(clientSecret)
+        }
+
+        val intentConfirmationHandler = createIntentConfirmationHandler(
+            intentConfirmationInterceptor = interceptor,
+            paymentLauncher = paymentLauncher,
+        )
+
+        intentConfirmationHandler.start(
+            intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+        )
+
+        val call = paymentLauncher.calls.awaitItem()
+
+        assertThat(call).isEqualTo(
+            FakePaymentLauncher.Call.HandleNextAction.SetupIntent(
+                clientSecret = clientSecret
+            )
+        )
+    }
+
+    @Test
+    fun `On payment launcher result succeeded, should be 'Succeeded' result`() = runTest {
+        val interceptor = FakeIntentConfirmationInterceptor().apply {
+            enqueueConfirmStep(ConfirmPaymentIntentParams.create("pi_123"))
+        }
+
+        val intentConfirmationHandler = createIntentConfirmationHandler(
+            intentConfirmationInterceptor = interceptor,
+            shouldRegister = false,
+        )
+
+        val callback = intentConfirmationHandler.registerAndRetrievePaymentResultCallback()
+
+        intentConfirmationHandler.start(
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+        )
+
+        callback(InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED))
+
+        val result = intentConfirmationHandler.awaitIntentResult()
+
+        assertThat(result).isEqualTo(
+            IntentConfirmationHandler.Result.Succeeded(
+                intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                deferredIntentConfirmationType = null,
+            )
+        )
+    }
+
+    @Test
+    fun `On payment launcher result canceled, should be 'Canceled' result`() = runTest {
+        val interceptor = FakeIntentConfirmationInterceptor().apply {
+            enqueueConfirmStep(ConfirmPaymentIntentParams.create("pi_123"))
+        }
+
+        val intentConfirmationHandler = createIntentConfirmationHandler(
+            intentConfirmationInterceptor = interceptor,
+            shouldRegister = false,
+        )
+
+        val callback = intentConfirmationHandler.registerAndRetrievePaymentResultCallback()
+
+        intentConfirmationHandler.start(
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+        )
+
+        callback(InternalPaymentResult.Canceled)
+
+        val result = intentConfirmationHandler.awaitIntentResult()
+
+        assertThat(result).isEqualTo(IntentConfirmationHandler.Result.Canceled)
+    }
+
+    @Test
+    fun `On payment launcher result failed, should be 'Failed' result`() = runTest {
+        val interceptor = FakeIntentConfirmationInterceptor().apply {
+            enqueueConfirmStep(ConfirmPaymentIntentParams.create("pi_123"))
+        }
+
+        val intentConfirmationHandler = createIntentConfirmationHandler(
+            intentConfirmationInterceptor = interceptor,
+            shouldRegister = false,
+        )
+
+        val callback = intentConfirmationHandler.registerAndRetrievePaymentResultCallback()
+
+        intentConfirmationHandler.start(
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+        )
+
+        val cause = IllegalStateException("This is a failure!")
+
+        callback(InternalPaymentResult.Failed(cause))
+
+        val result = intentConfirmationHandler.awaitIntentResult()
+
+        assertThat(result).isEqualTo(
+            IntentConfirmationHandler.Result.Failed(
+                cause = cause,
+                message = R.string.stripe_something_went_wrong.resolvableString,
+                type = IntentConfirmationHandler.ErrorType.Payment,
+            )
+        )
+    }
+
+    @Test
+    fun `On payment confirm, should store 'isAwaitingPaymentResult' in 'SavedStateHandle'`() = runTest {
+        val savedStateHandle = SavedStateHandle()
+        val interceptor = FakeIntentConfirmationInterceptor().apply {
+            enqueueConfirmStep(ConfirmPaymentIntentParams.create("pi_123"))
+        }
+
+        val intentConfirmationHandler = createIntentConfirmationHandler(
+            intentConfirmationInterceptor = interceptor,
+            savedStateHandle = savedStateHandle,
+        )
+
+        intentConfirmationHandler.start(
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+        )
+
+        assertThat(savedStateHandle.get<Boolean>("AwaitingPaymentResult")).isTrue()
+    }
+
+    @Test
+    fun `On payment handle next action, should store 'isAwaitingPaymentResult' in 'SavedStateHandle'`() = runTest {
+        val savedStateHandle = SavedStateHandle()
+        val interceptor = FakeIntentConfirmationInterceptor().apply {
+            enqueueNextActionStep("pi_123")
+        }
+
+        val intentConfirmationHandler = createIntentConfirmationHandler(
+            intentConfirmationInterceptor = interceptor,
+            savedStateHandle = savedStateHandle,
+        )
+
+        intentConfirmationHandler.start(
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+        )
+
+        assertThat(savedStateHandle.get<Boolean>("AwaitingPaymentResult")).isTrue()
+    }
+
+    @Test
+    fun `On init with 'SavedStateHandle', should receive result through 'awaitIntentResult'`() = runTest {
+        val savedStateHandle = SavedStateHandle().apply {
+            set("AwaitingPaymentResult", true)
+        }
+
+        val intentConfirmationHandler = createIntentConfirmationHandler(
+            savedStateHandle = savedStateHandle,
+        )
+
+        val callback = intentConfirmationHandler.registerAndRetrievePaymentResultCallback()
+
+        callback(InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED))
+
+        val result = intentConfirmationHandler.awaitIntentResult()
+
+        assertThat(result).isEqualTo(
+            IntentConfirmationHandler.Result.Succeeded(
+                intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                deferredIntentConfirmationType = null,
+            )
+        )
+    }
+
+    @Test
+    fun `On successful confirm with deferred intent, should return 'Client' confirmation type`() = runTest {
+        val interceptor = FakeIntentConfirmationInterceptor().apply {
+            enqueueConfirmStep(
+                confirmParams = ConfirmPaymentIntentParams.create("pi_123"),
+                isDeferred = true,
+            )
+        }
+
+        val intentConfirmationHandler = createIntentConfirmationHandler(
+            intentConfirmationInterceptor = interceptor,
+            shouldRegister = false,
+        )
+
+        val callback = intentConfirmationHandler.registerAndRetrievePaymentResultCallback()
+
+        intentConfirmationHandler.start(
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+        )
+
+        callback(InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED))
+
+        val result = intentConfirmationHandler.awaitIntentResult()
+
+        assertThat(result).isEqualTo(
+            IntentConfirmationHandler.Result.Succeeded(
+                intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+            )
+        )
+    }
+
+    @Test
+    fun `On successful confirm with non-deferred intent, should return null confirmation type`() = runTest {
+        val interceptor = FakeIntentConfirmationInterceptor()
+
+        interceptor.enqueueConfirmStep(
+            confirmParams = ConfirmPaymentIntentParams.create("pi_123"),
+            isDeferred = false,
+        )
+
+        val intentConfirmationHandler = createIntentConfirmationHandler(
+            intentConfirmationInterceptor = interceptor,
+            shouldRegister = false,
+        )
+
+        val callback = intentConfirmationHandler.registerAndRetrievePaymentResultCallback()
+
+        intentConfirmationHandler.start(
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+        )
+
+        callback(InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED))
+
+        val result = intentConfirmationHandler.awaitIntentResult()
+
+        assertThat(result).isEqualTo(
+            IntentConfirmationHandler.Result.Succeeded(
+                intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                deferredIntentConfirmationType = null,
+            )
+        )
+    }
+
+    private fun createIntentConfirmationHandler(
+        arguments: IntentConfirmationHandler.Args = IntentConfirmationHandler.Args(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(clientSecret = "pi_1234_secret_1234"),
+            shippingDetails = null,
+        ),
+        intentConfirmationInterceptor: IntentConfirmationInterceptor = FakeIntentConfirmationInterceptor(),
+        paymentLauncher: PaymentLauncher = FakePaymentLauncher(),
+        savedStateHandle: SavedStateHandle = SavedStateHandle(),
+        shouldRegister: Boolean = true
+    ): IntentConfirmationHandler {
+        return IntentConfirmationHandler(
+            arguments = arguments,
+            intentConfirmationInterceptor = intentConfirmationInterceptor,
+            paymentLauncherFactory = { paymentLauncher },
+            context = ApplicationProvider.getApplicationContext(),
+            coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+            savedStateHandle = savedStateHandle
+        ).apply {
+            if (shouldRegister) {
+                register(
+                    activityResultCaller = mock {
+                        on {
+                            registerForActivityResult<PaymentLauncherContract.Args, InternalPaymentResult>(
+                                any(),
+                                any()
+                            )
+                        } doReturn mock()
+                    },
+                    lifecycleOwner = TestLifecycleOwner(),
+                )
+            }
+        }
+    }
+
+    private fun IntentConfirmationHandler.registerAndRetrievePaymentResultCallback():
+        (result: InternalPaymentResult) -> Unit {
+        val argumentCaptor = argumentCaptor<ActivityResultCallback<InternalPaymentResult>>()
+
+        register(
+            activityResultCaller = mock {
+                on {
+                    registerForActivityResult<PaymentLauncherContract.Args, InternalPaymentResult>(
+                        any(),
+                        argumentCaptor.capture()
+                    )
+                } doReturn mock()
+            },
+            lifecycleOwner = TestLifecycleOwner(),
+        )
+
+        return {
+            argumentCaptor.firstValue.onActivityResult(it)
+        }
+    }
+
+    private fun IntentConfirmationHandler.Result?.asFailed(): IntentConfirmationHandler.Result.Failed {
+        return this as IntentConfirmationHandler.Result.Failed
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -570,7 +570,7 @@ internal class PaymentSheetViewModelTest {
         viewModel.updateSelection(paymentSelection)
         viewModel.checkout()
 
-        verify(viewModel).confirmStripeIntent(eq(expectedParams))
+        verify(paymentLauncher).confirm(eq(expectedParams))
     }
 
     @Test
@@ -592,7 +592,7 @@ internal class PaymentSheetViewModelTest {
         viewModel.updateSelection(paymentSelection)
         viewModel.checkout()
 
-        verify(viewModel).confirmStripeIntent(eq(expectedParams))
+        verify(paymentLauncher).confirm(eq(expectedParams))
     }
 
     @Test
@@ -615,7 +615,7 @@ internal class PaymentSheetViewModelTest {
             viewModel.updateSelection(paymentSelection)
             viewModel.checkout()
 
-            verify(viewModel).confirmStripeIntent(confirmParams)
+            verify(paymentLauncher).confirm(eq(confirmParams))
         }
 
     @Test
@@ -642,7 +642,7 @@ internal class PaymentSheetViewModelTest {
         viewModel.updateSelection(paymentSelection)
         viewModel.checkout()
 
-        verify(viewModel).confirmStripeIntent(eq(expectedParams))
+        verify(paymentLauncher).confirm(eq(expectedParams))
     }
 
     @Test
@@ -688,7 +688,7 @@ internal class PaymentSheetViewModelTest {
         viewModel.updateSelection(paymentSelection)
         viewModel.checkout()
 
-        verify(viewModel).confirmStripeIntent(eq(expectedParams))
+        verify(paymentLauncher).confirm(eq(expectedParams))
     }
 
     @Test
@@ -2035,6 +2035,7 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `Sends correct deferred_intent_confirmation_type for client-side confirmation of deferred intent`() = runTest {
         val viewModel = createViewModelForDeferredIntent()
+        val callback = viewModel.capturePaymentResultListener()
 
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
         val savedSelection = PaymentSelection.Saved(paymentMethod)
@@ -2051,7 +2052,7 @@ internal class PaymentSheetViewModelTest {
             confirmParams = confirmParams,
             isDeferred = true,
         )
-        viewModel.onPaymentResult(PaymentResult.Completed)
+        callback.onActivityResult(InternalPaymentResult.Completed(PAYMENT_INTENT))
 
         verify(eventReporter).onPaymentSuccess(
             paymentSelection = eq(savedSelection),
@@ -2062,6 +2063,7 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `Sends correct deferred_intent_confirmation_type for server-side confirmation of deferred intent`() = runTest {
         val viewModel = createViewModelForDeferredIntent()
+        val callback = viewModel.capturePaymentResultListener()
 
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
         val savedSelection = PaymentSelection.Saved(paymentMethod)
@@ -2070,7 +2072,7 @@ internal class PaymentSheetViewModelTest {
         viewModel.checkout()
 
         fakeIntentConfirmationInterceptor.enqueueNextActionStep("pi_123_secret_456")
-        viewModel.onPaymentResult(PaymentResult.Completed)
+        callback.onActivityResult(InternalPaymentResult.Completed(PAYMENT_INTENT))
 
         verify(eventReporter).onPaymentSuccess(
             paymentSelection = eq(savedSelection),
@@ -2262,7 +2264,8 @@ internal class PaymentSheetViewModelTest {
         }
 
         val viewModel = createViewModel(
-            bacsMandateConfirmationLauncherFactory = launcherFactory
+            bacsMandateConfirmationLauncherFactory = launcherFactory,
+            shouldRegister = false,
         ).apply {
             registerFromActivity(activityResultCaller, TestLifecycleOwner())
         }
@@ -2749,6 +2752,35 @@ internal class PaymentSheetViewModelTest {
             .isInstanceOf<SelectSavedPaymentMethods.CvcRecollectionState.NotRequired>()
     }
 
+    @Test
+    fun `On confirm with existing payment method, calls interceptor with expected parameters`() = runTest {
+        val initializationMode = InitializationMode.PaymentIntent(clientSecret = "pi_123")
+        val intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
+        val intentConfirmationInterceptor = FakeIntentConfirmationInterceptor()
+        val viewModel = createViewModel(
+            args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
+                initializationMode = initializationMode,
+            ),
+            stripeIntent = intent,
+            intentConfirmationInterceptor = intentConfirmationInterceptor
+        )
+
+        val paymentSelection = PaymentSelection.Saved(CARD_PAYMENT_METHOD)
+        viewModel.updateSelection(paymentSelection)
+        viewModel.checkout()
+
+        val call = intentConfirmationInterceptor.calls.awaitItem()
+
+        assertThat(call).isEqualTo(
+            FakeIntentConfirmationInterceptor.InterceptCall.WithExistingPaymentMethod(
+                initializationMode = initializationMode,
+                paymentMethod = CARD_PAYMENT_METHOD,
+                paymentMethodOptionsParams = null,
+                shippingValues = null,
+            )
+        )
+    }
+
     @OptIn(ExperimentalCvcRecollectionApi::class)
     @Test
     fun `getCvcRecollectionState returns correct state for deferred flow`() = runTest {
@@ -2841,6 +2873,7 @@ internal class PaymentSheetViewModelTest {
         )
 
         viewModel.updateSelection(selection)
+        viewModel.checkout()
 
         paymentResultListener.onActivityResult(InternalPaymentResult.Completed(intent))
 
@@ -2885,6 +2918,7 @@ internal class PaymentSheetViewModelTest {
         initialPaymentSelection: PaymentSelection? =
             customer?.paymentMethods?.firstOrNull()?.let { PaymentSelection.Saved(it) },
         bacsMandateConfirmationLauncherFactory: BacsMandateConfirmationLauncherFactory = mock(),
+        paymentLauncherFactory: StripePaymentLauncherAssistedFactory = this.paymentLauncherFactory,
         validationError: PaymentSheetLoadingException? = null,
         savedStateHandle: SavedStateHandle = SavedStateHandle(),
         paymentSheetLoader: PaymentSheetLoader = FakePaymentSheetLoader(
@@ -2897,6 +2931,7 @@ internal class PaymentSheetViewModelTest {
             paymentSelection = initialPaymentSelection,
             validationError = validationError,
         ),
+        shouldRegister: Boolean = true,
     ): PaymentSheetViewModel {
         val paymentConfiguration = PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
         return TestViewModelFactory.create(
@@ -2907,11 +2942,9 @@ internal class PaymentSheetViewModelTest {
                 application = application,
                 args = args,
                 eventReporter = eventReporter,
-                lazyPaymentConfig = { paymentConfiguration },
                 paymentSheetLoader = paymentSheetLoader,
                 customerRepository = customerRepository,
                 prefsRepository = prefsRepository,
-                paymentLauncherFactory = paymentLauncherFactory,
                 googlePayPaymentMethodLauncherFactory = googlePayLauncherFactory,
                 bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,
                 logger = Logger.noop(),
@@ -2919,10 +2952,27 @@ internal class PaymentSheetViewModelTest {
                 savedStateHandle = thisSavedStateHandle,
                 linkHandler = linkHandler,
                 linkConfigurationCoordinator = linkInteractor,
-                intentConfirmationInterceptor = intentConfirmationInterceptor,
+                intentConfirmationHandlerFactory = IntentConfirmationHandler.Factory(
+                    paymentSheetArguments = args,
+                    intentConfirmationInterceptor = intentConfirmationInterceptor,
+                    savedStateHandle = thisSavedStateHandle,
+                    stripePaymentLauncherAssistedFactory = paymentLauncherFactory,
+                    paymentConfigurationProvider = { paymentConfiguration },
+                    application = application,
+                ),
                 editInteractorFactory = fakeEditPaymentMethodInteractorFactory,
                 errorReporter = FakeErrorReporter(),
-            )
+            ).apply {
+                if (shouldRegister) {
+                    val activityResultCaller = mock<ActivityResultCaller> {
+                        on {
+                            registerForActivityResult<PaymentLauncherContract.Args, InternalPaymentResult>(any(), any())
+                        } doReturn mock()
+                    }
+
+                    registerFromActivity(activityResultCaller, TestLifecycleOwner())
+                }
+            }
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.utils
 
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
@@ -11,6 +13,8 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.coroutines.channels.Channel
 
 internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor {
+    private val _calls = Turbine<InterceptCall>()
+    val calls: ReceiveTurbine<InterceptCall> = _calls
 
     private val channel = Channel<IntentConfirmationInterceptor.NextStep>(capacity = 1)
 
@@ -51,6 +55,16 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         customerRequestedSave: Boolean,
     ): IntentConfirmationInterceptor.NextStep {
+        _calls.add(
+            InterceptCall.WithNewPaymentMethod(
+                initializationMode = initializationMode,
+                paymentMethodCreateParams = paymentMethodCreateParams,
+                paymentMethodOptionsParams = paymentMethodOptionsParams,
+                shippingValues = shippingValues,
+                customerRequestedSave = customerRequestedSave,
+            )
+        )
+
         return channel.receive()
     }
 
@@ -60,6 +74,32 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
         paymentMethodOptionsParams: PaymentMethodOptionsParams?,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
     ): IntentConfirmationInterceptor.NextStep {
+        _calls.add(
+            InterceptCall.WithExistingPaymentMethod(
+                initializationMode = initializationMode,
+                paymentMethod = paymentMethod,
+                paymentMethodOptionsParams = paymentMethodOptionsParams,
+                shippingValues = shippingValues,
+            )
+        )
+
         return channel.receive()
+    }
+
+    sealed interface InterceptCall {
+        data class WithNewPaymentMethod(
+            val initializationMode: PaymentSheet.InitializationMode,
+            val paymentMethodCreateParams: PaymentMethodCreateParams,
+            val paymentMethodOptionsParams: PaymentMethodOptionsParams?,
+            val shippingValues: ConfirmPaymentIntentParams.Shipping?,
+            val customerRequestedSave: Boolean,
+        ) : InterceptCall
+
+        data class WithExistingPaymentMethod(
+            val initializationMode: PaymentSheet.InitializationMode,
+            val paymentMethod: PaymentMethod,
+            val paymentMethodOptionsParams: PaymentMethodOptionsParams?,
+            val shippingValues: ConfirmPaymentIntentParams.Shipping?,
+        ) : InterceptCall
     }
 }


### PR DESCRIPTION
# Summary
Move primary logic for intent confirmation into `IntentConfirmationHandler`.

# Motivation
Helps move whole intent confirmation flow into a single location for handling intent confirmations that can be shared between `PaymentSheet` and `FlowController`.

# Video
https://github.com/user-attachments/assets/3d79549b-9e6a-4490-baa8-0fb2ef9e905a

