### PR TITLE
Update Emerge tools integration to use latest best practices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
         run: ./gradlew :paymentsheet-example:emergeUploadReleaseAab
         env:
           EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
+          EMERGE_TAG: pull_request
 
   check-for-untranslated-strings:
     name: Check for untranslated strings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,14 +48,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
-      - name: Generate Android release bundle
-        run: ./gradlew :paymentsheet-example:bundleRelease
-      - name: Upload artifact to Emerge
-        uses: EmergeTools/emerge-upload-action@3477b597fc62054136eb6f499e0ba78144f8a999
-        with:
-          artifact_path: paymentsheet-example/build/outputs/bundle/release/paymentsheet-example-release.aab
-          emerge_api_key: ${{ secrets.EMERGE_API_KEY }}
-          build_type: pull_request
+      - name: Upload release bundle to Emerge
+        run: ./gradlew :paymentsheet-example:emergeUploadReleaseAab
+        env:
+          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
 
   check-for-untranslated-strings:
     name: Check for untranslated strings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Upload release bundle to Emerge
         run: ./gradlew :paymentsheet-example:emergeUploadReleaseAab
         env:
-          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
+          EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
           EMERGE_TAG: pull_request
 
   check-for-untranslated-strings:

--- a/.github/workflows/financialconnections_pull_request.yml
+++ b/.github/workflows/financialconnections_pull_request.yml
@@ -12,4 +12,5 @@ jobs:
         run: ./gradlew :financial-connections-example:emergeUploadReleaseAab
         env:
           EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
+          EMERGE_TAG: release
 

--- a/.github/workflows/financialconnections_pull_request.yml
+++ b/.github/workflows/financialconnections_pull_request.yml
@@ -11,6 +11,6 @@ jobs:
       - name: Upload release bundle to Emerge
         run: ./gradlew :financial-connections-example:emergeUploadReleaseAab
         env:
-          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
+          EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
           EMERGE_TAG: release
 

--- a/.github/workflows/financialconnections_pull_request.yml
+++ b/.github/workflows/financialconnections_pull_request.yml
@@ -8,11 +8,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
-      - name: Generate Android release bundle
-        run: ./gradlew :financial-connections-example:bundleRelease
-      - name: Upload artifact to Emerge
-        uses: EmergeTools/emerge-upload-action@3477b597fc62054136eb6f499e0ba78144f8a999
-        with:
-          artifact_path: financial-connections-example/build/outputs/bundle/release/financial-connections-example-release.aab
-          emerge_api_key: ${{ secrets.EMERGE_API_KEY }}
-          build_type: release
+      - name: Upload release bundle to Emerge
+        run: ./gradlew :financial-connections-example:emergeUploadReleaseAab
+        env:
+          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
+

--- a/.github/workflows/identity_pull_request.yml
+++ b/.github/workflows/identity_pull_request.yml
@@ -88,11 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
-      - name: Generate Android release bundle
-        run: ./gradlew :identity-example:bundleRelease
-      - name: Upload artifact to Emerge
-        uses: EmergeTools/emerge-upload-action@3477b597fc62054136eb6f499e0ba78144f8a999
-        with:
-          artifact_path: identity-example/build/outputs/bundle/theme1Release/identity-example-theme1-release.aab
-          emerge_api_key: ${{ secrets.EMERGE_API_KEY }}
-          build_type: pull_request
+      - name: Upload release bundle to Emerge
+        run: ./gradlew :identity-example:emergeUploadReleaseAab
+        env:
+          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}

--- a/.github/workflows/identity_pull_request.yml
+++ b/.github/workflows/identity_pull_request.yml
@@ -92,3 +92,4 @@ jobs:
         run: ./gradlew :identity-example:emergeUploadTheme1ReleaseAab
         env:
           EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
+          EMERGE_TAG: pull_request

--- a/.github/workflows/identity_pull_request.yml
+++ b/.github/workflows/identity_pull_request.yml
@@ -91,5 +91,5 @@ jobs:
       - name: Upload release bundle to Emerge
         run: ./gradlew :identity-example:emergeUploadTheme1ReleaseAab
         env:
-          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
+          EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
           EMERGE_TAG: pull_request

--- a/.github/workflows/identity_pull_request.yml
+++ b/.github/workflows/identity_pull_request.yml
@@ -89,6 +89,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
       - name: Upload release bundle to Emerge
-        run: ./gradlew :identity-example:emergeUploadReleaseAab
+        run: ./gradlew :identity-example:emergeUploadTheme1ReleaseAab
         env:
           EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Upload Identity example release bundle to Emerge
         run: ./gradlew :identity-example:emergeUploadReleaseAab
         env:
-          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
+          EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
           EMERGE_TAG: push
   upload-financial-connections:
     runs-on: ubuntu-latest
@@ -26,7 +26,7 @@ jobs:
       - name: Upload Financial Connections example release bundle to Emerge
         run: ./gradlew :financial-connections-example:emergeUploadReleaseAab
         env:
-          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
+          EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
           EMERGE_TAG: push
   upload-payment-sheet:
     runs-on: ubuntu-latest
@@ -36,5 +36,5 @@ jobs:
       - name: Upload Payment Sheet example release bundle to Emerge
         run: ./gradlew :paymentsheet-example:emergeUploadReleaseAab
         env:
-          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
+          EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
           EMERGE_TAG: push

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,6 +17,7 @@ jobs:
         run: ./gradlew :identity-example:emergeUploadReleaseAab
         env:
           EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
+          EMERGE_TAG: push
   upload-financial-connections:
     runs-on: ubuntu-latest
     steps:
@@ -26,6 +27,7 @@ jobs:
         run: ./gradlew :financial-connections-example:emergeUploadReleaseAab
         env:
           EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
+          EMERGE_TAG: push
   upload-payment-sheet:
     runs-on: ubuntu-latest
     steps:
@@ -35,3 +37,4 @@ jobs:
         run: ./gradlew :paymentsheet-example:emergeUploadReleaseAab
         env:
           EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
+          EMERGE_TAG: push

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,37 +13,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
-      - name: Generate Android release bundle for Identity example app
-        run: ./gradlew :identity-example:bundleRelease
-      - name: Upload artifact to Emerge
-        uses: EmergeTools/emerge-upload-action@3477b597fc62054136eb6f499e0ba78144f8a999
-        with:
-          artifact_path: identity-example/build/outputs/bundle/theme1Release/identity-example-theme1-release.aab
-          emerge_api_key: ${{ secrets.EMERGE_API_KEY }}
-          build_type: push
+      - name: Upload Identity example release bundle to Emerge
+        run: ./gradlew :identity-example:emergeUploadReleaseAab
+        env:
+          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
   upload-financial-connections:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
-      - name: Generate Android release bundle for Financial Connections example app
-        run: ./gradlew :financial-connections-example:bundleRelease
-      - name: Upload artifact to Emerge
-        uses: EmergeTools/emerge-upload-action@3477b597fc62054136eb6f499e0ba78144f8a999
-        with:
-          artifact_path: financial-connections-example/build/outputs/bundle/release/financial-connections-example-release.aab
-          emerge_api_key: ${{ secrets.EMERGE_API_KEY }}
-          build_type: push
+      - name: Upload Financial Connections example release bundle to Emerge
+        run: ./gradlew :financial-connections-example:emergeUploadReleaseAab
+        env:
+          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
   upload-payment-sheet:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
-      - name: Generate Android release bundle for Payment Sheet example app
-        run: ./gradlew :paymentsheet-example:bundleRelease
-      - name: Upload artifact to Emerge
-        uses: EmergeTools/emerge-upload-action@3477b597fc62054136eb6f499e0ba78144f8a999
-        with:
-          artifact_path: paymentsheet-example/build/outputs/bundle/release/paymentsheet-example-release.aab
-          emerge_api_key: ${{ secrets.EMERGE_API_KEY }}
-          build_type: push
+      - name: Upload Financial Connections example release bundle to Emerge
+        run: ./gradlew :paymentsheet-example:emergeUploadReleaseAab
+        env:
+          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
-      - name: Upload Financial Connections example release bundle to Emerge
+      - name: Upload Payment Sheet example release bundle to Emerge
         run: ./gradlew :paymentsheet-example:emergeUploadReleaseAab
         env:
           EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ plugins {
     id 'com.google.devtools.ksp' version '1.9.24-1.0.20' apply false
     id 'dev.drewhamilton.poko' version '0.15.2' apply false
     id 'org.jetbrains.kotlin.jvm' version '1.9.24' apply false
+    id 'com.emergetools.android' version '4.0.0' apply false
 }
 
 apply plugin: "io.gitlab.arturbosch.detekt"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -30,7 +30,6 @@ ext.versions = [
         detekt                      : '1.23.6',
         diskLruCache                : '2.0.2',
         dokka                       : '1.9.10',
-        emergeSnapshots             : '1.1.4',
         espresso                    : '3.5.1',
         firebaseAppDistribution     : '4.0.1',
         fuel                        : '2.3.1',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -30,6 +30,7 @@ ext.versions = [
         detekt                      : '1.23.6',
         diskLruCache                : '2.0.2',
         dokka                       : '1.9.10',
+        emergeSnapshots             : '1.1.4',
         espresso                    : '3.5.1',
         firebaseAppDistribution     : '4.0.1',
         fuel                        : '2.3.1',

--- a/financial-connections-example/build.gradle
+++ b/financial-connections-example/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 def testEnvironment = System.getenv("test_environment") ?: "production"
 
 emerge {
-    apiToken.set(System.getenv("EMERGE_API_KEY"))
+    // Api token is implicitly set to the EMERGE_API_TOKEN env variable
 
     size {
         tag.set(System.getenv("EMERGE_TAG"))

--- a/financial-connections-example/build.gradle
+++ b/financial-connections-example/build.gradle
@@ -1,11 +1,15 @@
 apply from: configs.androidApplication
 
+apply plugin: 'com.emergetools.android'
 apply plugin: 'com.google.firebase.appdistribution'
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 
-
 def testEnvironment = System.getenv("test_environment") ?: "production"
+
+emerge {
+    apiToken.set(System.getenv("EMERGE_API_KEY"))
+}
 
 android {
     defaultConfig {

--- a/financial-connections-example/build.gradle
+++ b/financial-connections-example/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 def testEnvironment = System.getenv("test_environment") ?: "production"
 
 emerge {
-    apiToken.set(System.getenv("EMERGE_API_KEY"))
+    apiToken = System.getenv("EMERGE_API_KEY")
 }
 
 android {

--- a/financial-connections-example/build.gradle
+++ b/financial-connections-example/build.gradle
@@ -10,6 +10,10 @@ def testEnvironment = System.getenv("test_environment") ?: "production"
 emerge {
     apiToken.set(System.getenv("EMERGE_API_KEY"))
 
+    size {
+        tag.set(System.getenv("EMERGE_TAG"))
+    }
+
     vcs {
         gitHub {
             repoOwner.set("EmergeTools")

--- a/financial-connections-example/build.gradle
+++ b/financial-connections-example/build.gradle
@@ -16,7 +16,7 @@ emerge {
 
     vcs {
         gitHub {
-            repoOwner.set("EmergeTools")
+            repoOwner.set("stripe")
             repoName.set("stripe-android")
         }
     }

--- a/financial-connections-example/build.gradle
+++ b/financial-connections-example/build.gradle
@@ -9,6 +9,13 @@ def testEnvironment = System.getenv("test_environment") ?: "production"
 
 emerge {
     apiToken = System.getenv("EMERGE_API_KEY")
+
+    vcs {
+        gitHub {
+            repoOwner = "EmergeTools"
+            repoName = "stripe-android"
+        }
+    }
 }
 
 android {

--- a/financial-connections-example/build.gradle
+++ b/financial-connections-example/build.gradle
@@ -8,12 +8,12 @@ apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 def testEnvironment = System.getenv("test_environment") ?: "production"
 
 emerge {
-    apiToken = System.getenv("EMERGE_API_KEY")
+    apiToken.set(System.getenv("EMERGE_API_KEY"))
 
     vcs {
         gitHub {
-            repoOwner = "EmergeTools"
-            repoName = "stripe-android"
+            repoOwner.set("EmergeTools")
+            repoName.set("stripe-android")
         }
     }
 }

--- a/identity-example/build.gradle
+++ b/identity-example/build.gradle
@@ -14,8 +14,8 @@ emerge {
 
     vcs {
         gitHub {
-            repoOwner.set("EmergeTools")
-            repoName.set"stripe-android")
+            repoOwner.set("stripe")
+            repoName.set("stripe-android")
         }
     }
 }

--- a/identity-example/build.gradle
+++ b/identity-example/build.gradle
@@ -6,12 +6,16 @@ apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 assemble.dependsOn('lint')
 
 emerge {
-    apiToken.set(System.getenv("EMERGE_API_KEY"))
+    apiToken = System.getenv("EMERGE_API_KEY")
+
+    size {
+        tag.set(System.getenv("EMERGE_TAG"))
+    }
 
     vcs {
         gitHub {
-            repoOwner.set("EmergeTools")
-            repoName.set("stripe-android")
+            repoOwner = "EmergeTools"
+            repoName = "stripe-android"
         }
     }
 }

--- a/identity-example/build.gradle
+++ b/identity-example/build.gradle
@@ -1,8 +1,13 @@
 apply from: configs.androidApplication
 
+apply plugin: 'com.emergetools.android'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 
 assemble.dependsOn('lint')
+
+emerge {
+    apiToken.set(System.getenv("EMERGE_API_KEY"))
+}
 
 android {
     defaultConfig {

--- a/identity-example/build.gradle
+++ b/identity-example/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 assemble.dependsOn('lint')
 
 emerge {
-    apiToken = System.getenv("EMERGE_API_KEY")
+    apiToken.set(System.getenv("EMERGE_API_KEY"))
 
     size {
         tag.set(System.getenv("EMERGE_TAG"))
@@ -14,8 +14,8 @@ emerge {
 
     vcs {
         gitHub {
-            repoOwner = "EmergeTools"
-            repoName = "stripe-android"
+            repoOwner.set("EmergeTools")
+            repoName.set"stripe-android")
         }
     }
 }

--- a/identity-example/build.gradle
+++ b/identity-example/build.gradle
@@ -6,12 +6,12 @@ apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 assemble.dependsOn('lint')
 
 emerge {
-    apiToken = System.getenv("EMERGE_API_KEY")
+    apiToken.set(System.getenv("EMERGE_API_KEY"))
 
     vcs {
         gitHub {
-            repoOwner = "EmergeTools"
-            repoName = "stripe-android"
+            repoOwner.set("EmergeTools")
+            repoName.set("stripe-android")
         }
     }
 }

--- a/identity-example/build.gradle
+++ b/identity-example/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 assemble.dependsOn('lint')
 
 emerge {
-    apiToken.set(System.getenv("EMERGE_API_KEY"))
+    apiToken = System.getenv("EMERGE_API_KEY")
 }
 
 android {

--- a/identity-example/build.gradle
+++ b/identity-example/build.gradle
@@ -7,6 +7,13 @@ assemble.dependsOn('lint')
 
 emerge {
     apiToken = System.getenv("EMERGE_API_KEY")
+
+    vcs {
+        gitHub {
+            repoOwner = "EmergeTools"
+            repoName = "stripe-android"
+        }
+    }
 }
 
 android {

--- a/identity-example/build.gradle
+++ b/identity-example/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 assemble.dependsOn('lint')
 
 emerge {
-    apiToken.set(System.getenv("EMERGE_API_KEY"))
+    // Api token is implicitly set to the EMERGE_API_TOKEN env variable
 
     size {
         tag.set(System.getenv("EMERGE_TAG"))

--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -15,6 +15,13 @@ def getGooglePlacesApiKey() {
 
 emerge {
     apiToken = System.getenv("EMERGE_API_KEY")
+
+    vcs {
+        gitHub {
+            repoOwner = "EmergeTools"
+            repoName = "stripe-android"
+        }
+    }
 }
 
 dependencies {

--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -16,6 +16,10 @@ def getGooglePlacesApiKey() {
 emerge {
     apiToken.set(System.getenv("EMERGE_API_KEY"))
 
+    size {
+        tag.set(System.getenv("EMERGE_TAG"))
+    }
+
     vcs {
         gitHub {
             repoOwner.set("EmergeTools")

--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -14,12 +14,12 @@ def getGooglePlacesApiKey() {
 }
 
 emerge {
-    apiToken = System.getenv("EMERGE_API_KEY")
+    apiToken.set(System.getenv("EMERGE_API_KEY"))
 
     vcs {
         gitHub {
-            repoOwner = "EmergeTools"
-            repoName = "stripe-android"
+            repoOwner.set("EmergeTools")
+            repoName.set("stripe-android")
         }
     }
 }

--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -14,7 +14,7 @@ def getGooglePlacesApiKey() {
 }
 
 emerge {
-    apiToken.set(System.getenv("EMERGE_API_KEY"))
+    // Api token is implicitly set to the EMERGE_API_TOKEN env variable
 
     size {
         tag.set(System.getenv("EMERGE_TAG"))

--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -22,7 +22,7 @@ emerge {
 
     vcs {
         gitHub {
-            repoOwner.set("EmergeTools")
+            repoOwner.set("stripe")
             repoName.set("stripe-android")
         }
     }

--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -1,5 +1,6 @@
 apply from: configs.androidApplication
 
+apply plugin: 'com.emergetools.android'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'shot'
 
@@ -10,6 +11,10 @@ def getBackendUrl() {
 
 def getGooglePlacesApiKey() {
     return findProperty('STRIPE_PAYMENTSHEET_EXAMPLE_GOOGLE_PLACES_API_KEY') ?: ""
+}
+
+emerge {
+    apiToken = System.getenv("EMERGE_API_KEY")
 }
 
 dependencies {


### PR DESCRIPTION
# Summary
Updates Emerge Tools integration to use best practices. Emerge has deprecated the GitHub action for Android in favor of the Gradle plugin.

I was also curious about incorporating Emerge snapshot testing. See [emerge-android #2](https://github.com/EmergeTools/stripe-android/pull/2) for an example of that - happy to add that as well if Stripe is interested in trying Emerge's snapshot testing.

# Motivation
We're doing this as Stripe recently reached out about an issue with their existing integration. We noticed a few old practices being used, so we figured we'd help update everything to the latest and greatest 😄 .

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
N/A

# Changelog
N/A