### PR TITLE
Move `Bacs` handling to `IntentConfirmationHandler`

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -22,7 +22,6 @@
     <ID>LargeClass:PaymentMethodMetadataTest.kt$PaymentMethodMetadataTest</ID>
     <ID>LargeClass:PaymentOptionsViewModelTest.kt$PaymentOptionsViewModelTest</ID>
     <ID>LargeClass:PaymentSheetActivityTest.kt$PaymentSheetActivityTest</ID>
-    <ID>LargeClass:PaymentSheetViewModel.kt$PaymentSheetViewModel : BaseSheetViewModel</ID>
     <ID>LargeClass:PaymentSheetViewModelTest.kt$PaymentSheetViewModelTest</ID>
     <ID>LargeClass:USBankAccountFormViewModelTest.kt$USBankAccountFormViewModelTest</ID>
     <ID>LongMethod:AutocompleteScreen.kt$@Composable internal fun AutocompleteScreenUI(viewModel: AutocompleteViewModel)</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -907,6 +907,7 @@ internal class CustomerSheetViewModel(
                 intent = stripeIntent,
                 paymentSelection = selection,
                 shippingDetails = null,
+                appearance = configuration.appearance,
             )
         )
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -34,6 +34,8 @@ import com.stripe.android.paymentsheet.IntentConfirmationHandler
 import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.injection.IS_FLOW_CONTROLLER
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncherFactory
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.DefaultBacsMandateConfirmationLauncherFactory
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.paymentsheet.repositories.RealElementsSessionRepository
 import com.stripe.android.paymentsheet.ui.DefaultEditPaymentMethodViewInteractor
@@ -134,10 +136,15 @@ internal interface CustomerSheetViewModelModule {
         )
 
         @Provides
+        fun providesBacsMandateConfirmationLauncherFactory(): BacsMandateConfirmationLauncherFactory =
+            DefaultBacsMandateConfirmationLauncherFactory
+
+        @Provides
         fun providesIntentConfirmationHandlerFactory(
             application: Application,
             savedStateHandle: SavedStateHandle,
             paymentConfigurationProvider: Provider<PaymentConfiguration>,
+            bacsMandateConfirmationLauncherFactory: BacsMandateConfirmationLauncherFactory,
             stripePaymentLauncherAssistedFactory: StripePaymentLauncherAssistedFactory,
             statusBarColor: Int?,
             intentConfirmationInterceptor: IntentConfirmationInterceptor,
@@ -147,6 +154,7 @@ internal interface CustomerSheetViewModelModule {
                 intentConfirmationInterceptor = intentConfirmationInterceptor,
                 paymentConfigurationProvider = paymentConfigurationProvider,
                 stripePaymentLauncherAssistedFactory = stripePaymentLauncherAssistedFactory,
+                bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,
                 application = application,
                 statusBarColor = { statusBarColor },
                 savedStateHandle = savedStateHandle,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -12,6 +12,7 @@ import com.stripe.android.paymentsheet.IntentConfirmationHandler
 import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.PaymentSheetContractV2
 import com.stripe.android.paymentsheet.PrefsRepository
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncherFactory
 import dagger.Module
 import dagger.Provides
 import javax.inject.Provider
@@ -30,6 +31,7 @@ internal class PaymentSheetViewModelModule(private val starterArgs: PaymentSheet
         application: Application,
         savedStateHandle: SavedStateHandle,
         paymentConfigurationProvider: Provider<PaymentConfiguration>,
+        bacsMandateConfirmationLauncherFactory: BacsMandateConfirmationLauncherFactory,
         stripePaymentLauncherAssistedFactory: StripePaymentLauncherAssistedFactory,
         intentConfirmationInterceptor: IntentConfirmationInterceptor,
         errorReporter: ErrorReporter,
@@ -38,6 +40,7 @@ internal class PaymentSheetViewModelModule(private val starterArgs: PaymentSheet
             intentConfirmationInterceptor = intentConfirmationInterceptor,
             paymentConfigurationProvider = paymentConfigurationProvider,
             stripePaymentLauncherAssistedFactory = stripePaymentLauncherAssistedFactory,
+            bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,
             application = application,
             statusBarColor = { starterArgs.statusBarColor },
             savedStateHandle = savedStateHandle,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationLauncherFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationLauncherFactory.kt
@@ -2,7 +2,7 @@ package com.stripe.android.paymentsheet.paymentdatacollection.bacs
 
 import androidx.activity.result.ActivityResultLauncher
 
-internal interface BacsMandateConfirmationLauncherFactory {
+internal fun interface BacsMandateConfirmationLauncherFactory {
     fun create(
         activityResultLauncher: ActivityResultLauncher<BacsMandateConfirmationContract.Args>
     ): BacsMandateConfirmationLauncher

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -36,6 +36,7 @@ import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.FakeBacsMandateConfirmationLauncher
 import com.stripe.android.paymentsheet.ui.DefaultEditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.ui.EditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.ui.ModifiableEditPaymentMethodViewInteractor
@@ -175,6 +176,9 @@ internal object CustomerSheetTestHelper {
             intentConfirmationHandlerFactory = IntentConfirmationHandler.Factory(
                 intentConfirmationInterceptor = intentConfirmationInterceptor,
                 paymentConfigurationProvider = { paymentConfiguration },
+                bacsMandateConfirmationLauncherFactory = {
+                    FakeBacsMandateConfirmationLauncher()
+                },
                 stripePaymentLauncherAssistedFactory = object : StripePaymentLauncherAssistedFactory {
                     override fun create(
                         publishableKey: () -> String,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -57,6 +57,7 @@ import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddAnotherPaymentMethod
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.FakeBacsMandateConfirmationLauncher
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.WalletsProcessingState
 import com.stripe.android.paymentsheet.ui.GOOGLE_PAY_BUTTON_TEST_TAG
@@ -1094,7 +1095,6 @@ internal class PaymentSheetActivityTest {
                 customerRepository = FakeCustomerRepository(paymentMethods),
                 prefsRepository = FakePrefsRepository(),
                 googlePayPaymentMethodLauncherFactory = googlePayPaymentMethodLauncherFactory,
-                bacsMandateConfirmationLauncherFactory = mock(),
                 logger = Logger.noop(),
                 workContext = testDispatcher,
                 savedStateHandle = savedStateHandle,
@@ -1104,6 +1104,7 @@ internal class PaymentSheetActivityTest {
                     intentConfirmationInterceptor = fakeIntentConfirmationInterceptor,
                     savedStateHandle = savedStateHandle,
                     stripePaymentLauncherAssistedFactory = stripePaymentLauncherAssistedFactory,
+                    bacsMandateConfirmationLauncherFactory = { FakeBacsMandateConfirmationLauncher() },
                     paymentConfigurationProvider = { PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY) },
                     statusBarColor = { args.statusBarColor },
                     application = application,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -2794,7 +2794,6 @@ internal class PaymentSheetViewModelTest {
                 customerRepository = customerRepository,
                 prefsRepository = prefsRepository,
                 googlePayPaymentMethodLauncherFactory = googlePayLauncherFactory,
-                bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,
                 logger = Logger.noop(),
                 workContext = testDispatcher,
                 savedStateHandle = thisSavedStateHandle,
@@ -2803,6 +2802,7 @@ internal class PaymentSheetViewModelTest {
                 intentConfirmationHandlerFactory = IntentConfirmationHandler.Factory(
                     intentConfirmationInterceptor = intentConfirmationInterceptor,
                     savedStateHandle = thisSavedStateHandle,
+                    bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,
                     stripePaymentLauncherAssistedFactory = paymentLauncherFactory,
                     paymentConfigurationProvider = { paymentConfiguration },
                     statusBarColor = { args.statusBarColor },
@@ -2939,7 +2939,7 @@ internal class PaymentSheetViewModelTest {
             PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP
         private val ARGS_CUSTOMER_WITH_GOOGLEPAY = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY
 
-        private val PAYMENT_METHODS = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        private val PAYMENT_METHODS = listOf(CARD_PAYMENT_METHOD)
 
         val PAYMENT_INTENT = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
         val PAYMENT_INTENT_WITH_PAYMENT_METHOD = PaymentIntentFixtures.PI_WITH_PAYMENT_METHOD

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/FakeBacsMandateConfirmationLauncher.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/FakeBacsMandateConfirmationLauncher.kt
@@ -1,0 +1,24 @@
+package com.stripe.android.paymentsheet.paymentdatacollection.bacs
+
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
+import com.stripe.android.paymentsheet.PaymentSheet
+
+internal class FakeBacsMandateConfirmationLauncher : BacsMandateConfirmationLauncher {
+    private val _calls = Turbine<Call>()
+    val calls: ReceiveTurbine<Call> = _calls
+
+    override fun launch(data: BacsMandateData, appearance: PaymentSheet.Appearance) {
+        _calls.add(
+            Call(
+                data = data,
+                appearance = appearance
+            )
+        )
+    }
+
+    data class Call(
+        val data: BacsMandateData,
+        val appearance: PaymentSheet.Appearance,
+    )
+}


### PR DESCRIPTION
# Summary
Move `Bacs` handling to `IntentConfirmationHandler`

# Motivation
Removes duplicated code between `PaymentSheet` and `FlowController`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Video
https://github.com/user-attachments/assets/e2cefb6b-03e2-4a2b-ac03-42f27bea0ab9