### PR TITLE
Use `ResolvableString` in `IntentConfirmationInterceptor`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -1019,7 +1019,7 @@ internal class CustomerSheetViewModel(
                     it.copy(
                         isProcessing = false,
                         primaryButtonEnabled = it.formFieldValues != null,
-                        errorMessage = nextStep.message.resolvableString,
+                        errorMessage = nextStep.message,
                     )
                 }
                 Result.failure(nextStep.cause)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet
 
 import android.content.Context
 import com.stripe.android.core.exception.StripeException
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.ErrorReporter.UnexpectedErrorEvent
@@ -35,7 +36,7 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
         null -> {
             IntentConfirmationInterceptor.NextStep.Fail(
                 cause = IllegalStateException("Nothing selected."),
-                message = context.getString(R.string.stripe_something_went_wrong),
+                message = resolvableString(R.string.stripe_something_went_wrong),
             )
         }
         else -> {
@@ -48,7 +49,7 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
             )
             IntentConfirmationInterceptor.NextStep.Fail(
                 cause = exception,
-                message = context.getString(R.string.stripe_something_went_wrong),
+                message = resolvableString(R.string.stripe_something_went_wrong),
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -634,7 +634,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     confirmStripeIntent(nextStep.confirmParams)
                 }
                 is IntentConfirmationInterceptor.NextStep.Fail -> {
-                    onError(nextStep.message.resolvableString)
+                    onError(nextStep.message)
                 }
                 is IntentConfirmationInterceptor.NextStep.Complete -> {
                     processPayment(stripeIntent, PaymentResult.Completed)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.MandateDataParams
@@ -43,7 +44,6 @@ class DefaultIntentConfirmationInterceptorTest {
     @Test
     fun `Returns confirm as next step if invoked with client secret for existing payment method`() = runTest {
         val interceptor = DefaultIntentConfirmationInterceptor(
-            context = context,
             stripeRepository = object : AbsFakeStripeRepository() {},
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
@@ -69,7 +69,6 @@ class DefaultIntentConfirmationInterceptorTest {
     @Test
     fun `Returns confirm as next step if invoked with client secret for new payment method`() = runTest {
         val interceptor = DefaultIntentConfirmationInterceptor(
-            context = context,
             stripeRepository = object : AbsFakeStripeRepository() {},
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
@@ -124,7 +123,6 @@ class DefaultIntentConfirmationInterceptorTest {
     @Test
     fun `Fails if invoked without a confirm callback for existing payment method`() = runTest {
         val interceptor = DefaultIntentConfirmationInterceptor(
-            context = context,
             stripeRepository = object : AbsFakeStripeRepository() {},
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
@@ -155,7 +153,6 @@ class DefaultIntentConfirmationInterceptorTest {
     @Test
     fun `Fails if invoked without a confirm callback for new payment method`() = runTest {
         val interceptor = DefaultIntentConfirmationInterceptor(
-            context = context,
             stripeRepository = object : AbsFakeStripeRepository() {
                 override suspend fun createPaymentMethod(
                     paymentMethodCreateParams: PaymentMethodCreateParams,
@@ -192,7 +189,6 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         val interceptor = DefaultIntentConfirmationInterceptor(
-            context = context,
             stripeRepository = object : AbsFakeStripeRepository() {
                 override suspend fun createPaymentMethod(
                     paymentMethodCreateParams: PaymentMethodCreateParams,
@@ -216,7 +212,7 @@ class DefaultIntentConfirmationInterceptorTest {
         assertThat(nextStep).isEqualTo(
             IntentConfirmationInterceptor.NextStep.Fail(
                 cause = apiException,
-                message = "Something went wrong",
+                message = resolvableString(R.string.stripe_something_went_wrong),
             )
         )
     }
@@ -232,7 +228,6 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         val interceptor = DefaultIntentConfirmationInterceptor(
-            context = context,
             stripeRepository = object : AbsFakeStripeRepository() {
                 override suspend fun retrieveStripeIntent(
                     clientSecret: String,
@@ -259,7 +254,7 @@ class DefaultIntentConfirmationInterceptorTest {
         assertThat(nextStep).isEqualTo(
             IntentConfirmationInterceptor.NextStep.Fail(
                 cause = apiException,
-                message = "Something went wrong",
+                message = resolvableString(R.string.stripe_something_went_wrong),
             )
         )
     }
@@ -267,7 +262,6 @@ class DefaultIntentConfirmationInterceptorTest {
     @Test
     fun `Fails if callback returns failure with custom error message`() = runTest {
         val interceptor = DefaultIntentConfirmationInterceptor(
-            context = context,
             stripeRepository = mock(),
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
@@ -288,7 +282,7 @@ class DefaultIntentConfirmationInterceptorTest {
         assertThat(nextStep).isEqualTo(
             IntentConfirmationInterceptor.NextStep.Fail(
                 cause = TestException("that didn't work…"),
-                message = "that didn't work…",
+                message = resolvableString("that didn't work…"),
             )
         )
     }
@@ -296,7 +290,6 @@ class DefaultIntentConfirmationInterceptorTest {
     @Test
     fun `Fails if callback returns failure without custom error message`() = runTest {
         val interceptor = DefaultIntentConfirmationInterceptor(
-            context = context,
             stripeRepository = mock(),
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
@@ -315,7 +308,7 @@ class DefaultIntentConfirmationInterceptorTest {
         assertThat(nextStep).isEqualTo(
             IntentConfirmationInterceptor.NextStep.Fail(
                 cause = TestException(),
-                message = "Something went wrong",
+                message = resolvableString(R.string.stripe_something_went_wrong),
             )
         )
     }
@@ -325,7 +318,6 @@ class DefaultIntentConfirmationInterceptorTest {
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
 
         val interceptor = DefaultIntentConfirmationInterceptor(
-            context = context,
             stripeRepository = object : AbsFakeStripeRepository() {
                 override suspend fun retrieveStripeIntent(
                     clientSecret: String,
@@ -368,7 +360,6 @@ class DefaultIntentConfirmationInterceptorTest {
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
 
         val interceptor = DefaultIntentConfirmationInterceptor(
-            context = context,
             stripeRepository = object : AbsFakeStripeRepository() {
                 override suspend fun retrieveStripeIntent(
                     clientSecret: String,
@@ -409,7 +400,6 @@ class DefaultIntentConfirmationInterceptorTest {
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
 
         val interceptor = DefaultIntentConfirmationInterceptor(
-            context = context,
             stripeRepository = object : AbsFakeStripeRepository() {
                 override suspend fun retrieveStripeIntent(
                     clientSecret: String,
@@ -455,7 +445,6 @@ class DefaultIntentConfirmationInterceptorTest {
         val observedValues = mutableListOf<Boolean>()
 
         val interceptor = DefaultIntentConfirmationInterceptor(
-            context = context,
             stripeRepository = object : AbsFakeStripeRepository() {
                 override suspend fun retrieveStripeIntent(
                     clientSecret: String,
@@ -505,7 +494,6 @@ class DefaultIntentConfirmationInterceptorTest {
         val stripeRepository = mock<StripeRepository>()
 
         val interceptor = DefaultIntentConfirmationInterceptor(
-            context = context,
             stripeRepository = stripeRepository,
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
@@ -543,7 +531,6 @@ class DefaultIntentConfirmationInterceptorTest {
         val clientSecret = "pi_1234_secret_4321"
 
         val interceptor = DefaultIntentConfirmationInterceptor(
-            context = context,
             stripeRepository = mock(),
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
@@ -600,7 +587,6 @@ class DefaultIntentConfirmationInterceptorTest {
 
     private fun createIntentConfirmationInterceptor(): DefaultIntentConfirmationInterceptor {
         return DefaultIntentConfirmationInterceptor(
-            context = context,
             stripeRepository = object : AbsFakeStripeRepository() {},
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.utils
 
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.PaymentMethod
@@ -38,7 +39,7 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
     fun enqueueFailureStep(cause: Exception, message: String) {
         val nextStep = IntentConfirmationInterceptor.NextStep.Fail(
             cause = cause,
-            message = message
+            message = message.resolvableString
         )
         channel.trySend(nextStep)
     }


### PR DESCRIPTION
# Summary
Use `ResolvableString` in `IntentConfirmationInterceptor`

# Motivation
Keep from resolving strings in non-UI layers.