### PR TITLE
Use `FakeResultHandler` in tests for `IntentConfirmationHandler`

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeResultHandler.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeResultHandler.kt
@@ -1,0 +1,13 @@
+package com.stripe.android.utils
+
+class FakeResultHandler<T> {
+    private var callback: ((T) -> Unit)? = null
+
+    fun register(callback: (T) -> Unit) {
+        this.callback = callback
+    }
+
+    fun onResult(result: T) {
+        callback?.invoke(result)
+    }
+}


### PR DESCRIPTION
# Summary
Use `FakeResultHandler` in tests for `IntentConfirmationHandler`

# Motivation
Makes tests easier to read for `IntentConfirmationHandler`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified