### PR TITLE
Update click UX for "disabled" items.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/RowButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/RowButton.kt
@@ -18,6 +18,7 @@ import com.stripe.android.uicore.stripeColors
 internal fun RowButton(
     isEnabled: Boolean,
     isSelected: Boolean,
+    isClickable: Boolean = isEnabled,
     onClick: () -> Unit,
     contentPaddingValues: PaddingValues,
     modifier: Modifier,
@@ -35,7 +36,7 @@ internal fun RowButton(
             modifier = Modifier
                 .selectable(
                     selected = isSelected,
-                    enabled = isEnabled,
+                    enabled = isClickable,
                     onClick = onClick
                 )
                 .padding(contentPaddingValues)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTab.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTab.kt
@@ -67,6 +67,7 @@ internal fun SavedPaymentMethodTab(
     isSelected: Boolean,
     editState: PaymentOptionEditState,
     isEnabled: Boolean,
+    isClickable: Boolean = isEnabled,
     iconRes: Int,
     modifier: Modifier = Modifier,
     iconTint: Color? = null,
@@ -99,6 +100,7 @@ internal fun SavedPaymentMethodTab(
                 SavedPaymentMethodCard(
                     isSelected = isSelected,
                     isEnabled = isEnabled,
+                    isClickable = isClickable,
                     labelText = labelText,
                     iconRes = iconRes,
                     iconTint = iconTint,
@@ -174,6 +176,7 @@ private fun SavedPaymentMethodBadge(
 private fun SavedPaymentMethodCard(
     isSelected: Boolean,
     isEnabled: Boolean,
+    isClickable: Boolean = isEnabled,
     iconRes: Int,
     iconTint: Color?,
     labelText: String,
@@ -195,7 +198,7 @@ private fun SavedPaymentMethodCard(
                 .testTag("${SAVED_PAYMENT_METHOD_CARD_TEST_TAG}_$labelText")
                 .selectable(
                     selected = isSelected,
-                    enabled = isEnabled,
+                    enabled = isClickable,
                     onClick = onItemSelectedListener,
                 ),
         ) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTab.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTab.kt
@@ -99,7 +99,6 @@ internal fun SavedPaymentMethodTab(
             Column {
                 SavedPaymentMethodCard(
                     isSelected = isSelected,
-                    isEnabled = isEnabled,
                     isClickable = isClickable,
                     labelText = labelText,
                     iconRes = iconRes,
@@ -175,8 +174,7 @@ private fun SavedPaymentMethodBadge(
 @Composable
 private fun SavedPaymentMethodCard(
     isSelected: Boolean,
-    isEnabled: Boolean,
-    isClickable: Boolean = isEnabled,
+    isClickable: Boolean,
     iconRes: Int,
     iconTint: Color?,
     labelText: String,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -389,6 +389,7 @@ private fun SavedPaymentMethodTab(
             },
             isSelected = isSelected,
             isEnabled = isEnabled,
+            isClickable = !isEditing,
             iconRes = paymentMethod.paymentMethod.getSavedPaymentMethodIcon(),
             labelIcon = labelIcon,
             labelText = labelText,
@@ -399,9 +400,7 @@ private fun SavedPaymentMethodTab(
             onRemoveListener = { onItemRemoved(paymentMethod.paymentMethod) },
             onRemoveAccessibilityDescription = paymentMethod.getRemoveDescription(context.resources),
             onItemSelectedListener = {
-                if (!isEditing) {
-                    onItemSelected(paymentMethod.toPaymentSelection())
-                }
+                onItemSelected(paymentMethod.toPaymentSelection())
             },
             modifier = modifier,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUI.kt
@@ -35,6 +35,7 @@ internal fun ManageScreenUI(interactor: ManageScreenInteractor) {
             SavedPaymentMethodRowButton(
                 displayableSavedPaymentMethod = it,
                 isEnabled = true,
+                isClickable = !state.isEditing,
                 isSelected = isSelected,
                 trailingContent = {
                     TrailingContent(
@@ -56,9 +57,7 @@ internal fun ManageScreenUI(interactor: ManageScreenInteractor) {
                     )
                 },
                 onClick = {
-                    if (!state.isEditing) {
-                        interactor.handleViewAction(ManageScreenInteractor.ViewAction.SelectPaymentMethod(it))
-                    }
+                    interactor.handleViewAction(ManageScreenInteractor.ViewAction.SelectPaymentMethod(it))
                 },
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowButton.kt
@@ -23,6 +23,7 @@ import com.stripe.android.uicore.stripeColors
 internal fun PaymentMethodRowButton(
     isEnabled: Boolean,
     isSelected: Boolean,
+    isClickable: Boolean = isEnabled,
     iconContent: @Composable RowScope.() -> Unit,
     title: String,
     subtitle: String?,
@@ -39,6 +40,7 @@ internal fun PaymentMethodRowButton(
     RowButton(
         isEnabled = isEnabled,
         isSelected = isSelected,
+        isClickable = isClickable,
         onClick = onClick,
         contentPaddingValues = PaddingValues(horizontal = 12.dp, vertical = contentPaddingValues),
         modifier = modifier.fillMaxWidth().heightIn(48.dp),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
@@ -23,6 +23,7 @@ import com.stripe.android.uicore.strings.resolve
 internal fun SavedPaymentMethodRowButton(
     displayableSavedPaymentMethod: DisplayableSavedPaymentMethod,
     isEnabled: Boolean,
+    isClickable: Boolean = isEnabled,
     isSelected: Boolean,
     modifier: Modifier = Modifier,
     onClick: () -> Unit = {},
@@ -35,6 +36,7 @@ internal fun SavedPaymentMethodRowButton(
     PaymentMethodRowButton(
         isEnabled = isEnabled,
         isSelected = isSelected,
+        isClickable = isClickable,
         iconContent = {
             PaymentMethodIconFromResource(
                 iconRes = displayableSavedPaymentMethod.paymentMethod.getSavedPaymentMethodIcon(forVerticalMode = true),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUITest.kt
@@ -95,6 +95,26 @@ class ManageScreenUITest {
         }
 
     @Test
+    fun clickingPaymentMethod_whenInEditMode_doesNothing() =
+        runScenario(
+            initialState = ManageScreenInteractor.State(
+                paymentMethods = displayableSavedPaymentMethods,
+                currentSelection = null,
+                isEditing = true,
+                canDelete = true,
+                canEdit = true,
+            )
+        ) {
+            assertThat(viewActionRecorder.viewActions).isEmpty()
+
+            composeRule.onNodeWithTag(
+                "${TEST_TAG_SAVED_PAYMENT_METHOD_ROW_BUTTON}_${displayableSavedPaymentMethods[0].paymentMethod.id}"
+            ).performClick()
+
+            assertThat(viewActionRecorder.viewActions).isEmpty()
+        }
+
+    @Test
     fun clickingPaymentMethod_inEditMode_doesNothing() =
         runScenario(
             initialState = ManageScreenInteractor.State(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This change makes it so that we can disable clicking independently of disabling the whole row.

Before:


https://github.com/user-attachments/assets/c1fc43b0-6ed3-468f-b823-8ae4900fb8e6



After:

https://github.com/user-attachments/assets/2d515d09-2b8b-40e6-9a5c-ada1b80849dc


