### PR TITLE
Move signup functionality to shared module

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
@@ -6,6 +6,8 @@ import com.stripe.android.financialconnections.repository.api.ProvideApiRequestO
 import com.stripe.android.model.AttachConsumerToLinkAccountSession
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.ConsumerSessionLookup
+import com.stripe.android.model.ConsumerSessionSignup
+import com.stripe.android.model.ConsumerSignUpConsentAction.EnteredPhoneNumberClickedSaveToLink
 import com.stripe.android.model.CustomEmailType
 import com.stripe.android.model.VerificationType
 import com.stripe.android.repository.ConsumersApiService
@@ -16,6 +18,13 @@ import java.util.Locale
 internal interface FinancialConnectionsConsumerSessionRepository {
 
     suspend fun getCachedConsumerSession(): CachedConsumerSession?
+
+    suspend fun signUp(
+        email: String,
+        phoneNumber: String,
+        country: String,
+        locale: Locale?,
+    ): ConsumerSessionSignup
 
     suspend fun lookupConsumerSession(
         email: String,
@@ -80,7 +89,27 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
         clientSecret: String
     ): ConsumerSessionLookup = mutex.withLock {
         postConsumerSession(email, clientSecret).also { lookup ->
-            updateCachedConsumerSession("lookupConsumerSession", lookup)
+            updateCachedConsumerSessionFromLookup(lookup)
+        }
+    }
+
+    override suspend fun signUp(
+        email: String,
+        phoneNumber: String,
+        country: String,
+        locale: Locale?,
+    ): ConsumerSessionSignup = mutex.withLock {
+        consumersApiService.signUp(
+            email = email,
+            phoneNumber = phoneNumber,
+            country = country,
+            name = null,
+            locale = locale,
+            requestOptions = provideApiRequestOptions(useConsumerPublishableKey = false),
+            requestSurface = CONSUMER_SURFACE,
+            consentAction = EnteredPhoneNumberClickedSaveToLink,
+        ).also { signup ->
+            updateCachedConsumerSessionFromSignup(signup)
         }
     }
 
@@ -148,12 +177,18 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
         consumerSessionRepository.updateConsumerSession(consumerSession)
     }
 
-    private fun updateCachedConsumerSession(
-        source: String,
+    private fun updateCachedConsumerSessionFromLookup(
         lookup: ConsumerSessionLookup,
     ) {
-        logger.debug("SYNC_CACHE: updating local consumer session from $source")
+        logger.debug("SYNC_CACHE: updating local consumer session from lookupConsumerSession")
         consumerSessionRepository.storeNewConsumerSession(lookup.consumerSession, lookup.publishableKey)
+    }
+
+    private fun updateCachedConsumerSessionFromSignup(
+        signup: ConsumerSessionSignup,
+    ) {
+        logger.debug("SYNC_CACHE: updating local consumer session from signUp")
+        consumerSessionRepository.storeNewConsumerSession(signup.consumerSession, signup.publishableKey)
     }
 
     private companion object {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
@@ -108,9 +108,9 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
             requestOptions = provideApiRequestOptions(useConsumerPublishableKey = false),
             requestSurface = CONSUMER_SURFACE,
             consentAction = EnteredPhoneNumberClickedSaveToLink,
-        ).also { signup ->
+        ).onSuccess { signup ->
             updateCachedConsumerSessionFromSignup(signup)
-        }
+        }.getOrThrow()
     }
 
     override suspend fun startConsumerVerification(

--- a/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -60,18 +60,16 @@ internal class LinkApiRepository @Inject constructor(
         name: String?,
         consentAction: ConsumerSignUpConsentAction
     ): Result<ConsumerSessionSignup> = withContext(workContext) {
-        runCatching {
-            consumersApiService.signUp(
-                email = email,
-                phoneNumber = phone,
-                country = country,
-                name = name,
-                locale = locale,
-                consentAction = consentAction,
-                requestOptions = buildRequestOptions(),
-                requestSurface = REQUEST_SURFACE,
-            )
-        }
+        consumersApiService.signUp(
+            email = email,
+            phoneNumber = phone,
+            country = country,
+            name = name,
+            locale = locale,
+            consentAction = consentAction,
+            requestOptions = buildRequestOptions(),
+            requestSurface = REQUEST_SURFACE,
+        )
     }
 
     override suspend fun createCardPaymentDetails(

--- a/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -60,15 +60,18 @@ internal class LinkApiRepository @Inject constructor(
         name: String?,
         consentAction: ConsumerSignUpConsentAction
     ): Result<ConsumerSessionSignup> = withContext(workContext) {
-        stripeRepository.consumerSignUp(
-            email = email,
-            phoneNumber = phone,
-            country = country,
-            name = name,
-            locale = locale,
-            consentAction = consentAction,
-            requestOptions = buildRequestOptions(),
-        )
+        runCatching {
+            consumersApiService.signUp(
+                email = email,
+                phoneNumber = phone,
+                country = country,
+                name = name,
+                locale = locale,
+                consentAction = consentAction,
+                requestOptions = buildRequestOptions(),
+                requestSurface = REQUEST_SURFACE,
+            )
+        }
     }
 
     override suspend fun createCardPaymentDetails(

--- a/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -119,14 +119,15 @@ class LinkApiRepositoryTest {
             ConsumerSignUpConsentAction.Checkbox
         )
 
-        verify(stripeRepository).consumerSignUp(
-            eq(email),
-            eq(phone),
-            eq(country),
-            eq(name),
-            eq(Locale.US),
-            eq(ConsumerSignUpConsentAction.Checkbox),
-            eq(ApiRequest.Options(PUBLISHABLE_KEY, STRIPE_ACCOUNT_ID))
+        verify(consumersApiService).signUp(
+            email = email,
+            phoneNumber = phone,
+            country = country,
+            name = name,
+            locale = Locale.US,
+            requestSurface = "android_payment_element",
+            consentAction = ConsumerSignUpConsentAction.Checkbox,
+            requestOptions = ApiRequest.Options(PUBLISHABLE_KEY, STRIPE_ACCOUNT_ID),
         )
     }
 
@@ -134,16 +135,17 @@ class LinkApiRepositoryTest {
     fun `consumerSignUp returns successful result`() = runTest {
         val consumerSession = mock<ConsumerSessionSignup>()
         whenever(
-            stripeRepository.consumerSignUp(
+            consumersApiService.signUp(
                 email = any(),
                 phoneNumber = any(),
                 country = any(),
                 name = anyOrNull(),
                 locale = anyOrNull(),
+                requestSurface = any(),
                 consentAction = any(),
                 requestOptions = any()
             )
-        ).thenReturn(Result.success(consumerSession))
+        ).thenReturn(consumerSession)
 
         val result = linkRepository.consumerSignUp(
             "email",
@@ -160,16 +162,17 @@ class LinkApiRepositoryTest {
     @Test
     fun `consumerSignUp catches exception and returns failure`() = runTest {
         whenever(
-            stripeRepository.consumerSignUp(
+            consumersApiService.signUp(
                 email = any(),
                 phoneNumber = any(),
                 country = any(),
                 name = anyOrNull(),
                 locale = anyOrNull(),
+                requestSurface = any(),
                 consentAction = any(),
                 requestOptions = any()
             )
-        ).thenReturn(Result.failure(RuntimeException("error")))
+        ).thenThrow(RuntimeException("error"))
 
         val result = linkRepository.consumerSignUp(
             "email",

--- a/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -172,7 +172,7 @@ class LinkApiRepositoryTest {
                 consentAction = any(),
                 requestOptions = any()
             )
-        ).thenThrow(RuntimeException("error"))
+        ).thenReturn(Result.failure(RuntimeException("error")))
 
         val result = linkRepository.consumerSignUp(
             "email",

--- a/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -145,7 +145,7 @@ class LinkApiRepositoryTest {
                 consentAction = any(),
                 requestOptions = any()
             )
-        ).thenReturn(consumerSession)
+        ).thenReturn(Result.success(consumerSession))
 
         val result = linkRepository.consumerSignUp(
             "email",

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -12,8 +12,6 @@ import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetailsCreateParams
 import com.stripe.android.model.ConsumerSession
-import com.stripe.android.model.ConsumerSessionSignup
-import com.stripe.android.model.ConsumerSignUpConsentAction
 import com.stripe.android.model.CreateFinancialConnectionsSessionForDeferredPaymentParams
 import com.stripe.android.model.CreateFinancialConnectionsSessionParams
 import com.stripe.android.model.Customer
@@ -38,7 +36,6 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.Token
 import com.stripe.android.model.TokenParams
 import com.stripe.android.networking.StripeRepository
-import java.util.Locale
 
 abstract class AbsFakeStripeRepository : StripeRepository {
 
@@ -293,18 +290,6 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         hcaptchaEKey: String?,
         requestOptions: ApiRequest.Options
     ): Result<RadarSessionWithHCaptcha> {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun consumerSignUp(
-        email: String,
-        phoneNumber: String,
-        country: String,
-        name: String?,
-        locale: Locale?,
-        consentAction: ConsumerSignUpConsentAction,
-        requestOptions: ApiRequest.Options
-    ): Result<ConsumerSessionSignup> {
         TODO("Not yet implemented")
     }
 

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -53,8 +53,6 @@ import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetailsCreateParams
 import com.stripe.android.model.ConsumerSession
-import com.stripe.android.model.ConsumerSessionSignup
-import com.stripe.android.model.ConsumerSignUpConsentAction
 import com.stripe.android.model.CreateFinancialConnectionsSessionForDeferredPaymentParams
 import com.stripe.android.model.CreateFinancialConnectionsSessionParams
 import com.stripe.android.model.Customer
@@ -82,7 +80,6 @@ import com.stripe.android.model.parsers.CardMetadataJsonParser
 import com.stripe.android.model.parsers.ConsumerPaymentDetailsJsonParser
 import com.stripe.android.model.parsers.ConsumerPaymentDetailsShareJsonParser
 import com.stripe.android.model.parsers.ConsumerSessionJsonParser
-import com.stripe.android.model.parsers.ConsumerSessionSignupJsonParser
 import com.stripe.android.model.parsers.CustomerJsonParser
 import com.stripe.android.model.parsers.ElementsSessionJsonParser
 import com.stripe.android.model.parsers.FinancialConnectionsSessionJsonParser
@@ -1069,43 +1066,6 @@ class StripeApiRepository @JvmOverloads internal constructor(
         )
     }
 
-    /**
-     * Creates a new Link account for the credentials provided.
-     */
-    override suspend fun consumerSignUp(
-        email: String,
-        phoneNumber: String,
-        country: String,
-        name: String?,
-        locale: Locale?,
-        consentAction: ConsumerSignUpConsentAction,
-        requestOptions: ApiRequest.Options
-    ): Result<ConsumerSessionSignup> {
-        return fetchStripeModelResult(
-            apiRequest = apiRequestFactory.createPost(
-                url = consumerSignUpUrl,
-                options = requestOptions,
-                params = mapOf(
-                    "request_surface" to "android_payment_element",
-                    "country_inferring_method" to "PHONE_NUMBER",
-                    "email_address" to email.lowercase(),
-                    "phone_number" to phoneNumber,
-                    "country" to country,
-                    "consent_action" to consentAction.value
-                ).plus(
-                    locale?.let {
-                        mapOf("locale" to it.toLanguageTag())
-                    } ?: emptyMap()
-                ).plus(
-                    name?.let {
-                        mapOf("legal_name" to it)
-                    } ?: emptyMap()
-                )
-            ),
-            jsonParser = ConsumerSessionSignupJsonParser,
-        )
-    }
-
     override suspend fun createPaymentDetails(
         consumerSessionClientSecret: String,
         paymentDetailsCreateParams: ConsumerPaymentDetailsCreateParams,
@@ -1829,13 +1789,6 @@ class StripeApiRepository @JvmOverloads internal constructor(
         internal val paymentMethodsUrl: String
             @JvmSynthetic
             get() = getApiUrl("payment_methods")
-
-        /**
-         * @return `https://api.stripe.com/v1/consumers/accounts/sign_up`
-         */
-        internal val consumerSignUpUrl: String
-            @JvmSynthetic
-            get() = getApiUrl("consumers/accounts/sign_up")
 
         /**
          * @return `https://api.stripe.com/v1/consumers/sessions/log_out`

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -13,8 +13,6 @@ import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetailsCreateParams
 import com.stripe.android.model.ConsumerSession
-import com.stripe.android.model.ConsumerSessionSignup
-import com.stripe.android.model.ConsumerSignUpConsentAction
 import com.stripe.android.model.CreateFinancialConnectionsSessionForDeferredPaymentParams
 import com.stripe.android.model.CreateFinancialConnectionsSessionParams
 import com.stripe.android.model.Customer
@@ -38,7 +36,6 @@ import com.stripe.android.model.Stripe3ds2AuthResult
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.Token
 import com.stripe.android.model.TokenParams
-import java.util.Locale
 
 /**
  * An interface for data operations on Stripe API objects.
@@ -270,17 +267,6 @@ interface StripeRepository {
     ): Result<RadarSessionWithHCaptcha>
 
     // Link endpoints
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    @Suppress("LongParameterList")
-    suspend fun consumerSignUp(
-        email: String,
-        phoneNumber: String,
-        country: String,
-        name: String?,
-        locale: Locale?,
-        consentAction: ConsumerSignUpConsentAction,
-        requestOptions: ApiRequest.Options
-    ): Result<ConsumerSessionSignup>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun createPaymentDetails(

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -32,7 +32,6 @@ import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.ConsumerFixtures
 import com.stripe.android.model.ConsumerPaymentDetailsCreateParams
-import com.stripe.android.model.ConsumerSignUpConsentAction
 import com.stripe.android.model.CreateFinancialConnectionsSessionForDeferredPaymentParams
 import com.stripe.android.model.CreateFinancialConnectionsSessionParams
 import com.stripe.android.model.DeferredIntentParams
@@ -225,12 +224,6 @@ internal class StripeApiRepositoryTest {
     fun testConfirmPaymentIntentUrl() {
         assertThat(StripeApiRepository.getConfirmPaymentIntentUrl("pi123"))
             .isEqualTo("https://api.stripe.com/v1/payment_intents/pi123/confirm")
-    }
-
-    @Test
-    fun testConsumerSignUpUrl() {
-        assertThat(StripeApiRepository.consumerSignUpUrl)
-            .isEqualTo("https://api.stripe.com/v1/consumers/accounts/sign_up")
     }
 
     @Test
@@ -1744,46 +1737,6 @@ internal class StripeApiRepositoryTest {
             )
 
             verifyFraudDetectionDataAndAnalyticsRequests(PaymentAnalyticsEvent.SetupIntentRefresh)
-        }
-
-    @Test
-    fun `consumerSignUp() sends all parameters`() =
-        runTest {
-            val stripeResponse = StripeResponse(
-                200,
-                ConsumerFixtures.CONSUMER_VERIFIED_JSON.toString(),
-                emptyMap()
-            )
-            whenever(stripeNetworkClient.executeRequest(any<ApiRequest>()))
-                .thenReturn(stripeResponse)
-
-            val email = "email@example.com"
-            val phoneNumber = "phone number"
-            val country = "US"
-            val name = "name"
-            val locale = Locale.US
-            val consentAction = ConsumerSignUpConsentAction.Implied
-            create().consumerSignUp(
-                email,
-                phoneNumber,
-                country,
-                name,
-                locale,
-                consentAction,
-                DEFAULT_OPTIONS
-            )
-
-            verify(stripeNetworkClient).executeRequest(apiRequestArgumentCaptor.capture())
-            val params = requireNotNull(apiRequestArgumentCaptor.firstValue.params)
-
-            with(params) {
-                assertThat(this["email_address"]).isEqualTo(email)
-                assertThat(this["phone_number"]).isEqualTo(phoneNumber)
-                assertThat(this["country"]).isEqualTo(country)
-                assertThat(this["legal_name"]).isEqualTo(name)
-                assertThat(this["locale"]).isEqualTo(locale.toLanguageTag())
-                assertThat(this["consent_action"]).isEqualTo("implied_consent_withspm_mobile_v0")
-            }
         }
 
     @Test

--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerSignUpConsentAction.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerSignUpConsentAction.kt
@@ -4,9 +4,13 @@ import androidx.annotation.RestrictTo
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 enum class ConsumerSignUpConsentAction(val value: String) {
+    // Payments
     Checkbox("clicked_checkbox_nospm_mobile_v0"),
     CheckboxWithPrefilledEmail("clicked_checkbox_nospm_mobile_v0_0"),
     CheckboxWithPrefilledEmailAndPhone("clicked_checkbox_nospm_mobile_v0_1"),
     Implied("implied_consent_withspm_mobile_v0"),
-    ImpliedWithPrefilledEmail("implied_consent_withspm_mobile_v0_0")
+    ImpliedWithPrefilledEmail("implied_consent_withspm_mobile_v0_0"),
+
+    // Financial Connections
+    EnteredPhoneNumberClickedSaveToLink("entered_phone_number_clicked_save_to_link"),
 }

--- a/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
+++ b/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
@@ -6,6 +6,7 @@ import com.stripe.android.core.model.parsers.StripeErrorJsonParser
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.StripeNetworkClient
 import com.stripe.android.core.networking.executeRequestWithModelJsonParser
+import com.stripe.android.core.networking.executeRequestWithResultParser
 import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.model.AttachConsumerToLinkAccountSession
 import com.stripe.android.model.ConsumerSession
@@ -32,7 +33,7 @@ interface ConsumersApiService {
         requestSurface: String,
         consentAction: ConsumerSignUpConsentAction,
         requestOptions: ApiRequest.Options,
-    ): ConsumerSessionSignup
+    ): Result<ConsumerSessionSignup>
 
     suspend fun lookupConsumerSession(
         email: String,
@@ -91,8 +92,8 @@ class ConsumersApiServiceImpl(
         requestSurface: String,
         consentAction: ConsumerSignUpConsentAction,
         requestOptions: ApiRequest.Options,
-    ): ConsumerSessionSignup {
-        return executeRequestWithModelJsonParser(
+    ): Result<ConsumerSessionSignup> {
+        return executeRequestWithResultParser(
             stripeErrorJsonParser = stripeErrorJsonParser,
             stripeNetworkClient = stripeNetworkClient,
             request = apiRequestFactory.createPost(

--- a/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
+++ b/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
@@ -10,15 +10,29 @@ import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.model.AttachConsumerToLinkAccountSession
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.ConsumerSessionLookup
+import com.stripe.android.model.ConsumerSessionSignup
+import com.stripe.android.model.ConsumerSignUpConsentAction
 import com.stripe.android.model.CustomEmailType
 import com.stripe.android.model.VerificationType
 import com.stripe.android.model.parsers.AttachConsumerToLinkAccountSessionJsonParser
 import com.stripe.android.model.parsers.ConsumerSessionJsonParser
 import com.stripe.android.model.parsers.ConsumerSessionLookupJsonParser
+import com.stripe.android.model.parsers.ConsumerSessionSignupJsonParser
 import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 interface ConsumersApiService {
+
+    suspend fun signUp(
+        email: String,
+        phoneNumber: String,
+        country: String,
+        name: String?,
+        locale: Locale?,
+        requestSurface: String,
+        consentAction: ConsumerSignUpConsentAction,
+        requestOptions: ApiRequest.Options,
+    ): ConsumerSessionSignup
 
     suspend fun lookupConsumerSession(
         email: String,
@@ -67,6 +81,43 @@ class ConsumersApiServiceImpl(
         apiVersion = apiVersion,
         sdkVersion = sdkVersion
     )
+
+    override suspend fun signUp(
+        email: String,
+        phoneNumber: String,
+        country: String,
+        name: String?,
+        locale: Locale?,
+        requestSurface: String,
+        consentAction: ConsumerSignUpConsentAction,
+        requestOptions: ApiRequest.Options,
+    ): ConsumerSessionSignup {
+        return executeRequestWithModelJsonParser(
+            stripeErrorJsonParser = stripeErrorJsonParser,
+            stripeNetworkClient = stripeNetworkClient,
+            request = apiRequestFactory.createPost(
+                url = consumerAccountsSignUpUrl,
+                options = requestOptions,
+                params = mapOf(
+                    "email_address" to email.lowercase(),
+                    "phone_number" to phoneNumber,
+                    "country" to country,
+                    "country_inferring_method" to "PHONE_NUMBER",
+                    "consent_action" to consentAction.value,
+                    "request_surface" to requestSurface,
+                ).plus(
+                    locale?.let {
+                        mapOf("locale" to it.toLanguageTag())
+                    } ?: emptyMap()
+                ).plus(
+                    name?.let {
+                        mapOf("legal_name" to it)
+                    } ?: emptyMap()
+                ),
+            ),
+            responseJsonParser = ConsumerSessionSignupJsonParser,
+        )
+    }
 
     /**
      * Retrieves the ConsumerSession if the given email is associated with a Link account.
@@ -176,6 +227,13 @@ class ConsumersApiServiceImpl(
     }
 
     internal companion object {
+
+        /**
+         * @return `https://api.stripe.com/v1/consumers/accounts/sign_up`
+         */
+        internal val consumerAccountsSignUpUrl: String =
+            getApiUrl("consumers/accounts/sign_up")
+
         /**
          * @return `https://api.stripe.com/v1/consumers/sessions/lookup`
          */

--- a/payments-model/src/test/java/com/stripe/android/ConsumerFixtures.kt
+++ b/payments-model/src/test/java/com/stripe/android/ConsumerFixtures.kt
@@ -18,6 +18,7 @@ object ConsumerFixtures {
         """
             {
               "auth_session_client_secret": null,
+              "publishable_key": "asdfg123",
               "consumer_session": {
                 "client_secret": "secret",
                 "email_address": "email@example.com",

--- a/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
@@ -63,7 +63,7 @@ class ConsumersApiServiceImplTest {
             consentAction = ConsumerSignUpConsentAction.Checkbox,
             requestSurface = requestSurface,
             requestOptions = DEFAULT_OPTIONS,
-        )
+        ).getOrThrow()
 
         assertThat(signup.consumerSession.verificationSessions).isEmpty()
         assertThat(signup.consumerSession.emailAddress).isEqualTo(email)

--- a/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.model.ConsumerSession
+import com.stripe.android.model.ConsumerSignUpConsentAction
 import com.stripe.android.model.VerificationType
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
@@ -32,6 +33,44 @@ class ConsumersApiServiceImplTest {
         apiVersion = ApiVersion(betas = emptySet()).code,
         appInfo = null
     )
+
+    @Test
+    fun `signUp() sends all parameters`() = runTest {
+        val email = "email@example.com"
+        val requestSurface = "android_payment_element"
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/consumers/accounts/sign_up"),
+            header("Authorization", "Bearer ${DEFAULT_OPTIONS.apiKey}"),
+            header("User-Agent", "Stripe/v1 ${StripeSdkVersion.VERSION}"),
+            bodyPart("email_address", "email%40example.com"),
+            bodyPart("phone_number", "%2B15555555568"),
+            bodyPart("country", "US"),
+            bodyPart("locale", "en-US"),
+            bodyPart("consent_action", "clicked_checkbox_nospm_mobile_v0"),
+            bodyPart("request_surface", requestSurface),
+        ) { response ->
+            response.setBody(ConsumerFixtures.EXISTING_CONSUMER_JSON.toString())
+        }
+
+        val signup = consumersApiService.signUp(
+            email = email,
+            phoneNumber = "+15555555568",
+            country = "US",
+            name = null,
+            locale = Locale.US,
+            consentAction = ConsumerSignUpConsentAction.Checkbox,
+            requestSurface = requestSurface,
+            requestOptions = DEFAULT_OPTIONS,
+        )
+
+        assertThat(signup.consumerSession.verificationSessions).isEmpty()
+        assertThat(signup.consumerSession.emailAddress).isEqualTo(email)
+        assertThat(signup.consumerSession.redactedPhoneNumber).isEqualTo("+1********68")
+        assertThat(signup.consumerSession.clientSecret).isEqualTo("secret")
+        assertThat(signup.publishableKey).isEqualTo("asdfg123")
+    }
 
     @Test
     fun `lookupConsumerSession() sends all parameters`() = runTest {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request moves the signup network call from `StripeRepository` to `ConsumersApiService`, which allows us to reuse it in Financial Connections. This also required moving the internal `ConsumerSignUpConsentAction` to `payments-model` and adding an FC-specific enum case.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
