### PR TITLE
Update CHANGELOG update step to be idempotent

### DIFF
--- a/scripts/deploy/update_version_numbers.rb
+++ b/scripts/deploy/update_version_numbers.rb
@@ -35,13 +35,17 @@ def update_version()
 end
 
 def update_changelog()
-    date = Time.now.strftime("%Y-%m-%d")
+    changelog_contents = File.read("CHANGELOG.md")
 
-    replace_in_file(
-        "CHANGELOG.md",
-        /## XX.XX.XX - 20XX-XX-XX/,
-        "## XX.XX.XX - 20XX-XX-XX\n\n## #{@version} - #{date}"
-    )
+    if (!changelog_contents.include? @version)
+        date = Time.now.strftime("%Y-%m-%d")
+
+        replace_in_file(
+            "CHANGELOG.md",
+            /## XX.XX.XX - 20XX-XX-XX/,
+            "## XX.XX.XX - 20XX-XX-XX\n\n## #{@version} - #{date}"
+        )
+    end
 
     execute_or_fail("git add CHANGELOG.md")
 end


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update CHANGELOG update step to be idempotent

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Previously, if you ran this step twice, then the version + date would be added to the CHANGELOG twice. And then the github release changelog would be computed incorrectly. This ensures that we don't add the version to the changelog multiple times.

This doesn't happen for the other version update steps, because those are pure replacements. This one is different because it's an additive change

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Used the dry run feature to validate that this won't update the changelog if the version is already included in the changelog