### PR TITLE
Consolidate version bump steps in release script

### DIFF
--- a/scripts/deploy/create_github_release.rb
+++ b/scripts/deploy/create_github_release.rb
@@ -99,7 +99,7 @@ private def changelog_entries_for_version
         return changelog_contents[start_pos...end_pos].strip
     end
 
-    raise ArgumentError.new("version #{@version} not found in changelog")
+    raise ArgumentError.new("Version #{@version} not found in changelog. Have you finished merging the version bump PR?")
 end
 
 private def build_example_release_apk

--- a/scripts/deploy/deploy.rb
+++ b/scripts/deploy/deploy.rb
@@ -60,13 +60,8 @@ steps = [
     method(:validate_version_number),
     method(:ensure_clean_repo),
     method(:pull_latest),
-    method(:switch_to_release_branch),
 
     # Update version number
-    method(:update_read_me),
-    method(:update_stripe_sdk_version),
-    method(:update_gradle_properties),
-    method(:update_changelog),
     method(:create_version_bump_pr),
 
     method(:create_github_release),

--- a/scripts/deploy/version_bump_pr_steps.rb
+++ b/scripts/deploy/version_bump_pr_steps.rb
@@ -28,25 +28,35 @@ def revert_version_bump_changes()
 end
 
 def create_version_bump_pr()
+    switch_to_release_branch()
+    update_read_me()
+    update_stripe_sdk_version()
+    update_gradle_properties()
+    update_changelog()
+    execute_or_fail("git commit -m \"Bump version to #{@version}\"")
+
     begin
-        execute_or_fail("git commit -m \"Bump version to #{@version}\"")
         execute_or_fail("git push -u origin")
+
+        pr_description = create_pr_description()
+
+        create_pr(
+             release_branch,
+             "Bump version to #{@version}",
+             pr_description,
+             "Merge the version bump PR"
+        )
     rescue
-        # Undo all of the above if any of the steps fail.
-        execute("git reset HEAD~")
-        # Don't continue if any of the above failed.
+        revert_version_bump_changes()
+        execute("git checkout #{@deploy_branch}")
         raise
     end
 
-
-    pr_description = create_pr_description()
-
-    create_pr(
-         release_branch,
-         "Bump version to #{@version}",
-         pr_description,
-         "Merge the version bump PR"
-    )
+    # If this is a dry run, we need to stay on the release/ branch to do a github release. This is
+    # because the github release depends on the changes we made to the CHANGELOG.
+    if (!@is_dry_run)
+        execute_or_fail("git checkout #{@deploy_branch}")
+    end
 end
 
 private def release_branch


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Consolidate version bump steps in release script

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
You should be able to restart any step in the release script if it fails. Before this change, the `create_version_bump_pr` step didn't actually work this way -- if you committed and then creating the PR failed, you couldn't just rerun the step (there was nothing to commit). This fixes that.

It also is more consistent with the granularity and failure handling of the other steps. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Re-ran the script, confirmed it worked. Also forced a couple failures and confirm restarting worked. 
