### PR TITLE
Add operation to attach consumer to LAS

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
@@ -112,9 +112,9 @@ internal interface FinancialConnectionsSheetNativeModule {
             logger: Logger,
         ) = FinancialConnectionsConsumerSessionRepository(
             financialConnectionsConsumersApiService = financialConnectionsConsumersApiService,
+            provideApiRequestOptions = provideApiRequestOptions,
             consumersApiService = consumersApiService,
             consumerSessionRepository = consumerSessionRepository,
-            provideApiRequestOptions = provideApiRequestOptions,
             locale = locale ?: Locale.getDefault(),
             logger = logger,
         )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
@@ -24,9 +24,11 @@ import com.stripe.android.financialconnections.analytics.DefaultFinancialConnect
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTrackerImpl
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEventReporter
+import com.stripe.android.financialconnections.domain.AttachConsumerToLinkAccountSession
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.IsLinkWithStripe
 import com.stripe.android.financialconnections.domain.RealIsLinkWithStripe
+import com.stripe.android.financialconnections.domain.RealAttachConsumerToLinkAccountSession
 import com.stripe.android.financialconnections.features.common.enableWorkManager
 import com.stripe.android.financialconnections.repository.ConsumerSessionProvider
 import com.stripe.android.financialconnections.repository.ConsumerSessionRepository
@@ -81,6 +83,11 @@ internal interface FinancialConnectionsSheetSharedModule {
 
     @Binds
     fun bindsIsLinkWithStripe(impl: RealIsLinkWithStripe): IsLinkWithStripe
+
+    @Binds
+    fun bindsAttachConsumerToLinkAccountSession(
+        impl: RealAttachConsumerToLinkAccountSession,
+    ): AttachConsumerToLinkAccountSession
 
     companion object {
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
@@ -27,8 +27,8 @@ import com.stripe.android.financialconnections.analytics.FinancialConnectionsEve
 import com.stripe.android.financialconnections.domain.AttachConsumerToLinkAccountSession
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.IsLinkWithStripe
-import com.stripe.android.financialconnections.domain.RealIsLinkWithStripe
 import com.stripe.android.financialconnections.domain.RealAttachConsumerToLinkAccountSession
+import com.stripe.android.financialconnections.domain.RealIsLinkWithStripe
 import com.stripe.android.financialconnections.features.common.enableWorkManager
 import com.stripe.android.financialconnections.repository.ConsumerSessionProvider
 import com.stripe.android.financialconnections.repository.ConsumerSessionRepository

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/AttachConsumerToLinkAccountSession.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/AttachConsumerToLinkAccountSession.kt
@@ -1,0 +1,29 @@
+package com.stripe.android.financialconnections.domain
+
+import com.stripe.android.financialconnections.FinancialConnectionsSheet
+import com.stripe.android.financialconnections.repository.FinancialConnectionsConsumerSessionRepository
+import javax.inject.Inject
+
+internal fun interface AttachConsumerToLinkAccountSession {
+    suspend operator fun invoke(
+        consumerSessionClientSecret: String,
+    )
+}
+
+internal class RealAttachConsumerToLinkAccountSession @Inject constructor(
+    private val configuration: FinancialConnectionsSheet.Configuration,
+    private val consumerRepository: FinancialConnectionsConsumerSessionRepository,
+    private val getOrFetchSync: GetOrFetchSync,
+) : AttachConsumerToLinkAccountSession {
+
+    override suspend operator fun invoke(
+        consumerSessionClientSecret: String,
+    ) {
+        consumerRepository.attachLinkConsumerToLinkAccountSession(
+            consumerSessionClientSecret = consumerSessionClientSecret,
+            clientSecret = configuration.financialConnectionsSessionClientSecret,
+        )
+
+        getOrFetchSync(refetchCondition = GetOrFetchSync.RefetchCondition.Always)
+    }
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/AttachConsumerToLinkAccountSession.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/AttachConsumerToLinkAccountSession.kt
@@ -13,7 +13,6 @@ internal fun interface AttachConsumerToLinkAccountSession {
 internal class RealAttachConsumerToLinkAccountSession @Inject constructor(
     private val configuration: FinancialConnectionsSheet.Configuration,
     private val consumerRepository: FinancialConnectionsConsumerSessionRepository,
-    private val getOrFetchSync: GetOrFetchSync,
 ) : AttachConsumerToLinkAccountSession {
 
     override suspend operator fun invoke(
@@ -23,7 +22,5 @@ internal class RealAttachConsumerToLinkAccountSession @Inject constructor(
             consumerSessionClientSecret = consumerSessionClientSecret,
             clientSecret = configuration.financialConnectionsSessionClientSecret,
         )
-
-        getOrFetchSync(refetchCondition = GetOrFetchSync.RefetchCondition.Always)
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModel.kt
@@ -17,6 +17,7 @@ import com.stripe.android.financialconnections.di.FinancialConnectionsSheetNativ
 import com.stripe.android.financialconnections.domain.AttachConsumerToLinkAccountSession
 import com.stripe.android.financialconnections.domain.ConfirmVerification
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
+import com.stripe.android.financialconnections.domain.GetOrFetchSync.RefetchCondition.Always
 import com.stripe.android.financialconnections.domain.IsLinkWithStripe
 import com.stripe.android.financialconnections.domain.LookupConsumerAndStartVerification
 import com.stripe.android.financialconnections.domain.MarkLinkVerified
@@ -149,6 +150,7 @@ internal class NetworkingLinkVerificationViewModel @AssistedInject constructor(
         runCatching {
             if (isLinkWithStripe()) {
                 attachConsumerToLinkAccountSession(payload.consumerSessionClientSecret)
+                getOrFetchSync(refetchCondition = Always).manifest
             } else {
                 markLinkVerified()
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
@@ -3,6 +3,7 @@ package com.stripe.android.financialconnections.repository
 import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.repository.api.FinancialConnectionsConsumersApiService
 import com.stripe.android.financialconnections.repository.api.ProvideApiRequestOptions
+import com.stripe.android.model.AttachConsumerToLinkAccountSession
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.ConsumerSessionLookup
 import com.stripe.android.model.CustomEmailType
@@ -33,6 +34,11 @@ internal interface FinancialConnectionsConsumerSessionRepository {
         verificationCode: String,
         type: VerificationType,
     ): ConsumerSession
+
+    suspend fun attachLinkConsumerToLinkAccountSession(
+        consumerSessionClientSecret: String,
+        clientSecret: String,
+    ): AttachConsumerToLinkAccountSession
 
     companion object {
         operator fun invoke(
@@ -111,6 +117,18 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
         ).also { session ->
             updateCachedConsumerSession("confirmConsumerVerification", session)
         }
+    }
+
+    override suspend fun attachLinkConsumerToLinkAccountSession(
+        consumerSessionClientSecret: String,
+        clientSecret: String,
+    ): AttachConsumerToLinkAccountSession {
+        return consumersApiService.attachLinkConsumerToLinkAccountSession(
+            consumerSessionClientSecret = consumerSessionClientSecret,
+            clientSecret = clientSecret,
+            requestSurface = CONSUMER_SURFACE,
+            requestOptions = provideApiRequestOptions(useConsumerPublishableKey = false),
+        )
     }
 
     private suspend fun postConsumerSession(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModelTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.financialconnections.TestFinancialConnectionsAnalytics
 import com.stripe.android.financialconnections.domain.AttachConsumerToLinkAccountSession
 import com.stripe.android.financialconnections.domain.ConfirmVerification
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
+import com.stripe.android.financialconnections.domain.GetOrFetchSync.RefetchCondition
 import com.stripe.android.financialconnections.domain.LookupConsumerAndStartVerification
 import com.stripe.android.financialconnections.domain.MarkLinkVerified
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
@@ -248,7 +249,7 @@ class NetworkingLinkVerificationViewModelTest {
         val onStartVerificationCaptor = argumentCaptor<suspend () -> Unit>()
         val onVerificationStartedCaptor = argumentCaptor<suspend (ConsumerSession) -> Unit>()
 
-        whenever(getOrFetchSync()).thenReturn(
+        whenever(getOrFetchSync(any())).thenReturn(
             syncResponse(sessionManifest().copy(accountholderCustomerEmailAddress = email))
         )
         whenever(attachConsumerToLinkAccountSession.invoke(any())).thenReturn(Unit)
@@ -278,6 +279,7 @@ class NetworkingLinkVerificationViewModelTest {
         }
 
         verify(attachConsumerToLinkAccountSession).invoke(consumerSession.clientSecret)
+        verify(getOrFetchSync).invoke(RefetchCondition.Always)
         verify(markLinkVerified, never()).invoke()
 
         navigationManager.assertNavigatedTo(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModelTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.financialconnections.ApiKeyFixtures.sessionManifest
 import com.stripe.android.financialconnections.ApiKeyFixtures.syncResponse
 import com.stripe.android.financialconnections.CoroutineTestRule
 import com.stripe.android.financialconnections.TestFinancialConnectionsAnalyticsTracker
+import com.stripe.android.financialconnections.domain.AttachConsumerToLinkAccountSession
 import com.stripe.android.financialconnections.domain.ConfirmVerification
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.LookupConsumerAndStartVerification
@@ -29,6 +30,7 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -45,9 +47,11 @@ class NetworkingLinkVerificationViewModelTest {
     private val markLinkVerified = mock<MarkLinkVerified>()
     private val analyticsTracker = TestFinancialConnectionsAnalyticsTracker()
     private val nativeAuthFlowCoordinator = NativeAuthFlowCoordinator()
+    private val attachConsumerToLinkAccountSession = mock<AttachConsumerToLinkAccountSession>()
 
     private fun buildViewModel(
-        state: NetworkingLinkVerificationState = NetworkingLinkVerificationState()
+        state: NetworkingLinkVerificationState = NetworkingLinkVerificationState(),
+        isLinkWithStripe: Boolean = false,
     ) = NetworkingLinkVerificationViewModel(
         navigationManager = navigationManager,
         getOrFetchSync = getOrFetchSync,
@@ -58,6 +62,8 @@ class NetworkingLinkVerificationViewModelTest {
         logger = Logger.noop(),
         initialState = state,
         nativeAuthFlowCoordinator = nativeAuthFlowCoordinator,
+        isLinkWithStripe = { isLinkWithStripe },
+        attachConsumerToLinkAccountSession = attachConsumerToLinkAccountSession,
     )
 
     @Test
@@ -234,4 +240,49 @@ class NetworkingLinkVerificationViewModelTest {
                 pane = NETWORKING_LINK_VERIFICATION
             )
         }
+
+    @Test
+    fun `otpEntered - attaches consumer to LAS and navigates to account picker in Instant Debits`() = runTest {
+        val email = "email@email.com"
+        val consumerSession = consumerSession()
+        val onStartVerificationCaptor = argumentCaptor<suspend () -> Unit>()
+        val onVerificationStartedCaptor = argumentCaptor<suspend (ConsumerSession) -> Unit>()
+
+        whenever(getOrFetchSync()).thenReturn(
+            syncResponse(sessionManifest().copy(accountholderCustomerEmailAddress = email))
+        )
+        whenever(attachConsumerToLinkAccountSession.invoke(any())).thenReturn(Unit)
+
+        val viewModel = buildViewModel(isLinkWithStripe = true)
+
+        verify(lookupConsumerAndStartVerification).invoke(
+            email = eq(email),
+            businessName = anyOrNull(),
+            verificationType = eq(VerificationType.SMS),
+            onConsumerNotFound = any(),
+            onLookupError = any(),
+            onStartVerification = onStartVerificationCaptor.capture(),
+            onVerificationStarted = onVerificationStartedCaptor.capture(),
+            onStartVerificationError = any()
+        )
+
+        onStartVerificationCaptor.firstValue()
+        onVerificationStartedCaptor.firstValue(consumerSession)
+
+        val otpController = viewModel.stateFlow.value.payload()!!.otpElement.controller
+
+        val otpCode = "111111"
+
+        for (index in otpCode.indices) {
+            otpController.onValueChanged(index, otpCode[index].toString())
+        }
+
+        verify(attachConsumerToLinkAccountSession).invoke(consumerSession.clientSecret)
+        verify(markLinkVerified, never()).invoke()
+
+        navigationManager.assertNavigatedTo(
+            destination = Destination.LinkAccountPicker,
+            pane = NETWORKING_LINK_VERIFICATION,
+        )
+    }
 }

--- a/payments-model/api/payments-model.api
+++ b/payments-model/api/payments-model.api
@@ -28,6 +28,14 @@ public final class com/stripe/android/cards/CardNumber$Unvalidated : com/stripe/
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/stripe/android/model/AttachConsumerToLinkAccountSession$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/AttachConsumerToLinkAccountSession;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/AttachConsumerToLinkAccountSession;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/model/BankAccount : com/stripe/android/core/model/StripeModel, com/stripe/android/model/StripePaymentSource {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final fun component1 ()Ljava/lang/String;

--- a/payments-model/src/main/java/com/stripe/android/model/AttachConsumerToLinkAccountSession.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/AttachConsumerToLinkAccountSession.kt
@@ -1,0 +1,12 @@
+package com.stripe.android.model
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.core.model.StripeModel
+import kotlinx.parcelize.Parcelize
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Parcelize
+data class AttachConsumerToLinkAccountSession(
+    val id: String,
+    val clientSecret: String,
+) : StripeModel

--- a/payments-model/src/main/java/com/stripe/android/model/parsers/AttachConsumerToLinkAccountSessionJsonParser.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/parsers/AttachConsumerToLinkAccountSessionJsonParser.kt
@@ -1,0 +1,15 @@
+package com.stripe.android.model.parsers
+
+import com.stripe.android.core.model.parsers.ModelJsonParser
+import com.stripe.android.model.AttachConsumerToLinkAccountSession
+import org.json.JSONObject
+
+internal object AttachConsumerToLinkAccountSessionJsonParser : ModelJsonParser<AttachConsumerToLinkAccountSession> {
+
+    override fun parse(json: JSONObject): AttachConsumerToLinkAccountSession {
+        return AttachConsumerToLinkAccountSession(
+            id = json.getString("id"),
+            clientSecret = json.getString("client_secret"),
+        )
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds an `AttachConsumerToLinkAccountSession` interactor that attaches the consumer and places a call to `synchronize`.

This is already being used in `NetworkingLinkVerificationViewModel` for returning users, and will be added to `NetworkingLinkSignupViewModel` once I work on the new user experience.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[BANKCON-11515](https://jira.corp.stripe.com/browse/BANKCON-11515)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
