### PR TITLE
Add `FakePaymentLauncher` & track calls to `FakeIntentConfirmationInterceptor`

### DIFF
--- a/payments-core-testing/build.gradle
+++ b/payments-core-testing/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation libs.kotlin.coroutinesAndroid
     implementation testLibs.junit
     implementation testLibs.kotlin.coroutines
+    implementation testLibs.turbine
     implementation testLibs.leakCanaryInstrumentation
 
     androidTestImplementation project(':stripe-ui-core') // Resources defined here, but used in payments-core.

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/FakePaymentLauncher.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/FakePaymentLauncher.kt
@@ -1,0 +1,54 @@
+package com.stripe.android.testing
+
+import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.ConfirmSetupIntentParams
+import com.stripe.android.model.ConfirmStripeIntentParams
+import com.stripe.android.payments.paymentlauncher.PaymentLauncher
+
+class FakePaymentLauncher : PaymentLauncher {
+    private val _calls = mutableListOf<Call>()
+    val calls: List<Call>
+        get() = _calls.toList()
+
+    override fun confirm(params: ConfirmPaymentIntentParams) {
+        _calls.add(Call.Confirm.PaymentIntent(params))
+    }
+
+    override fun confirm(params: ConfirmSetupIntentParams) {
+        _calls.add(Call.Confirm.SetupIntent(params))
+    }
+
+    override fun handleNextActionForPaymentIntent(clientSecret: String) {
+        _calls.add(Call.HandleNextAction.PaymentIntent(clientSecret))
+    }
+
+    override fun handleNextActionForSetupIntent(clientSecret: String) {
+        _calls.add(Call.HandleNextAction.SetupIntent(clientSecret))
+    }
+
+    sealed interface Call {
+        sealed interface Confirm<T : ConfirmStripeIntentParams> : Call {
+            val params: T
+
+            data class PaymentIntent(
+                override val params: ConfirmPaymentIntentParams
+            ) : Confirm<ConfirmPaymentIntentParams>
+
+            data class SetupIntent(
+                override val params: ConfirmSetupIntentParams
+            ) : Confirm<ConfirmSetupIntentParams>
+        }
+
+        sealed interface HandleNextAction : Call {
+            val clientSecret: String
+
+            data class PaymentIntent(
+                override val clientSecret: String
+            ) : HandleNextAction
+
+            data class SetupIntent(
+                override val clientSecret: String
+            ) : HandleNextAction
+        }
+    }
+}

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/FakePaymentLauncher.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/FakePaymentLauncher.kt
@@ -1,14 +1,15 @@
 package com.stripe.android.testing
 
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.payments.paymentlauncher.PaymentLauncher
 
 class FakePaymentLauncher : PaymentLauncher {
-    private val _calls = mutableListOf<Call>()
-    val calls: List<Call>
-        get() = _calls.toList()
+    private val _calls = Turbine<Call>()
+    val calls: ReceiveTurbine<Call> = _calls
 
     override fun confirm(params: ConfirmPaymentIntentParams) {
         _calls.add(Call.Confirm.PaymentIntent(params))

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.utils
 
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
@@ -11,9 +13,8 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.coroutines.channels.Channel
 
 internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor {
-    private val _calls = mutableListOf<InterceptCall>()
-    val calls: List<InterceptCall>
-        get() = _calls.toList()
+    private val _calls = Turbine<InterceptCall>()
+    val calls: ReceiveTurbine<InterceptCall> = _calls
 
     private val channel = Channel<IntentConfirmationInterceptor.NextStep>(capacity = 1)
 


### PR DESCRIPTION
# Summary
Add `FakePaymentLauncher` & track calls to `FakeIntentConfirmationInterceptor`

# Motivation
Adds & updates test implementations of `PaymentSheet` utilities to track calls to the methods without needing to use Mockito.
