### PR TITLE
[NME] Accepting and sending new api param for acquiring consent for networking manual entry consent


### DIFF
--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -385,6 +385,7 @@ enum class Merchant(
     Networking("networking"),
     LiveTesting("live_testing", canSwitchBetweenTestAndLive = false),
     TestMode("testmode", canSwitchBetweenTestAndLive = false),
+    NME("nme", canSwitchBetweenTestAndLive = true),
     Custom("other");
 
     companion object {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SelectNetworkedAccounts.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SelectNetworkedAccounts.kt
@@ -13,11 +13,13 @@ internal class SelectNetworkedAccounts @Inject constructor(
     suspend operator fun invoke(
         consumerSessionClientSecret: String,
         selectedAccountIds: Set<String>,
+        consentAcquired: Boolean
     ): InstitutionResponse {
         return repository.postShareNetworkedAccounts(
             clientSecret = configuration.financialConnectionsSessionClientSecret,
             consumerSessionClientSecret = consumerSessionClientSecret,
             selectedAccountIds = selectedAccountIds,
+            consentAcquired = consentAcquired
         )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SelectNetworkedAccounts.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SelectNetworkedAccounts.kt
@@ -13,7 +13,7 @@ internal class SelectNetworkedAccounts @Inject constructor(
     suspend operator fun invoke(
         consumerSessionClientSecret: String,
         selectedAccountIds: Set<String>,
-        consentAcquired: Boolean
+        consentAcquired: Boolean?
     ): InstitutionResponse {
         return repository.postShareNetworkedAccounts(
             clientSecret = configuration.financialConnectionsSessionClientSecret,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerPreviewParameterProvider.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerPreviewParameterProvider.kt
@@ -36,7 +36,8 @@ internal class LinkAccountPickerPreviewParameterProvider :
                 singleAccount = true,
                 multipleAccountTypesSelectedDataAccessNotice = display().multipleAccountTypesSelectedDataAccessNotice,
                 aboveCta = display().aboveCta,
-                defaultDataAccessNotice = null
+                defaultDataAccessNotice = null,
+                acquireConsentOnPrimaryCtaClick = false
             )
         ),
     )
@@ -59,7 +60,8 @@ internal class LinkAccountPickerPreviewParameterProvider :
                 singleAccount = true,
                 multipleAccountTypesSelectedDataAccessNotice = display().multipleAccountTypesSelectedDataAccessNotice,
                 aboveCta = display().aboveCta,
-                defaultDataAccessNotice = null
+                defaultDataAccessNotice = null,
+                acquireConsentOnPrimaryCtaClick = false
             )
         ),
     )
@@ -78,7 +80,8 @@ internal class LinkAccountPickerPreviewParameterProvider :
                 singleAccount = true,
                 multipleAccountTypesSelectedDataAccessNotice = display().multipleAccountTypesSelectedDataAccessNotice,
                 aboveCta = display().aboveCta,
-                defaultDataAccessNotice = null
+                defaultDataAccessNotice = null,
+                acquireConsentOnPrimaryCtaClick = false
             )
         ),
     )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
@@ -117,7 +117,7 @@ internal class LinkAccountPickerViewModel @AssistedInject constructor(
                 defaultCta = display.defaultCta,
                 consumerSessionClientSecret = consumerSession.clientSecret,
                 singleAccount = manifest.singleAccount,
-                acquireConsentOnPrimaryCtaClick = accountsResponse.acquireCtaOnPrimaryCtaClick ?: false,
+                acquireConsentOnPrimaryCtaClick = accountsResponse.acquireConsentOnPrimaryCtaClick ?: false,
                 selectedAccountIds = selectedAccountIds
             )
         }.execute {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
@@ -117,6 +117,7 @@ internal class LinkAccountPickerViewModel @AssistedInject constructor(
                 defaultCta = display.defaultCta,
                 consumerSessionClientSecret = consumerSession.clientSecret,
                 singleAccount = manifest.singleAccount,
+                acquireConsentOnPrimaryCtaClick = accountsResponse.acquireCtaOnPrimaryCtaClick ?: false,
                 selectedAccountIds = selectedAccountIds
             )
         }.execute {
@@ -215,6 +216,7 @@ internal class LinkAccountPickerViewModel @AssistedInject constructor(
 
             if (nextPane == SUCCESS) {
                 selectAccounts(
+                    acquireConsentOnPrimaryCtaClick = payload.acquireConsentOnPrimaryCtaClick,
                     consumerSessionClientSecret = payload.consumerSessionClientSecret,
                     accountIds = accountIds,
                 )
@@ -225,12 +227,14 @@ internal class LinkAccountPickerViewModel @AssistedInject constructor(
     }
 
     private suspend fun selectAccounts(
+        acquireConsentOnPrimaryCtaClick: Boolean,
         consumerSessionClientSecret: String,
         accountIds: Set<String>,
     ) {
         selectNetworkedAccounts(
             consumerSessionClientSecret = consumerSessionClientSecret,
             selectedAccountIds = accountIds,
+            consentAcquired = acquireConsentOnPrimaryCtaClick,
         )
         FinancialConnections.emitEvent(name = Name.ACCOUNTS_SELECTED)
         navigationManager.tryNavigateTo(Destination.Success(referrer = PANE))
@@ -379,6 +383,7 @@ internal data class LinkAccountPickerState(
         val multipleAccountTypesSelectedDataAccessNotice: DataAccessNotice?,
         val aboveCta: String?,
         val defaultDataAccessNotice: DataAccessNotice?,
+        val acquireConsentOnPrimaryCtaClick: Boolean,
     ) {
 
         val selectedAccounts: List<LinkedAccount>

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationViewModel.kt
@@ -171,6 +171,7 @@ internal class LinkStepUpVerificationViewModel @AssistedInject constructor(
         selectNetworkedAccounts(
             consumerSessionClientSecret = payload.consumerSessionClientSecret,
             selectedAccountIds = selectedAccounts.map { it.id }.toSet(),
+            consentAcquired = null
         )
 
         navigationManager.tryNavigateTo(Destination.Success(referrer = PANE))

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessContent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessContent.kt
@@ -68,6 +68,7 @@ import com.stripe.android.financialconnections.ui.components.FinancialConnection
 import com.stripe.android.financialconnections.ui.components.StringAnnotation
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.typography
+import com.stripe.android.uicore.text.MiddleEllipsisText
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -241,7 +242,7 @@ private fun SuccessFooter(
             .testTag("done_button")
             .fillMaxWidth()
     ) {
-        Text(
+        MiddleEllipsisText(
             text = when (merchantName) {
                 null -> stringResource(id = R.string.stripe_success_pane_done)
                 else -> stringResource(id = R.string.stripe_success_pane_done_with_merchant, merchantName)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/NetworkedAccountsList.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/NetworkedAccountsList.kt
@@ -13,5 +13,7 @@ internal data class NetworkedAccountsList(
 
     @SerialName(value = "next_pane_on_add_account") val nextPaneOnAddAccount: Pane? = null,
 
-    @SerialName(value = "partner_to_core_auths") val partnerToCoreAuths: Map<String, String>? = null
+    @SerialName(value = "partner_to_core_auths") val partnerToCoreAuths: Map<String, String>? = null,
+
+    @SerialName(value = "acquire_cta_on_primary_cta_click") val acquireCtaOnPrimaryCtaClick: Boolean? = false,
 )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/NetworkedAccountsList.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/NetworkedAccountsList.kt
@@ -15,5 +15,5 @@ internal data class NetworkedAccountsList(
 
     @SerialName(value = "partner_to_core_auths") val partnerToCoreAuths: Map<String, String>? = null,
 
-    @SerialName(value = "acquire_cta_on_primary_cta_click") val acquireCtaOnPrimaryCtaClick: Boolean? = false,
+    @SerialName(value = "acquire_consent_on_primary_cta_click") val acquireConsentOnPrimaryCtaClick: Boolean? = false,
 )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsAccountsRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsAccountsRepository.kt
@@ -62,6 +62,7 @@ internal interface FinancialConnectionsAccountsRepository {
         clientSecret: String,
         consumerSessionClientSecret: String,
         selectedAccountIds: Set<String>,
+        consentAcquired: Boolean?
     ): InstitutionResponse
 
     suspend fun pollAccountNumbers(linkedAccounts: Set<String>)
@@ -148,7 +149,8 @@ private class FinancialConnectionsAccountsRepositoryImpl(
     override suspend fun postShareNetworkedAccounts(
         clientSecret: String,
         consumerSessionClientSecret: String,
-        selectedAccountIds: Set<String>
+        selectedAccountIds: Set<String>,
+        consentAcquired: Boolean?
     ): InstitutionResponse {
         val request = apiRequestFactory.createPost(
             url = shareNetworkedAccountsUrl,
@@ -156,7 +158,8 @@ private class FinancialConnectionsAccountsRepositoryImpl(
             params = mapOf(
                 PARAMS_CLIENT_SECRET to clientSecret,
                 PARAMS_CONSUMER_CLIENT_SECRET to consumerSessionClientSecret,
-            ) + selectedAccountIds.mapIndexed { index, selectedAccountId ->
+                "consent_acquired" to consentAcquired,
+            ).filterNotNullValues() + selectedAccountIds.mapIndexed { index, selectedAccountId ->
                 "$PARAM_SELECTED_ACCOUNTS[$index]" to selectedAccountId
             },
         )

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModelTest.kt
@@ -156,6 +156,7 @@ class LinkAccountPickerViewModelTest {
             selectNetworkedAccounts(
                 consumerSessionClientSecret = any(),
                 selectedAccountIds = any(),
+                consentAcquired = any()
             )
         ).thenReturn(InstitutionResponse(showManualEntry = false, listOf(institution())))
 
@@ -196,6 +197,7 @@ class LinkAccountPickerViewModelTest {
                 selectNetworkedAccounts(
                     consumerSessionClientSecret = any(),
                     selectedAccountIds = any(),
+                    consentAcquired = any()
                 )
             ).thenReturn(InstitutionResponse(showManualEntry = false, listOf(institution())))
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationViewModelTest.kt
@@ -181,8 +181,9 @@ class LinkStepUpVerificationViewModelTest {
             verify(confirmVerification).email(any(), eq("111111"))
             verify(markLinkVerified).invoke()
             verify(selectNetworkedAccounts).invoke(
-                consumerSession.clientSecret,
-                setOf(selectedAccount.id)
+                consumerSessionClientSecret = consumerSession.clientSecret,
+                selectedAccountIds = setOf(selectedAccount.id),
+                consentAcquired = null
             )
             navigationManager.assertNavigatedTo(
                 Destination.Success,

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/AbsFinancialConnectionsAccountsRepository.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/AbsFinancialConnectionsAccountsRepository.kt
@@ -53,7 +53,8 @@ internal abstract class AbsFinancialConnectionsAccountsRepository : FinancialCon
     override suspend fun postShareNetworkedAccounts(
         clientSecret: String,
         consumerSessionClientSecret: String,
-        selectedAccountIds: Set<String>
+        selectedAccountIds: Set<String>,
+        consentAcquired: Boolean?
     ): InstitutionResponse {
         TODO("Not yet implemented")
     }


### PR DESCRIPTION
# Summary

Mid flow consent support:

- On a `Consent -> Manual Entry -> LinkAccountPicker` navigation, consent will be acquired when clicking the connect account CTA.
- To do that, backend sends an `acquireConsentOnPrimaryCtaClick` field, that we'll pass into selectNetworkedAccounts.
- Also notice the CTA text now says `Agree and connect`.

Equivalent [Stripe.js PR](https://git.corp.stripe.com/stripe-internal/stripe-js-v3/pull/23488)

https://github.com/user-attachments/assets/165c6295-53ad-4928-919c-15a7e17d6093

# Motivation
:notebook_with_decorative_cover: &nbsp;**[Android] Accepting and sending new api param for acquiring consent for networking manual entry consent**
:globe_with_meridians: &nbsp;[BANKCON-11711](https://jira.corp.stripe.com/browse/BANKCON-11711)

> <https://git.corp.stripe.com/stripe-internal/stripe-js-v3/pull/23488>
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->