### PR TITLE
Rename PaymentAuthenticator to PaymentNextActionHandler

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -321,7 +321,7 @@ constructor(
         source: Source,
         requestOptions: ApiRequest.Options
     ) {
-        authenticatorRegistry.getAuthenticator(source).nextAction(
+        authenticatorRegistry.getAuthenticator(source).performNextAction(
             host,
             source,
             requestOptions
@@ -448,7 +448,7 @@ constructor(
         stripeIntent: StripeIntent,
         requestOptions: ApiRequest.Options
     ) {
-        authenticatorRegistry.getAuthenticator(stripeIntent).nextAction(
+        authenticatorRegistry.getAuthenticator(stripeIntent).performNextAction(
             host,
             stripeIntent,
             requestOptions

--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -321,7 +321,7 @@ constructor(
         source: Source,
         requestOptions: ApiRequest.Options
     ) {
-        authenticatorRegistry.getAuthenticator(source).authenticate(
+        authenticatorRegistry.getAuthenticator(source).nextAction(
             host,
             source,
             requestOptions
@@ -448,7 +448,7 @@ constructor(
         stripeIntent: StripeIntent,
         requestOptions: ApiRequest.Options
     ) {
-        authenticatorRegistry.getAuthenticator(stripeIntent).authenticate(
+        authenticatorRegistry.getAuthenticator(stripeIntent).nextAction(
             host,
             stripeIntent,
             requestOptions

--- a/payments-core/src/main/java/com/stripe/android/payments/core/ActivityResultLauncherHost.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/ActivityResultLauncherHost.kt
@@ -6,7 +6,7 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.RestrictTo
 import com.stripe.android.payments.PaymentFlowResult
-import com.stripe.android.payments.core.authentication.PaymentAuthenticator
+import com.stripe.android.payments.core.authentication.PaymentNextActionHandler
 import com.stripe.android.view.AuthActivityStarter
 
 /**
@@ -19,7 +19,7 @@ import com.stripe.android.view.AuthActivityStarter
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface ActivityResultLauncherHost {
     /**
-     * Notify the [PaymentAuthenticator] that a new [ActivityResultCaller] and
+     * Notify the [PaymentNextActionHandler] that a new [ActivityResultCaller] and
      * [ActivityResultCallback] is available. This happens when the host Activity is recreated and
      * its [ActivityResultLauncher] needs to be re-registered.
      */

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/NoOpIntentNextActionHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/NoOpIntentNextActionHandler.kt
@@ -8,21 +8,21 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * [PaymentAuthenticator] implementation to perform no-op, just return to client's host.
+ * [PaymentNextActionHandler] implementation to perform no-op, just return to client's host.
  */
 @Singleton
 @JvmSuppressWildcards
-internal class NoOpIntentAuthenticator @Inject constructor(
+internal class NoOpIntentNextActionHandler @Inject constructor(
     private val paymentRelayStarterFactory: (AuthActivityStarterHost) -> PaymentRelayStarter
-) : PaymentAuthenticator<StripeIntent>() {
+) : PaymentNextActionHandler<StripeIntent>() {
 
-    override suspend fun performAuthentication(
+    override suspend fun performNextAction(
         host: AuthActivityStarterHost,
-        authenticatable: StripeIntent,
+        actionable: StripeIntent,
         requestOptions: ApiRequest.Options
     ) {
         val args = PaymentRelayStarter.Args.create(
-            stripeIntent = authenticatable,
+            stripeIntent = actionable,
             stripeAccountId = requestOptions.stripeAccount,
         )
         paymentRelayStarterFactory(host).start(args)

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/NoOpIntentNextActionHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/NoOpIntentNextActionHandler.kt
@@ -16,7 +16,7 @@ internal class NoOpIntentNextActionHandler @Inject constructor(
     private val paymentRelayStarterFactory: (AuthActivityStarterHost) -> PaymentRelayStarter
 ) : PaymentNextActionHandler<StripeIntent>() {
 
-    override suspend fun performNextAction(
+    override suspend fun performNextActionOnResumed(
         host: AuthActivityStarterHost,
         actionable: StripeIntent,
         requestOptions: ApiRequest.Options

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/PaymentAuthenticatorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/PaymentAuthenticatorRegistry.kt
@@ -3,14 +3,14 @@ package com.stripe.android.payments.core.authentication
 import com.stripe.android.payments.core.ActivityResultLauncherHost
 
 /**
- * Registry to map [Authenticatable] to the corresponding [PaymentAuthenticator].
+ * Registry to map [Authenticatable] to the corresponding [PaymentNextActionHandler].
  */
 internal interface PaymentAuthenticatorRegistry : ActivityResultLauncherHost {
 
     /**
-     * Returns the correct [PaymentAuthenticator] to handle the [Authenticatable].
+     * Returns the correct [PaymentNextActionHandler] to handle the [Authenticatable].
      */
     fun <Authenticatable> getAuthenticator(
         authenticatable: Authenticatable
-    ): PaymentAuthenticator<Authenticatable>
+    ): PaymentNextActionHandler<Authenticatable>
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/PaymentNextActionHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/PaymentNextActionHandler.kt
@@ -16,29 +16,29 @@ import kotlinx.coroutines.CompletableDeferred
  * A class to authenticate a [StripeIntent] or [Source].
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-abstract class PaymentAuthenticator<Authenticatable> : ActivityResultLauncherHost {
+abstract class PaymentNextActionHandler<Actionable> : ActivityResultLauncherHost {
 
     /**
      * Authenticates a [StripeIntent] or [Source].
      *
      * @param host the host([Activity] or [Fragment]) where client is calling from, used to redirect back to client
-     * @param authenticatable the [StripeIntent] or [Source] object to authenticate
+     * @param actionable the [StripeIntent] or [Source] object to perform next action on (e.g authenticate)
      * @param requestOptions configurations for the API request which triggers the authentication
      */
-    suspend fun authenticate(
+    suspend fun nextAction(
         host: AuthActivityStarterHost,
-        authenticatable: Authenticatable,
+        actionable: Actionable,
         requestOptions: ApiRequest.Options
     ) {
         val lifecycleOwner = host.lifecycleOwner
 
         lifecycleOwner.awaitResumed()
-        performAuthentication(host, authenticatable, requestOptions)
+        performNextAction(host, actionable, requestOptions)
     }
 
-    protected abstract suspend fun performAuthentication(
+    protected abstract suspend fun performNextAction(
         host: AuthActivityStarterHost,
-        authenticatable: Authenticatable,
+        actionable: Actionable,
         requestOptions: ApiRequest.Options
     )
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/PaymentNextActionHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/PaymentNextActionHandler.kt
@@ -25,7 +25,7 @@ abstract class PaymentNextActionHandler<Actionable> : ActivityResultLauncherHost
      * @param actionable the [StripeIntent] or [Source] object to perform next action on (e.g authenticate)
      * @param requestOptions configurations for the API request which triggers the authentication
      */
-    suspend fun nextAction(
+    suspend fun performNextAction(
         host: AuthActivityStarterHost,
         actionable: Actionable,
         requestOptions: ApiRequest.Options
@@ -33,10 +33,10 @@ abstract class PaymentNextActionHandler<Actionable> : ActivityResultLauncherHost
         val lifecycleOwner = host.lifecycleOwner
 
         lifecycleOwner.awaitResumed()
-        performNextAction(host, actionable, requestOptions)
+        performNextActionOnResumed(host, actionable, requestOptions)
     }
 
-    protected abstract suspend fun performNextAction(
+    protected abstract suspend fun performNextActionOnResumed(
         host: AuthActivityStarterHost,
         actionable: Actionable,
         requestOptions: ApiRequest.Options

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/SourceNextActionHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/SourceNextActionHandler.kt
@@ -21,11 +21,11 @@ import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
 /**
- * [PaymentAuthenticator] implementation to authenticate [Source].
+ * [PaymentNextActionHandler] implementation to authenticate [Source].
  */
 @Singleton
 @JvmSuppressWildcards
-internal class SourceAuthenticator @Inject constructor(
+internal class SourceNextActionHandler @Inject constructor(
     private val paymentBrowserAuthStarterFactory: (AuthActivityStarterHost) -> PaymentBrowserAuthStarter,
     private val paymentRelayStarterFactory: (AuthActivityStarterHost) -> PaymentRelayStarter,
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
@@ -34,21 +34,21 @@ internal class SourceAuthenticator @Inject constructor(
     @UIContext private val uiContext: CoroutineContext,
     @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
     @Named(IS_INSTANT_APP) private val isInstantApp: Boolean
-) : PaymentAuthenticator<Source>() {
+) : PaymentNextActionHandler<Source>() {
 
-    override suspend fun performAuthentication(
+    override suspend fun performNextAction(
         host: AuthActivityStarterHost,
-        authenticatable: Source,
+        actionable: Source,
         requestOptions: ApiRequest.Options
     ) {
-        if (authenticatable.flow == Source.Flow.Redirect) {
+        if (actionable.flow == Source.Flow.Redirect) {
             startSourceAuth(
                 host,
-                authenticatable,
+                actionable,
                 requestOptions
             )
         } else {
-            bypassAuth(host, authenticatable, requestOptions.stripeAccount)
+            bypassAuth(host, actionable, requestOptions.stripeAccount)
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/SourceNextActionHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/SourceNextActionHandler.kt
@@ -36,7 +36,7 @@ internal class SourceNextActionHandler @Inject constructor(
     @Named(IS_INSTANT_APP) private val isInstantApp: Boolean
 ) : PaymentNextActionHandler<Source>() {
 
-    override suspend fun performNextAction(
+    override suspend fun performNextActionOnResumed(
         host: AuthActivityStarterHost,
         actionable: Source,
         requestOptions: ApiRequest.Options

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/UnsupportedNextActionHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/UnsupportedNextActionHandler.kt
@@ -11,20 +11,20 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * [PaymentAuthenticator] to return if there is no available authenticators. Informs the correct
+ * [PaymentNextActionHandler] to return if there is no available authenticators. Informs the correct
  * dependency to include for that authenticator.
  */
 @Singleton
 @JvmSuppressWildcards
-internal class UnsupportedAuthenticator @Inject constructor(
+internal class UnsupportedNextActionHandler @Inject constructor(
     private val paymentRelayStarterFactory: (AuthActivityStarterHost) -> PaymentRelayStarter
-) : PaymentAuthenticator<StripeIntent>() {
-    override suspend fun performAuthentication(
+) : PaymentNextActionHandler<StripeIntent>() {
+    override suspend fun performNextAction(
         host: AuthActivityStarterHost,
-        authenticatable: StripeIntent,
+        actionable: StripeIntent,
         requestOptions: ApiRequest.Options
     ) {
-        val exception = authenticatable.nextActionData?.let {
+        val exception = actionable.nextActionData?.let {
             val nextActionType = it::class.java
             StripeException.create(
                 IllegalArgumentException(
@@ -42,7 +42,7 @@ internal class UnsupportedAuthenticator @Inject constructor(
             .start(
                 PaymentRelayStarter.Args.ErrorArgs(
                     exception = exception,
-                    requestCode = authenticatable.getRequestCode()
+                    requestCode = actionable.getRequestCode()
                 )
             )
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/UnsupportedNextActionHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/UnsupportedNextActionHandler.kt
@@ -19,7 +19,7 @@ import javax.inject.Singleton
 internal class UnsupportedNextActionHandler @Inject constructor(
     private val paymentRelayStarterFactory: (AuthActivityStarterHost) -> PaymentRelayStarter
 ) : PaymentNextActionHandler<StripeIntent>() {
-    override suspend fun performNextAction(
+    override suspend fun performNextActionOnResumed(
         host: AuthActivityStarterHost,
         actionable: StripeIntent,
         requestOptions: ApiRequest.Options

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/VoucherNextActionHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/VoucherNextActionHandler.kt
@@ -20,7 +20,7 @@ internal class VoucherNextActionHandler @Inject constructor(
     private val noOpIntentAuthenticator: NoOpIntentNextActionHandler,
     private val context: Context,
 ) : PaymentNextActionHandler<StripeIntent>() {
-    override suspend fun performNextAction(
+    override suspend fun performNextActionOnResumed(
         host: AuthActivityStarterHost,
         actionable: StripeIntent,
         requestOptions: ApiRequest.Options
@@ -31,13 +31,13 @@ internal class VoucherNextActionHandler @Inject constructor(
                 ErrorReporter.UnexpectedErrorEvent.MISSING_HOSTED_VOUCHER_URL,
                 additionalNonPiiParams = mapOf("next_action_type" to (actionable.nextActionType?.code ?: ""))
             )
-            noOpIntentAuthenticator.nextAction(
+            noOpIntentAuthenticator.performNextAction(
                 host,
                 actionable,
                 requestOptions
             )
         } else {
-            webIntentAuthenticator.nextAction(
+            webIntentAuthenticator.performNextAction(
                 host,
                 actionable,
                 requestOptions

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/VoucherNextActionHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/VoucherNextActionHandler.kt
@@ -10,36 +10,36 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * [PaymentAuthenticator] for [NextActionData.DisplayVoucherDetails], redirects to
- * [WebIntentAuthenticator] or [NoOpIntentAuthenticator] based on whether if there is a
+ * [PaymentNextActionHandler] for [NextActionData.DisplayVoucherDetails], redirects to
+ * [WebIntentNextActionHandler] or [NoOpIntentNextActionHandler] based on whether if there is a
  * hostedVoucherUrl set.
  */
 @Singleton
-internal class VoucherAuthenticator @Inject constructor(
-    private val webIntentAuthenticator: WebIntentAuthenticator,
-    private val noOpIntentAuthenticator: NoOpIntentAuthenticator,
+internal class VoucherNextActionHandler @Inject constructor(
+    private val webIntentAuthenticator: WebIntentNextActionHandler,
+    private val noOpIntentAuthenticator: NoOpIntentNextActionHandler,
     private val context: Context,
-) : PaymentAuthenticator<StripeIntent>() {
-    override suspend fun performAuthentication(
+) : PaymentNextActionHandler<StripeIntent>() {
+    override suspend fun performNextAction(
         host: AuthActivityStarterHost,
-        authenticatable: StripeIntent,
+        actionable: StripeIntent,
         requestOptions: ApiRequest.Options
     ) {
-        val detailsData = authenticatable.nextActionData as NextActionData.DisplayVoucherDetails
+        val detailsData = actionable.nextActionData as NextActionData.DisplayVoucherDetails
         if (detailsData.hostedVoucherUrl == null) {
             ErrorReporter.createFallbackInstance(context).report(
                 ErrorReporter.UnexpectedErrorEvent.MISSING_HOSTED_VOUCHER_URL,
-                additionalNonPiiParams = mapOf("next_action_type" to (authenticatable.nextActionType?.code ?: ""))
+                additionalNonPiiParams = mapOf("next_action_type" to (actionable.nextActionType?.code ?: ""))
             )
-            noOpIntentAuthenticator.authenticate(
+            noOpIntentAuthenticator.nextAction(
                 host,
-                authenticatable,
+                actionable,
                 requestOptions
             )
         } else {
-            webIntentAuthenticator.authenticate(
+            webIntentAuthenticator.nextAction(
                 host,
-                authenticatable,
+                actionable,
                 requestOptions
             )
         }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentNextActionHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentNextActionHandler.kt
@@ -39,7 +39,7 @@ internal class WebIntentNextActionHandler @Inject constructor(
     private val redirectResolver: RedirectResolver,
 ) : PaymentNextActionHandler<StripeIntent>() {
 
-    override suspend fun performNextAction(
+    override suspend fun performNextActionOnResumed(
         host: AuthActivityStarterHost,
         actionable: StripeIntent,
         requestOptions: ApiRequest.Options

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3DS2NextActionHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3DS2NextActionHandler.kt
@@ -10,7 +10,7 @@ import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.PaymentFlowResult
-import com.stripe.android.payments.core.authentication.PaymentAuthenticator
+import com.stripe.android.payments.core.authentication.PaymentNextActionHandler
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.stripe3ds2.transaction.SdkTransactionId
 import com.stripe.android.view.AuthActivityStarterHost
@@ -19,15 +19,15 @@ import javax.inject.Named
 import javax.inject.Singleton
 
 /**
- * [PaymentAuthenticator] authenticating through Stripe's 3ds2 SDK.
+ * [PaymentNextActionHandler] authenticating through Stripe's 3ds2 SDK.
  */
 @Singleton
-internal class Stripe3DS2Authenticator @Inject constructor(
+internal class Stripe3DS2NextActionHandler @Inject constructor(
     private val config: PaymentAuthConfig,
     @Named(ENABLE_LOGGING) private val enableLogging: Boolean,
     @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
     @Named(PRODUCT_USAGE) private val productUsage: Set<String>
-) : PaymentAuthenticator<StripeIntent>() {
+) : PaymentNextActionHandler<StripeIntent>() {
 
     /**
      * [stripe3ds2CompletionLauncher] is mutable and might be updated during
@@ -58,17 +58,17 @@ internal class Stripe3DS2Authenticator @Inject constructor(
         stripe3ds2CompletionLauncher = null
     }
 
-    override suspend fun performAuthentication(
+    override suspend fun performNextAction(
         host: AuthActivityStarterHost,
-        authenticatable: StripeIntent,
+        actionable: StripeIntent,
         requestOptions: ApiRequest.Options
     ) {
         stripe3ds2CompletionStarterFactory(host).start(
             Stripe3ds2TransactionContract.Args(
                 SdkTransactionId.create(),
                 config.stripe3ds2Config,
-                authenticatable,
-                authenticatable.nextActionData as StripeIntent.NextActionData.SdkData.Use3DS2,
+                actionable,
+                actionable.nextActionData as StripeIntent.NextActionData.SdkData.Use3DS2,
                 requestOptions,
                 enableLogging = enableLogging,
                 host.statusBarColor,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3DS2NextActionHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3DS2NextActionHandler.kt
@@ -58,7 +58,7 @@ internal class Stripe3DS2NextActionHandler @Inject constructor(
         stripe3ds2CompletionLauncher = null
     }
 
-    override suspend fun performNextAction(
+    override suspend fun performNextActionOnResumed(
         host: AuthActivityStarterHost,
         actionable: StripeIntent,
         requestOptions: ApiRequest.Options

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationAnnotations.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationAnnotations.kt
@@ -1,13 +1,13 @@
 package com.stripe.android.payments.core.injection
 
 import com.stripe.android.model.StripeIntent.NextActionData
-import com.stripe.android.payments.core.authentication.PaymentAuthenticator
+import com.stripe.android.payments.core.authentication.PaymentNextActionHandler
 import dagger.MapKey
 import javax.inject.Qualifier
 import kotlin.reflect.KClass
 
 /**
- * [Qualifier] for the multibinding map between [NextActionData] and [PaymentAuthenticator].
+ * [Qualifier] for the multibinding map between [NextActionData] and [PaymentNextActionHandler].
  */
 @Qualifier
 annotation class IntentAuthenticatorMap

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationModule.kt
@@ -7,11 +7,11 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.StripeIntent.NextActionData
 import com.stripe.android.payments.DefaultReturnUrl
 import com.stripe.android.payments.core.authentication.DefaultPaymentAuthenticatorRegistry
-import com.stripe.android.payments.core.authentication.PaymentAuthenticator
+import com.stripe.android.payments.core.authentication.PaymentNextActionHandler
 import com.stripe.android.payments.core.authentication.RealRedirectResolver
 import com.stripe.android.payments.core.authentication.RedirectResolver
-import com.stripe.android.payments.core.authentication.VoucherAuthenticator
-import com.stripe.android.payments.core.authentication.WebIntentAuthenticator
+import com.stripe.android.payments.core.authentication.VoucherNextActionHandler
+import com.stripe.android.payments.core.authentication.WebIntentNextActionHandler
 import com.stripe.android.view.AuthActivityStarterHost
 import dagger.Binds
 import dagger.Lazy
@@ -21,7 +21,7 @@ import dagger.multibindings.IntoMap
 import javax.inject.Singleton
 
 /**
- * Provides mappings between [NextActionData] and [PaymentAuthenticator] provided by payment SDK.
+ * Provides mappings between [NextActionData] and [PaymentNextActionHandler] provided by payment SDK.
  */
 @Module
 @SuppressWarnings("UnnecessaryAbstractClass")
@@ -31,72 +31,72 @@ internal abstract class AuthenticationModule {
     @IntoMap
     @IntentAuthenticatorKey(NextActionData.SdkData.Use3DS1::class)
     abstract fun binds3DS1Authenticator(
-        webIntentAuthenticator: WebIntentAuthenticator
-    ): PaymentAuthenticator<StripeIntent>
+        webIntentAuthenticator: WebIntentNextActionHandler
+    ): PaymentNextActionHandler<StripeIntent>
 
     @IntentAuthenticatorMap
     @Binds
     @IntoMap
     @IntentAuthenticatorKey(NextActionData.RedirectToUrl::class)
     abstract fun bindsRedirectAuthenticator(
-        webIntentAuthenticator: WebIntentAuthenticator
-    ): PaymentAuthenticator<StripeIntent>
+        webIntentAuthenticator: WebIntentNextActionHandler
+    ): PaymentNextActionHandler<StripeIntent>
 
     @IntentAuthenticatorMap
     @Binds
     @IntoMap
     @IntentAuthenticatorKey(NextActionData.AlipayRedirect::class)
     abstract fun bindsAlipayRedirectAuthenticator(
-        webIntentAuthenticator: WebIntentAuthenticator
-    ): PaymentAuthenticator<StripeIntent>
+        webIntentAuthenticator: WebIntentNextActionHandler
+    ): PaymentNextActionHandler<StripeIntent>
 
     @IntentAuthenticatorMap
     @Binds
     @IntoMap
     @IntentAuthenticatorKey(NextActionData.DisplayMultibancoDetails::class)
     abstract fun bindsMultibancoAuthenticator(
-        voucherAuthenticator: VoucherAuthenticator
-    ): PaymentAuthenticator<StripeIntent>
+        voucherAuthenticator: VoucherNextActionHandler
+    ): PaymentNextActionHandler<StripeIntent>
 
     @IntentAuthenticatorMap
     @Binds
     @IntoMap
     @IntentAuthenticatorKey(NextActionData.DisplayOxxoDetails::class)
     abstract fun bindsOxxoAuthenticator(
-        voucherAuthenticator: VoucherAuthenticator
-    ): PaymentAuthenticator<StripeIntent>
+        voucherAuthenticator: VoucherNextActionHandler
+    ): PaymentNextActionHandler<StripeIntent>
 
     @IntentAuthenticatorMap
     @Binds
     @IntoMap
     @IntentAuthenticatorKey(NextActionData.DisplayKonbiniDetails::class)
     abstract fun bindsKonbiniAuthenticator(
-        voucherAuthenticator: VoucherAuthenticator
-    ): PaymentAuthenticator<StripeIntent>
+        voucherAuthenticator: VoucherNextActionHandler
+    ): PaymentNextActionHandler<StripeIntent>
 
     @IntentAuthenticatorMap
     @Binds
     @IntoMap
     @IntentAuthenticatorKey(NextActionData.DisplayBoletoDetails::class)
     abstract fun bindsBoletoAuthenticator(
-        voucherAuthenticator: VoucherAuthenticator
-    ): PaymentAuthenticator<StripeIntent>
+        voucherAuthenticator: VoucherNextActionHandler
+    ): PaymentNextActionHandler<StripeIntent>
 
     @IntentAuthenticatorMap
     @Binds
     @IntoMap
     @IntentAuthenticatorKey(NextActionData.CashAppRedirect::class)
     abstract fun bindsCashAppRedirectAuthenticator(
-        webIntentAuthenticator: WebIntentAuthenticator
-    ): PaymentAuthenticator<StripeIntent>
+        webIntentAuthenticator: WebIntentNextActionHandler
+    ): PaymentNextActionHandler<StripeIntent>
 
     @IntentAuthenticatorMap
     @Binds
     @IntoMap
     @IntentAuthenticatorKey(NextActionData.SwishRedirect::class)
     abstract fun bindsSwishRedirectAuthenticator(
-        webIntentAuthenticator: WebIntentAuthenticator
-    ): PaymentAuthenticator<StripeIntent>
+        webIntentAuthenticator: WebIntentNextActionHandler
+    ): PaymentNextActionHandler<StripeIntent>
 
     @Binds
     abstract fun bindsRedirectResolver(impl: RealRedirectResolver): RedirectResolver

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule.kt
@@ -3,8 +3,8 @@ package com.stripe.android.payments.core.injection
 import com.stripe.android.PaymentAuthConfig
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.StripeIntent.NextActionData
-import com.stripe.android.payments.core.authentication.PaymentAuthenticator
-import com.stripe.android.payments.core.authentication.threeds2.Stripe3DS2Authenticator
+import com.stripe.android.payments.core.authentication.PaymentNextActionHandler
+import com.stripe.android.payments.core.authentication.threeds2.Stripe3DS2NextActionHandler
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -12,7 +12,7 @@ import dagger.multibindings.IntoMap
 import javax.inject.Singleton
 
 /**
- * Provides [PaymentAuthenticator] for [NextActionData.SdkData.Use3DS2].
+ * Provides [PaymentNextActionHandler] for [NextActionData.SdkData.Use3DS2].
  * Requires 3ds2 SDK.
  */
 @Module(
@@ -27,8 +27,8 @@ internal abstract class Stripe3DSAuthenticatorModule {
     @IntoMap
     @IntentAuthenticatorKey(NextActionData.SdkData.Use3DS2::class)
     abstract fun bindsStripe3DSAuthenticator(
-        stripe3ds2Authenticator: Stripe3DS2Authenticator
-    ): PaymentAuthenticator<StripeIntent>
+        stripe3ds2Authenticator: Stripe3DS2NextActionHandler
+    ): PaymentNextActionHandler<StripeIntent>
 
     companion object {
         @Provides

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/WeChatPayAuthenticatorModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/WeChatPayAuthenticatorModule.kt
@@ -2,16 +2,16 @@ package com.stripe.android.payments.core.injection
 
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.StripeIntent.NextActionData
-import com.stripe.android.payments.core.authentication.PaymentAuthenticator
-import com.stripe.android.payments.core.authentication.UnsupportedAuthenticator
+import com.stripe.android.payments.core.authentication.PaymentNextActionHandler
+import com.stripe.android.payments.core.authentication.UnsupportedNextActionHandler
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
 
 /**
- * Provides [PaymentAuthenticator] for [NextActionData.WeChatPayRedirect] through reflection,
+ * Provides [PaymentNextActionHandler] for [NextActionData.WeChatPayRedirect] through reflection,
  * requires "com.stripe:stripe-wechatpay:[StripeSdkVersion.VERSION_NAME]" dependency.
- * Will register a [UnsupportedAuthenticator] if the dependency is not added.
+ * Will register a [UnsupportedNextActionHandler] if the dependency is not added.
  */
 @Module
 internal class WeChatPayAuthenticatorModule {
@@ -20,14 +20,14 @@ internal class WeChatPayAuthenticatorModule {
     @IntoMap
     @IntentAuthenticatorKey(NextActionData.WeChatPayRedirect::class)
     internal fun provideWeChatAuthenticator(
-        unsupportedAuthenticator: UnsupportedAuthenticator
-    ): PaymentAuthenticator<StripeIntent> {
+        unsupportedAuthenticator: UnsupportedNextActionHandler
+    ): PaymentNextActionHandler<StripeIntent> {
         return runCatching {
             @Suppress("UNCHECKED_CAST")
             Class.forName(
                 "com.stripe.android.payments.wechatpay.WeChatPayAuthenticator"
             ).getConstructor()
-                .newInstance() as PaymentAuthenticator<StripeIntent>
+                .newInstance() as PaymentNextActionHandler<StripeIntent>
         }.getOrDefault(unsupportedAuthenticator)
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -141,7 +141,7 @@ internal class PaymentLauncherViewModel @Inject constructor(
                             )
                         }
                     } else {
-                        authenticatorRegistry.getAuthenticator(intent).nextAction(
+                        authenticatorRegistry.getAuthenticator(intent).performNextAction(
                             host,
                             intent,
                             apiRequestOptionsProvider.get()
@@ -218,7 +218,7 @@ internal class PaymentLauncherViewModel @Inject constructor(
                 onSuccess = { intent ->
                     authenticatorRegistry
                         .getAuthenticator(intent)
-                        .nextAction(
+                        .performNextAction(
                             host,
                             intent,
                             apiRequestOptionsProvider.get()

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -141,7 +141,7 @@ internal class PaymentLauncherViewModel @Inject constructor(
                             )
                         }
                     } else {
-                        authenticatorRegistry.getAuthenticator(intent).authenticate(
+                        authenticatorRegistry.getAuthenticator(intent).nextAction(
                             host,
                             intent,
                             apiRequestOptionsProvider.get()
@@ -218,7 +218,7 @@ internal class PaymentLauncherViewModel @Inject constructor(
                 onSuccess = { intent ->
                     authenticatorRegistry
                         .getAuthenticator(intent)
-                        .authenticate(
+                        .nextAction(
                             host,
                             intent,
                             apiRequestOptionsProvider.get()

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/DefaultPaymentNextActionHandlerRegistryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/DefaultPaymentNextActionHandlerRegistryTest.kt
@@ -25,14 +25,14 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
 @RunWith(RobolectricTestRunner::class)
-class DefaultPaymentAuthenticatorRegistryTest {
-    private val noOpIntentAuthenticator = mock<NoOpIntentAuthenticator>()
-    private val sourceAuthenticator = mock<SourceAuthenticator>()
-    private val threeDs1lAuthenticator = mock<PaymentAuthenticator<StripeIntent>>()
-    private val threeDs2lAuthenticator = mock<PaymentAuthenticator<StripeIntent>>()
-    private val redirectToUrlAuthenticator = mock<PaymentAuthenticator<StripeIntent>>()
-    private val alipayRedirectAuthenticator = mock<PaymentAuthenticator<StripeIntent>>()
-    private val dispayOxxoDetailsAuthenticator = mock<PaymentAuthenticator<StripeIntent>>()
+class DefaultPaymentNextActionHandlerRegistryTest {
+    private val noOpIntentAuthenticator = mock<NoOpIntentNextActionHandler>()
+    private val sourceAuthenticator = mock<SourceNextActionHandler>()
+    private val threeDs1lAuthenticator = mock<PaymentNextActionHandler<StripeIntent>>()
+    private val threeDs2lAuthenticator = mock<PaymentNextActionHandler<StripeIntent>>()
+    private val redirectToUrlAuthenticator = mock<PaymentNextActionHandler<StripeIntent>>()
+    private val alipayRedirectAuthenticator = mock<PaymentNextActionHandler<StripeIntent>>()
+    private val dispayOxxoDetailsAuthenticator = mock<PaymentNextActionHandler<StripeIntent>>()
 
     private val registry = DefaultPaymentAuthenticatorRegistry(
         noOpIntentAuthenticator = noOpIntentAuthenticator,
@@ -98,7 +98,7 @@ class DefaultPaymentAuthenticatorRegistryTest {
 
     private fun verifyIntentWithType(
         nextActionData: NextActionData,
-        paymentAuthenticator: PaymentAuthenticator<StripeIntent>
+        paymentNextActionHandler: PaymentNextActionHandler<StripeIntent>
     ) {
         val stripeIntent = mock<StripeIntent>()
         whenever(stripeIntent.requiresAction()).thenReturn(true)
@@ -106,7 +106,7 @@ class DefaultPaymentAuthenticatorRegistryTest {
         assertThat(
             registry.getAuthenticator(stripeIntent)
         ).isEqualTo(
-            paymentAuthenticator
+            paymentNextActionHandler
         )
     }
 

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/GenericAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/GenericAuthenticatorTest.kt
@@ -26,15 +26,15 @@ class GenericAuthenticatorTest {
 
     @Test
     fun `Only starts authentication flow once lifecycle changes to resumed`() = runTest {
-        val authenticator = TestAuthenticator()
+        val authenticator = TestNextActionHandler()
         lifecycleOwner.currentState = Lifecycle.State.CREATED
 
         val completable = CompletableDeferred<Unit>()
 
         launch(backgroundScope.coroutineContext) {
-            authenticator.authenticate(
+            authenticator.nextAction(
                 host = host,
-                authenticatable = mock(),
+                actionable = mock(),
                 requestOptions = mock(),
             )
             completable.complete(Unit)
@@ -50,12 +50,12 @@ class GenericAuthenticatorTest {
 
     @Test
     fun `Immediately starts authentication flow if lifecycle already resumed`() = runTest {
-        val authenticator = TestAuthenticator()
+        val authenticator = TestNextActionHandler()
         lifecycleOwner.currentState = Lifecycle.State.RESUMED
 
-        authenticator.authenticate(
+        authenticator.nextAction(
             host = host,
-            authenticatable = mock(),
+            actionable = mock(),
             requestOptions = mock(),
         )
 
@@ -63,14 +63,14 @@ class GenericAuthenticatorTest {
     }
 }
 
-private class TestAuthenticator : PaymentAuthenticator<StripeIntent>() {
+private class TestNextActionHandler : PaymentNextActionHandler<StripeIntent>() {
 
     var wasInvoked: Boolean = false
         private set
 
-    override suspend fun performAuthentication(
+    override suspend fun performNextAction(
         host: AuthActivityStarterHost,
-        authenticatable: StripeIntent,
+        actionable: StripeIntent,
         requestOptions: ApiRequest.Options
     ) {
         wasInvoked = true

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/GenericAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/GenericAuthenticatorTest.kt
@@ -32,7 +32,7 @@ class GenericAuthenticatorTest {
         val completable = CompletableDeferred<Unit>()
 
         launch(backgroundScope.coroutineContext) {
-            authenticator.nextAction(
+            authenticator.performNextAction(
                 host = host,
                 actionable = mock(),
                 requestOptions = mock(),
@@ -53,7 +53,7 @@ class GenericAuthenticatorTest {
         val authenticator = TestNextActionHandler()
         lifecycleOwner.currentState = Lifecycle.State.RESUMED
 
-        authenticator.nextAction(
+        authenticator.performNextAction(
             host = host,
             actionable = mock(),
             requestOptions = mock(),
@@ -68,7 +68,7 @@ private class TestNextActionHandler : PaymentNextActionHandler<StripeIntent>() {
     var wasInvoked: Boolean = false
         private set
 
-    override suspend fun performNextAction(
+    override suspend fun performNextActionOnResumed(
         host: AuthActivityStarterHost,
         actionable: StripeIntent,
         requestOptions: ApiRequest.Options

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticatorTest.kt
@@ -49,7 +49,7 @@ class NoOpIntentAuthenticatorTest {
             )
         )
 
-        authenticator.nextAction(
+        authenticator.performNextAction(
             host,
             PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
             REQUEST_OPTIONS
@@ -73,7 +73,7 @@ class NoOpIntentAuthenticatorTest {
                 host
             )
         )
-        authenticator.nextAction(
+        authenticator.performNextAction(
             host,
             PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
             REQUEST_OPTIONS

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticatorTest.kt
@@ -35,7 +35,7 @@ class NoOpIntentAuthenticatorTest {
     private val paymentRelayStarterFactory =
         mock<(AuthActivityStarterHost) -> PaymentRelayStarter>()
 
-    private val authenticator = NoOpIntentAuthenticator(
+    private val authenticator = NoOpIntentNextActionHandler(
         paymentRelayStarterFactory
     )
 
@@ -49,7 +49,7 @@ class NoOpIntentAuthenticatorTest {
             )
         )
 
-        authenticator.authenticate(
+        authenticator.nextAction(
             host,
             PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
             REQUEST_OPTIONS
@@ -73,7 +73,7 @@ class NoOpIntentAuthenticatorTest {
                 host
             )
         )
-        authenticator.authenticate(
+        authenticator.nextAction(
             host,
             PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
             REQUEST_OPTIONS

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/SourceAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/SourceAuthenticatorTest.kt
@@ -48,7 +48,7 @@ class SourceAuthenticatorTest {
     )
     private val testDispatcher = UnconfinedTestDispatcher()
 
-    private val authenticator = SourceAuthenticator(
+    private val authenticator = SourceNextActionHandler(
         paymentBrowserAuthStarterFactory,
         paymentRelayStarterFactory,
         analyticsRequestExecutor,
@@ -62,9 +62,9 @@ class SourceAuthenticatorTest {
     @Test
     fun authenticate_withNoneFlowSource_shouldBypassAuth() =
         runTest {
-            authenticator.authenticate(
+            authenticator.nextAction(
                 host = host,
-                authenticatable = SourceFixtures.SOURCE_WITH_SOURCE_ORDER.copy(
+                actionable = SourceFixtures.SOURCE_WITH_SOURCE_ORDER.copy(
                     flow = Source.Flow.None
                 ),
                 requestOptions = mock()

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/SourceAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/SourceAuthenticatorTest.kt
@@ -62,7 +62,7 @@ class SourceAuthenticatorTest {
     @Test
     fun authenticate_withNoneFlowSource_shouldBypassAuth() =
         runTest {
-            authenticator.nextAction(
+            authenticator.performNextAction(
                 host = host,
                 actionable = SourceFixtures.SOURCE_WITH_SOURCE_ORDER.copy(
                     flow = Source.Flow.None

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
@@ -49,7 +49,7 @@ class Stripe3DS2AuthenticatorTest {
         runTest {
             val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2
 
-            authenticator.nextAction(
+            authenticator.performNextAction(
                 host,
                 paymentIntent,
                 REQUEST_OPTIONS
@@ -73,7 +73,7 @@ class Stripe3DS2AuthenticatorTest {
             authenticator.stripe3ds2CompletionLauncher = mockLauncher
 
             val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2
-            authenticator.nextAction(
+            authenticator.performNextAction(
                 host,
                 paymentIntent,
                 REQUEST_OPTIONS

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
@@ -8,7 +8,7 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentAuthConfig
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentIntentFixtures
-import com.stripe.android.payments.core.authentication.threeds2.Stripe3DS2Authenticator
+import com.stripe.android.payments.core.authentication.threeds2.Stripe3DS2NextActionHandler
 import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2TransactionContract
 import com.stripe.android.view.AuthActivityStarterHost
 import kotlinx.coroutines.test.runTest
@@ -37,7 +37,7 @@ class Stripe3DS2AuthenticatorTest {
             .build()
     ).build()
 
-    private val authenticator = Stripe3DS2Authenticator(
+    private val authenticator = Stripe3DS2NextActionHandler(
         paymentAuthConfig,
         enableLogging = false,
         publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
@@ -49,7 +49,7 @@ class Stripe3DS2AuthenticatorTest {
         runTest {
             val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2
 
-            authenticator.authenticate(
+            authenticator.nextAction(
                 host,
                 paymentIntent,
                 REQUEST_OPTIONS
@@ -73,7 +73,7 @@ class Stripe3DS2AuthenticatorTest {
             authenticator.stripe3ds2CompletionLauncher = mockLauncher
 
             val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2
-            authenticator.authenticate(
+            authenticator.nextAction(
                 host,
                 paymentIntent,
                 REQUEST_OPTIONS

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticatorTest.kt
@@ -51,7 +51,7 @@ class UnsupportedAuthenticatorTest {
 
     @Test
     fun verifyWeChat() = runTest {
-        authenticator.nextAction(
+        authenticator.performNextAction(
             host,
             PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE,
             REQUEST_OPTIONS
@@ -75,7 +75,7 @@ class UnsupportedAuthenticatorTest {
 
     @Test
     fun verifyNullNextActionType() = runTest {
-        authenticator.nextAction(
+        authenticator.performNextAction(
             host,
             PI_SUCCEEDED,
             REQUEST_OPTIONS

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticatorTest.kt
@@ -30,7 +30,7 @@ class UnsupportedAuthenticatorTest {
     private val paymentRelayStarterFactory =
         mock<(AuthActivityStarterHost) -> PaymentRelayStarter>()
 
-    private val authenticator = UnsupportedAuthenticator(
+    private val authenticator = UnsupportedNextActionHandler(
         paymentRelayStarterFactory
     )
 
@@ -51,7 +51,7 @@ class UnsupportedAuthenticatorTest {
 
     @Test
     fun verifyWeChat() = runTest {
-        authenticator.authenticate(
+        authenticator.nextAction(
             host,
             PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE,
             REQUEST_OPTIONS
@@ -75,7 +75,7 @@ class UnsupportedAuthenticatorTest {
 
     @Test
     fun verifyNullNextActionType() = runTest {
-        authenticator.authenticate(
+        authenticator.nextAction(
             host,
             PI_SUCCEEDED,
             REQUEST_OPTIONS

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticatorTest.kt
@@ -163,7 +163,7 @@ class WebIntentAuthenticatorTest {
         expectedShouldCancelIntentOnUserNavigation: Boolean = true,
         expectedAnalyticsEvent: PaymentAnalyticsEvent?
     ) = runTest {
-        val authenticator = WebIntentAuthenticator(
+        val authenticator = WebIntentNextActionHandler(
             paymentBrowserAuthStarterFactory = paymentBrowserAuthStarterFactory,
             analyticsRequestExecutor = analyticsRequestExecutor,
             paymentAnalyticsRequestFactory = analyticsRequestFactory,
@@ -176,7 +176,7 @@ class WebIntentAuthenticatorTest {
             redirectResolver = redirectResolver,
         )
 
-        authenticator.authenticate(
+        authenticator.nextAction(
             host,
             stripeIntent,
             REQUEST_OPTIONS

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticatorTest.kt
@@ -176,7 +176,7 @@ class WebIntentAuthenticatorTest {
             redirectResolver = redirectResolver,
         )
 
-        authenticator.nextAction(
+        authenticator.performNextAction(
             host,
             stripeIntent,
             REQUEST_OPTIONS

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
@@ -177,7 +177,7 @@ class PaymentLauncherViewModelTest {
                 eq(apiRequestOptions),
                 eq(EXPAND_PAYMENT_METHOD)
             )
-            verify(piAuthenticator).nextAction(
+            verify(piAuthenticator).performNextAction(
                 eq(authHost),
                 eq(paymentIntent),
                 eq(apiRequestOptions)
@@ -210,7 +210,7 @@ class PaymentLauncherViewModelTest {
                 eq(apiRequestOptions),
                 eq(EXPAND_PAYMENT_METHOD)
             )
-            verify(piAuthenticator).nextAction(
+            verify(piAuthenticator).performNextAction(
                 eq(authHost),
                 eq(paymentIntent),
                 eq(apiRequestOptions)
@@ -244,7 +244,7 @@ class PaymentLauncherViewModelTest {
                 eq(apiRequestOptions),
                 eq(EXPAND_PAYMENT_METHOD)
             )
-            verify(piAuthenticator, never()).nextAction(
+            verify(piAuthenticator, never()).performNextAction(
                 eq(authHost),
                 eq(paymentIntent),
                 eq(apiRequestOptions)
@@ -275,7 +275,7 @@ class PaymentLauncherViewModelTest {
                 eq(apiRequestOptions),
                 eq(EXPAND_PAYMENT_METHOD)
             )
-            verify(siAuthenticator).nextAction(
+            verify(siAuthenticator).performNextAction(
                 eq(authHost),
                 eq(setupIntent),
                 eq(apiRequestOptions)
@@ -308,7 +308,7 @@ class PaymentLauncherViewModelTest {
                 eq(apiRequestOptions),
                 eq(EXPAND_PAYMENT_METHOD)
             )
-            verify(siAuthenticator).nextAction(
+            verify(siAuthenticator).performNextAction(
                 eq(authHost),
                 eq(setupIntent),
                 eq(apiRequestOptions)
@@ -363,7 +363,7 @@ class PaymentLauncherViewModelTest {
             createViewModel().handleNextActionForStripeIntent(CLIENT_SECRET, authHost)
 
             verify(savedStateHandle).set(PaymentLauncherViewModel.KEY_HAS_STARTED, true)
-            verify(stripeIntentAuthenticator).nextAction(
+            verify(stripeIntentAuthenticator).performNextAction(
                 eq(authHost),
                 eq(stripeIntent),
                 eq(apiRequestOptions)

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
@@ -30,7 +30,7 @@ import com.stripe.android.payments.DefaultReturnUrl
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.payments.PaymentIntentFlowResultProcessor
 import com.stripe.android.payments.SetupIntentFlowResultProcessor
-import com.stripe.android.payments.core.authentication.PaymentAuthenticator
+import com.stripe.android.payments.core.authentication.PaymentNextActionHandler
 import com.stripe.android.payments.core.authentication.PaymentAuthenticatorRegistry
 import com.stripe.android.testing.fakeCreationExtras
 import com.stripe.android.view.AuthActivityStarterHost
@@ -86,11 +86,11 @@ class PaymentLauncherViewModelTest {
         paymentMethodId = PM_ID
     )
     private val paymentIntent = mock<PaymentIntent>()
-    private val piAuthenticator = mock<PaymentAuthenticator<PaymentIntent>>()
+    private val piAuthenticator = mock<PaymentNextActionHandler<PaymentIntent>>()
     private val setupIntent = mock<SetupIntent>()
-    private val siAuthenticator = mock<PaymentAuthenticator<SetupIntent>>()
+    private val siAuthenticator = mock<PaymentNextActionHandler<SetupIntent>>()
     private val stripeIntent = mock<StripeIntent>()
-    private val stripeIntentAuthenticator = mock<PaymentAuthenticator<StripeIntent>>()
+    private val stripeIntentAuthenticator = mock<PaymentNextActionHandler<StripeIntent>>()
     private val succeededPaymentResult =
         PaymentIntentResult(paymentIntent, StripeIntentResult.Outcome.SUCCEEDED)
     private val failedPaymentResult =
@@ -177,7 +177,7 @@ class PaymentLauncherViewModelTest {
                 eq(apiRequestOptions),
                 eq(EXPAND_PAYMENT_METHOD)
             )
-            verify(piAuthenticator).authenticate(
+            verify(piAuthenticator).nextAction(
                 eq(authHost),
                 eq(paymentIntent),
                 eq(apiRequestOptions)
@@ -210,7 +210,7 @@ class PaymentLauncherViewModelTest {
                 eq(apiRequestOptions),
                 eq(EXPAND_PAYMENT_METHOD)
             )
-            verify(piAuthenticator).authenticate(
+            verify(piAuthenticator).nextAction(
                 eq(authHost),
                 eq(paymentIntent),
                 eq(apiRequestOptions)
@@ -244,7 +244,7 @@ class PaymentLauncherViewModelTest {
                 eq(apiRequestOptions),
                 eq(EXPAND_PAYMENT_METHOD)
             )
-            verify(piAuthenticator, never()).authenticate(
+            verify(piAuthenticator, never()).nextAction(
                 eq(authHost),
                 eq(paymentIntent),
                 eq(apiRequestOptions)
@@ -275,7 +275,7 @@ class PaymentLauncherViewModelTest {
                 eq(apiRequestOptions),
                 eq(EXPAND_PAYMENT_METHOD)
             )
-            verify(siAuthenticator).authenticate(
+            verify(siAuthenticator).nextAction(
                 eq(authHost),
                 eq(setupIntent),
                 eq(apiRequestOptions)
@@ -308,7 +308,7 @@ class PaymentLauncherViewModelTest {
                 eq(apiRequestOptions),
                 eq(EXPAND_PAYMENT_METHOD)
             )
-            verify(siAuthenticator).authenticate(
+            verify(siAuthenticator).nextAction(
                 eq(authHost),
                 eq(setupIntent),
                 eq(apiRequestOptions)
@@ -363,7 +363,7 @@ class PaymentLauncherViewModelTest {
             createViewModel().handleNextActionForStripeIntent(CLIENT_SECRET, authHost)
 
             verify(savedStateHandle).set(PaymentLauncherViewModel.KEY_HAS_STARTED, true)
-            verify(stripeIntentAuthenticator).authenticate(
+            verify(stripeIntentAuthenticator).nextAction(
                 eq(authHost),
                 eq(stripeIntent),
                 eq(apiRequestOptions)

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
@@ -30,8 +30,8 @@ import com.stripe.android.payments.DefaultReturnUrl
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.payments.PaymentIntentFlowResultProcessor
 import com.stripe.android.payments.SetupIntentFlowResultProcessor
-import com.stripe.android.payments.core.authentication.PaymentNextActionHandler
 import com.stripe.android.payments.core.authentication.PaymentAuthenticatorRegistry
+import com.stripe.android.payments.core.authentication.PaymentNextActionHandler
 import com.stripe.android.testing.fakeCreationExtras
 import com.stripe.android.view.AuthActivityStarterHost
 import kotlinx.coroutines.test.UnconfinedTestDispatcher

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAuthenticators.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAuthenticators.kt
@@ -3,17 +3,17 @@ package com.stripe.android.paymentsheet
 import androidx.annotation.Keep
 import androidx.annotation.RestrictTo
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.payments.core.authentication.PaymentAuthenticator
-import com.stripe.android.paymentsheet.paymentdatacollection.polling.PollingAuthenticator
+import com.stripe.android.payments.core.authentication.PaymentNextActionHandler
+import com.stripe.android.paymentsheet.paymentdatacollection.polling.PollingNextActionHandler
 
 // This class is used via reflection in DefaultPaymentAuthenticatorRegistry.
 @Keep
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object PaymentSheetAuthenticators {
-    fun get(): Map<Class<out StripeIntent.NextActionData>, PaymentAuthenticator<StripeIntent>> {
+    fun get(): Map<Class<out StripeIntent.NextActionData>, PaymentNextActionHandler<StripeIntent>> {
         return mapOf(
-            StripeIntent.NextActionData.UpiAwaitNotification::class.java to PollingAuthenticator(),
-            StripeIntent.NextActionData.BlikAuthorize::class.java to PollingAuthenticator(),
+            StripeIntent.NextActionData.UpiAwaitNotification::class.java to PollingNextActionHandler(),
+            StripeIntent.NextActionData.BlikAuthorize::class.java to PollingNextActionHandler(),
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingNextActionHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingNextActionHandler.kt
@@ -9,7 +9,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.payments.core.analytics.ErrorReporter
-import com.stripe.android.payments.core.authentication.PaymentAuthenticator
+import com.stripe.android.payments.core.authentication.PaymentNextActionHandler
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.uicore.utils.AnimationConstants
 import com.stripe.android.view.AuthActivityStarterHost
@@ -21,19 +21,19 @@ private const val BLIK_TIME_LIMIT_IN_SECONDS = 60
 private const val BLIK_INITIAL_DELAY_IN_SECONDS = 5
 private const val BLIK_MAX_ATTEMPTS = 12
 
-internal class PollingAuthenticator : PaymentAuthenticator<StripeIntent>() {
+internal class PollingNextActionHandler : PaymentNextActionHandler<StripeIntent>() {
 
     private var pollingLauncher: ActivityResultLauncher<PollingContract.Args>? = null
 
-    override suspend fun performAuthentication(
+    override suspend fun performNextAction(
         host: AuthActivityStarterHost,
-        authenticatable: StripeIntent,
+        actionable: StripeIntent,
         requestOptions: ApiRequest.Options
     ) {
-        val args = when (authenticatable.paymentMethod?.type) {
+        val args = when (actionable.paymentMethod?.type) {
             PaymentMethod.Type.Upi ->
                 PollingContract.Args(
-                    clientSecret = requireNotNull(authenticatable.clientSecret),
+                    clientSecret = requireNotNull(actionable.clientSecret),
                     statusBarColor = host.statusBarColor,
                     timeLimitInSeconds = UPI_TIME_LIMIT_IN_SECONDS,
                     initialDelayInSeconds = UPI_INITIAL_DELAY_IN_SECONDS,
@@ -42,7 +42,7 @@ internal class PollingAuthenticator : PaymentAuthenticator<StripeIntent>() {
                 )
             PaymentMethod.Type.Blik ->
                 PollingContract.Args(
-                    clientSecret = requireNotNull(authenticatable.clientSecret),
+                    clientSecret = requireNotNull(actionable.clientSecret),
                     statusBarColor = host.statusBarColor,
                     timeLimitInSeconds = BLIK_TIME_LIMIT_IN_SECONDS,
                     initialDelayInSeconds = BLIK_INITIAL_DELAY_IN_SECONDS,
@@ -52,7 +52,7 @@ internal class PollingAuthenticator : PaymentAuthenticator<StripeIntent>() {
             else ->
                 error(
                     "Received invalid payment method type " +
-                        "${authenticatable.paymentMethod?.type?.code} " +
+                        "${actionable.paymentMethod?.type?.code} " +
                         "in PollingAuthenticator"
                 )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingNextActionHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingNextActionHandler.kt
@@ -25,7 +25,7 @@ internal class PollingNextActionHandler : PaymentNextActionHandler<StripeIntent>
 
     private var pollingLauncher: ActivityResultLauncher<PollingContract.Args>? = null
 
-    override suspend fun performNextAction(
+    override suspend fun performNextActionOnResumed(
         host: AuthActivityStarterHost,
         actionable: StripeIntent,
         requestOptions: ApiRequest.Options

--- a/wechatpay/src/main/java/com/stripe/android/payments/wechatpay/WeChatPayNextActionHandler.kt
+++ b/wechatpay/src/main/java/com/stripe/android/payments/wechatpay/WeChatPayNextActionHandler.kt
@@ -52,7 +52,7 @@ class WeChatPayNextActionHandler : PaymentNextActionHandler<StripeIntent>() {
         weChatPayAuthLauncher = null
     }
 
-    override suspend fun performNextAction(
+    override suspend fun performNextActionOnResumed(
         host: AuthActivityStarterHost,
         actionable: StripeIntent,
         requestOptions: ApiRequest.Options

--- a/wechatpay/src/main/java/com/stripe/android/payments/wechatpay/WeChatPayNextActionHandler.kt
+++ b/wechatpay/src/main/java/com/stripe/android/payments/wechatpay/WeChatPayNextActionHandler.kt
@@ -9,16 +9,16 @@ import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.getRequestCode
 import com.stripe.android.payments.PaymentFlowResult
-import com.stripe.android.payments.core.authentication.PaymentAuthenticator
+import com.stripe.android.payments.core.authentication.PaymentNextActionHandler
 import com.stripe.android.payments.wechatpay.reflection.DefaultWeChatPayReflectionHelper
 import com.stripe.android.payments.wechatpay.reflection.WeChatPayReflectionHelper
 import com.stripe.android.view.AuthActivityStarterHost
 
 /**
- * [PaymentAuthenticator] implementation to authenticate through WeChatPay SDK.
+ * [PaymentNextActionHandler] implementation to authenticate through WeChatPay SDK.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class WeChatPayAuthenticator : PaymentAuthenticator<StripeIntent>() {
+class WeChatPayNextActionHandler : PaymentNextActionHandler<StripeIntent>() {
     /**
      * [weChatPayAuthLauncher] is mutable and might be updated during
      * through [onNewActivityResultCaller]
@@ -52,9 +52,9 @@ class WeChatPayAuthenticator : PaymentAuthenticator<StripeIntent>() {
         weChatPayAuthLauncher = null
     }
 
-    override suspend fun performAuthentication(
+    override suspend fun performNextAction(
         host: AuthActivityStarterHost,
-        authenticatable: StripeIntent,
+        actionable: StripeIntent,
         requestOptions: ApiRequest.Options
     ) {
         require(reflectionHelper.isWeChatPayAvailable()) {
@@ -64,9 +64,9 @@ class WeChatPayAuthenticator : PaymentAuthenticator<StripeIntent>() {
 
         val weChatPayRedirect =
             requireNotNull(
-                authenticatable.nextActionData as? StripeIntent.NextActionData.WeChatPayRedirect
+                actionable.nextActionData as? StripeIntent.NextActionData.WeChatPayRedirect
             ) {
-                val incorrectNextActionDataType = authenticatable.nextActionData?.let {
+                val incorrectNextActionDataType = actionable.nextActionData?.let {
                     it::class.java.simpleName
                 } ?: run {
                     "null"
@@ -77,11 +77,11 @@ class WeChatPayAuthenticator : PaymentAuthenticator<StripeIntent>() {
 
         weChatAuthLauncherFactory(
             host,
-            authenticatable.getRequestCode()
+            actionable.getRequestCode()
         ).start(
             WeChatPayAuthContract.Args(
                 weChatPayRedirect.weChat,
-                authenticatable.clientSecret.orEmpty()
+                actionable.clientSecret.orEmpty()
             )
         )
     }

--- a/wechatpay/src/test/java/com/stripe/android/payments/wechatpay/WeChatPayAuthenticatorTest.kt
+++ b/wechatpay/src/test/java/com/stripe/android/payments/wechatpay/WeChatPayAuthenticatorTest.kt
@@ -62,7 +62,7 @@ class WeChatPayAuthenticatorTest {
                 "WeChatPay dependency is not found, add " +
                     "${WeChatPayReflectionHelper.WECHAT_PAY_GRADLE_DEP} in app's build.gradle"
             ) {
-                authenticator.nextAction(
+                authenticator.performNextAction(
                     host,
                     PaymentIntentFixtures.PI_REQUIRES_BLIK_AUTHORIZE,
                     REQUEST_OPTIONS
@@ -77,7 +77,7 @@ class WeChatPayAuthenticatorTest {
                 "stripeIntent.nextActionData should be WeChatPayRedirect, " +
                     "instead it is BlikAuthorize"
             ) {
-                authenticator.nextAction(
+                authenticator.performNextAction(
                     host,
                     PaymentIntentFixtures.PI_REQUIRES_BLIK_AUTHORIZE,
                     REQUEST_OPTIONS
@@ -92,7 +92,7 @@ class WeChatPayAuthenticatorTest {
                 "stripeIntent.nextActionData should be WeChatPayRedirect, " +
                     "instead it is null"
             ) {
-                authenticator.nextAction(
+                authenticator.performNextAction(
                     host,
                     PaymentIntentFixtures.PI_NO_NEXT_ACTION_DATA,
                     REQUEST_OPTIONS
@@ -104,7 +104,7 @@ class WeChatPayAuthenticatorTest {
     @Ignore("Flaky mockito behavior: https://github.com/mockito/mockito/issues/2026")
     fun `wechatPayAuthStarter should start when stripeIntent is WeChatPay`() =
         runTest {
-            authenticator.nextAction(
+            authenticator.performNextAction(
                 host,
                 PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE,
                 REQUEST_OPTIONS

--- a/wechatpay/src/test/java/com/stripe/android/payments/wechatpay/WeChatPayAuthenticatorTest.kt
+++ b/wechatpay/src/test/java/com/stripe/android/payments/wechatpay/WeChatPayAuthenticatorTest.kt
@@ -29,7 +29,7 @@ import kotlin.test.assertFailsWith
 class WeChatPayAuthenticatorTest {
     private val mockWeChatPayAuthStarter: WeChatPayAuthStarter = mock()
     private val mockReflectionHelper: WeChatPayReflectionHelper = mock()
-    private val authenticator = WeChatPayAuthenticator().also {
+    private val authenticator = WeChatPayNextActionHandler().also {
         it.weChatAuthLauncherFactory = { _, _ -> mockWeChatPayAuthStarter }
         it.reflectionHelper = mockReflectionHelper
     }
@@ -62,7 +62,7 @@ class WeChatPayAuthenticatorTest {
                 "WeChatPay dependency is not found, add " +
                     "${WeChatPayReflectionHelper.WECHAT_PAY_GRADLE_DEP} in app's build.gradle"
             ) {
-                authenticator.authenticate(
+                authenticator.nextAction(
                     host,
                     PaymentIntentFixtures.PI_REQUIRES_BLIK_AUTHORIZE,
                     REQUEST_OPTIONS
@@ -77,7 +77,7 @@ class WeChatPayAuthenticatorTest {
                 "stripeIntent.nextActionData should be WeChatPayRedirect, " +
                     "instead it is BlikAuthorize"
             ) {
-                authenticator.authenticate(
+                authenticator.nextAction(
                     host,
                     PaymentIntentFixtures.PI_REQUIRES_BLIK_AUTHORIZE,
                     REQUEST_OPTIONS
@@ -92,7 +92,7 @@ class WeChatPayAuthenticatorTest {
                 "stripeIntent.nextActionData should be WeChatPayRedirect, " +
                     "instead it is null"
             ) {
-                authenticator.authenticate(
+                authenticator.nextAction(
                     host,
                     PaymentIntentFixtures.PI_NO_NEXT_ACTION_DATA,
                     REQUEST_OPTIONS
@@ -104,7 +104,7 @@ class WeChatPayAuthenticatorTest {
     @Ignore("Flaky mockito behavior: https://github.com/mockito/mockito/issues/2026")
     fun `wechatPayAuthStarter should start when stripeIntent is WeChatPay`() =
         runTest {
-            authenticator.authenticate(
+            authenticator.nextAction(
                 host,
                 PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE,
                 REQUEST_OPTIONS


### PR DESCRIPTION
# Summary

Rename PaymentAuthenticator to PaymentNextActionHandler

[JIRA](https://jira.corp.stripe.com/browse/MOBILESDK-2052)

# Motivation

Most of the `Authenticator`s don't authenticate besides **3ds**. It's meant to perform actions needed for each payment method/LPM to complete payment (delegation?). `PaymentNextActionHandler` is a better name because it covers all usecases instead of just authentication.

# TODO

* Rename DI classes
* Rename variables from `*Authenticator` to `*NextActionHandler`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
