### PR TITLE
Fix a flakey test.

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -4,15 +4,12 @@ import android.content.Context
 import android.os.Build
 import androidx.activity.result.ActivityResultLauncher
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertAny
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsSelected
-import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.isNotEnabled
 import androidx.compose.ui.test.isSelected
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onChildren
@@ -191,7 +188,6 @@ internal class PaymentSheetActivityTest {
         }
     }
 
-    @OptIn(ExperimentalTestApi::class)
     @Test
     fun `link button should not be enabled when editing`() {
         val viewModel = createViewModel(isLinkAvailable = true)
@@ -203,10 +199,6 @@ internal class PaymentSheetActivityTest {
                 .assertIsEnabled()
 
             viewModel.toggleEditing()
-            composeTestRule.waitUntilAtLeastOneExists(
-                hasTestTag(LinkButtonTestTag).and(isNotEnabled()),
-                timeoutMillis = 5_000
-            )
 
             composeTestRule
                 .onNodeWithTag(LinkButtonTestTag)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultSelectSavedPaymentMethodsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultSelectSavedPaymentMethodsInteractorTest.kt
@@ -11,9 +11,6 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormScreenState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestCoroutineScheduler
-import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.mockito.kotlin.mock
@@ -34,8 +31,6 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             editing = MutableStateFlow(expectedIsEditing),
             isProcessing = MutableStateFlow(expectedIsProcessing),
         ) {
-            dispatcher.scheduler.advanceUntilIdle()
-
             interactor.state.test {
                 awaitItem().run {
                     assertThat(paymentOptionsItems).isEqualTo(expectedPaymentOptionsItems)
@@ -63,8 +58,6 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
 
             isEditingFlow.value = !initialIsEditingValue
 
-            dispatcher.scheduler.advanceUntilIdle()
-
             interactor.state.test {
                 awaitItem().run {
                     assertThat(isEditing).isEqualTo(!initialIsEditingValue)
@@ -86,8 +79,6 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             }
 
             isProcessingFlow.value = !initialIsProcessingValue
-
-            dispatcher.scheduler.advanceUntilIdle()
 
             interactor.state.test {
                 awaitItem().run {
@@ -113,8 +104,6 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             val newPaymentMethods = PaymentMethodFixtures.createCards(2)
             val newPaymentOptionsState = createPaymentOptionsItems(newPaymentMethods)
             paymentOptionsStateFlow.value = newPaymentOptionsState
-
-            dispatcher.scheduler.advanceUntilIdle()
 
             interactor.state.test {
                 awaitItem().run {
@@ -213,8 +202,6 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             ),
             currentSelection = currentSelectionFlow,
         ) {
-            dispatcher.scheduler.advanceUntilIdle()
-
             interactor.state.test {
                 awaitItem().run {
                     assertThat(selectedPaymentOptionsItem).isEqualTo(PaymentOptionsItem.Link)
@@ -236,8 +223,6 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             ),
             currentSelection = currentSelectionFlow,
         ) {
-            dispatcher.scheduler.advanceUntilIdle()
-
             interactor.state.test {
                 awaitItem().run {
                     assertThat(selectedPaymentOptionsItem).isEqualTo(PaymentOptionsItem.Link)
@@ -245,7 +230,6 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             }
 
             currentSelectionFlow.value = PaymentSelection.GooglePay
-            dispatcher.scheduler.advanceUntilIdle()
 
             interactor.state.test {
                 awaitItem().run {
@@ -268,8 +252,6 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             ),
             currentSelection = currentSelectionFlow,
         ) {
-            dispatcher.scheduler.advanceUntilIdle()
-
             interactor.state.test {
                 awaitItem().run {
                     assertThat(selectedPaymentOptionsItem).isEqualTo(PaymentOptionsItem.Link)
@@ -277,7 +259,6 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             }
 
             currentSelectionFlow.value = newPaymentSelection()
-            dispatcher.scheduler.advanceUntilIdle()
 
             interactor.state.test {
                 awaitItem().run {
@@ -301,8 +282,6 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             currentSelection = currentSelectionFlow,
             mostRecentlySelectedSavedPaymentMethod = mostRecentlySelectedSavedPaymentMethod,
         ) {
-            dispatcher.scheduler.advanceUntilIdle()
-
             interactor.state.test {
                 awaitItem().run {
                     assertThat(
@@ -329,8 +308,6 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             currentSelection = currentSelectionFlow,
             mostRecentlySelectedSavedPaymentMethod = mostRecentlySelectedSavedPaymentMethod,
         ) {
-            dispatcher.scheduler.advanceUntilIdle()
-
             interactor.state.test {
                 awaitItem().run {
                     assertThat(
@@ -342,7 +319,6 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             }
 
             mostRecentlySelectedSavedPaymentMethod.value = paymentMethods[0]
-            dispatcher.scheduler.advanceUntilIdle()
 
             interactor.state.test {
                 awaitItem().run {
@@ -374,8 +350,6 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             currentSelection = currentSelectionFlow,
             mostRecentlySelectedSavedPaymentMethod = mostRecentlySelectedSavedPaymentMethod,
         ) {
-            dispatcher.scheduler.advanceUntilIdle()
-
             interactor.state.test {
                 awaitItem().run {
                     assertThat(
@@ -387,7 +361,6 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             }
 
             currentSelectionFlow.value = PaymentSelection.Link
-            dispatcher.scheduler.advanceUntilIdle()
 
             interactor.state.test {
                 awaitItem().run {
@@ -413,8 +386,6 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             currentSelection = currentSelectionFlow,
             mostRecentlySelectedSavedPaymentMethod = mostRecentlySelectedSavedPaymentMethod,
         ) {
-            dispatcher.scheduler.advanceUntilIdle()
-
             interactor.state.test {
                 awaitItem().run {
                     assertThat(
@@ -425,7 +396,6 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
 
             currentSelectionFlow.value = null
             mostRecentlySelectedSavedPaymentMethod.value = null
-            dispatcher.scheduler.advanceUntilIdle()
 
             interactor.state.test {
                 awaitItem().run {
@@ -488,8 +458,6 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
         onPaymentMethodSelected: (PaymentSelection?) -> Unit = { notImplemented() },
         testBlock: suspend TestParams.() -> Unit,
     ) {
-        val dispatcher = StandardTestDispatcher(TestCoroutineScheduler())
-
         val interactor = DefaultSelectSavedPaymentMethodsInteractor(
             paymentOptionsItems,
             editing,
@@ -500,12 +468,10 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             onEditPaymentMethod,
             onDeletePaymentMethod,
             onPaymentMethodSelected,
-            dispatcher = dispatcher,
         )
 
         TestParams(
             interactor = interactor,
-            dispatcher = dispatcher,
         ).apply {
             runTest {
                 testBlock()
@@ -515,6 +481,5 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
 
     private class TestParams(
         val interactor: SelectSavedPaymentMethodsInteractor,
-        val dispatcher: TestDispatcher,
     )
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We've seen a lot of flakes in this test lately. Figured it out and fixed it!

<details>
  <summary>I reproduced this with the following</summary>


```
package com.stripe.android.paymentsheet;

import org.junit.rules.TestRule;
import org.junit.runner.Description;
import org.junit.runners.model.Statement;

/** Got flaky tests? Shampoo them away. */
public final class ShampooRule implements TestRule {
    private final int iterations;

    public ShampooRule(int iterations) {
        if (iterations < 1) throw new IllegalArgumentException("iterations < 1: " + iterations);
        this.iterations = iterations;
    }

    @Override public Statement apply(final Statement base, Description description) {
        return new Statement() {
            @Override public void evaluate() throws Throwable {
                for (int i = 0; i < iterations; i++) {
                    try {
                        base.evaluate();
                    } catch (Throwable e) {
                        throw new AssertionError("Failed on iteration: " + i, e);
                    }
                }
            }
        };
    }
}
```

```
    private val composeTestRule = createAndroidComposeRule<PaymentSheetActivity>()

    @get:Rule
    val rule = RuleChain.emptyRuleChain()
        .around(InstantTaskExecutorRule())
        .around(composeTestRule)
        .around(ShampooRule(200))
```

```
@Test
    fun `link button should not be enabled when editing`() {
        val viewModel = createViewModel(isLinkAvailable = true)
        val scenario = activityScenario(viewModel)

        scenario.launch(intent).onActivity {
            composeTestRule
                .onNodeWithTag(LinkButtonTestTag)
                .assertIsEnabled()

            viewModel.toggleEditing()

            composeTestRule
                .onNodeWithTag(LinkButtonTestTag)
                .assertExists()
                .assertIsNotEnabled()
        }

        scenario.close()
    }
```
</details>