### PR TITLE
Update release script to ensure that the github and sonatype releases are done from the release branch

### DIFF
--- a/scripts/deploy/common.rb
+++ b/scripts/deploy/common.rb
@@ -39,6 +39,10 @@ def replace_in_file(filename, pattern, replacement)
   File.write(filename, new_content)
 end
 
+def switch_to_release_branch()
+    switch_to_new_branch(release_branch, @deploy_branch)
+end
+
 def ensure_directory_is_clean()
     stdout, stderr, status = Open3.capture3("git status --porcelain")
 

--- a/scripts/deploy/create_github_release.rb
+++ b/scripts/deploy/create_github_release.rb
@@ -9,6 +9,10 @@ require_relative 'gnupg_utils'
 @release_url = nil
 
 def create_github_release
+    # Must be run on the release branch, because it depends on changes made in
+    # create_version_bump_pr (updating CHANGELOG.md)
+    switch_to_release_branch()
+
     build_example_release_apk
     tag_release
 

--- a/scripts/deploy/deploy.rb
+++ b/scripts/deploy/deploy.rb
@@ -61,7 +61,6 @@ steps = [
     method(:validate_version_number),
     method(:ensure_clean_repo),
     method(:pull_latest),
-    method(:switch_to_release_branch),
 
     # Update version number
     method(:create_version_bump_pr),
@@ -70,7 +69,6 @@ steps = [
     method(:publish_to_sonatype),
 
     # Create a Github release
-
     method(:create_github_release),
 
     # Do docs updates

--- a/scripts/deploy/deploy.rb
+++ b/scripts/deploy/deploy.rb
@@ -61,6 +61,7 @@ steps = [
     method(:validate_version_number),
     method(:ensure_clean_repo),
     method(:pull_latest),
+    method(:switch_to_release_branch),
 
     # Update version number
     method(:create_version_bump_pr),
@@ -69,6 +70,7 @@ steps = [
     method(:publish_to_sonatype),
 
     # Create a Github release
+
     method(:create_github_release),
 
     # Do docs updates

--- a/scripts/deploy/publish_to_sonatype.rb
+++ b/scripts/deploy/publish_to_sonatype.rb
@@ -6,6 +6,10 @@ require_relative 'common'
 require_relative 'gnupg_utils'
 
 def publish_to_sonatype
+    # Must be run on the release branch, because it depends on changes made in
+    # create_version_bump_pr (updating the VERSION file)
+    switch_to_release_branch()
+
     m2_settings = Nokogiri::XML(fetch_password("bindings/java-maven-api-token"))
 
     # Required in order to use xpath sanely (the commands below would

--- a/scripts/deploy/version_bump_pr_steps.rb
+++ b/scripts/deploy/version_bump_pr_steps.rb
@@ -19,10 +19,6 @@ def pull_latest()
     execute_or_fail("git pull")
 end
 
-def switch_to_release_branch()
-    switch_to_new_branch(release_branch, @deploy_branch)
-end
-
 def revert_version_bump_changes()
     delete_git_branch(release_branch, @deploy_branch)
 end
@@ -56,12 +52,6 @@ def create_version_bump_pr()
         revert_version_bump_changes()
         execute("git checkout #{@deploy_branch}")
         raise
-    end
-
-    # If this is a dry run, we need to stay on the release/ branch to do a github release. This is
-    # because the github release depends on the changes we made to the CHANGELOG.
-    if (!@is_dry_run)
-        execute_or_fail("git checkout #{@deploy_branch}")
     end
 end
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update release script to ensure that the github and sonatype releases are done from the release branch

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
These both need to be run from the release branch to ensure that they are run with the updates from creating the version bump PR. 

The alternative fix to this would be to:
- wait for the version bump PR to be merged
- switch back to the "deploy branch" (usually master)
- pull
- and then run the github + sonatype steps

We don't want to require this, because we may want to run parts of the github + sonatype release scripts before the version bump PR is merged (to parallelize slow parts of our release process)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

