### PR TITLE
Introduce `IntentConfirmationHandler.State` into `IntentConfirmationHandler`

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -638,6 +638,7 @@ internal class PlaygroundTestDriver(
 
         pressBuy()
 
+        button.waitForEnabled()
         button.click()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -797,9 +797,10 @@ internal class PaymentSheetActivityTest {
                 .onNodeWithText(errorMessage)
                 .assertDoesNotExist()
 
-            viewModel.checkoutIdentifier = CheckoutIdentifier.SheetTopWallet
-            viewModel.viewState.value =
-                PaymentSheetViewState.Reset(PaymentSheetViewState.UserErrorMessage(errorMessage.resolvableString))
+            fakeIntentConfirmationInterceptor.enqueueFailureStep(
+                IllegalStateException(errorMessage),
+                errorMessage
+            )
 
             composeTestRule
                 .onNodeWithText(errorMessage)


### PR DESCRIPTION
# Summary
This PR introduced a new `IntentConfirmationHandler.State` type which is used to declare the state of `IntentConfirmationHandler` through a `state` field with an observable `StateFlow` type.

# Motivation
`awaitIntentResult` works if you only care for what about the start and the end of the confirmation process. It does not work well if you need to know information about what is going in the middle of the confirmation process. With `Google Pay` for example, we hide the `PaymentSheet` content while the Google Pay sheet is shown and re-show it when it is visible again. `PaymentSheet` also cares about what about what payment option was used in order to decide whether to show a full-screen loading state (for Google Pay & Link web flow) or a primary button loading state (for all other LPM types). We can expose this information much more easily with a `StateFlow` and `State` rather than require the implementor to decide how it works. A side bonus is that we can potentially combine this at the top-level for building the overall `Sheet` states for `PaymentSheet` and `FlowController`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified