### PR TITLE
Do not preselect accounts with drawer on selection on LinkAccountPicker.

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
@@ -94,7 +94,10 @@ internal class LinkAccountPickerViewModel @AssistedInject constructor(
             // When accounts load, preselect the first selectable account
             val selectedAccountIds = listOfNotNull(
                 accounts
-                    .firstOrNull { account -> account.display.allowSelection }
+                    .firstOrNull { account ->
+                        account.display.allowSelection &&
+                            account.display.drawerOnSelection == null
+                    }
                     ?.account?.id
             )
 


### PR DESCRIPTION
# Summary
Do not preselect accounts with drawer on selection on LinkAccountPicker.

A follow-up backend PR resorting accounts so that those with drawer are below the real selectable ones is coming.

<img width="381" alt="image" src="https://github.com/user-attachments/assets/3533cc0d-1c9f-496b-89c6-a7daaffb4147">

# Motivation

https://jira.corp.stripe.com/browse/BANKCON-11709

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
