### PR TITLE
Align `ConsumerSession` with server response

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/ConsumerSessionRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/ConsumerSessionRepository.kt
@@ -44,7 +44,7 @@ internal class RealConsumerSessionRepository @Inject constructor(
         emailAddress = emailAddress,
         phoneNumber = getRedactedPhoneNumber(),
         clientSecret = clientSecret,
-        publishableKey = publishableKey,
+        publishableKey = null, // TODO(tillh-stripe): Coming in the follow-up
         isVerified = verificationSessions.any {
             it.state == ConsumerSession.VerificationSession.SessionState.Verified
         },

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/ApiKeyFixtures.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/ApiKeyFixtures.kt
@@ -133,7 +133,6 @@ internal object ApiKeyFixtures {
         redactedPhoneNumber = "+1********12",
         redactedFormattedPhoneNumber = "(***) *** **12",
         verificationSessions = emptyList(),
-        publishableKey = null
     )
 
     fun verifiedConsumerSession() = ConsumerSession(
@@ -147,6 +146,5 @@ internal object ApiKeyFixtures {
                 state = ConsumerSession.VerificationSession.SessionState.Verified,
             )
         ),
-        publishableKey = null
     )
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/RealConsumerSessionRepositoryTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/RealConsumerSessionRepositoryTest.kt
@@ -14,7 +14,6 @@ class RealConsumerSessionRepositoryTest {
             emailAddress = "email@email.com",
             redactedFormattedPhoneNumber = "(***) ***-1234",
             redactedPhoneNumber = "******1234",
-            publishableKey = "pk_123",
             verificationSessions = listOf(
                 ConsumerSession.VerificationSession(
                     type = ConsumerSession.VerificationSession.SessionType.Sms,
@@ -32,7 +31,7 @@ class RealConsumerSessionRepositoryTest {
                 emailAddress = "email@email.com",
                 phoneNumber = "(•••) •••-1234",
                 clientSecret = "abc_123",
-                publishableKey = "pk_123",
+                publishableKey = null,
                 isVerified = true,
             )
         )
@@ -45,7 +44,6 @@ class RealConsumerSessionRepositoryTest {
             emailAddress = "email@email.com",
             redactedFormattedPhoneNumber = "(***) ***-1234",
             redactedPhoneNumber = "******1234",
-            publishableKey = "pk_123",
             verificationSessions = listOf(
                 ConsumerSession.VerificationSession(
                     type = ConsumerSession.VerificationSession.SessionType.Sms,
@@ -63,7 +61,7 @@ class RealConsumerSessionRepositoryTest {
                 emailAddress = "email@email.com",
                 phoneNumber = "(•••) •••-1234",
                 clientSecret = "abc_123",
-                publishableKey = "pk_123",
+                publishableKey = null,
                 isVerified = false,
             )
         )

--- a/link/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/link/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -14,6 +14,7 @@ import com.stripe.android.link.repositories.LinkRepository
 import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.ConsumerSession
+import com.stripe.android.model.ConsumerSessionLookup
 import com.stripe.android.model.ConsumerSignUpConsentAction
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -61,13 +62,10 @@ internal class LinkAccountManager @Inject constructor(
             .onFailure { error ->
                 linkEventsReporter.onAccountLookupFailure(error)
             }.map { consumerSessionLookup ->
-                consumerSessionLookup.consumerSession?.let { consumerSession ->
-                    if (startSession) {
-                        setAccountNullable(consumerSession)
-                    } else {
-                        LinkAccount(consumerSession)
-                    }
-                }
+                setLinkAccountFromLookupResult(
+                    lookup = consumerSessionLookup,
+                    startSession = startSession,
+                )
             }
 
     /**
@@ -170,8 +168,11 @@ internal class LinkAccountManager @Inject constructor(
         consentAction: SignUpConsentAction
     ): Result<LinkAccount> =
         linkRepository.consumerSignUp(email, phone, country, name, consentAction.consumerAction)
-            .map { consumerSession ->
-                setAccount(consumerSession)
+            .map { consumerSessionSignup ->
+                setAccount(
+                    consumerSession = consumerSessionSignup.consumerSession,
+                    publishableKey = consumerSessionSignup.publishableKey,
+                )
             }
 
     /**
@@ -216,22 +217,45 @@ internal class LinkAccountManager @Inject constructor(
         }
     }
 
-    private fun setAccount(consumerSession: ConsumerSession): LinkAccount {
-        maybeUpdateConsumerPublishableKey(consumerSession)
+    private fun setAccount(
+        consumerSession: ConsumerSession,
+        publishableKey: String?,
+    ): LinkAccount {
+        maybeUpdateConsumerPublishableKey(consumerSession.emailAddress, publishableKey)
         val newAccount = LinkAccount(consumerSession)
         _linkAccount.value = newAccount
         return newAccount
     }
 
+    fun setLinkAccountFromLookupResult(
+        lookup: ConsumerSessionLookup,
+        startSession: Boolean,
+    ): LinkAccount? {
+        return lookup.consumerSession?.let { consumerSession ->
+            if (startSession) {
+                setAccountNullable(
+                    consumerSession = consumerSession,
+                    publishableKey = lookup.publishableKey,
+                )
+            } else {
+                LinkAccount(consumerSession)
+            }
+        }
+    }
+
     @VisibleForTesting
-    fun setAccountNullable(consumerSession: ConsumerSession?): LinkAccount? =
-        consumerSession?.let {
-            setAccount(it)
+    private fun setAccountNullable(
+        consumerSession: ConsumerSession?,
+        publishableKey: String?,
+    ): LinkAccount? {
+        return consumerSession?.let {
+            setAccount(consumerSession = it, publishableKey = publishableKey)
         } ?: run {
             _linkAccount.value = null
             consumerPublishableKey = null
             null
         }
+    }
 
     /**
      * Update the [consumerPublishableKey] value if needed.
@@ -239,13 +263,16 @@ internal class LinkAccountManager @Inject constructor(
      * Only calls to [lookupConsumer] and [signUp] return the publishable key. For other calls, we
      * want to keep using the current key unless the user signed out.
      */
-    private fun maybeUpdateConsumerPublishableKey(newSession: ConsumerSession) {
-        newSession.publishableKey?.let {
+    private fun maybeUpdateConsumerPublishableKey(
+        newEmail: String,
+        publishableKey: String?,
+    ) {
+        if (publishableKey != null) {
             // If the session has a key, start using it
-            consumerPublishableKey = it
-        } ?: run {
+            consumerPublishableKey = publishableKey
+        } else {
             // Keep the current key if it's the same user, reset it if the user changed
-            if (_linkAccount.value?.email != newSession.emailAddress) {
+            if (_linkAccount.value?.email != newEmail) {
                 consumerPublishableKey = null
             }
         }

--- a/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -12,6 +12,7 @@ import com.stripe.android.model.ConsumerPaymentDetailsCreateParams
 import com.stripe.android.model.ConsumerPaymentDetailsCreateParams.Card.Companion.extraConfirmationParams
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.ConsumerSessionLookup
+import com.stripe.android.model.ConsumerSessionSignup
 import com.stripe.android.model.ConsumerSignUpConsentAction
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.StripeIntent
@@ -58,7 +59,7 @@ internal class LinkApiRepository @Inject constructor(
         country: String,
         name: String?,
         consentAction: ConsumerSignUpConsentAction
-    ): Result<ConsumerSession> = withContext(workContext) {
+    ): Result<ConsumerSessionSignup> = withContext(workContext) {
         stripeRepository.consumerSignUp(
             email = email,
             phoneNumber = phone,

--- a/link/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/link/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -3,6 +3,7 @@ package com.stripe.android.link.repositories
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.ConsumerSessionLookup
+import com.stripe.android.model.ConsumerSessionSignup
 import com.stripe.android.model.ConsumerSignUpConsentAction
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.StripeIntent
@@ -28,7 +29,7 @@ internal interface LinkRepository {
         country: String,
         name: String?,
         consentAction: ConsumerSignUpConsentAction
-    ): Result<ConsumerSession>
+    ): Result<ConsumerSessionSignup>
 
     /**
      * Create a new card payment method in the consumer account.

--- a/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -6,8 +6,8 @@ import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.model.PaymentDetailsFixtures
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetailsCreateParams
-import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.ConsumerSessionLookup
+import com.stripe.android.model.ConsumerSessionSignup
 import com.stripe.android.model.ConsumerSignUpConsentAction
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -132,7 +132,7 @@ class LinkApiRepositoryTest {
 
     @Test
     fun `consumerSignUp returns successful result`() = runTest {
-        val consumerSession = mock<ConsumerSession>()
+        val consumerSession = mock<ConsumerSessionSignup>()
         whenever(
             stripeRepository.consumerSignUp(
                 email = any(),

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -12,6 +12,7 @@ import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetailsCreateParams
 import com.stripe.android.model.ConsumerSession
+import com.stripe.android.model.ConsumerSessionSignup
 import com.stripe.android.model.ConsumerSignUpConsentAction
 import com.stripe.android.model.CreateFinancialConnectionsSessionForDeferredPaymentParams
 import com.stripe.android.model.CreateFinancialConnectionsSessionParams
@@ -303,7 +304,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         locale: Locale?,
         consentAction: ConsumerSignUpConsentAction,
         requestOptions: ApiRequest.Options
-    ): Result<ConsumerSession> {
+    ): Result<ConsumerSessionSignup> {
         TODO("Not yet implemented")
     }
 

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -53,6 +53,7 @@ import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetailsCreateParams
 import com.stripe.android.model.ConsumerSession
+import com.stripe.android.model.ConsumerSessionSignup
 import com.stripe.android.model.ConsumerSignUpConsentAction
 import com.stripe.android.model.CreateFinancialConnectionsSessionForDeferredPaymentParams
 import com.stripe.android.model.CreateFinancialConnectionsSessionParams
@@ -81,6 +82,7 @@ import com.stripe.android.model.parsers.CardMetadataJsonParser
 import com.stripe.android.model.parsers.ConsumerPaymentDetailsJsonParser
 import com.stripe.android.model.parsers.ConsumerPaymentDetailsShareJsonParser
 import com.stripe.android.model.parsers.ConsumerSessionJsonParser
+import com.stripe.android.model.parsers.ConsumerSessionSignupJsonParser
 import com.stripe.android.model.parsers.CustomerJsonParser
 import com.stripe.android.model.parsers.ElementsSessionJsonParser
 import com.stripe.android.model.parsers.FinancialConnectionsSessionJsonParser
@@ -1078,7 +1080,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
         locale: Locale?,
         consentAction: ConsumerSignUpConsentAction,
         requestOptions: ApiRequest.Options
-    ): Result<ConsumerSession> {
+    ): Result<ConsumerSessionSignup> {
         return fetchStripeModelResult(
             apiRequest = apiRequestFactory.createPost(
                 url = consumerSignUpUrl,
@@ -1100,7 +1102,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
                     } ?: emptyMap()
                 )
             ),
-            jsonParser = ConsumerSessionJsonParser(),
+            jsonParser = ConsumerSessionSignupJsonParser,
         )
     }
 

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -13,6 +13,7 @@ import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetailsCreateParams
 import com.stripe.android.model.ConsumerSession
+import com.stripe.android.model.ConsumerSessionSignup
 import com.stripe.android.model.ConsumerSignUpConsentAction
 import com.stripe.android.model.CreateFinancialConnectionsSessionForDeferredPaymentParams
 import com.stripe.android.model.CreateFinancialConnectionsSessionParams
@@ -279,7 +280,7 @@ interface StripeRepository {
         locale: Locale?,
         consentAction: ConsumerSignUpConsentAction,
         requestOptions: ApiRequest.Options
-    ): Result<ConsumerSession>
+    ): Result<ConsumerSessionSignup>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun createPaymentDetails(

--- a/payments-model/api/payments-model.api
+++ b/payments-model/api/payments-model.api
@@ -275,6 +275,29 @@ public final class com/stripe/android/model/ConsumerSessionLookup$Creator : andr
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/model/ConsumerSessionSignup$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/model/ConsumerSessionSignup$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/model/ConsumerSessionSignup;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/model/ConsumerSessionSignup;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/model/ConsumerSessionSignup$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/model/ConsumerSessionSignup$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ConsumerSessionSignup;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/ConsumerSessionSignup;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public abstract interface class com/stripe/android/model/StripeParamsModel : android/os/Parcelable {
 	public abstract fun toParamMap ()Ljava/util/Map;
 }

--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerSession.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerSession.kt
@@ -7,9 +7,6 @@ import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-/**
- * The result of a call to Link consumer sign up.
- */
 @Parcelize
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Serializable
@@ -24,8 +21,6 @@ data class ConsumerSession(
     val redactedPhoneNumber: String,
     @SerialName("verification_sessions")
     val verificationSessions: List<VerificationSession> = emptyList(),
-    @SerialName("publishable_key")
-    val publishableKey: String? = null
 ) : StripeModel {
 
     @Parcelize

--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerSessionSignup.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerSessionSignup.kt
@@ -7,18 +7,14 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * The result of a call to retrieve the [ConsumerSession] for a Link user.
+ * The result of a call to Link consumer sign up.
  */
 @Parcelize
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Serializable
-data class ConsumerSessionLookup(
-    @SerialName("exists")
-    val exists: Boolean,
+data class ConsumerSessionSignup(
     @SerialName("consumer_session")
-    val consumerSession: ConsumerSession? = null,
-    @SerialName("error_message")
-    val errorMessage: String? = null,
+    val consumerSession: ConsumerSession,
     @SerialName("publishable_key")
     val publishableKey: String? = null,
 ) : StripeModel

--- a/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerSessionJsonParser.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerSessionJsonParser.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.model.parsers
 
 import androidx.annotation.RestrictTo
-import com.stripe.android.core.model.StripeJsonUtils.optString
 import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.ConsumerSession
 import org.json.JSONObject
@@ -25,7 +24,6 @@ class ConsumerSessionJsonParser : ModelJsonParser<ConsumerSession> {
             redactedFormattedPhoneNumber = consumerSessionJson.getString(FIELD_CONSUMER_SESSION_FORMATTED_PHONE),
             redactedPhoneNumber = consumerSessionJson.getString(FIELD_CONSUMER_SESSION_PHONE),
             verificationSessions = verificationSession,
-            publishableKey = optString(json, FIELD_PUBLISHABLE_KEY)
         )
     }
 
@@ -41,7 +39,6 @@ class ConsumerSessionJsonParser : ModelJsonParser<ConsumerSession> {
 
     private companion object {
         private const val FIELD_CONSUMER_SESSION = "consumer_session"
-        private const val FIELD_PUBLISHABLE_KEY = "publishable_key"
 
         private const val FIELD_CONSUMER_SESSION_SECRET = "client_secret"
         private const val FIELD_CONSUMER_SESSION_EMAIL = "email_address"

--- a/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerSessionSignupJsonParser.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerSessionSignupJsonParser.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.model.parsers
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.core.model.StripeJsonUtils.optString
+import com.stripe.android.core.model.parsers.ModelJsonParser
+import com.stripe.android.model.ConsumerSessionSignup
+import org.json.JSONObject
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+object ConsumerSessionSignupJsonParser : ModelJsonParser<ConsumerSessionSignup> {
+
+    override fun parse(json: JSONObject): ConsumerSessionSignup? {
+        val consumerSession = ConsumerSessionJsonParser().parse(json)
+        val publishableKey = optString(json, "publishable_key")
+
+        return consumerSession?.let { session ->
+            ConsumerSessionSignup(session, publishableKey)
+        }
+    }
+}

--- a/payments-model/src/test/java/com/stripe/android/model/parsers/ConsumerSessionJsonParserTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/model/parsers/ConsumerSessionJsonParserTest.kt
@@ -23,7 +23,6 @@ class ConsumerSessionJsonParserTest {
                         state = ConsumerSession.VerificationSession.SessionState.Started
                     )
                 ),
-                publishableKey = "asdfg123"
             )
         )
     }
@@ -44,7 +43,6 @@ class ConsumerSessionJsonParserTest {
                         state = ConsumerSession.VerificationSession.SessionState.Verified
                     )
                 ),
-                publishableKey = null
             )
         )
     }
@@ -65,7 +63,6 @@ class ConsumerSessionJsonParserTest {
                         state = ConsumerSession.VerificationSession.SessionState.Started
                     )
                 ),
-                publishableKey = null
             )
         )
     }

--- a/payments-model/src/test/java/com/stripe/android/model/parsers/ConsumerSessionLookupJsonParserTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/model/parsers/ConsumerSessionLookupJsonParserTest.kt
@@ -32,7 +32,6 @@ class ConsumerSessionLookupJsonParserTest {
                     redactedPhoneNumber = "+1********68",
                     redactedFormattedPhoneNumber = "(***) *** **68",
                     verificationSessions = emptyList(),
-                    publishableKey = null
                 ),
                 errorMessage = null
             )

--- a/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
@@ -57,7 +57,6 @@ class ConsumersApiServiceImplTest {
 
         assertThat(lookup.exists).isTrue()
         assertThat(lookup.errorMessage).isNull()
-        assertThat(lookup.consumerSession?.publishableKey).isNull()
         assertThat(lookup.consumerSession?.verificationSessions).isEmpty()
         assertThat(lookup.consumerSession?.emailAddress).isEqualTo(email)
         assertThat(lookup.consumerSession?.redactedPhoneNumber).isEqualTo("+1********68")


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request removes `publishableKey` from `ConsumerSession` and adds it to `ConsumerSessionLookup` and the new `ConsumerSessionSignup`.

A consumer session, as returned by the backend, does not contain a publishable key. This is fine for the Payments side, where the custom `ConsumerSessionJsonParser` allows deviation from the remote data model. However, now that Financial Connections also wants to use the consumer session’s publishable key, it presents an issue: We use the default serializer, which means that we’re ending up with a `null` publishable key.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
