### PR TITLE
Add version number validation to deploy process

### DIFF
--- a/scripts/deploy/deploy.rb
+++ b/scripts/deploy/deploy.rb
@@ -4,6 +4,7 @@ require 'colorize'
 require 'optparse'
 
 require_relative 'update_version_numbers'
+require_relative 'validate_version_number'
 
 @step_index = 1
 
@@ -44,6 +45,7 @@ OptionParser.new do |opts|
 end.parse!
 
 steps = [
+    method(:validate_version_number),
     method(:update_read_me),
     method(:update_stripe_sdk_version),
     method(:update_gradle_properties),

--- a/scripts/deploy/validate_version_number.rb
+++ b/scripts/deploy/validate_version_number.rb
@@ -1,0 +1,55 @@
+#!/usr/bin/env ruby
+
+require 'octokit'
+
+def validate_version_number_format(version_number)
+  part_names = ['major', 'minor', 'patch']
+  parts = version_number.split('.')
+
+  unless parts.length() == 3
+    abort("Invalid version number. It should consist of a major, minor, and patch number.")
+  end
+
+  parts.each_with_index do | part, index |
+    if part.start_with?('0') && part.length() > 1
+      part_name = part_names[index]
+      abort("Invalid version number: #{part_name} number can\'t begin with 0.")
+    end
+  end
+end
+
+def target_version_is_newer(target_version, current_version)
+  target_major, target_minor, target_patch = target_version.split('.')
+  # We tag version numbers to start with "v", so we need to remove that before comparing to the
+  # target version.
+  current_major, current_minor, current_patch = current_version[1..].split('.')
+
+  if target_major < current_major
+    false
+  elsif target_major > current_major
+    true
+  elsif target_minor < current_minor
+    false
+  elsif target_minor > current_minor
+    true
+  else
+    target_patch > current_patch
+  end
+end
+
+def get_current_version()
+  latest_version = Octokit.latest_release("stripe/stripe-android")
+  latest_version.tag_name
+end
+
+def validate_target_version_is_newer(target_version)
+    current_version = get_current_version()
+    if !target_version_is_newer(target_version, current_version)
+        raise "Expected target version #{target_version} to be newer than #{current_version}."
+    end
+end
+
+def validate_version_number()
+    validate_version_number_format(@version)
+    validate_target_version_is_newer(@version)
+end


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add version number validation to deploy process

The formatting check is from our current propose script. The target version being newer than the current process is modified from our existing deploy script.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Updates to release process -- ensure the version number provided is sane.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Tested:
- a valid version works
- poorly formatted version fails
- providing a version "older" than the current one fails
