### PR TITLE
Respect kill-switch in native Instant Debits flow

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -129,8 +129,8 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
         }
         val manifest = sync.manifest
         val isInstantDebits = stateFlow.value.isInstantDebits
-        val nativeAuthFlowEnabled = nativeRouter.nativeAuthFlowEnabled(manifest, isInstantDebits)
-        nativeRouter.logExposure(manifest, isInstantDebits)
+        val nativeAuthFlowEnabled = nativeRouter.nativeAuthFlowEnabled(manifest)
+        nativeRouter.logExposure(manifest)
         val hostedAuthUrl = buildHostedAuthUrl(manifest.hostedAuthUrl, isInstantDebits)
         if (hostedAuthUrl == null) {
             finishWithResult(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
@@ -135,7 +135,7 @@ class FinancialConnectionsSheetViewModelTest {
             // Given
             whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)
             whenever(getOrFetchSync(any())).thenReturn(syncResponse)
-            whenever(nativeRouter.nativeAuthFlowEnabled(any(), any())).thenReturn(false)
+            whenever(nativeRouter.nativeAuthFlowEnabled(any())).thenReturn(false)
 
             // When
             val viewModel = createViewModel(
@@ -158,7 +158,7 @@ class FinancialConnectionsSheetViewModelTest {
         // Given
         whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)
         whenever(getOrFetchSync(any())).thenReturn(syncResponse)
-        whenever(nativeRouter.nativeAuthFlowEnabled(any(), any())).thenReturn(false)
+        whenever(nativeRouter.nativeAuthFlowEnabled(any())).thenReturn(false)
 
         // When
         val viewModel = createViewModel(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/NativeAuthFlowRouterTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/NativeAuthFlowRouterTest.kt
@@ -31,9 +31,10 @@ internal class NativeAuthFlowRouterTest {
             assignments = mapOf(
                 "connections_mobile_native" to "treatment"
             ),
-            features = mapOf()
+            features = mapOf(),
+            isInstantDebits = false,
         )
-        val nativeAuthFlowEnabled = router.nativeAuthFlowEnabled(syncResponse.manifest, isInstantDebits = false)
+        val nativeAuthFlowEnabled = router.nativeAuthFlowEnabled(syncResponse.manifest)
 
         assertThat(nativeAuthFlowEnabled).isTrue()
     }
@@ -44,9 +45,10 @@ internal class NativeAuthFlowRouterTest {
             assignments = mapOf(
                 "connections_mobile_native" to "treatment"
             ),
-            features = mapOf()
+            features = mapOf(),
+            isInstantDebits = true,
         )
-        val nativeAuthFlowEnabled = router.nativeAuthFlowEnabled(syncResponse.manifest, isInstantDebits = true)
+        val nativeAuthFlowEnabled = router.nativeAuthFlowEnabled(syncResponse.manifest)
 
         assertThat(nativeAuthFlowEnabled).isTrue()
     }
@@ -59,9 +61,10 @@ internal class NativeAuthFlowRouterTest {
             ),
             features = mapOf(
                 "bank_connections_mobile_native_version_killswitch" to true
-            )
+            ),
+            isInstantDebits = false,
         )
-        val nativeAuthFlowEnabled = router.nativeAuthFlowEnabled(syncResponse.manifest, isInstantDebits = false)
+        val nativeAuthFlowEnabled = router.nativeAuthFlowEnabled(syncResponse.manifest)
 
         assertThat(nativeAuthFlowEnabled).isFalse()
     }
@@ -74,9 +77,10 @@ internal class NativeAuthFlowRouterTest {
             ),
             features = mapOf(
                 "bank_connections_mobile_native_version_killswitch" to true
-            )
+            ),
+            isInstantDebits = true,
         )
-        val nativeAuthFlowEnabled = router.nativeAuthFlowEnabled(syncResponse.manifest, isInstantDebits = true)
+        val nativeAuthFlowEnabled = router.nativeAuthFlowEnabled(syncResponse.manifest)
 
         assertThat(nativeAuthFlowEnabled).isFalse()
     }
@@ -89,9 +93,10 @@ internal class NativeAuthFlowRouterTest {
             ),
             features = mapOf(
                 "bank_connections_mobile_native_version_killswitch" to false
-            )
+            ),
+            isInstantDebits = false,
         )
-        val nativeAuthFlowEnabled = router.nativeAuthFlowEnabled(syncResponse.manifest, isInstantDebits = false)
+        val nativeAuthFlowEnabled = router.nativeAuthFlowEnabled(syncResponse.manifest)
 
         assertThat(nativeAuthFlowEnabled).isFalse()
     }
@@ -104,9 +109,10 @@ internal class NativeAuthFlowRouterTest {
             ),
             features = mapOf(
                 "bank_connections_mobile_native_version_killswitch" to false
-            )
+            ),
+            isInstantDebits = false,
         )
-        router.logExposure(syncResponse.manifest, isInstantDebits = false)
+        router.logExposure(syncResponse.manifest)
 
         verify(eventTracker).track(
             Exposure(
@@ -125,9 +131,10 @@ internal class NativeAuthFlowRouterTest {
             ),
             features = mapOf(
                 "bank_connections_mobile_native_version_killswitch" to false
-            )
+            ),
+            isInstantDebits = true,
         )
-        router.logExposure(syncResponse.manifest, isInstantDebits = true)
+        router.logExposure(syncResponse.manifest)
 
         verifyNoInteractions(eventTracker)
     }
@@ -140,22 +147,25 @@ internal class NativeAuthFlowRouterTest {
             ),
             features = mapOf(
                 "bank_connections_mobile_native_version_killswitch" to true
-            )
+            ),
+            isInstantDebits = false,
         )
-        router.logExposure(syncResponse.manifest, isInstantDebits = false)
+        router.logExposure(syncResponse.manifest)
 
         verifyNoInteractions(eventTracker)
     }
 
     private fun syncWithAssignments(
         assignments: Map<String, String>,
-        features: Map<String, Boolean>
+        features: Map<String, Boolean>,
+        isInstantDebits: Boolean,
     ) = ApiKeyFixtures.syncResponse().copy(
         manifest = ApiKeyFixtures.sessionManifest().copy(
             assignmentEventId = "id",
             accountholderToken = "token",
             experimentAssignments = assignments,
-            features = features
+            features = features,
+            isLinkWithStripe = isInstantDebits,
         )
     )
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/NativeAuthFlowRouterTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/NativeAuthFlowRouterTest.kt
@@ -39,7 +39,7 @@ internal class NativeAuthFlowRouterTest {
     }
 
     @Test
-    fun `nativeAuthFlowEnabled - false if experiment is treatment but instant debits`() {
+    fun `nativeAuthFlowEnabled - true if experiment is treatment and no kill switch in instant debits`() {
         val syncResponse = syncWithAssignments(
             assignments = mapOf(
                 "connections_mobile_native" to "treatment"
@@ -48,7 +48,7 @@ internal class NativeAuthFlowRouterTest {
         )
         val nativeAuthFlowEnabled = router.nativeAuthFlowEnabled(syncResponse.manifest, isInstantDebits = true)
 
-        assertThat(nativeAuthFlowEnabled).isFalse()
+        assertThat(nativeAuthFlowEnabled).isTrue()
     }
 
     @Test
@@ -62,6 +62,21 @@ internal class NativeAuthFlowRouterTest {
             )
         )
         val nativeAuthFlowEnabled = router.nativeAuthFlowEnabled(syncResponse.manifest, isInstantDebits = false)
+
+        assertThat(nativeAuthFlowEnabled).isFalse()
+    }
+
+    @Test
+    fun `nativeAuthFlowEnabled - false if experiment is treatment but kill switch is on in instant debits`() {
+        val syncResponse = syncWithAssignments(
+            assignments = mapOf(
+                "connections_mobile_native" to "treatment"
+            ),
+            features = mapOf(
+                "bank_connections_mobile_native_version_killswitch" to true
+            )
+        )
+        val nativeAuthFlowEnabled = router.nativeAuthFlowEnabled(syncResponse.manifest, isInstantDebits = true)
 
         assertThat(nativeAuthFlowEnabled).isFalse()
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates the `NativeAuthFlowRouter` for the native Instant Debits flow.

We continue to use `bank_connections_mobile_native_version_killswitch` to determine whether to show the native or web flow, but no longer hard-code the web flow for Instant Debits.

(cc @mats-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[BANKCON-11571](https://jira.corp.stripe.com/browse/BANKCON-11571)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
