### PR TITLE
Add `ApiRequestOptionsProvider` in FC SDK

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
@@ -17,6 +17,7 @@ import com.stripe.android.financialconnections.model.SynchronizeSessionResponse
 import com.stripe.android.financialconnections.navigation.NavigationManager
 import com.stripe.android.financialconnections.navigation.NavigationManagerImpl
 import com.stripe.android.financialconnections.network.FinancialConnectionsRequestExecutor
+import com.stripe.android.financialconnections.repository.ApiRequestOptionsProvider
 import com.stripe.android.financialconnections.repository.FinancialConnectionsAccountsRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsConsumerSessionRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsInstitutionsRepository
@@ -98,14 +99,14 @@ internal interface FinancialConnectionsSheetNativeModule {
         @Provides
         fun providesFinancialConnectionsConsumerSessionRepository(
             consumersApiService: ConsumersApiService,
-            apiOptions: ApiRequest.Options,
+            apiOptionsProvider: ApiRequestOptionsProvider,
             financialConnectionsConsumersApiService: FinancialConnectionsConsumersApiService,
             locale: Locale?,
             logger: Logger,
         ) = FinancialConnectionsConsumerSessionRepository(
             financialConnectionsConsumersApiService = financialConnectionsConsumersApiService,
             consumersApiService = consumersApiService,
-            apiOptions = apiOptions,
+            apiOptionsProvider = apiOptionsProvider,
             locale = locale ?: Locale.getDefault(),
             logger = logger,
         )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
@@ -25,9 +25,13 @@ import com.stripe.android.financialconnections.analytics.FinancialConnectionsAna
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTrackerImpl
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEventReporter
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
+import com.stripe.android.financialconnections.domain.IsLinkWithStripe
+import com.stripe.android.financialconnections.domain.RealIsLinkWithStripe
 import com.stripe.android.financialconnections.features.common.enableWorkManager
+import com.stripe.android.financialconnections.repository.ApiRequestOptionsProvider
 import com.stripe.android.financialconnections.repository.FinancialConnectionsRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsRepositoryImpl
+import com.stripe.android.financialconnections.repository.RealApiRequestOptionsProvider
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -65,6 +69,12 @@ internal interface FinancialConnectionsSheetSharedModule {
     @Binds
     @Singleton
     fun bindsAnalyticsRequestV2Executor(impl: DefaultAnalyticsRequestV2Executor): AnalyticsRequestV2Executor
+
+    @Binds
+    fun bindsIsLinkWithStripe(impl: RealIsLinkWithStripe): IsLinkWithStripe
+
+    @Binds
+    fun bindsApiRequestOptionsProvider(impl: RealApiRequestOptionsProvider): ApiRequestOptionsProvider
 
     companion object {
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/IsLinkWithStripe.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/IsLinkWithStripe.kt
@@ -1,0 +1,16 @@
+package com.stripe.android.financialconnections.domain
+
+import javax.inject.Inject
+
+internal fun interface IsLinkWithStripe {
+    suspend operator fun invoke(): Boolean
+}
+
+internal class RealIsLinkWithStripe @Inject constructor(
+    private val getOrFetchSync: GetOrFetchSync,
+) : IsLinkWithStripe {
+
+    override suspend operator fun invoke(): Boolean {
+        return getOrFetchSync().manifest.isLinkWithStripe ?: false
+    }
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/ApiRequestOptionsProvider.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/ApiRequestOptionsProvider.kt
@@ -1,0 +1,53 @@
+package com.stripe.android.financialconnections.repository
+
+import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.financialconnections.domain.IsLinkWithStripe
+import javax.inject.Inject
+
+internal const val KeyConsumerPublishableKey = "ConsumerPublishableKey"
+private const val KeyTentativeConsumerPublishableKey = "KeyTentativeConsumerPublishableKey"
+
+internal interface ApiRequestOptionsProvider {
+    fun provideApiRequestOptions(): ApiRequest.Options
+    suspend fun setTentativeConsumerPublishableKey(key: String?)
+    suspend fun confirmConsumerPublishableKey()
+}
+
+internal class RealApiRequestOptionsProvider @Inject constructor(
+    private val originalRequestOptions: ApiRequest.Options,
+    private val savedStateHandle: SavedStateHandle,
+    private val isLinkWithStripe: IsLinkWithStripe,
+) : ApiRequestOptionsProvider {
+
+    override fun provideApiRequestOptions(): ApiRequest.Options {
+        val consumerKey = retrieveConsumerPublishableKey()
+
+        return if (consumerKey != null) {
+            ApiRequest.Options(apiKey = consumerKey)
+        } else {
+            originalRequestOptions
+        }
+    }
+
+    override suspend fun setTentativeConsumerPublishableKey(key: String?) {
+        if (isLinkWithStripe()) {
+            savedStateHandle[KeyTentativeConsumerPublishableKey] = key
+        }
+    }
+
+    override suspend fun confirmConsumerPublishableKey() {
+        if (isLinkWithStripe()) {
+            val key = retrieveTentativeConsumerPublishableKey()
+            savedStateHandle[KeyConsumerPublishableKey] = key
+        }
+    }
+
+    private fun retrieveConsumerPublishableKey(): String? {
+        return savedStateHandle[KeyConsumerPublishableKey]
+    }
+
+    private fun retrieveTentativeConsumerPublishableKey(): String? {
+        return savedStateHandle[KeyTentativeConsumerPublishableKey]
+    }
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepository.kt
@@ -54,9 +54,12 @@ internal interface FinancialConnectionsRepository {
 
 internal class FinancialConnectionsRepositoryImpl @Inject constructor(
     private val requestExecutor: FinancialConnectionsRequestExecutor,
-    private val apiOptions: ApiRequest.Options,
+    private val apiOptionsProvider: ApiRequestOptionsProvider,
     private val apiRequestFactory: ApiRequest.Factory
 ) : FinancialConnectionsRepository {
+
+    private val apiOptions: ApiRequest.Options
+        get() = apiOptionsProvider.provideApiRequestOptions()
 
     override suspend fun getFinancialConnectionsAccounts(
         getFinancialConnectionsAcccountsParams: GetFinancialConnectionsAcccountsParams

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepositoryImplTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepositoryImplTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.repository
 
+import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
 import com.stripe.android.core.networking.ApiRequest
@@ -33,7 +34,11 @@ class FinancialConnectionsRepositoryImplTest {
             logger = Logger.noop(),
         ),
         apiRequestFactory = apiRequestFactory,
-        apiOptions = ApiRequest.Options(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
+        apiOptionsProvider = RealApiRequestOptionsProvider(
+            originalRequestOptions = ApiRequest.Options(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY),
+            savedStateHandle = SavedStateHandle(),
+            isLinkWithStripe = { false },
+        ),
     )
 
     @Test

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/RealApiRequestOptionsProviderTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/RealApiRequestOptionsProviderTest.kt
@@ -1,0 +1,102 @@
+package com.stripe.android.financialconnections.repository
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.financialconnections.ApiKeyFixtures
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class RealApiRequestOptionsProviderTest {
+
+    private val originalRequestOptions = ApiRequest.Options(
+        apiKey = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
+        stripeAccount = null,
+    )
+
+    private val consumerPublishableKey = "pk_this_is_not_valid_but_its_ok_for_a_test"
+
+    @Test
+    fun `Only sets consumer publishable key tentatively`() = runTest {
+        val savedStateHandle = SavedStateHandle()
+
+        val provider = RealApiRequestOptionsProvider(
+            originalRequestOptions = originalRequestOptions,
+            savedStateHandle = savedStateHandle,
+            isLinkWithStripe = { true },
+        )
+
+        provider.setTentativeConsumerPublishableKey(consumerPublishableKey)
+        provider.assertIsProvidingOriginalPublishableKey()
+    }
+
+    @Test
+    fun `Provides consumer publishable key after being confirmed`() = runTest {
+        val savedStateHandle = SavedStateHandle()
+
+        val provider = RealApiRequestOptionsProvider(
+            originalRequestOptions = originalRequestOptions,
+            savedStateHandle = savedStateHandle,
+            isLinkWithStripe = { true },
+        )
+
+        provider.setTentativeConsumerPublishableKey(consumerPublishableKey)
+        provider.assertIsProvidingOriginalPublishableKey()
+
+        provider.confirmConsumerPublishableKey()
+        provider.assertIsProvidingConsumerPublishableKey()
+    }
+
+    @Test
+    fun `Does not set consumer publishable key if not in Instant Debits flow`() = runTest {
+        val provider = RealApiRequestOptionsProvider(
+            originalRequestOptions = originalRequestOptions,
+            savedStateHandle = SavedStateHandle(),
+            isLinkWithStripe = { false },
+        )
+
+        provider.setTentativeConsumerPublishableKey(consumerPublishableKey)
+        provider.confirmConsumerPublishableKey()
+
+        provider.assertIsProvidingOriginalPublishableKey()
+    }
+
+    @Test
+    fun `Sets consumer publishable key if in Instant Debits flow`() = runTest {
+        val provider = RealApiRequestOptionsProvider(
+            originalRequestOptions = originalRequestOptions,
+            savedStateHandle = SavedStateHandle(),
+            isLinkWithStripe = { true },
+        )
+
+        provider.setTentativeConsumerPublishableKey(consumerPublishableKey)
+        provider.confirmConsumerPublishableKey()
+
+        provider.assertIsProvidingConsumerPublishableKey()
+    }
+
+    @Test
+    fun `Provides consumer publishable key if SavedStateHandle includes it`() = runTest {
+        val provider = RealApiRequestOptionsProvider(
+            originalRequestOptions = originalRequestOptions,
+            savedStateHandle = SavedStateHandle(
+                initialState = mapOf(
+                    KeyConsumerPublishableKey to consumerPublishableKey,
+                ),
+            ),
+            isLinkWithStripe = { true },
+        )
+
+        provider.assertIsProvidingConsumerPublishableKey()
+    }
+
+    private fun ApiRequestOptionsProvider.assertIsProvidingOriginalPublishableKey() {
+        val key = provideApiRequestOptions().apiKey
+        assertThat(key).isEqualTo(originalRequestOptions.apiKey)
+    }
+
+    private fun ApiRequestOptionsProvider.assertIsProvidingConsumerPublishableKey() {
+        val key = provideApiRequestOptions().apiKey
+        assertThat(key).isEqualTo(consumerPublishableKey)
+    }
+}

--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerSessionLookup.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerSessionLookup.kt
@@ -18,5 +18,7 @@ data class ConsumerSessionLookup(
     @SerialName("consumer_session")
     val consumerSession: ConsumerSession? = null,
     @SerialName("error_message")
-    val errorMessage: String? = null
+    val errorMessage: String? = null,
+    @SerialName("publishable_key")
+    val publishableKey: String? = null,
 ) : StripeModel


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds an `ApiRequestOptionsProvider` for the native Instant Debits flow.

After the consumer verifies their Link account, the Instant Debits flow will use the consumer publishable key (as opposed to the merchant one) to make API requests. The provider enables that behavior:

1. It stores the publishable key returned in the consumer lookup response as a “tentative” key.
2. Once the consumer verifies their account, the tentative key is set as the main key going forward.
3. We will have to slightly break out of this for the call to create a `PaymentMethod` later on, but I’ll do that work once it’s needed.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[BANKCON-11514](https://jira.corp.stripe.com/browse/BANKCON-11514)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
