### PR TITLE
Move SavedPaymentMethodMutator specific logic to it's test class.

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -193,35 +193,6 @@ internal class PaymentOptionsViewModelTest {
     }
 
     @Test
-    fun `removePaymentMethod removes it from payment methods list`() = runTest {
-        val cards = PaymentMethodFixtures.createCards(3)
-        val viewModel = createViewModel(
-            args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(paymentMethods = cards)
-        )
-
-        viewModel.savedPaymentMethodMutator.removePaymentMethod(cards[1])
-
-        assertThat(viewModel.customerStateHolder.paymentMethods.value)
-            .containsExactly(cards[0], cards[2])
-    }
-
-    @Test
-    fun `Removing selected payment method clears selection`() = runTest {
-        val cards = PaymentMethodFixtures.createCards(3)
-        val viewModel = createViewModel(
-            args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(paymentMethods = cards)
-        )
-
-        val selection = PaymentSelection.Saved(cards[1])
-        viewModel.updateSelection(selection)
-        assertThat(viewModel.selection.value).isEqualTo(selection)
-
-        viewModel.savedPaymentMethodMutator.removePaymentMethod(selection.paymentMethod)
-
-        assertThat(viewModel.selection.value).isNull()
-    }
-
-    @Test
     fun `when paymentMethods is empty, primary button and text below button are gone`() = runTest {
         val paymentMethod = PaymentMethodFixtures.US_BANK_ACCOUNT
         val viewModel = createViewModel(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -95,7 +95,6 @@ import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.SAVE_PROCESSING
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentIntentFactory
-import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.testing.SessionTestRule
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.utils.DummyActivityResultCaller
@@ -192,21 +191,6 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `removePaymentMethod triggers async removal`() = runTest {
-        val customerRepository = spy(FakeCustomerRepository())
-        val viewModel = createViewModel(
-            customerRepository = customerRepository
-        )
-
-        viewModel.savedPaymentMethodMutator.removePaymentMethod(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
-
-        verify(customerRepository).detachPaymentMethod(
-            any(),
-            eq(PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!)
-        )
-    }
-
-    @Test
     fun `correct event is sent when dropdown is opened in EditPaymentMethod`() = runTest {
         val paymentMethods = listOf(CARD_WITH_NETWORKS_PAYMENT_METHOD)
 
@@ -268,55 +252,6 @@ internal class PaymentSheetViewModelTest {
                 )
             }
         }
-    }
-
-    @Test
-    fun `removePaymentMethod should use loaded customer info when removing payment methods`() = runTest {
-        val paymentMethods = PaymentMethodFactory.cards(1)
-
-        val customerRepository = spy(
-            FakeCustomerRepository(
-                onDetachPaymentMethod = {
-                    Result.success(paymentMethods.first())
-                }
-            )
-        )
-        val viewModel = createViewModel(
-            args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                    customer = PaymentSheet.CustomerConfiguration(
-                        id = "cus_1",
-                        ephemeralKeySecret = "ephemeral_key_1"
-                    )
-                )
-            ),
-            customer = CustomerState(
-                id = "cus_2",
-                ephemeralKeySecret = "ephemeral_key_2",
-                paymentMethods = paymentMethods,
-                permissions = CustomerState.Permissions(
-                    canRemovePaymentMethods = true,
-                    canRemoveDuplicates = false,
-                ),
-            ),
-            customerRepository = customerRepository
-        )
-
-        viewModel.savedPaymentMethodMutator.removePaymentMethod(paymentMethods.first())
-
-        val customerInfoCaptor = argumentCaptor<CustomerRepository.CustomerInfo>()
-
-        verify(customerRepository).detachPaymentMethod(
-            customerInfoCaptor.capture(),
-            any(),
-        )
-
-        assertThat(customerInfoCaptor.firstValue).isEqualTo(
-            CustomerRepository.CustomerInfo(
-                id = "cus_2",
-                ephemeralKeySecret = "ephemeral_key_2",
-            )
-        )
     }
 
     @Test
@@ -1628,24 +1563,6 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `Sets editing to false when removing the last payment method while editing`() = runTest {
-        val customerPaymentMethods = PaymentMethodFixtures.createCards(1)
-        val viewModel = createViewModel(
-            customer = EMPTY_CUSTOMER_STATE.copy(paymentMethods = customerPaymentMethods)
-        )
-
-        viewModel.savedPaymentMethodMutator.editing.test {
-            assertThat(awaitItem()).isFalse()
-
-            viewModel.savedPaymentMethodMutator.toggleEditing()
-            assertThat(awaitItem()).isTrue()
-
-            viewModel.savedPaymentMethodMutator.removePaymentMethod(customerPaymentMethods.single())
-            assertThat(awaitItem()).isFalse()
-        }
-    }
-
-    @Test
     fun `updateSelection with new payment method updates the current selection`() = runTest {
         val viewModel = createViewModel(initialPaymentSelection = null)
 
@@ -1703,20 +1620,6 @@ internal class PaymentSheetViewModelTest {
             viewModel.updateSelection(savedSelection)
             assertThat(awaitItem()).isEqualTo(savedSelection)
             assertThat(viewModel.newPaymentSelection).isEqualTo(null)
-        }
-    }
-
-    @Test
-    fun `Resets the backstack if the last customer payment method is removed`() = runTest {
-        val paymentMethods = PaymentMethodFixtures.createCards(1)
-        val viewModel = createViewModel(
-            customer = EMPTY_CUSTOMER_STATE.copy(paymentMethods = paymentMethods)
-        )
-
-        viewModel.navigationHandler.currentScreen.test {
-            assertThat(awaitItem()).isInstanceOf<SelectSavedPaymentMethods>()
-            viewModel.savedPaymentMethodMutator.removePaymentMethod(paymentMethods.single())
-            assertThat(awaitItem()).isInstanceOf<AddFirstPaymentMethod>()
         }
     }
 
@@ -2609,23 +2512,6 @@ internal class PaymentSheetViewModelTest {
         viewModel.transitionToAddPaymentScreen()
 
         verify(eventReporter, times(2)).onPaymentMethodFormShown("card")
-    }
-
-    @Test
-    fun `on 'removePaymentMethod' with no CustomerConfiguration available, should not attempt detach`() = runTest {
-        val customerRepository = spy(FakeCustomerRepository())
-        val viewModel = createViewModel(
-            customer = null,
-            args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                    customer = null
-                )
-            ),
-        )
-
-        viewModel.savedPaymentMethodMutator.removePaymentMethod(PAYMENT_METHODS.first())
-
-        verify(customerRepository, never()).detachPaymentMethod(any(), any())
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -6,15 +6,21 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.navigation.NavigationHandler
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
+import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.uicore.utils.stateFlowOf
+import com.stripe.android.utils.FakeCustomerRepository
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
 
 class SavedPaymentMethodMutatorTest {
     @Test
@@ -98,32 +104,112 @@ class SavedPaymentMethodMutatorTest {
         }
     }
 
+    @Test
+    fun `removePaymentMethod triggers async removal`() {
+        var calledDetach = false
+        val customerRepository = FakeCustomerRepository(
+            onDetachPaymentMethod = { paymentMethodId ->
+                assertThat(paymentMethodId).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!)
+                calledDetach = true
+                Result.failure(IllegalStateException())
+            }
+        )
+
+        runScenario(customerRepository = customerRepository) {
+            customerStateHolder.customer = CustomerState.createForLegacyEphemeralKey(
+                customerId = "cus_123",
+                accessType = PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey("ek_123"),
+                paymentMethods = listOf(
+                    PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                )
+            )
+
+            customerStateHolder.paymentMethods.test {
+                assertThat(awaitItem().size).isEqualTo(1)
+                savedPaymentMethodMutator.removePaymentMethod(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+                assertThat(awaitItem()).isEmpty()
+            }
+
+            assertThat(calledDetach).isTrue()
+        }
+    }
+
+    @Test
+    fun `removePaymentMethod with no CustomerConfiguration available, should not attempt detach`() = runScenario {
+        var calledDetach = false
+        val customerRepository = FakeCustomerRepository(
+            onDetachPaymentMethod = {
+                calledDetach = true
+                throw AssertionError("Not expected")
+            }
+        )
+
+        runScenario(customerRepository = customerRepository) {
+            savedPaymentMethodMutator.removePaymentMethod(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+
+            assertThat(calledDetach).isFalse()
+        }
+    }
+
+    @Test
+    fun `Sets editing to false when removing the last payment method while editing`() = runScenario {
+        val customerPaymentMethods = PaymentMethodFixtures.createCards(1)
+        customerStateHolder.customer = EMPTY_CUSTOMER_STATE.copy(paymentMethods = customerPaymentMethods)
+
+        savedPaymentMethodMutator.editing.test {
+            assertThat(awaitItem()).isFalse()
+
+            savedPaymentMethodMutator.toggleEditing()
+            assertThat(awaitItem()).isTrue()
+
+            savedPaymentMethodMutator.removePaymentMethod(customerPaymentMethods.single())
+            assertThat(awaitItem()).isFalse()
+        }
+    }
+
+    @Test
+    fun `Removing selected payment method clears selection`() = runScenario {
+        val cards = PaymentMethodFixtures.createCards(3)
+        customerStateHolder.customer = EMPTY_CUSTOMER_STATE.copy(paymentMethods = cards)
+
+        val selection = PaymentSelection.Saved(cards[1])
+        selectionSource.value = selection
+
+        selectionSource.test {
+            assertThat(awaitItem()).isEqualTo(selection)
+            savedPaymentMethodMutator.removePaymentMethod(selection.paymentMethod)
+            assertThat(awaitItem()).isNull()
+        }
+    }
+
     private fun runScenario(
-        savedStateHandle: SavedStateHandle = SavedStateHandle(),
+        customerRepository: CustomerRepository = FakeCustomerRepository(),
         allowsRemovalOfLastSavedPaymentMethod: Boolean = true,
         isCbcEligible: () -> Boolean = { false },
         block: suspend Scenario.() -> Unit
     ) {
         runTest {
-            val selection: StateFlow<PaymentSelection?> = stateFlowOf(null)
+            val selection: MutableStateFlow<PaymentSelection?> = MutableStateFlow(null)
+
             val customerStateHolder = CustomerStateHolder(
-                savedStateHandle = savedStateHandle,
+                savedStateHandle = SavedStateHandle(),
                 selection = selection,
             )
+            val navigationHandler = mock<NavigationHandler>()
+            whenever(navigationHandler.currentScreen).thenReturn(stateFlowOf(PaymentSheetScreen.Loading))
             val savedPaymentMethodMutator = SavedPaymentMethodMutator(
                 editInteractorFactory = mock(),
                 eventReporter = mock(),
-                savedStateHandle = savedStateHandle,
                 coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
                 workContext = coroutineContext,
-                navigationHandler = mock(),
-                customerRepository = mock(),
+                navigationHandler = navigationHandler,
+                customerRepository = customerRepository,
                 allowsRemovalOfLastSavedPaymentMethod = allowsRemovalOfLastSavedPaymentMethod,
                 selection = selection,
                 providePaymentMethodName = { it?.resolvableString.orEmpty() },
                 customerStateHolder = customerStateHolder,
                 addFirstPaymentMethodScreenFactory = { throw AssertionError("Not implemented") },
-                updateSelection = { throw AssertionError("Not implemented") },
+                clearSelection = { selection.value = null },
                 isCbcEligible = isCbcEligible,
                 isGooglePayReady = stateFlowOf(false),
                 isLinkEnabled = stateFlowOf(false),
@@ -133,6 +219,7 @@ class SavedPaymentMethodMutatorTest {
             Scenario(
                 savedPaymentMethodMutator = savedPaymentMethodMutator,
                 customerStateHolder = customerStateHolder,
+                selectionSource = selection,
             ).apply {
                 block()
             }
@@ -142,5 +229,6 @@ class SavedPaymentMethodMutatorTest {
     private data class Scenario(
         val savedPaymentMethodMutator: SavedPaymentMethodMutator,
         val customerStateHolder: CustomerStateHolder,
+        val selectionSource: MutableStateFlow<PaymentSelection?>,
     )
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I mostly just left tests in place when doing refactors. But now I'm starting to remove unnecessary/duplicative tests, and adding necessary test to where they're needed.

The end goal here is to not have access to `savedPaymentMethodMutator` from the view models (probably). Although it might make sense to leave a reference to it from `PaymentOptionsViewModel`, since that one is always loaded.
