### PR TITLE
Fix process death for external payment methods

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationHandler.kt
@@ -284,6 +284,12 @@ internal class IntentConfirmationHandler(
     private fun confirmExternalPaymentMethod(
         paymentSelection: PaymentSelection.ExternalPaymentMethod
     ) {
+        /*
+         * In case of process death, we should store that we waiting for a payment result to return from a
+         * payment confirmation activity
+         */
+        storeIsAwaitingForPaymentResult()
+
         ExternalPaymentMethodInterceptor.intercept(
             externalPaymentMethodType = paymentSelection.type,
             billingDetails = paymentSelection.billingDetails,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
@@ -562,6 +562,29 @@ class IntentConfirmationHandlerTest {
     }
 
     @Test
+    fun `On launch EPMs handler, should store 'AwaitingPaymentResult' in 'SavedStateHandle'`() = runTest {
+        ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler = EXTERNAL_PAYMENT_METHOD_CONFIRM_HANDLER
+
+        val savedStateHandle = SavedStateHandle()
+        val interceptor = FakeIntentConfirmationInterceptor().apply {
+            enqueueNextActionStep("pi_123")
+        }
+
+        val intentConfirmationHandler = createIntentConfirmationHandler(
+            intentConfirmationInterceptor = interceptor,
+            savedStateHandle = savedStateHandle,
+        )
+
+        intentConfirmationHandler.start(
+            arguments = DEFAULT_ARGUMENTS.copy(
+                paymentSelection = EXTERNAL_PAYMENT_METHOD
+            ),
+        )
+
+        assertThat(savedStateHandle.get<Boolean>("AwaitingPaymentResult")).isTrue()
+    }
+
+    @Test
     fun `On start Bacs mandate, should store 'AwaitingPreConfirmResult' in 'SavedStateHandle'`() = runTest {
         val savedStateHandle = SavedStateHandle()
 


### PR DESCRIPTION
# Summary
Fix process death for external payment methods

# Motivation
Allows users to be properly notified of EPM payments in `PaymentSheet` & `FlowController`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Video
https://github.com/user-attachments/assets/a972f582-6ebd-43e2-8594-09395eaaae3c