### PR TITLE
Add case for link-account-picker pane in Consent link handling


### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentState.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentState.kt
@@ -31,4 +31,5 @@ internal enum class ConsentClickableText(val value: String) {
     LEGAL_DETAILS("stripe://legal-details-notice"),
     MANUAL_ENTRY("stripe://manual-entry"),
     LINK_LOGIN_WARMUP("stripe://link-login"),
+    LINK_ACCOUNT_PICKER("stripe://link-account-picker"),
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentViewModel.kt
@@ -21,6 +21,7 @@ import com.stripe.android.financialconnections.features.notice.NoticeSheetState.
 import com.stripe.android.financialconnections.features.notice.PresentSheet
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
+import com.stripe.android.financialconnections.navigation.Destination
 import com.stripe.android.financialconnections.navigation.Destination.Companion.KEY_NEXT_PANE_ON_DISABLE_NETWORKING
 import com.stripe.android.financialconnections.navigation.Destination.ManualEntry
 import com.stripe.android.financialconnections.navigation.Destination.NetworkingLinkLoginWarmup
@@ -131,6 +132,12 @@ internal class ConsentViewModel @AssistedInject constructor(
                         )
                     )
                 },
+                // Surfaces where user has signed in to Link and then launches the auth flow.
+                ConsentClickableText.LINK_ACCOUNT_PICKER.value to {
+                    navigationManager.tryNavigateTo(
+                        route = Destination.LinkAccountPicker(referrer = Pane.CONSENT)
+                    )
+                }
             )
         )
     }


### PR DESCRIPTION
# Summary
- Unneeded today as there's no mobile surface where users can log in to link then launch the AuthFlow, but adding it just in case that's a thing in the future.  

# Motivation
:notebook_with_decorative_cover: &nbsp;**[Android] Add case for link-account-picker pane in Consent link handling.**
:globe_with_meridians: &nbsp;[BANKCON-11811](https://jira.corp.stripe.com/browse/BANKCON-11811)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified