### PR TITLE
Move confirmation-specific arguments into `PaymentConfirmationOption`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -178,8 +178,8 @@ interface ErrorReporter {
         EXTERNAL_PAYMENT_METHOD_SERIALIZATION_FAILURE(
             partialEventName = "elements.external_payment_methods_serializer.error"
         ),
-        INTENT_CONFIRMATION_INTERCEPTOR_INVALID_PAYMENT_SELECTION(
-            partialEventName = "intent_confirmation_interceptor.intercept.invalid_payment_selection"
+        INTENT_CONFIRMATION_HANDLER_INVALID_PAYMENT_CONFIRMATION_OPTION(
+            partialEventName = "intent_confirmation_handler.invalid_payment_confirmation_option"
         ),
         EXTERNAL_PAYMENT_METHOD_UNEXPECTED_RESULT_CODE(
             partialEventName = "paymentsheet.external_payment_method.unexpected_result_code"

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -326,6 +326,14 @@ public final class com/stripe/android/paymentsheet/IntentConfirmationHandler$Arg
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$BacsPaymentMethod$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$BacsPaymentMethod;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$BacsPaymentMethod;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$ExternalPaymentMethod$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$ExternalPaymentMethod;
@@ -350,19 +358,19 @@ public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$Goo
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$New$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$PaymentMethod$New$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$New;
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$PaymentMethod$New;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$New;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$PaymentMethod$New;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$Saved$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$PaymentMethod$Saved$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$Saved;
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$PaymentMethod$Saved;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$Saved;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$PaymentMethod$Saved;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -40,6 +40,7 @@ import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResu
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAvailable
 import com.stripe.android.paymentsheet.IntentConfirmationHandler
+import com.stripe.android.paymentsheet.PaymentConfirmationOption
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
@@ -47,7 +48,6 @@ import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
-import com.stripe.android.paymentsheet.toPaymentConfirmationOption
 import com.stripe.android.paymentsheet.ui.EditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.ui.ModifiableEditPaymentMethodViewInteractor
 import com.stripe.android.paymentsheet.ui.PaymentMethodRemovalDelayMillis
@@ -898,17 +898,17 @@ internal class CustomerSheetViewModel(
         clientSecret: String,
         paymentMethod: PaymentMethod
     ): Result<Unit> {
-        val selection = PaymentSelection.Saved(paymentMethod)
-
         intentConfirmationHandler.start(
             arguments = IntentConfirmationHandler.Args(
-                initializationMode = PaymentSheet.InitializationMode.SetupIntent(
-                    clientSecret = clientSecret
-                ),
                 intent = stripeIntent,
-                confirmationOption = selection.toPaymentConfirmationOption(configuration = null),
-                shippingDetails = null,
-                appearance = configuration.appearance,
+                confirmationOption = PaymentConfirmationOption.PaymentMethod.Saved(
+                    initializationMode = PaymentSheet.InitializationMode.SetupIntent(
+                        clientSecret = clientSecret
+                    ),
+                    shippingDetails = null,
+                    paymentMethod = paymentMethod,
+                    optionsParams = null,
+                ),
             )
         )
 
@@ -917,7 +917,7 @@ internal class CustomerSheetViewModel(
                 safeUpdateSelectPaymentMethodState { viewState ->
                     viewState.copy(
                         savedPaymentMethods = listOf(paymentMethod) + viewState.savedPaymentMethods,
-                        paymentSelection = selection,
+                        paymentSelection = PaymentSelection.Saved(paymentMethod),
                         primaryButtonVisible = true,
                         primaryButtonLabel = resources.getString(
                             R.string.stripe_paymentsheet_confirm

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -141,7 +141,6 @@ internal interface CustomerSheetViewModelModule {
 
         @Provides
         fun providesIntentConfirmationHandlerFactory(
-            application: Application,
             savedStateHandle: SavedStateHandle,
             paymentConfigurationProvider: Provider<PaymentConfiguration>,
             bacsMandateConfirmationLauncherFactory: BacsMandateConfirmationLauncherFactory,
@@ -156,7 +155,6 @@ internal interface CustomerSheetViewModelModule {
                 stripePaymentLauncherAssistedFactory = stripePaymentLauncherAssistedFactory,
                 googlePayPaymentMethodLauncherFactory = null,
                 bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,
-                application = application,
                 statusBarColor = { statusBarColor },
                 savedStateHandle = savedStateHandle,
                 errorReporter = errorReporter,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
@@ -1,53 +1,32 @@
 package com.stripe.android.paymentsheet
 
-import android.content.Context
-import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.model.ConfirmPaymentIntentParams
-import com.stripe.android.payments.core.analytics.ErrorReporter
-import com.stripe.android.payments.core.analytics.ErrorReporter.UnexpectedErrorEvent
+import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
 
 internal suspend fun IntentConfirmationInterceptor.intercept(
-    initializationMode: PaymentSheet.InitializationMode,
-    confirmationOption: PaymentConfirmationOption?,
-    shippingValues: ConfirmPaymentIntentParams.Shipping?,
-    context: Context,
+    confirmationOption: PaymentConfirmationOption.PaymentMethod?,
 ): IntentConfirmationInterceptor.NextStep {
     return when (confirmationOption) {
-        is PaymentConfirmationOption.New -> {
+        is PaymentConfirmationOption.PaymentMethod.New -> {
             intercept(
-                initializationMode = initializationMode,
+                initializationMode = confirmationOption.initializationMode,
                 paymentMethodOptionsParams = confirmationOption.optionsParams,
                 paymentMethodCreateParams = confirmationOption.createParams,
-                shippingValues = shippingValues,
+                shippingValues = confirmationOption.shippingDetails?.toConfirmPaymentIntentShipping(),
                 customerRequestedSave = confirmationOption.shouldSave,
             )
         }
-        is PaymentConfirmationOption.Saved -> {
+        is PaymentConfirmationOption.PaymentMethod.Saved -> {
             intercept(
-                initializationMode = initializationMode,
+                initializationMode = confirmationOption.initializationMode,
                 paymentMethod = confirmationOption.paymentMethod,
                 paymentMethodOptionsParams = confirmationOption.optionsParams,
-                shippingValues = shippingValues,
+                shippingValues = confirmationOption.shippingDetails?.toConfirmPaymentIntentShipping(),
             )
         }
         null -> {
             IntentConfirmationInterceptor.NextStep.Fail(
                 cause = IllegalStateException("Nothing selected."),
-                message = resolvableString(R.string.stripe_something_went_wrong),
-            )
-        }
-        else -> {
-            val exception = IllegalStateException(
-                "Attempting to confirm intent for invalid confirmation option: $confirmationOption"
-            )
-            val errorReporter = ErrorReporter.createFallbackInstance(context)
-            errorReporter.report(
-                errorEvent = UnexpectedErrorEvent.INTENT_CONFIRMATION_INTERCEPTOR_INVALID_PAYMENT_SELECTION,
-                stripeException = StripeException.create(exception),
-            )
-            IntentConfirmationInterceptor.NextStep.Fail(
-                cause = exception,
                 message = resolvableString(R.string.stripe_something_went_wrong),
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationOption.kt
@@ -1,20 +1,17 @@
 package com.stripe.android.paymentsheet
 
 import android.os.Parcelable
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodOptionsParams
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import kotlinx.parcelize.Parcelize
+import com.stripe.android.model.PaymentMethod as PaymentMethodModel
 
 internal sealed interface PaymentConfirmationOption : Parcelable {
     @Parcelize
-    data class Saved(
-        val paymentMethod: PaymentMethod,
-        val optionsParams: PaymentMethodOptionsParams?,
-    ) : PaymentConfirmationOption
-
-    @Parcelize
     data class GooglePay(
+        val initializationMode: PaymentSheet.InitializationMode,
+        val shippingDetails: AddressDetails?,
         val config: Config,
     ) : PaymentConfirmationOption {
         @Parcelize
@@ -32,13 +29,37 @@ internal sealed interface PaymentConfirmationOption : Parcelable {
     @Parcelize
     data class ExternalPaymentMethod(
         val type: String,
-        val billingDetails: PaymentMethod.BillingDetails?,
+        val billingDetails: PaymentMethodModel.BillingDetails?,
     ) : PaymentConfirmationOption
 
     @Parcelize
-    data class New(
+    data class BacsPaymentMethod(
+        val initializationMode: PaymentSheet.InitializationMode,
+        val shippingDetails: AddressDetails?,
         val createParams: PaymentMethodCreateParams,
         val optionsParams: PaymentMethodOptionsParams?,
-        val shouldSave: Boolean
+        val appearance: PaymentSheet.Appearance,
     ) : PaymentConfirmationOption
+
+    sealed interface PaymentMethod : PaymentConfirmationOption {
+        val initializationMode: PaymentSheet.InitializationMode
+        val shippingDetails: AddressDetails?
+
+        @Parcelize
+        data class Saved(
+            override val initializationMode: PaymentSheet.InitializationMode,
+            override val shippingDetails: AddressDetails?,
+            val paymentMethod: PaymentMethodModel,
+            val optionsParams: PaymentMethodOptionsParams?,
+        ) : PaymentMethod
+
+        @Parcelize
+        data class New(
+            override val initializationMode: PaymentSheet.InitializationMode,
+            override val shippingDetails: AddressDetails?,
+            val createParams: PaymentMethodCreateParams,
+            val optionsParams: PaymentMethodOptionsParams?,
+            val shouldSave: Boolean
+        ) : PaymentMethod
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationOptionKtx.kt
@@ -1,12 +1,16 @@
 package com.stripe.android.paymentsheet
 
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentSelection
 
 internal fun PaymentSelection.toPaymentConfirmationOption(
-    configuration: PaymentSheet.Configuration?,
+    initializationMode: PaymentSheet.InitializationMode,
+    configuration: PaymentSheet.Configuration,
 ): PaymentConfirmationOption? {
     return when (this) {
-        is PaymentSelection.Saved -> PaymentConfirmationOption.Saved(
+        is PaymentSelection.Saved -> PaymentConfirmationOption.PaymentMethod.Saved(
+            initializationMode = initializationMode,
+            shippingDetails = configuration.shippingDetails,
             paymentMethod = paymentMethod,
             optionsParams = paymentMethodOptionsParams,
         )
@@ -15,14 +19,28 @@ internal fun PaymentSelection.toPaymentConfirmationOption(
             billingDetails = billingDetails,
         )
         is PaymentSelection.New -> {
-            PaymentConfirmationOption.New(
-                createParams = paymentMethodCreateParams,
-                optionsParams = paymentMethodOptionsParams,
-                shouldSave = customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse,
-            )
+            if (paymentMethodCreateParams.typeCode == PaymentMethod.Type.BacsDebit.code) {
+                PaymentConfirmationOption.BacsPaymentMethod(
+                    initializationMode = initializationMode,
+                    shippingDetails = configuration.shippingDetails,
+                    createParams = paymentMethodCreateParams,
+                    optionsParams = paymentMethodOptionsParams,
+                    appearance = configuration.appearance,
+                )
+            } else {
+                PaymentConfirmationOption.PaymentMethod.New(
+                    initializationMode = initializationMode,
+                    shippingDetails = configuration.shippingDetails,
+                    createParams = paymentMethodCreateParams,
+                    optionsParams = paymentMethodOptionsParams,
+                    shouldSave = customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse,
+                )
+            }
         }
-        is PaymentSelection.GooglePay -> configuration?.googlePay?.let { googlePay ->
+        is PaymentSelection.GooglePay -> configuration.googlePay?.let { googlePay ->
             PaymentConfirmationOption.GooglePay(
+                initializationMode = initializationMode,
+                shippingDetails = configuration.shippingDetails,
                 config = PaymentConfirmationOption.GooglePay.Config(
                     environment = googlePay.environment,
                     merchantName = configuration.merchantDisplayName,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -464,15 +464,12 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             val stripeIntent = awaitStripeIntent()
 
             val confirmationOption = paymentSelectionWithCvcIfEnabled(paymentSelection)
-                ?.toPaymentConfirmationOption(config)
+                ?.toPaymentConfirmationOption(args.initializationMode, config)
 
             intentConfirmationHandler.start(
                 arguments = IntentConfirmationHandler.Args(
-                    initializationMode = args.initializationMode,
-                    shippingDetails = args.config.shippingDetails,
                     intent = stripeIntent,
                     confirmationOption = confirmationOption,
-                    appearance = config.appearance,
                 ),
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.flowcontroller
 
 import android.app.Activity
-import android.app.Application
 import android.content.Context
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
@@ -87,7 +86,6 @@ internal class DefaultFlowController @Inject internal constructor(
     private val prefsRepositoryFactory: @JvmSuppressWildcards (PaymentSheet.CustomerConfiguration?) -> PrefsRepository,
     activityResultCaller: ActivityResultCaller,
     // Properties provided through injection
-    application: Application,
     private val context: Context,
     private val eventReporter: EventReporter,
     private val viewModel: FlowControllerViewModel,
@@ -129,7 +127,6 @@ internal class DefaultFlowController @Inject internal constructor(
         stripePaymentLauncherAssistedFactory = paymentLauncherFactory,
         googlePayPaymentMethodLauncherFactory = googlePayPaymentMethodLauncherFactory,
         errorReporter = errorReporter,
-        application = application,
         logger = logger,
     ).create(viewModelScope.plus(workContext))
 
@@ -391,14 +388,15 @@ internal class DefaultFlowController @Inject internal constructor(
     ) {
         viewModelScope.launch {
             val stripeIntent = requireNotNull(state.stripeIntent)
+            val initializationMode = requireNotNull(initializationMode)
 
             intentConfirmationHandler.start(
                 arguments = IntentConfirmationHandler.Args(
-                    initializationMode = initializationMode!!,
-                    confirmationOption = paymentSelection?.toPaymentConfirmationOption(state.config),
+                    confirmationOption = paymentSelection?.toPaymentConfirmationOption(
+                        initializationMode = initializationMode,
+                        configuration = state.config,
+                    ),
                     intent = stripeIntent,
-                    shippingDetails = state.config.shippingDetails,
-                    appearance = state.config.appearance,
                 )
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.injection
 
-import android.app.Application
 import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.PaymentConfiguration
@@ -30,7 +29,6 @@ internal class PaymentSheetViewModelModule(private val starterArgs: PaymentSheet
 
     @Provides
     fun providesIntentConfirmationHandlerFactory(
-        application: Application,
         savedStateHandle: SavedStateHandle,
         paymentConfigurationProvider: Provider<PaymentConfiguration>,
         bacsMandateConfirmationLauncherFactory: BacsMandateConfirmationLauncherFactory,
@@ -46,7 +44,6 @@ internal class PaymentSheetViewModelModule(private val starterArgs: PaymentSheet
             stripePaymentLauncherAssistedFactory = stripePaymentLauncherAssistedFactory,
             bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,
             googlePayPaymentMethodLauncherFactory = googlePayPaymentMethodLauncherFactory,
-            application = application,
             statusBarColor = { starterArgs.statusBarColor },
             savedStateHandle = savedStateHandle,
             errorReporter = errorReporter,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateData.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateData.kt
@@ -11,7 +11,7 @@ internal data class BacsMandateData(
 ) {
     companion object {
         fun fromConfirmationOption(
-            confirmationOption: PaymentConfirmationOption.New,
+            confirmationOption: PaymentConfirmationOption.BacsPaymentMethod,
         ): BacsMandateData? {
             val overrideParams = confirmationOption.createParams
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -206,7 +206,6 @@ internal object CustomerSheetTestHelper {
                 },
                 statusBarColor = { null },
                 savedStateHandle = SavedStateHandle(),
-                application = application,
                 errorReporter = FakeErrorReporter(),
                 logger = FakeUserFacingLogger(),
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
@@ -1,7 +1,5 @@
 package com.stripe.android.paymentsheet
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.networking.ApiRequest
@@ -37,8 +35,6 @@ class DefaultIntentConfirmationInterceptorTest {
 
     @get:Rule
     val intentConfirmationInterceptorTestRule = IntentConfirmationInterceptorTestRule()
-
-    private val context = ApplicationProvider.getApplicationContext<Context>()
 
     @Test
     fun `Returns confirm as next step if invoked with client secret for existing payment method`() = runTest {
@@ -96,15 +92,14 @@ class DefaultIntentConfirmationInterceptorTest {
             val interceptor = createIntentConfirmationInterceptor()
 
             val nextStep = interceptor.intercept(
-                initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),
-                confirmationOption = PaymentConfirmationOption.Saved(
+                confirmationOption = PaymentConfirmationOption.PaymentMethod.Saved(
+                    initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),
+                    shippingDetails = null,
                     paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                     optionsParams = PaymentMethodOptionsParams.Card(
                         setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
                     )
                 ),
-                shippingValues = null,
-                context = context,
             )
 
             val confirmNextStep = nextStep as? IntentConfirmationInterceptor.NextStep.Confirm

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentConfirmationOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentConfirmationOptionKtxTest.kt
@@ -21,8 +21,15 @@ class PaymentConfirmationOptionKtxTest {
             ),
         )
 
-        assertThat(paymentSelection.toPaymentConfirmationOption(configuration = null)).isEqualTo(
-            PaymentConfirmationOption.New(
+        assertThat(
+            paymentSelection.toPaymentConfirmationOption(
+                initializationMode = PI_INITIALIZATION_MODE,
+                configuration = PaymentSheetFixtures.CONFIG_CUSTOMER,
+            )
+        ).isEqualTo(
+            PaymentConfirmationOption.PaymentMethod.New(
+                initializationMode = PI_INITIALIZATION_MODE,
+                shippingDetails = null,
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = PaymentMethodOptionsParams.Card(network = "cartes_bancaires"),
                 shouldSave = false,
@@ -36,8 +43,15 @@ class PaymentConfirmationOptionKtxTest {
             customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse,
         )
 
-        assertThat(paymentSelection.toPaymentConfirmationOption(configuration = null)).isEqualTo(
-            PaymentConfirmationOption.New(
+        assertThat(
+            paymentSelection.toPaymentConfirmationOption(
+                initializationMode = SI_INITIALIZATION_MODE,
+                configuration = PaymentSheetFixtures.CONFIG_CUSTOMER,
+            )
+        ).isEqualTo(
+            PaymentConfirmationOption.PaymentMethod.New(
+                initializationMode = SI_INITIALIZATION_MODE,
+                shippingDetails = null,
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = null,
                 shouldSave = false,
@@ -51,11 +65,51 @@ class PaymentConfirmationOptionKtxTest {
             customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse,
         )
 
-        assertThat(paymentSelection.toPaymentConfirmationOption(configuration = null)).isEqualTo(
-            PaymentConfirmationOption.New(
+        assertThat(
+            paymentSelection.toPaymentConfirmationOption(
+                initializationMode = PI_INITIALIZATION_MODE,
+                configuration = PaymentSheetFixtures.CONFIG_CUSTOMER,
+            )
+        ).isEqualTo(
+            PaymentConfirmationOption.PaymentMethod.New(
+                initializationMode = PI_INITIALIZATION_MODE,
+                shippingDetails = null,
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = null,
                 shouldSave = true,
+            )
+        )
+    }
+
+    @Test
+    fun `On Bacs selection, should convert to Bacs confirmation option properly`() {
+        val bacsDebitParams = PaymentMethodCreateParams.create(
+            bacsDebit = PaymentMethodCreateParams.BacsDebit(
+                accountNumber = "00012345",
+                sortCode = "108800"
+            ),
+            billingDetails = PaymentMethod.BillingDetails(
+                name = "John Doe",
+                email = "email@email.com",
+            ),
+        )
+
+        val paymentSelection = createNewPaymentSelection(
+            createParams = bacsDebitParams,
+        )
+
+        assertThat(
+            paymentSelection.toPaymentConfirmationOption(
+                initializationMode = PI_INITIALIZATION_MODE,
+                configuration = PaymentSheetFixtures.CONFIG_CUSTOMER
+            )
+        ).isEqualTo(
+            PaymentConfirmationOption.BacsPaymentMethod(
+                initializationMode = PI_INITIALIZATION_MODE,
+                shippingDetails = null,
+                createParams = bacsDebitParams,
+                optionsParams = null,
+                appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
             )
         )
     }
@@ -66,8 +120,15 @@ class PaymentConfirmationOptionKtxTest {
             customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
         )
 
-        assertThat(paymentSelection.toPaymentConfirmationOption(configuration = null)).isEqualTo(
-            PaymentConfirmationOption.New(
+        assertThat(
+            paymentSelection.toPaymentConfirmationOption(
+                initializationMode = SI_INITIALIZATION_MODE,
+                configuration = PaymentSheetFixtures.CONFIG_CUSTOMER,
+            )
+        ).isEqualTo(
+            PaymentConfirmationOption.PaymentMethod.New(
+                initializationMode = SI_INITIALIZATION_MODE,
+                shippingDetails = null,
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = null,
                 shouldSave = false,
@@ -84,8 +145,15 @@ class PaymentConfirmationOptionKtxTest {
             ),
         )
 
-        assertThat(paymentSelection.toPaymentConfirmationOption(configuration = null)).isEqualTo(
-            PaymentConfirmationOption.Saved(
+        assertThat(
+            paymentSelection.toPaymentConfirmationOption(
+                initializationMode = PI_INITIALIZATION_MODE,
+                configuration = PaymentSheetFixtures.CONFIG_CUSTOMER,
+            )
+        ).isEqualTo(
+            PaymentConfirmationOption.PaymentMethod.Saved(
+                initializationMode = PI_INITIALIZATION_MODE,
+                shippingDetails = null,
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 optionsParams = PaymentMethodOptionsParams.Card(
                     cvc = "505"
@@ -110,7 +178,12 @@ class PaymentConfirmationOptionKtxTest {
             iconResource = 0,
         )
 
-        assertThat(paymentSelection.toPaymentConfirmationOption(configuration = null)).isEqualTo(
+        assertThat(
+            paymentSelection.toPaymentConfirmationOption(
+                initializationMode = PI_INITIALIZATION_MODE,
+                configuration = PaymentSheetFixtures.CONFIG_CUSTOMER,
+            )
+        ).isEqualTo(
             PaymentConfirmationOption.ExternalPaymentMethod(
                 type = "paypal",
                 billingDetails = PaymentMethod.BillingDetails(
@@ -124,15 +197,11 @@ class PaymentConfirmationOptionKtxTest {
     }
 
     @Test
-    fun `On Google Pay selection with a null configuration, should return null`() {
-        assertThat(PaymentSelection.GooglePay.toPaymentConfirmationOption(configuration = null)).isNull()
-    }
-
-    @Test
     fun `On Google Pay selection with config with null google pay config, should return null`() {
         assertThat(
             PaymentSelection.GooglePay.toPaymentConfirmationOption(
-                configuration = PaymentSheetFixtures.CONFIG_CUSTOMER
+                initializationMode = PI_INITIALIZATION_MODE,
+                configuration = PaymentSheetFixtures.CONFIG_CUSTOMER,
             )
         ).isNull()
     }
@@ -141,6 +210,7 @@ class PaymentConfirmationOptionKtxTest {
     fun `On Google Pay selection with config with google pay config, should return expected option`() {
         assertThat(
             PaymentSelection.GooglePay.toPaymentConfirmationOption(
+                initializationMode = SI_INITIALIZATION_MODE,
                 configuration = PaymentSheetFixtures.CONFIG_GOOGLEPAY.copy(
                     googlePay = PaymentSheetFixtures.CONFIG_GOOGLEPAY.googlePay?.copy(
                         label = "Merchant Payments",
@@ -151,6 +221,8 @@ class PaymentConfirmationOptionKtxTest {
             )
         ).isEqualTo(
             PaymentConfirmationOption.GooglePay(
+                initializationMode = SI_INITIALIZATION_MODE,
+                shippingDetails = null,
                 config = PaymentConfirmationOption.GooglePay.Config(
                     environment = PaymentSheet.GooglePayConfiguration.Environment.Production,
                     merchantName = "Merchant, Inc.",
@@ -166,7 +238,12 @@ class PaymentConfirmationOptionKtxTest {
 
     @Test
     fun `On Link selection, should return null`() {
-        assertThat(PaymentSelection.Link.toPaymentConfirmationOption(configuration = null)).isNull()
+        assertThat(
+            PaymentSelection.Link.toPaymentConfirmationOption(
+                initializationMode = PI_INITIALIZATION_MODE,
+                configuration = PaymentSheetFixtures.CONFIG_CUSTOMER,
+            )
+        ).isNull()
     }
 
     private fun createNewPaymentSelection(
@@ -180,6 +257,16 @@ class PaymentConfirmationOptionKtxTest {
             paymentMethodOptionsParams = optionsParams,
             brand = CardBrand.CartesBancaires,
             customerRequestedSave = customerRequestedSave,
+        )
+    }
+
+    private companion object {
+        val PI_INITIALIZATION_MODE = PaymentSheet.InitializationMode.PaymentIntent(
+            clientSecret = "pi_123"
+        )
+
+        val SI_INITIALIZATION_MODE = PaymentSheet.InitializationMode.SetupIntent(
+            clientSecret = "pi_123"
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -1118,7 +1118,6 @@ internal class PaymentSheetActivityTest {
                     googlePayPaymentMethodLauncherFactory = googlePayPaymentMethodLauncherFactory,
                     paymentConfigurationProvider = { PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY) },
                     statusBarColor = { args.statusBarColor },
-                    application = application,
                     errorReporter = FakeErrorReporter(),
                     logger = FakeUserFacingLogger(),
                 ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -2802,7 +2802,6 @@ internal class PaymentSheetViewModelTest {
                     googlePayPaymentMethodLauncherFactory = googlePayLauncherFactory,
                     paymentConfigurationProvider = { paymentConfiguration },
                     statusBarColor = { args.statusBarColor },
-                    application = application,
                     errorReporter = FakeErrorReporter(),
                     logger = FakeUserFacingLogger(),
                 ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -2202,7 +2202,6 @@ internal class DefaultFlowControllerTest {
         intentConfirmationInterceptor = fakeIntentConfirmationInterceptor,
         errorReporter = FakeErrorReporter(),
         cvcRecollectionLauncherFactory = cvcRecollectionLauncherFactory,
-        application = ApplicationProvider.getApplicationContext(),
         initializedViaCompose = false,
         workContext = testScope.coroutineContext,
         logger = FakeUserFacingLogger(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateDataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateDataTest.kt
@@ -4,6 +4,8 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentConfirmationOption
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import org.junit.Test
 
 class BacsMandateDataTest {
@@ -61,11 +63,15 @@ class BacsMandateDataTest {
 
     private fun createPaymentConfirmationOption(
         createParams: PaymentMethodCreateParams,
-    ): PaymentConfirmationOption.New {
-        return PaymentConfirmationOption.New(
+    ): PaymentConfirmationOption.BacsPaymentMethod {
+        return PaymentConfirmationOption.BacsPaymentMethod(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123",
+            ),
+            shippingDetails = null,
             createParams = createParams,
             optionsParams = null,
-            shouldSave = false,
+            appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
         )
     }
 }


### PR DESCRIPTION
# Summary
Move confirmation-specific arguments into `PaymentConfirmationOption`

# Motivation
Better isolation of confirmation-specific arguments from the overall function of `IntentConfirmationHandler`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
