### PR TITLE
Shard `PaymentSheet` instrumentation tests using Gradle-managed devices

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -269,18 +269,10 @@ workflows:
       - conclude_all
     steps:
       - script@1:
-          title: Assemble Instrumentation tests
-          timeout: 600
-          inputs:
-            - content: ./gradlew :paymentsheet:assembleAndroidTest
-      - wait-for-android-emulator@1:
-          inputs:
-            - boot_timeout: 600
-      - script@1:
           title: Execute instrumentation tests
           timeout: 1200
           inputs:
-            - content: ./gradlew :paymentsheet:connectedAndroidTest
+            - content: ./gradlew :paymentsheet:pixel2api33DebugAndroidTest
   run-example-instrumentation-tests:
     before_run:
       - start_emulator

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,7 @@ android.enableR8.fullMode=true
 android.nonFinalResIds=true
 android.nonTransitiveRClass=true
 android.useAndroidX=true
+android.experimental.androidTest.numManagedDeviceShards=3
 
 # Update StripeSdkVersion.VERSION_NAME when publishing a new release
 VERSION_NAME=20.48.3

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -130,6 +130,16 @@ android {
         kotlinOptions {
             freeCompilerArgs += ["-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"]
         }
+
+        managedDevices {
+            localDevices {
+                register("pixel2api33") {
+                    device = "Pixel 2"
+                    apiLevel = 33
+                    systemImageSource = "aosp"
+                }
+            }
+        }
     }
 
     composeOptions {


### PR DESCRIPTION
# Summary
Shard `PaymentSheet` instrumentation tests using Gradle-managed devices.

# Motivation
Improves CI times for `PaymentSheet` instrumentation tests.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
