### PR TITLE
Get email from cached consumer session in Instant Debits

### DIFF
--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModelTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.financialconnections.CoroutineTestRule
 import com.stripe.android.financialconnections.TestFinancialConnectionsAnalyticsTracker
 import com.stripe.android.financialconnections.domain.AttachConsumerToLinkAccountSession
 import com.stripe.android.financialconnections.domain.ConfirmVerification
+import com.stripe.android.financialconnections.domain.GetCachedConsumerSession
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.GetOrFetchSync.RefetchCondition
 import com.stripe.android.financialconnections.domain.LookupConsumerAndStartVerification
@@ -48,11 +49,12 @@ class NetworkingLinkVerificationViewModelTest {
     private val markLinkVerified = mock<MarkLinkVerified>()
     private val analyticsTracker = TestFinancialConnectionsAnalyticsTracker()
     private val nativeAuthFlowCoordinator = NativeAuthFlowCoordinator()
+    private val getCachedConsumerSession = mock<GetCachedConsumerSession>()
     private val attachConsumerToLinkAccountSession = mock<AttachConsumerToLinkAccountSession>()
 
     private fun buildViewModel(
         state: NetworkingLinkVerificationState = NetworkingLinkVerificationState(),
-        isLinkWithStripe: Boolean = false,
+        isInstantDebits: Boolean = false,
     ) = NetworkingLinkVerificationViewModel(
         navigationManager = navigationManager,
         getOrFetchSync = getOrFetchSync,
@@ -63,7 +65,8 @@ class NetworkingLinkVerificationViewModelTest {
         logger = Logger.noop(),
         initialState = state,
         nativeAuthFlowCoordinator = nativeAuthFlowCoordinator,
-        isLinkWithStripe = { isLinkWithStripe },
+        getCachedConsumerSession = getCachedConsumerSession,
+        isLinkWithStripe = { isInstantDebits },
         attachConsumerToLinkAccountSession = attachConsumerToLinkAccountSession,
     )
 
@@ -254,7 +257,7 @@ class NetworkingLinkVerificationViewModelTest {
         )
         whenever(attachConsumerToLinkAccountSession.invoke(any())).thenReturn(Unit)
 
-        val viewModel = buildViewModel(isLinkWithStripe = true)
+        val viewModel = buildViewModel(isInstantDebits = true)
 
         verify(lookupConsumerAndStartVerification).invoke(
             email = eq(email),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates `NetworkingLinkVerificationViewModel` for the NUX in the Instant Debits flow: Instead of taking the email address from the `accountholderCustomerEmailAddress` (which will not be populated), we take it from the `ConsumerSession` that was created in the previous screen.

This isn’t ideal. We should move the `ConsumerSession` creation out of the verification screen _for all possible flows_, so that we can remove this custom logic again. This would also align more closely with the behavior on Web.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[BANKCON-11697](https://jira.corp.stripe.com/browse/BANKCON-11697)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
