### PR TITLE
Create `PaymentConfirmationExtras` and use in `IntentConfirmationHandler`

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -326,6 +326,14 @@ public final class com/stripe/android/paymentsheet/IntentConfirmationHandler$Arg
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentsheet/PaymentConfirmationExtras$Intent$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationExtras$Intent;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentConfirmationExtras$Intent;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$BacsPaymentMethod$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$BacsPaymentMethod;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationExtras.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationExtras.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.paymentsheet
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+internal sealed interface PaymentConfirmationExtras : Parcelable {
+    @Parcelize
+    data class Intent(
+        val deferredIntentConfirmationType: DeferredIntentConfirmationType
+    ) : PaymentConfirmationExtras
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationResult.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationResult.kt
@@ -20,7 +20,7 @@ internal sealed interface PaymentConfirmationResult {
      */
     data class Succeeded(
         val intent: StripeIntent,
-        val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        val extras: PaymentConfirmationExtras?,
     ) : PaymentConfirmationResult
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -306,7 +306,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             // PaymentSheet and return a `Completed` result to the caller.
             handlePaymentCompleted(
                 intent = pendingResult.intent,
-                deferredIntentConfirmationType = pendingResult.deferredIntentConfirmationType,
+                deferredIntentConfirmationType = retrieveDeferredIntentConfirmationType(pendingResult.extras),
                 finishImmediately = true
             )
         } else if (state.validationError != null) {
@@ -541,12 +541,21 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         when (result) {
             is PaymentConfirmationResult.Succeeded -> handlePaymentCompleted(
                 intent = result.intent,
-                deferredIntentConfirmationType = result.deferredIntentConfirmationType,
+                deferredIntentConfirmationType = retrieveDeferredIntentConfirmationType(result.extras),
                 finishImmediately = false,
             )
             is PaymentConfirmationResult.Failed -> processIntentFailure(result)
             is PaymentConfirmationResult.Canceled,
             null -> resetViewState()
+        }
+    }
+
+    private fun retrieveDeferredIntentConfirmationType(
+        extras: PaymentConfirmationExtras?
+    ): DeferredIntentConfirmationType? {
+        return when (extras) {
+            is PaymentConfirmationExtras.Intent -> extras.deferredIntentConfirmationType
+            else -> null
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -36,6 +36,7 @@ import com.stripe.android.paymentsheet.IntentConfirmationHandler
 import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.PaymentCancellationAction
 import com.stripe.android.paymentsheet.PaymentConfirmationErrorType
+import com.stripe.android.paymentsheet.PaymentConfirmationExtras
 import com.stripe.android.paymentsheet.PaymentConfirmationResult
 import com.stripe.android.paymentsheet.PaymentOptionCallback
 import com.stripe.android.paymentsheet.PaymentOptionContract
@@ -551,14 +552,16 @@ internal class DefaultFlowController @Inject internal constructor(
                     prefsRepositoryFactory(viewModel.state?.config?.customer).savePaymentSelection(it)
                 }
 
+                val deferredIntentConfirmationType = retrieveDeferredIntentConfirmationType(result.extras)
+
                 eventReporter.onPaymentSuccess(
                     paymentSelection = viewModel.paymentSelection,
-                    deferredIntentConfirmationType = result.deferredIntentConfirmationType,
+                    deferredIntentConfirmationType = deferredIntentConfirmationType,
                 )
 
                 onPaymentResult(
                     paymentResult = PaymentResult.Completed,
-                    deferredIntentConfirmationType = result.deferredIntentConfirmationType,
+                    deferredIntentConfirmationType = deferredIntentConfirmationType,
                     shouldLog = false,
                 )
             }
@@ -684,6 +687,15 @@ internal class DefaultFlowController @Inject internal constructor(
             PaymentConfirmationErrorType.Internal,
             PaymentConfirmationErrorType.MerchantIntegration,
             PaymentConfirmationErrorType.Fatal -> null
+        }
+    }
+
+    private fun retrieveDeferredIntentConfirmationType(
+        extras: PaymentConfirmationExtras?
+    ): DeferredIntentConfirmationType? {
+        return when (extras) {
+            is PaymentConfirmationExtras.Intent -> extras.deferredIntentConfirmationType
+            else -> null
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
@@ -293,7 +293,9 @@ class IntentConfirmationHandlerTest {
         assertThat(result).isEqualTo(
             PaymentConfirmationResult.Succeeded(
                 intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-                deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+                extras = PaymentConfirmationExtras.Intent(
+                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+                ),
             )
         )
     }
@@ -507,7 +509,7 @@ class IntentConfirmationHandlerTest {
 
             val expectedResult = PaymentConfirmationResult.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
-                deferredIntentConfirmationType = null,
+                extras = null,
             )
 
             assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
@@ -783,7 +785,9 @@ class IntentConfirmationHandlerTest {
 
             val expectedResult = PaymentConfirmationResult.Succeeded(
                 intent = DEFAULT_ARGUMENTS.intent,
-                deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+                extras = PaymentConfirmationExtras.Intent(
+                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+                ),
             )
 
             assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
@@ -816,7 +820,7 @@ class IntentConfirmationHandlerTest {
         assertThat(result).isEqualTo(
             PaymentConfirmationResult.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
-                deferredIntentConfirmationType = null,
+                extras = null,
             )
         )
     }
@@ -852,7 +856,9 @@ class IntentConfirmationHandlerTest {
         assertThat(result).isEqualTo(
             PaymentConfirmationResult.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
-                deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+                extras = PaymentConfirmationExtras.Intent(
+                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+                ),
             )
         )
     }
@@ -896,7 +902,7 @@ class IntentConfirmationHandlerTest {
 
             val expectedResult = PaymentConfirmationResult.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
-                deferredIntentConfirmationType = null,
+                extras = null,
             )
 
             assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
@@ -1023,7 +1029,7 @@ class IntentConfirmationHandlerTest {
 
             val expectedResult = PaymentConfirmationResult.Succeeded(
                 intent = DEFAULT_ARGUMENTS.intent,
-                deferredIntentConfirmationType = null,
+                extras = null,
             )
 
             assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)


### PR DESCRIPTION
# Summary
Create `PaymentConfirmationExtras` and use in `IntentConfirmationHandler` instead of directly tracking `deferredIntentConfirmationType`.

# Motivation
`deferredIntentConfirmationType` is used by `PaymentSheet` and `FlowController` for reporting events but isn't relevant for other intent types. Wrapping `deferredIntentConfirmationType` in another type should make it more clear that payment confirmation flows can return extra values without directly exposing and tracking `deferredIntentConfirmationType` within `IntentConfirmationHandler`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
