### PR TITLE
Move async helper to common & use in `CustomerSheetLoader`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/coroutines/CoroutinesKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/coroutines/CoroutinesKtx.kt
@@ -1,0 +1,35 @@
+package com.stripe.android.common.coroutines
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+
+/*
+ * This is a helper for catching thrown exceptions from 'async' calls within a suspendable function.
+ *
+ * If a 'runCatching' task wraps a task with 'async' calls, any 'async' failures are not caught by 'runCatching'
+ * but instead by the coroutine, causing the whole coroutine scope to fail and close which propagates the uncaught
+ * exception to the caller. This is counter-intuitive to the idea of catching all exceptions that occur from a
+ * task.
+ *
+ * This function instead launches inside one coroutine scope a 'runCatching' call that creates its own coroutine
+ * scope to launch the task in. If the inner coroutine scope fails and throws an exception, the 'runCatching' call
+ * will be able to catch the exception and return a 'Result' type to the caller rather than throw an exception to
+ * it. If a failure occurs, we can also run the 'onFailure' logic inside the outer work coroutine rather than the
+ * caller's coroutine.
+ */
+internal suspend fun <T> CoroutineContext.runCatching(
+    onFailure: ((error: Throwable) -> Unit)? = null,
+    task: suspend CoroutineScope.() -> T
+): Result<T> {
+    return withContext(this) {
+        runCatching {
+            coroutineScope {
+                task()
+            }
+        }.onFailure {
+            onFailure?.invoke(it)
+        }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 import org.junit.Before
@@ -37,6 +38,7 @@ import org.junit.Test
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.milliseconds
 
 @Suppress("LargeClass")
@@ -566,6 +568,7 @@ class DefaultCustomerSheetLoaderTest {
             lpmRepository = lpmRepository,
             isFinancialConnectionsAvailable = { false },
             errorReporter = FakeErrorReporter(),
+            workContext = coroutineContext,
         )
 
         val completable = CompletableDeferred<Unit>()
@@ -603,6 +606,7 @@ class DefaultCustomerSheetLoaderTest {
             lpmRepository = lpmRepository,
             isFinancialConnectionsAvailable = { false },
             errorReporter = FakeErrorReporter(),
+            workContext = coroutineContext,
         )
 
         val result = loader.load(configuration)
@@ -722,6 +726,7 @@ class DefaultCustomerSheetLoaderTest {
         ),
         lpmRepository: LpmRepository = this.lpmRepository,
         errorReporter: ErrorReporter = FakeErrorReporter(),
+        workContext: CoroutineContext = UnconfinedTestDispatcher()
     ): CustomerSheetLoader {
         return DefaultCustomerSheetLoader(
             isLiveModeProvider = isLiveModeProvider,
@@ -733,6 +738,7 @@ class DefaultCustomerSheetLoaderTest {
             isFinancialConnectionsAvailable = isFinancialConnectionsAvailable,
             customerAdapterProvider = customerAdapterProvider,
             errorReporter = errorReporter,
+            workContext = workContext,
         )
     }
 


### PR DESCRIPTION
# Summary
Move async helper to common & use in `CustomerSheetLoader`

# Motivation
Cleans up code in `CustomerSheetLoader`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified