### PR TITLE
Update vertical mode card form titles to match design

### DIFF
--- a/payments-ui-core/res/values/strings.xml
+++ b/payments-ui-core/res/values/strings.xml
@@ -65,6 +65,8 @@
   <string name="stripe_pay_button_amount">Pay %s</string>
   <!-- Title for a bank account payment method -->
   <string name="stripe_payment_method_bank">Bank</string>
+  <!-- Title shown above a view allowing the customer to save their first card. -->
+  <string name="stripe_paymentsheet_add_card">Add card</string>
   <!-- Title shown above a view allowing the customer to save a card. -->
   <string name="stripe_paymentsheet_add_new_card">Add new card</string>
   <!-- Card details entry form header title -->

--- a/payments-ui-core/res/values/strings.xml
+++ b/payments-ui-core/res/values/strings.xml
@@ -65,7 +65,7 @@
   <string name="stripe_pay_button_amount">Pay %s</string>
   <!-- Title for a bank account payment method -->
   <string name="stripe_payment_method_bank">Bank</string>
-  <!-- Title shown above a view allowing the customer to save their first card. -->
+  <!-- Label of a button displayed below a card entry form that saves the card details -->
   <string name="stripe_paymentsheet_add_card">Add card</string>
   <!-- Title shown above a view allowing the customer to save a card. -->
   <string name="stripe_paymentsheet_add_new_card">Add new card</string>

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -154,9 +154,12 @@ internal data class PaymentMethodMetadata(
 
     fun formHeaderInformationForCode(
         code: String,
+        customerHasSavedPaymentMethods: Boolean,
     ): FormHeaderInformation? {
         return if (isExternalPaymentMethod(code)) {
-            getUiDefinitionFactoryForExternalPaymentMethod(code)?.createFormHeaderInformation()
+            getUiDefinitionFactoryForExternalPaymentMethod(code)?.createFormHeaderInformation(
+                customerHasSavedPaymentMethods = customerHasSavedPaymentMethods
+            )
         } else {
             val definition = supportedPaymentMethodDefinitions().firstOrNull { it.type.code == code } ?: return null
 
@@ -164,6 +167,7 @@ internal data class PaymentMethodMetadata(
                 metadata = this,
                 definition = definition,
                 sharedDataSpecs = sharedDataSpecs,
+                customerHasSavedPaymentMethods = customerHasSavedPaymentMethods,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
@@ -85,7 +85,7 @@ internal sealed interface UiDefinitionFactory {
     interface Simple : UiDefinitionFactory {
         fun createSupportedPaymentMethod(): SupportedPaymentMethod
 
-        fun createFormHeaderInformation(): FormHeaderInformation {
+        fun createFormHeaderInformation(customerHasSavedPaymentMethods: Boolean): FormHeaderInformation {
             return createSupportedPaymentMethod().asFormHeaderInformation()
         }
 
@@ -127,9 +127,10 @@ internal sealed interface UiDefinitionFactory {
         definition: PaymentMethodDefinition,
         metadata: PaymentMethodMetadata,
         sharedDataSpecs: List<SharedDataSpec>,
+        customerHasSavedPaymentMethods: Boolean,
     ): FormHeaderInformation? = when (this) {
         is Simple -> {
-            createFormHeaderInformation()
+            createFormHeaderInformation(customerHasSavedPaymentMethods = customerHasSavedPaymentMethods)
         }
 
         is RequiresSharedDataSpec -> {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -47,9 +47,14 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
         iconRequiresTinting = true,
     )
 
-    override fun createFormHeaderInformation(): FormHeaderInformation {
+    override fun createFormHeaderInformation(customerHasSavedPaymentMethods: Boolean): FormHeaderInformation {
+        val displayName = if (customerHasSavedPaymentMethods) {
+            R.string.stripe_paymentsheet_add_new_card
+        } else {
+            R.string.stripe_paymentsheet_add_card
+        }
         return createSupportedPaymentMethod().asFormHeaderInformation().copy(
-            displayName = R.string.stripe_paymentsheet_add_new_card.resolvableString,
+            displayName = displayName.resolvableString,
             shouldShowIcon = false,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UsBankAccountDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UsBankAccountDefinition.kt
@@ -39,7 +39,7 @@ private object UsBankAccountUiDefinitionFactory : UiDefinitionFactory.Simple {
         darkThemeIconUrl = null,
     )
 
-    override fun createFormHeaderInformation(): FormHeaderInformation {
+    override fun createFormHeaderInformation(customerHasSavedPaymentMethods: Boolean): FormHeaderInformation {
         return createSupportedPaymentMethod().asFormHeaderInformation().copy(
             displayName = R.string.stripe_paymentsheet_add_us_bank_account.resolvableString,
             shouldShowIcon = false,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -124,6 +124,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                         selectedPaymentMethodCode = selectedPaymentMethodCode,
                         viewModel = viewModel,
                         paymentMethodMetadata = paymentMethodMetadata,
+                        customerStateHolder = customerStateHolder,
                     )
                     PaymentSheetScreen.VerticalModeForm(interactor = interactor)
                 },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
@@ -7,6 +7,7 @@ import com.stripe.android.lpmfoundations.FormHeaderInformation
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
+import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.FormHelper
 import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.forms.FormFieldValues
@@ -111,6 +112,7 @@ internal class DefaultVerticalModeFormInteractor(
             selectedPaymentMethodCode: String,
             viewModel: BaseSheetViewModel,
             paymentMethodMetadata: PaymentMethodMetadata,
+            customerStateHolder: CustomerStateHolder,
         ): VerticalModeFormInteractor {
             val coroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
             val formHelper = FormHelper.create(viewModel = viewModel, paymentMethodMetadata = paymentMethodMetadata)
@@ -134,7 +136,7 @@ internal class DefaultVerticalModeFormInteractor(
                 ),
                 headerInformation = paymentMethodMetadata.formHeaderInformationForCode(
                     selectedPaymentMethodCode,
-                    customerHasSavedPaymentMethods = viewModel.customerStateHolder.paymentMethods.value.isNotEmpty(),
+                    customerHasSavedPaymentMethods = customerStateHolder.paymentMethods.value.isNotEmpty(),
                 ),
                 isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
                 canGoBackDelegate = { viewModel.navigationHandler.canGoBack },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
@@ -132,7 +132,10 @@ internal class DefaultVerticalModeFormInteractor(
                     hostedSurface = CollectBankAccountLauncher.HOSTED_SURFACE_PAYMENT_ELEMENT,
                     selectedPaymentMethodCode = selectedPaymentMethodCode
                 ),
-                headerInformation = paymentMethodMetadata.formHeaderInformationForCode(selectedPaymentMethodCode),
+                headerInformation = paymentMethodMetadata.formHeaderInformationForCode(
+                    selectedPaymentMethodCode,
+                    customerHasSavedPaymentMethods = viewModel.customerStateHolder.paymentMethods.value.isNotEmpty(),
+                ),
                 isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
                 canGoBackDelegate = { viewModel.navigationHandler.canGoBack },
                 processing = viewModel.processing,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
@@ -21,6 +21,7 @@ internal object VerticalModeInitialScreenFactory {
                     selectedPaymentMethodCode = supportedPaymentMethodTypes.first(),
                     viewModel = viewModel,
                     paymentMethodMetadata = paymentMethodMetadata,
+                    customerStateHolder = customerStateHolder,
                 ),
                 showsWalletHeader = true,
             )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -515,7 +515,10 @@ internal class PaymentMethodMetadataTest {
     @Test
     fun `formHeaderInformationForCode is correct for UiDefinitionFactorySimple`() = runTest {
         val metadata = PaymentMethodMetadataFactory.create()
-        val headerInformation = metadata.formHeaderInformationForCode(code = "card")!!
+        val headerInformation = metadata.formHeaderInformationForCode(
+            code = "card",
+            customerHasSavedPaymentMethods = true
+        )!!
         assertThat(headerInformation.displayName).isEqualTo(R.string.stripe_paymentsheet_add_new_card.resolvableString)
         assertThat(headerInformation.shouldShowIcon).isFalse()
     }
@@ -527,7 +530,10 @@ internal class PaymentMethodMetadataTest {
                 paymentMethodTypes = listOf("card", "bancontact")
             ),
         )
-        val headerInformation = metadata.formHeaderInformationForCode(code = "bancontact")!!
+        val headerInformation = metadata.formHeaderInformationForCode(
+            code = "bancontact",
+            customerHasSavedPaymentMethods = true,
+        )!!
         assertThat(headerInformation.displayName)
             .isEqualTo(R.string.stripe_paymentsheet_payment_method_bancontact.resolvableString)
         assertThat(headerInformation.shouldShowIcon).isTrue()
@@ -540,6 +546,7 @@ internal class PaymentMethodMetadataTest {
         val metadata = PaymentMethodMetadataFactory.create(externalPaymentMethodSpecs = listOf(paypalSpec))
         val headerInformation = metadata.formHeaderInformationForCode(
             code = paypalSpec.type,
+            customerHasSavedPaymentMethods = true,
         )!!
         assertThat(headerInformation.displayName).isEqualTo(paypalSpec.label.resolvableString)
         assertThat(headerInformation.shouldShowIcon).isTrue()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
@@ -43,7 +43,7 @@ internal class VerticalModeFormUITest {
     private val formPage = FormPage(composeRule)
 
     @Test
-    fun testWithCardProperties() = runScenario(createCardState()) {
+    fun testWithCardProperties() = runScenario(createCardState(customerHasSavedPaymentMethods = true)) {
         viewActionRecorder.consume(VerticalModeFormInteractor.ViewAction.FormFieldValuesChanged(null))
         assertThat(viewActionRecorder.viewActions).isEmpty()
         formPage.cardNumber.performTextInput("4242")
@@ -67,10 +67,19 @@ internal class VerticalModeFormUITest {
     }
 
     @Test
-    fun testCardShowsHeader() = runScenario(createCardState()) {
+    fun testCardShowsHeader() = runScenario(createCardState(customerHasSavedPaymentMethods = true)) {
         formPage.headerIcon.assertDoesNotExist()
         formPage.title.assertExists()
         formPage.title.assert(hasText("Add new card"))
+    }
+
+    @Test
+    fun testCardShowsAddCardHeader_whenCustomerHasNoSavedPMs() = runScenario(
+        createCardState(customerHasSavedPaymentMethods = false)
+    ) {
+        formPage.headerIcon.assertDoesNotExist()
+        formPage.title.assertExists()
+        formPage.title.assert(hasText("Add card"))
     }
 
     @Test
@@ -121,10 +130,10 @@ internal class VerticalModeFormUITest {
         }
     }
 
-    private fun createCardState(): VerticalModeFormInteractor.State {
+    private fun createCardState(customerHasSavedPaymentMethods: Boolean): VerticalModeFormInteractor.State {
         val headerInformation =
             (CardDefinition.uiDefinitionFactory() as UiDefinitionFactory.Simple).createFormHeaderInformation(
-                customerHasSavedPaymentMethods = true,
+                customerHasSavedPaymentMethods = customerHasSavedPaymentMethods,
             )
         return VerticalModeFormInteractor.State(
             selectedPaymentMethodCode = PaymentMethod.Type.Card.code,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
@@ -123,7 +123,9 @@ internal class VerticalModeFormUITest {
 
     private fun createCardState(): VerticalModeFormInteractor.State {
         val headerInformation =
-            (CardDefinition.uiDefinitionFactory() as UiDefinitionFactory.Simple).createFormHeaderInformation()
+            (CardDefinition.uiDefinitionFactory() as UiDefinitionFactory.Simple).createFormHeaderInformation(
+                customerHasSavedPaymentMethods = true,
+            )
         return VerticalModeFormInteractor.State(
             selectedPaymentMethodCode = PaymentMethod.Type.Card.code,
             isProcessing = false,
@@ -152,7 +154,7 @@ internal class VerticalModeFormUITest {
                     "cashapp"
                 )
             )
-        ).formHeaderInformationForCode("cashapp")
+        ).formHeaderInformationForCode("cashapp", customerHasSavedPaymentMethods = true)
         return VerticalModeFormInteractor.State(
             selectedPaymentMethodCode = PaymentMethod.Type.CashAppPay.code,
             isProcessing = false,
@@ -182,7 +184,10 @@ internal class VerticalModeFormUITest {
                 )
             )
         )
-        val headerInformation = paymentMethodMetadata.formHeaderInformationForCode("klarna")
+        val headerInformation = paymentMethodMetadata.formHeaderInformationForCode(
+            "klarna",
+            customerHasSavedPaymentMethods = true,
+        )
         return VerticalModeFormInteractor.State(
             selectedPaymentMethodCode = PaymentMethod.Type.Klarna.code,
             isProcessing = false,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update vertical mode card form titles to match design

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
According to [vertical mode designs](https://www.figma.com/design/ysEUcRWOfdEH4C0jBA0EkH/MPE-LPM-Visibility?node-id=5623-69849&t=GKOWPKChwffqc6Gr-0), if the user has a saved card, then the add a card form should have the title "Add new card". Otherwise, it should have the title "Add card". Before this PR, we always showed "Add new card".

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [] Modified tests
- [X] Manually verified

# Screen recording

https://github.com/user-attachments/assets/c2bedf7c-5159-4bca-99cb-1eef6044a912



