### PR TITLE
Make `CustomerState` observable in `CustomerStateHolder` & use in `PaymentOptionsItemMapper`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CustomerStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CustomerStateHolder.kt
@@ -12,18 +12,14 @@ internal class CustomerStateHolder(
     private val savedStateHandle: SavedStateHandle,
     private val selection: StateFlow<PaymentSelection?>,
 ) {
-    var customer: CustomerState?
-        get() = savedStateHandle[SAVED_CUSTOMER]
-        set(value) {
-            savedStateHandle[SAVED_CUSTOMER] = value
-        }
+    val customer: StateFlow<CustomerState?> = savedStateHandle
+        .getStateFlow<CustomerState?>(SAVED_CUSTOMER, null)
 
     /**
      * The list of saved payment methods for the current customer.
      * Value is null until it's loaded, and non-null (could be empty) after that.
      */
-    val paymentMethods: StateFlow<List<PaymentMethod>> = savedStateHandle
-        .getStateFlow<CustomerState?>(SAVED_CUSTOMER, null)
+    val paymentMethods: StateFlow<List<PaymentMethod>> = customer
         .mapAsStateFlow { state ->
             state?.paymentMethods ?: emptyList()
         }
@@ -32,6 +28,10 @@ internal class CustomerStateHolder(
         SAVED_PM_SELECTION,
         initialValue = (selection.value as? PaymentSelection.Saved)?.paymentMethod
     )
+
+    fun setCustomerState(customerState: CustomerState?) {
+        savedStateHandle[SAVED_CUSTOMER] = customerState
+    }
 
     fun updateMostRecentlySelectedSavedPaymentMethod(paymentMethod: PaymentMethod?) {
         savedStateHandle[SAVED_PM_SELECTION] = paymentMethod

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -154,7 +154,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
         if (paymentMethodMetadata.value == null) {
             setPaymentMethodMetadata(args.state.paymentMethodMetadata)
         }
-        customerStateHolder.customer = args.state.customer
+        customerStateHolder.setCustomerState(args.state.customer)
         savedStateHandle[SAVE_PROCESSING] = false
 
         updateSelection(args.state.paymentSelection)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -320,7 +320,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     private suspend fun initializeWithState(state: PaymentSheetState.Full) {
-        customerStateHolder.customer = state.customer
+        customerStateHolder.setCustomerState(state.customer)
 
         updateSelection(state.paymentSelection)
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapper.kt
@@ -5,11 +5,12 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.PaymentOptionsItem
 import com.stripe.android.paymentsheet.PaymentOptionsStateFactory
+import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 internal class PaymentOptionsItemsMapper(
-    private val paymentMethods: StateFlow<List<PaymentMethod>>,
+    private val customerState: StateFlow<CustomerState?>,
     private val isGooglePayReady: StateFlow<Boolean>,
     private val isLinkEnabled: StateFlow<Boolean?>,
     private val nameProvider: (PaymentMethodCode?) -> ResolvableString,
@@ -19,12 +20,12 @@ internal class PaymentOptionsItemsMapper(
 
     operator fun invoke(): StateFlow<List<PaymentOptionsItem>> {
         return combineAsStateFlow(
-            paymentMethods,
+            customerState,
             isLinkEnabled,
             isGooglePayReady,
-        ) { paymentMethods, isLinkEnabled, isGooglePayReady ->
+        ) { customerState, isLinkEnabled, isGooglePayReady ->
             createPaymentOptionsItems(
-                paymentMethods = paymentMethods,
+                paymentMethods = customerState?.paymentMethods ?: listOf(),
                 isLinkEnabled = isLinkEnabled,
                 // TODO(samer-stripe): Set this based on customer_session permissions
                 canRemovePaymentMethods = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CustomerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CustomerStateHolderTest.kt
@@ -14,7 +14,9 @@ import kotlin.test.Test
 internal class CustomerStateHolderTest {
     @Test
     fun `customer is initialized as null`() = runScenario {
-        assertThat(customerStateHolder.customer).isNull()
+        customerStateHolder.customer.test {
+            assertThat(awaitItem()).isNull()
+        }
     }
 
     @Test
@@ -34,7 +36,9 @@ internal class CustomerStateHolderTest {
         )
         savedStateHandle[CustomerStateHolder.SAVED_CUSTOMER] = customerState
         runScenario(savedStateHandle = savedStateHandle) {
-            assertThat(customerStateHolder.customer).isEqualTo(customerState)
+            customerStateHolder.customer.test {
+                assertThat(awaitItem()).isEqualTo(customerState)
+            }
         }
     }
 
@@ -43,10 +47,12 @@ internal class CustomerStateHolderTest {
         customerStateHolder.paymentMethods.test {
             assertThat(awaitItem()).isEmpty()
 
-            customerStateHolder.customer = CustomerState.createForLegacyEphemeralKey(
-                customerId = "cus_123",
-                accessType = PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey("ek_123"),
-                paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+            customerStateHolder.setCustomerState(
+                CustomerState.createForLegacyEphemeralKey(
+                    customerId = "cus_123",
+                    accessType = PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey("ek_123"),
+                    paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+                )
             )
 
             assertThat(awaitItem()).hasSize(1)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -30,10 +30,12 @@ class SavedPaymentMethodMutatorTest {
         savedPaymentMethodMutator.canEdit.test {
             assertThat(awaitItem()).isFalse()
 
-            customerStateHolder.customer = CustomerState.createForLegacyEphemeralKey(
-                customerId = "cus_123",
-                accessType = PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey("ek_123"),
-                paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+            customerStateHolder.setCustomerState(
+                CustomerState.createForLegacyEphemeralKey(
+                    customerId = "cus_123",
+                    accessType = PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey("ek_123"),
+                    paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+                )
             )
             assertThat(awaitItem()).isTrue()
         }
@@ -46,30 +48,28 @@ class SavedPaymentMethodMutatorTest {
         savedPaymentMethodMutator.canEdit.test {
             assertThat(awaitItem()).isFalse()
 
-            customerStateHolder.customer = CustomerState.createForLegacyEphemeralKey(
-                customerId = "cus_123",
-                accessType = PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey("ek_123"),
-                paymentMethods = listOf(
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                    PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD
+            customerStateHolder.setCustomerState(
+                CustomerState.createForLegacyEphemeralKey(
+                    customerId = "cus_123",
+                    accessType = PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey("ek_123"),
+                    paymentMethods = listOf(
+                        PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                        PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD
+                    )
                 )
             )
             assertThat(awaitItem()).isTrue()
 
-            customerStateHolder.customer = CustomerState.createForLegacyEphemeralKey(
-                customerId = "cus_123",
-                accessType = PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey("ek_123"),
-                paymentMethods = listOf(
-                    PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD,
+            customerStateHolder.setCustomerState(
+                CustomerState.createForLegacyEphemeralKey(
+                    customerId = "cus_123",
+                    accessType = PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey("ek_123"),
+                    paymentMethods = listOf(
+                        PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD,
+                    )
                 )
             )
             assertThat(awaitItem()).isFalse()
-
-            customerStateHolder.customer = CustomerState.createForLegacyEphemeralKey(
-                customerId = "cus_123",
-                accessType = PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey("ek_123"),
-                paymentMethods = listOf()
-            )
         }
     }
 
@@ -81,23 +81,27 @@ class SavedPaymentMethodMutatorTest {
         savedPaymentMethodMutator.canEdit.test {
             assertThat(awaitItem()).isFalse()
 
-            customerStateHolder.customer = CustomerState.createForLegacyEphemeralKey(
-                customerId = "cus_123",
-                accessType = PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey("ek_123"),
-                paymentMethods = listOf(
-                    PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD,
+            customerStateHolder.setCustomerState(
+                CustomerState.createForLegacyEphemeralKey(
+                    customerId = "cus_123",
+                    accessType = PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey("ek_123"),
+                    paymentMethods = listOf(
+                        PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD,
+                    )
                 )
             )
             assertThat(awaitItem()).isTrue()
 
-            customerStateHolder.customer = null
+            customerStateHolder.setCustomerState(null)
             assertThat(awaitItem()).isFalse()
 
-            customerStateHolder.customer = CustomerState.createForLegacyEphemeralKey(
-                customerId = "cus_123",
-                accessType = PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey("ek_123"),
-                paymentMethods = listOf(
-                    PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD
+            customerStateHolder.setCustomerState(
+                CustomerState.createForLegacyEphemeralKey(
+                    customerId = "cus_123",
+                    accessType = PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey("ek_123"),
+                    paymentMethods = listOf(
+                        PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD
+                    )
                 )
             )
             assertThat(awaitItem()).isTrue()
@@ -116,11 +120,13 @@ class SavedPaymentMethodMutatorTest {
         )
 
         runScenario(customerRepository = customerRepository) {
-            customerStateHolder.customer = CustomerState.createForLegacyEphemeralKey(
-                customerId = "cus_123",
-                accessType = PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey("ek_123"),
-                paymentMethods = listOf(
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD
+            customerStateHolder.setCustomerState(
+                CustomerState.createForLegacyEphemeralKey(
+                    customerId = "cus_123",
+                    accessType = PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey("ek_123"),
+                    paymentMethods = listOf(
+                        PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                    )
                 )
             )
 
@@ -154,7 +160,7 @@ class SavedPaymentMethodMutatorTest {
     @Test
     fun `Sets editing to false when removing the last payment method while editing`() = runScenario {
         val customerPaymentMethods = PaymentMethodFixtures.createCards(1)
-        customerStateHolder.customer = EMPTY_CUSTOMER_STATE.copy(paymentMethods = customerPaymentMethods)
+        customerStateHolder.setCustomerState(EMPTY_CUSTOMER_STATE.copy(paymentMethods = customerPaymentMethods))
 
         savedPaymentMethodMutator.editing.test {
             assertThat(awaitItem()).isFalse()
@@ -170,7 +176,7 @@ class SavedPaymentMethodMutatorTest {
     @Test
     fun `Removing selected payment method clears selection`() = runScenario {
         val cards = PaymentMethodFixtures.createCards(3)
-        customerStateHolder.customer = EMPTY_CUSTOMER_STATE.copy(paymentMethods = cards)
+        customerStateHolder.setCustomerState(EMPTY_CUSTOMER_STATE.copy(paymentMethods = cards))
 
         val selection = PaymentSelection.Saved(cards[1])
         selectionSource.value = selection
@@ -196,13 +202,15 @@ class SavedPaymentMethodMutatorTest {
         val repository = FakeCustomerRepository()
 
         runScenario(repository) {
-            customerStateHolder.customer = CustomerState(
-                id = "cus_1",
-                ephemeralKeySecret = "ek_1",
-                paymentMethods = listOf(),
-                permissions = CustomerState.Permissions(
-                    canRemovePaymentMethods = true,
-                    canRemoveDuplicates = shouldRemoveDuplicates,
+            customerStateHolder.setCustomerState(
+                CustomerState(
+                    id = "cus_1",
+                    ephemeralKeySecret = "ek_1",
+                    paymentMethods = listOf(),
+                    permissions = CustomerState.Permissions(
+                        canRemovePaymentMethods = true,
+                        canRemoveDuplicates = shouldRemoveDuplicates,
+                    )
                 )
             )
 


### PR DESCRIPTION
# Summary
Make `CustomerState` observable in `CustomerStateHolder` & use in `PaymentOptionsItemMapper`

# Motivation
There are additional values we will use from `CustomerState` to build `PaymentOptionItem` instances, such as figuring out if we can remove payment methods. This PR sets us up do so by making `CustomerState` available in `PaymentOptionsItemMapper`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified