### PR TITLE
Move click disablement while in editing to the UI.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -261,12 +261,10 @@ internal class PaymentOptionsViewModel @Inject constructor(
     }
 
     override fun handlePaymentMethodSelected(selection: PaymentSelection?) {
-        if (!savedPaymentMethodMutator.editing.value) {
-            updateSelection(selection)
+        updateSelection(selection)
 
-            if (selection?.requiresConfirmation != true) {
-                onUserSelection()
-            }
+        if (selection?.requiresConfirmation != true) {
+            onUserSelection()
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -522,7 +522,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     override fun handlePaymentMethodSelected(selection: PaymentSelection?) {
-        if (!savedPaymentMethodMutator.editing.value && selection != this.selection.value) {
+        if (selection != this.selection.value) {
             updateSelection(selection)
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -347,7 +347,11 @@ private fun SavedPaymentMethodTab(
             onModifyAccessibilityDescription = paymentMethod.getModifyDescription(context.resources),
             onRemoveListener = { onItemRemoved(paymentMethod.paymentMethod) },
             onRemoveAccessibilityDescription = paymentMethod.getRemoveDescription(context.resources),
-            onItemSelectedListener = { onItemSelected(paymentMethod.toPaymentSelection()) },
+            onItemSelectedListener = {
+                if (!isEditing) {
+                    onItemSelected(paymentMethod.toPaymentSelection())
+                }
+            },
             modifier = modifier,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -464,22 +464,6 @@ internal class PaymentOptionsViewModelTest {
     }
 
     @Test
-    fun `Ignores payment selection while in edit mode`() = runTest {
-        val viewModel = createViewModel().apply {
-            updateSelection(PaymentSelection.Link)
-        }
-
-        viewModel.savedPaymentMethodMutator.toggleEditing()
-        viewModel.handlePaymentMethodSelected(PaymentSelection.GooglePay)
-
-        assertThat(viewModel.selection.value).isEqualTo(PaymentSelection.Link)
-
-        viewModel.savedPaymentMethodMutator.toggleEditing()
-        viewModel.handlePaymentMethodSelected(PaymentSelection.GooglePay)
-        assertThat(viewModel.selection.value).isEqualTo(PaymentSelection.GooglePay)
-    }
-
-    @Test
     fun `Does not close the sheet if the selected payment method requires confirmation`() =
         runTest {
             val selection = PaymentSelection.Saved(PaymentMethodFixtures.US_BANK_ACCOUNT)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1646,22 +1646,6 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `Ignores payment selection while in edit mode`() = runTest {
-        val viewModel = createViewModel().apply {
-            updateSelection(PaymentSelection.Link)
-        }
-
-        viewModel.savedPaymentMethodMutator.toggleEditing()
-        viewModel.handlePaymentMethodSelected(PaymentSelection.GooglePay)
-
-        assertThat(viewModel.selection.value).isEqualTo(PaymentSelection.Link)
-
-        viewModel.savedPaymentMethodMutator.toggleEditing()
-        viewModel.handlePaymentMethodSelected(PaymentSelection.GooglePay)
-        assertThat(viewModel.selection.value).isEqualTo(PaymentSelection.GooglePay)
-    }
-
-    @Test
     fun `updateSelection with new payment method updates the current selection`() = runTest {
         val viewModel = createViewModel(initialPaymentSelection = null)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsTest.kt
@@ -81,6 +81,34 @@ class PaymentOptionsTest {
     }
 
     @Test
+    fun `Does not update selection when item is pressed in edit mode`() {
+        var didCallOnItemSelected = false
+
+        composeTestRule.setContent {
+            SavedPaymentMethodTabLayoutUI(
+                paymentOptionsItems = listOf(PaymentOptionsItem.AddCard, PaymentOptionsItem.GooglePay),
+                selectedPaymentOptionsItem = PaymentOptionsItem.GooglePay,
+                isEditing = true,
+                isProcessing = false,
+                onAddCardPressed = {},
+                onItemSelected = { didCallOnItemSelected = true },
+                onModifyItem = {},
+                onItemRemoved = {},
+            )
+        }
+
+        val testTag = "${SAVED_PAYMENT_METHOD_CARD_TEST_TAG}_Google Pay"
+
+        assertThat(didCallOnItemSelected).isFalse()
+
+        composeTestRule
+            .onNodeWithTag(testTag)
+            .performClick()
+
+        assertThat(didCallOnItemSelected).isFalse()
+    }
+
+    @Test
     fun `When items are removable & editing, should show removable badge`() {
         composeTestRule.setContent {
             SavedPaymentMethodTabLayoutUI(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I'm trying to move more edit handling to be as close to the source as possible. It also makes sense to have this logic in one place, rather than multiple view models handling this.
