### PR TITLE
Move toggleEdit to the interactors.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
@@ -29,13 +29,17 @@ internal sealed class CustomerSheetViewState(
     open val allowsRemovalOfLastSavedPaymentMethod: Boolean,
     open val canRemovePaymentMethods: Boolean,
 ) {
-    val topBarState: PaymentSheetTopBarState
-        get() = PaymentSheetTopBarStateFactory.create(
+    fun topBarState(onEditIconPressed: () -> Unit): PaymentSheetTopBarState {
+        return PaymentSheetTopBarStateFactory.create(
             hasBackStack = canNavigateBack,
             isLiveMode = isLiveMode,
-            isEditing = isEditing,
-            canEdit = canEdit(allowsRemovalOfLastSavedPaymentMethod, savedPaymentMethods, cbcEligibility),
+            editable = PaymentSheetTopBarState.Editable.Maybe(
+                isEditing = isEditing,
+                canEdit = canEdit(allowsRemovalOfLastSavedPaymentMethod, savedPaymentMethods, cbcEligibility),
+                onEditIconPressed = onEditIconPressed,
+            ),
         )
+    }
 
     fun shouldDisplayDismissConfirmationModal(
         isFinancialConnectionsAvailable: IsFinancialConnectionsAvailable,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -48,15 +48,14 @@ internal fun CustomerSheetScreen(
     PaymentSheetScaffold(
         topBar = {
             PaymentSheetTopBar(
-                state = viewState.topBarState,
+                state = viewState.topBarState {
+                    viewActionHandler(CustomerSheetViewAction.OnEditPressed)
+                },
                 isEnabled = !viewState.isProcessing,
                 handleBackPressed = {
                     viewActionHandler(
                         CustomerSheetViewAction.OnBackPressed
                     )
-                },
-                toggleEditing = {
-                    viewActionHandler(CustomerSheetViewAction.OnEditPressed)
                 },
             )
         },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -110,8 +110,13 @@ internal sealed interface PaymentSheetScreen {
                 PaymentSheetTopBarStateFactory.create(
                     hasBackStack = false,
                     isLiveMode = interactor.isLiveMode,
-                    isEditing = state.isEditing,
-                    canEdit = state.canEdit,
+                    editable = PaymentSheetTopBarState.Editable.Maybe(
+                        isEditing = state.isEditing,
+                        canEdit = state.canEdit,
+                        onEditIconPressed = {
+                            interactor.handleViewAction(SelectSavedPaymentMethodsInteractor.ViewAction.ToggleEdit)
+                        },
+                    ),
                 )
             }
         }
@@ -193,8 +198,7 @@ internal sealed interface PaymentSheetScreen {
                 PaymentSheetTopBarStateFactory.create(
                     hasBackStack = true,
                     isLiveMode = interactor.isLiveMode,
-                    isEditing = false,
-                    canEdit = false,
+                    editable = PaymentSheetTopBarState.Editable.Never,
                 )
             )
         }
@@ -239,8 +243,7 @@ internal sealed interface PaymentSheetScreen {
                 PaymentSheetTopBarStateFactory.create(
                     hasBackStack = false,
                     isLiveMode = interactor.isLiveMode,
-                    isEditing = false,
-                    canEdit = false,
+                    editable = PaymentSheetTopBarState.Editable.Never,
                 )
             )
         }
@@ -288,8 +291,7 @@ internal sealed interface PaymentSheetScreen {
                 PaymentSheetTopBarStateFactory.create(
                     hasBackStack = true,
                     isLiveMode = isLiveMode,
-                    isEditing = false,
-                    canEdit = false,
+                    editable = PaymentSheetTopBarState.Editable.Never,
                 )
             )
         }
@@ -322,8 +324,7 @@ internal sealed interface PaymentSheetScreen {
                 PaymentSheetTopBarStateFactory.create(
                     hasBackStack = false,
                     isLiveMode = interactor.isLiveMode,
-                    isEditing = false,
-                    canEdit = false,
+                    editable = PaymentSheetTopBarState.Editable.Never,
                 )
             )
         }
@@ -363,8 +364,7 @@ internal sealed interface PaymentSheetScreen {
                 PaymentSheetTopBarStateFactory.create(
                     hasBackStack = true,
                     isLiveMode = interactor.isLiveMode,
-                    isEditing = false,
-                    canEdit = false,
+                    editable = PaymentSheetTopBarState.Editable.Never,
                 )
             )
         }
@@ -396,8 +396,13 @@ internal sealed interface PaymentSheetScreen {
                 PaymentSheetTopBarStateFactory.create(
                     hasBackStack = true,
                     isLiveMode = interactor.isLiveMode,
-                    isEditing = state.isEditing,
-                    canEdit = state.canEdit,
+                    editable = PaymentSheetTopBarState.Editable.Maybe(
+                        isEditing = state.isEditing,
+                        canEdit = state.canEdit,
+                        onEditIconPressed = {
+                            interactor.handleViewAction(ManageScreenInteractor.ViewAction.ToggleEdit)
+                        },
+                    ),
                 )
             }
         }
@@ -437,8 +442,7 @@ internal sealed interface PaymentSheetScreen {
                 PaymentSheetTopBarStateFactory.create(
                     hasBackStack = true,
                     isLiveMode = interactor.state.isLiveMode,
-                    isEditing = false,
-                    canEdit = false,
+                    editable = PaymentSheetTopBarState.Editable.Never,
                 )
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationActivity.kt
@@ -74,13 +74,13 @@ internal class BacsMandateConfirmationActivity : AppCompatActivity() {
                                     contentDescription = StripeUiCoreR.string.stripe_back,
                                     showEditMenu = false,
                                     showTestModeLabel = false,
-                                    editMenuLabel = StripeR.string.stripe_edit
+                                    editMenuLabel = StripeR.string.stripe_edit,
+                                    onEditIconPressed = {},
                                 ),
                                 isEnabled = true,
                                 handleBackPressed = {
                                     viewModel.handleViewAction(OnBackPressed)
                                 },
-                                toggleEditing = {},
                             )
                         },
                         content = {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -120,7 +120,6 @@ private fun PaymentSheetScreen(
                 state = topBarState,
                 isEnabled = !processing,
                 handleBackPressed = viewModel::handleBackPressed,
-                toggleEditing = viewModel.savedPaymentMethodMutator::toggleEditing,
             )
         },
         content = content,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBar.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBar.kt
@@ -43,7 +43,6 @@ internal fun PaymentSheetTopBar(
     state: PaymentSheetTopBarState?,
     isEnabled: Boolean,
     handleBackPressed: () -> Unit,
-    toggleEditing: () -> Unit,
     elevation: Dp = 0.dp,
 ) {
     if (state != null) {
@@ -52,7 +51,6 @@ internal fun PaymentSheetTopBar(
             isEnabled = isEnabled,
             elevation = elevation,
             onNavigationIconPressed = handleBackPressed,
-            onEditIconPressed = toggleEditing,
         )
     }
 }
@@ -63,7 +61,6 @@ internal fun PaymentSheetTopBar(
     isEnabled: Boolean,
     elevation: Dp,
     onNavigationIconPressed: () -> Unit,
-    onEditIconPressed: () -> Unit,
 ) {
     val keyboardController = LocalTextInputService.current
     val tintColor = MaterialTheme.stripeColors.appBarIcon
@@ -99,7 +96,7 @@ internal fun PaymentSheetTopBar(
                     labelResourceId = state.editMenuLabel,
                     isEnabled = isEnabled,
                     tintColor = tintColor,
-                    onClick = onEditIconPressed,
+                    onClick = state.onEditIconPressed,
                 )
             }
         },
@@ -173,6 +170,7 @@ internal fun PaymentSheetTopBar_Preview() {
             showTestModeLabel = true,
             showEditMenu = true,
             editMenuLabel = StripeR.string.stripe_edit,
+            onEditIconPressed = {},
         )
 
         PaymentSheetTopBar(
@@ -180,7 +178,6 @@ internal fun PaymentSheetTopBar_Preview() {
             isEnabled = true,
             elevation = 0.dp,
             onNavigationIconPressed = {},
-            onEditIconPressed = {},
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarState.kt
@@ -12,14 +12,23 @@ internal data class PaymentSheetTopBarState(
     val showTestModeLabel: Boolean,
     val showEditMenu: Boolean,
     @StringRes val editMenuLabel: Int,
-)
+    val onEditIconPressed: () -> Unit,
+) {
+    sealed interface Editable {
+        data object Never : Editable
+        data class Maybe(
+            val isEditing: Boolean,
+            val canEdit: Boolean,
+            val onEditIconPressed: () -> Unit,
+        ) : Editable
+    }
+}
 
 internal object PaymentSheetTopBarStateFactory {
     fun create(
         hasBackStack: Boolean,
         isLiveMode: Boolean,
-        isEditing: Boolean,
-        canEdit: Boolean,
+        editable: PaymentSheetTopBarState.Editable,
     ): PaymentSheetTopBarState {
         val icon = if (hasBackStack) {
             R.drawable.stripe_ic_paymentsheet_back
@@ -33,7 +42,7 @@ internal object PaymentSheetTopBarStateFactory {
             R.string.stripe_paymentsheet_close
         }
 
-        val editMenuLabel = if (isEditing) {
+        val editMenuLabel = if ((editable as? PaymentSheetTopBarState.Editable.Maybe)?.isEditing == true) {
             StripeR.string.stripe_done
         } else {
             StripeR.string.stripe_edit
@@ -43,8 +52,10 @@ internal object PaymentSheetTopBarStateFactory {
             icon = icon,
             contentDescription = contentDescription,
             showTestModeLabel = !isLiveMode,
-            showEditMenu = canEdit,
+            showEditMenu = (editable as? PaymentSheetTopBarState.Editable.Maybe)?.canEdit == true,
             editMenuLabel = editMenuLabel,
+            onEditIconPressed = (editable as? PaymentSheetTopBarState.Editable.Maybe)?.onEditIconPressed
+                ?: {},
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SelectSavedPaymentMethodsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SelectSavedPaymentMethodsInteractor.kt
@@ -37,11 +37,10 @@ internal interface SelectSavedPaymentMethodsInteractor {
 
     sealed class ViewAction {
         data object AddCardPressed : ViewAction()
-
         data class SelectPaymentMethod(val selection: PaymentSelection?) : ViewAction()
-
         data class DeletePaymentMethod(val paymentMethod: PaymentMethod) : ViewAction()
         data class EditPaymentMethod(val paymentMethod: PaymentMethod) : ViewAction()
+        data object ToggleEdit : ViewAction()
     }
 }
 
@@ -49,6 +48,7 @@ internal class DefaultSelectSavedPaymentMethodsInteractor(
     private val paymentOptionsItems: StateFlow<List<PaymentOptionsItem>>,
     private val editing: StateFlow<Boolean>,
     private val canEdit: StateFlow<Boolean>,
+    private val toggleEdit: () -> Unit,
     private val isProcessing: StateFlow<Boolean>,
     private val currentSelection: StateFlow<PaymentSelection?>,
     private val mostRecentlySelectedSavedPaymentMethod: StateFlow<PaymentMethod?>,
@@ -184,6 +184,7 @@ internal class DefaultSelectSavedPaymentMethodsInteractor(
             )
 
             SelectSavedPaymentMethodsInteractor.ViewAction.AddCardPressed -> onAddCardPressed()
+            SelectSavedPaymentMethodsInteractor.ViewAction.ToggleEdit -> toggleEdit()
         }
     }
 
@@ -200,6 +201,7 @@ internal class DefaultSelectSavedPaymentMethodsInteractor(
                 paymentOptionsItems = viewModel.savedPaymentMethodMutator.paymentOptionsItems,
                 editing = viewModel.savedPaymentMethodMutator.editing,
                 canEdit = viewModel.savedPaymentMethodMutator.canEdit,
+                toggleEdit = viewModel.savedPaymentMethodMutator::toggleEditing,
                 isProcessing = viewModel.processing,
                 currentSelection = viewModel.selection,
                 mostRecentlySelectedSavedPaymentMethod =

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
@@ -39,6 +39,7 @@ internal interface ManageScreenInteractor {
         data class SelectPaymentMethod(val paymentMethod: DisplayableSavedPaymentMethod) : ViewAction()
         data class DeletePaymentMethod(val paymentMethod: DisplayableSavedPaymentMethod) : ViewAction()
         data class EditPaymentMethod(val paymentMethod: DisplayableSavedPaymentMethod) : ViewAction()
+        data object ToggleEdit : ViewAction()
     }
 }
 
@@ -48,6 +49,7 @@ internal class DefaultManageScreenInteractor(
     private val selection: StateFlow<PaymentSelection?>,
     private val editing: StateFlow<Boolean>,
     private val canEdit: StateFlow<Boolean>,
+    private val toggleEdit: () -> Unit,
     private val allowsRemovalOfLastSavedPaymentMethod: Boolean,
     private val providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString,
     private val onSelectPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
@@ -120,6 +122,7 @@ internal class DefaultManageScreenInteractor(
                 handlePaymentMethodSelected(viewAction.paymentMethod)
             is ManageScreenInteractor.ViewAction.DeletePaymentMethod -> onDeletePaymentMethod(viewAction.paymentMethod)
             is ManageScreenInteractor.ViewAction.EditPaymentMethod -> onEditPaymentMethod(viewAction.paymentMethod)
+            ManageScreenInteractor.ViewAction.ToggleEdit -> toggleEdit()
         }
     }
 
@@ -158,6 +161,7 @@ internal class DefaultManageScreenInteractor(
                 selection = viewModel.selection,
                 editing = viewModel.savedPaymentMethodMutator.editing,
                 canEdit = viewModel.savedPaymentMethodMutator.canEdit,
+                toggleEdit = viewModel.savedPaymentMethodMutator::toggleEditing,
                 allowsRemovalOfLastSavedPaymentMethod = viewModel.config.allowsRemovalOfLastSavedPaymentMethod,
                 providePaymentMethodName = viewModel.savedPaymentMethodMutator.providePaymentMethodName,
                 onSelectPaymentMethod = {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -479,19 +479,19 @@ class CustomerSheetViewModelTest {
         viewModel.viewState.test {
             var viewState = awaitViewState<SelectPaymentMethod>()
             assertThat(viewState.isEditing).isFalse()
-            assertThat(viewState.topBarState.showEditMenu).isTrue()
+            assertThat(viewState.topBarState {}.showEditMenu).isTrue()
 
             viewModel.handleViewAction(CustomerSheetViewAction.OnEditPressed)
 
             viewState = awaitViewState()
             assertThat(viewState.isEditing).isTrue()
-            assertThat(viewState.topBarState.showEditMenu).isTrue()
+            assertThat(viewState.topBarState {}.showEditMenu).isTrue()
 
             viewModel.handleViewAction(CustomerSheetViewAction.OnItemRemoved(CARD_PAYMENT_METHOD))
 
             viewState = awaitViewState()
             assertThat(viewState.isEditing).isFalse()
-            assertThat(viewState.topBarState.showEditMenu).isFalse()
+            assertThat(viewState.topBarState {}.showEditMenu).isFalse()
         }
     }
 
@@ -509,19 +509,19 @@ class CustomerSheetViewModelTest {
         viewModel.viewState.test {
             var viewState = awaitViewState<SelectPaymentMethod>()
             assertThat(viewState.isEditing).isFalse()
-            assertThat(viewState.topBarState.showEditMenu).isTrue()
+            assertThat(viewState.topBarState {}.showEditMenu).isTrue()
 
             viewModel.handleViewAction(CustomerSheetViewAction.OnEditPressed)
 
             viewState = awaitViewState()
             assertThat(viewState.isEditing).isTrue()
-            assertThat(viewState.topBarState.showEditMenu).isTrue()
+            assertThat(viewState.topBarState {}.showEditMenu).isTrue()
 
             viewModel.handleViewAction(CustomerSheetViewAction.OnItemRemoved(CARD_PAYMENT_METHOD))
 
             viewState = awaitViewState()
             assertThat(viewState.isEditing).isFalse()
-            assertThat(viewState.topBarState.showEditMenu).isFalse()
+            assertThat(viewState.topBarState {}.showEditMenu).isFalse()
         }
     }
 
@@ -3170,14 +3170,14 @@ class CustomerSheetViewModelTest {
             viewModel.viewState.test {
                 val viewState = awaitViewState<SelectPaymentMethod>()
 
-                assertThat(viewState.topBarState.showEditMenu).isTrue()
+                assertThat(viewState.topBarState {}.showEditMenu).isTrue()
 
                 viewModel.handleViewAction(CustomerSheetViewAction.OnEditPressed)
 
                 val viewStateAfterClickingEdit = awaitViewState<SelectPaymentMethod>()
 
                 assertThat(viewStateAfterClickingEdit.isEditing).isTrue()
-                assertThat(viewStateAfterClickingEdit.topBarState.showEditMenu).isTrue()
+                assertThat(viewStateAfterClickingEdit.topBarState {}.showEditMenu).isTrue()
             }
 
             viewModel.removePaymentMethodFromEditScreen(paymentMethodToRemove)
@@ -3186,7 +3186,7 @@ class CustomerSheetViewModelTest {
                 val viewStateAfterRemoval = awaitViewState<SelectPaymentMethod>()
 
                 assertThat(viewStateAfterRemoval.isEditing).isFalse()
-                assertThat(viewStateAfterRemoval.topBarState.showEditMenu).isFalse()
+                assertThat(viewStateAfterRemoval.topBarState {}.showEditMenu).isFalse()
             }
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultSelectSavedPaymentMethodsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultSelectSavedPaymentMethodsInteractorTest.kt
@@ -204,6 +204,20 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
     }
 
     @Test
+    fun handleViewAction_ToggleEdit_calls_toggleEdit() {
+        var hasCalledToggleEdit = false
+        runScenario(
+            toggleEdit = { hasCalledToggleEdit = true }
+        ) {
+            interactor.handleViewAction(
+                SelectSavedPaymentMethodsInteractor.ViewAction.ToggleEdit
+            )
+
+            assertThat(hasCalledToggleEdit).isTrue()
+        }
+    }
+
+    @Test
     fun selectedPaymentOptionItem_currentSelectionIsLink() {
         val currentSelectionFlow = MutableStateFlow(PaymentSelection.Link)
 
@@ -463,6 +477,7 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
         paymentOptionsItems: StateFlow<List<PaymentOptionsItem>> = MutableStateFlow(emptyList()),
         editing: StateFlow<Boolean> = MutableStateFlow(false),
         canEdit: StateFlow<Boolean> = MutableStateFlow(true),
+        toggleEdit: () -> Unit = { notImplemented() },
         isProcessing: StateFlow<Boolean> = MutableStateFlow(false),
         currentSelection: StateFlow<PaymentSelection?> = MutableStateFlow(null),
         mostRecentlySelectedSavedPaymentMethod: MutableStateFlow<PaymentMethod?> = MutableStateFlow(null),
@@ -476,6 +491,7 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             paymentOptionsItems = paymentOptionsItems,
             editing = editing,
             canEdit = canEdit,
+            toggleEdit = toggleEdit,
             isProcessing = isProcessing,
             currentSelection = currentSelection,
             mostRecentlySelectedSavedPaymentMethod = mostRecentlySelectedSavedPaymentMethod,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarScreenshotTest.kt
@@ -32,6 +32,7 @@ class PaymentSheetTopBarScreenshotTest {
             showTestModeLabel = false,
             showEditMenu = false,
             editMenuLabel = StripeR.string.stripe_edit,
+            onEditIconPressed = {},
         )
 
         paparazzi.snapshot {
@@ -40,7 +41,6 @@ class PaymentSheetTopBarScreenshotTest {
                 isEnabled = true,
                 elevation = 0.dp,
                 onNavigationIconPressed = {},
-                onEditIconPressed = {},
             )
         }
     }
@@ -53,6 +53,7 @@ class PaymentSheetTopBarScreenshotTest {
             showTestModeLabel = true,
             showEditMenu = true,
             editMenuLabel = StripeR.string.stripe_edit,
+            onEditIconPressed = {},
         )
 
         paparazzi.snapshot {
@@ -61,7 +62,6 @@ class PaymentSheetTopBarScreenshotTest {
                 isEnabled = true,
                 elevation = 0.dp,
                 onNavigationIconPressed = {},
-                onEditIconPressed = {},
             )
         }
     }
@@ -74,6 +74,7 @@ class PaymentSheetTopBarScreenshotTest {
             showTestModeLabel = true,
             showEditMenu = true,
             editMenuLabel = StripeR.string.stripe_done,
+            onEditIconPressed = {},
         )
 
         paparazzi.snapshot {
@@ -82,7 +83,6 @@ class PaymentSheetTopBarScreenshotTest {
                 isEnabled = true,
                 elevation = 0.dp,
                 onNavigationIconPressed = {},
-                onEditIconPressed = {},
             )
         }
     }
@@ -95,6 +95,7 @@ class PaymentSheetTopBarScreenshotTest {
             showTestModeLabel = true,
             showEditMenu = false,
             editMenuLabel = StripeR.string.stripe_edit,
+            onEditIconPressed = {},
         )
 
         paparazzi.snapshot {
@@ -103,7 +104,6 @@ class PaymentSheetTopBarScreenshotTest {
                 isEnabled = true,
                 elevation = 0.dp,
                 onNavigationIconPressed = {},
-                onEditIconPressed = {},
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarStateFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarStateFactoryTest.kt
@@ -49,7 +49,11 @@ class PaymentSheetTopBarStateFactoryTest {
     @Test
     fun `showEditMenu=true when canEdit=true`() {
         val state = buildTopBarState(
-            canEdit = true,
+            editable = PaymentSheetTopBarState.Editable.Maybe(
+                canEdit = true,
+                isEditing = false,
+                onEditIconPressed = {},
+            ),
         )
 
         assertThat(state.showEditMenu).isTrue()
@@ -58,7 +62,20 @@ class PaymentSheetTopBarStateFactoryTest {
     @Test
     fun `showEditMenu=false when canEdit=false`() {
         val state = buildTopBarState(
-            canEdit = false,
+            editable = PaymentSheetTopBarState.Editable.Maybe(
+                canEdit = false,
+                isEditing = false,
+                onEditIconPressed = {},
+            ),
+        )
+
+        assertThat(state.showEditMenu).isFalse()
+    }
+
+    @Test
+    fun `showEditMenu=false when editable=Never`() {
+        val state = buildTopBarState(
+            editable = PaymentSheetTopBarState.Editable.Never,
         )
 
         assertThat(state.showEditMenu).isFalse()
@@ -67,7 +84,11 @@ class PaymentSheetTopBarStateFactoryTest {
     @Test
     fun `editMenuLabel=edit when isEditing=false`() {
         val state = buildTopBarState(
-            isEditing = false,
+            editable = PaymentSheetTopBarState.Editable.Maybe(
+                canEdit = false,
+                isEditing = false,
+                onEditIconPressed = {},
+            ),
         )
 
         assertThat(state.editMenuLabel).isEqualTo(StripeR.string.stripe_edit)
@@ -76,7 +97,11 @@ class PaymentSheetTopBarStateFactoryTest {
     @Test
     fun `editMenuLabel=done when isEditing=true`() {
         val state = buildTopBarState(
-            isEditing = true,
+            editable = PaymentSheetTopBarState.Editable.Maybe(
+                canEdit = false,
+                isEditing = true,
+                onEditIconPressed = {},
+            ),
         )
 
         assertThat(state.editMenuLabel).isEqualTo(StripeR.string.stripe_done)
@@ -85,14 +110,12 @@ class PaymentSheetTopBarStateFactoryTest {
     private fun buildTopBarState(
         canNavigateBack: Boolean = false,
         isLiveMode: Boolean = false,
-        isEditing: Boolean = false,
-        canEdit: Boolean = false,
+        editable: PaymentSheetTopBarState.Editable = PaymentSheetTopBarState.Editable.Never,
     ): PaymentSheetTopBarState {
         return PaymentSheetTopBarStateFactory.create(
             hasBackStack = canNavigateBack,
             isLiveMode = isLiveMode,
-            isEditing = isEditing,
-            canEdit = canEdit,
+            editable,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarTest.kt
@@ -43,7 +43,6 @@ class PaymentSheetTopBarTest {
                     isEnabled = true,
                     elevation = 0.dp,
                     onNavigationIconPressed = { didCallOnNavigationIconPressed = true },
-                    onEditIconPressed = { throw AssertionError("Not expected") },
                 )
             }
         }
@@ -71,7 +70,6 @@ class PaymentSheetTopBarTest {
                     isEnabled = false,
                     elevation = 0.dp,
                     onNavigationIconPressed = { didCallOnNavigationIconPressed = true },
-                    onEditIconPressed = { throw AssertionError("Not expected") },
                 )
             }
         }
@@ -90,11 +88,10 @@ class PaymentSheetTopBarTest {
 
         composeTestRule.setContent {
             PaymentSheetTopBar(
-                state = mockState(showEditMenu = true),
+                state = mockState(showEditMenu = true, onEditIconPressed = { didCallOnEditIconPressed = true }),
                 isEnabled = true,
                 elevation = 0.dp,
                 onNavigationIconPressed = { throw AssertionError("Not expected") },
-                onEditIconPressed = { didCallOnEditIconPressed = true },
             )
         }
 
@@ -107,6 +104,7 @@ class PaymentSheetTopBarTest {
 
     private fun mockState(
         showEditMenu: Boolean = false,
+        onEditIconPressed: () -> Unit = { throw AssertionError("Not expected") }
     ): PaymentSheetTopBarState {
         return PaymentSheetTopBarState(
             icon = R.drawable.stripe_ic_paymentsheet_back,
@@ -114,6 +112,7 @@ class PaymentSheetTopBarTest {
             showTestModeLabel = false,
             showEditMenu = showEditMenu,
             editMenuLabel = StripeR.string.stripe_edit,
+            onEditIconPressed = onEditIconPressed,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
@@ -277,12 +277,27 @@ class DefaultManageScreenInteractorTest {
         }
     }
 
+    @Test
+    fun `handleViewAction ToggleEdit calls toggleEdit`() {
+        var hasCalledToggleEdit = false
+        val initialPaymentMethods = PaymentMethodFixtures.createCards(2)
+        runScenario(
+            initialPaymentMethods = initialPaymentMethods,
+            currentSelection = null,
+            toggleEdit = { hasCalledToggleEdit = true },
+        ) {
+            interactor.handleViewAction(ManageScreenInteractor.ViewAction.ToggleEdit)
+            assertThat(hasCalledToggleEdit).isTrue()
+        }
+    }
+
     private val notImplemented: () -> Nothing = { throw AssertionError("Not implemented") }
 
     private fun runScenario(
         initialPaymentMethods: List<PaymentMethod>?,
         currentSelection: PaymentSelection?,
         isEditing: Boolean = false,
+        toggleEdit: () -> Unit = { notImplemented() },
         allowsRemovalOfLastSavedPaymentMethod: Boolean = true,
         onSelectPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit = { notImplemented() },
         handleBackPressed: () -> Unit = { notImplemented() },
@@ -303,6 +318,7 @@ class DefaultManageScreenInteractorTest {
             selection = selection,
             editing = editing,
             canEdit = canEdit,
+            toggleEdit = toggleEdit,
             allowsRemovalOfLastSavedPaymentMethod = allowsRemovalOfLastSavedPaymentMethod,
             providePaymentMethodName = { (it ?: "Missing name").resolvableString },
             onSelectPaymentMethod = onSelectPaymentMethod,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
My goal is to eventually move SavedPaymentMethodMutator to be not stored in BaseSheetViewModel, but passed around the screens it's used. 

In order to do that, I needed to pull out the handling of editing specific logic, and this is one bit of it.
