### PR TITLE
Add intent type to load succeeded analytic event

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -56,6 +56,7 @@ internal class DefaultEventReporter @Inject internal constructor(
         linkEnabled: Boolean,
         googlePaySupported: Boolean,
         currency: String?,
+        initializationMode: PaymentSheet.InitializationMode,
     ) {
         this.currency = currency
         this.linkEnabled = linkEnabled
@@ -72,6 +73,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
+                initializationMode = initializationMode,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -31,6 +31,7 @@ internal interface EventReporter {
         linkEnabled: Boolean,
         googlePaySupported: Boolean,
         currency: String?,
+        initializationMode: PaymentSheet.InitializationMode,
     )
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -36,6 +36,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
     class LoadSucceeded(
         paymentSelection: PaymentSelection?,
+        initializationMode: PaymentSheet.InitializationMode,
         duration: Duration?,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
@@ -45,6 +46,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         override val additionalParams: Map<String, Any?> = mapOf(
             FIELD_DURATION to duration?.asSeconds,
             FIELD_SELECTED_LPM to paymentSelection.defaultAnalyticsValue,
+            FIELD_INTENT_TYPE to initializationMode.defaultAnalyticsValue,
         )
 
         private val PaymentSelection?.defaultAnalyticsValue: String
@@ -53,6 +55,18 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
                 is PaymentSelection.Link -> "link"
                 is PaymentSelection.Saved -> paymentMethod.type?.code ?: "saved"
                 else -> "none"
+            }
+
+        private val PaymentSheet.InitializationMode.defaultAnalyticsValue: String
+            get() = when (this) {
+                is PaymentSheet.InitializationMode.DeferredIntent -> {
+                    when (this.intentConfiguration.mode) {
+                        is PaymentSheet.IntentConfiguration.Mode.Payment -> "deferred_payment_intent"
+                        is PaymentSheet.IntentConfiguration.Mode.Setup -> "deferred_setup_intent"
+                    }
+                }
+                is PaymentSheet.InitializationMode.PaymentIntent -> "payment_intent"
+                is PaymentSheet.InitializationMode.SetupIntent -> "setup_intent"
             }
     }
 
@@ -465,6 +479,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_LINK_CONTEXT = "link_context"
         const val FIELD_EXTERNAL_PAYMENT_METHODS = "external_payment_methods"
         const val FIELD_COMPOSE = "compose"
+        const val FIELD_INTENT_TYPE = "intent_type"
 
         const val VALUE_EDIT_CBC_EVENT_SOURCE = "edit"
         const val VALUE_ADD_CBC_EVENT_SOURCE = "add"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -157,6 +157,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             state = state,
             isReloadingAfterProcessDeath = isReloadingAfterProcessDeath,
             isGooglePaySupported = isGooglePaySupported(),
+            initializationMode = initializationMode,
         )
 
         return@withContextCatching state
@@ -512,6 +513,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         state: PaymentSheetState.Full,
         isReloadingAfterProcessDeath: Boolean,
         isGooglePaySupported: Boolean,
+        initializationMode: PaymentSheet.InitializationMode,
     ) {
         elementsSession.sessionsError?.let { sessionsError ->
             eventReporter.onElementsSessionLoadFailed(sessionsError)
@@ -527,6 +529,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
                 googlePaySupported = isGooglePaySupported,
                 currency = elementsSession.stripeIntent.currency,
                 paymentSelection = state.paymentSelection,
+                initializationMode = initializationMode,
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -683,6 +683,9 @@ class DefaultEventReporterTest {
         linkEnabled: Boolean = true,
         googlePayReady: Boolean = true,
         currency: String? = "usd",
+        initializationMode: PaymentSheet.InitializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+            clientSecret = "cs_example"
+        ),
     ) {
         onInit(configuration, isDeferred = false)
         onLoadStarted(initializedViaCompose = false)
@@ -690,7 +693,8 @@ class DefaultEventReporterTest {
             paymentSelection = paymentSelection,
             googlePaySupported = googlePayReady,
             linkEnabled = linkEnabled,
-            currency = currency
+            currency = currency,
+            initializationMode = initializationMode,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -804,9 +804,10 @@ internal class DefaultPaymentSheetLoaderTest {
     @Test
     fun `Emits correct events when loading succeeds for non-deferred intent`() = runTest {
         val loader = createPaymentSheetLoader()
+        val initializationMode = PaymentSheet.InitializationMode.PaymentIntent("secret")
 
         loader.load(
-            initializationMode = PaymentSheet.InitializationMode.PaymentIntent("secret"),
+            initializationMode = initializationMode,
             paymentSheetConfiguration = PaymentSheet.Configuration(
                 merchantDisplayName = "Some Name",
                 customer = PaymentSheet.CustomerConfiguration(
@@ -825,6 +826,7 @@ internal class DefaultPaymentSheetLoaderTest {
             linkEnabled = true,
             googlePaySupported = true,
             currency = "usd",
+            initializationMode = initializationMode,
         )
     }
 
@@ -854,16 +856,17 @@ internal class DefaultPaymentSheetLoaderTest {
     @Test
     fun `Emits correct events when loading succeeds for deferred intent`() = runTest {
         val loader = createPaymentSheetLoader()
-
-        loader.load(
-            initializationMode = PaymentSheet.InitializationMode.DeferredIntent(
-                intentConfiguration = PaymentSheet.IntentConfiguration(
-                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(
-                        amount = 1234,
-                        currency = "cad",
-                    ),
+        val initializationMode = PaymentSheet.InitializationMode.DeferredIntent(
+            intentConfiguration = PaymentSheet.IntentConfiguration(
+                mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                    amount = 1234,
+                    currency = "cad",
                 ),
             ),
+        )
+
+        loader.load(
+            initializationMode = initializationMode,
             paymentSheetConfiguration = PaymentSheet.Configuration("Some Name"),
             initializedViaCompose = true,
         )
@@ -874,6 +877,7 @@ internal class DefaultPaymentSheetLoaderTest {
             linkEnabled = true,
             googlePaySupported = true,
             currency = "usd",
+            initializationMode = initializationMode,
         )
     }
 
@@ -1649,9 +1653,10 @@ internal class DefaultPaymentSheetLoaderTest {
         prefsRepository.savePaymentSelection(paymentSelection)
 
         val loader = createPaymentSheetLoader()
+        val initializationMode = PaymentSheet.InitializationMode.PaymentIntent("secret")
 
         loader.load(
-            initializationMode = PaymentSheet.InitializationMode.PaymentIntent("secret"),
+            initializationMode = initializationMode,
             paymentSheetConfiguration = PaymentSheet.Configuration(
                 merchantDisplayName = "Some Name",
                 customer = PaymentSheet.CustomerConfiguration(
@@ -1668,6 +1673,7 @@ internal class DefaultPaymentSheetLoaderTest {
             linkEnabled = true,
             googlePaySupported = true,
             currency = "usd",
+            initializationMode = initializationMode,
         )
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add intent type to load succeeded analytic event

Matches iOS analytic added here: https://github.com/stripe/stripe-ios/pull/3693

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3320

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified