### PR TITLE
Get isEditing from the current screen.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationActivity.kt
@@ -21,7 +21,6 @@ import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.bottomsheet.rememberStripeBottomSheetState
 import com.stripe.android.uicore.utils.fadeOut
 import kotlinx.coroutines.flow.collectLatest
-import com.stripe.android.R as StripeR
 import com.stripe.android.ui.core.R as StripeUiCoreR
 
 internal class BacsMandateConfirmationActivity : AppCompatActivity() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationActivity.kt
@@ -74,7 +74,7 @@ internal class BacsMandateConfirmationActivity : AppCompatActivity() {
                                     contentDescription = StripeUiCoreR.string.stripe_back,
                                     showEditMenu = false,
                                     showTestModeLabel = false,
-                                    editMenuLabel = StripeR.string.stripe_edit,
+                                    isEditing = false,
                                     onEditIconPressed = {},
                                 ),
                                 isEnabled = true,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBar.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBar.kt
@@ -169,7 +169,7 @@ internal fun PaymentSheetTopBar_Preview() {
             contentDescription = StripeUiCoreR.string.stripe_back,
             showTestModeLabel = true,
             showEditMenu = true,
-            editMenuLabel = StripeR.string.stripe_edit,
+            isEditing = false,
             onEditIconPressed = {},
         )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBar.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBar.kt
@@ -33,7 +33,6 @@ import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.StripeThemeDefaults
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.stripeTypography
-import com.stripe.android.R as StripeR
 import com.stripe.android.ui.core.R as StripeUiCoreR
 
 internal const val SHEET_NAVIGATION_BUTTON_TAG = "SHEET_NAVIGATION_BUTTON_TAG"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarState.kt
@@ -11,9 +11,18 @@ internal data class PaymentSheetTopBarState(
     @StringRes val contentDescription: Int,
     val showTestModeLabel: Boolean,
     val showEditMenu: Boolean,
-    @StringRes val editMenuLabel: Int,
+    val isEditing: Boolean,
     val onEditIconPressed: () -> Unit,
 ) {
+    @get:StringRes val editMenuLabel: Int
+        get() {
+            return if (isEditing) {
+                StripeR.string.stripe_done
+            } else {
+                StripeR.string.stripe_edit
+            }
+        }
+
     sealed interface Editable {
         data object Never : Editable
         data class Maybe(
@@ -42,18 +51,12 @@ internal object PaymentSheetTopBarStateFactory {
             R.string.stripe_paymentsheet_close
         }
 
-        val editMenuLabel = if ((editable as? PaymentSheetTopBarState.Editable.Maybe)?.isEditing == true) {
-            StripeR.string.stripe_done
-        } else {
-            StripeR.string.stripe_edit
-        }
-
         return PaymentSheetTopBarState(
             icon = icon,
             contentDescription = contentDescription,
             showTestModeLabel = !isLiveMode,
             showEditMenu = (editable as? PaymentSheetTopBarState.Editable.Maybe)?.canEdit == true,
-            editMenuLabel = editMenuLabel,
+            isEditing = (editable as? PaymentSheetTopBarState.Editable.Maybe)?.isEditing == true,
             onEditIconPressed = (editable as? PaymentSheetTopBarState.Editable.Maybe)?.onEditIconPressed
                 ?: {},
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -28,6 +28,8 @@ import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.ui.core.elements.CvcConfig
 import com.stripe.android.ui.core.elements.CvcController
 import com.stripe.android.uicore.utils.combineAsStateFlow
+import com.stripe.android.uicore.utils.flatMapLatestAsStateFlow
+import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -105,7 +107,11 @@ internal abstract class BaseSheetViewModel(
 
     protected val buttonsEnabled = combineAsStateFlow(
         processing,
-        savedPaymentMethodMutator.editing,
+        navigationHandler.currentScreen.flatMapLatestAsStateFlow { currentScreen ->
+            currentScreen.topBarState().mapAsStateFlow { topBarState ->
+                topBarState?.isEditing == true
+            }
+        },
     ) { isProcessing, isEditing ->
         !isProcessing && !isEditing
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarScreenshotTest.kt
@@ -31,7 +31,7 @@ class PaymentSheetTopBarScreenshotTest {
             contentDescription = StripeR.string.stripe_close,
             showTestModeLabel = false,
             showEditMenu = false,
-            editMenuLabel = StripeR.string.stripe_edit,
+            isEditing = false,
             onEditIconPressed = {},
         )
 
@@ -52,7 +52,7 @@ class PaymentSheetTopBarScreenshotTest {
             contentDescription = StripeR.string.stripe_close,
             showTestModeLabel = true,
             showEditMenu = true,
-            editMenuLabel = StripeR.string.stripe_edit,
+            isEditing = false,
             onEditIconPressed = {},
         )
 
@@ -73,7 +73,7 @@ class PaymentSheetTopBarScreenshotTest {
             contentDescription = StripeR.string.stripe_close,
             showTestModeLabel = true,
             showEditMenu = true,
-            editMenuLabel = StripeR.string.stripe_done,
+            isEditing = true,
             onEditIconPressed = {},
         )
 
@@ -94,7 +94,7 @@ class PaymentSheetTopBarScreenshotTest {
             contentDescription = StripeUiCoreR.string.stripe_back,
             showTestModeLabel = true,
             showEditMenu = false,
-            editMenuLabel = StripeR.string.stripe_edit,
+            isEditing = false,
             onEditIconPressed = {},
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarStateFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarStateFactoryTest.kt
@@ -91,6 +91,7 @@ class PaymentSheetTopBarStateFactoryTest {
             ),
         )
 
+        assertThat(state.isEditing).isEqualTo(false)
         assertThat(state.editMenuLabel).isEqualTo(StripeR.string.stripe_edit)
     }
 
@@ -104,7 +105,17 @@ class PaymentSheetTopBarStateFactoryTest {
             ),
         )
 
+        assertThat(state.isEditing).isEqualTo(true)
         assertThat(state.editMenuLabel).isEqualTo(StripeR.string.stripe_done)
+    }
+
+    @Test
+    fun `isEditing=false when editable=Never`() {
+        val state = buildTopBarState(
+            editable = PaymentSheetTopBarState.Editable.Never,
+        )
+
+        assertThat(state.isEditing).isEqualTo(false)
     }
 
     private fun buildTopBarState(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarTest.kt
@@ -19,7 +19,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.robolectric.annotation.Config
-import com.stripe.android.R as StripeR
 import com.stripe.android.ui.core.R as StripeUiCoreR
 
 @RunWith(AndroidJUnit4::class)
@@ -111,7 +110,7 @@ class PaymentSheetTopBarTest {
             contentDescription = StripeUiCoreR.string.stripe_back,
             showTestModeLabel = false,
             showEditMenu = showEditMenu,
-            editMenuLabel = StripeR.string.stripe_edit,
+            isEditing = false,
             onEditIconPressed = onEditIconPressed,
         )
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I'm attempting to move `SavedPaymentMethodMutator` out of `BaseSheetViewModel`. Now we don't reference the `isEditing` portion of `SavedPaymentMethodMutator`, and it's state now comes from the individual screen.
