### PR TITLE
Move intent confirmation logic into `IntentConfirmationDefinition`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationDefinition.kt
@@ -1,0 +1,144 @@
+package com.stripe.android.paymentsheet
+
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
+import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.ConfirmSetupIntentParams
+import com.stripe.android.model.ConfirmStripeIntentParams
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
+import com.stripe.android.payments.paymentlauncher.PaymentLauncher
+import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
+
+internal class IntentConfirmationDefinition(
+    private val intentConfirmationInterceptor: IntentConfirmationInterceptor,
+    private val paymentLauncherFactory: (ActivityResultLauncher<PaymentLauncherContract.Args>) -> PaymentLauncher,
+) : PaymentConfirmationDefinition<
+    PaymentConfirmationOption.PaymentMethod,
+    PaymentLauncher,
+    IntentConfirmationDefinition.Args,
+    InternalPaymentResult
+    > {
+    override suspend fun action(
+        confirmationOption: PaymentConfirmationOption.PaymentMethod,
+        intent: StripeIntent
+    ): PaymentConfirmationDefinition.ConfirmationAction<Args> {
+        val nextStep = intentConfirmationInterceptor.intercept(confirmationOption = confirmationOption)
+
+        val deferredIntentConfirmationType = nextStep.deferredIntentConfirmationType
+
+        return when (nextStep) {
+            is IntentConfirmationInterceptor.NextStep.HandleNextAction -> {
+                PaymentConfirmationDefinition.ConfirmationAction.Launch(
+                    launcherArguments = Args.NextAction(nextStep.clientSecret),
+                    deferredIntentConfirmationType = deferredIntentConfirmationType,
+                )
+            }
+            is IntentConfirmationInterceptor.NextStep.Confirm -> {
+                PaymentConfirmationDefinition.ConfirmationAction.Launch(
+                    launcherArguments = Args.Confirm(nextStep.confirmParams),
+                    deferredIntentConfirmationType = deferredIntentConfirmationType,
+                )
+            }
+            is IntentConfirmationInterceptor.NextStep.Fail -> {
+                PaymentConfirmationDefinition.ConfirmationAction.Fail(
+                    cause = nextStep.cause,
+                    message = nextStep.message,
+                    errorType = PaymentConfirmationErrorType.Internal,
+                )
+            }
+            is IntentConfirmationInterceptor.NextStep.Complete -> {
+                PaymentConfirmationDefinition.ConfirmationAction.Complete(
+                    intent = intent,
+                    confirmationOption = confirmationOption,
+                    deferredIntentConfirmationType = deferredIntentConfirmationType,
+                )
+            }
+        }
+    }
+
+    override fun createLauncher(
+        activityResultCaller: ActivityResultCaller,
+        onResult: (InternalPaymentResult) -> Unit
+    ): PaymentLauncher {
+        return paymentLauncherFactory(
+            activityResultCaller.registerForActivityResult(
+                PaymentLauncherContract(),
+                onResult
+            )
+        )
+    }
+
+    override fun launch(
+        launcher: PaymentLauncher,
+        arguments: Args,
+        confirmationOption: PaymentConfirmationOption.PaymentMethod,
+        intent: StripeIntent,
+    ) {
+        when (arguments) {
+            is Args.Confirm -> launchConfirm(launcher, arguments.confirmNextParams)
+            is Args.NextAction -> launchNextAction(launcher, arguments.clientSecret, intent)
+        }
+    }
+
+    override fun toPaymentConfirmationResult(
+        confirmationOption: PaymentConfirmationOption.PaymentMethod,
+        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        intent: StripeIntent,
+        result: InternalPaymentResult
+    ): PaymentConfirmationResult {
+        return when (result) {
+            is InternalPaymentResult.Completed -> PaymentConfirmationResult.Succeeded(
+                intent = result.intent,
+                confirmationOption = confirmationOption,
+                deferredIntentConfirmationType = deferredIntentConfirmationType,
+            )
+            is InternalPaymentResult.Failed -> PaymentConfirmationResult.Failed(
+                cause = result.throwable,
+                message = result.throwable.stripeErrorMessage(),
+                type = PaymentConfirmationErrorType.Payment,
+            )
+            is InternalPaymentResult.Canceled -> PaymentConfirmationResult.Canceled(
+                action = PaymentCancellationAction.InformCancellation
+            )
+        }
+    }
+
+    private fun launchNextAction(
+        launcher: PaymentLauncher,
+        clientSecret: String,
+        intent: StripeIntent,
+    ) {
+        when (intent) {
+            is PaymentIntent -> {
+                launcher.handleNextActionForPaymentIntent(clientSecret)
+            }
+            is SetupIntent -> {
+                launcher.handleNextActionForSetupIntent(clientSecret)
+            }
+        }
+    }
+
+    private fun launchConfirm(
+        launcher: PaymentLauncher,
+        confirmStripeIntentParams: ConfirmStripeIntentParams
+    ) {
+        when (confirmStripeIntentParams) {
+            is ConfirmPaymentIntentParams -> {
+                launcher.confirm(confirmStripeIntentParams)
+            }
+            is ConfirmSetupIntentParams -> {
+                launcher.confirm(confirmStripeIntentParams)
+            }
+        }
+    }
+
+    sealed interface Args {
+        data class NextAction(val clientSecret: String) : Args
+
+        data class Confirm(val confirmNextParams: ConfirmStripeIntentParams) : Args
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationDefinition.kt
@@ -1,0 +1,56 @@
+package com.stripe.android.paymentsheet
+
+import android.os.Parcelable
+import androidx.activity.result.ActivityResultCaller
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.model.StripeIntent
+
+internal interface PaymentConfirmationDefinition<
+    TConfirmationOption : PaymentConfirmationOption,
+    TLauncher,
+    TLauncherArgs,
+    TLauncherResult : Parcelable
+    > {
+    suspend fun action(
+        confirmationOption: TConfirmationOption,
+        intent: StripeIntent,
+    ): ConfirmationAction<TLauncherArgs>
+
+    fun launch(
+        launcher: TLauncher,
+        arguments: TLauncherArgs,
+        confirmationOption: TConfirmationOption,
+        intent: StripeIntent,
+    )
+
+    fun createLauncher(
+        activityResultCaller: ActivityResultCaller,
+        onResult: (TLauncherResult) -> Unit,
+    ): TLauncher
+
+    fun toPaymentConfirmationResult(
+        confirmationOption: TConfirmationOption,
+        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        intent: StripeIntent,
+        result: TLauncherResult,
+    ): PaymentConfirmationResult
+
+    sealed interface ConfirmationAction<TLauncherArgs> {
+        data class Complete<TLauncherArgs>(
+            val intent: StripeIntent,
+            val confirmationOption: PaymentConfirmationOption,
+            val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        ) : ConfirmationAction<TLauncherArgs>
+
+        data class Fail<TLauncherArgs>(
+            val cause: Throwable,
+            val message: ResolvableString,
+            val errorType: PaymentConfirmationErrorType,
+        ) : ConfirmationAction<TLauncherArgs>
+
+        data class Launch<TLauncherArgs>(
+            val launcherArguments: TLauncherArgs,
+            val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        ) : ConfirmationAction<TLauncherArgs>
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationResult.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationResult.kt
@@ -20,6 +20,7 @@ internal sealed interface PaymentConfirmationResult {
      */
     data class Succeeded(
         val intent: StripeIntent,
+        val confirmationOption: PaymentConfirmationOption,
         val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
     ) : PaymentConfirmationResult
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationDefinitionTest.kt
@@ -1,0 +1,407 @@
+package com.stripe.android.paymentsheet
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.ConfirmSetupIntentParams
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParamsFixtures
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.PaymentMethodOptionsParams
+import com.stripe.android.model.SetupIntentFixtures
+import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
+import com.stripe.android.payments.paymentlauncher.PaymentLauncher
+import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
+import com.stripe.android.testing.FakePaymentLauncher
+import com.stripe.android.utils.FakeIntentConfirmationInterceptor
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+class IntentConfirmationDefinitionTest {
+    @Test
+    fun `'createLauncher' should call factory when creating launcher`() {
+        val launcher = FakePaymentLauncher()
+
+        val definition = createIntentConfirmationDefinition(
+            paymentLauncher = launcher,
+        )
+
+        val createdLauncher = definition.createLauncher(
+            activityResultCaller = mock {
+                on {
+                    registerForActivityResult<PaymentLauncherContract.Args, InternalPaymentResult>(any(), any())
+                } doReturn mock()
+            },
+            onResult = {}
+        )
+
+        assertThat(createdLauncher).isEqualTo(launcher)
+    }
+
+    @Test
+    fun `On 'action' with new payment method, should call 'IntentConfirmationInterceptor' with expected params`() =
+        runTest {
+            val intentConfirmationInterceptor = FakeIntentConfirmationInterceptor().apply {
+                enqueueCompleteStep()
+            }
+
+            val definition = createIntentConfirmationDefinition(
+                intentConfirmationInterceptor = intentConfirmationInterceptor,
+            )
+
+            definition.action(
+                confirmationOption = PaymentConfirmationOption.PaymentMethod.New(
+                    initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                        clientSecret = "pi_123"
+                    ),
+                    createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                    optionsParams = null,
+                    shippingDetails = AddressDetails(name = "John Doe"),
+                    shouldSave = true,
+                ),
+                intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            )
+
+            assertThat(intentConfirmationInterceptor.calls.awaitItem()).isEqualTo(
+                FakeIntentConfirmationInterceptor.InterceptCall.WithNewPaymentMethod(
+                    initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                        clientSecret = "pi_123"
+                    ),
+                    paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                    paymentMethodOptionsParams = null,
+                    shippingValues = AddressDetails(name = "John Doe").toConfirmPaymentIntentShipping(),
+                    customerRequestedSave = true,
+                )
+            )
+        }
+
+    @Test
+    fun `On 'action' with saved payment method, should call 'IntentConfirmationInterceptor' with expected params`() =
+        runTest {
+            val intentConfirmationInterceptor = FakeIntentConfirmationInterceptor().apply {
+                enqueueCompleteStep()
+            }
+
+            val definition = createIntentConfirmationDefinition(
+                intentConfirmationInterceptor = intentConfirmationInterceptor,
+            )
+
+            definition.action(
+                confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+                intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            )
+
+            assertThat(intentConfirmationInterceptor.calls.awaitItem()).isEqualTo(
+                FakeIntentConfirmationInterceptor.InterceptCall.WithExistingPaymentMethod(
+                    initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                        clientSecret = "pi_123"
+                    ),
+                    paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                    paymentMethodOptionsParams = PaymentMethodOptionsParams.Card(
+                        cvc = "505",
+                    ),
+                    shippingValues = AddressDetails(name = "John Doe").toConfirmPaymentIntentShipping(),
+                )
+            )
+        }
+
+    @Test
+    fun `On 'IntentConfirmationInterceptor' complete, should return 'Complete' confirmation action`() = runTest {
+        val intentConfirmationInterceptor = FakeIntentConfirmationInterceptor().apply {
+            enqueueCompleteStep()
+        }
+
+        val definition = createIntentConfirmationDefinition(
+            intentConfirmationInterceptor = intentConfirmationInterceptor,
+        )
+
+        val action = definition.action(
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+        )
+
+        assertThat(action).isEqualTo(
+            PaymentConfirmationDefinition.ConfirmationAction.Complete<IntentConfirmationDefinition.Args>(
+                intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+                confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+                deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+            )
+        )
+    }
+
+    @Test
+    fun `On 'IntentConfirmationInterceptor' failure, should return 'Fail' confirmation action`() = runTest {
+        val message = "Failed!"
+        val cause = IllegalStateException("Failed with exception!")
+
+        val intentConfirmationInterceptor = FakeIntentConfirmationInterceptor().apply {
+            enqueueFailureStep(
+                cause = cause,
+                message = message
+            )
+        }
+
+        val definition = createIntentConfirmationDefinition(
+            intentConfirmationInterceptor = intentConfirmationInterceptor,
+        )
+
+        val action = definition.action(
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+        )
+
+        assertThat(action).isEqualTo(
+            PaymentConfirmationDefinition.ConfirmationAction.Fail<IntentConfirmationDefinition.Args>(
+                cause = cause,
+                message = message.resolvableString,
+                errorType = PaymentConfirmationErrorType.Internal,
+            )
+        )
+    }
+
+    @Test
+    fun `On 'IntentConfirmationInterceptor' next step, should return 'Launch' confirmation action`() = runTest {
+        val intentConfirmationInterceptor = FakeIntentConfirmationInterceptor().apply {
+            enqueueNextActionStep(clientSecret = "pi_123")
+        }
+
+        val definition = createIntentConfirmationDefinition(
+            intentConfirmationInterceptor = intentConfirmationInterceptor,
+        )
+
+        val action = definition.action(
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+        )
+
+        assertThat(action).isEqualTo(
+            PaymentConfirmationDefinition.ConfirmationAction.Launch<IntentConfirmationDefinition.Args>(
+                launcherArguments = IntentConfirmationDefinition.Args.NextAction(
+                    clientSecret = "pi_123"
+                ),
+                deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+            )
+        )
+    }
+
+    @Test
+    fun `On 'IntentConfirmationInterceptor' confirm, should return 'Launch' confirmation action`() = runTest {
+        val confirmParams = ConfirmSetupIntentParams.create(
+            clientSecret = "pi_1234",
+            paymentMethodType = PaymentMethod.Type.Card
+        )
+
+        val intentConfirmationInterceptor = FakeIntentConfirmationInterceptor().apply {
+            enqueueConfirmStep(confirmParams = confirmParams)
+        }
+
+        val definition = createIntentConfirmationDefinition(
+            intentConfirmationInterceptor = intentConfirmationInterceptor,
+        )
+
+        val action = definition.action(
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+            intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+        )
+
+        assertThat(action).isEqualTo(
+            PaymentConfirmationDefinition.ConfirmationAction.Launch<IntentConfirmationDefinition.Args>(
+                launcherArguments = IntentConfirmationDefinition.Args.Confirm(
+                    confirmNextParams = confirmParams,
+                ),
+                deferredIntentConfirmationType = null,
+            )
+        )
+    }
+
+    @Test
+    fun `On launch with confirm action and 'SetupIntent' params, should launch with expected params`() = runTest {
+        val confirmParams = ConfirmSetupIntentParams.create(
+            clientSecret = "pi_1234",
+            paymentMethodType = PaymentMethod.Type.Card
+        )
+
+        val launcher = FakePaymentLauncher()
+
+        val definition = createIntentConfirmationDefinition(
+            paymentLauncher = launcher,
+        )
+
+        definition.launch(
+            launcher = launcher,
+            arguments = IntentConfirmationDefinition.Args.Confirm(confirmParams),
+            intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+        )
+
+        assertThat(launcher.calls.awaitItem()).isEqualTo(
+            FakePaymentLauncher.Call.Confirm.SetupIntent(confirmParams)
+        )
+    }
+
+    @Test
+    fun `On launch with next step action and 'SetupIntent', should launch with expected params`() = runTest {
+        val launcher = FakePaymentLauncher()
+
+        val definition = createIntentConfirmationDefinition(
+            paymentLauncher = launcher,
+        )
+
+        definition.launch(
+            launcher = launcher,
+            arguments = IntentConfirmationDefinition.Args.NextAction(clientSecret = "si_123"),
+            intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+        )
+
+        assertThat(launcher.calls.awaitItem()).isEqualTo(
+            FakePaymentLauncher.Call.HandleNextAction.SetupIntent(clientSecret = "si_123")
+        )
+    }
+
+    @Test
+    fun `On launch with confirm action and 'PaymentIntent' params, should launch with expected params`() = runTest {
+        val confirmParams = ConfirmPaymentIntentParams.create(
+            clientSecret = "pi_1234",
+            paymentMethodType = PaymentMethod.Type.Card
+        )
+
+        val launcher = FakePaymentLauncher()
+
+        val definition = createIntentConfirmationDefinition(
+            paymentLauncher = launcher,
+        )
+
+        definition.launch(
+            launcher = launcher,
+            arguments = IntentConfirmationDefinition.Args.Confirm(confirmParams),
+            intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+        )
+
+        assertThat(launcher.calls.awaitItem()).isEqualTo(
+            FakePaymentLauncher.Call.Confirm.PaymentIntent(confirmParams)
+        )
+    }
+
+    @Test
+    fun `On launch with next step action and 'PaymentIntent', should launch with expected params`() = runTest {
+        val launcher = FakePaymentLauncher()
+
+        val definition = createIntentConfirmationDefinition(
+            paymentLauncher = launcher,
+        )
+
+        definition.launch(
+            launcher = launcher,
+            arguments = IntentConfirmationDefinition.Args.NextAction(clientSecret = "pi_123"),
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+        )
+
+        assertThat(launcher.calls.awaitItem()).isEqualTo(
+            FakePaymentLauncher.Call.HandleNextAction.PaymentIntent(clientSecret = "pi_123")
+        )
+    }
+
+    @Test
+    fun `On 'Completed' payment result, should return successful confirmation result`() {
+        val launcher = FakePaymentLauncher()
+
+        val definition = createIntentConfirmationDefinition(
+            paymentLauncher = launcher,
+        )
+
+        val result = definition.toPaymentConfirmationResult(
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+            result = InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED),
+        )
+
+        assertThat(result).isEqualTo(
+            PaymentConfirmationResult.Succeeded(
+                intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+                deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+            ),
+        )
+    }
+
+    @Test
+    fun `On 'Failed' payment result, should return failed confirmation result`() {
+        val launcher = FakePaymentLauncher()
+
+        val definition = createIntentConfirmationDefinition(
+            paymentLauncher = launcher,
+        )
+
+        val exception = IllegalStateException("Failed!")
+
+        val result = definition.toPaymentConfirmationResult(
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            deferredIntentConfirmationType = null,
+            result = InternalPaymentResult.Failed(exception),
+        )
+
+        assertThat(result).isEqualTo(
+            PaymentConfirmationResult.Failed(
+                cause = exception,
+                message = R.string.stripe_something_went_wrong.resolvableString,
+                type = PaymentConfirmationErrorType.Payment,
+            ),
+        )
+    }
+
+    @Test
+    fun `On 'Canceled' payment result, should return canceled confirmation result`() {
+        val launcher = FakePaymentLauncher()
+
+        val definition = createIntentConfirmationDefinition(
+            paymentLauncher = launcher,
+        )
+
+        val result = definition.toPaymentConfirmationResult(
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            deferredIntentConfirmationType = null,
+            result = InternalPaymentResult.Canceled,
+        )
+
+        assertThat(result).isEqualTo(
+            PaymentConfirmationResult.Canceled(
+                action = PaymentCancellationAction.InformCancellation,
+            ),
+        )
+    }
+
+    private fun createIntentConfirmationDefinition(
+        intentConfirmationInterceptor: IntentConfirmationInterceptor = FakeIntentConfirmationInterceptor(),
+        paymentLauncher: PaymentLauncher = FakePaymentLauncher()
+    ): IntentConfirmationDefinition {
+        return IntentConfirmationDefinition(
+            intentConfirmationInterceptor = intentConfirmationInterceptor,
+            paymentLauncherFactory = { paymentLauncher }
+        )
+    }
+
+    private companion object {
+        private val SAVED_PAYMENT_CONFIRMATION_OPTION = PaymentConfirmationOption.PaymentMethod.Saved(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123"
+            ),
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            optionsParams = PaymentMethodOptionsParams.Card(
+                cvc = "505",
+            ),
+            shippingDetails = AddressDetails(name = "John Doe"),
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationDefinitionTest.kt
@@ -55,30 +55,29 @@ class IntentConfirmationDefinitionTest {
                 intentConfirmationInterceptor = intentConfirmationInterceptor,
             )
 
+            val initializationMode = PaymentSheet.InitializationMode.PaymentIntent(clientSecret = "pi_123")
+            val createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD
+            val shippingDetails = AddressDetails(name = "John Doe")
+
             definition.action(
                 confirmationOption = PaymentConfirmationOption.PaymentMethod.New(
-                    initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
-                        clientSecret = "pi_123"
-                    ),
-                    createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                    initializationMode = initializationMode,
+                    createParams = createParams,
                     optionsParams = null,
-                    shippingDetails = AddressDetails(name = "John Doe"),
+                    shippingDetails = shippingDetails,
                     shouldSave = true,
                 ),
                 intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
             )
 
-            assertThat(intentConfirmationInterceptor.calls.awaitItem()).isEqualTo(
-                FakeIntentConfirmationInterceptor.InterceptCall.WithNewPaymentMethod(
-                    initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
-                        clientSecret = "pi_123"
-                    ),
-                    paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                    paymentMethodOptionsParams = null,
-                    shippingValues = AddressDetails(name = "John Doe").toConfirmPaymentIntentShipping(),
-                    customerRequestedSave = true,
-                )
-            )
+            val result = intentConfirmationInterceptor
+                .await<FakeIntentConfirmationInterceptor.InterceptCall.WithNewPaymentMethod>()
+
+            assertThat(result.initializationMode).isEqualTo(initializationMode)
+            assertThat(result.paymentMethodCreateParams).isEqualTo(createParams)
+            assertThat(result.paymentMethodOptionsParams).isNull()
+            assertThat(result.shippingValues).isEqualTo(shippingDetails.toConfirmPaymentIntentShipping())
+            assertThat(result.customerRequestedSave).isTrue()
         }
 
     @Test
@@ -92,22 +91,21 @@ class IntentConfirmationDefinitionTest {
                 intentConfirmationInterceptor = intentConfirmationInterceptor,
             )
 
+            val confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION
+
             definition.action(
-                confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+                confirmationOption = confirmationOption,
                 intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
             )
 
-            assertThat(intentConfirmationInterceptor.calls.awaitItem()).isEqualTo(
-                FakeIntentConfirmationInterceptor.InterceptCall.WithExistingPaymentMethod(
-                    initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
-                        clientSecret = "pi_123"
-                    ),
-                    paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                    paymentMethodOptionsParams = PaymentMethodOptionsParams.Card(
-                        cvc = "505",
-                    ),
-                    shippingValues = AddressDetails(name = "John Doe").toConfirmPaymentIntentShipping(),
-                )
+            val result = intentConfirmationInterceptor
+                .await<FakeIntentConfirmationInterceptor.InterceptCall.WithExistingPaymentMethod>()
+
+            assertThat(result.initializationMode).isEqualTo(confirmationOption.initializationMode)
+            assertThat(result.paymentMethod).isEqualTo(confirmationOption.paymentMethod)
+            assertThat(result.paymentMethodOptionsParams).isEqualTo(confirmationOption.optionsParams)
+            assertThat(result.shippingValues).isEqualTo(
+                confirmationOption.shippingDetails?.toConfirmPaymentIntentShipping()
             )
         }
 
@@ -126,13 +124,11 @@ class IntentConfirmationDefinitionTest {
             intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
         )
 
-        assertThat(action).isEqualTo(
-            PaymentConfirmationDefinition.ConfirmationAction.Complete<IntentConfirmationDefinition.Args>(
-                intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-                confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
-                deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
-            )
-        )
+        val completeAction = action.asComplete()
+
+        assertThat(completeAction.intent).isEqualTo(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        assertThat(completeAction.confirmationOption).isEqualTo(SAVED_PAYMENT_CONFIRMATION_OPTION)
+        assertThat(completeAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Server)
     }
 
     @Test
@@ -156,13 +152,11 @@ class IntentConfirmationDefinitionTest {
             intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
         )
 
-        assertThat(action).isEqualTo(
-            PaymentConfirmationDefinition.ConfirmationAction.Fail<IntentConfirmationDefinition.Args>(
-                cause = cause,
-                message = message.resolvableString,
-                errorType = PaymentConfirmationErrorType.Internal,
-            )
-        )
+        val failAction = action.asFail()
+
+        assertThat(failAction.cause).isEqualTo(cause)
+        assertThat(failAction.message).isEqualTo(message.resolvableString)
+        assertThat(failAction.errorType).isEqualTo(PaymentConfirmationErrorType.Internal)
     }
 
     @Test
@@ -180,14 +174,14 @@ class IntentConfirmationDefinitionTest {
             intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
         )
 
-        assertThat(action).isEqualTo(
-            PaymentConfirmationDefinition.ConfirmationAction.Launch<IntentConfirmationDefinition.Args>(
-                launcherArguments = IntentConfirmationDefinition.Args.NextAction(
-                    clientSecret = "pi_123"
-                ),
-                deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+        val launchAction = action.asLaunch()
+
+        assertThat(launchAction.launcherArguments).isEqualTo(
+            IntentConfirmationDefinition.Args.NextAction(
+                clientSecret = "pi_123"
             )
         )
+        assertThat(launchAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Server)
     }
 
     @Test
@@ -210,14 +204,14 @@ class IntentConfirmationDefinitionTest {
             intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
         )
 
-        assertThat(action).isEqualTo(
-            PaymentConfirmationDefinition.ConfirmationAction.Launch<IntentConfirmationDefinition.Args>(
-                launcherArguments = IntentConfirmationDefinition.Args.Confirm(
-                    confirmNextParams = confirmParams,
-                ),
-                deferredIntentConfirmationType = null,
+        val launchAction = action.asLaunch()
+
+        assertThat(launchAction.launcherArguments).isEqualTo(
+            IntentConfirmationDefinition.Args.Confirm(
+                confirmNextParams = confirmParams,
             )
         )
+        assertThat(launchAction.deferredIntentConfirmationType).isNull()
     }
 
     @Test
@@ -325,13 +319,11 @@ class IntentConfirmationDefinitionTest {
             result = InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED),
         )
 
-        assertThat(result).isEqualTo(
-            PaymentConfirmationResult.Succeeded(
-                intent = PaymentIntentFixtures.PI_SUCCEEDED,
-                confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
-                deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
-            ),
-        )
+        val succeededResult = result.asSucceeded()
+
+        assertThat(succeededResult.intent).isEqualTo(PaymentIntentFixtures.PI_SUCCEEDED)
+        assertThat(succeededResult.confirmationOption).isEqualTo(SAVED_PAYMENT_CONFIRMATION_OPTION)
+        assertThat(succeededResult.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
     }
 
     @Test
@@ -351,13 +343,11 @@ class IntentConfirmationDefinitionTest {
             result = InternalPaymentResult.Failed(exception),
         )
 
-        assertThat(result).isEqualTo(
-            PaymentConfirmationResult.Failed(
-                cause = exception,
-                message = R.string.stripe_something_went_wrong.resolvableString,
-                type = PaymentConfirmationErrorType.Payment,
-            ),
-        )
+        val failedResult = result.asFailed()
+
+        assertThat(failedResult.cause).isEqualTo(exception)
+        assertThat(failedResult.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
+        assertThat(failedResult.type).isEqualTo(PaymentConfirmationErrorType.Payment)
     }
 
     @Test
@@ -375,11 +365,9 @@ class IntentConfirmationDefinitionTest {
             result = InternalPaymentResult.Canceled,
         )
 
-        assertThat(result).isEqualTo(
-            PaymentConfirmationResult.Canceled(
-                action = PaymentCancellationAction.InformCancellation,
-            ),
-        )
+        val canceledResult = result.asCanceled()
+
+        assertThat(canceledResult.action).isEqualTo(PaymentCancellationAction.InformCancellation)
     }
 
     private fun createIntentConfirmationDefinition(
@@ -390,6 +378,38 @@ class IntentConfirmationDefinitionTest {
             intentConfirmationInterceptor = intentConfirmationInterceptor,
             paymentLauncherFactory = { paymentLauncher }
         )
+    }
+
+    private suspend inline fun <reified T : FakeIntentConfirmationInterceptor.InterceptCall>
+        FakeIntentConfirmationInterceptor.await(): T {
+        return calls.awaitItem() as T
+    }
+
+    private inline fun <reified T> PaymentConfirmationDefinition.ConfirmationAction<T>.asComplete():
+        PaymentConfirmationDefinition.ConfirmationAction.Complete<T> {
+        return this as PaymentConfirmationDefinition.ConfirmationAction.Complete<T>
+    }
+
+    private inline fun <reified T> PaymentConfirmationDefinition.ConfirmationAction<T>.asFail():
+        PaymentConfirmationDefinition.ConfirmationAction.Fail<T> {
+        return this as PaymentConfirmationDefinition.ConfirmationAction.Fail<T>
+    }
+
+    private inline fun <reified T> PaymentConfirmationDefinition.ConfirmationAction<T>.asLaunch():
+        PaymentConfirmationDefinition.ConfirmationAction.Launch<T> {
+        return this as PaymentConfirmationDefinition.ConfirmationAction.Launch<T>
+    }
+
+    private fun PaymentConfirmationResult.asSucceeded(): PaymentConfirmationResult.Succeeded {
+        return this as PaymentConfirmationResult.Succeeded
+    }
+
+    private fun PaymentConfirmationResult.asFailed(): PaymentConfirmationResult.Failed {
+        return this as PaymentConfirmationResult.Failed
+    }
+
+    private fun PaymentConfirmationResult.asCanceled(): PaymentConfirmationResult.Canceled {
+        return this as PaymentConfirmationResult.Canceled
     }
 
     private companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
@@ -293,6 +293,7 @@ class IntentConfirmationHandlerTest {
         assertThat(result).isEqualTo(
             PaymentConfirmationResult.Succeeded(
                 intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+                confirmationOption = DEFAULT_ARGUMENTS.confirmationOption,
                 deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
             )
         )
@@ -507,6 +508,7 @@ class IntentConfirmationHandlerTest {
 
             val expectedResult = PaymentConfirmationResult.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                confirmationOption = DEFAULT_ARGUMENTS.confirmationOption,
                 deferredIntentConfirmationType = null,
             )
 
@@ -783,6 +785,13 @@ class IntentConfirmationHandlerTest {
 
             val expectedResult = PaymentConfirmationResult.Succeeded(
                 intent = DEFAULT_ARGUMENTS.intent,
+                confirmationOption = PaymentConfirmationOption.PaymentMethod.New(
+                    initializationMode = confirmationOption.initializationMode,
+                    shippingDetails = confirmationOption.shippingDetails,
+                    createParams = confirmationOption.createParams,
+                    optionsParams = confirmationOption.optionsParams,
+                    shouldSave = false,
+                ),
                 deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
             )
 
@@ -797,6 +806,7 @@ class IntentConfirmationHandlerTest {
     fun `On init with 'SavedStateHandle', should receive result through 'awaitIntentResult'`() = runTest {
         val savedStateHandle = SavedStateHandle().apply {
             set("AwaitingPaymentResult", true)
+            set("IntentConfirmationArguments", DEFAULT_ARGUMENTS)
         }
 
         val intentConfirmationHandler = createIntentConfirmationHandler(
@@ -816,6 +826,7 @@ class IntentConfirmationHandlerTest {
         assertThat(result).isEqualTo(
             PaymentConfirmationResult.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                confirmationOption = DEFAULT_ARGUMENTS.confirmationOption,
                 deferredIntentConfirmationType = null,
             )
         )
@@ -852,6 +863,7 @@ class IntentConfirmationHandlerTest {
         assertThat(result).isEqualTo(
             PaymentConfirmationResult.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                confirmationOption = DEFAULT_ARGUMENTS.confirmationOption,
                 deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
             )
         )
@@ -896,6 +908,7 @@ class IntentConfirmationHandlerTest {
 
             val expectedResult = PaymentConfirmationResult.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                confirmationOption = DEFAULT_ARGUMENTS.confirmationOption,
                 deferredIntentConfirmationType = null,
             )
 
@@ -1023,6 +1036,7 @@ class IntentConfirmationHandlerTest {
 
             val expectedResult = PaymentConfirmationResult.Succeeded(
                 intent = DEFAULT_ARGUMENTS.intent,
+                confirmationOption = EXTERNAL_PAYMENT_METHOD,
                 deferredIntentConfirmationType = null,
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -2692,7 +2692,20 @@ internal class PaymentSheetViewModelTest {
 
     private suspend fun testProcessDeathRestorationAfterPaymentSuccess(loadStateBeforePaymentResult: Boolean) {
         val stripeIntent = PaymentIntentFactory.create(status = StripeIntent.Status.Succeeded)
-        val savedStateHandle = SavedStateHandle(initialState = mapOf("AwaitingPaymentResult" to true))
+        val savedStateHandle = SavedStateHandle(
+            initialState = mapOf(
+                "AwaitingPaymentResult" to true,
+                "IntentConfirmationArguments" to IntentConfirmationHandler.Args(
+                    intent = PAYMENT_INTENT,
+                    confirmationOption = PaymentConfirmationOption.PaymentMethod.Saved(
+                        initializationMode = ARGS_CUSTOMER_WITH_GOOGLEPAY.initializationMode,
+                        paymentMethod = CARD_PAYMENT_METHOD,
+                        optionsParams = null,
+                        shippingDetails = null,
+                    )
+                )
+            )
+        )
         val paymentSheetLoader = RelayingPaymentSheetLoader()
 
         val viewModel = createViewModel(


### PR DESCRIPTION
# Summary
Moves the intent confirmation flow into a definition file where intent confirmation can be managed on its own outside of `IntentConfirmationHandler`

# Motivation
This makes it easier to understand what is going on when performing intent confirmation. Using `PaymentConfirmationDefinition` types, we can also move other confirmation flows into their own definitions as well (Bacs, Google Pay, EPMs, CVC) so that they can be managed in isolation.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified