### PR TITLE
Move editing to SavedPaymentMethodMutator.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -254,7 +254,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     }
 
     override fun handlePaymentMethodSelected(selection: PaymentSelection?) {
-        if (!editing.value) {
+        if (!savedPaymentMethodMutator.editing.value) {
             updateSelection(selection)
 
             if (selection?.requiresConfirmation != true) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -516,7 +516,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     override fun handlePaymentMethodSelected(selection: PaymentSelection?) {
-        if (!editing.value && selection != this.selection.value) {
+        if (!savedPaymentMethodMutator.editing.value && selection != this.selection.value) {
             updateSelection(selection)
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -120,7 +120,7 @@ private fun PaymentSheetScreen(
                 state = topBarState,
                 isEnabled = !processing,
                 handleBackPressed = viewModel::handleBackPressed,
-                toggleEditing = viewModel::toggleEditing,
+                toggleEditing = viewModel.savedPaymentMethodMutator::toggleEditing,
             )
         },
         content = content,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SelectSavedPaymentMethodsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SelectSavedPaymentMethodsInteractor.kt
@@ -194,7 +194,7 @@ internal class DefaultSelectSavedPaymentMethodsInteractor(
         fun create(viewModel: BaseSheetViewModel): SelectSavedPaymentMethodsInteractor {
             return DefaultSelectSavedPaymentMethodsInteractor(
                 paymentOptionsItems = viewModel.savedPaymentMethodMutator.paymentOptionsItems,
-                editing = viewModel.editing,
+                editing = viewModel.savedPaymentMethodMutator.editing,
                 canEdit = viewModel.savedPaymentMethodMutator.canEdit,
                 isProcessing = viewModel.processing,
                 currentSelection = viewModel.selection,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
@@ -153,7 +153,7 @@ internal class DefaultManageScreenInteractor(
                 paymentMethods = viewModel.savedPaymentMethodMutator.paymentMethods,
                 paymentMethodMetadata = requireNotNull(viewModel.paymentMethodMetadata.value),
                 selection = viewModel.selection,
-                editing = viewModel.editing,
+                editing = viewModel.savedPaymentMethodMutator.editing,
                 canEdit = viewModel.savedPaymentMethodMutator.canEdit,
                 allowsRemovalOfLastSavedPaymentMethod = viewModel.config.allowsRemovalOfLastSavedPaymentMethod,
                 providePaymentMethodName = viewModel::providePaymentMethodName,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -469,12 +469,12 @@ internal class PaymentOptionsViewModelTest {
             updateSelection(PaymentSelection.Link)
         }
 
-        viewModel.toggleEditing()
+        viewModel.savedPaymentMethodMutator.toggleEditing()
         viewModel.handlePaymentMethodSelected(PaymentSelection.GooglePay)
 
         assertThat(viewModel.selection.value).isEqualTo(PaymentSelection.Link)
 
-        viewModel.toggleEditing()
+        viewModel.savedPaymentMethodMutator.toggleEditing()
         viewModel.handlePaymentMethodSelected(PaymentSelection.GooglePay)
         assertThat(viewModel.selection.value).isEqualTo(PaymentSelection.GooglePay)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -183,7 +183,7 @@ internal class PaymentSheetActivityTest {
         scenario.launch(intent).onActivity { activity ->
             assertThat(activity.buyButton.isEnabled).isTrue()
 
-            viewModel.toggleEditing()
+            viewModel.savedPaymentMethodMutator.toggleEditing()
             assertThat(activity.buyButton.isEnabled).isFalse()
         }
     }
@@ -198,7 +198,7 @@ internal class PaymentSheetActivityTest {
                 .onNodeWithTag(LinkButtonTestTag)
                 .assertIsEnabled()
 
-            viewModel.toggleEditing()
+            viewModel.savedPaymentMethodMutator.toggleEditing()
 
             composeTestRule
                 .onNodeWithTag(LinkButtonTestTag)
@@ -435,7 +435,7 @@ internal class PaymentSheetActivityTest {
         val scenario = activityScenario(viewModel)
 
         scenario.launch(intent).onActivity { activity ->
-            viewModel.toggleEditing()
+            viewModel.savedPaymentMethodMutator.toggleEditing()
 
             composeTestRule.onNodeWithTag(
                 TEST_TAG_REMOVE_BADGE,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1631,10 +1631,10 @@ internal class PaymentSheetViewModelTest {
             customer = EMPTY_CUSTOMER_STATE.copy(paymentMethods = customerPaymentMethods)
         )
 
-        viewModel.editing.test {
+        viewModel.savedPaymentMethodMutator.editing.test {
             assertThat(awaitItem()).isFalse()
 
-            viewModel.toggleEditing()
+            viewModel.savedPaymentMethodMutator.toggleEditing()
             assertThat(awaitItem()).isTrue()
 
             viewModel.savedPaymentMethodMutator.removePaymentMethod(customerPaymentMethods.single())
@@ -1648,12 +1648,12 @@ internal class PaymentSheetViewModelTest {
             updateSelection(PaymentSelection.Link)
         }
 
-        viewModel.toggleEditing()
+        viewModel.savedPaymentMethodMutator.toggleEditing()
         viewModel.handlePaymentMethodSelected(PaymentSelection.GooglePay)
 
         assertThat(viewModel.selection.value).isEqualTo(PaymentSelection.Link)
 
-        viewModel.toggleEditing()
+        viewModel.savedPaymentMethodMutator.toggleEditing()
         viewModel.handlePaymentMethodSelected(PaymentSelection.GooglePay)
         assertThat(viewModel.selection.value).isEqualTo(PaymentSelection.GooglePay)
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
My hope is to move all the editing functionality to the screen specific interactors, and I should have moved this with everything else initially.