### PR TITLE
Add ordered LPMs to load succeeded analytic event

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -57,6 +57,7 @@ internal class DefaultEventReporter @Inject internal constructor(
         googlePaySupported: Boolean,
         currency: String?,
         initializationMode: PaymentSheet.InitializationMode,
+        orderedLpms: List<String>,
     ) {
         this.currency = currency
         this.linkEnabled = linkEnabled
@@ -74,6 +75,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
                 initializationMode = initializationMode,
+                orderedLpms = orderedLpms,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -32,6 +32,7 @@ internal interface EventReporter {
         googlePaySupported: Boolean,
         currency: String?,
         initializationMode: PaymentSheet.InitializationMode,
+        orderedLpms: List<String>,
     )
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -37,6 +37,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     class LoadSucceeded(
         paymentSelection: PaymentSelection?,
         initializationMode: PaymentSheet.InitializationMode,
+        orderedLpms: List<String>,
         duration: Duration?,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
@@ -47,6 +48,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
             FIELD_DURATION to duration?.asSeconds,
             FIELD_SELECTED_LPM to paymentSelection.defaultAnalyticsValue,
             FIELD_INTENT_TYPE to initializationMode.defaultAnalyticsValue,
+            FIELD_ORDERED_LPMS to orderedLpms.joinToString(",")
         )
 
         private val PaymentSelection?.defaultAnalyticsValue: String
@@ -480,6 +482,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_EXTERNAL_PAYMENT_METHODS = "external_payment_methods"
         const val FIELD_COMPOSE = "compose"
         const val FIELD_INTENT_TYPE = "intent_type"
+        const val FIELD_ORDERED_LPMS = "ordered_lpms"
 
         const val VALUE_EDIT_CBC_EVENT_SOURCE = "edit"
         const val VALUE_ADD_CBC_EVENT_SOURCE = "add"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -530,6 +530,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
                 currency = elementsSession.stripeIntent.currency,
                 paymentSelection = state.paymentSelection,
                 initializationMode = initializationMode,
+                orderedLpms = state.paymentMethodMetadata.sortedSupportedPaymentMethods().map { it.code },
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -695,6 +695,7 @@ class DefaultEventReporterTest {
             linkEnabled = linkEnabled,
             currency = currency,
             initializationMode = initializationMode,
+            orderedLpms = listOf("card", "klarna"),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -275,6 +275,7 @@ class PaymentSheetEventTest {
             duration = (5L).seconds,
             paymentSelection = null,
             initializationMode = paymentIntentInitializationMode,
+            orderedLpms = listOf("card", "klarna")
         )
 
         assertThat(event.eventName).isEqualTo("mc_load_succeeded")
@@ -286,6 +287,7 @@ class PaymentSheetEventTest {
                 "duration" to 5f,
                 "selected_lpm" to "none",
                 "intent_type" to "payment_intent",
+                "ordered_lpms" to "card,klarna"
             )
         )
     }
@@ -299,6 +301,7 @@ class PaymentSheetEventTest {
             duration = (5L).seconds,
             paymentSelection = PaymentSelection.GooglePay,
             initializationMode = paymentIntentInitializationMode,
+            orderedLpms = listOf("card"),
         )
 
         assertThat(event.params).containsEntry("selected_lpm", "google_pay")
@@ -313,6 +316,7 @@ class PaymentSheetEventTest {
             duration = (5L).seconds,
             paymentSelection = PaymentSelection.Link,
             initializationMode = paymentIntentInitializationMode,
+            orderedLpms = listOf("card"),
         )
 
         assertThat(event.params).containsEntry("selected_lpm", "link")
@@ -329,6 +333,7 @@ class PaymentSheetEventTest {
                 paymentMethod = PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD
             ),
             initializationMode = paymentIntentInitializationMode,
+            orderedLpms = listOf("card"),
         )
 
         assertThat(event.params).containsEntry("selected_lpm", "sepa_debit")
@@ -1351,6 +1356,7 @@ class PaymentSheetEventTest {
         duration: Duration = (5L).seconds,
         paymentSelection: PaymentSelection? = null,
         initializationMode: PaymentSheet.InitializationMode = paymentIntentInitializationMode,
+        orderedLpms: List<String> = listOf("card"),
     ): PaymentSheetEvent.LoadSucceeded {
         return PaymentSheetEvent.LoadSucceeded(
             isDeferred = isDeferred,
@@ -1359,6 +1365,7 @@ class PaymentSheetEventTest {
             duration = duration,
             paymentSelection = paymentSelection,
             initializationMode = initializationMode,
+            orderedLpms = orderedLpms,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -827,6 +827,7 @@ internal class DefaultPaymentSheetLoaderTest {
             googlePaySupported = true,
             currency = "usd",
             initializationMode = initializationMode,
+            orderedLpms = listOf("card", "link"),
         )
     }
 
@@ -878,6 +879,7 @@ internal class DefaultPaymentSheetLoaderTest {
             googlePaySupported = true,
             currency = "usd",
             initializationMode = initializationMode,
+            orderedLpms = listOf("card", "link"),
         )
     }
 
@@ -1674,6 +1676,7 @@ internal class DefaultPaymentSheetLoaderTest {
             googlePaySupported = true,
             currency = "usd",
             initializationMode = initializationMode,
+            orderedLpms = listOf("card", "link"),
         )
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add ordered LPMs to load succeeded analytic event

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3333

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified