### PR TITLE
Add fallback if launching Link account picker with no bank accounts

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
@@ -44,6 +44,7 @@ import com.stripe.android.financialconnections.model.PartnerAccount
 import com.stripe.android.financialconnections.navigation.Destination
 import com.stripe.android.financialconnections.navigation.Destination.InstitutionPicker
 import com.stripe.android.financialconnections.navigation.NavigationManager
+import com.stripe.android.financialconnections.navigation.PopUpToBehavior
 import com.stripe.android.financialconnections.navigation.destination
 import com.stripe.android.financialconnections.navigation.topappbar.TopAppBarStateUpdate
 import com.stripe.android.financialconnections.presentation.Async
@@ -138,8 +139,7 @@ internal class LinkAccountPickerViewModel @AssistedInject constructor(
             LinkAccountPickerState::payload,
             onSuccess = { payload ->
                 if (payload.accounts.isEmpty()) {
-                    val nextPane = payload.nextPaneOnNewAccount ?: Pane.INSTITUTION_PICKER
-                    navigationManager.tryNavigateTo(nextPane.destination(referrer = PANE))
+                    skipToNextPane(payload)
                 }
             },
             onFail = { error ->
@@ -162,6 +162,19 @@ internal class LinkAccountPickerViewModel @AssistedInject constructor(
                     pane = PANE
                 )
             },
+        )
+    }
+
+    private fun skipToNextPane(payload: LinkAccountPickerState.Payload) {
+        val nextPane = payload.nextPaneOnNewAccount ?: Pane.INSTITUTION_PICKER
+
+        navigationManager.tryNavigateTo(
+            route = nextPane.destination(referrer = PANE),
+            popUpTo = PopUpToBehavior.Route(
+                // Prevent back navigation, since we're only showing an empty list
+                route = Pane.CONSENT.destination.fullRoute,
+                inclusive = true,
+            ),
         )
     }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
@@ -136,6 +136,12 @@ internal class LinkAccountPickerViewModel @AssistedInject constructor(
     private fun observeAsyncs() {
         onAsync(
             LinkAccountPickerState::payload,
+            onSuccess = { payload ->
+                if (payload.accounts.isEmpty()) {
+                    val nextPane = payload.nextPaneOnNewAccount ?: Pane.INSTITUTION_PICKER
+                    navigationManager.tryNavigateTo(nextPane.destination(referrer = PANE))
+                }
+            },
             onFail = { error ->
                 eventTracker.logError(
                     extraMessage = "Error fetching payload",

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModelTest.kt
@@ -26,6 +26,7 @@ import com.stripe.android.financialconnections.model.NetworkedAccountsList
 import com.stripe.android.financialconnections.model.ReturningNetworkingUserAccountPicker
 import com.stripe.android.financialconnections.model.TextUpdate
 import com.stripe.android.financialconnections.navigation.Destination.LinkStepUpVerification
+import com.stripe.android.financialconnections.navigation.PopUpToBehavior
 import com.stripe.android.financialconnections.navigation.destination
 import com.stripe.android.financialconnections.repository.CachedConsumerSession
 import com.stripe.android.financialconnections.utils.TestNavigationManager
@@ -132,6 +133,10 @@ class LinkAccountPickerViewModelTest {
         navigationManager.assertNavigatedTo(
             destination = Pane.LINK_LOGIN.destination,
             pane = Pane.LINK_ACCOUNT_PICKER,
+            popUpTo = PopUpToBehavior.Route(
+                route = Pane.CONSENT.destination.fullRoute,
+                inclusive = true,
+            ),
         )
     }
 
@@ -153,6 +158,10 @@ class LinkAccountPickerViewModelTest {
         navigationManager.assertNavigatedTo(
             destination = Pane.INSTITUTION_PICKER.destination,
             pane = Pane.LINK_ACCOUNT_PICKER,
+            popUpTo = PopUpToBehavior.Route(
+                route = Pane.CONSENT.destination.fullRoute,
+                inclusive = true,
+            ),
         )
     }
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModelTest.kt
@@ -115,6 +115,48 @@ class LinkAccountPickerViewModelTest {
     }
 
     @Test
+    fun `init - Redirects to nextPaneOnNewAccount if no bank accounts`() = runTest {
+        whenever(getSync()).thenReturn(syncResponse())
+        whenever(getCachedConsumerSession()).thenReturn(consumerSession())
+
+        whenever(fetchNetworkedAccounts(any())).thenReturn(
+            NetworkedAccountsList(
+                data = emptyList(),
+                display = display(emptyList()),
+                nextPaneOnAddAccount = Pane.LINK_LOGIN, // Random pane to test it
+            )
+        )
+
+        buildViewModel(LinkAccountPickerState())
+
+        navigationManager.assertNavigatedTo(
+            destination = Pane.LINK_LOGIN.destination,
+            pane = Pane.LINK_ACCOUNT_PICKER,
+        )
+    }
+
+    @Test
+    fun `init - Redirects to institution picker if no bank accounts and no nextPaneOnAddAccount`() = runTest {
+        whenever(getSync()).thenReturn(syncResponse())
+        whenever(getCachedConsumerSession()).thenReturn(consumerSession())
+
+        whenever(fetchNetworkedAccounts(any())).thenReturn(
+            NetworkedAccountsList(
+                data = emptyList(),
+                display = display(emptyList()),
+                nextPaneOnAddAccount = null,
+            )
+        )
+
+        buildViewModel(LinkAccountPickerState())
+
+        navigationManager.assertNavigatedTo(
+            destination = Pane.INSTITUTION_PICKER.destination,
+            pane = Pane.LINK_ACCOUNT_PICKER,
+        )
+    }
+
+    @Test
     fun `onNewBankAccountClick - navigates to AddNewAccount#NextPane`() = runTest {
         val response = twoAccounts().copy(
             nextPaneOnAddAccount = Pane.INSTITUTION_PICKER


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds fallback logic to the Link account picker if it’s launched with no networked bank accounts. We forward to `nextPaneOnAddBankAccount` if available, and to the institution picker if not. We also clear the back stack, so the user can’t navigate back to an empty screen.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[BANKCON-11813](https://jira.corp.stripe.com/browse/BANKCON-11813)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
