### PR TITLE
Abstract out LinkInlineHandler from BaseSheetViewModel.

### DIFF
--- a/financial-connections-example/detekt-baseline.xml
+++ b/financial-connections-example/detekt-baseline.xml
@@ -1,7 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <SmellBaseline>
   <ManuallySuppressedIssues/>
-  <CurrentIssues>
-    <ID>LongMethod:FinancialConnectionsPlaygroundActivity.kt$FinancialConnectionsPlaygroundActivity$@Composable private fun FinancialConnectionsScreen()</ID>
-  </CurrentIssues>
+  <CurrentIssues/>
 </SmellBaseline>

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -6,18 +6,17 @@
     <ID>CyclomaticComplexMethod:PlaceholderHelper.kt$PlaceholderHelper$@VisibleForTesting internal fun specForPlaceholderField( field: PlaceholderField, placeholderOverrideList: List&lt;IdentifierSpec>, requiresMandate: Boolean, configuration: PaymentSheet.BillingDetailsCollectionConfiguration, )</ID>
     <ID>CyclomaticComplexMethod:TransformSpecToElements.kt$TransformSpecToElements$fun transform( specs: List&lt;FormItemSpec>, placeholderOverrideList: List&lt;IdentifierSpec> = emptyList(), ): List&lt;FormElement></ID>
     <ID>EmptyFunctionBlock:PrimaryButtonAnimator.kt$PrimaryButtonAnimator.&lt;no name provided>${ }</ID>
+    <ID>EmptyFunctionBlock:VerticalModeFormUITest.kt$VerticalModeFormUITest.&lt;no name provided>${}</ID>
     <ID>ForbiddenComment:PaymentOptionFactory.kt$PaymentOptionFactory$// TODO: Should use labelResource paymentMethodCreateParams or extension function</ID>
     <ID>FunctionNaming:PaymentSheetTopBar.kt$@Preview @Composable internal fun PaymentSheetTopBar_Preview()</ID>
     <ID>FunctionNaming:PaymentSheetTopBar.kt$@Preview @Composable internal fun TestModeBadge_Preview()</ID>
     <ID>FunctionOnlyReturningConstant:FlowControllerModule.kt$FlowControllerModule$@Provides @Singleton @Named(IS_FLOW_CONTROLLER) fun provideIsFlowController()</ID>
     <ID>FunctionOnlyReturningConstant:PaymentSheetLauncherModule.kt$PaymentSheetLauncherModule.Companion$@Provides @Singleton @Named(IS_FLOW_CONTROLLER) fun provideIsFlowController()</ID>
-    <ID>LargeClass:BaseSheetViewModel.kt$BaseSheetViewModel : AndroidViewModel</ID>
     <ID>LargeClass:CustomerAdapterTest.kt$CustomerAdapterTest</ID>
     <ID>LargeClass:CustomerSheetViewModel.kt$CustomerSheetViewModel : ViewModel</ID>
     <ID>LargeClass:CustomerSheetViewModelTest.kt$CustomerSheetViewModelTest</ID>
     <ID>LargeClass:DefaultFlowController.kt$DefaultFlowController : FlowController</ID>
     <ID>LargeClass:DefaultFlowControllerTest.kt$DefaultFlowControllerTest</ID>
-    <ID>LargeClass:DefaultPaymentMethodVerticalLayoutInteractorTest.kt$DefaultPaymentMethodVerticalLayoutInteractorTest</ID>
     <ID>LargeClass:DefaultPaymentSheetLoaderTest.kt$DefaultPaymentSheetLoaderTest</ID>
     <ID>LargeClass:PaymentMethodMetadataTest.kt$PaymentMethodMetadataTest</ID>
     <ID>LargeClass:PaymentOptionsViewModelTest.kt$PaymentOptionsViewModelTest</ID>
@@ -33,13 +32,13 @@
     <ID>LongMethod:FormViewModelTest.kt$FormViewModelTest$@Test fun `Verify params are set when required address fields are complete`()</ID>
     <ID>LongMethod:PaymentOptionFactory.kt$PaymentOptionFactory$fun create(selection: PaymentSelection): PaymentOption</ID>
     <ID>LongMethod:PaymentSheetConfigurationKtx.kt$internal fun PaymentSheet.Appearance.parseAppearance()</ID>
-    <ID>LongMethod:PaymentSheetLoader.kt$DefaultPaymentSheetLoader$private suspend fun create( elementsSession: ElementsSession, config: PaymentSheet.Configuration, metadata: PaymentMethodMetadata, ): PaymentSheetState.Full</ID>
     <ID>LongMethod:PaymentSheetViewModelTest.kt$PaymentSheetViewModelTest$@Test fun `Can complete payment after switching to another LPM from card selection with inline Link signup state`()</ID>
     <ID>LongMethod:PlaceholderHelperTest.kt$PlaceholderHelperTest$@Test fun `Test correct placeholder is removed for placeholder spec`()</ID>
     <ID>LongMethod:USBankAccountEmitters.kt$@Composable internal fun USBankAccountEmitters( viewModel: USBankAccountFormViewModel, usBankAccountFormArgs: USBankAccountFormArguments, )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable internal fun BillingDetailsForm( instantDebits: Boolean, formArgs: FormArguments, isProcessing: Boolean, isPaymentFlow: Boolean, nameController: TextFieldController, emailController: TextFieldController, phoneController: PhoneNumberController, addressController: AddressController, lastTextFieldIdentifier: IdentifierSpec?, sameAsShippingElement: SameAsShippingElement?, )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable internal fun USBankAccountForm( formArgs: FormArguments, usBankAccountFormArgs: USBankAccountFormArguments, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable private fun AccountDetailsForm( showCheckbox: Boolean, isProcessing: Boolean, bankName: String?, last4: String?, saveForFutureUseElement: SaveForFutureUseElement, onRemoveAccount: () -> Unit, )</ID>
+    <ID>MagicNumber:AddPaymentMethodInteractor.kt$DefaultAddPaymentMethodInteractor.Companion$5_000</ID>
     <ID>MagicNumber:BaseSheetActivity.kt$BaseSheetActivity$30</ID>
     <ID>MagicNumber:NewPaymentMethodTabLayoutUI.kt$.3f</ID>
     <ID>MagicNumber:NewPaymentMethodTabLayoutUI.kt$.4f</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
@@ -72,8 +72,6 @@ internal class LinkHandler @Inject constructor(
         MutableSharedFlow<ProcessingState>(replay = 1, extraBufferCapacity = 5)
     val processingState: Flow<ProcessingState> = _processingState
 
-    val linkInlineSelection = MutableStateFlow<PaymentSelection.New.LinkInline?>(null)
-
     private val _isLinkEnabled = MutableStateFlow<Boolean?>(null)
     val isLinkEnabled: StateFlow<Boolean?> = _isLinkEnabled
 
@@ -86,13 +84,11 @@ internal class LinkHandler @Inject constructor(
 
     val linkSignupMode: Flow<LinkSignupMode?> = combine(
         linkConfiguration,
-        linkInlineSelection,
         accountStatus.take(1), // We only care about the initial status, as the status might change during checkout
-    ) { linkConfig, linkInlineSelection, linkAccountStatus ->
-        val linkInlineSelectionValid = linkInlineSelection != null
+    ) { linkConfig, linkAccountStatus ->
         val validFundingSource = linkConfig?.stripeIntent?.linkFundingSources?.contains(Card.code) == true
         val notLoggedIn = linkAccountStatus == AccountStatus.SignedOut
-        val ableToShowLink = validFundingSource && (notLoggedIn || linkInlineSelectionValid)
+        val ableToShowLink = validFundingSource && notLoggedIn
         linkConfig?.signupMode.takeIf { ableToShowLink }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkInlineHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkInlineHandler.kt
@@ -1,0 +1,115 @@
+package com.stripe.android.paymentsheet
+
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.link.ui.inline.InlineSignupViewState
+import com.stripe.android.link.ui.inline.UserInput
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.ui.PrimaryButton
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.uicore.utils.mapAsStateFlow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+
+internal class LinkInlineHandler(
+    private val coroutineScope: CoroutineScope,
+    private val payWithLink: suspend (
+        userInput: UserInput?,
+        paymentSelection: PaymentSelection?,
+        shouldCompleteLinkInlineFlow: Boolean,
+    ) -> Unit,
+    private val selection: StateFlow<PaymentSelection?>,
+    private val updateLinkPrimaryButtonUiState: (PrimaryButton.UIState?) -> Unit,
+    private val primaryButtonLabel: StateFlow<ResolvableString?>,
+    private val shouldCompleteLinkFlowInline: Boolean,
+) {
+    private val linkInlineSignUpState = MutableStateFlow<InlineSignupViewState?>(null)
+
+    init {
+        coroutineScope.launch {
+            var inLinkSignUpMode = false
+
+            combine(
+                selection,
+                linkInlineSignUpState
+            ) { paymentSelection, linkInlineSignUpState ->
+                Pair(paymentSelection, linkInlineSignUpState)
+            }.collect { pair ->
+                val (paymentSelection, linkInlineSignUpState) = pair
+                // Only reset custom primary button state if we haven't already
+                if (paymentSelection !is PaymentSelection.New.Card) {
+                    if (inLinkSignUpMode) {
+                        // US bank account will update the custom primary state on its own
+                        if (paymentSelection !is PaymentSelection.New.USBankAccount) {
+                            updateLinkPrimaryButtonUiState(null)
+                        }
+
+                        inLinkSignUpMode = false
+                    }
+
+                    return@collect
+                }
+
+                inLinkSignUpMode = true
+
+                if (linkInlineSignUpState != null) {
+                    updatePrimaryButton(linkInlineSignUpState)
+                }
+            }
+        }
+    }
+
+    private fun updatePrimaryButton(viewState: InlineSignupViewState) {
+        val label = primaryButtonLabel.value ?: return
+
+        updateLinkPrimaryButtonUiState(
+            if (viewState.useLink) {
+                val userInput = viewState.userInput
+                val paymentSelection = selection.value
+
+                if (userInput != null && paymentSelection != null) {
+                    PrimaryButton.UIState(
+                        label = label,
+                        onClick = { payWithLinkInline(userInput) },
+                        enabled = true,
+                        lockVisible = shouldCompleteLinkFlowInline,
+                    )
+                } else {
+                    PrimaryButton.UIState(
+                        label = label,
+                        onClick = {},
+                        enabled = false,
+                        lockVisible = shouldCompleteLinkFlowInline,
+                    )
+                }
+            } else {
+                null
+            }
+        )
+    }
+
+    private fun payWithLinkInline(userInput: UserInput?) {
+        coroutineScope.launch {
+            payWithLink(userInput, selection.value, shouldCompleteLinkFlowInline)
+        }
+    }
+
+    fun onStateUpdated(state: InlineSignupViewState) {
+        linkInlineSignUpState.value = state
+    }
+
+    companion object {
+        fun create(viewModel: BaseSheetViewModel, coroutineScope: CoroutineScope): LinkInlineHandler {
+            return LinkInlineHandler(
+                coroutineScope = coroutineScope,
+                payWithLink = viewModel.linkHandler::payWithLinkInline,
+                selection = viewModel.selection,
+                updateLinkPrimaryButtonUiState = { viewModel.customPrimaryButtonUiState.value = it },
+                primaryButtonLabel = viewModel.primaryButtonUiState.mapAsStateFlow { it?.label },
+                shouldCompleteLinkFlowInline = viewModel.shouldCompleteLinkFlowInline,
+            )
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -101,7 +101,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
 
     override val walletsState: StateFlow<WalletsState?> = combineAsStateFlow(
         linkHandler.isLinkEnabled,
-        linkEmailFlow,
+        linkConfigurationCoordinator.emailFlow,
         buttonsEnabled,
         supportedPaymentMethodsFlow,
         googlePayState,
@@ -160,7 +160,6 @@ internal class PaymentOptionsViewModel @Inject constructor(
         // This is bad, but I don't think there's a better option
         PaymentSheet.FlowController.linkHandler = linkHandler
 
-        linkHandler.linkInlineSelection.value = args.state.paymentSelection as? PaymentSelection.New.LinkInline
         linkHandler.setupLink(linkState)
 
         // After recovering from don't keep activities the paymentMethodMetadata will be saved,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -217,7 +217,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     override val walletsState: StateFlow<WalletsState?> = combineAsStateFlow(
         linkHandler.isLinkEnabled,
-        linkEmailFlow,
+        linkConfigurationCoordinator.emailFlow,
         googlePayState,
         buttonsEnabled,
         supportedPaymentMethodsFlow,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -237,7 +237,7 @@ internal sealed interface PaymentSheetScreen {
     class Form(
         private val interactor: VerticalModeFormInteractor,
         private val showsWalletHeader: Boolean = false,
-    ) : PaymentSheetScreen {
+    ) : PaymentSheetScreen, Closeable {
 
         override val showsBuyButton: Boolean = true
         override val showsContinueButton: Boolean = true
@@ -251,6 +251,10 @@ internal sealed interface PaymentSheetScreen {
         @Composable
         override fun Content(viewModel: BaseSheetViewModel, modifier: Modifier) {
             VerticalModeFormUI(interactor)
+        }
+
+        override fun close() {
+            interactor.close()
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
@@ -10,6 +10,7 @@ import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import kotlinx.coroutines.flow.update
 
 /**
  * [USBankAccountFormArguments] provides the arguments required to render the [USBankAccountForm].
@@ -88,7 +89,7 @@ internal class USBankAccountFormArguments(
                 onMandateTextChanged = viewModel::updateMandateText,
                 onConfirmUSBankAccount = viewModel::handleConfirmUSBankAccount,
                 onCollectBankAccountResult = null,
-                onUpdatePrimaryButtonUIState = viewModel::updateCustomPrimaryButtonUiState,
+                onUpdatePrimaryButtonUIState = { viewModel.customPrimaryButtonUiState.update(it) },
                 onUpdatePrimaryButtonState = viewModel::updatePrimaryButtonState,
                 onError = viewModel::onError
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
@@ -7,18 +7,27 @@ import com.stripe.android.lpmfoundations.FormHeaderInformation
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
 import com.stripe.android.paymentsheet.FormHelper
+import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.utils.combineAsStateFlow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
 
 internal interface VerticalModeFormInteractor {
     val state: StateFlow<State>
 
     fun handleViewAction(viewAction: ViewAction)
+
+    fun close()
 
     data class State(
         val selectedPaymentMethodCode: String,
@@ -42,6 +51,13 @@ internal class DefaultVerticalModeFormInteractor(
     private val selectedPaymentMethodCode: String,
     private val viewModel: BaseSheetViewModel,
 ) : VerticalModeFormInteractor {
+    private val coroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+    private val linkInlineHandler = LinkInlineHandler.create(viewModel, coroutineScope)
+    private val linkSignupMode = viewModel.linkHandler.linkSignupMode.stateIn(
+        scope = coroutineScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = null,
+    )
     private val formHelper = FormHelper.create(viewModel)
     private val formArguments: FormArguments = formHelper.createFormArguments(selectedPaymentMethodCode)
     private val formElements: List<FormElement> = formHelper.formElementsForCode(selectedPaymentMethodCode)
@@ -54,7 +70,7 @@ internal class DefaultVerticalModeFormInteractor(
 
     override val state: StateFlow<VerticalModeFormInteractor.State> = combineAsStateFlow(
         viewModel.processing,
-        viewModel.linkSignupMode,
+        linkSignupMode,
         viewModel.paymentMethodMetadata,
     ) { isProcessing, linkSignupMode, paymentMethodMetadata ->
         VerticalModeFormInteractor.State(
@@ -78,8 +94,12 @@ internal class DefaultVerticalModeFormInteractor(
                 formHelper.onFormFieldValuesChanged(viewAction.formValues, selectedPaymentMethodCode)
             }
             is VerticalModeFormInteractor.ViewAction.LinkSignupStateChanged -> {
-                viewModel.onLinkSignUpStateUpdated(viewAction.linkInlineSignupViewState)
+                linkInlineHandler.onStateUpdated(viewAction.linkInlineSignupViewState)
             }
         }
+    }
+
+    override fun close() {
+        coroutineScope.cancel()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
@@ -4,8 +4,11 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.parsers.PaymentMethodJsonParser
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormScreenState
+import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.ExternalPaymentMethodSpec
 import org.json.JSONObject
+import org.mockito.kotlin.mock
 import java.util.UUID
 import java.util.concurrent.ThreadLocalRandom
 
@@ -411,6 +414,38 @@ internal object PaymentMethodFixtures {
         PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
         CardBrand.Visa,
         customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
+    )
+
+    val GENERIC_PAYMENT_SELECTION = PaymentSelection.New.GenericPaymentMethod(
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_paypal,
+        label = resolvableString("PayPal"),
+        paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.PAYPAL,
+        customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
+        lightThemeIconUrl = null,
+        darkThemeIconUrl = null,
+    )
+
+    val US_BANK_PAYMENT_SELECTION = PaymentSelection.New.USBankAccount(
+        labelResource = "Test",
+        iconResource = 0,
+        paymentMethodCreateParams = mock(),
+        customerRequestedSave = mock(),
+        input = PaymentSelection.New.USBankAccount.Input(
+            name = "",
+            email = null,
+            phone = null,
+            address = null,
+            saveForFutureUse = false,
+        ),
+        instantDebits = null,
+        screenState = USBankAccountFormScreenState.SavedAccount(
+            financialConnectionsSessionId = "session_1234",
+            intentId = "intent_1234",
+            bankName = "Stripe Bank",
+            last4 = "6789",
+            primaryButtonText = resolvableString("Continue"),
+            mandateText = null,
+        ),
     )
 
 //

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/LinkInlineHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/LinkInlineHandlerTest.kt
@@ -1,0 +1,172 @@
+package com.stripe.android.paymentsheet
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.link.ui.inline.InlineSignupViewState
+import com.stripe.android.link.ui.inline.LinkSignupMode
+import com.stripe.android.link.ui.inline.SignUpConsentAction
+import com.stripe.android.link.ui.inline.UserInput
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.ui.PrimaryButton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class LinkInlineHandlerTest {
+    private val incompleteInlineSignupViewState = InlineSignupViewState(
+        userInput = null,
+        merchantName = "Example, Inc.",
+        signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
+        fields = emptyList(),
+        prefillEligibleFields = emptySet(),
+        isExpanded = false,
+    )
+
+    private val filledOutInlineSignupViewState = InlineSignupViewState(
+        userInput = UserInput.SignUp(
+            email = "email@email.com",
+            phone = "1234567890",
+            country = "US",
+            name = null,
+            consentAction = SignUpConsentAction.Checkbox,
+        ),
+        merchantName = "Example, Inc.",
+        signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
+        fields = emptyList(),
+        prefillEligibleFields = emptySet(),
+        isExpanded = true,
+    )
+
+    @Test
+    fun `initialization causes no side effects`() = runScenario {
+        assertThat(linkInlineHandler).isNotNull()
+    }
+
+    @Test
+    fun `onStateUpdated with valid selection updates LinkPrimaryButtonUiState`() {
+        var updatedLinkPrimaryButtonUiState: PrimaryButton.UIState? = null
+        runScenario(
+            updateLinkPrimaryButtonUiState = { updatedLinkPrimaryButtonUiState = it },
+        ) {
+            selection.value = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
+            primaryButtonLabel.value = resolvableString("Continue")
+            linkInlineHandler.onStateUpdated(filledOutInlineSignupViewState)
+        }
+        assertThat(updatedLinkPrimaryButtonUiState).isNotNull()
+    }
+
+    @Test
+    fun `onStateUpdated with valid incomplete user input updates LinkPrimaryButtonUiState`() {
+        var hasCalledUpdateLinkPrimaryButtonUiState = false
+        runScenario(
+            updateLinkPrimaryButtonUiState = {
+                assertThat(it).isNull()
+                hasCalledUpdateLinkPrimaryButtonUiState = true
+            }
+        ) {
+            selection.value = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
+            primaryButtonLabel.value = resolvableString("Continue")
+            linkInlineHandler.onStateUpdated(incompleteInlineSignupViewState)
+        }
+        assertThat(hasCalledUpdateLinkPrimaryButtonUiState).isTrue()
+    }
+
+    @Test
+    fun `updating selection away from card and link removes custom primary state`() {
+        var updatedLinkPrimaryButtonUiState: PrimaryButton.UIState? = null
+
+        runScenario(
+            updateLinkPrimaryButtonUiState = { updatedLinkPrimaryButtonUiState = it },
+        ) {
+            selection.value = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
+            primaryButtonLabel.value = resolvableString("Continue")
+
+            linkInlineHandler.onStateUpdated(filledOutInlineSignupViewState)
+            assertThat(updatedLinkPrimaryButtonUiState).isNotNull()
+
+            selection.value = PaymentMethodFixtures.GENERIC_PAYMENT_SELECTION
+            assertThat(updatedLinkPrimaryButtonUiState).isNull()
+        }
+    }
+
+    @Test
+    fun `updating selection to us bank does not reset custom primary state`() {
+        var updatedLinkPrimaryButtonUiState: PrimaryButton.UIState? = null
+
+        runScenario(
+            updateLinkPrimaryButtonUiState = { updatedLinkPrimaryButtonUiState = it },
+        ) {
+            selection.value = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
+            primaryButtonLabel.value = resolvableString("Continue")
+
+            linkInlineHandler.onStateUpdated(filledOutInlineSignupViewState)
+            assertThat(updatedLinkPrimaryButtonUiState).isNotNull()
+
+            selection.value = PaymentMethodFixtures.US_BANK_PAYMENT_SELECTION
+            assertThat(updatedLinkPrimaryButtonUiState).isNotNull()
+        }
+    }
+
+    @Test
+    fun `calling onClick on updatedLinkPrimaryButtonUiState calls payWithLink`() {
+        var updatedLinkPrimaryButtonUiState: PrimaryButton.UIState? = null
+        var hasCalledPayWithLink = false
+        runScenario(
+            updateLinkPrimaryButtonUiState = { updatedLinkPrimaryButtonUiState = it },
+            payWithLink = { userInput, paymentSelection, shouldCompleteLinkFlowInline ->
+                assertThat(userInput).isEqualTo(filledOutInlineSignupViewState.userInput)
+                assertThat(paymentSelection).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+                assertThat(shouldCompleteLinkFlowInline).isTrue()
+                hasCalledPayWithLink = true
+            }
+        ) {
+            selection.value = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
+            primaryButtonLabel.value = resolvableString("Continue")
+            linkInlineHandler.onStateUpdated(filledOutInlineSignupViewState)
+            assertThat(updatedLinkPrimaryButtonUiState).isNotNull()
+            assertThat(hasCalledPayWithLink).isFalse()
+            updatedLinkPrimaryButtonUiState!!.onClick()
+            assertThat(hasCalledPayWithLink).isTrue()
+        }
+    }
+
+    private fun runScenario(
+        updateLinkPrimaryButtonUiState: (PrimaryButton.UIState?) -> Unit = {
+            throw AssertionError("Not implemented")
+        },
+        payWithLink: suspend (
+            userInput: UserInput?,
+            paymentSelection: PaymentSelection?,
+            shouldCompleteLinkInlineFlow: Boolean,
+        ) -> Unit = { _, _, _ -> throw AssertionError("Not implemented") },
+        block: suspend Scenario.() -> Unit,
+    ) {
+        runTest {
+            val selection: MutableStateFlow<PaymentSelection?> = MutableStateFlow(null)
+            val primaryButtonLabel: MutableStateFlow<ResolvableString?> = MutableStateFlow(null)
+            val linkInlineHandler = LinkInlineHandler(
+                coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+                payWithLink = payWithLink,
+                selection = selection,
+                updateLinkPrimaryButtonUiState = updateLinkPrimaryButtonUiState,
+                primaryButtonLabel = primaryButtonLabel,
+                shouldCompleteLinkFlowInline = true,
+            )
+            Scenario(
+                linkInlineHandler = linkInlineHandler,
+                selection = selection,
+                primaryButtonLabel = primaryButtonLabel,
+            ).apply { block() }
+        }
+    }
+
+    private class Scenario(
+        val linkInlineHandler: LinkInlineHandler,
+        val selection: MutableStateFlow<PaymentSelection?>,
+        val primaryButtonLabel: MutableStateFlow<ResolvableString?>,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -7,6 +7,7 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.testing.TestLifecycleOwner
+import androidx.lifecycle.viewModelScope
 import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.test
 import app.cash.turbine.turbineScope
@@ -820,7 +821,8 @@ internal class PaymentSheetViewModelTest {
                 )
             )
 
-            viewModel.updatePrimaryButtonForLinkSignup(
+            val linkInlineHandler = LinkInlineHandler.create(viewModel, viewModel.viewModelScope)
+            linkInlineHandler.onStateUpdated(
                 InlineSignupViewState.create(
                     config = linkConfiguration
                 ).copy(
@@ -2466,7 +2468,8 @@ internal class PaymentSheetViewModelTest {
 
                 assertThat(awaitItem()?.enabled).isTrue()
 
-                viewModel.onLinkSignUpStateUpdated(
+                val linkInlineHandler = LinkInlineHandler.create(viewModel, viewModel.viewModelScope)
+                linkInlineHandler.onStateUpdated(
                     InlineSignupViewState.create(config = LINK_CONFIG).copy(
                         isExpanded = true,
                         userInput = UserInput.SignUp(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultAddPaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultAddPaymentMethodInteractorTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -335,7 +336,7 @@ class DefaultAddPaymentMethodInteractorTest {
             onFormFieldValuesChanged = onFormFieldValuesChanged,
             reportPaymentMethodTypeSelected = reportPaymentMethodTypeSelected,
             createUSBankAccountFormArguments = createUSBankAccountFormArguments,
-            dispatcher = dispatcher,
+            coroutineScope = CoroutineScope(dispatcher),
         )
 
         TestParams(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
@@ -111,6 +111,8 @@ internal class VerticalModeFormUITest {
             override fun handleViewAction(viewAction: VerticalModeFormInteractor.ViewAction) {
                 viewActionRecorder.record(viewAction)
             }
+
+            override fun close() {}
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This cleanly pulls out some code into it's own class, and is now only referenced in the screens it's used in! This also removed some dead code.
