### PR TITLE
Fix process death handling for pre-confirmation steps in `IntentConfirmationHandler`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -65,12 +65,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Provider
-import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalCvcRecollectionApi::class)
 @FlowControllerScope
@@ -198,11 +196,9 @@ internal class DefaultFlowController @Inject internal constructor(
         )
 
         viewModelScope.launch {
-            val result = withTimeoutOrNull(1.seconds) {
-                intentConfirmationHandler.awaitIntentResult()
-            }
+            val result = intentConfirmationHandler.awaitIntentResult()
 
-            if (result != null) {
+            result?.let {
                 onIntentResult(result)
             }
         }


### PR DESCRIPTION
# Summary
Fix process death handling for pre-confirmation steps in `IntentConfirmationHandler`

# Motivation
Allows users to successfully pay with `Bacs` after process death if they are still in the mandate screen when process death occurs.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Video
https://github.com/user-attachments/assets/c52c5459-744c-4ca9-8ff9-78057b779fb9