### PR TITLE
Update dry run verification steps for new release script

### DIFF
--- a/scripts/deploy/create_github_release.rb
+++ b/scripts/deploy/create_github_release.rb
@@ -26,6 +26,12 @@ def create_github_release
 
         rputs "Created new release"
         open_url(release_response.html_url)
+
+        if (@is_dry_run)
+            rputs "Please verify that the release was opened + created properly. It should contain a changelog of the changes for this release."
+            rputs "Since this is a dry run, you should see the release as a draft. It will be missing a tag + source code attachments."
+            wait_for_user
+        end
     rescue
         delete_release_tag
     end

--- a/scripts/deploy/deploy.rb
+++ b/scripts/deploy/deploy.rb
@@ -78,13 +78,7 @@ steps = [
 execute_steps(steps, @step_index)
 
 if (@is_dry_run)
-    rputs "Please verify that the dry run worked as expected.
-
-    You should see a PR opened that bumps version numbers in the stripe-android codebase on branch release/<new release number>.
-
-    You should also see a draft release opened in the stripe-android repo which includes a changelog and example app apk for the new version. It's expected that the draft release will be missing a version tag and source code zip files.
-
-    When you're done, press enter to revert all changes."
+    rputs "Press enter to revert all changes made during the dry run."
     wait_for_user()
 
     delete_github_release()

--- a/scripts/deploy/update_dokka.rb
+++ b/scripts/deploy/update_dokka.rb
@@ -23,11 +23,17 @@ def generate_dokka()
     begin
         execute_or_fail("git push -u origin")
 
+        if (@is_dry_run)
+            user_message = "Verify that a draft PR was opened containing only docs updates."
+        else
+            user_message = "Send the dokka PR for review and enable auto-merge. Then, continue with the next steps."
+        end
+
         create_pr(
             dokka_branch_name,
             dokka_change_description,
             dokka_change_description,
-            "Send the dokka PR for review and enable auto-merge. Then, continue with the next steps."
+            user_message
         )
     rescue
         revert_dokka_changes

--- a/scripts/deploy/version_bump_pr_steps.rb
+++ b/scripts/deploy/version_bump_pr_steps.rb
@@ -40,12 +40,17 @@ def create_version_bump_pr()
 
 
     pr_description = create_pr_description()
+    if (@is_dry_run)
+        user_message = "Verify that a draft PR containing version number bumps was opened. If this was a real release, you would need to wait for this PR to merge before continuing."
+    else
+        user_message = "Verify that a PR containing version number bumps was opened. Merge this PR before continuing to the next steps."
+    end
 
     create_pr(
          release_branch,
          "Bump version to #{@version}",
          pr_description,
-         "Merge the version bump PR"
+         user_message
     )
 end
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update dry run verification steps for new release script.

There's now messages on how to verify throughout the release script instead of all at the end.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Previously, I was adding info on how to verify that a dry run worked correctly to the end of the script. This had a couple downsides:
- As I added new steps, I would forget to add verification info to the end
- It makes it harder for the person doing the dry run to verify everything. 
- It takes longer to catch issues with the dry run.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Re-ran the script and verified that the messages (and everything else) worked correctly.
