### PR TITLE
Add `Customer Session Override Allow Redisplay` settings definition

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -40,6 +40,8 @@ class CheckoutRequest private constructor(
     val paymentMethodRedisplayFeature: FeatureState?,
     @SerialName("customer_session_payment_method_allow_redisplay_filters")
     val paymentMethodRedisplayFilters: List<AllowRedisplayFilter>?,
+    @SerialName("customer_session_payment_method_save_allow_redisplay_override")
+    val paymentMethodOverrideRedisplay: AllowRedisplayFilter?,
 ) {
     @Serializable
     enum class CustomerKeyType {
@@ -71,6 +73,7 @@ class CheckoutRequest private constructor(
             AllowRedisplayFilter.Limited,
             AllowRedisplayFilter.Always,
         )
+        private var paymentMethodOverrideRedisplay: AllowRedisplayFilter? = null
 
         fun initialization(initialization: String?) = apply {
             this.initialization = initialization
@@ -132,6 +135,10 @@ class CheckoutRequest private constructor(
             this.paymentMethodRedisplayFilters = filters
         }
 
+        fun paymentMethodOverrideRedisplay(override: AllowRedisplayFilter?) {
+            this.paymentMethodOverrideRedisplay = override
+        }
+
         fun requireCvcRecollection(requireCvcRecollection: Boolean?) = apply {
             this.requireCvcRecollection = requireCvcRecollection
         }
@@ -154,6 +161,7 @@ class CheckoutRequest private constructor(
                 paymentMethodRemoveFeature = paymentMethodRemoveFeature,
                 paymentMethodRedisplayFeature = paymentMethodRedisplayFeature,
                 paymentMethodRedisplayFilters = paymentMethodRedisplayFilters,
+                paymentMethodOverrideRedisplay = paymentMethodOverrideRedisplay,
             )
         }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionOverrideRedisplaySettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionOverrideRedisplaySettingsDefinition.kt
@@ -1,0 +1,40 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.paymentsheet.example.playground.model.AllowRedisplayFilter
+import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
+
+internal object CustomerSessionOverrideRedisplaySettingsDefinition :
+    PlaygroundSettingDefinition<CustomerSessionOverrideRedisplaySettingsDefinition.OverrideAllowRedisplay>,
+    PlaygroundSettingDefinition.Saveable<CustomerSessionOverrideRedisplaySettingsDefinition.OverrideAllowRedisplay>
+    by EnumSaveable(
+        key = "customer_session_payment_method_override_redisplay",
+        values = CustomerSessionOverrideRedisplaySettingsDefinition.OverrideAllowRedisplay.entries.toTypedArray(),
+        defaultValue = OverrideAllowRedisplay.NotSet,
+    ),
+    PlaygroundSettingDefinition.Displayable<CustomerSessionOverrideRedisplaySettingsDefinition.OverrideAllowRedisplay> {
+    override val displayName: String = "Customer Session Override Allow Redisplay"
+
+    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
+        return configurationData.integrationType.isPaymentFlow()
+    }
+
+    override fun createOptions(
+        configurationData: PlaygroundConfigurationData
+    ) = listOf(
+        PlaygroundSettingDefinition.Displayable.Option("Not Set", OverrideAllowRedisplay.NotSet),
+        PlaygroundSettingDefinition.Displayable.Option("Always", OverrideAllowRedisplay.Always),
+        PlaygroundSettingDefinition.Displayable.Option("Limited", OverrideAllowRedisplay.Limited),
+        PlaygroundSettingDefinition.Displayable.Option("Unspecified", OverrideAllowRedisplay.Unspecified),
+    )
+
+    override fun configure(value: OverrideAllowRedisplay, checkoutRequestBuilder: CheckoutRequest.Builder) {
+        checkoutRequestBuilder.paymentMethodOverrideRedisplay(value.filter)
+    }
+
+    enum class OverrideAllowRedisplay(override val value: String, val filter: AllowRedisplayFilter?) : ValueEnum {
+        Always("always", AllowRedisplayFilter.Always),
+        Limited("limited", AllowRedisplayFilter.Limited),
+        Unspecified("unspecified", AllowRedisplayFilter.Unspecified),
+        NotSet("notSet", null)
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -321,6 +321,7 @@ internal class PlaygroundSettings private constructor(
             CustomerSessionRemoveSettingsDefinition,
             CustomerSessionRedisplaySettingsDefinition,
             CustomerSessionRedisplayFiltersSettingsDefinition,
+            CustomerSessionOverrideRedisplaySettingsDefinition,
             CustomerSettingsDefinition,
             CheckoutModeSettingsDefinition,
             LinkSettingsDefinition,


### PR DESCRIPTION
# Summary
Add `Customer Session Override Allow Redisplay` settings definition

# Motivation
Allows for manually testing setting an override for the `allow_redisplay` value for `CustomerSession`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
