### PR TITLE
Make `ConfirmationOption` non-nullable & report errors on invalid selection

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -178,6 +178,18 @@ interface ErrorReporter {
         EXTERNAL_PAYMENT_METHOD_SERIALIZATION_FAILURE(
             partialEventName = "elements.external_payment_methods_serializer.error"
         ),
+        PAYMENT_SHEET_NO_PAYMENT_SELECTION_ON_CHECKOUT(
+            partialEventName = "paymentsheet.no_payment_selection"
+        ),
+        PAYMENT_SHEET_INVALID_PAYMENT_SELECTION_ON_CHECKOUT(
+            partialEventName = "paymentsheet.invalid_payment_selection"
+        ),
+        FLOW_CONTROLLER_NO_PAYMENT_SELECTION_ON_CHECKOUT(
+            partialEventName = "flow_controller.no_payment_selection"
+        ),
+        FLOW_CONTROLLER_INVALID_PAYMENT_SELECTION_ON_CHECKOUT(
+            partialEventName = "flow_controller.invalid_payment_selection"
+        ),
         INTENT_CONFIRMATION_HANDLER_INVALID_PAYMENT_CONFIRMATION_OPTION(
             partialEventName = "intent_confirmation_handler.invalid_payment_confirmation_option"
         ),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationHandler.kt
@@ -249,8 +249,7 @@ internal class IntentConfirmationHandler(
             onIntentResult(
                 PaymentConfirmationResult.Failed(
                     cause = IllegalStateException(
-                        "Attempted to confirm invalid " +
-                            "${confirmationOption?.let { it::class.java } ?: "null"} confirmation type"
+                        "Attempted to confirm invalid ${confirmationOption::class.qualifiedName} confirmation type"
                     ),
                     message = R.string.stripe_something_went_wrong.resolvableString,
                     type = PaymentConfirmationErrorType.Internal,
@@ -692,7 +691,7 @@ internal class IntentConfirmationHandler(
     @Parcelize
     internal data class Args(
         val intent: StripeIntent,
-        val confirmationOption: PaymentConfirmationOption?
+        val confirmationOption: PaymentConfirmationOption
     ) : Parcelable
 
     /**

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -1122,6 +1122,7 @@ internal class PaymentSheetActivityTest {
                     logger = FakeUserFacingLogger(),
                 ),
                 editInteractorFactory = FakeEditPaymentMethodInteractor.Factory,
+                errorReporter = FakeErrorReporter(),
             )
         }
     }


### PR DESCRIPTION
# Summary
Make `PaymentConfirmationOption` non-nullable in `IntentConfirmationHandler` & report unexpected errors on no or invalid selection in `PaymentSheet` and `FlowController`.

# Motivation
The handler shouldn't be responsible for dealing with a null selection type. This is a presentation issue that should be handled by the invalid products themselves.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
