### PR TITLE
Use `ActivityResultCaller` in `FlowController`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerActivityResultCaller.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerActivityResultCaller.kt
@@ -1,0 +1,35 @@
+package com.stripe.android.paymentsheet.flowcontroller
+
+import androidx.activity.result.ActivityResultCallback
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.ActivityResultRegistry
+import androidx.activity.result.ActivityResultRegistryOwner
+import androidx.activity.result.contract.ActivityResultContract
+
+internal class FlowControllerActivityResultCaller(
+    private val registryOwner: ActivityResultRegistryOwner
+) : ActivityResultCaller {
+    override fun <I : Any?, O : Any?> registerForActivityResult(
+        contract: ActivityResultContract<I, O>,
+        callback: ActivityResultCallback<O>
+    ): ActivityResultLauncher<I> {
+        return registryOwner.activityResultRegistry.register(createKey(contract), contract, callback)
+    }
+
+    override fun <I : Any?, O : Any?> registerForActivityResult(
+        contract: ActivityResultContract<I, O>,
+        registry: ActivityResultRegistry,
+        callback: ActivityResultCallback<O>
+    ): ActivityResultLauncher<I> {
+        return registry.register(createKey(contract), contract, callback)
+    }
+
+    private fun <I : Any?, O : Any?> createKey(contract: ActivityResultContract<I, O>): String {
+        return "${FLOW_CONTROLLER_KEY}_${contract::class.java.name}"
+    }
+
+    private companion object {
+        const val FLOW_CONTROLLER_KEY = "FlowController"
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerComponent.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.paymentsheet.flowcontroller
 
-import androidx.activity.result.ActivityResultRegistryOwner
+import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.paymentsheet.InitializedViaCompose
 import com.stripe.android.paymentsheet.PaymentOptionCallback
@@ -20,8 +20,8 @@ internal interface FlowControllerComponent {
         fun lifeCycleOwner(lifecycleOwner: LifecycleOwner): Builder
 
         @BindsInstance
-        fun activityResultRegistryOwner(
-            activityResultRegistryOwner: ActivityResultRegistryOwner,
+        fun activityResultCaller(
+            activityResultCaller: ActivityResultCaller,
         ): Builder
 
         @BindsInstance

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactory.kt
@@ -48,7 +48,7 @@ internal class FlowControllerFactory(
         DefaultFlowController.getInstance(
             viewModelStoreOwner = viewModelStoreOwner,
             lifecycleOwner = lifecycleOwner,
-            activityResultRegistryOwner = activityResultRegistryOwner,
+            activityResultCaller = FlowControllerActivityResultCaller(activityResultRegistryOwner),
             statusBarColor = statusBarColor,
             paymentOptionCallback = paymentOptionCallback,
             paymentResultCallback = paymentResultCallback,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -3,9 +3,8 @@ package com.stripe.android.paymentsheet.flowcontroller
 import android.content.Context
 import android.graphics.Color
 import androidx.activity.result.ActivityResultCallback
+import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.ActivityResultRegistry
-import androidx.activity.result.ActivityResultRegistryOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.testing.TestLifecycleOwner
@@ -165,12 +164,7 @@ internal class DefaultFlowControllerTest {
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
 
-    private val activityResultRegistry: ActivityResultRegistry = mock()
-
-    private val activityResultRegistryOwner = object : ActivityResultRegistryOwner {
-        override val activityResultRegistry: ActivityResultRegistry
-            get() = this@DefaultFlowControllerTest.activityResultRegistry
-    }
+    private val activityResultCaller: ActivityResultCaller = mock()
 
     private val fakeIntentConfirmationInterceptor = FakeIntentConfirmationInterceptor()
 
@@ -181,64 +175,56 @@ internal class DefaultFlowControllerTest {
         PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
 
         whenever(
-            activityResultRegistry.register(
-                any(),
+            activityResultCaller.registerForActivityResult(
                 any<PaymentOptionContract>(),
                 any()
             )
         ).thenReturn(paymentOptionActivityLauncher)
 
         whenever(
-            activityResultRegistry.register(
-                any(),
+            activityResultCaller.registerForActivityResult(
                 any<AddressElementActivityContract>(),
                 any()
             )
         ).thenReturn(addressElementActivityLauncher)
 
         whenever(
-            activityResultRegistry.register(
-                any(),
+            activityResultCaller.registerForActivityResult(
                 any<GooglePayPaymentMethodLauncherContractV2>(),
                 any()
             )
         ).thenReturn(googlePayActivityLauncher)
 
         whenever(
-            activityResultRegistry.register(
-                any(),
+            activityResultCaller.registerForActivityResult(
                 any<LinkActivityContract>(),
                 any()
             )
         ).thenReturn(linkActivityResultLauncher)
 
         whenever(
-            activityResultRegistry.register(
-                any(),
+            activityResultCaller.registerForActivityResult(
                 any<SepaMandateContract>(),
                 any()
             )
         ).thenReturn(sepaMandateActivityLauncher)
 
         whenever(
-            activityResultRegistry.register(
-                any(),
+            activityResultCaller.registerForActivityResult(
                 any<PaymentLauncherContract>(),
                 any()
             )
         ).thenReturn(mock())
 
         whenever(
-            activityResultRegistry.register(
-                any(),
+            activityResultCaller.registerForActivityResult(
                 any<BacsMandateConfirmationContract>(),
                 any()
             )
         ).thenReturn(mock())
 
         whenever(
-            activityResultRegistry.register(
-                any(),
+            activityResultCaller.registerForActivityResult(
                 any<ExternalPaymentMethodContract>(),
                 any()
             )
@@ -248,8 +234,7 @@ internal class DefaultFlowControllerTest {
             .thenReturn(paymentLauncher)
 
         whenever(
-            activityResultRegistry.register(
-                any(),
+            activityResultCaller.registerForActivityResult(
                 any<CvcRecollectionContract>(),
                 any()
             )
@@ -1613,8 +1598,7 @@ internal class DefaultFlowControllerTest {
         }
 
         whenever(
-            activityResultRegistry.register(
-                any(),
+            activityResultCaller.registerForActivityResult(
                 any<BacsMandateConfirmationContract>(),
                 onResult.capture()
             )
@@ -1668,8 +1652,7 @@ internal class DefaultFlowControllerTest {
         }
 
         whenever(
-            activityResultRegistry.register(
-                any(),
+            activityResultCaller.registerForActivityResult(
                 any<CvcRecollectionContract>(),
                 onResult.capture()
             )
@@ -2055,7 +2038,7 @@ internal class DefaultFlowControllerTest {
     ) = DefaultFlowController(
         viewModelScope = testScope,
         lifecycleOwner = lifecycleOwner,
-        activityResultRegistryOwner = activityResultRegistryOwner,
+        activityResultCaller = activityResultCaller,
         statusBarColor = { STATUS_BAR_COLOR },
         paymentOptionFactory = PaymentOptionFactory(
             resources = context.resources,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerActivityResultCallerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerActivityResultCallerTest.kt
@@ -1,0 +1,90 @@
+package com.stripe.android.paymentsheet.flowcontroller
+
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.ActivityResultCallback
+import androidx.activity.result.ActivityResultRegistry
+import androidx.activity.result.ActivityResultRegistryOwner
+import androidx.activity.result.contract.ActivityResultContract
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class FlowControllerActivityResultCallerTest {
+    @Test
+    fun `on register callback, registry owner should register callback properly`() {
+        val registry = mock<ActivityResultRegistry> {
+            on {
+                register(
+                    any<String>(),
+                    any<TestActivityResultContract>(),
+                    any<ActivityResultCallback<String>>(),
+                )
+            } doReturn mock()
+        }
+
+        val activityResultRegistryOwner = mock<ActivityResultRegistryOwner> {
+            on { activityResultRegistry } doReturn registry
+        }
+
+        val caller = FlowControllerActivityResultCaller(activityResultRegistryOwner)
+
+        val contract = TestActivityResultContract()
+        val callback = ActivityResultCallback<String> {}
+
+        caller.registerForActivityResult(
+            contract,
+            callback
+        )
+
+        verify(registry).register(
+            "FlowController_${TestActivityResultContract::class.java.name}",
+            contract,
+            callback,
+        )
+    }
+
+    @Test
+    fun `on register callback with registry, registry owner should register callback properly`() {
+        val registry = mock<ActivityResultRegistry> {
+            on {
+                register(
+                    any<String>(),
+                    any<TestActivityResultContract>(),
+                    any<ActivityResultCallback<String>>(),
+                )
+            } doReturn mock()
+        }
+
+        val activityResultRegistryOwner = mock<ActivityResultRegistryOwner>()
+
+        val caller = FlowControllerActivityResultCaller(activityResultRegistryOwner)
+
+        val contract = TestActivityResultContract()
+        val callback = ActivityResultCallback<String> {}
+
+        caller.registerForActivityResult(
+            contract,
+            registry,
+            callback
+        )
+
+        verify(registry).register(
+            "FlowController_${TestActivityResultContract::class.java.name}",
+            contract,
+            callback,
+        )
+    }
+
+    private class TestActivityResultContract : ActivityResultContract<String, String>() {
+        override fun createIntent(context: Context, input: String): Intent {
+            throw NotImplementedError("Should not be called!")
+        }
+
+        override fun parseResult(resultCode: Int, intent: Intent?): String {
+            throw NotImplementedError("Should not be called!")
+        }
+    }
+}


### PR DESCRIPTION
# Summary
Update `FlowController` to use a custom implementation of `ActivityResultCaller`.

# Motivation
Allows `FlowController` to be initialized with `ActivityResultCaller`. Ensures all our products use the same `ActivityResultCaller` API while still allowing for `FlowController` to work properly with `Compose` AND also avoiding any registered callback conflicts.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
