### PR TITLE
Handle navigating to RUX when clicking manual entry CTA on consent


### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentState.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentState.kt
@@ -30,4 +30,5 @@ internal enum class ConsentClickableText(val value: String) {
     DATA("stripe://data-access-notice"),
     LEGAL_DETAILS("stripe://legal-details-notice"),
     MANUAL_ENTRY("stripe://manual-entry"),
+    LINK_LOGIN_WARMUP("stripe://link-login"),
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentViewModel.kt
@@ -120,6 +120,10 @@ internal class ConsentViewModel @AssistedInject constructor(
                 ConsentClickableText.MANUAL_ENTRY.value to {
                     navigationManager.tryNavigateTo(Destination.ManualEntry(referrer = Pane.CONSENT))
                 },
+                // Clicked on the "Manual entry" link on NME flows -> Navigate to the Link Login Warmup screen
+                ConsentClickableText.LINK_LOGIN_WARMUP.value to {
+                    navigationManager.tryNavigateTo(Destination.NetworkingLinkLoginWarmup(referrer = Pane.CONSENT))
+                },
             )
         )
     }


### PR DESCRIPTION
# Summary
- Handles link login navigation from manual entry CTA.
- No impact on prod (this is fflag based)

https://github.com/user-attachments/assets/8260ae84-a1ce-4ed4-9ede-6bcf11b31d62


# Motivation
:notebook_with_decorative_cover: &nbsp;**[Android] Handle navigating to RUX when clicking manual entry CTA on consent**
:globe_with_meridians: &nbsp;[BANKCON-11417](https://jira.corp.stripe.com/browse/BANKCON-11417)

> See this PR: 
>
> [Prompt Networking RUX when clicking the manual entry button as an NME eligible return user](https://git.corp.stripe.com/stripe-internal/pay-server/pull/848671)
>
> See also: <https://git.corp.stripe.com/stripe-internal/stripe-js-v3/pull/23020>
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->