### PR TITLE
Fix index out of bounds crash in DropdownFieldController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 20XX-XX-XX
 
+### PaymentSheet
+* [FIXED][8971](https://github.com/stripe/stripe-android/pull/8971) Fixed a crash caused by an index out of bounds exception
+
 ## 20.48.2 - 2024-07-29
 
 ### PaymentSheet

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldController.kt
@@ -27,7 +27,7 @@ class DropdownFieldController(
     val selectedIndex: StateFlow<Int> = _selectedIndex
     override val label: StateFlow<Int> = MutableStateFlow(config.label)
     override val fieldValue = selectedIndex.mapAsStateFlow { displayItems[it] }
-    override val rawFieldValue = selectedIndex.mapAsStateFlow { config.rawItems[it] }
+    override val rawFieldValue = selectedIndex.mapAsStateFlow { config.rawItems.getOrNull(it) }
     override val error: StateFlow<FieldError?> = stateFlowOf(null)
     override val showOptionalLabel: Boolean = false // not supported yet
     override val isComplete: StateFlow<Boolean> = MutableStateFlow(true)
@@ -51,15 +51,20 @@ class DropdownFieldController(
      * This is called when the value changed to is a display value.
      */
     fun onValueChange(index: Int) {
-        _selectedIndex.value = index
+        safelyUpdateSelectedIndex(index)
     }
 
     /**
      * This is called when the value changed to is a raw backing value, not a display value.
      */
     override fun onRawValueChange(rawValue: String) {
-        _selectedIndex.value =
-            displayItems.indexOf(config.convertFromRaw(rawValue)).takeUnless { it == -1 } ?: 0
+        safelyUpdateSelectedIndex(displayItems.indexOf(config.convertFromRaw(rawValue)).takeUnless { it == -1 } ?: 0)
+    }
+
+    private fun safelyUpdateSelectedIndex(index: Int) {
+        if (index < displayItems.size) {
+            _selectedIndex.value = index
+        }
     }
 
     @Composable


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fix index out of bounds crash in DropdownFieldController

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3398

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
* [FIXED][8971](https://github.com/stripe/stripe-android/pull/8971) Fixed a crash caused by an index out of bounds exception
