### PR TITLE
Separate CustomerStateHolder from SavedPaymentMethodMutator.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CustomerStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CustomerStateHolder.kt
@@ -1,0 +1,51 @@
+package com.stripe.android.paymentsheet
+
+import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.CustomerState
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.uicore.utils.mapAsStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+internal class CustomerStateHolder(
+    private val savedStateHandle: SavedStateHandle,
+    private val selection: StateFlow<PaymentSelection?>,
+) {
+    var customer: CustomerState?
+        get() = savedStateHandle[SAVED_CUSTOMER]
+        set(value) {
+            savedStateHandle[SAVED_CUSTOMER] = value
+        }
+
+    /**
+     * The list of saved payment methods for the current customer.
+     * Value is null until it's loaded, and non-null (could be empty) after that.
+     */
+    val paymentMethods: StateFlow<List<PaymentMethod>> = savedStateHandle
+        .getStateFlow<CustomerState?>(SAVED_CUSTOMER, null)
+        .mapAsStateFlow { state ->
+            state?.paymentMethods ?: emptyList()
+        }
+
+    val mostRecentlySelectedSavedPaymentMethod: StateFlow<PaymentMethod?> = savedStateHandle.getStateFlow(
+        SAVED_PM_SELECTION,
+        initialValue = (selection.value as? PaymentSelection.Saved)?.paymentMethod
+    )
+
+    fun updateMostRecentlySelectedSavedPaymentMethod(paymentMethod: PaymentMethod?) {
+        savedStateHandle[SAVED_PM_SELECTION] = paymentMethod
+    }
+
+    companion object {
+        const val SAVED_CUSTOMER = "customer_info"
+        private const val SAVED_PM_SELECTION = "saved_selection"
+
+        fun create(viewModel: BaseSheetViewModel): CustomerStateHolder {
+            return CustomerStateHolder(
+                savedStateHandle = viewModel.savedStateHandle,
+                selection = viewModel.selection,
+            )
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -156,7 +156,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
         if (paymentMethodMetadata.value == null) {
             setPaymentMethodMetadata(args.state.paymentMethodMetadata)
         }
-        savedPaymentMethodMutator.customer = args.state.customer
+        customerStateHolder.customer = args.state.customer
         savedStateHandle[SAVE_PROCESSING] = false
 
         updateSelection(args.state.paymentSelection)
@@ -214,7 +214,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
             PaymentOptionResult.Canceled(
                 mostRecentError = null,
                 paymentSelection = determinePaymentSelectionUponCancel(),
-                paymentMethods = savedPaymentMethodMutator.paymentMethods.value,
+                paymentMethods = customerStateHolder.paymentMethods.value,
             )
         )
     }
@@ -230,7 +230,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     }
 
     private fun PaymentSelection.Saved.takeIfStillValid(): PaymentSelection.Saved? {
-        val paymentMethods = savedPaymentMethodMutator.paymentMethods.value
+        val paymentMethods = customerStateHolder.paymentMethods.value
         val isStillAround = paymentMethods.any { it.id == paymentMethod.id }
         return this.takeIf { isStillAround }
     }
@@ -282,7 +282,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
         _paymentOptionResult.tryEmit(
             PaymentOptionResult.Succeeded(
                 paymentSelection = paymentSelection,
-                paymentMethods = savedPaymentMethodMutator.paymentMethods.value
+                paymentMethods = customerStateHolder.paymentMethods.value
             )
         )
     }
@@ -291,7 +291,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
         _paymentOptionResult.tryEmit(
             PaymentOptionResult.Succeeded(
                 paymentSelection = paymentSelection,
-                paymentMethods = savedPaymentMethodMutator.paymentMethods.value
+                paymentMethods = customerStateHolder.paymentMethods.value
             )
         )
     }
@@ -306,6 +306,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
                     viewModel = this,
                     paymentMethodMetadata = paymentMethodMetadata,
                     savedPaymentMethods = savedPaymentMethods,
+                    customerStateHolder = customerStateHolder,
                     savedPaymentMethodMutator = savedPaymentMethodMutator,
                 )
             )
@@ -314,6 +315,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
             val interactor = DefaultSelectSavedPaymentMethodsInteractor.create(
                 viewModel = this,
                 paymentMethodMetadata = paymentMethodMetadata,
+                customerStateHolder = customerStateHolder,
                 savedPaymentMethodMutator = savedPaymentMethodMutator,
             )
             SelectSavedPaymentMethods(interactor = interactor)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -349,7 +349,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     private suspend fun initializeWithState(state: PaymentSheetState.Full) {
-        savedPaymentMethodMutator.customer = state.customer
+        customerStateHolder.customer = state.customer
 
         updateSelection(state.paymentSelection)
 
@@ -748,15 +748,17 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     viewModel = this,
                     paymentMethodMetadata = paymentMethodMetadata,
                     savedPaymentMethods = savedPaymentMethods,
+                    customerStateHolder = customerStateHolder,
                     savedPaymentMethodMutator = savedPaymentMethodMutator,
                 )
             )
         }
-        val hasPaymentMethods = savedPaymentMethodMutator.paymentMethods.value.isNotEmpty()
+        val hasPaymentMethods = customerStateHolder.paymentMethods.value.isNotEmpty()
         val target = if (hasPaymentMethods) {
             val interactor = DefaultSelectSavedPaymentMethodsInteractor.create(
                 viewModel = this,
                 paymentMethodMetadata = paymentMethodMetadata,
+                customerStateHolder = customerStateHolder,
                 savedPaymentMethodMutator = savedPaymentMethodMutator,
             )
             PaymentSheetScreen.SelectSavedPaymentMethods(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SelectSavedPaymentMethodsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SelectSavedPaymentMethodsInteractor.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.ui
 
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentOptionsItem
 import com.stripe.android.paymentsheet.PaymentOptionsStateFactory
 import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
@@ -197,6 +198,7 @@ internal class DefaultSelectSavedPaymentMethodsInteractor(
         fun create(
             viewModel: BaseSheetViewModel,
             paymentMethodMetadata: PaymentMethodMetadata,
+            customerStateHolder: CustomerStateHolder,
             savedPaymentMethodMutator: SavedPaymentMethodMutator,
         ): SelectSavedPaymentMethodsInteractor {
             return DefaultSelectSavedPaymentMethodsInteractor(
@@ -206,8 +208,7 @@ internal class DefaultSelectSavedPaymentMethodsInteractor(
                 toggleEdit = savedPaymentMethodMutator::toggleEditing,
                 isProcessing = viewModel.processing,
                 currentSelection = viewModel.selection,
-                mostRecentlySelectedSavedPaymentMethod =
-                savedPaymentMethodMutator.mostRecentlySelectedSavedPaymentMethod,
+                mostRecentlySelectedSavedPaymentMethod = customerStateHolder.mostRecentlySelectedSavedPaymentMethod,
                 onAddCardPressed = {
                     val interactor = DefaultAddPaymentMethodInteractor.create(
                         viewModel = viewModel,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageOneSavedPaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageOneSavedPaymentMethodInteractor.kt
@@ -4,6 +4,7 @@ import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
@@ -51,10 +52,11 @@ internal class DefaultManageOneSavedPaymentMethodInteractor(
         fun create(
             viewModel: BaseSheetViewModel,
             paymentMethodMetadata: PaymentMethodMetadata,
+            customerStateHolder: CustomerStateHolder,
             savedPaymentMethodMutator: SavedPaymentMethodMutator,
         ): ManageOneSavedPaymentMethodInteractor {
             return DefaultManageOneSavedPaymentMethodInteractor(
-                paymentMethod = savedPaymentMethodMutator.paymentMethods.value.first(),
+                paymentMethod = customerStateHolder.paymentMethods.value.first(),
                 paymentMethodMetadata = paymentMethodMetadata,
                 providePaymentMethodName = savedPaymentMethodMutator.providePaymentMethodName,
                 onDeletePaymentMethod = savedPaymentMethodMutator::removePaymentMethod,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
@@ -4,6 +4,7 @@ import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -155,10 +156,11 @@ internal class DefaultManageScreenInteractor(
         fun create(
             viewModel: BaseSheetViewModel,
             paymentMethodMetadata: PaymentMethodMetadata,
+            customerStateHolder: CustomerStateHolder,
             savedPaymentMethodMutator: SavedPaymentMethodMutator,
         ): ManageScreenInteractor {
             return DefaultManageScreenInteractor(
-                paymentMethods = savedPaymentMethodMutator.paymentMethods,
+                paymentMethods = customerStateHolder.paymentMethods,
                 paymentMethodMetadata = paymentMethodMetadata,
                 selection = viewModel.selection,
                 editing = savedPaymentMethodMutator.editing,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -5,6 +5,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.FormHelper
 import com.stripe.android.paymentsheet.R
@@ -89,6 +90,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         fun create(
             viewModel: BaseSheetViewModel,
             paymentMethodMetadata: PaymentMethodMetadata,
+            customerStateHolder: CustomerStateHolder,
             savedPaymentMethodMutator: SavedPaymentMethodMutator,
         ): PaymentMethodVerticalLayoutInteractor {
             val formHelper = FormHelper.create(viewModel = viewModel, paymentMethodMetadata = paymentMethodMetadata)
@@ -103,6 +105,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                     val interactor = DefaultManageScreenInteractor.create(
                         viewModel = viewModel,
                         paymentMethodMetadata = paymentMethodMetadata,
+                        customerStateHolder = customerStateHolder,
                         savedPaymentMethodMutator = savedPaymentMethodMutator,
                     )
                     PaymentSheetScreen.ManageSavedPaymentMethods(interactor = interactor)
@@ -111,6 +114,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                     val interactor = DefaultManageOneSavedPaymentMethodInteractor.create(
                         viewModel = viewModel,
                         paymentMethodMetadata = paymentMethodMetadata,
+                        customerStateHolder = customerStateHolder,
                         savedPaymentMethodMutator = savedPaymentMethodMutator,
                     )
                     PaymentSheetScreen.ManageOneSavedPaymentMethod(interactor = interactor)
@@ -123,9 +127,8 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                     )
                     PaymentSheetScreen.VerticalModeForm(interactor = interactor)
                 },
-                paymentMethods = savedPaymentMethodMutator.paymentMethods,
-                mostRecentlySelectedSavedPaymentMethod =
-                savedPaymentMethodMutator.mostRecentlySelectedSavedPaymentMethod,
+                paymentMethods = customerStateHolder.paymentMethods,
+                mostRecentlySelectedSavedPaymentMethod = customerStateHolder.mostRecentlySelectedSavedPaymentMethod,
                 providePaymentMethodName = savedPaymentMethodMutator.providePaymentMethodName,
                 allowsRemovalOfLastSavedPaymentMethod = viewModel.config.allowsRemovalOfLastSavedPaymentMethod,
                 onEditPaymentMethod = { savedPaymentMethodMutator.modifyPaymentMethod(it.paymentMethod) },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.verticalmode
 
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
@@ -11,6 +12,7 @@ internal object VerticalModeInitialScreenFactory {
         viewModel: BaseSheetViewModel,
         paymentMethodMetadata: PaymentMethodMetadata,
         savedPaymentMethods: List<PaymentMethod>,
+        customerStateHolder: CustomerStateHolder,
         savedPaymentMethodMutator: SavedPaymentMethodMutator,
     ): PaymentSheetScreen {
         val supportedPaymentMethodTypes = paymentMethodMetadata.supportedPaymentMethodTypes()
@@ -28,6 +30,7 @@ internal object VerticalModeInitialScreenFactory {
         val interactor = DefaultPaymentMethodVerticalLayoutInteractor.create(
             viewModel = viewModel,
             paymentMethodMetadata = paymentMethodMetadata,
+            customerStateHolder = customerStateHolder,
             savedPaymentMethodMutator = savedPaymentMethodMutator,
         )
         return PaymentSheetScreen.VerticalMode(interactor = interactor)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -11,6 +11,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.payments.paymentlauncher.PaymentResult
+import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.MandateHandler
 import com.stripe.android.paymentsheet.NewOrExternalPaymentSelection
@@ -101,6 +102,7 @@ internal abstract class BaseSheetViewModel(
      */
     abstract var newPaymentSelection: NewOrExternalPaymentSelection?
 
+    val customerStateHolder: CustomerStateHolder = CustomerStateHolder.create(this)
     val savedPaymentMethodMutator: SavedPaymentMethodMutator = SavedPaymentMethodMutator.create(this)
 
     protected val buttonsEnabled = combineAsStateFlow(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CustomerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CustomerStateHolderTest.kt
@@ -1,0 +1,68 @@
+package com.stripe.android.paymentsheet
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.CustomerState
+import com.stripe.android.uicore.utils.stateFlowOf
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+internal class CustomerStateHolderTest {
+    @Test
+    fun `customer is initialized as null`() = runScenario {
+        assertThat(customerStateHolder.customer).isNull()
+    }
+
+    @Test
+    fun `customer is restored from savedStateHandle`() {
+        val savedStateHandle = SavedStateHandle()
+        val customerState = CustomerState.createForLegacyEphemeralKey(
+            customerId = "cus_123",
+            accessType = PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey("ek_123"),
+            paymentMethods = emptyList()
+        )
+        savedStateHandle[CustomerStateHolder.SAVED_CUSTOMER] = customerState
+        runScenario(savedStateHandle = savedStateHandle) {
+            assertThat(customerStateHolder.customer).isEqualTo(customerState)
+        }
+    }
+
+    @Test
+    fun `paymentMethods emit once customer is updated`() = runScenario {
+        customerStateHolder.paymentMethods.test {
+            assertThat(awaitItem()).isEmpty()
+
+            customerStateHolder.customer = CustomerState.createForLegacyEphemeralKey(
+                customerId = "cus_123",
+                accessType = PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey("ek_123"),
+                paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+            )
+
+            assertThat(awaitItem()).hasSize(1)
+        }
+    }
+
+    private fun runScenario(
+        savedStateHandle: SavedStateHandle = SavedStateHandle(),
+        selection: StateFlow<PaymentSelection?> = stateFlowOf(null),
+        block: suspend Scenario.() -> Unit
+    ) {
+        val customerStateHolder = CustomerStateHolder(
+            savedStateHandle = savedStateHandle,
+            selection = selection,
+        )
+        Scenario(customerStateHolder).apply {
+            runTest {
+                block()
+            }
+        }
+    }
+
+    private data class Scenario(
+        val customerStateHolder: CustomerStateHolder,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -201,7 +201,7 @@ internal class PaymentOptionsViewModelTest {
 
         viewModel.savedPaymentMethodMutator.removePaymentMethod(cards[1])
 
-        assertThat(viewModel.savedPaymentMethodMutator.paymentMethods.value)
+        assertThat(viewModel.customerStateHolder.paymentMethods.value)
             .containsExactly(cards[0], cards[2])
     }
 
@@ -232,7 +232,7 @@ internal class PaymentOptionsViewModelTest {
 
         viewModel.savedPaymentMethodMutator.removePaymentMethod(paymentMethod)
 
-        assertThat(viewModel.savedPaymentMethodMutator.paymentMethods.value).isEmpty()
+        assertThat(viewModel.customerStateHolder.paymentMethods.value).isEmpty()
         assertThat(viewModel.primaryButtonUiState.value).isNull()
         assertThat(viewModel.mandateHandler.mandateText.value?.text).isNull()
     }
@@ -281,7 +281,7 @@ internal class PaymentOptionsViewModelTest {
             )
         )
 
-        viewModel.savedPaymentMethodMutator.paymentMethods.test {
+        viewModel.customerStateHolder.paymentMethods.test {
             assertThat(awaitItem()).isNotEmpty()
         }
     }
@@ -294,7 +294,7 @@ internal class PaymentOptionsViewModelTest {
             )
         )
 
-        viewModel.savedPaymentMethodMutator.paymentMethods.test {
+        viewModel.customerStateHolder.paymentMethods.test {
             assertThat(awaitItem()).isEmpty()
         }
     }
@@ -658,7 +658,7 @@ internal class PaymentOptionsViewModelTest {
 
         turbineScope {
             val screenTurbine = viewModel.navigationHandler.currentScreen.testIn(this)
-            val paymentMethodsTurbine = viewModel.savedPaymentMethodMutator.paymentMethods.testIn(this)
+            val paymentMethodsTurbine = viewModel.customerStateHolder.paymentMethods.testIn(this)
 
             assertThat(screenTurbine.awaitItem()).isInstanceOf<SelectSavedPaymentMethods>()
 
@@ -710,7 +710,7 @@ internal class PaymentOptionsViewModelTest {
 
         turbineScope {
             val screenTurbine = viewModel.navigationHandler.currentScreen.testIn(this)
-            val paymentMethodsTurbine = viewModel.savedPaymentMethodMutator.paymentMethods.testIn(this)
+            val paymentMethodsTurbine = viewModel.customerStateHolder.paymentMethods.testIn(this)
 
             assertThat(screenTurbine.awaitItem()).isInstanceOf<SelectSavedPaymentMethods>()
 
@@ -805,7 +805,7 @@ internal class PaymentOptionsViewModelTest {
         viewModel.navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isInstanceOf<SelectSavedPaymentMethods>()
         }
-        viewModel.savedPaymentMethodMutator.paymentMethods.test {
+        viewModel.customerStateHolder.paymentMethods.test {
             assertThat(awaitItem()).isEmpty()
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -498,7 +498,7 @@ internal class PaymentSheetViewModelTest {
             ).toParamMap()
         )
 
-        assertThat(viewModel.savedPaymentMethodMutator.paymentMethods.value).isEqualTo(
+        assertThat(viewModel.customerStateHolder.paymentMethods.value).isEqualTo(
             listOf(updatedPaymentMethod) + paymentMethods.takeLast(4)
         )
     }
@@ -1442,7 +1442,7 @@ internal class PaymentSheetViewModelTest {
             )
         )
 
-        viewModel.savedPaymentMethodMutator.paymentMethods.test {
+        viewModel.customerStateHolder.paymentMethods.test {
             assertThat(awaitItem()).isNotEmpty()
         }
     }
@@ -1451,7 +1451,7 @@ internal class PaymentSheetViewModelTest {
     fun `paymentMethods is empty if customer has no payment methods`() = runTest {
         val viewModel = createViewModel(customer = EMPTY_CUSTOMER_STATE)
 
-        viewModel.savedPaymentMethodMutator.paymentMethods.test {
+        viewModel.customerStateHolder.paymentMethods.test {
             assertThat(awaitItem()).isEmpty()
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I'd like to create the CustomerStateHolder when determining the initial screen, and pass it along to the screens it's needed in.

Once that's done, I'd like to create the SavedPaymentMethodMutator ONLY where it's needed.

This is some pre work to split them, and pass them independently.