### PR TITLE
Add mechanism to use consumer publishable key for API requests

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
@@ -17,6 +17,8 @@ import com.stripe.android.financialconnections.model.SynchronizeSessionResponse
 import com.stripe.android.financialconnections.navigation.NavigationManager
 import com.stripe.android.financialconnections.navigation.NavigationManagerImpl
 import com.stripe.android.financialconnections.network.FinancialConnectionsRequestExecutor
+import com.stripe.android.financialconnections.repository.ConsumerPublishableKeyProvider
+import com.stripe.android.financialconnections.repository.ConsumerPublishableKeyStore
 import com.stripe.android.financialconnections.repository.FinancialConnectionsAccountsRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsConsumerSessionRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsInstitutionsRepository
@@ -99,6 +101,7 @@ internal interface FinancialConnectionsSheetNativeModule {
         fun providesFinancialConnectionsConsumerSessionRepository(
             consumersApiService: ConsumersApiService,
             apiOptions: ApiRequest.Options,
+            consumerPublishableKeyStore: ConsumerPublishableKeyStore,
             financialConnectionsConsumersApiService: FinancialConnectionsConsumersApiService,
             locale: Locale?,
             logger: Logger,
@@ -106,6 +109,7 @@ internal interface FinancialConnectionsSheetNativeModule {
             financialConnectionsConsumersApiService = financialConnectionsConsumersApiService,
             consumersApiService = consumersApiService,
             apiOptions = apiOptions,
+            consumerPublishableKeyStore = consumerPublishableKeyStore,
             locale = locale ?: Locale.getDefault(),
             logger = logger,
         )
@@ -116,12 +120,14 @@ internal interface FinancialConnectionsSheetNativeModule {
             requestExecutor: FinancialConnectionsRequestExecutor,
             apiOptions: ApiRequest.Options,
             apiRequestFactory: ApiRequest.Factory,
+            consumerPublishableKeyProvider: ConsumerPublishableKeyProvider,
             logger: Logger,
             savedStateHandle: SavedStateHandle,
         ) = FinancialConnectionsAccountsRepository(
             requestExecutor = requestExecutor,
             apiRequestFactory = apiRequestFactory,
             apiOptions = apiOptions,
+            consumerPublishableKeyProvider = consumerPublishableKeyProvider,
             logger = logger,
             savedStateHandle = savedStateHandle,
         )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
@@ -25,7 +25,12 @@ import com.stripe.android.financialconnections.analytics.FinancialConnectionsAna
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTrackerImpl
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEventReporter
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
+import com.stripe.android.financialconnections.domain.IsLinkWithStripe
+import com.stripe.android.financialconnections.domain.RealIsLinkWithStripe
 import com.stripe.android.financialconnections.features.common.enableWorkManager
+import com.stripe.android.financialconnections.repository.ConsumerPublishableKeyManager
+import com.stripe.android.financialconnections.repository.ConsumerPublishableKeyProvider
+import com.stripe.android.financialconnections.repository.ConsumerPublishableKeyStore
 import com.stripe.android.financialconnections.repository.FinancialConnectionsRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsRepositoryImpl
 import dagger.Binds
@@ -65,6 +70,15 @@ internal interface FinancialConnectionsSheetSharedModule {
     @Binds
     @Singleton
     fun bindsAnalyticsRequestV2Executor(impl: DefaultAnalyticsRequestV2Executor): AnalyticsRequestV2Executor
+
+    @Binds
+    fun bindsIsLinkWithStripe(impl: RealIsLinkWithStripe): IsLinkWithStripe
+
+    @Binds
+    fun bindsConsumerPublishableKeyStore(impl: ConsumerPublishableKeyManager): ConsumerPublishableKeyStore
+
+    @Binds
+    fun bindsConsumerPublishableKeyProvider(impl: ConsumerPublishableKeyManager): ConsumerPublishableKeyProvider
 
     companion object {
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/IsLinkWithStripe.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/IsLinkWithStripe.kt
@@ -1,0 +1,16 @@
+package com.stripe.android.financialconnections.domain
+
+import javax.inject.Inject
+
+internal fun interface IsLinkWithStripe {
+    suspend operator fun invoke(): Boolean
+}
+
+internal class RealIsLinkWithStripe @Inject constructor(
+    private val getOrFetchSync: GetOrFetchSync,
+) : IsLinkWithStripe {
+
+    override suspend operator fun invoke(): Boolean {
+        return getOrFetchSync().manifest.isLinkWithStripe ?: false
+    }
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/ConsumerPublishableKeyStore.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/ConsumerPublishableKeyStore.kt
@@ -1,0 +1,49 @@
+package com.stripe.android.financialconnections.repository
+
+import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.financialconnections.domain.IsLinkWithStripe
+import javax.inject.Inject
+
+internal const val KeyConsumerPublishableKey = "ConsumerPublishableKey"
+private const val KeyTentativeConsumerPublishableKey = "KeyTentativeConsumerPublishableKey"
+
+internal interface ConsumerPublishableKeyStore {
+    suspend fun setTentativeConsumerPublishableKey(key: String?)
+    suspend fun confirmConsumerPublishableKey()
+}
+
+internal fun interface ConsumerPublishableKeyProvider {
+    fun provideConsumerPublishableKey(): String?
+}
+
+internal class ConsumerPublishableKeyManager @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+    private val isLinkWithStripe: IsLinkWithStripe,
+) : ConsumerPublishableKeyStore, ConsumerPublishableKeyProvider {
+
+    override fun provideConsumerPublishableKey(): String? {
+        return savedStateHandle[KeyConsumerPublishableKey]
+    }
+
+    override suspend fun setTentativeConsumerPublishableKey(key: String?) {
+        if (isLinkWithStripe()) {
+            savedStateHandle[KeyTentativeConsumerPublishableKey] = key
+        }
+    }
+
+    override suspend fun confirmConsumerPublishableKey() {
+        if (isLinkWithStripe()) {
+            val key = savedStateHandle.get<String>(KeyTentativeConsumerPublishableKey)
+            savedStateHandle[KeyConsumerPublishableKey] = key
+        }
+    }
+}
+
+/**
+ * Returns [ApiRequest.Options] with the previously received consumer publishable key (stored via
+ * [ConsumerPublishableKeyStore]) or null if none was received.
+ */
+internal fun ConsumerPublishableKeyProvider.createApiRequestOptions(): ApiRequest.Options? {
+    return provideConsumerPublishableKey()?.let { ApiRequest.Options(apiKey = it) }
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
@@ -37,6 +37,7 @@ internal interface FinancialConnectionsConsumerSessionRepository {
         operator fun invoke(
             consumersApiService: ConsumersApiService,
             apiOptions: ApiRequest.Options,
+            consumerPublishableKeyStore: ConsumerPublishableKeyStore,
             financialConnectionsConsumersApiService: FinancialConnectionsConsumersApiService,
             locale: Locale?,
             logger: Logger,
@@ -44,6 +45,7 @@ internal interface FinancialConnectionsConsumerSessionRepository {
             FinancialConnectionsConsumerSessionRepositoryImpl(
                 consumersApiService = consumersApiService,
                 apiOptions = apiOptions,
+                consumerPublishableKeyStore = consumerPublishableKeyStore,
                 financialConnectionsConsumersApiService = financialConnectionsConsumersApiService,
                 locale = locale,
                 logger = logger,
@@ -55,6 +57,7 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
     private val financialConnectionsConsumersApiService: FinancialConnectionsConsumersApiService,
     private val consumersApiService: ConsumersApiService,
     private val apiOptions: ApiRequest.Options,
+    private val consumerPublishableKeyStore: ConsumerPublishableKeyStore,
     private val locale: Locale?,
     private val logger: Logger,
 ) : FinancialConnectionsConsumerSessionRepository {
@@ -70,6 +73,7 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
         clientSecret: String
     ): ConsumerSessionLookup = mutex.withLock {
         postConsumerSession(email, clientSecret).also { lookup ->
+            consumerPublishableKeyStore.setTentativeConsumerPublishableKey(lookup.publishableKey)
             updateCachedConsumerSession("lookupConsumerSession", lookup.consumerSession)
         }
     }
@@ -105,6 +109,7 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
             requestSurface = CONSUMER_SURFACE,
             requestOptions = apiOptions
         ).also { session ->
+            consumerPublishableKeyStore.confirmConsumerPublishableKey()
             updateCachedConsumerSession("confirmConsumerVerification", session)
         }
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepository.kt
@@ -59,6 +59,9 @@ internal class FinancialConnectionsRepositoryImpl @Inject constructor(
     private val consumerPublishableKeyProvider: ConsumerPublishableKeyProvider,
 ) : FinancialConnectionsRepository {
 
+    private val consumerApiRequestOptions: ApiRequest.Options?
+        get() = consumerPublishableKeyProvider.createApiRequestOptions()
+
     override suspend fun getFinancialConnectionsAccounts(
         getFinancialConnectionsAcccountsParams: GetFinancialConnectionsAcccountsParams
     ): FinancialConnectionsAccountList {
@@ -93,7 +96,6 @@ internal class FinancialConnectionsRepositoryImpl @Inject constructor(
         clientSecret: String,
         terminalError: String?
     ): FinancialConnectionsSession {
-        val consumerApiRequestOptions = consumerPublishableKeyProvider.createApiRequestOptions()
         val financialConnectionsRequest = apiRequestFactory.createPost(
             url = completeUrl,
             options = consumerApiRequestOptions ?: apiOptions,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepository.kt
@@ -55,7 +55,8 @@ internal interface FinancialConnectionsRepository {
 internal class FinancialConnectionsRepositoryImpl @Inject constructor(
     private val requestExecutor: FinancialConnectionsRequestExecutor,
     private val apiOptions: ApiRequest.Options,
-    private val apiRequestFactory: ApiRequest.Factory
+    private val apiRequestFactory: ApiRequest.Factory,
+    private val consumerPublishableKeyProvider: ConsumerPublishableKeyProvider,
 ) : FinancialConnectionsRepository {
 
     override suspend fun getFinancialConnectionsAccounts(
@@ -92,9 +93,10 @@ internal class FinancialConnectionsRepositoryImpl @Inject constructor(
         clientSecret: String,
         terminalError: String?
     ): FinancialConnectionsSession {
+        val consumerApiRequestOptions = consumerPublishableKeyProvider.createApiRequestOptions()
         val financialConnectionsRequest = apiRequestFactory.createPost(
             url = completeUrl,
-            options = apiOptions,
+            options = consumerApiRequestOptions ?: apiOptions,
             params = mapOf(
                 NetworkConstants.PARAMS_CLIENT_SECRET to clientSecret,
                 "terminal_error" to terminalError

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/ApiKeyFixtures.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/ApiKeyFixtures.kt
@@ -7,7 +7,9 @@ import com.stripe.android.financialconnections.model.FinancialConnectionsAuthori
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
+import com.stripe.android.financialconnections.model.InstitutionResponse
 import com.stripe.android.financialconnections.model.ManualEntryMode
+import com.stripe.android.financialconnections.model.NetworkedAccountsList
 import com.stripe.android.financialconnections.model.PartnerAccount
 import com.stripe.android.financialconnections.model.PartnerAccountsList
 import com.stripe.android.financialconnections.model.SynchronizeSessionResponse
@@ -95,6 +97,12 @@ internal object ApiKeyFixtures {
         nextPane = FinancialConnectionsSessionManifest.Pane.CONSENT,
     )
 
+    fun networkedAccountsList(
+        vararg ids: String,
+    ) = NetworkedAccountsList(
+        data = ids.map { partnerAccount().copy(id = it) },
+    )
+
     fun institution() = FinancialConnectionsInstitution(
         id = "id",
         name = "name",
@@ -102,6 +110,10 @@ internal object ApiKeyFixtures {
         featured = true,
         featuredOrder = null,
         mobileHandoffCapable = false
+    )
+
+    fun institutionResponse() = InstitutionResponse(
+        data = listOf(institution()),
     )
 
     fun partnerAccount() = PartnerAccount(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/ConsumerPublishableKeyManagerTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/ConsumerPublishableKeyManagerTest.kt
@@ -1,0 +1,90 @@
+package com.stripe.android.financialconnections.repository
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class ConsumerPublishableKeyManagerTest {
+
+    private val consumerPublishableKey = "pk_this_is_not_valid_but_its_ok_for_a_test"
+
+    @Test
+    fun `Only sets consumer publishable key tentatively`() = runTest {
+        val savedStateHandle = SavedStateHandle()
+
+        val manager = ConsumerPublishableKeyManager(
+            savedStateHandle = savedStateHandle,
+            isLinkWithStripe = { true },
+        )
+
+        manager.setTentativeConsumerPublishableKey(consumerPublishableKey)
+        manager.assertIsNotProvidingConsumerPublishableKey()
+    }
+
+    @Test
+    fun `Provides consumer publishable key after being confirmed`() = runTest {
+        val savedStateHandle = SavedStateHandle()
+
+        val manager = ConsumerPublishableKeyManager(
+            savedStateHandle = savedStateHandle,
+            isLinkWithStripe = { true },
+        )
+
+        manager.setTentativeConsumerPublishableKey(consumerPublishableKey)
+        manager.assertIsNotProvidingConsumerPublishableKey()
+
+        manager.confirmConsumerPublishableKey()
+        manager.assertIsProvidingConsumerPublishableKey()
+    }
+
+    @Test
+    fun `Does not set consumer publishable key if not in Instant Debits flow`() = runTest {
+        val manager = ConsumerPublishableKeyManager(
+            savedStateHandle = SavedStateHandle(),
+            isLinkWithStripe = { false },
+        )
+
+        manager.setTentativeConsumerPublishableKey(consumerPublishableKey)
+        manager.confirmConsumerPublishableKey()
+
+        manager.assertIsNotProvidingConsumerPublishableKey()
+    }
+
+    @Test
+    fun `Sets consumer publishable key if in Instant Debits flow`() = runTest {
+        val manager = ConsumerPublishableKeyManager(
+            savedStateHandle = SavedStateHandle(),
+            isLinkWithStripe = { true },
+        )
+
+        manager.setTentativeConsumerPublishableKey(consumerPublishableKey)
+        manager.confirmConsumerPublishableKey()
+
+        manager.assertIsProvidingConsumerPublishableKey()
+    }
+
+    @Test
+    fun `Provides consumer publishable key if SavedStateHandle includes it`() = runTest {
+        val manager = ConsumerPublishableKeyManager(
+            savedStateHandle = SavedStateHandle(
+                initialState = mapOf(
+                    KeyConsumerPublishableKey to consumerPublishableKey,
+                ),
+            ),
+            isLinkWithStripe = { true },
+        )
+
+        manager.assertIsProvidingConsumerPublishableKey()
+    }
+
+    private fun ConsumerPublishableKeyManager.assertIsNotProvidingConsumerPublishableKey() {
+        val key = provideConsumerPublishableKey()
+        assertThat(key).isNull()
+    }
+
+    private fun ConsumerPublishableKeyManager.assertIsProvidingConsumerPublishableKey() {
+        val key = provideConsumerPublishableKey()
+        assertThat(key).isEqualTo(consumerPublishableKey)
+    }
+}

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsAccountsRepositoryImplTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsAccountsRepositoryImplTest.kt
@@ -5,6 +5,9 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.financialconnections.ApiKeyFixtures
+import com.stripe.android.financialconnections.ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+import com.stripe.android.financialconnections.ApiKeyFixtures.institutionResponse
+import com.stripe.android.financialconnections.ApiKeyFixtures.networkedAccountsList
 import com.stripe.android.financialconnections.ApiKeyFixtures.partnerAccount
 import com.stripe.android.financialconnections.ApiKeyFixtures.partnerAccountList
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
@@ -15,6 +18,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.KSerializer
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
@@ -25,19 +29,22 @@ import org.mockito.kotlin.whenever
 internal class FinancialConnectionsAccountsRepositoryImplTest {
 
     private val mockRequestExecutor = mock<FinancialConnectionsRequestExecutor>()
-    private val apiRequestFactory = mock<ApiRequest.Factory>()
+    private val apiRequestFactory = ApiRequest.Factory()
     private val configuration = FinancialConnectionsSheet.Configuration(
         ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
-        ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+        DEFAULT_PUBLISHABLE_KEY
     )
     private val authSessionId = "AuthSessionId"
 
-    private fun buildRepository() = FinancialConnectionsAccountsRepository(
+    private fun buildRepository(
+        consumerPublishableKeyProvider: ConsumerPublishableKeyProvider = ConsumerPublishableKeyProvider { null },
+    ) = FinancialConnectionsAccountsRepository(
         apiOptions = ApiRequest.Options(
-            apiKey = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+            apiKey = DEFAULT_PUBLISHABLE_KEY
         ),
         requestExecutor = mockRequestExecutor,
         apiRequestFactory = apiRequestFactory,
+        consumerPublishableKeyProvider = consumerPublishableKeyProvider,
         logger = Logger.noop(),
         savedStateHandle = SavedStateHandle(),
     )
@@ -48,7 +55,7 @@ internal class FinancialConnectionsAccountsRepositoryImplTest {
         val expectedAccounts = partnerAccountList().copy(
             data = listOf(partnerAccount().copy(id = "id_1", linkedAccountId = "linked_id_1"))
         )
-        givenRequestReturnsAccounts(expectedAccounts)
+        mockPartnerAccountsList(expectedAccounts)
 
         // first call calls backend and caches.
         repository.postAuthorizationSessionAccounts(
@@ -69,26 +76,113 @@ internal class FinancialConnectionsAccountsRepositoryImplTest {
         )
     }
 
-    /**
-     * Simulates an API call to retrieve manifest that takes some time.
-     */
-    private suspend fun givenRequestReturnsAccounts(
-        partnerAccountList: PartnerAccountsList
-    ) {
-        val mock = mock<ApiRequest>()
-        whenever(
-            apiRequestFactory.createPost(
-                url = any(),
-                options = any(),
-                params = any(),
-                shouldCache = eq(false)
+    @Test
+    fun `getNetworkedAccounts - uses consumer publishable key if available`() = runTest {
+        assertUsesConsumerPublishableKey {
+            mockNetworkedAccountsList()
+            getNetworkedAccounts(
+                clientSecret = "client_secret",
+                consumerSessionClientSecret = "consumer_session_client_secret",
             )
-        ).thenReturn(mock)
+        }
+    }
+
+    @Test
+    fun `getNetworkedAccounts - uses merchant publishable key if no consumer publishable key`() = runTest {
+        assertUsesMerchantPublishableKey {
+            mockNetworkedAccountsList()
+
+            getNetworkedAccounts(
+                clientSecret = "client_secret",
+                consumerSessionClientSecret = "consumer_session_client_secret",
+            )
+        }
+    }
+
+    @Test
+    fun `postShareNetworkedAccounts - uses consumer publishable key if available`() = runTest {
+        assertUsesConsumerPublishableKey {
+            mockInstitutionResponse()
+
+            postShareNetworkedAccounts(
+                clientSecret = "client_secret",
+                consumerSessionClientSecret = "consumer_session_client_secret",
+                selectedAccountIds = setOf("account_id_1"),
+            )
+        }
+    }
+
+    @Test
+    fun `postShareNetworkedAccounts - uses merchant publishable key if no consumer publishable key`() = runTest {
+        assertUsesMerchantPublishableKey {
+            mockInstitutionResponse()
+
+            postShareNetworkedAccounts(
+                clientSecret = "client_secret",
+                consumerSessionClientSecret = "consumer_session_client_secret",
+                selectedAccountIds = setOf("account_id_1"),
+            )
+        }
+    }
+
+    private suspend fun assertUsesConsumerPublishableKey(
+        operation: suspend FinancialConnectionsAccountsRepository.() -> Unit,
+    ) {
+        val consumerPublishableKey = "pk_123_consumer"
+
+        val repository = buildRepository(
+            consumerPublishableKeyProvider = { consumerPublishableKey },
+        )
+
+        repository.operation()
+
+        val requestArgumentCaptor = argumentCaptor<ApiRequest>()
+
+        verify(mockRequestExecutor).execute(
+            request = requestArgumentCaptor.capture(),
+            responseSerializer = any<KSerializer<*>>(),
+        )
+
+        assertThat(requestArgumentCaptor.firstValue.options.apiKey).isEqualTo(consumerPublishableKey)
+    }
+
+    private suspend fun assertUsesMerchantPublishableKey(
+        operation: suspend FinancialConnectionsAccountsRepository.() -> Unit,
+    ) {
+        val repository = buildRepository(
+            consumerPublishableKeyProvider = { null },
+        )
+
+        repository.operation()
+
+        val requestArgumentCaptor = argumentCaptor<ApiRequest>()
+
+        verify(mockRequestExecutor).execute(
+            request = requestArgumentCaptor.capture(),
+            responseSerializer = any<KSerializer<*>>(),
+        )
+
+        assertThat(requestArgumentCaptor.firstValue.options.apiKey).isEqualTo(DEFAULT_PUBLISHABLE_KEY)
+    }
+
+    private suspend fun mockPartnerAccountsList(partnerAccountList: PartnerAccountsList) {
         given(
             mockRequestExecutor.execute(
                 any(),
                 any<KSerializer<*>>()
             )
         ).willReturn(partnerAccountList)
+    }
+
+    private suspend fun mockNetworkedAccountsList() {
+        whenever(mockRequestExecutor.execute(any(), any<KSerializer<*>>())).thenReturn(
+            networkedAccountsList("account_id_1", "account_id_2")
+        )
+    }
+
+    private suspend fun mockInstitutionResponse() {
+        whenever(mockRequestExecutor.execute(any(), any<KSerializer<*>>())).thenReturn(
+            institutionResponse()
+        )
     }
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepositoryImplTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepositoryImplTest.kt
@@ -75,8 +75,8 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
     fun `Stores tentative consumer publishable key on consumer session lookup`() = runTest {
         val consumerPublishableKey = "pk_123_consumer"
 
-        val apiOptionsProvider: ConsumerPublishableKeyStore = mock()
-        val repository = buildRepository(apiOptionsProvider)
+        val consumerPublishableKeyStore = mock<ConsumerPublishableKeyStore>()
+        val repository = buildRepository(consumerPublishableKeyStore)
 
         whenever(
             financialConnectionsConsumersApiService.postConsumerSession(any(), any(), any())
@@ -91,8 +91,8 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
 
         repository.lookupConsumerSession("test@example.com", "client_secret")
 
-        verify(apiOptionsProvider).setTentativeConsumerPublishableKey(eq(consumerPublishableKey))
-        verify(apiOptionsProvider, never()).confirmConsumerPublishableKey()
+        verify(consumerPublishableKeyStore).setTentativeConsumerPublishableKey(eq(consumerPublishableKey))
+        verify(consumerPublishableKeyStore, never()).confirmConsumerPublishableKey()
     }
 
     @Test
@@ -182,8 +182,8 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
 
     @Test
     fun `Confirms tentative consumer publishable key on consumer verification`() = runTest {
-        val apiOptionsProvider: ConsumerPublishableKeyStore = mock()
-        val repository = buildRepository(apiOptionsProvider)
+        val consumerPublishableKeyStore = mock<ConsumerPublishableKeyStore>()
+        val repository = buildRepository(consumerPublishableKeyStore)
 
         whenever(
             consumersApiService.confirmConsumerVerification(
@@ -203,7 +203,7 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
             type = VerificationType.SMS,
         )
 
-        verify(apiOptionsProvider).confirmConsumerPublishableKey()
+        verify(consumerPublishableKeyStore).confirmConsumerPublishableKey()
     }
 
     private fun buildRepository(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepositoryImplTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepositoryImplTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.repository
 
+import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.core.Logger
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.financialconnections.ApiKeyFixtures.consumerSession
@@ -13,9 +14,11 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.Locale
@@ -30,15 +33,6 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
     private val apiOptions: ApiRequest.Options = mock()
     private val logger: Logger = mock()
     private val locale: Locale = Locale.getDefault()
-
-    private fun buildRepository() =
-        FinancialConnectionsConsumerSessionRepository(
-            consumersApiService = consumersApiService,
-            financialConnectionsConsumersApiService = financialConnectionsConsumersApiService,
-            apiOptions = apiOptions,
-            locale = locale,
-            logger = logger
-        )
 
     @Test
     fun testLookupConsumerSession() = runTest {
@@ -75,6 +69,30 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
 
         // ensures there's a cached consumer session after the lookup call.
         assertEquals(repository.getCachedConsumerSession(), consumerSession)
+    }
+
+    @Test
+    fun `Stores tentative consumer publishable key on consumer session lookup`() = runTest {
+        val consumerPublishableKey = "pk_123_consumer"
+
+        val apiOptionsProvider: ConsumerPublishableKeyStore = mock()
+        val repository = buildRepository(apiOptionsProvider)
+
+        whenever(
+            financialConnectionsConsumersApiService.postConsumerSession(any(), any(), any())
+        ).thenReturn(
+            ConsumerSessionLookup(
+                consumerSession = consumerSession(),
+                errorMessage = null,
+                exists = true,
+                publishableKey = consumerPublishableKey,
+            )
+        )
+
+        repository.lookupConsumerSession("test@example.com", "client_secret")
+
+        verify(apiOptionsProvider).setTentativeConsumerPublishableKey(eq(consumerPublishableKey))
+        verify(apiOptionsProvider, never()).confirmConsumerPublishableKey()
     }
 
     @Test
@@ -160,5 +178,47 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
 
         // ensures there's a cached consumer session after the lookup call.
         assertEquals(repository.getCachedConsumerSession(), consumerSession)
+    }
+
+    @Test
+    fun `Confirms tentative consumer publishable key on consumer verification`() = runTest {
+        val apiOptionsProvider: ConsumerPublishableKeyStore = mock()
+        val repository = buildRepository(apiOptionsProvider)
+
+        whenever(
+            consumersApiService.confirmConsumerVerification(
+                consumerSessionClientSecret = any(),
+                verificationCode = any(),
+                requestSurface = any(),
+                type = any(),
+                requestOptions = any(),
+            )
+        ).thenReturn(
+            consumerSession()
+        )
+
+        repository.confirmConsumerVerification(
+            consumerSessionClientSecret = "client_secret",
+            verificationCode = "123456",
+            type = VerificationType.SMS,
+        )
+
+        verify(apiOptionsProvider).confirmConsumerPublishableKey()
+    }
+
+    private fun buildRepository(
+        consumerPublishableKeyStore: ConsumerPublishableKeyStore = ConsumerPublishableKeyManager(
+            savedStateHandle = SavedStateHandle(),
+            isLinkWithStripe = { false },
+        ),
+    ): FinancialConnectionsConsumerSessionRepository {
+        return FinancialConnectionsConsumerSessionRepository(
+            consumersApiService = consumersApiService,
+            financialConnectionsConsumersApiService = financialConnectionsConsumersApiService,
+            apiOptions = apiOptions,
+            consumerPublishableKeyStore = consumerPublishableKeyStore,
+            locale = locale,
+            logger = logger,
+        )
     }
 }

--- a/financial-connections/src/test/resources/json/linked_account_session_complete.json
+++ b/financial-connections/src/test/resources/json/linked_account_session_complete.json
@@ -1,0 +1,44 @@
+{
+  "id": "fcsess_123",
+  "accounts": {
+    "object": "list",
+    "data": [],
+    "has_more": false,
+    "total_count": 1,
+    "url": "/v1/financial_connections/accounts"
+  },
+  "client_secret": "fcsess_client_secret_123",
+  "filters": {
+    "account_subcategories": null,
+    "countries": null
+  },
+  "livemode": false,
+  "payment_account": {
+    "id": "fca_123",
+    "balance": null,
+    "balance_refresh": null,
+    "category": "cash",
+    "created": 1719262140,
+    "display_name": "Account Closed",
+    "institution_name": "StripeBank",
+    "last4": "1234",
+    "livemode": false,
+    "ownership": null,
+    "ownership_refresh": null,
+    "permissions": [
+      "payment_method"
+    ],
+    "status": "inactive",
+    "subcategory": "checking",
+    "subscriptions": [],
+    "supported_payment_method_types": [
+      "us_bank_account",
+      "link"
+    ],
+    "transaction_refresh": null
+  },
+  "permissions": [
+    "payment_method"
+  ],
+  "prefetch": []
+}

--- a/financial-connections/src/test/resources/json/linked_account_session_complete.json
+++ b/financial-connections/src/test/resources/json/linked_account_session_complete.json
@@ -8,37 +8,24 @@
     "url": "/v1/financial_connections/accounts"
   },
   "client_secret": "fcsess_client_secret_123",
-  "filters": {
-    "account_subcategories": null,
-    "countries": null
-  },
   "livemode": false,
   "payment_account": {
     "id": "fca_123",
-    "balance": null,
-    "balance_refresh": null,
     "category": "cash",
     "created": 1719262140,
-    "display_name": "Account Closed",
     "institution_name": "StripeBank",
     "last4": "1234",
     "livemode": false,
-    "ownership": null,
-    "ownership_refresh": null,
     "permissions": [
       "payment_method"
     ],
     "status": "inactive",
-    "subcategory": "checking",
-    "subscriptions": [],
     "supported_payment_method_types": [
       "us_bank_account",
       "link"
-    ],
-    "transaction_refresh": null
+    ]
   },
   "permissions": [
     "payment_method"
-  ],
-  "prefetch": []
+  ]
 }

--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerSessionLookup.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerSessionLookup.kt
@@ -18,5 +18,7 @@ data class ConsumerSessionLookup(
     @SerialName("consumer_session")
     val consumerSession: ConsumerSession? = null,
     @SerialName("error_message")
-    val errorMessage: String? = null
+    val errorMessage: String? = null,
+    @SerialName("publishable_key")
+    val publishableKey: String? = null,
 ) : StripeModel


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds a mechanism in the Financial Connections SDK to dynamically use the consumer publishable key instead of the merchant one in the Instant Debits flow. In Instant Debits, we need to use the consumer publishable key to make API requests after the Link consumer has passed the OTP verification, with only a couple of exceptions.

This pull request implements this behavior for _some_ API requests in the returning-user experience. I’ll add it to the remaining requests after implementing the `attach Link consumer to LAS` ([Jira](https://jira.corp.stripe.com/browse/BANKCON-11515)), as only then we’d be able to test the entire flow.

**Approach**: I added a `ConsumerPublishableKeyManager` that implements both a provider and store interface. I chose this approach because most repositories only require the provider interface, which can now be more easily mocked as a functional interface. I also added an `IsLinkWithStripe` interactor, which will be used in all places where we have diverging logic based on the product.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[BANKCON-11514](https://jira.corp.stripe.com/browse/BANKCON-11514)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
