### PR TITLE
Integrate `IntentConfirmationHandler` in `FlowController`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerModule.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.flowcontroller
 
+import android.app.Application
 import android.content.Context
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
@@ -19,6 +20,9 @@ import javax.inject.Singleton
     ]
 )
 internal object FlowControllerModule {
+    @Provides
+    @Singleton
+    fun providesAppContext(application: Application): Context = application.applicationContext
 
     @Provides
     @Singleton

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.paymentsheet.flowcontroller
 
-import android.content.Context
+import android.app.Application
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
@@ -34,7 +34,7 @@ internal interface FlowControllerStateComponent {
     @Component.Builder
     interface Builder {
         @BindsInstance
-        fun appContext(appContext: Context): Builder
+        fun application(application: Application): Builder
 
         @BindsInstance
         fun flowControllerViewModel(viewModel: FlowControllerViewModel): Builder

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
@@ -4,19 +4,18 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.analytics.SessionSavedStateHandler
-import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 
 internal class FlowControllerViewModel(
     application: Application,
-    private val handle: SavedStateHandle,
+    val handle: SavedStateHandle,
 ) : AndroidViewModel(application) {
 
     val flowControllerStateComponent: FlowControllerStateComponent =
         DaggerFlowControllerStateComponent
             .builder()
-            .appContext(application)
+            .application(application)
             .flowControllerViewModel(this)
             .build()
 
@@ -33,12 +32,6 @@ internal class FlowControllerViewModel(
             handle[STATE_KEY] = value
         }
 
-    var deferredIntentConfirmationType: DeferredIntentConfirmationType?
-        get() = handle[KEY_DEFERRED_INTENT_CONFIRMATION_TYPE]
-        set(value) {
-            handle[KEY_DEFERRED_INTENT_CONFIRMATION_TYPE] = value
-        }
-
     private val restartSession = SessionSavedStateHandler.attachTo(this, handle)
 
     fun resetSession() {
@@ -47,6 +40,5 @@ internal class FlowControllerViewModel(
 
     private companion object {
         private const val STATE_KEY = "state"
-        private const val KEY_DEFERRED_INTENT_CONFIRMATION_TYPE = "KEY_DEFERRED_INTENT_CONFIRMATION_TYPE"
     }
 }


### PR DESCRIPTION
# Summary
Integrate `IntentConfirmationHandler` in `FlowController`

# Motivation
Removes duplicated logic between `PaymentSheet`, `CustomerSheet`, and `FlowController`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Video

