### PR TITLE
Remove implementation detail knowledge from PaymentSheetActivityTest.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTab.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTab.kt
@@ -50,6 +50,7 @@ import com.stripe.android.uicore.shouldUseDarkDynamicColor
 const val SAVED_PAYMENT_METHOD_CARD_TEST_TAG = "SAVED_PAYMENT_METHOD_CARD_TEST_TAG"
 
 internal const val TEST_TAG_REMOVE_BADGE = "remove_badge"
+internal const val TEST_TAG_MODIFY_BADGE = "modify_badge"
 
 private const val EDIT_ICON_SCALE = 0.6f
 private val editIconColorLight = Color(0x99000000)
@@ -268,7 +269,8 @@ private fun ModifyBadge(
             .size(20.dp)
             .clip(CircleShape)
             .background(color = backgroundColor)
-            .clickable(onClick = onPressed),
+            .clickable(onClick = onPressed)
+            .testTag(TEST_TAG_MODIFY_BADGE),
     )
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
@@ -11,6 +11,7 @@ import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException
 import com.stripe.android.paymentsheet.state.PaymentSheetState
+import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import kotlinx.coroutines.delay
 import kotlin.time.Duration
 
@@ -23,6 +24,7 @@ internal class FakePaymentSheetLoader(
     private val delay: Duration = Duration.ZERO,
     private val linkState: LinkState? = null,
     private val validationError: PaymentSheetLoadingException? = null,
+    private val cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
 ) : PaymentSheetLoader {
 
     fun updatePaymentMethods(paymentMethods: List<PaymentMethod>) {
@@ -59,6 +61,7 @@ internal class FakePaymentSheetLoader(
                         allowsPaymentMethodsRequiringShippingAddress = paymentSheetConfiguration
                             .allowsPaymentMethodsRequiringShippingAddress,
                         isGooglePayReady = isGooglePayAvailable,
+                        cbcEligibility = cbcEligibility,
                     ),
                 )
             )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This removes implementation details knowledge (of SavedPaymentMethodMutator) from `PaymentSheetActivityTest`, and uses the UI to drive the desired behavior instead.