### PR TITLE
Move `Google Pay` handling to `IntentConfirmationHandler`

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -334,6 +334,22 @@ public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$Ext
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$GooglePay$Config$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$GooglePay$Config;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$GooglePay$Config;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$GooglePay$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$GooglePay;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$GooglePay;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$New$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$New;

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -906,7 +906,7 @@ internal class CustomerSheetViewModel(
                     clientSecret = clientSecret
                 ),
                 intent = stripeIntent,
-                confirmationOption = selection.toPaymentConfirmationOption(),
+                confirmationOption = selection.toPaymentConfirmationOption(configuration = null),
                 shippingDetails = null,
                 appearance = configuration.appearance,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -23,6 +23,7 @@ import com.stripe.android.customersheet.CustomerSheetViewState
 import com.stripe.android.customersheet.DefaultCustomerSheetLoader
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.analytics.DefaultCustomerSheetEventReporter
+import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
@@ -145,20 +146,24 @@ internal interface CustomerSheetViewModelModule {
             savedStateHandle: SavedStateHandle,
             paymentConfigurationProvider: Provider<PaymentConfiguration>,
             bacsMandateConfirmationLauncherFactory: BacsMandateConfirmationLauncherFactory,
+            googlePayPaymentMethodLauncherFactory: GooglePayPaymentMethodLauncherFactory,
             stripePaymentLauncherAssistedFactory: StripePaymentLauncherAssistedFactory,
             statusBarColor: Int?,
             intentConfirmationInterceptor: IntentConfirmationInterceptor,
             errorReporter: ErrorReporter,
+            logger: Logger,
         ): IntentConfirmationHandler.Factory {
             return IntentConfirmationHandler.Factory(
                 intentConfirmationInterceptor = intentConfirmationInterceptor,
                 paymentConfigurationProvider = paymentConfigurationProvider,
                 stripePaymentLauncherAssistedFactory = stripePaymentLauncherAssistedFactory,
+                googlePayPaymentMethodLauncherFactory = googlePayPaymentMethodLauncherFactory,
                 bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,
                 application = application,
                 statusBarColor = { statusBarColor },
                 savedStateHandle = savedStateHandle,
                 errorReporter = errorReporter,
+                logger = logger,
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -23,7 +23,6 @@ import com.stripe.android.customersheet.CustomerSheetViewState
 import com.stripe.android.customersheet.DefaultCustomerSheetLoader
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.analytics.DefaultCustomerSheetEventReporter
-import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
@@ -146,7 +145,6 @@ internal interface CustomerSheetViewModelModule {
             savedStateHandle: SavedStateHandle,
             paymentConfigurationProvider: Provider<PaymentConfiguration>,
             bacsMandateConfirmationLauncherFactory: BacsMandateConfirmationLauncherFactory,
-            googlePayPaymentMethodLauncherFactory: GooglePayPaymentMethodLauncherFactory,
             stripePaymentLauncherAssistedFactory: StripePaymentLauncherAssistedFactory,
             statusBarColor: Int?,
             intentConfirmationInterceptor: IntentConfirmationInterceptor,
@@ -157,7 +155,7 @@ internal interface CustomerSheetViewModelModule {
                 intentConfirmationInterceptor = intentConfirmationInterceptor,
                 paymentConfigurationProvider = paymentConfigurationProvider,
                 stripePaymentLauncherAssistedFactory = stripePaymentLauncherAssistedFactory,
-                googlePayPaymentMethodLauncherFactory = googlePayPaymentMethodLauncherFactory,
+                googlePayPaymentMethodLauncherFactory = null,
                 bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,
                 application = application,
                 statusBarColor = { statusBarColor },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationHandler.kt
@@ -73,10 +73,10 @@ internal class IntentConfirmationHandler(
     private var googlePayPaymentMethodLauncher:
         ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>? = null
 
-    private var contentVisible: Boolean
-        get() = savedStateHandle[CONTENT_VISIBLE_KEY] ?: true
+    private var isPaymentSheetVisible: Boolean
+        get() = savedStateHandle[IS_PAYMENT_SHEET_VISIBLE_KEY] ?: true
         set(value) {
-            savedStateHandle[CONTENT_VISIBLE_KEY] = value
+            savedStateHandle[IS_PAYMENT_SHEET_VISIBLE_KEY] = value
         }
 
     private var deferredIntentConfirmationType: DeferredIntentConfirmationType?
@@ -102,7 +102,7 @@ internal class IntentConfirmationHandler(
 
     private val _state = MutableStateFlow(
         if (hasReloadedFromProcessDeath) {
-            State.Confirming(contentVisible)
+            State.Confirming(isPaymentSheetVisible)
         } else {
             State.Idle
         }
@@ -180,7 +180,7 @@ internal class IntentConfirmationHandler(
             return
         }
 
-        _state.value = State.Confirming(contentVisible = true)
+        _state.value = State.Confirming(isPaymentSheetVisible = true)
         currentArguments = arguments
 
         coroutineScope.launch {
@@ -362,7 +362,7 @@ internal class IntentConfirmationHandler(
             return
         }
 
-        _state.value = State.Confirming(contentVisible = false)
+        _state.value = State.Confirming(isPaymentSheetVisible = false)
 
         val activityLauncher = runCatching {
             requireNotNull(googlePayPaymentMethodLauncher)
@@ -544,7 +544,7 @@ internal class IntentConfirmationHandler(
             when (result) {
                 is GooglePayPaymentMethodLauncher.Result.Completed -> {
                     currentArguments?.let { arguments ->
-                        _state.value = State.Confirming(contentVisible = true)
+                        _state.value = State.Confirming(isPaymentSheetVisible = true)
 
                         val confirmationOption = PaymentConfirmationOption.Saved(
                             paymentMethod = result.paymentMethod,
@@ -669,7 +669,7 @@ internal class IntentConfirmationHandler(
          * Indicates the the handler is currently confirming a payment.
          */
         data class Confirming(
-            val contentVisible: Boolean,
+            val isPaymentSheetVisible: Boolean,
         ) : State
 
         /**
@@ -808,6 +808,6 @@ internal class IntentConfirmationHandler(
         private const val AWAITING_PAYMENT_RESULT_KEY = "AwaitingPaymentResult"
         private const val DEFERRED_INTENT_CONFIRMATION_TYPE = "DeferredIntentConfirmationType"
         private const val ARGUMENTS_KEY = "IntentConfirmationArguments"
-        private const val CONTENT_VISIBLE_KEY = "ContentVisibleDuringIntentConfirmation"
+        private const val IS_PAYMENT_SHEET_VISIBLE_KEY = "PaymentSheetVisibleDuringIntentConfirmation"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationOption.kt
@@ -14,6 +14,22 @@ internal sealed interface PaymentConfirmationOption : Parcelable {
     ) : PaymentConfirmationOption
 
     @Parcelize
+    data class GooglePay(
+        val config: Config,
+    ) : PaymentConfirmationOption {
+        @Parcelize
+        data class Config(
+            val environment: PaymentSheet.GooglePayConfiguration.Environment?,
+            val merchantName: String,
+            val merchantCountryCode: String,
+            val merchantCurrencyCode: String?,
+            val customAmount: Long?,
+            val customLabel: String?,
+            val billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration,
+        ) : Parcelable
+    }
+
+    @Parcelize
     data class ExternalPaymentMethod(
         val type: String,
         val billingDetails: PaymentMethod.BillingDetails?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationOptionKtx.kt
@@ -2,7 +2,9 @@ package com.stripe.android.paymentsheet
 
 import com.stripe.android.paymentsheet.model.PaymentSelection
 
-internal fun PaymentSelection.toPaymentConfirmationOption(): PaymentConfirmationOption? {
+internal fun PaymentSelection.toPaymentConfirmationOption(
+    configuration: PaymentSheet.Configuration?,
+): PaymentConfirmationOption? {
     return when (this) {
         is PaymentSelection.Saved -> PaymentConfirmationOption.Saved(
             paymentMethod = paymentMethod,
@@ -19,7 +21,19 @@ internal fun PaymentSelection.toPaymentConfirmationOption(): PaymentConfirmation
                 shouldSave = customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse,
             )
         }
-        is PaymentSelection.Link,
-        is PaymentSelection.GooglePay -> null
+        is PaymentSelection.GooglePay -> configuration?.googlePay?.let { googlePay ->
+            PaymentConfirmationOption.GooglePay(
+                config = PaymentConfirmationOption.GooglePay.Config(
+                    environment = googlePay.environment,
+                    merchantName = configuration.merchantDisplayName,
+                    merchantCountryCode = googlePay.countryCode,
+                    merchantCurrencyCode = googlePay.currencyCode,
+                    customAmount = googlePay.amount,
+                    customLabel = googlePay.label,
+                    billingDetailsCollectionConfiguration = configuration.billingDetailsCollectionConfiguration,
+                )
+            )
+        }
+        is PaymentSelection.Link -> null
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -10,9 +10,7 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.lifecycleScope
 import com.stripe.android.common.ui.ElementsBottomSheetLayout
-import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.PaymentSheetScreen
 import com.stripe.android.paymentsheet.utils.applicationIsTaskOwner
@@ -48,14 +46,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
         viewModel.registerFromActivity(
             activityResultCaller = this,
             lifecycleOwner = this,
-        )
-
-        viewModel.setupGooglePay(
-            lifecycleScope,
-            registerForActivityResult(
-                GooglePayPaymentMethodLauncherContractV2(),
-                viewModel::onGooglePayResult
-            )
         )
 
         if (!applicationIsTaskOwner()) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -342,7 +342,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 when (state) {
                     is IntentConfirmationHandler.State.Idle -> Unit
                     is IntentConfirmationHandler.State.Confirming -> {
-                        setContentVisible(state.contentVisible)
+                        setContentVisible(state.isPaymentSheetVisible)
 
                         if (viewState.value !is PaymentSheetViewState.StartProcessing) {
                             startProcessing(checkoutIdentifier)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -556,6 +556,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 message = failure.message,
             )
             IntentConfirmationHandler.ErrorType.Fatal -> onFatal(failure.cause)
+            IntentConfirmationHandler.ErrorType.MerchantIntegration,
             IntentConfirmationHandler.ErrorType.Internal -> onError(failure.message)
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet
 
 import android.app.Application
 import androidx.activity.result.ActivityResultCaller
-import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -21,8 +20,6 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.requireApplication
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
-import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
-import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentIntent
@@ -54,7 +51,6 @@ import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.PrimaryButtonUiStateMapper
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -69,7 +65,6 @@ import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
-import com.stripe.android.R as StripeR
 
 internal class PaymentSheetViewModel @Inject internal constructor(
     // Properties provided through PaymentSheetViewModelComponent.Builder
@@ -79,7 +74,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     private val paymentSheetLoader: PaymentSheetLoader,
     customerRepository: CustomerRepository,
     private val prefsRepository: PrefsRepository,
-    private val googlePayPaymentMethodLauncherFactory: GooglePayPaymentMethodLauncherFactory,
     private val logger: Logger,
     @IOContext workContext: CoroutineContext,
     savedStateHandle: SavedStateHandle,
@@ -134,8 +128,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         get() = args.initializationMode.isProcessingPayment
 
     override var newPaymentSelection: NewOrExternalPaymentSelection? = null
-
-    private var googlePayPaymentMethodLauncher: GooglePayPaymentMethodLauncher? = null
 
     private val googlePayButtonType: GooglePayButtonType =
         when (args.config.googlePay?.buttonType) {
@@ -349,25 +341,19 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             intentConfirmationHandler.state.collectLatest { state ->
                 when (state) {
                     is IntentConfirmationHandler.State.Idle -> Unit
-                    is IntentConfirmationHandler.State.Confirming -> startProcessing(checkoutIdentifier)
-                    is IntentConfirmationHandler.State.Complete -> processIntentResult(state.result)
+                    is IntentConfirmationHandler.State.Confirming -> {
+                        setContentVisible(state.contentVisible)
+
+                        if (viewState.value !is PaymentSheetViewState.StartProcessing) {
+                            startProcessing(checkoutIdentifier)
+                        }
+                    }
+                    is IntentConfirmationHandler.State.Complete -> {
+                        setContentVisible(true)
+                        processIntentResult(state.result)
+                    }
                 }
             }
-        }
-    }
-
-    fun setupGooglePay(
-        lifecycleScope: CoroutineScope,
-        activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>
-    ) {
-        googlePayLauncherConfig?.let { config ->
-            googlePayPaymentMethodLauncher =
-                googlePayPaymentMethodLauncherFactory.create(
-                    lifecycleScope = lifecycleScope,
-                    config = config,
-                    readyCallback = { /* Nothing to do here */ },
-                    activityResultLauncher = activityResultLauncher
-                )
         }
     }
 
@@ -389,7 +375,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     fun checkoutWithGooglePay() {
-        setContentVisible(false)
         checkout(PaymentSelection.GooglePay, CheckoutIdentifier.SheetTopWallet)
     }
 
@@ -397,26 +382,9 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         paymentSelection: PaymentSelection?,
         identifier: CheckoutIdentifier,
     ) {
-        if (paymentSelection is PaymentSelection.GooglePay) {
-            startProcessing(identifier)
+        this.checkoutIdentifier = identifier
 
-            paymentMethodMetadata.value?.stripeIntent?.let { stripeIntent ->
-                googlePayPaymentMethodLauncher?.present(
-                    currencyCode = (stripeIntent as? PaymentIntent)?.currency
-                        ?: args.googlePayConfig?.currencyCode.orEmpty(),
-                    amount = when (stripeIntent) {
-                        is PaymentIntent -> stripeIntent.amount ?: 0L
-                        is SetupIntent -> args.googlePayConfig?.amount ?: 0L
-                    },
-                    transactionId = stripeIntent.id,
-                    label = args.googlePayConfig?.label,
-                )
-            }
-        } else {
-            this.checkoutIdentifier = identifier
-
-            confirmPaymentSelection(paymentSelection)
-        }
+        confirmPaymentSelection(paymentSelection)
     }
 
     override fun handlePaymentMethodSelected(selection: PaymentSelection?) {
@@ -484,7 +452,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             val stripeIntent = awaitStripeIntent()
 
             val confirmationOption = paymentSelectionWithCvcIfEnabled(paymentSelection)
-                ?.toPaymentConfirmationOption()
+                ?.toPaymentConfirmationOption(config)
 
             intentConfirmationHandler.start(
                 arguments = IntentConfirmationHandler.Args(
@@ -583,6 +551,10 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 error = PaymentSheetConfirmationError.ExternalPaymentMethod,
                 message = failure.message,
             )
+            is IntentConfirmationHandler.ErrorType.GooglePay -> handlePaymentFailed(
+                error = PaymentSheetConfirmationError.GooglePay(failure.type.errorCode),
+                message = failure.message,
+            )
             IntentConfirmationHandler.ErrorType.Fatal -> onFatal(failure.cause)
             IntentConfirmationHandler.ErrorType.Internal -> onError(failure.message)
         }
@@ -604,37 +576,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 )
             }
             is PaymentResult.Canceled -> {
-                resetViewState()
-            }
-        }
-    }
-
-    internal fun onGooglePayResult(result: GooglePayPaymentMethodLauncher.Result) {
-        setContentVisible(true)
-        when (result) {
-            is GooglePayPaymentMethodLauncher.Result.Completed -> {
-                val newPaymentSelection = PaymentSelection.Saved(
-                    paymentMethod = result.paymentMethod,
-                    walletType = PaymentSelection.Saved.WalletType.GooglePay,
-                )
-
-                updateSelection(newPaymentSelection)
-                confirmPaymentSelection(newPaymentSelection)
-            }
-            is GooglePayPaymentMethodLauncher.Result.Failed -> {
-                logger.error("Error processing Google Pay payment", result.error)
-                eventReporter.onPaymentFailure(
-                    paymentSelection = PaymentSelection.GooglePay,
-                    error = PaymentSheetConfirmationError.GooglePay(result.errorCode),
-                )
-                val errorMessage = when (result.errorCode) {
-                    GooglePayPaymentMethodLauncher.NETWORK_ERROR ->
-                        StripeR.string.stripe_failure_connection_error
-                    else -> StripeR.string.stripe_internal_error
-                }
-                onError(errorMessage.resolvableString)
-            }
-            is GooglePayPaymentMethodLauncher.Result.Canceled -> {
                 resetViewState()
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -683,6 +683,7 @@ internal class DefaultFlowController @Inject internal constructor(
             is IntentConfirmationHandler.ErrorType.GooglePay ->
                 PaymentSheetConfirmationError.GooglePay(errorCode)
             IntentConfirmationHandler.ErrorType.Internal,
+            IntentConfirmationHandler.ErrorType.MerchantIntegration,
             IntentConfirmationHandler.ErrorType.Fatal -> null
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -4,7 +4,9 @@ import android.app.Application
 import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
+import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
@@ -32,19 +34,23 @@ internal class PaymentSheetViewModelModule(private val starterArgs: PaymentSheet
         savedStateHandle: SavedStateHandle,
         paymentConfigurationProvider: Provider<PaymentConfiguration>,
         bacsMandateConfirmationLauncherFactory: BacsMandateConfirmationLauncherFactory,
+        googlePayPaymentMethodLauncherFactory: GooglePayPaymentMethodLauncherFactory,
         stripePaymentLauncherAssistedFactory: StripePaymentLauncherAssistedFactory,
         intentConfirmationInterceptor: IntentConfirmationInterceptor,
         errorReporter: ErrorReporter,
+        logger: Logger,
     ): IntentConfirmationHandler.Factory {
         return IntentConfirmationHandler.Factory(
             intentConfirmationInterceptor = intentConfirmationInterceptor,
             paymentConfigurationProvider = paymentConfigurationProvider,
             stripePaymentLauncherAssistedFactory = stripePaymentLauncherAssistedFactory,
             bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,
+            googlePayPaymentMethodLauncherFactory = googlePayPaymentMethodLauncherFactory,
             application = application,
             statusBarColor = { starterArgs.statusBarColor },
             savedStateHandle = savedStateHandle,
             errorReporter = errorReporter,
+            logger = logger,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -18,6 +18,9 @@ import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.customersheet.FakeCustomerAdapter
 import com.stripe.android.customersheet.FakeStripeRepository
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
+import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
@@ -47,6 +50,7 @@ import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.utils.DummyActivityResultCaller
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.StandardTestDispatcher
 import org.mockito.kotlin.mock
 import kotlin.coroutines.CoroutineContext
@@ -190,10 +194,20 @@ internal object CustomerSheetTestHelper {
                         return mock()
                     }
                 },
+                googlePayPaymentMethodLauncherFactory = object : GooglePayPaymentMethodLauncherFactory {
+                    override fun create(
+                        lifecycleScope: CoroutineScope,
+                        config: GooglePayPaymentMethodLauncher.Config,
+                        readyCallback: GooglePayPaymentMethodLauncher.ReadyCallback,
+                        activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
+                        skipReadyCheck: Boolean
+                    ): GooglePayPaymentMethodLauncher = mock()
+                },
                 statusBarColor = { null },
                 savedStateHandle = SavedStateHandle(),
                 application = application,
                 errorReporter = FakeErrorReporter(),
+                logger = Logger.noop(),
             ),
             eventReporter = eventReporter,
             customerSheetLoader = customerSheetLoader,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
@@ -1331,7 +1331,7 @@ class IntentConfirmationHandlerTest {
             "GooglePayConfig.currencyCode is required in order to use " +
                 "Google Pay when processing a Setup Intent"
         )
-        assertThat(result.type).isEqualTo(IntentConfirmationHandler.ErrorType.Internal)
+        assertThat(result.type).isEqualTo(IntentConfirmationHandler.ErrorType.MerchantIntegration)
         assertThat(result.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
@@ -150,7 +150,7 @@ class IntentConfirmationHandlerTest {
                 ),
             )
 
-            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(contentVisible = true))
+            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(isPaymentSheetVisible = true))
 
             ensureAllEventsConsumed()
         }
@@ -491,7 +491,7 @@ class IntentConfirmationHandlerTest {
                 arguments = DEFAULT_ARGUMENTS,
             )
 
-            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(contentVisible = true))
+            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(isPaymentSheetVisible = true))
 
             paymentResultCallbackHandler.onResult(InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED))
 
@@ -531,7 +531,7 @@ class IntentConfirmationHandlerTest {
                 arguments = DEFAULT_ARGUMENTS,
             )
 
-            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(contentVisible = true))
+            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(isPaymentSheetVisible = true))
 
             paymentResultCallbackHandler.onResult(InternalPaymentResult.Canceled)
 
@@ -570,7 +570,7 @@ class IntentConfirmationHandlerTest {
                 arguments = DEFAULT_ARGUMENTS,
             )
 
-            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(contentVisible = true))
+            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(isPaymentSheetVisible = true))
 
             val cause = IllegalStateException("This is a failure!")
 
@@ -699,7 +699,7 @@ class IntentConfirmationHandlerTest {
         )
 
         intentConfirmationHandler.state.test {
-            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(contentVisible = true))
+            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(isPaymentSheetVisible = true))
 
             dispatcher.scheduler.advanceTimeBy(delayTime = 1.01.seconds)
 
@@ -743,7 +743,7 @@ class IntentConfirmationHandlerTest {
         )
 
         intentConfirmationHandler.state.test {
-            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(contentVisible = true))
+            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(isPaymentSheetVisible = true))
 
             dispatcher.scheduler.advanceTimeBy(delayTime = 200.seconds)
 
@@ -854,7 +854,7 @@ class IntentConfirmationHandlerTest {
                 arguments = DEFAULT_ARGUMENTS,
             )
 
-            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(contentVisible = true))
+            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(isPaymentSheetVisible = true))
 
             paymentResultCallbackHandler.onResult(InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED))
 
@@ -975,7 +975,7 @@ class IntentConfirmationHandlerTest {
                 ),
             )
 
-            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(contentVisible = true))
+            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(isPaymentSheetVisible = true))
 
             epmsCallbackHandler.onResult(PaymentResult.Completed)
 
@@ -1012,7 +1012,7 @@ class IntentConfirmationHandlerTest {
                 ),
             )
 
-            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(contentVisible = true))
+            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(isPaymentSheetVisible = true))
 
             val exception = APIException()
 
@@ -1052,7 +1052,7 @@ class IntentConfirmationHandlerTest {
                 ),
             )
 
-            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(contentVisible = true))
+            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(isPaymentSheetVisible = true))
 
             epmsCallbackHandler.onResult(PaymentResult.Canceled)
 
@@ -1248,7 +1248,7 @@ class IntentConfirmationHandlerTest {
                 ),
             )
 
-            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(contentVisible = true))
+            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(isPaymentSheetVisible = true))
 
             bacsMandateConfirmationCallbackHandler.onResult(BacsMandateConfirmationResult.ModifyDetails)
 
@@ -1291,7 +1291,7 @@ class IntentConfirmationHandlerTest {
                 ),
             )
 
-            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(contentVisible = true))
+            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(isPaymentSheetVisible = true))
 
             bacsMandateConfirmationCallbackHandler.onResult(BacsMandateConfirmationResult.Cancelled)
 
@@ -1453,8 +1453,8 @@ class IntentConfirmationHandlerTest {
                 ),
             )
 
-            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(contentVisible = true))
-            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(contentVisible = false))
+            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(isPaymentSheetVisible = true))
+            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(isPaymentSheetVisible = false))
 
             googlePayCallbackHandler.onResult(GooglePayPaymentMethodLauncher.Result.Canceled)
 
@@ -1485,8 +1485,8 @@ class IntentConfirmationHandlerTest {
                 ),
             )
 
-            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(contentVisible = true))
-            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(contentVisible = false))
+            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(isPaymentSheetVisible = true))
+            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(isPaymentSheetVisible = false))
 
             val exception = IllegalStateException("Failed!")
 
@@ -1529,8 +1529,8 @@ class IntentConfirmationHandlerTest {
                 ),
             )
 
-            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(contentVisible = true))
-            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(contentVisible = false))
+            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(isPaymentSheetVisible = true))
+            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(isPaymentSheetVisible = false))
 
             googlePayCallbackHandler.onResult(
                 GooglePayPaymentMethodLauncher.Result.Completed(
@@ -1538,7 +1538,7 @@ class IntentConfirmationHandlerTest {
                 )
             )
 
-            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(contentVisible = true))
+            assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming(isPaymentSheetVisible = true))
 
             val call = intentConfirmationInterceptor.calls.awaitItem()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentConfirmationOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentConfirmationOptionKtxTest.kt
@@ -21,7 +21,7 @@ class PaymentConfirmationOptionKtxTest {
             ),
         )
 
-        assertThat(paymentSelection.toPaymentConfirmationOption()).isEqualTo(
+        assertThat(paymentSelection.toPaymentConfirmationOption(configuration = null)).isEqualTo(
             PaymentConfirmationOption.New(
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = PaymentMethodOptionsParams.Card(network = "cartes_bancaires"),
@@ -36,7 +36,7 @@ class PaymentConfirmationOptionKtxTest {
             customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse,
         )
 
-        assertThat(paymentSelection.toPaymentConfirmationOption()).isEqualTo(
+        assertThat(paymentSelection.toPaymentConfirmationOption(configuration = null)).isEqualTo(
             PaymentConfirmationOption.New(
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = null,
@@ -51,7 +51,7 @@ class PaymentConfirmationOptionKtxTest {
             customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse,
         )
 
-        assertThat(paymentSelection.toPaymentConfirmationOption()).isEqualTo(
+        assertThat(paymentSelection.toPaymentConfirmationOption(configuration = null)).isEqualTo(
             PaymentConfirmationOption.New(
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = null,
@@ -66,7 +66,7 @@ class PaymentConfirmationOptionKtxTest {
             customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
         )
 
-        assertThat(paymentSelection.toPaymentConfirmationOption()).isEqualTo(
+        assertThat(paymentSelection.toPaymentConfirmationOption(configuration = null)).isEqualTo(
             PaymentConfirmationOption.New(
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = null,
@@ -84,7 +84,7 @@ class PaymentConfirmationOptionKtxTest {
             ),
         )
 
-        assertThat(paymentSelection.toPaymentConfirmationOption()).isEqualTo(
+        assertThat(paymentSelection.toPaymentConfirmationOption(configuration = null)).isEqualTo(
             PaymentConfirmationOption.Saved(
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 optionsParams = PaymentMethodOptionsParams.Card(
@@ -110,7 +110,7 @@ class PaymentConfirmationOptionKtxTest {
             iconResource = 0,
         )
 
-        assertThat(paymentSelection.toPaymentConfirmationOption()).isEqualTo(
+        assertThat(paymentSelection.toPaymentConfirmationOption(configuration = null)).isEqualTo(
             PaymentConfirmationOption.ExternalPaymentMethod(
                 type = "paypal",
                 billingDetails = PaymentMethod.BillingDetails(
@@ -124,13 +124,49 @@ class PaymentConfirmationOptionKtxTest {
     }
 
     @Test
-    fun `On Google Pay selection, should return null`() {
-        assertThat(PaymentSelection.GooglePay.toPaymentConfirmationOption()).isNull()
+    fun `On Google Pay selection with a null configuration, should return null`() {
+        assertThat(PaymentSelection.GooglePay.toPaymentConfirmationOption(configuration = null)).isNull()
+    }
+
+    @Test
+    fun `On Google Pay selection with config with null google pay config, should return null`() {
+        assertThat(
+            PaymentSelection.GooglePay.toPaymentConfirmationOption(
+                configuration = PaymentSheetFixtures.CONFIG_CUSTOMER
+            )
+        ).isNull()
+    }
+
+    @Test
+    fun `On Google Pay selection with config with google pay config, should return expected option`() {
+        assertThat(
+            PaymentSelection.GooglePay.toPaymentConfirmationOption(
+                configuration = PaymentSheetFixtures.CONFIG_GOOGLEPAY.copy(
+                    googlePay = PaymentSheetFixtures.CONFIG_GOOGLEPAY.googlePay?.copy(
+                        label = "Merchant Payments",
+                        amount = 5000,
+                        environment = PaymentSheet.GooglePayConfiguration.Environment.Production
+                    )
+                )
+            )
+        ).isEqualTo(
+            PaymentConfirmationOption.GooglePay(
+                config = PaymentConfirmationOption.GooglePay.Config(
+                    environment = PaymentSheet.GooglePayConfiguration.Environment.Production,
+                    merchantName = "Merchant, Inc.",
+                    merchantCountryCode = "US",
+                    merchantCurrencyCode = "USD",
+                    customAmount = 5000,
+                    customLabel = "Merchant Payments",
+                    billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration()
+                )
+            )
+        )
     }
 
     @Test
     fun `On Link selection, should return null`() {
-        assertThat(PaymentSelection.Link.toPaymentConfirmationOption()).isNull()
+        assertThat(PaymentSelection.Link.toPaymentConfirmationOption(configuration = null)).isNull()
     }
 
     private fun createNewPaymentSelection(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkActivityResult
@@ -650,6 +651,7 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `Google Pay checkout cancelled returns to Idle state`() = runTest {
         val viewModel = createViewModel()
+        val googlePayListener = viewModel.captureGooglePayListener()
 
         viewModel.checkoutWithGooglePay()
 
@@ -661,7 +663,7 @@ internal class PaymentSheetViewModelTest {
                 .isEqualTo(WalletsProcessingState.Processing)
             assertThat(processingTurbine.awaitItem()).isTrue()
 
-            viewModel.onGooglePayResult(GooglePayPaymentMethodLauncher.Result.Canceled)
+            googlePayListener.onActivityResult(GooglePayPaymentMethodLauncher.Result.Canceled)
             assertThat(viewModel.contentVisible.value).isTrue()
 
             assertThat(walletsProcessingStateTurbine.awaitItem())
@@ -702,6 +704,7 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `Google Pay checkout failed returns to Idle state and shows error`() = runTest {
         val viewModel = createViewModel()
+        val googlePayListener = viewModel.captureGooglePayListener()
 
         viewModel.checkoutWithGooglePay()
 
@@ -713,7 +716,7 @@ internal class PaymentSheetViewModelTest {
                 .isEqualTo(WalletsProcessingState.Processing)
             assertThat(processingTurbine.awaitItem()).isTrue()
 
-            viewModel.onGooglePayResult(
+            googlePayListener.onActivityResult(
                 GooglePayPaymentMethodLauncher.Result.Failed(
                     Exception("Test exception"),
                     Status.RESULT_INTERNAL_ERROR.statusCode
@@ -1260,6 +1263,7 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `Resets selection correctly after cancelling Google Pay`() = runTest {
         val viewModel = createViewModel(initialPaymentSelection = null)
+        val googlePayListener = viewModel.captureGooglePayListener()
 
         val initialSelection = PaymentSelection.New.Card(
             PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
@@ -1274,7 +1278,7 @@ internal class PaymentSheetViewModelTest {
             viewModel.transitionToAddPaymentScreen()
             assertThat(awaitItem()).isEqualTo(initialSelection)
             viewModel.checkoutWithGooglePay()
-            viewModel.onGooglePayResult(GooglePayPaymentMethodLauncher.Result.Canceled)
+            googlePayListener.onActivityResult(GooglePayPaymentMethodLauncher.Result.Canceled)
 
             // Still using the initial PaymentSelection
             expectNoEvents()
@@ -1360,11 +1364,12 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `Content should be hidden when Google Pay is visible`() = runTest {
         val viewModel = createViewModel()
+        val googlePayListener = viewModel.captureGooglePayListener()
         viewModel.contentVisible.test {
             assertThat(awaitItem()).isTrue()
             viewModel.checkoutWithGooglePay()
             assertThat(awaitItem()).isFalse()
-            viewModel.onGooglePayResult(GooglePayPaymentMethodLauncher.Result.Canceled)
+            googlePayListener.onActivityResult(GooglePayPaymentMethodLauncher.Result.Canceled)
             assertThat(awaitItem()).isTrue()
         }
     }
@@ -2053,11 +2058,6 @@ internal class PaymentSheetViewModelTest {
             isGooglePayReady = true,
         )
 
-        viewModel.setupGooglePay(
-            lifecycleScope = mock(),
-            activityResultLauncher = mock(),
-        )
-
         viewModel.checkoutWithGooglePay()
 
         verify(googlePayLauncher).present(
@@ -2089,11 +2089,6 @@ internal class PaymentSheetViewModelTest {
             args = args,
             isGooglePayReady = true,
             stripeIntent = SETUP_INTENT,
-        )
-
-        viewModel.setupGooglePay(
-            lifecycleScope = mock(),
-            activityResultLauncher = mock(),
         )
 
         viewModel.checkoutWithGooglePay()
@@ -2793,7 +2788,6 @@ internal class PaymentSheetViewModelTest {
                 paymentSheetLoader = paymentSheetLoader,
                 customerRepository = customerRepository,
                 prefsRepository = prefsRepository,
-                googlePayPaymentMethodLauncherFactory = googlePayLauncherFactory,
                 logger = Logger.noop(),
                 workContext = testDispatcher,
                 savedStateHandle = thisSavedStateHandle,
@@ -2804,10 +2798,12 @@ internal class PaymentSheetViewModelTest {
                     savedStateHandle = thisSavedStateHandle,
                     bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,
                     stripePaymentLauncherAssistedFactory = paymentLauncherFactory,
+                    googlePayPaymentMethodLauncherFactory = googlePayLauncherFactory,
                     paymentConfigurationProvider = { paymentConfiguration },
                     statusBarColor = { args.statusBarColor },
                     application = application,
-                    errorReporter = FakeErrorReporter()
+                    errorReporter = FakeErrorReporter(),
+                    logger = Logger.noop(),
                 ),
                 editInteractorFactory = fakeEditPaymentMethodInteractorFactory,
             ).apply {
@@ -2925,6 +2921,30 @@ internal class PaymentSheetViewModelTest {
         )
 
         return paymentResultListenerCaptor.firstValue
+    }
+
+    private fun PaymentSheetViewModel.captureGooglePayListener():
+        ActivityResultCallback<GooglePayPaymentMethodLauncher.Result> {
+        val mockActivityResultCaller = mock<ActivityResultCaller> {
+            on {
+                registerForActivityResult<
+                    GooglePayPaymentMethodLauncherContractV2.Args,
+                    GooglePayPaymentMethodLauncher.Result
+                    >(any(), any())
+            } doReturn mock()
+        }
+
+        registerFromActivity(mockActivityResultCaller, TestLifecycleOwner())
+
+        val googlePayListenerCaptor =
+            argumentCaptor<ActivityResultCallback<GooglePayPaymentMethodLauncher.Result>>()
+
+        verify(mockActivityResultCaller).registerForActivityResult(
+            any<GooglePayPaymentMethodLauncherContractV2>(),
+            googlePayListenerCaptor.capture(),
+        )
+
+        return googlePayListenerCaptor.firstValue
     }
 
     private fun getPaymentMethodOptionJsonStringWithCvcRecollectionValue(enabled: Boolean): String {


### PR DESCRIPTION
# Summary
Move `Google Pay` handling to `IntentConfirmationHandler`.

# Motivation
Removes duplicated Google Pay code between `PaymentSheet` and `FlowController`. This also synchronizes the logic between `PaymentSheet` and `FlowController` for how to handle Google Pay launching and validation.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Video
Since Google Pay is a restricted application, parts of the video showing usage of Google Pay are hidden.
<video src="https://github.com/user-attachments/assets/a98966e1-d62c-4628-aca3-8dcd1904c579" />

With process death
<video src="https://github.com/user-attachments/assets/c0414f96-354b-470d-b574-1a36e22d65c4" />