### PR TITLE
Add new pre-confirm state in `IntentConfirmationHandler`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -341,8 +341,20 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             intentConfirmationHandler.state.collectLatest { state ->
                 when (state) {
                     is IntentConfirmationHandler.State.Idle -> Unit
+                    is IntentConfirmationHandler.State.Preconfirming -> {
+                        if (
+                            state.inPreconfirmFlow &&
+                            state.confirmationOption is PaymentConfirmationOption.GooglePay
+                        ) {
+                            setContentVisible(false)
+                        } else {
+                            setContentVisible(true)
+                        }
+
+                        startProcessing(checkoutIdentifier)
+                    }
                     is IntentConfirmationHandler.State.Confirming -> {
-                        setContentVisible(state.isPaymentSheetVisible)
+                        setContentVisible(true)
 
                         if (viewState.value !is PaymentSheetViewState.StartProcessing) {
                             startProcessing(checkoutIdentifier)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -199,6 +199,7 @@ internal class DefaultFlowController @Inject internal constructor(
             intentConfirmationHandler.state.collectLatest { state ->
                 when (state) {
                     is IntentConfirmationHandler.State.Idle,
+                    is IntentConfirmationHandler.State.Preconfirming,
                     is IntentConfirmationHandler.State.Confirming -> Unit
                     is IntentConfirmationHandler.State.Complete -> onIntentResult(state.result)
                 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
@@ -150,6 +150,12 @@ class IntentConfirmationHandlerTest {
                 ),
             )
 
+            assertThat(awaitItem()).isEqualTo(
+                IntentConfirmationHandler.State.Preconfirming(
+                    confirmationOption = DEFAULT_ARGUMENTS.confirmationOption,
+                    inPreconfirmFlow = false,
+                )
+            )
             assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming)
 
             ensureAllEventsConsumed()
@@ -491,6 +497,12 @@ class IntentConfirmationHandlerTest {
                 arguments = DEFAULT_ARGUMENTS,
             )
 
+            assertThat(awaitItem()).isEqualTo(
+                IntentConfirmationHandler.State.Preconfirming(
+                    confirmationOption = DEFAULT_ARGUMENTS.confirmationOption,
+                    inPreconfirmFlow = false,
+                )
+            )
             assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming)
 
             paymentResultCallbackHandler.onResult(InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED))
@@ -531,6 +543,12 @@ class IntentConfirmationHandlerTest {
                 arguments = DEFAULT_ARGUMENTS,
             )
 
+            assertThat(awaitItem()).isEqualTo(
+                IntentConfirmationHandler.State.Preconfirming(
+                    confirmationOption = DEFAULT_ARGUMENTS.confirmationOption,
+                    inPreconfirmFlow = false,
+                )
+            )
             assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming)
 
             paymentResultCallbackHandler.onResult(InternalPaymentResult.Canceled)
@@ -570,6 +588,12 @@ class IntentConfirmationHandlerTest {
                 arguments = DEFAULT_ARGUMENTS,
             )
 
+            assertThat(awaitItem()).isEqualTo(
+                IntentConfirmationHandler.State.Preconfirming(
+                    confirmationOption = DEFAULT_ARGUMENTS.confirmationOption,
+                    inPreconfirmFlow = false,
+                )
+            )
             assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming)
 
             val cause = IllegalStateException("This is a failure!")
@@ -862,6 +886,12 @@ class IntentConfirmationHandlerTest {
                 arguments = DEFAULT_ARGUMENTS,
             )
 
+            assertThat(awaitItem()).isEqualTo(
+                IntentConfirmationHandler.State.Preconfirming(
+                    confirmationOption = DEFAULT_ARGUMENTS.confirmationOption,
+                    inPreconfirmFlow = false,
+                )
+            )
             assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming)
 
             paymentResultCallbackHandler.onResult(InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED))
@@ -983,6 +1013,12 @@ class IntentConfirmationHandlerTest {
                 ),
             )
 
+            assertThat(awaitItem()).isEqualTo(
+                IntentConfirmationHandler.State.Preconfirming(
+                    confirmationOption = EXTERNAL_PAYMENT_METHOD,
+                    inPreconfirmFlow = false,
+                )
+            )
             assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming)
 
             epmsCallbackHandler.onResult(PaymentResult.Completed)
@@ -1020,6 +1056,12 @@ class IntentConfirmationHandlerTest {
                 ),
             )
 
+            assertThat(awaitItem()).isEqualTo(
+                IntentConfirmationHandler.State.Preconfirming(
+                    confirmationOption = EXTERNAL_PAYMENT_METHOD,
+                    inPreconfirmFlow = false,
+                )
+            )
             assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming)
 
             val exception = APIException()
@@ -1060,6 +1102,12 @@ class IntentConfirmationHandlerTest {
                 ),
             )
 
+            assertThat(awaitItem()).isEqualTo(
+                IntentConfirmationHandler.State.Preconfirming(
+                    confirmationOption = EXTERNAL_PAYMENT_METHOD,
+                    inPreconfirmFlow = false,
+                )
+            )
             assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming)
 
             epmsCallbackHandler.onResult(PaymentResult.Canceled)


### PR DESCRIPTION
# Summary
Add new pre-confirm state in `IntentConfirmationHandler`

# Motivation
Can better indicate what state we are in the `IntentConfirmationHandler` and whether we are in the pre-confirm flow or not. This helps remove implementation specific details from `IntentConfirmationHandler`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Video
| PaymentSheet | FlowController |
| -------------- | --------------- |
| <video src="https://github.com/user-attachments/assets/2596905e-b73d-41c0-955d-3835f0fa7187" /> | <video src="https://github.com/user-attachments/assets/f5a1b48f-e426-40ef-9f66-3fd0064a126e" /> |



