### PR TITLE
Restructure `PaymentConfirmationOption` with `arguments` subtype.

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -326,6 +326,14 @@ public final class com/stripe/android/paymentsheet/IntentConfirmationHandler$Arg
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$ExternalPaymentMethod$Args$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$ExternalPaymentMethod$Args;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$ExternalPaymentMethod$Args;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$ExternalPaymentMethod$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$ExternalPaymentMethod;
@@ -334,11 +342,11 @@ public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$Ext
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$GooglePay$Config$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$GooglePay$Args$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$GooglePay$Config;
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$GooglePay$Args;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$GooglePay$Config;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$GooglePay$Args;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
@@ -350,19 +358,35 @@ public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$Goo
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$New$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$PaymentMethod$New$Args$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$New;
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$PaymentMethod$New$Args;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$New;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$PaymentMethod$New$Args;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$Saved$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$PaymentMethod$New$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$Saved;
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$PaymentMethod$New;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$Saved;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$PaymentMethod$New;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$PaymentMethod$Saved$Args$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$PaymentMethod$Saved$Args;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$PaymentMethod$Saved$Args;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$PaymentMethod$Saved$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$PaymentMethod$Saved;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$PaymentMethod$Saved;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
@@ -9,25 +9,29 @@ import com.stripe.android.payments.core.analytics.ErrorReporter.UnexpectedErrorE
 
 internal suspend fun IntentConfirmationInterceptor.intercept(
     initializationMode: PaymentSheet.InitializationMode,
-    confirmationOption: PaymentConfirmationOption?,
+    confirmationOption: PaymentConfirmationOption<*>?,
     shippingValues: ConfirmPaymentIntentParams.Shipping?,
     context: Context,
 ): IntentConfirmationInterceptor.NextStep {
     return when (confirmationOption) {
-        is PaymentConfirmationOption.New -> {
+        is PaymentConfirmationOption.PaymentMethod.New -> {
+            val arguments = confirmationOption.arguments
+
             intercept(
                 initializationMode = initializationMode,
-                paymentMethodOptionsParams = confirmationOption.optionsParams,
-                paymentMethodCreateParams = confirmationOption.createParams,
+                paymentMethodOptionsParams = arguments.optionsParams,
+                paymentMethodCreateParams = arguments.createParams,
                 shippingValues = shippingValues,
-                customerRequestedSave = confirmationOption.shouldSave,
+                customerRequestedSave = arguments.shouldSave,
             )
         }
-        is PaymentConfirmationOption.Saved -> {
+        is PaymentConfirmationOption.PaymentMethod.Saved -> {
+            val arguments = confirmationOption.arguments
+
             intercept(
                 initializationMode = initializationMode,
-                paymentMethod = confirmationOption.paymentMethod,
-                paymentMethodOptionsParams = confirmationOption.optionsParams,
+                paymentMethod = arguments.paymentMethod,
+                paymentMethodOptionsParams = arguments.optionsParams,
                 shippingValues = shippingValues,
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationOptionKtx.kt
@@ -4,26 +4,32 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 
 internal fun PaymentSelection.toPaymentConfirmationOption(
     configuration: PaymentSheet.Configuration?,
-): PaymentConfirmationOption? {
+): PaymentConfirmationOption<*>? {
     return when (this) {
-        is PaymentSelection.Saved -> PaymentConfirmationOption.Saved(
-            paymentMethod = paymentMethod,
-            optionsParams = paymentMethodOptionsParams,
+        is PaymentSelection.Saved -> PaymentConfirmationOption.PaymentMethod.Saved(
+            arguments = PaymentConfirmationOption.PaymentMethod.Saved.Args(
+                paymentMethod = paymentMethod,
+                optionsParams = paymentMethodOptionsParams,
+            )
         )
         is PaymentSelection.ExternalPaymentMethod -> PaymentConfirmationOption.ExternalPaymentMethod(
-            type = type,
-            billingDetails = billingDetails,
+            arguments = PaymentConfirmationOption.ExternalPaymentMethod.Args(
+                type = type,
+                billingDetails = billingDetails,
+            )
         )
         is PaymentSelection.New -> {
-            PaymentConfirmationOption.New(
-                createParams = paymentMethodCreateParams,
-                optionsParams = paymentMethodOptionsParams,
-                shouldSave = customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse,
+            PaymentConfirmationOption.PaymentMethod.New(
+                arguments = PaymentConfirmationOption.PaymentMethod.New.Args(
+                    createParams = paymentMethodCreateParams,
+                    optionsParams = paymentMethodOptionsParams,
+                    shouldSave = customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse,
+                )
             )
         }
         is PaymentSelection.GooglePay -> configuration?.googlePay?.let { googlePay ->
             PaymentConfirmationOption.GooglePay(
-                config = PaymentConfirmationOption.GooglePay.Config(
+                arguments = PaymentConfirmationOption.GooglePay.Args(
                     environment = googlePay.environment,
                     merchantName = configuration.merchantDisplayName,
                     merchantCountryCode = googlePay.countryCode,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateData.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateData.kt
@@ -11,9 +11,9 @@ internal data class BacsMandateData(
 ) {
     companion object {
         fun fromConfirmationOption(
-            confirmationOption: PaymentConfirmationOption.New,
+            confirmationOption: PaymentConfirmationOption.PaymentMethod.New,
         ): BacsMandateData? {
-            val overrideParams = confirmationOption.createParams
+            val overrideParams = confirmationOption.arguments.createParams
 
             val bacsDebit = PaymentMethodCreateParams.createBacsFromParams(overrideParams)
             val name = PaymentMethodCreateParams.getNameFromParams(overrideParams)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
@@ -97,10 +97,12 @@ class DefaultIntentConfirmationInterceptorTest {
 
             val nextStep = interceptor.intercept(
                 initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),
-                confirmationOption = PaymentConfirmationOption.Saved(
-                    paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                    optionsParams = PaymentMethodOptionsParams.Card(
-                        setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+                confirmationOption = PaymentConfirmationOption.PaymentMethod.Saved(
+                    arguments = PaymentConfirmationOption.PaymentMethod.Saved.Args(
+                        paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                        optionsParams = PaymentMethodOptionsParams.Card(
+                            setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+                        )
                     )
                 ),
                 shippingValues = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
@@ -98,9 +98,11 @@ class IntentConfirmationHandlerTest {
                 initializationMode = initializationMode,
                 shippingDetails = shippingDetails,
                 intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-                confirmationOption = PaymentConfirmationOption.Saved(
-                    paymentMethod = savedPaymentMethod,
-                    optionsParams = paymentMethodOptionsParams,
+                confirmationOption = PaymentConfirmationOption.PaymentMethod.Saved(
+                    arguments = PaymentConfirmationOption.PaymentMethod.Saved.Args(
+                        paymentMethod = savedPaymentMethod,
+                        optionsParams = paymentMethodOptionsParams,
+                    )
                 ),
                 appearance = APPEARANCE,
             ),
@@ -143,9 +145,11 @@ class IntentConfirmationHandlerTest {
                     initializationMode = PaymentSheet.InitializationMode.PaymentIntent(clientSecret = "ci_123"),
                     shippingDetails = null,
                     intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-                    confirmationOption = PaymentConfirmationOption.Saved(
-                        paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                        optionsParams = null,
+                    confirmationOption = PaymentConfirmationOption.PaymentMethod.Saved(
+                        arguments = PaymentConfirmationOption.PaymentMethod.Saved.Args(
+                            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                            optionsParams = null,
+                        )
                     ),
                     appearance = APPEARANCE,
                 ),
@@ -185,10 +189,12 @@ class IntentConfirmationHandlerTest {
                 initializationMode = initializationMode,
                 shippingDetails = null,
                 intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-                confirmationOption = PaymentConfirmationOption.New(
-                    createParams = newCard,
-                    optionsParams = null,
-                    shouldSave = true,
+                confirmationOption = PaymentConfirmationOption.PaymentMethod.New(
+                    arguments = PaymentConfirmationOption.PaymentMethod.New.Args(
+                        createParams = newCard,
+                        optionsParams = null,
+                        shouldSave = true,
+                    )
                 ),
                 appearance = APPEARANCE,
             ),
@@ -235,9 +241,11 @@ class IntentConfirmationHandlerTest {
                 initializationMode = initializationMode,
                 shippingDetails = null,
                 intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-                confirmationOption = PaymentConfirmationOption.Saved(
-                    paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                    optionsParams = null,
+                confirmationOption = PaymentConfirmationOption.PaymentMethod.Saved(
+                    arguments = PaymentConfirmationOption.PaymentMethod.Saved.Args(
+                        paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                        optionsParams = null,
+                    )
                 ),
                 appearance = APPEARANCE,
             ),
@@ -922,10 +930,12 @@ class IntentConfirmationHandlerTest {
         intentConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
                 confirmationOption = EXTERNAL_PAYMENT_METHOD.copy(
-                    billingDetails = PaymentMethod.BillingDetails(
-                        name = "John Doe",
-                        address = Address(
-                            city = "South San Francisco"
+                    arguments = EXTERNAL_PAYMENT_METHOD.arguments.copy(
+                        billingDetails = PaymentMethod.BillingDetails(
+                            name = "John Doe",
+                            address = Address(
+                                city = "South San Francisco"
+                            )
                         )
                     )
                 )
@@ -1254,11 +1264,11 @@ class IntentConfirmationHandlerTest {
             bacsMandateConfirmationCallbackHandler = bacsMandateConfirmationCallbackHandler,
         )
 
-        val paymentSelection = createBacsPaymentConfirmationOption()
+        val confirmationOption = createBacsPaymentConfirmationOption()
 
         intentConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
-                confirmationOption = paymentSelection
+                confirmationOption = confirmationOption
             ),
         )
 
@@ -1269,7 +1279,7 @@ class IntentConfirmationHandlerTest {
         assertThat(call).isEqualTo(
             FakeIntentConfirmationInterceptor.InterceptCall.WithNewPaymentMethod(
                 initializationMode = DEFAULT_ARGUMENTS.initializationMode,
-                paymentMethodCreateParams = paymentSelection.createParams,
+                paymentMethodCreateParams = confirmationOption.arguments.createParams,
                 shippingValues = null,
                 paymentMethodOptionsParams = null,
                 customerRequestedSave = false,
@@ -1400,7 +1410,7 @@ class IntentConfirmationHandlerTest {
                     clientSecret = "si_123_secret_123",
                 ),
                 confirmationOption = GOOGLE_PAY_OPTION.copy(
-                    config = GOOGLE_PAY_OPTION.config.copy(
+                    arguments = GOOGLE_PAY_OPTION.arguments.copy(
                         merchantCurrencyCode = null,
                     )
                 ),
@@ -1436,7 +1446,7 @@ class IntentConfirmationHandlerTest {
             arguments = DEFAULT_ARGUMENTS.copy(
                 intent = paymentIntent,
                 confirmationOption = GOOGLE_PAY_OPTION.copy(
-                    config = GOOGLE_PAY_OPTION.config.copy(
+                    arguments = GOOGLE_PAY_OPTION.arguments.copy(
                         billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                             email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
                             phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
@@ -1769,20 +1779,22 @@ class IntentConfirmationHandlerTest {
     private fun createBacsPaymentConfirmationOption(
         name: String? = "John Doe",
         email: String? = "johndoe@email.com",
-    ): PaymentConfirmationOption.New {
-        return PaymentConfirmationOption.New(
-            createParams = PaymentMethodCreateParams.create(
-                bacsDebit = PaymentMethodCreateParams.BacsDebit(
-                    accountNumber = "00012345",
-                    sortCode = "108800"
+    ): PaymentConfirmationOption.PaymentMethod.New {
+        return PaymentConfirmationOption.PaymentMethod.New(
+            arguments = PaymentConfirmationOption.PaymentMethod.New.Args(
+                createParams = PaymentMethodCreateParams.create(
+                    bacsDebit = PaymentMethodCreateParams.BacsDebit(
+                        accountNumber = "00012345",
+                        sortCode = "108800"
+                    ),
+                    billingDetails = PaymentMethod.BillingDetails(
+                        name = name,
+                        email = email,
+                    )
                 ),
-                billingDetails = PaymentMethod.BillingDetails(
-                    name = name,
-                    email = email,
-                )
-            ),
-            optionsParams = null,
-            shouldSave = false,
+                optionsParams = null,
+                shouldSave = false,
+            )
         )
     }
 
@@ -1792,20 +1804,24 @@ class IntentConfirmationHandlerTest {
             initializationMode = PaymentSheet.InitializationMode.PaymentIntent(clientSecret = "pi_456_secret_456"),
             shippingDetails = null,
             intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-            confirmationOption = PaymentConfirmationOption.Saved(
-                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                optionsParams = null,
+            confirmationOption = PaymentConfirmationOption.PaymentMethod.Saved(
+                arguments = PaymentConfirmationOption.PaymentMethod.Saved.Args(
+                    paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                    optionsParams = null,
+                )
             ),
             appearance = APPEARANCE
         )
 
         val EXTERNAL_PAYMENT_METHOD = PaymentConfirmationOption.ExternalPaymentMethod(
-            type = "paypal",
-            billingDetails = null
+            arguments = PaymentConfirmationOption.ExternalPaymentMethod.Args(
+                type = "paypal",
+                billingDetails = null
+            )
         )
 
         val GOOGLE_PAY_OPTION = PaymentConfirmationOption.GooglePay(
-            config = PaymentConfirmationOption.GooglePay.Config(
+            arguments = PaymentConfirmationOption.GooglePay.Args(
                 environment = PaymentSheet.GooglePayConfiguration.Environment.Production,
                 merchantName = "Merchant, Inc.",
                 merchantCurrencyCode = "USD",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentConfirmationOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentConfirmationOptionKtxTest.kt
@@ -22,10 +22,12 @@ class PaymentConfirmationOptionKtxTest {
         )
 
         assertThat(paymentSelection.toPaymentConfirmationOption(configuration = null)).isEqualTo(
-            PaymentConfirmationOption.New(
-                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                optionsParams = PaymentMethodOptionsParams.Card(network = "cartes_bancaires"),
-                shouldSave = false,
+            PaymentConfirmationOption.PaymentMethod.New(
+                arguments = PaymentConfirmationOption.PaymentMethod.New.Args(
+                    createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                    optionsParams = PaymentMethodOptionsParams.Card(network = "cartes_bancaires"),
+                    shouldSave = false,
+                )
             )
         )
     }
@@ -37,10 +39,12 @@ class PaymentConfirmationOptionKtxTest {
         )
 
         assertThat(paymentSelection.toPaymentConfirmationOption(configuration = null)).isEqualTo(
-            PaymentConfirmationOption.New(
-                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                optionsParams = null,
-                shouldSave = false,
+            PaymentConfirmationOption.PaymentMethod.New(
+                arguments = PaymentConfirmationOption.PaymentMethod.New.Args(
+                    createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                    optionsParams = null,
+                    shouldSave = false,
+                )
             )
         )
     }
@@ -52,10 +56,12 @@ class PaymentConfirmationOptionKtxTest {
         )
 
         assertThat(paymentSelection.toPaymentConfirmationOption(configuration = null)).isEqualTo(
-            PaymentConfirmationOption.New(
-                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                optionsParams = null,
-                shouldSave = true,
+            PaymentConfirmationOption.PaymentMethod.New(
+                arguments = PaymentConfirmationOption.PaymentMethod.New.Args(
+                    createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                    optionsParams = null,
+                    shouldSave = true,
+                )
             )
         )
     }
@@ -67,10 +73,12 @@ class PaymentConfirmationOptionKtxTest {
         )
 
         assertThat(paymentSelection.toPaymentConfirmationOption(configuration = null)).isEqualTo(
-            PaymentConfirmationOption.New(
-                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                optionsParams = null,
-                shouldSave = false,
+            PaymentConfirmationOption.PaymentMethod.New(
+                arguments = PaymentConfirmationOption.PaymentMethod.New.Args(
+                    createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                    optionsParams = null,
+                    shouldSave = false,
+                )
             )
         )
     }
@@ -85,11 +93,13 @@ class PaymentConfirmationOptionKtxTest {
         )
 
         assertThat(paymentSelection.toPaymentConfirmationOption(configuration = null)).isEqualTo(
-            PaymentConfirmationOption.Saved(
-                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                optionsParams = PaymentMethodOptionsParams.Card(
-                    cvc = "505"
-                ),
+            PaymentConfirmationOption.PaymentMethod.Saved(
+                arguments = PaymentConfirmationOption.PaymentMethod.Saved.Args(
+                    paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                    optionsParams = PaymentMethodOptionsParams.Card(
+                        cvc = "505"
+                    ),
+                )
             )
         )
     }
@@ -112,11 +122,13 @@ class PaymentConfirmationOptionKtxTest {
 
         assertThat(paymentSelection.toPaymentConfirmationOption(configuration = null)).isEqualTo(
             PaymentConfirmationOption.ExternalPaymentMethod(
-                type = "paypal",
-                billingDetails = PaymentMethod.BillingDetails(
-                    name = "John Doe",
-                    address = Address(
-                        city = "South San Francisco"
+                arguments = PaymentConfirmationOption.ExternalPaymentMethod.Args(
+                    type = "paypal",
+                    billingDetails = PaymentMethod.BillingDetails(
+                        name = "John Doe",
+                        address = Address(
+                            city = "South San Francisco"
+                        )
                     )
                 )
             )
@@ -151,7 +163,7 @@ class PaymentConfirmationOptionKtxTest {
             )
         ).isEqualTo(
             PaymentConfirmationOption.GooglePay(
-                config = PaymentConfirmationOption.GooglePay.Config(
+                arguments = PaymentConfirmationOption.GooglePay.Args(
                     environment = PaymentSheet.GooglePayConfiguration.Environment.Production,
                     merchantName = "Merchant, Inc.",
                     merchantCountryCode = "US",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateDataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateDataTest.kt
@@ -61,11 +61,13 @@ class BacsMandateDataTest {
 
     private fun createPaymentConfirmationOption(
         createParams: PaymentMethodCreateParams,
-    ): PaymentConfirmationOption.New {
-        return PaymentConfirmationOption.New(
-            createParams = createParams,
-            optionsParams = null,
-            shouldSave = false,
+    ): PaymentConfirmationOption.PaymentMethod.New {
+        return PaymentConfirmationOption.PaymentMethod.New(
+            arguments = PaymentConfirmationOption.PaymentMethod.New.Args(
+                createParams = createParams,
+                optionsParams = null,
+                shouldSave = false,
+            )
         )
     }
 }


### PR DESCRIPTION
# Summary
Restructure `PaymentConfirmationOption` with `arguments` subtype. Also moves `New` and `Saved` types into a supertype called `PaymentMethod`.

# Motivation
Allows for referencing arguments at the top-level of payment confirmation option as needed. Makes it easier for creating `PaymentConfirmationDefinition` types.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
