### PR TITLE
Enable/Disable payment method removal based on customer permissions for `CustomerSession`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
@@ -98,9 +98,7 @@ internal class DefaultManageScreenInteractor(
     init {
         coroutineScope.launch {
             state.collect { state ->
-                if (!state.canEdit) {
-                    safeNavigateBack()
-                } else if (!state.isEditing && !state.canRemove && state.paymentMethods.size == 1) {
+                if (!state.isEditing && !state.canEdit && state.paymentMethods.size == 1) {
                     handlePaymentMethodSelected(state.paymentMethods.first())
                     safeNavigateBack()
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -309,10 +309,6 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
             return PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE
         }
 
-        if (!canEdit && !canRemove) {
-            return PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE
-        }
-
         return when (paymentMethods.size) {
             0 -> PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE
             1 -> {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FakeEditPaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FakeEditPaymentMethodInteractor.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.paymentsheet
 
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
@@ -41,7 +43,11 @@ internal class FakeEditPaymentMethodInteractor(
         // No-op
     }
 
-    object Factory : ModifiableEditPaymentMethodViewInteractor.Factory {
+    class Factory : ModifiableEditPaymentMethodViewInteractor.Factory {
+        private val _calls = Turbine<Call>()
+
+        val calls: ReceiveTurbine<Call> = _calls
+
         override fun create(
             initialPaymentMethod: PaymentMethod,
             eventHandler: (EditPaymentMethodViewInteractor.Event) -> Unit,
@@ -51,7 +57,14 @@ internal class FakeEditPaymentMethodInteractor(
             canRemove: Boolean,
             isLiveMode: Boolean,
         ): ModifiableEditPaymentMethodViewInteractor {
-            return FakeEditPaymentMethodInteractor(initialPaymentMethod)
+            _calls.add(Call(initialPaymentMethod, canRemove))
+
+            return FakeEditPaymentMethodInteractor(initialPaymentMethod, canRemove)
         }
+
+        data class Call(
+            val initialPaymentMethod: PaymentMethod,
+            val canRemove: Boolean,
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -1121,7 +1121,7 @@ internal class PaymentSheetActivityTest {
                     errorReporter = FakeErrorReporter(),
                     logger = FakeUserFacingLogger(),
                 ),
-                editInteractorFactory = FakeEditPaymentMethodInteractor.Factory,
+                editInteractorFactory = FakeEditPaymentMethodInteractor.Factory(),
                 errorReporter = FakeErrorReporter(),
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
@@ -80,7 +80,7 @@ class DefaultManageScreenInteractorTest {
     }
 
     @Test
-    fun cannotRemoveOrEdit_shouldNavigateBack() {
+    fun cannotRemoveOrEdit_multiplePaymentsMethods_shouldNotNavigateBack() {
         var backPressed = false
         fun handleBackPressed() {
             backPressed = true
@@ -98,7 +98,7 @@ class DefaultManageScreenInteractorTest {
             canRemoveSource.value = false
             canEditSource.value = false
 
-            assertThat(backPressed).isTrue()
+            assertThat(backPressed).isFalse()
         }
     }
 
@@ -134,7 +134,7 @@ class DefaultManageScreenInteractorTest {
     }
 
     @Test
-    fun cannotRemoveButCanEdit_removesAllButLastPaymentMethod_navsBackWhenEditingFinishes() {
+    fun cannotRemoveOrEdit_removesAllButLastPaymentMethod_navsBackWhenEditingFinishes() {
         var backPressed = false
         fun handleBackPressed() {
             backPressed = true
@@ -160,6 +160,7 @@ class DefaultManageScreenInteractorTest {
 
             paymentMethodsSource.value = listOf(paymentMethods[2])
             canRemoveSource.value = false
+            canEditSource.value = false
 
             assertThat(backPressed).isFalse()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -123,6 +123,24 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
+    fun `state has manage_all action when multiple PMs are available, cannot edit and cannot remove`() {
+        runScenario(
+            initialPaymentMethods = PaymentMethodFixtures.createCards(3),
+        ) {
+            canRemove.value = false
+            canEdit.value = false
+
+            interactor.state.test {
+                awaitItem().run {
+                    assertThat(availableSavedPaymentMethodAction).isEqualTo(
+                        PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
     fun `state has manage_one saved PM action when one saved PM, can edit, and can remove`() {
         runScenario(
             initialPaymentMethods = PaymentMethodFactory.cards(1),


### PR DESCRIPTION
# Summary
Enable/Disable payment method removal based on customer permissions for `CustomerSession`

# Motivation
`CustomerSession` allows merchants to define if their customers can or cannot remove payment methods. This PR takes those permissions into account, enabling and disabling UI elements based on if its removable.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Video
<video src="https://github.com/user-attachments/assets/34a4da84-e2d3-407c-8092-d804dcf4ef20" />