### PR TITLE
Remove unnecessary advance until idles.

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -2665,9 +2665,6 @@ class CustomerSheetViewModelTest {
             val updatedViewState = awaitViewState<SelectPaymentMethod>()
             assertThat(updatedViewState.savedPaymentMethods).containsExactlyElementsIn(paymentMethods)
 
-            // Simulate the delay
-            testDispatcher.scheduler.advanceUntilIdle()
-
             // Show users that the payment method was removed briefly
             assertThat(awaitItem()).isInstanceOf<SelectPaymentMethod>()
             assertThat(awaitItem()).isInstanceOf<AddPaymentMethod>()
@@ -2702,9 +2699,6 @@ class CustomerSheetViewModelTest {
             // once we return to the SPM screen.
             val updatedViewState = awaitViewState<SelectPaymentMethod>()
             assertThat(updatedViewState.savedPaymentMethods).containsExactlyElementsIn(paymentMethods)
-
-            // Simulate the delay
-            testDispatcher.scheduler.advanceUntilIdle()
 
             val finalViewState = awaitViewState<SelectPaymentMethod>()
             assertThat(finalViewState.savedPaymentMethods).containsExactly(paymentMethods.last())
@@ -2768,9 +2762,6 @@ class CustomerSheetViewModelTest {
                 // once we return to the SPM screen.
                 val updatedViewState = awaitViewState<SelectPaymentMethod>()
                 assertThat(updatedViewState.savedPaymentMethods).containsExactlyElementsIn(paymentMethods)
-
-                // Simulate the delay
-                testDispatcher.scheduler.advanceUntilIdle()
 
                 verify(eventReporter).onUpdatePaymentMethodSucceeded(CardBrand.Visa)
 
@@ -2963,9 +2954,6 @@ class CustomerSheetViewModelTest {
                 )
             )
             editViewState.editPaymentMethodInteractor.handleViewAction(OnUpdatePressed)
-
-            // Simulate the delay
-            testDispatcher.scheduler.advanceUntilIdle()
 
             verify(eventReporter).onUpdatePaymentMethodFailed(
                 eq(CardBrand.Visa),
@@ -3307,9 +3295,6 @@ class CustomerSheetViewModelTest {
             val updatedViewState = awaitViewState<SelectPaymentMethod>()
             assertThat(updatedViewState.savedPaymentMethods).contains(originalPaymentMethod)
 
-            // Simulate the delay
-            testDispatcher.scheduler.advanceUntilIdle()
-
             val finalViewState = awaitViewState<SelectPaymentMethod>()
             assertThat(finalViewState.savedPaymentMethods).contains(updatedPaymentMethod)
         }
@@ -3328,9 +3313,6 @@ class CustomerSheetViewModelTest {
 
             val updatedViewState = awaitViewState<SelectPaymentMethod>()
             assertThat(updatedViewState.savedPaymentMethods).contains(paymentMethodToRemove)
-
-            // Simulate the delay
-            testDispatcher.scheduler.advanceUntilIdle()
 
             val finalViewState = awaitViewState<SelectPaymentMethod>()
             assertThat(finalViewState.savedPaymentMethods).doesNotContain(paymentMethodToRemove)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -40,7 +40,7 @@ import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -62,7 +62,7 @@ internal class PaymentOptionsViewModelTest {
     @get:Rule
     val rule = InstantTaskExecutorRule()
 
-    private val testDispatcher = StandardTestDispatcher()
+    private val testDispatcher = UnconfinedTestDispatcher()
 
     private val eventReporter = mock<EventReporter>()
     private val customerRepository = mock<CustomerRepository>()
@@ -200,7 +200,6 @@ internal class PaymentOptionsViewModelTest {
         )
 
         viewModel.savedPaymentMethodMutator.removePaymentMethod(cards[1])
-        testDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(viewModel.savedPaymentMethodMutator.paymentMethods.value)
             .containsExactly(cards[0], cards[2])
@@ -218,7 +217,6 @@ internal class PaymentOptionsViewModelTest {
         assertThat(viewModel.selection.value).isEqualTo(selection)
 
         viewModel.savedPaymentMethodMutator.removePaymentMethod(selection.paymentMethod)
-        testDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(viewModel.selection.value).isNull()
     }
@@ -233,7 +231,6 @@ internal class PaymentOptionsViewModelTest {
         )
 
         viewModel.savedPaymentMethodMutator.removePaymentMethod(paymentMethod)
-        testDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(viewModel.savedPaymentMethodMutator.paymentMethods.value).isEmpty()
         assertThat(viewModel.primaryButtonUiState.value).isNull()
@@ -551,7 +548,6 @@ internal class PaymentOptionsViewModelTest {
         viewModel.paymentOptionResult.test {
             // Simulate user removing the selected payment method
             viewModel.savedPaymentMethodMutator.removePaymentMethod(selection.paymentMethod)
-            testDispatcher.scheduler.advanceUntilIdle()
 
             viewModel.onUserCancel()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditPaymentMethodViewInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditPaymentMethodViewInteractorTest.kt
@@ -8,8 +8,6 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -19,7 +17,7 @@ import org.mockito.kotlin.verify
 import kotlin.coroutines.CoroutineContext
 
 class DefaultEditPaymentMethodViewInteractorTest {
-    private val testDispatcher = StandardTestDispatcher(TestCoroutineScheduler())
+    private val testDispatcher = UnconfinedTestDispatcher()
 
     @Test
     fun `on init, view state should be initialized properly`() = runTest {
@@ -203,8 +201,6 @@ class DefaultEditPaymentMethodViewInteractorTest {
 
         interactor.handleViewAction(EditPaymentMethodViewAction.OnRemoveConfirmed)
 
-        testDispatcher.scheduler.advanceUntilIdle()
-
         interactor.viewState.test {
             val viewState = awaitItem()
 
@@ -275,8 +271,6 @@ class DefaultEditPaymentMethodViewInteractorTest {
         )
 
         interactor.handleViewAction(EditPaymentMethodViewAction.OnUpdatePressed)
-
-        testDispatcher.scheduler.advanceUntilIdle()
 
         interactor.viewState.test {
             val viewState = awaitItem()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We don't rely on the behavior of the StandardTestDispatcher, so just using unconfined.
