### PR TITLE
Move confirmation nested models into separate their own types & files.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -41,6 +41,7 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAvailable
 import com.stripe.android.paymentsheet.IntentConfirmationHandler
 import com.stripe.android.paymentsheet.PaymentConfirmationOption
+import com.stripe.android.paymentsheet.PaymentConfirmationResult
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
@@ -913,7 +914,7 @@ internal class CustomerSheetViewModel(
         )
 
         return when (val result = intentConfirmationHandler.awaitIntentResult()) {
-            is IntentConfirmationHandler.Result.Succeeded -> {
+            is PaymentConfirmationResult.Succeeded -> {
                 safeUpdateSelectPaymentMethodState { viewState ->
                     viewState.copy(
                         savedPaymentMethods = listOf(paymentMethod) + viewState.savedPaymentMethods,
@@ -927,7 +928,7 @@ internal class CustomerSheetViewModel(
                 onBackPressed()
                 Result.success(Unit)
             }
-            is IntentConfirmationHandler.Result.Failed -> {
+            is PaymentConfirmationResult.Failed -> {
                 updateViewState<CustomerSheetViewState.AddPaymentMethod> {
                     it.copy(
                         isProcessing = false,
@@ -937,7 +938,7 @@ internal class CustomerSheetViewModel(
                 }
                 Result.failure(result.cause)
             }
-            is IntentConfirmationHandler.Result.Canceled -> {
+            is PaymentConfirmationResult.Canceled -> {
                 updateViewState<CustomerSheetViewState.AddPaymentMethod> {
                     it.copy(
                         enabled = true,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentCancellationAction.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentCancellationAction.kt
@@ -1,0 +1,22 @@
+package com.stripe.android.paymentsheet
+
+/**
+ * Action to perform if a user cancels a running confirmation process.
+ */
+internal enum class PaymentCancellationAction {
+    /**
+     * This actions means the user has cancels a critical confirmation step and that the user should be notified
+     * of the cancellation if relevant.
+     */
+    InformCancellation,
+
+    /**
+     * This action means that the user has asked to modify the payment details of their selected payment option.
+     */
+    ModifyPaymentDetails,
+
+    /**
+     * Means no action should be taken if the user cancels a step in the confirmation process.
+     */
+    None,
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationErrorType.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationErrorType.kt
@@ -1,0 +1,36 @@
+package com.stripe.android.paymentsheet
+
+/**
+ * Types of errors that can occur when confirming a payment.
+ */
+internal sealed interface PaymentConfirmationErrorType {
+    /**
+     * Fatal confirmation error that occurred while confirming a payment. This should never happen.
+     */
+    data object Fatal : PaymentConfirmationErrorType
+
+    /**
+     * Indicates an error when processing a payment during the confirmation process.
+     */
+    data object Payment : PaymentConfirmationErrorType
+
+    /**
+     * Indicates an internal process error occurred during the confirmation process.
+     */
+    data object Internal : PaymentConfirmationErrorType
+
+    /**
+     * Indicates a merchant integration error occurred during the confirmation process.
+     */
+    data object MerchantIntegration : PaymentConfirmationErrorType
+
+    /**
+     * Indicates an error occurred when confirming with external payment methods
+     */
+    data object ExternalPaymentMethod : PaymentConfirmationErrorType
+
+    /**
+     * Indicates an error occurred when confirming with Google Pay
+     */
+    data class GooglePay(val errorCode: Int) : PaymentConfirmationErrorType
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationResult.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationResult.kt
@@ -1,0 +1,35 @@
+package com.stripe.android.paymentsheet
+
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.model.StripeIntent
+
+/**
+ * Defines the result types that can be returned after completing a payment confirmation process.
+ */
+internal sealed interface PaymentConfirmationResult {
+    /**
+     * Indicates that the confirmation process was canceled by the customer.
+     */
+    data class Canceled(
+        val action: PaymentCancellationAction,
+    ) : PaymentConfirmationResult
+
+    /**
+     * Indicates that the confirmation process has been successfully completed. A [StripeIntent] with an updated
+     * state is returned as part of the result as well.
+     */
+    data class Succeeded(
+        val intent: StripeIntent,
+        val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+    ) : PaymentConfirmationResult
+
+    /**
+     * Indicates that the confirmation process has failed. A cause and potentially a resolvable message are
+     * returned as part of the result.
+     */
+    data class Failed(
+        val cause: Throwable,
+        val message: ResolvableString,
+        val type: PaymentConfirmationErrorType,
+    ) : PaymentConfirmationResult
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -301,7 +301,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     private suspend fun handlePaymentSheetStateLoaded(state: PaymentSheetState.Full) {
         val pendingResult = intentConfirmationHandler.awaitIntentResult()
 
-        if (pendingResult is IntentConfirmationHandler.Result.Succeeded) {
+        if (pendingResult is PaymentConfirmationResult.Succeeded) {
             // If we just received a transaction result after process death, we don't error. Instead, we dismiss
             // PaymentSheet and return a `Completed` result to the caller.
             handlePaymentCompleted(
@@ -326,7 +326,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         linkHandler.setupLink(state.linkState)
 
         val pendingFailedPaymentResult = intentConfirmationHandler.awaitIntentResult()
-            as? IntentConfirmationHandler.Result.Failed
+            as? PaymentConfirmationResult.Failed
         val errorMessage = pendingFailedPaymentResult?.cause?.stripeErrorMessage()
 
         resetViewState(errorMessage)
@@ -537,36 +537,36 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         }
     }
 
-    private fun processIntentResult(result: IntentConfirmationHandler.Result?) {
+    private fun processIntentResult(result: PaymentConfirmationResult?) {
         when (result) {
-            is IntentConfirmationHandler.Result.Succeeded -> handlePaymentCompleted(
+            is PaymentConfirmationResult.Succeeded -> handlePaymentCompleted(
                 intent = result.intent,
                 deferredIntentConfirmationType = result.deferredIntentConfirmationType,
                 finishImmediately = false,
             )
-            is IntentConfirmationHandler.Result.Failed -> processIntentFailure(result)
-            is IntentConfirmationHandler.Result.Canceled,
+            is PaymentConfirmationResult.Failed -> processIntentFailure(result)
+            is PaymentConfirmationResult.Canceled,
             null -> resetViewState()
         }
     }
 
-    private fun processIntentFailure(failure: IntentConfirmationHandler.Result.Failed) {
+    private fun processIntentFailure(failure: PaymentConfirmationResult.Failed) {
         when (failure.type) {
-            IntentConfirmationHandler.ErrorType.Payment -> handlePaymentFailed(
+            PaymentConfirmationErrorType.Payment -> handlePaymentFailed(
                 error = PaymentSheetConfirmationError.Stripe(failure.cause),
                 message = failure.message,
             )
-            IntentConfirmationHandler.ErrorType.ExternalPaymentMethod -> handlePaymentFailed(
+            PaymentConfirmationErrorType.ExternalPaymentMethod -> handlePaymentFailed(
                 error = PaymentSheetConfirmationError.ExternalPaymentMethod,
                 message = failure.message,
             )
-            is IntentConfirmationHandler.ErrorType.GooglePay -> handlePaymentFailed(
+            is PaymentConfirmationErrorType.GooglePay -> handlePaymentFailed(
                 error = PaymentSheetConfirmationError.GooglePay(failure.type.errorCode),
                 message = failure.message,
             )
-            IntentConfirmationHandler.ErrorType.Fatal -> onFatal(failure.cause)
-            IntentConfirmationHandler.ErrorType.MerchantIntegration,
-            IntentConfirmationHandler.ErrorType.Internal -> onError(failure.message)
+            PaymentConfirmationErrorType.Fatal -> onFatal(failure.cause)
+            PaymentConfirmationErrorType.MerchantIntegration,
+            PaymentConfirmationErrorType.Internal -> onError(failure.message)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
@@ -291,7 +291,7 @@ class IntentConfirmationHandlerTest {
         val result = intentConfirmationHandler.awaitIntentResult()
 
         assertThat(result).isEqualTo(
-            IntentConfirmationHandler.Result.Succeeded(
+            PaymentConfirmationResult.Succeeded(
                 intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
             )
@@ -321,10 +321,10 @@ class IntentConfirmationHandlerTest {
         val result = intentConfirmationHandler.awaitIntentResult()
 
         assertThat(result).isEqualTo(
-            IntentConfirmationHandler.Result.Failed(
+            PaymentConfirmationResult.Failed(
                 cause = cause,
                 message = message.resolvableString,
-                type = IntentConfirmationHandler.ErrorType.Internal,
+                type = PaymentConfirmationErrorType.Internal,
             )
         )
     }
@@ -357,7 +357,7 @@ class IntentConfirmationHandlerTest {
             assertThat(failedResult.cause).isInstanceOf(IllegalArgumentException::class.java)
             assertThat(failedResult.cause.message).isEqualTo(message)
             assertThat(failedResult.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
-            assertThat(failedResult.type).isEqualTo(IntentConfirmationHandler.ErrorType.Fatal)
+            assertThat(failedResult.type).isEqualTo(PaymentConfirmationErrorType.Fatal)
         }
 
     @Test
@@ -505,7 +505,7 @@ class IntentConfirmationHandlerTest {
 
             paymentResultCallbackHandler.onResult(InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED))
 
-            val expectedResult = IntentConfirmationHandler.Result.Succeeded(
+            val expectedResult = PaymentConfirmationResult.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
                 deferredIntentConfirmationType = null,
             )
@@ -551,8 +551,8 @@ class IntentConfirmationHandlerTest {
 
             paymentResultCallbackHandler.onResult(InternalPaymentResult.Canceled)
 
-            val expectedResult = IntentConfirmationHandler.Result.Canceled(
-                action = IntentConfirmationHandler.CancellationAction.InformCancellation,
+            val expectedResult = PaymentConfirmationResult.Canceled(
+                action = PaymentCancellationAction.InformCancellation,
             )
 
             assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
@@ -598,10 +598,10 @@ class IntentConfirmationHandlerTest {
 
             paymentResultCallbackHandler.onResult(InternalPaymentResult.Failed(cause))
 
-            val expectedResult = IntentConfirmationHandler.Result.Failed(
+            val expectedResult = PaymentConfirmationResult.Failed(
                 cause = cause,
                 message = R.string.stripe_something_went_wrong.resolvableString,
-                type = IntentConfirmationHandler.ErrorType.Payment,
+                type = PaymentConfirmationErrorType.Payment,
             )
 
             assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
@@ -725,8 +725,8 @@ class IntentConfirmationHandlerTest {
 
             dispatcher.scheduler.advanceTimeBy(delayTime = 1.01.seconds)
 
-            val expectedResult = IntentConfirmationHandler.Result.Canceled(
-                action = IntentConfirmationHandler.CancellationAction.None
+            val expectedResult = PaymentConfirmationResult.Canceled(
+                action = PaymentCancellationAction.None
             )
 
             assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
@@ -781,7 +781,7 @@ class IntentConfirmationHandlerTest {
 
             assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Confirming)
 
-            val expectedResult = IntentConfirmationHandler.Result.Succeeded(
+            val expectedResult = PaymentConfirmationResult.Succeeded(
                 intent = DEFAULT_ARGUMENTS.intent,
                 deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
             )
@@ -814,7 +814,7 @@ class IntentConfirmationHandlerTest {
         val result = intentConfirmationHandler.awaitIntentResult()
 
         assertThat(result).isEqualTo(
-            IntentConfirmationHandler.Result.Succeeded(
+            PaymentConfirmationResult.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
                 deferredIntentConfirmationType = null,
             )
@@ -850,7 +850,7 @@ class IntentConfirmationHandlerTest {
         val result = intentConfirmationHandler.awaitIntentResult()
 
         assertThat(result).isEqualTo(
-            IntentConfirmationHandler.Result.Succeeded(
+            PaymentConfirmationResult.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
                 deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
             )
@@ -894,7 +894,7 @@ class IntentConfirmationHandlerTest {
 
             paymentResultCallbackHandler.onResult(InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED))
 
-            val expectedResult = IntentConfirmationHandler.Result.Succeeded(
+            val expectedResult = PaymentConfirmationResult.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
                 deferredIntentConfirmationType = null,
             )
@@ -964,7 +964,7 @@ class IntentConfirmationHandlerTest {
             "externalPaymentMethodConfirmHandler is null. Cannot process payment for payment selection: paypal"
         )
         assertThat(intentResult.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
-        assertThat(intentResult.type).isEqualTo(IntentConfirmationHandler.ErrorType.ExternalPaymentMethod)
+        assertThat(intentResult.type).isEqualTo(PaymentConfirmationErrorType.ExternalPaymentMethod)
     }
 
     @Test
@@ -987,7 +987,7 @@ class IntentConfirmationHandlerTest {
             "externalPaymentMethodLauncher is null. Cannot process payment for payment selection: paypal"
         )
         assertThat(intentResult.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
-        assertThat(intentResult.type).isEqualTo(IntentConfirmationHandler.ErrorType.ExternalPaymentMethod)
+        assertThat(intentResult.type).isEqualTo(PaymentConfirmationErrorType.ExternalPaymentMethod)
     }
 
     @Test
@@ -1021,7 +1021,7 @@ class IntentConfirmationHandlerTest {
 
             epmsCallbackHandler.onResult(PaymentResult.Completed)
 
-            val expectedResult = IntentConfirmationHandler.Result.Succeeded(
+            val expectedResult = PaymentConfirmationResult.Succeeded(
                 intent = DEFAULT_ARGUMENTS.intent,
                 deferredIntentConfirmationType = null,
             )
@@ -1066,10 +1066,10 @@ class IntentConfirmationHandlerTest {
 
             epmsCallbackHandler.onResult(PaymentResult.Failed(exception))
 
-            val expectedResult = IntentConfirmationHandler.Result.Failed(
+            val expectedResult = PaymentConfirmationResult.Failed(
                 cause = exception,
                 message = R.string.stripe_something_went_wrong.resolvableString,
-                type = IntentConfirmationHandler.ErrorType.ExternalPaymentMethod,
+                type = PaymentConfirmationErrorType.ExternalPaymentMethod,
             )
 
             assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
@@ -1110,8 +1110,8 @@ class IntentConfirmationHandlerTest {
 
             epmsCallbackHandler.onResult(PaymentResult.Canceled)
 
-            val expectedResult = IntentConfirmationHandler.Result.Canceled(
-                action = IntentConfirmationHandler.CancellationAction.None,
+            val expectedResult = PaymentConfirmationResult.Canceled(
+                action = PaymentCancellationAction.None,
             )
 
             assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
@@ -1176,7 +1176,7 @@ class IntentConfirmationHandlerTest {
         val result = intentConfirmationHandler.awaitIntentResult().asFailed()
 
         assertThat(result.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
-        assertThat(result.type).isEqualTo(IntentConfirmationHandler.ErrorType.Internal)
+        assertThat(result.type).isEqualTo(PaymentConfirmationErrorType.Internal)
         assertThat(result.cause.message).isEqualTo("Required value was null.")
     }
 
@@ -1201,7 +1201,7 @@ class IntentConfirmationHandlerTest {
         val result = intentConfirmationHandler.awaitIntentResult().asFailed()
 
         assertThat(result.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
-        assertThat(result.type).isEqualTo(IntentConfirmationHandler.ErrorType.Internal)
+        assertThat(result.type).isEqualTo(PaymentConfirmationErrorType.Internal)
         assertThat(result.cause.message).isEqualTo(
             "Given payment selection could not be converted to Bacs data!"
         )
@@ -1228,7 +1228,7 @@ class IntentConfirmationHandlerTest {
         val result = intentConfirmationHandler.awaitIntentResult().asFailed()
 
         assertThat(result.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
-        assertThat(result.type).isEqualTo(IntentConfirmationHandler.ErrorType.Internal)
+        assertThat(result.type).isEqualTo(PaymentConfirmationErrorType.Internal)
         assertThat(result.cause.message).isEqualTo(
             "Given payment selection could not be converted to Bacs data!"
         )
@@ -1316,8 +1316,8 @@ class IntentConfirmationHandlerTest {
 
             interceptor.calls.expectNoEvents()
 
-            val expectedResult = IntentConfirmationHandler.Result.Canceled(
-                action = IntentConfirmationHandler.CancellationAction.ModifyPaymentDetails,
+            val expectedResult = PaymentConfirmationResult.Canceled(
+                action = PaymentCancellationAction.ModifyPaymentDetails,
             )
 
             assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
@@ -1370,8 +1370,8 @@ class IntentConfirmationHandlerTest {
 
             interceptor.calls.expectNoEvents()
 
-            val expectedResult = IntentConfirmationHandler.Result.Canceled(
-                action = IntentConfirmationHandler.CancellationAction.None,
+            val expectedResult = PaymentConfirmationResult.Canceled(
+                action = PaymentCancellationAction.None,
             )
 
             assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
@@ -1407,7 +1407,7 @@ class IntentConfirmationHandlerTest {
             "Google Pay when processing a Setup Intent"
 
         assertThat(result.cause.message).isEqualTo(message)
-        assertThat(result.type).isEqualTo(IntentConfirmationHandler.ErrorType.MerchantIntegration)
+        assertThat(result.type).isEqualTo(PaymentConfirmationErrorType.MerchantIntegration)
         assertThat(result.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
 
         assertThat(logger.getLoggedMessages()).contains(message)
@@ -1546,8 +1546,8 @@ class IntentConfirmationHandlerTest {
 
             googlePayCallbackHandler.onResult(GooglePayPaymentMethodLauncher.Result.Canceled)
 
-            val expectedResult = IntentConfirmationHandler.Result.Canceled(
-                action = IntentConfirmationHandler.CancellationAction.InformCancellation,
+            val expectedResult = PaymentConfirmationResult.Canceled(
+                action = PaymentCancellationAction.InformCancellation,
             )
 
             assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Complete(expectedResult))
@@ -1595,10 +1595,10 @@ class IntentConfirmationHandlerTest {
                 )
             )
 
-            val expectedResult = IntentConfirmationHandler.Result.Failed(
+            val expectedResult = PaymentConfirmationResult.Failed(
                 cause = exception,
                 message = com.stripe.android.R.string.stripe_internal_error.resolvableString,
-                type = IntentConfirmationHandler.ErrorType.GooglePay(127),
+                type = PaymentConfirmationErrorType.GooglePay(127),
             )
 
             assertThat(awaitItem()).isEqualTo(IntentConfirmationHandler.State.Complete(expectedResult))
@@ -1755,8 +1755,8 @@ class IntentConfirmationHandlerTest {
         )
     }
 
-    private fun IntentConfirmationHandler.Result?.asFailed(): IntentConfirmationHandler.Result.Failed {
-        return this as IntentConfirmationHandler.Result.Failed
+    private fun PaymentConfirmationResult?.asFailed(): PaymentConfirmationResult.Failed {
+        return this as PaymentConfirmationResult.Failed
     }
 
     private fun createBacsPaymentConfirmationOption(


### PR DESCRIPTION
# Summary
Move confirmation nested models into separate their own types & files.

# Motivation
Cleans up `IntentConfirmationHandler` and allows usage of types outside the handler as well.