### PR TITLE
Move `ExternalPaymentMethod` handling to `IntentConfirmationHandler`

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -318,6 +318,14 @@ public final class com/stripe/android/paymentsheet/FlowControllerComposeKt {
 	public static final fun rememberPaymentSheetFlowController (Lcom/stripe/android/paymentsheet/PaymentOptionCallback;Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;Landroidx/compose/runtime/Composer;I)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;
 }
 
+public final class com/stripe/android/paymentsheet/IntentConfirmationHandler$Args$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/IntentConfirmationHandler$Args;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/IntentConfirmationHandler$Args;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public abstract interface class com/stripe/android/paymentsheet/PaymentOptionCallback {
 	public abstract fun onPaymentOption (Lcom/stripe/android/paymentsheet/model/PaymentOption;)V
 }

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -18,6 +18,7 @@
     <ID>LargeClass:DefaultFlowController.kt$DefaultFlowController : FlowController</ID>
     <ID>LargeClass:DefaultFlowControllerTest.kt$DefaultFlowControllerTest</ID>
     <ID>LargeClass:DefaultPaymentSheetLoaderTest.kt$DefaultPaymentSheetLoaderTest</ID>
+    <ID>LargeClass:IntentConfirmationHandlerTest.kt$IntentConfirmationHandlerTest</ID>
     <ID>LargeClass:PaymentMethodMetadataTest.kt$PaymentMethodMetadataTest</ID>
     <ID>LargeClass:PaymentOptionsViewModelTest.kt$PaymentOptionsViewModelTest</ID>
     <ID>LargeClass:PaymentSheetActivityTest.kt$PaymentSheetActivityTest</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -141,6 +141,7 @@ internal interface CustomerSheetViewModelModule {
             stripePaymentLauncherAssistedFactory: StripePaymentLauncherAssistedFactory,
             statusBarColor: Int?,
             intentConfirmationInterceptor: IntentConfirmationInterceptor,
+            errorReporter: ErrorReporter,
         ): IntentConfirmationHandler.Factory {
             return IntentConfirmationHandler.Factory(
                 intentConfirmationInterceptor = intentConfirmationInterceptor,
@@ -149,6 +150,7 @@ internal interface CustomerSheetViewModelModule {
                 application = application,
                 statusBarColor = { statusBarColor },
                 savedStateHandle = savedStateHandle,
+                errorReporter = errorReporter,
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.IOContext
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.IntentConfirmationHandler
@@ -31,6 +32,7 @@ internal class PaymentSheetViewModelModule(private val starterArgs: PaymentSheet
         paymentConfigurationProvider: Provider<PaymentConfiguration>,
         stripePaymentLauncherAssistedFactory: StripePaymentLauncherAssistedFactory,
         intentConfirmationInterceptor: IntentConfirmationInterceptor,
+        errorReporter: ErrorReporter,
     ): IntentConfirmationHandler.Factory {
         return IntentConfirmationHandler.Factory(
             intentConfirmationInterceptor = intentConfirmationInterceptor,
@@ -39,6 +41,7 @@ internal class PaymentSheetViewModelModule(private val starterArgs: PaymentSheet
             application = application,
             statusBarColor = { starterArgs.statusBarColor },
             savedStateHandle = savedStateHandle,
+            errorReporter = errorReporter,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -189,6 +189,7 @@ internal object CustomerSheetTestHelper {
                 statusBarColor = { null },
                 savedStateHandle = SavedStateHandle(),
                 application = application,
+                errorReporter = FakeErrorReporter(),
             ),
             eventReporter = eventReporter,
             customerSheetLoader = customerSheetLoader,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
@@ -1,11 +1,13 @@
 package com.stripe.android.paymentsheet
 
 import androidx.activity.result.ActivityResultCallback
+import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
@@ -21,9 +23,12 @@ import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.payments.paymentlauncher.PaymentLauncher
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
+import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.FakePaymentLauncher
+import com.stripe.android.utils.FakeExternalPaymentMethodLauncher
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -618,6 +623,170 @@ class IntentConfirmationHandlerTest {
         )
     }
 
+    @Test
+    fun `On external PM, should launch external PM handler with expected params`() = runTest {
+        ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler = EXTERNAL_PAYMENT_METHOD_CONFIRM_HANDLER
+
+        val fakeExternalPaymentMethodLauncher = FakeExternalPaymentMethodLauncher()
+
+        val intentConfirmationHandler = createIntentConfirmationHandler(
+            shouldRegister = false
+        ).apply {
+            setExternalPaymentMethodLauncher(fakeExternalPaymentMethodLauncher)
+        }
+
+        intentConfirmationHandler.start(
+            arguments = DEFAULT_ARGUMENTS.copy(
+                paymentSelection = EXTERNAL_PAYMENT_METHOD.copy(
+                    billingDetails = PaymentMethod.BillingDetails(
+                        name = "John Doe",
+                        address = Address(
+                            city = "South San Francisco"
+                        )
+                    )
+                )
+            ),
+        )
+
+        val launch = fakeExternalPaymentMethodLauncher.calls.awaitItem()
+
+        assertThat(launch).isEqualTo(
+            FakeExternalPaymentMethodLauncher.Launch(
+                input = ExternalPaymentMethodInput(
+                    type = "paypal",
+                    billingDetails = PaymentMethod.BillingDetails(
+                        name = "John Doe",
+                        address = Address(
+                            city = "South San Francisco",
+                        ),
+                    ),
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `On external PM with no confirm handler, should return failed result`() = runTest {
+        ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler = null
+
+        val intentConfirmationHandler = createIntentConfirmationHandler(
+            shouldRegister = false,
+        )
+
+        intentConfirmationHandler.start(
+            arguments = DEFAULT_ARGUMENTS.copy(
+                paymentSelection = EXTERNAL_PAYMENT_METHOD,
+            ),
+        )
+
+        val intentResult = intentConfirmationHandler.awaitIntentResult().asFailed()
+
+        assertThat(intentResult.cause.message).isEqualTo(
+            "externalPaymentMethodConfirmHandler is null. Cannot process payment for payment selection: paypal"
+        )
+        assertThat(intentResult.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
+        assertThat(intentResult.type).isEqualTo(IntentConfirmationHandler.ErrorType.ExternalPaymentMethod)
+    }
+
+    @Test
+    fun `On external PM with no launcher, should return failed result`() = runTest {
+        ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler = EXTERNAL_PAYMENT_METHOD_CONFIRM_HANDLER
+
+        val intentConfirmationHandler = createIntentConfirmationHandler(
+            shouldRegister = false,
+        )
+
+        intentConfirmationHandler.start(
+            arguments = DEFAULT_ARGUMENTS.copy(
+                paymentSelection = EXTERNAL_PAYMENT_METHOD,
+            ),
+        )
+
+        val intentResult = intentConfirmationHandler.awaitIntentResult().asFailed()
+
+        assertThat(intentResult.cause.message).isEqualTo(
+            "externalPaymentMethodLauncher is null. Cannot process payment for payment selection: paypal"
+        )
+        assertThat(intentResult.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
+        assertThat(intentResult.type).isEqualTo(IntentConfirmationHandler.ErrorType.ExternalPaymentMethod)
+    }
+
+    @Test
+    fun `On external PM succeeded result, should return intent succeeded result`() = runTest {
+        ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler = EXTERNAL_PAYMENT_METHOD_CONFIRM_HANDLER
+
+        val intentConfirmationHandler = createIntentConfirmationHandler()
+
+        val epmCallback = intentConfirmationHandler.registerAndRetrieveExternalPaymentMethodCallback()
+
+        intentConfirmationHandler.start(
+            arguments = DEFAULT_ARGUMENTS.copy(
+                paymentSelection = EXTERNAL_PAYMENT_METHOD,
+            ),
+        )
+
+        epmCallback(PaymentResult.Completed)
+
+        val intentResult = intentConfirmationHandler.awaitIntentResult()
+
+        assertThat(intentResult).isEqualTo(
+            IntentConfirmationHandler.Result.Succeeded(
+                intent = DEFAULT_ARGUMENTS.intent,
+                deferredIntentConfirmationType = null,
+            )
+        )
+    }
+
+    @Test
+    fun `On external PM failed result, should return intent failed result`() = runTest {
+        ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler = EXTERNAL_PAYMENT_METHOD_CONFIRM_HANDLER
+
+        val intentConfirmationHandler = createIntentConfirmationHandler()
+
+        val epmCallback = intentConfirmationHandler.registerAndRetrieveExternalPaymentMethodCallback()
+
+        intentConfirmationHandler.start(
+            arguments = DEFAULT_ARGUMENTS.copy(
+                paymentSelection = EXTERNAL_PAYMENT_METHOD,
+            ),
+        )
+
+        val exception = APIException()
+
+        epmCallback(PaymentResult.Failed(exception))
+
+        val intentResult = intentConfirmationHandler.awaitIntentResult()
+
+        assertThat(intentResult).isEqualTo(
+            IntentConfirmationHandler.Result.Failed(
+                cause = exception,
+                message = R.string.stripe_something_went_wrong.resolvableString,
+                type = IntentConfirmationHandler.ErrorType.ExternalPaymentMethod,
+            )
+        )
+    }
+
+    @Test
+    fun `On external PM canceled result, should return intent canceled result`() = runTest {
+        ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler = EXTERNAL_PAYMENT_METHOD_CONFIRM_HANDLER
+
+        val intentConfirmationHandler = createIntentConfirmationHandler()
+
+        val epmCallback = intentConfirmationHandler.registerAndRetrieveExternalPaymentMethodCallback()
+
+        intentConfirmationHandler.start(
+            arguments = DEFAULT_ARGUMENTS.copy(
+                paymentSelection = EXTERNAL_PAYMENT_METHOD,
+            ),
+        )
+
+        epmCallback(PaymentResult.Canceled)
+
+        val intentResult = intentConfirmationHandler.awaitIntentResult()
+
+        assertThat(intentResult).isEqualTo(IntentConfirmationHandler.Result.Canceled)
+    }
+
     private fun createIntentConfirmationHandler(
         intentConfirmationInterceptor: IntentConfirmationInterceptor = FakeIntentConfirmationInterceptor(),
         paymentLauncher: PaymentLauncher = FakePaymentLauncher(),
@@ -629,6 +798,7 @@ class IntentConfirmationHandlerTest {
             paymentLauncherFactory = { paymentLauncher },
             context = ApplicationProvider.getApplicationContext(),
             coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+            errorReporter = FakeErrorReporter(),
             savedStateHandle = savedStateHandle
         ).apply {
             if (shouldRegister) {
@@ -668,6 +838,43 @@ class IntentConfirmationHandlerTest {
         }
     }
 
+    private fun IntentConfirmationHandler.setExternalPaymentMethodLauncher(
+        launcher: ActivityResultLauncher<ExternalPaymentMethodInput>
+    ) {
+        register(
+            activityResultCaller = mock {
+                on {
+                    registerForActivityResult<ExternalPaymentMethodInput, PaymentResult>(
+                        any(),
+                        any()
+                    )
+                } doReturn launcher
+            },
+            lifecycleOwner = TestLifecycleOwner(),
+        )
+    }
+
+    private fun IntentConfirmationHandler.registerAndRetrieveExternalPaymentMethodCallback():
+        (result: PaymentResult) -> Unit {
+        val argumentCaptor = argumentCaptor<ActivityResultCallback<PaymentResult>>()
+
+        register(
+            activityResultCaller = mock {
+                on {
+                    registerForActivityResult<ExternalPaymentMethodInput, PaymentResult>(
+                        any(),
+                        argumentCaptor.capture()
+                    )
+                } doReturn mock()
+            },
+            lifecycleOwner = TestLifecycleOwner(),
+        )
+
+        return {
+            argumentCaptor.secondValue.onActivityResult(it)
+        }
+    }
+
     private fun IntentConfirmationHandler.Result?.asFailed(): IntentConfirmationHandler.Result.Failed {
         return this as IntentConfirmationHandler.Result.Failed
     }
@@ -679,5 +886,18 @@ class IntentConfirmationHandlerTest {
             intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
             paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
         )
+
+        val EXTERNAL_PAYMENT_METHOD = PaymentSelection.ExternalPaymentMethod(
+            type = "paypal",
+            label = "Paypal".resolvableString,
+            iconResource = 0,
+            darkThemeIconUrl = null,
+            lightThemeIconUrl = null,
+            billingDetails = null
+        )
+
+        val EXTERNAL_PAYMENT_METHOD_CONFIRM_HANDLER = ExternalPaymentMethodConfirmHandler { _, _ ->
+            // Do nothing since we aren't testing full EPM flow
+        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
@@ -896,8 +896,15 @@ class IntentConfirmationHandlerTest {
             billingDetails = null
         )
 
+        /**
+         * The external payment method confirm handler is not used in [ExternalPaymentMethodInterceptor] which is
+         * not tested here but is instead meant to be used in the launched activity the interceptor attempts to launch.
+         * Since we only care that [IntentConfirmationHandler] is actually attempting to launch the EPM handler as well
+         * as its interactions, we don't do anything here except for using the handler to validate that we can launch
+         * the EPM handler.
+         */
         val EXTERNAL_PAYMENT_METHOD_CONFIRM_HANDLER = ExternalPaymentMethodConfirmHandler { _, _ ->
-            // Do nothing since we aren't testing full EPM flow
+            // Do nothing
         }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -1107,9 +1107,9 @@ internal class PaymentSheetActivityTest {
                     paymentConfigurationProvider = { PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY) },
                     statusBarColor = { args.statusBarColor },
                     application = application,
+                    errorReporter = FakeErrorReporter(),
                 ),
                 editInteractorFactory = FakeEditPaymentMethodInteractor.Factory,
-                errorReporter = FakeErrorReporter(),
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -2807,9 +2807,9 @@ internal class PaymentSheetViewModelTest {
                     paymentConfigurationProvider = { paymentConfiguration },
                     statusBarColor = { args.statusBarColor },
                     application = application,
+                    errorReporter = FakeErrorReporter()
                 ),
                 editInteractorFactory = fakeEditPaymentMethodInteractorFactory,
-                errorReporter = FakeErrorReporter(),
             ).apply {
                 if (shouldRegister) {
                     val activityResultCaller = mock<ActivityResultCaller> {

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeExternalPaymentMethodLauncher.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeExternalPaymentMethodLauncher.kt
@@ -1,0 +1,29 @@
+package com.stripe.android.utils
+
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.app.ActivityOptionsCompat
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
+import com.stripe.android.paymentsheet.ExternalPaymentMethodInput
+
+internal class FakeExternalPaymentMethodLauncher : ActivityResultLauncher<ExternalPaymentMethodInput>() {
+    private val _calls = Turbine<Launch>()
+    val calls: ReceiveTurbine<Launch> = _calls
+
+    override fun launch(input: ExternalPaymentMethodInput?, options: ActivityOptionsCompat?) {
+        _calls.add(Launch(input))
+    }
+
+    override fun unregister() {
+        throw NotImplementedError("Not used in testing!")
+    }
+
+    override fun getContract(): ActivityResultContract<ExternalPaymentMethodInput, *> {
+        throw NotImplementedError("Not used in testing!")
+    }
+
+    data class Launch(
+        val input: ExternalPaymentMethodInput?,
+    )
+}


### PR DESCRIPTION
# Summary
Move `ExternalPaymentMethod` handling to `IntentConfirmationHandler`

# Motivation
Moves duplicated code from `PaymentSheet` & `FlowController` to a isolated location.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Video
https://github.com/user-attachments/assets/96c9f0ab-8e26-48ff-92b0-28967bb645c2