### PR TITLE
Move `PaymentMethodMetadata` creation into a factory method and its own method in `CustomerSheetLoader`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.lpmfoundations.paymentmethod
 
 import android.os.Parcelable
+import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.lpmfoundations.FormHeaderInformation
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.ExternalPaymentMethodUiDefinitionFactory
@@ -10,6 +12,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.financialconnections.DefaultIsFinancialConnectionsAvailable
+import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAvailable
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.ui.core.Amount
@@ -215,6 +218,35 @@ internal data class PaymentMethodMetadata(
                 sharedDataSpecs = sharedDataSpecs,
                 externalPaymentMethodSpecs = externalPaymentMethodSpecs,
                 isGooglePayReady = isGooglePayReady,
+            )
+        }
+
+        @OptIn(ExperimentalCustomerSheetApi::class)
+        internal fun create(
+            elementsSession: ElementsSession,
+            configuration: CustomerSheet.Configuration,
+            sharedDataSpecs: List<SharedDataSpec>,
+            isGooglePayReady: Boolean,
+            isFinancialConnectionsAvailable: IsFinancialConnectionsAvailable,
+        ): PaymentMethodMetadata {
+            return PaymentMethodMetadata(
+                stripeIntent = elementsSession.stripeIntent,
+                billingDetailsCollectionConfiguration = configuration.billingDetailsCollectionConfiguration,
+                allowsDelayedPaymentMethods = true,
+                allowsPaymentMethodsRequiringShippingAddress = false,
+                paymentMethodOrder = configuration.paymentMethodOrder,
+                cbcEligibility = CardBrandChoiceEligibility.create(
+                    isEligible = elementsSession.isEligibleForCardBrandChoice,
+                    preferredNetworks = configuration.preferredNetworks,
+                ),
+                merchantName = configuration.merchantDisplayName,
+                defaultBillingDetails = configuration.defaultBillingDetails,
+                shippingDetails = null,
+                hasCustomerConfiguration = true,
+                sharedDataSpecs = sharedDataSpecs,
+                isGooglePayReady = isGooglePayReady,
+                financialConnectionsAvailable = isFinancialConnectionsAvailable(),
+                externalPaymentMethodSpecs = emptyList(),
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -2,6 +2,8 @@ package com.stripe.android.lpmfoundations.paymentmethod
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.AffirmDefinition
 import com.stripe.android.model.CardBrand
@@ -713,7 +715,7 @@ internal class PaymentMethodMetadataTest {
     }
 
     @Test
-    fun `should create metadata properly with elements session response, configuration, and data specs`() {
+    fun `should create metadata properly with elements session response, payment sheet config, and data specs`() {
         val billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
             name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
             phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
@@ -771,6 +773,63 @@ internal class PaymentMethodMetadataTest {
                 externalPaymentMethodSpecs = listOf(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC),
                 hasCustomerConfiguration = true,
                 isGooglePayReady = false,
+            )
+        )
+    }
+
+    @OptIn(ExperimentalCustomerSheetApi::class)
+    @Test
+    fun `should create metadata properly with elements session response, customer sheet config, and data specs`() {
+        val billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+            name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+            email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+            address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+            attachDefaultsToPaymentMethod = true,
+        )
+
+        val defaultBillingDetails = PaymentSheet.BillingDetails(
+            address = PaymentSheet.Address(line1 = "123 Apple Street")
+        )
+
+        val configuration = CustomerSheet.Configuration.builder(merchantDisplayName = "Merchant Inc.")
+            .billingDetailsCollectionConfiguration(billingDetailsCollectionConfiguration)
+            .defaultBillingDetails(defaultBillingDetails)
+            .preferredNetworks(listOf(CardBrand.CartesBancaires, CardBrand.Visa))
+            .paymentMethodOrder(listOf("us_bank_account", "card", "sepa_debit"))
+            .build()
+
+        val metadata = PaymentMethodMetadata.create(
+            elementsSession = createElementsSession(
+                intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+                isEligibleForCardBrandChoice = true,
+            ),
+            configuration = configuration,
+            sharedDataSpecs = listOf(SharedDataSpec("card")),
+            isGooglePayReady = true,
+            isFinancialConnectionsAvailable = {
+                false
+            }
+        )
+
+        assertThat(metadata).isEqualTo(
+            PaymentMethodMetadata(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+                billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
+                allowsDelayedPaymentMethods = true,
+                allowsPaymentMethodsRequiringShippingAddress = false,
+                paymentMethodOrder = listOf("us_bank_account", "card", "sepa_debit"),
+                cbcEligibility = CardBrandChoiceEligibility.Eligible(
+                    preferredNetworks = listOf(CardBrand.CartesBancaires, CardBrand.Visa)
+                ),
+                merchantName = "Merchant Inc.",
+                defaultBillingDetails = defaultBillingDetails,
+                shippingDetails = null,
+                sharedDataSpecs = listOf(SharedDataSpec("card")),
+                externalPaymentMethodSpecs = listOf(),
+                hasCustomerConfiguration = true,
+                isGooglePayReady = true,
+                financialConnectionsAvailable = false,
             )
         )
     }


### PR DESCRIPTION
# Summary
Move `PaymentMethodMetadata` creation into a factory method and its own method in `CustomerSheetLoader`

# Motivation
Cleans up logic in `CustomerSheetLoader`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified