### PR TITLE
Fix crash when switching from US to CA in country drop down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### PaymentSheet
 * [FIXED][8825](https://github.com/stripe/stripe-android/pull/8825) Fixed an issue the amount in the buy button in `PaymentSheet` did not formatted with set per-application locale.
+* [FIXED][8928](https://github.com/stripe/stripe-android/pull/8928) Fixed an issue in where changing country from the US to Canada would crash if certain states were selected.
 
 ## 20.48.1 - 2024-07-15
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldUI.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.dp
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.utils.collectAsState
+import com.stripe.android.uicore.utils.mapAsStateFlow
 
 @Preview
 @Composable
@@ -91,7 +92,9 @@ fun DropDown(
     val shouldEnable = enabled && !shouldDisableDropdownWithSingleItem
 
     var expanded by remember { mutableStateOf(false) }
-    val selectedItemLabel = controller.getSelectedItemLabel(selectedIndex)
+    val selectedItemLabel by controller.selectedIndex.mapAsStateFlow {
+        controller.getSelectedItemLabel(selectedIndex)
+    }.collectAsState()
     val interactionSource = remember { MutableInteractionSource() }
     val currentTextColor = if (shouldEnable) {
         MaterialTheme.stripeColors.onComponent


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fix crash when switching from US to CA in country drop down

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fixes a bug

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

See section below for manual testing. 

# Screen recording
Before:

https://github.com/user-attachments/assets/a6a2d00a-6980-4e3d-8c00-c4696f02238d


After:


https://github.com/user-attachments/assets/de4a3587-a8a8-4d64-906e-80acf328d976



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
* [FIXED][8928](https://github.com/stripe/stripe-android/pull/8928) Fixed an issue in where changing country from the US to Canada would crash if certain states were selected.