### PR TITLE
Perform intent confirmation work in `DefaultFlowController` in a work context.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
+import com.stripe.android.core.injection.IOContext
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
@@ -65,10 +66,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Provider
+import kotlin.coroutines.CoroutineContext
 
 @OptIn(ExperimentalCvcRecollectionApi::class)
 @FlowControllerScope
@@ -103,6 +106,7 @@ internal class DefaultFlowController @Inject internal constructor(
     intentConfirmationInterceptor: IntentConfirmationInterceptor,
     private val errorReporter: ErrorReporter,
     @InitializedViaCompose private val initializedViaCompose: Boolean,
+    @IOContext workContext: CoroutineContext,
 ) : PaymentSheet.FlowController {
     private val paymentOptionActivityLauncher: ActivityResultLauncher<PaymentOptionContract.Args>
     private val googlePayActivityLauncher:
@@ -125,7 +129,7 @@ internal class DefaultFlowController @Inject internal constructor(
         stripePaymentLauncherAssistedFactory = paymentLauncherFactory,
         errorReporter = errorReporter,
         application = application,
-    ).create(viewModelScope)
+    ).create(viewModelScope.plus(workContext))
 
     private val initializationMode: PaymentSheet.InitializationMode?
         get() = viewModel.previousConfigureRequest?.initializationMode

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -2210,6 +2210,7 @@ internal class DefaultFlowControllerTest {
         cvcRecollectionLauncherFactory = cvcRecollectionLauncherFactory,
         application = ApplicationProvider.getApplicationContext(),
         initializedViaCompose = false,
+        workContext = testScope.coroutineContext,
     )
 
     private fun createViewModel(): FlowControllerViewModel {


### PR DESCRIPTION
# Summary
Perform intent confirmation work in `DefaultFlowController` in a work context.

# Motivation
Keeps any IO work that `DefaultFlowController` does off of the `viewModelScope`'s main context.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
