### PR TITLE
Revert "Update release notes for 20.48.2"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,8 @@
 # CHANGELOG
 
-## 20.48.2 - 2024-07-22
-
-### PaymentSheet
-* [FIXED][8825](https://github.com/stripe/stripe-android/pull/8825) Fixed an issue the amount in the buy button in `PaymentSheet` did not formatted with set per-application locale.
+## XX.XX.XX - 20XX-XX-XX
 
 ## 20.48.1 - 2024-07-15
-
-### PaymentSheet
 * [FIXED][8746](https://github.com/stripe/stripe-android/pull/8746) Fixed an issue where successful TWINT payments were sometimes incorrectly considered 'canceled'.
 * [FIXED][8670](https://github.com/stripe/stripe-android/pull/8670) Fixed `PaymentSheet` PrimaryButton text not translating for per app localization.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## XX.XX.XX - 20XX-XX-XX
 
+### PaymentSheet
+* [FIXED][8825](https://github.com/stripe/stripe-android/pull/8825) Fixed an issue the amount in the buy button in `PaymentSheet` did not formatted with set per-application locale.
+
 ## 20.48.1 - 2024-07-15
+
+### PaymentSheet
 * [FIXED][8746](https://github.com/stripe/stripe-android/pull/8746) Fixed an issue where successful TWINT payments were sometimes incorrectly considered 'canceled'.
 * [FIXED][8670](https://github.com/stripe/stripe-android/pull/8670) Fixed `PaymentSheet` PrimaryButton text not translating for per app localization.
 


### PR DESCRIPTION
Reverts stripe/stripe-android#8841

Release failed this week due to sonatype outage