### PR TITLE
Remove an unnecessary usage of viewModel.savedPaymentMethodMutator.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -15,6 +15,7 @@ import com.stripe.android.core.utils.requireApplication
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -160,7 +161,12 @@ internal class PaymentOptionsViewModel @Inject constructor(
 
         updateSelection(args.state.paymentSelection)
 
-        navigationHandler.resetTo(determineInitialBackStack(args.state.paymentMethodMetadata))
+        navigationHandler.resetTo(
+            determineInitialBackStack(
+                paymentMethodMetadata = args.state.paymentMethodMetadata,
+                savedPaymentMethods = args.state.customer?.paymentMethods.orEmpty(),
+            )
+        )
     }
 
     private fun handleLinkProcessingState(processingState: LinkHandler.ProcessingState) {
@@ -292,12 +298,16 @@ internal class PaymentOptionsViewModel @Inject constructor(
         )
     }
 
-    private fun determineInitialBackStack(paymentMethodMetadata: PaymentMethodMetadata): List<PaymentSheetScreen> {
+    private fun determineInitialBackStack(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        savedPaymentMethods: List<PaymentMethod>,
+    ): List<PaymentSheetScreen> {
         if (config.paymentMethodLayout == PaymentSheet.PaymentMethodLayout.Vertical) {
             return listOf(
                 VerticalModeInitialScreenFactory.create(
                     viewModel = this,
-                    paymentMethodMetadata = paymentMethodMetadata
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    savedPaymentMethods = savedPaymentMethods,
                 )
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -381,7 +381,12 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         val errorMessage = pendingFailedPaymentResult?.throwable?.stripeErrorMessage()
 
         resetViewState(errorMessage)
-        navigationHandler.resetTo(determineInitialBackStack(state.paymentMethodMetadata))
+        navigationHandler.resetTo(
+            determineInitialBackStack(
+                paymentMethodMetadata = state.paymentMethodMetadata,
+                savedPaymentMethods = state.customer?.paymentMethods.orEmpty(),
+            )
+        )
     }
 
     fun setupGooglePay(
@@ -808,12 +813,16 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     override fun onError(error: ResolvableString?) = resetViewState(error)
 
-    private fun determineInitialBackStack(paymentMethodMetadata: PaymentMethodMetadata): List<PaymentSheetScreen> {
+    private fun determineInitialBackStack(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        savedPaymentMethods: List<PaymentMethod>,
+    ): List<PaymentSheetScreen> {
         if (config.paymentMethodLayout == PaymentSheet.PaymentMethodLayout.Vertical) {
             return listOf(
                 VerticalModeInitialScreenFactory.create(
                     viewModel = this,
                     paymentMethodMetadata = paymentMethodMetadata,
+                    savedPaymentMethods = savedPaymentMethods,
                 )
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
@@ -1,12 +1,16 @@
 package com.stripe.android.paymentsheet.verticalmode
 
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 
 internal object VerticalModeInitialScreenFactory {
-    fun create(viewModel: BaseSheetViewModel, paymentMethodMetadata: PaymentMethodMetadata): PaymentSheetScreen {
-        val savedPaymentMethods = viewModel.savedPaymentMethodMutator.paymentMethods.value
+    fun create(
+        viewModel: BaseSheetViewModel,
+        paymentMethodMetadata: PaymentMethodMetadata,
+        savedPaymentMethods: List<PaymentMethod>,
+    ): PaymentSheetScreen {
         val supportedPaymentMethodTypes = paymentMethodMetadata.supportedPaymentMethodTypes()
 
         if (supportedPaymentMethodTypes.size == 1 && savedPaymentMethods.isEmpty()) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We have the data, and we can pass it directly!