### PR TITLE
Replace `PaymentSelection` with `PaymentConfirmationOption` in payment confirmation.

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -326,6 +326,30 @@ public final class com/stripe/android/paymentsheet/IntentConfirmationHandler$Arg
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$ExternalPaymentMethod$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$ExternalPaymentMethod;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$ExternalPaymentMethod;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$New$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$New;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$New;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$Saved$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$Saved;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$Saved;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public abstract interface class com/stripe/android/paymentsheet/PaymentOptionCallback {
 	public abstract fun onPaymentOption (Lcom/stripe/android/paymentsheet/model/PaymentOption;)V
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -47,6 +47,7 @@ import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
+import com.stripe.android.paymentsheet.toPaymentConfirmationOption
 import com.stripe.android.paymentsheet.ui.EditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.ui.ModifiableEditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.ui.PaymentMethodRemovalDelayMillis
@@ -905,7 +906,7 @@ internal class CustomerSheetViewModel(
                     clientSecret = clientSecret
                 ),
                 intent = stripeIntent,
-                paymentSelection = selection,
+                confirmationOption = selection.toPaymentConfirmationOption(),
                 shippingDetails = null,
                 appearance = configuration.appearance,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationOption.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.paymentsheet
+
+import android.os.Parcelable
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodOptionsParams
+import kotlinx.parcelize.Parcelize
+
+internal sealed interface PaymentConfirmationOption : Parcelable {
+    @Parcelize
+    data class Saved(
+        val paymentMethod: PaymentMethod,
+        val optionsParams: PaymentMethodOptionsParams?,
+    ) : PaymentConfirmationOption
+
+    @Parcelize
+    data class ExternalPaymentMethod(
+        val type: String,
+        val billingDetails: PaymentMethod.BillingDetails?,
+    ) : PaymentConfirmationOption
+
+    @Parcelize
+    data class New(
+        val createParams: PaymentMethodCreateParams,
+        val optionsParams: PaymentMethodOptionsParams?,
+        val shouldSave: Boolean
+    ) : PaymentConfirmationOption
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationOptionKtx.kt
@@ -1,0 +1,25 @@
+package com.stripe.android.paymentsheet
+
+import com.stripe.android.paymentsheet.model.PaymentSelection
+
+internal fun PaymentSelection.toPaymentConfirmationOption(): PaymentConfirmationOption? {
+    return when (this) {
+        is PaymentSelection.Saved -> PaymentConfirmationOption.Saved(
+            paymentMethod = paymentMethod,
+            optionsParams = paymentMethodOptionsParams,
+        )
+        is PaymentSelection.ExternalPaymentMethod -> PaymentConfirmationOption.ExternalPaymentMethod(
+            type = type,
+            billingDetails = billingDetails,
+        )
+        is PaymentSelection.New -> {
+            PaymentConfirmationOption.New(
+                createParams = paymentMethodCreateParams,
+                optionsParams = paymentMethodOptionsParams,
+                shouldSave = customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse,
+            )
+        }
+        is PaymentSelection.Link,
+        is PaymentSelection.GooglePay -> null
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -470,12 +470,15 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         viewModelScope.launch(workContext) {
             val stripeIntent = awaitStripeIntent()
 
+            val confirmationOption = paymentSelectionWithCvcIfEnabled(paymentSelection)
+                ?.toPaymentConfirmationOption()
+
             intentConfirmationHandler.start(
                 arguments = IntentConfirmationHandler.Args(
                     initializationMode = args.initializationMode,
                     shippingDetails = args.config.shippingDetails,
                     intent = stripeIntent,
-                    paymentSelection = paymentSelectionWithCvcIfEnabled(paymentSelection),
+                    confirmationOption = confirmationOption,
                     appearance = config.appearance,
                 ),
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -57,6 +57,7 @@ import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.Cvc
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionLauncherFactory
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionResult
 import com.stripe.android.paymentsheet.state.PaymentSheetState
+import com.stripe.android.paymentsheet.toPaymentConfirmationOption
 import com.stripe.android.paymentsheet.ui.SepaMandateContract
 import com.stripe.android.paymentsheet.ui.SepaMandateResult
 import com.stripe.android.paymentsheet.utils.canSave
@@ -396,7 +397,7 @@ internal class DefaultFlowController @Inject internal constructor(
             intentConfirmationHandler.start(
                 arguments = IntentConfirmationHandler.Args(
                     initializationMode = initializationMode!!,
-                    paymentSelection = paymentSelection,
+                    confirmationOption = paymentSelection?.toPaymentConfirmationOption(),
                     intent = stripeIntent,
                     shippingDetails = state.config.shippingDetails,
                     appearance = state.config.appearance,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateData.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateData.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.paymentsheet.paymentdatacollection.bacs
 
 import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.PaymentConfirmationOption
 
 internal data class BacsMandateData(
     val name: String,
@@ -10,10 +10,10 @@ internal data class BacsMandateData(
     val sortCode: String
 ) {
     companion object {
-        fun fromPaymentSelection(
-            paymentSelection: PaymentSelection.New.GenericPaymentMethod
+        fun fromConfirmationOption(
+            confirmationOption: PaymentConfirmationOption.New,
         ): BacsMandateData? {
-            val overrideParams = paymentSelection.paymentMethodCreateParams
+            val overrideParams = confirmationOption.createParams
 
             val bacsDebit = PaymentMethodCreateParams.createBacsFromParams(overrideParams)
             val name = PaymentMethodCreateParams.getNameFromParams(overrideParams)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
@@ -18,7 +18,6 @@ import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentsheet.PaymentSheet.InitializationMode
-import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.utils.IntentConfirmationInterceptorTestRule
 import kotlinx.coroutines.test.runTest
@@ -98,9 +97,9 @@ class DefaultIntentConfirmationInterceptorTest {
 
             val nextStep = interceptor.intercept(
                 initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),
-                paymentSelection = PaymentSelection.Saved(
+                confirmationOption = PaymentConfirmationOption.Saved(
                     paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                    paymentMethodOptionsParams = PaymentMethodOptionsParams.Card(
+                    optionsParams = PaymentMethodOptionsParams.Card(
                         setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
                     )
                 ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
@@ -11,7 +11,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.Address
-import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardParams
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
@@ -25,7 +24,6 @@ import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.payments.paymentlauncher.PaymentLauncher
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
-import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncher
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationResult
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateData
@@ -80,9 +78,9 @@ class IntentConfirmationHandlerTest {
                 initializationMode = initializationMode,
                 shippingDetails = shippingDetails,
                 intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-                paymentSelection = PaymentSelection.Saved(
+                confirmationOption = PaymentConfirmationOption.Saved(
                     paymentMethod = savedPaymentMethod,
-                    paymentMethodOptionsParams = paymentMethodOptionsParams,
+                    optionsParams = paymentMethodOptionsParams,
                 ),
                 appearance = APPEARANCE,
             ),
@@ -125,7 +123,6 @@ class IntentConfirmationHandlerTest {
                 expYear = 2035,
             )
         )
-        val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
 
         val intentConfirmationHandler = createIntentConfirmationHandler(
             intentConfirmationInterceptor = interceptor,
@@ -136,10 +133,10 @@ class IntentConfirmationHandlerTest {
                 initializationMode = initializationMode,
                 shippingDetails = null,
                 intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-                paymentSelection = PaymentSelection.New.Card(
-                    paymentMethodCreateParams = newCard,
-                    brand = CardBrand.Visa,
-                    customerRequestedSave = customerRequestedSave,
+                confirmationOption = PaymentConfirmationOption.New(
+                    createParams = newCard,
+                    optionsParams = null,
+                    shouldSave = true,
                 ),
                 appearance = APPEARANCE,
             ),
@@ -186,7 +183,10 @@ class IntentConfirmationHandlerTest {
                 initializationMode = initializationMode,
                 shippingDetails = null,
                 intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-                paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+                confirmationOption = PaymentConfirmationOption.Saved(
+                    paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                    optionsParams = null,
+                ),
                 appearance = APPEARANCE,
             ),
         )
@@ -577,7 +577,7 @@ class IntentConfirmationHandlerTest {
 
         intentConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
-                paymentSelection = EXTERNAL_PAYMENT_METHOD
+                confirmationOption = EXTERNAL_PAYMENT_METHOD
             ),
         )
 
@@ -595,7 +595,7 @@ class IntentConfirmationHandlerTest {
 
         intentConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
-                paymentSelection = createBacsPaymentSelection(),
+                confirmationOption = createBacsPaymentConfirmationOption(),
             ),
         )
 
@@ -634,7 +634,7 @@ class IntentConfirmationHandlerTest {
         }
 
         val bacsArguments = DEFAULT_ARGUMENTS.copy(
-            paymentSelection = createBacsPaymentSelection()
+            confirmationOption = createBacsPaymentConfirmationOption()
         )
 
         val savedStateHandle = SavedStateHandle().apply {
@@ -782,7 +782,7 @@ class IntentConfirmationHandlerTest {
 
         intentConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
-                paymentSelection = EXTERNAL_PAYMENT_METHOD.copy(
+                confirmationOption = EXTERNAL_PAYMENT_METHOD.copy(
                     billingDetails = PaymentMethod.BillingDetails(
                         name = "John Doe",
                         address = Address(
@@ -818,7 +818,7 @@ class IntentConfirmationHandlerTest {
 
         intentConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
-                paymentSelection = EXTERNAL_PAYMENT_METHOD,
+                confirmationOption = EXTERNAL_PAYMENT_METHOD,
             ),
         )
 
@@ -841,7 +841,7 @@ class IntentConfirmationHandlerTest {
 
         intentConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
-                paymentSelection = EXTERNAL_PAYMENT_METHOD,
+                confirmationOption = EXTERNAL_PAYMENT_METHOD,
             ),
         )
 
@@ -868,7 +868,7 @@ class IntentConfirmationHandlerTest {
 
         intentConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
-                paymentSelection = EXTERNAL_PAYMENT_METHOD,
+                confirmationOption = EXTERNAL_PAYMENT_METHOD,
             ),
         )
 
@@ -898,7 +898,7 @@ class IntentConfirmationHandlerTest {
 
         intentConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
-                paymentSelection = EXTERNAL_PAYMENT_METHOD,
+                confirmationOption = EXTERNAL_PAYMENT_METHOD,
             ),
         )
 
@@ -931,7 +931,7 @@ class IntentConfirmationHandlerTest {
 
         intentConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
-                paymentSelection = EXTERNAL_PAYMENT_METHOD,
+                confirmationOption = EXTERNAL_PAYMENT_METHOD,
             ),
         )
 
@@ -962,7 +962,7 @@ class IntentConfirmationHandlerTest {
 
         intentConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
-                paymentSelection = createBacsPaymentSelection(),
+                confirmationOption = createBacsPaymentConfirmationOption(),
                 appearance = appearance,
             ),
         )
@@ -995,7 +995,7 @@ class IntentConfirmationHandlerTest {
 
         intentConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
-                paymentSelection = createBacsPaymentSelection(),
+                confirmationOption = createBacsPaymentConfirmationOption(),
             ),
         )
 
@@ -1018,7 +1018,7 @@ class IntentConfirmationHandlerTest {
 
         intentConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
-                paymentSelection = createBacsPaymentSelection(
+                confirmationOption = createBacsPaymentConfirmationOption(
                     name = null,
                 ),
             ),
@@ -1045,7 +1045,7 @@ class IntentConfirmationHandlerTest {
 
         intentConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
-                paymentSelection = createBacsPaymentSelection(
+                confirmationOption = createBacsPaymentConfirmationOption(
                     email = null,
                 ),
             ),
@@ -1076,11 +1076,11 @@ class IntentConfirmationHandlerTest {
             bacsMandateConfirmationCallbackHandler = bacsMandateConfirmationCallbackHandler,
         )
 
-        val paymentSelection = createBacsPaymentSelection()
+        val paymentSelection = createBacsPaymentConfirmationOption()
 
         intentConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
-                paymentSelection = paymentSelection
+                confirmationOption = paymentSelection
             ),
         )
 
@@ -1091,7 +1091,7 @@ class IntentConfirmationHandlerTest {
         assertThat(call).isEqualTo(
             FakeIntentConfirmationInterceptor.InterceptCall.WithNewPaymentMethod(
                 initializationMode = DEFAULT_ARGUMENTS.initializationMode,
-                paymentMethodCreateParams = paymentSelection.paymentMethodCreateParams,
+                paymentMethodCreateParams = paymentSelection.createParams,
                 shippingValues = null,
                 paymentMethodOptionsParams = null,
                 customerRequestedSave = false,
@@ -1116,11 +1116,11 @@ class IntentConfirmationHandlerTest {
             bacsMandateConfirmationCallbackHandler = bacsMandateConfirmationCallbackHandler,
         )
 
-        val paymentSelection = createBacsPaymentSelection()
+        val paymentSelection = createBacsPaymentConfirmationOption()
 
         intentConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
-                paymentSelection = paymentSelection
+                confirmationOption = paymentSelection
             ),
         )
 
@@ -1150,11 +1150,11 @@ class IntentConfirmationHandlerTest {
             bacsMandateConfirmationCallbackHandler = bacsMandateConfirmationCallbackHandler,
         )
 
-        val paymentSelection = createBacsPaymentSelection()
+        val paymentSelection = createBacsPaymentConfirmationOption()
 
         intentConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
-                paymentSelection = paymentSelection
+                confirmationOption = paymentSelection
             ),
         )
 
@@ -1247,12 +1247,12 @@ class IntentConfirmationHandlerTest {
         return this as IntentConfirmationHandler.Result.Failed
     }
 
-    private fun createBacsPaymentSelection(
+    private fun createBacsPaymentConfirmationOption(
         name: String? = "John Doe",
         email: String? = "johndoe@email.com",
-    ): PaymentSelection.New.GenericPaymentMethod {
-        return PaymentSelection.New.GenericPaymentMethod(
-            paymentMethodCreateParams = PaymentMethodCreateParams.create(
+    ): PaymentConfirmationOption.New {
+        return PaymentConfirmationOption.New(
+            createParams = PaymentMethodCreateParams.create(
                 bacsDebit = PaymentMethodCreateParams.BacsDebit(
                     accountNumber = "00012345",
                     sortCode = "108800"
@@ -1262,11 +1262,8 @@ class IntentConfirmationHandlerTest {
                     email = email,
                 )
             ),
-            customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
-            darkThemeIconUrl = null,
-            lightThemeIconUrl = null,
-            iconResource = 0,
-            label = "Bacs".resolvableString
+            optionsParams = null,
+            shouldSave = false,
         )
     }
 
@@ -1276,16 +1273,15 @@ class IntentConfirmationHandlerTest {
             initializationMode = PaymentSheet.InitializationMode.PaymentIntent(clientSecret = "pi_456_secret_456"),
             shippingDetails = null,
             intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            confirmationOption = PaymentConfirmationOption.Saved(
+                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                optionsParams = null,
+            ),
             appearance = APPEARANCE
         )
 
-        val EXTERNAL_PAYMENT_METHOD = PaymentSelection.ExternalPaymentMethod(
+        val EXTERNAL_PAYMENT_METHOD = PaymentConfirmationOption.ExternalPaymentMethod(
             type = "paypal",
-            label = "Paypal".resolvableString,
-            iconResource = 0,
-            darkThemeIconUrl = null,
-            lightThemeIconUrl = null,
             billingDetails = null
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentConfirmationOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentConfirmationOptionKtxTest.kt
@@ -1,0 +1,149 @@
+package com.stripe.android.paymentsheet
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.Address
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodCreateParamsFixtures
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.PaymentMethodOptionsParams
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import org.junit.Test
+
+class PaymentConfirmationOptionKtxTest {
+    @Test
+    fun `On new selection, should convert to new confirmation option properly`() {
+        val paymentSelection = createNewPaymentSelection(
+            optionsParams = PaymentMethodOptionsParams.Card(
+                network = "cartes_bancaires"
+            ),
+        )
+
+        assertThat(paymentSelection.toPaymentConfirmationOption()).isEqualTo(
+            PaymentConfirmationOption.New(
+                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                optionsParams = PaymentMethodOptionsParams.Card(network = "cartes_bancaires"),
+                shouldSave = false,
+            )
+        )
+    }
+
+    @Test
+    fun `On new selection with requested no reuse, should convert to new confirmation option properly`() {
+        val paymentSelection = createNewPaymentSelection(
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse,
+        )
+
+        assertThat(paymentSelection.toPaymentConfirmationOption()).isEqualTo(
+            PaymentConfirmationOption.New(
+                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                optionsParams = null,
+                shouldSave = false,
+            )
+        )
+    }
+
+    @Test
+    fun `On new selection with requested reuse, should convert to new confirmation option properly`() {
+        val paymentSelection = createNewPaymentSelection(
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse,
+        )
+
+        assertThat(paymentSelection.toPaymentConfirmationOption()).isEqualTo(
+            PaymentConfirmationOption.New(
+                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                optionsParams = null,
+                shouldSave = true,
+            )
+        )
+    }
+
+    @Test
+    fun `On new selection with no reuse request, should convert to new confirmation option properly`() {
+        val paymentSelection = createNewPaymentSelection(
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
+        )
+
+        assertThat(paymentSelection.toPaymentConfirmationOption()).isEqualTo(
+            PaymentConfirmationOption.New(
+                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                optionsParams = null,
+                shouldSave = false,
+            )
+        )
+    }
+
+    @Test
+    fun `On saved selection, should convert to saved confirmation option properly`() {
+        val paymentSelection = PaymentSelection.Saved(
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            paymentMethodOptionsParams = PaymentMethodOptionsParams.Card(
+                cvc = "505"
+            ),
+        )
+
+        assertThat(paymentSelection.toPaymentConfirmationOption()).isEqualTo(
+            PaymentConfirmationOption.Saved(
+                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                optionsParams = PaymentMethodOptionsParams.Card(
+                    cvc = "505"
+                ),
+            )
+        )
+    }
+
+    @Test
+    fun `On EPM selection, should convert to EPM confirmation option properly`() {
+        val paymentSelection = PaymentSelection.ExternalPaymentMethod(
+            type = "paypal",
+            billingDetails = PaymentMethod.BillingDetails(
+                name = "John Doe",
+                address = Address(
+                    city = "South San Francisco"
+                )
+            ),
+            darkThemeIconUrl = null,
+            lightThemeIconUrl = null,
+            label = "Paypal".resolvableString,
+            iconResource = 0,
+        )
+
+        assertThat(paymentSelection.toPaymentConfirmationOption()).isEqualTo(
+            PaymentConfirmationOption.ExternalPaymentMethod(
+                type = "paypal",
+                billingDetails = PaymentMethod.BillingDetails(
+                    name = "John Doe",
+                    address = Address(
+                        city = "South San Francisco"
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `On Google Pay selection, should return null`() {
+        assertThat(PaymentSelection.GooglePay.toPaymentConfirmationOption()).isNull()
+    }
+
+    @Test
+    fun `On Link selection, should return null`() {
+        assertThat(PaymentSelection.Link.toPaymentConfirmationOption()).isNull()
+    }
+
+    private fun createNewPaymentSelection(
+        createParams: PaymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+        optionsParams: PaymentMethodOptionsParams? = null,
+        customerRequestedSave: PaymentSelection.CustomerRequestedSave =
+            PaymentSelection.CustomerRequestedSave.NoRequest,
+    ): PaymentSelection.New {
+        return PaymentSelection.New.Card(
+            paymentMethodCreateParams = createParams,
+            paymentMethodOptionsParams = optionsParams,
+            brand = CardBrand.CartesBancaires,
+            customerRequestedSave = customerRequestedSave,
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateDataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateDataTest.kt
@@ -1,22 +1,16 @@
 package com.stripe.android.paymentsheet.paymentdatacollection.bacs
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.PaymentConfirmationOption
 import org.junit.Test
 
 class BacsMandateDataTest {
     @Test
-    fun `when payment selection is Bacs and name & email are provided, 'fromPaymentSelection' should return data`() {
-        val selection = PaymentSelection.New.GenericPaymentMethod(
-            label = "".resolvableString,
-            iconResource = 0,
-            customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
-            lightThemeIconUrl = null,
-            darkThemeIconUrl = null,
-            paymentMethodCreateParams = PaymentMethodCreateParams.Companion.create(
+    fun `when payment option is Bacs and name & email are provided, 'fromConfirmationOption' should return data`() {
+        val option = createPaymentConfirmationOption(
+            createParams = PaymentMethodCreateParams.Companion.create(
                 bacsDebit = PaymentMethodCreateParams.BacsDebit(
                     accountNumber = "00012345",
                     sortCode = "10-88-00"
@@ -25,10 +19,10 @@ class BacsMandateDataTest {
                     name = "John Doe",
                     email = "johndoe@email.com"
                 )
-            )
+            ),
         )
 
-        assertThat(BacsMandateData.fromPaymentSelection(selection)).isEqualTo(
+        assertThat(BacsMandateData.fromConfirmationOption(option)).isEqualTo(
             BacsMandateData(
                 name = "John Doe",
                 email = "johndoe@email.com",
@@ -39,39 +33,39 @@ class BacsMandateDataTest {
     }
 
     @Test
-    fun `when payment selection is Bacs but without name or email, 'fromPaymentSelection' should return null`() {
-        val selection = PaymentSelection.New.GenericPaymentMethod(
-            label = "".resolvableString,
-            iconResource = 0,
-            customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
-            lightThemeIconUrl = null,
-            darkThemeIconUrl = null,
-            paymentMethodCreateParams = PaymentMethodCreateParams.Companion.create(
+    fun `when payment option is Bacs but without name or email, 'fromConfirmationOption' should return null`() {
+        val option = createPaymentConfirmationOption(
+            createParams = PaymentMethodCreateParams.Companion.create(
                 bacsDebit = PaymentMethodCreateParams.BacsDebit(
                     accountNumber = "00012345",
                     sortCode = "10-88-00"
                 ),
                 billingDetails = PaymentMethod.BillingDetails()
-            )
+            ),
         )
 
-        assertThat(BacsMandateData.fromPaymentSelection(selection)).isNull()
+        assertThat(BacsMandateData.fromConfirmationOption(option)).isNull()
     }
 
     @Test
-    fun `when payment selection is not Bacs, 'fromPaymentSelection' should return null`() {
-        val selection = PaymentSelection.New.GenericPaymentMethod(
-            label = "".resolvableString,
-            iconResource = 0,
-            customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
-            lightThemeIconUrl = null,
-            darkThemeIconUrl = null,
-            paymentMethodCreateParams = PaymentMethodCreateParams.Companion.create(
+    fun `when payment option is not Bacs, 'fromConfirmationOption' should return null`() {
+        val option = createPaymentConfirmationOption(
+            createParams = PaymentMethodCreateParams.Companion.create(
                 card = PaymentMethodCreateParams.Card(),
                 billingDetails = PaymentMethod.BillingDetails()
-            )
+            ),
         )
 
-        assertThat(BacsMandateData.fromPaymentSelection(selection)).isNull()
+        assertThat(BacsMandateData.fromConfirmationOption(option)).isNull()
+    }
+
+    private fun createPaymentConfirmationOption(
+        createParams: PaymentMethodCreateParams,
+    ): PaymentConfirmationOption.New {
+        return PaymentConfirmationOption.New(
+            createParams = createParams,
+            optionsParams = null,
+            shouldSave = false,
+        )
     }
 }


### PR DESCRIPTION
# Summary
Replace `PaymentSelection` with `PaymentConfirmationOption` in payment confirmation.

# Motivation
`PaymentSelection` contains a lot of values only relevant for UI elements and form validation but not relevant for payment confirmation. `PaymentConfirmationOption` contains only values relevant for payment confirmation. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified
