### PR TITLE
Update Amount.buildPayButtonLabel to pass application locale if set

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/Amount.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/Amount.kt
@@ -2,9 +2,11 @@ package com.stripe.android.ui.core
 
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
+import androidx.appcompat.app.AppCompatDelegate
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.format.CurrencyFormatter
 import kotlinx.parcelize.Parcelize
+import java.util.Locale
 
 /**
  * This class represents the long value amount to charge and the currency code of the amount.
@@ -19,6 +21,10 @@ data class Amount(val value: Long, val currencyCode: String) : Parcelable {
     fun buildPayButtonLabel() =
         resolvableString(
             R.string.stripe_pay_button_amount,
-            CurrencyFormatter.format(value, currencyCode)
+            CurrencyFormatter.format(
+                amount = value,
+                amountCurrencyCode = currencyCode,
+                targetLocale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
+            )
         )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PrimaryButtonUiStateMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PrimaryButtonUiStateMapperTest.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.paymentsheet.viewmodels
 
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
@@ -319,6 +321,37 @@ class PrimaryButtonUiStateMapperTest {
 
         result.test {
             assertThat(awaitItem()?.enabled).isTrue()
+        }
+    }
+
+    @Test
+    fun `Formats currency correctly based on per app localization`() = runTest {
+        val appLocale: LocaleListCompat = LocaleListCompat.forLanguageTags("fr")
+        AppCompatDelegate.setApplicationLocales(appLocale)
+
+        val mapper = createMapper(
+            isProcessingPayment = true,
+            currentScreenFlow = stateFlowOf(
+                PaymentSheetScreen.SelectSavedPaymentMethods(FakeSelectSavedPaymentMethodsInteractor)
+            ),
+            buttonsEnabledFlow = stateFlowOf(true),
+            amountFlow = stateFlowOf(Amount(value = 1234, currencyCode = "usd")),
+            selectionFlow = stateFlowOf(null),
+            customPrimaryButtonUiStateFlow = stateFlowOf(null),
+            cvcFlow = stateFlowOf(false)
+        )
+
+        val result = mapper.forCompleteFlow()
+
+        result.test {
+            assertThat(
+                awaitItem()?.label
+            ).isEqualTo(
+                resolvableString(
+                    id = com.stripe.android.ui.core.R.string.stripe_pay_button_amount,
+                    formatArgs = arrayOf("12,34 \$US")
+                )
+            )
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PrimaryButtonUiStateMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PrimaryButtonUiStateMapperTest.kt
@@ -355,6 +355,37 @@ class PrimaryButtonUiStateMapperTest {
         }
     }
 
+    @Test
+    fun `Formats currency correctly with no per app localization`() = runTest {
+        val mapper = createMapper(
+            isProcessingPayment = true,
+            currentScreenFlow = stateFlowOf(
+                PaymentSheetScreen.SelectSavedPaymentMethods(FakeSelectSavedPaymentMethodsInteractor)
+            ),
+            buttonsEnabledFlow = stateFlowOf(true),
+            amountFlow = stateFlowOf(Amount(value = 1234, currencyCode = "usd")),
+            selectionFlow = stateFlowOf(null),
+            customPrimaryButtonUiStateFlow = stateFlowOf(null),
+            cvcFlow = stateFlowOf(false)
+        )
+
+        val result = mapper.forCompleteFlow()
+
+        AppCompatDelegate.setApplicationLocales(LocaleListCompat.getEmptyLocaleList())
+        assertThat(AppCompatDelegate.getApplicationLocales()).isEqualTo(LocaleListCompat.getEmptyLocaleList())
+
+        result.test {
+            assertThat(
+                awaitItem()?.label
+            ).isEqualTo(
+                resolvableString(
+                    id = com.stripe.android.ui.core.R.string.stripe_pay_button_amount,
+                    formatArgs = arrayOf("\$12.34")
+                )
+            )
+        }
+    }
+
     private fun createMapper(
         isProcessingPayment: Boolean,
         config: PaymentSheet.Configuration = PaymentSheet.Configuration("Some Name"),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update Amount.buildBuyButtonLabel to pass per app locale if set

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Correctly format currency on Buy button for users setting per app locale

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified



# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![Screenshot_1721336511](https://github.com/user-attachments/assets/68b8535e-f235-4a5b-a5a1-c3318cd30899) | ![Screenshot_1721336455](https://github.com/user-attachments/assets/1e4e5e41-fe87-4d84-89f5-43bfc57dbde1) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
