### PR TITLE
Add initial network tests for `CustomerSession` for `PaymentSheet`

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetCustomerSessionTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetCustomerSessionTest.kt
@@ -1,0 +1,166 @@
+package com.stripe.android.paymentsheet
+
+import com.stripe.android.core.utils.urlEncode
+import com.stripe.android.networktesting.RequestMatchers.bodyPart
+import com.stripe.android.networktesting.RequestMatchers.host
+import com.stripe.android.networktesting.RequestMatchers.method
+import com.stripe.android.networktesting.RequestMatchers.path
+import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.paymentsheet.utils.IntegrationType
+import com.stripe.android.paymentsheet.utils.PaymentSheetTestRunnerContext
+import com.stripe.android.paymentsheet.utils.TestRules
+import com.stripe.android.paymentsheet.utils.assertCompleted
+import com.stripe.android.paymentsheet.utils.runPaymentSheetTest
+import org.junit.Rule
+import org.junit.Test
+
+class PaymentSheetCustomerSessionTest {
+    @get:Rule
+    val testRules: TestRules = TestRules.create()
+
+    private val composeTestRule = testRules.compose
+    private val networkRule = testRules.networkRule
+
+    private val page: PaymentSheetPage = PaymentSheetPage(composeTestRule)
+
+    @Test
+    fun allowRedisplayIsUnspecifiedWhenNotSavingWithPaymentIntent() = runPaymentSheetTest(
+        networkRule = networkRule,
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
+        enqueueElementsSessionWithPaymentIntentAndCustomerSession()
+
+        testContext.presentWithPaymentIntent()
+
+        page.fillOutCardDetails()
+
+        enqueuePaymentIntentConfirmWithExpectedAllowRedisplay(allowRedisplay = "unspecified")
+
+        page.clickPrimaryButton()
+    }
+
+    @Test
+    fun allowRedisplayIsAlwaysWhenSavingWithPaymentIntent() = runPaymentSheetTest(
+        networkRule = networkRule,
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
+        enqueueElementsSessionWithPaymentIntentAndCustomerSession()
+
+        testContext.presentWithPaymentIntent()
+
+        page.fillOutCardDetails()
+        clickOnSaveForFutureUsage()
+
+        enqueuePaymentIntentConfirmWithExpectedAllowRedisplay(allowRedisplay = "always")
+
+        page.clickPrimaryButton()
+    }
+
+    @Test
+    fun allowRedisplayIsLimitedWhenNotSavingWithSetupIntent() = runPaymentSheetTest(
+        networkRule = networkRule,
+        integrationType = IntegrationType.Compose,
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
+        enqueueElementsSessionWithSetupIntentAndCustomerSession()
+
+        testContext.presentWithSetupIntent()
+
+        page.fillOutCardDetails()
+
+        enqueueSetupIntentConfirmWithExpectedAllowRedisplay(allowRedisplay = "limited")
+
+        page.clickPrimaryButton()
+    }
+
+    @Test
+    fun allowRedisplayIsAlwaysWhenSavingWithSetupIntent() = runPaymentSheetTest(
+        networkRule = networkRule,
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
+        enqueueElementsSessionWithSetupIntentAndCustomerSession()
+
+        testContext.presentWithSetupIntent()
+        clickOnSaveForFutureUsage()
+
+        page.fillOutCardDetails()
+
+        enqueueSetupIntentConfirmWithExpectedAllowRedisplay(allowRedisplay = "always")
+
+        page.clickPrimaryButton()
+    }
+
+    private fun enqueueElementsSessionWithPaymentIntentAndCustomerSession() {
+        enqueueElementsSession("elements-sessions-requires_pm_with_ps_pi_cs.json")
+    }
+
+    private fun enqueueElementsSessionWithSetupIntentAndCustomerSession() {
+        enqueueElementsSession("elements-sessions-requires_pm_with_ps_si_cs.json")
+    }
+
+    private fun enqueuePaymentIntentConfirmWithExpectedAllowRedisplay(allowRedisplay: String) {
+        return networkRule.enqueue(
+            method("POST"),
+            path("/v1/payment_intents/pi_example/confirm"),
+            bodyPart(urlEncode("payment_method_data[allow_redisplay]"), allowRedisplay)
+        ) { response ->
+            response.testBodyFromFile("payment-intent-confirm.json")
+        }
+    }
+
+    private fun enqueueSetupIntentConfirmWithExpectedAllowRedisplay(allowRedisplay: String) {
+        return networkRule.enqueue(
+            method("POST"),
+            path("/v1/setup_intents/seti_example/confirm"),
+            bodyPart(urlEncode("payment_method_data[allow_redisplay]"), allowRedisplay)
+        ) { response ->
+            response.testBodyFromFile("setup-intent-confirm.json")
+        }
+    }
+
+    private fun enqueueElementsSession(responseFilePath: String) {
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("GET"),
+            path("/v1/elements/sessions"),
+        ) { response ->
+            response.testBodyFromFile(responseFilePath)
+        }
+    }
+
+    private fun clickOnSaveForFutureUsage() {
+        page.clickOnSaveForFutureUsage("Merchant, Inc.")
+    }
+
+    @OptIn(ExperimentalCustomerSessionApi::class)
+    private fun PaymentSheetTestRunnerContext.presentWithPaymentIntent() {
+        presentPaymentSheet {
+            presentWithPaymentIntent(
+                paymentIntentClientSecret = "pi_example_secret_example",
+                configuration = PaymentSheet.Configuration(
+                    merchantDisplayName = "Merchant, Inc.",
+                    customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
+                        id = "cus_1",
+                        clientSecret = "cuss_1",
+                    ),
+                ),
+            )
+        }
+    }
+
+    @OptIn(ExperimentalCustomerSessionApi::class)
+    private fun PaymentSheetTestRunnerContext.presentWithSetupIntent() {
+        presentPaymentSheet {
+            presentWithSetupIntent(
+                setupIntentClientSecret = "seti_example_secret_example",
+                configuration = PaymentSheet.Configuration(
+                    merchantDisplayName = "Merchant, Inc.",
+                    customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
+                        id = "cus_1",
+                        clientSecret = "cuss_1",
+                    ),
+                ),
+            )
+        }
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetTestRunner.kt
@@ -44,7 +44,7 @@ internal class PaymentSheetTestRunnerContext(
 
 internal fun runPaymentSheetTest(
     networkRule: NetworkRule,
-    integrationType: IntegrationType,
+    integrationType: IntegrationType = IntegrationType.Compose,
     createIntentCallback: CreateIntentCallback? = null,
     resultCallback: PaymentSheetResultCallback,
     block: (PaymentSheetTestRunnerContext) -> Unit,

--- a/paymentsheet/src/androidTest/resources/elements-sessions-requires_pm_with_ps_pi_cs.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-requires_pm_with_ps_pi_cs.json
@@ -1,0 +1,97 @@
+{
+  "business_name": "Mobile Example Account",
+  "google_pay_preference": "enabled",
+  "merchant_country": "US",
+  "merchant_currency": "usd",
+  "merchant_id": "acct_1HvTI7Lu5o3P18Zp",
+  "meta_pay_signed_container_context": null,
+  "order": null,
+  "ordered_payment_method_types_and_wallets": [
+    "card"
+  ],
+  "customer": {
+    "payment_methods": [],
+    "customer_session": {
+      "id": "cuss_654321",
+      "livemode": false,
+      "api_key": "ek_12345",
+      "api_key_expiry": 1899787184,
+      "customer": "cus_12345",
+      "components": {
+        "payment_sheet": {
+          "enabled": true,
+          "features": {
+            "payment_method_save": "enabled",
+            "payment_method_remove": "enabled",
+            "payment_method_save_allow_redisplay_override": null
+          }
+        },
+        "customer_sheet": {
+          "enabled": false,
+          "features": null
+        }
+      }
+    },
+    "default_payment_method": null
+  },
+  "payment_method_preference": {
+    "object": "payment_method_preference",
+    "country_code": "US",
+    "ordered_payment_method_types": [
+      "card"
+    ],
+    "payment_intent": {
+      "id": "pi_example",
+      "object": "payment_intent",
+      "amount": 5099,
+      "amount_details": {
+        "tip": {}
+      },
+      "automatic_payment_methods": {
+        "enabled": true
+      },
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "client_secret": "pi_example_secret_example",
+      "confirmation_method": "automatic",
+      "created": 1674750417,
+      "currency": "usd",
+      "description": null,
+      "last_payment_error": null,
+      "livemode": false,
+      "next_action": null,
+      "payment_method": null,
+      "payment_method_options": {
+        "us_bank_account": {
+          "verification_method": "automatic"
+        }
+      },
+      "payment_method_types": [
+        "card"
+      ],
+      "processing": null,
+      "receipt_email": null,
+      "setup_future_usage": null,
+      "shipping": null,
+      "source": null,
+      "status": "requires_payment_method"
+    },
+    "type": "payment_intent"
+  },
+  "payment_method_specs": [
+    {
+      "async": false,
+      "fields": [],
+      "type": "card"
+    }
+  ],
+  "paypal_express_config": {
+    "client_id": null,
+    "paypal_merchant_id": null
+  },
+  "shipping_address_settings": {
+    "autocomplete_allowed": true
+  },
+  "unactivated_payment_method_types": []
+}

--- a/paymentsheet/src/androidTest/resources/elements-sessions-requires_pm_with_ps_si_cs.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-requires_pm_with_ps_si_cs.json
@@ -1,0 +1,100 @@
+{
+  "apple_pay_preference": "enabled",
+  "business_name": "Mobile Example Account",
+  "google_pay_preference": "enabled",
+  "link_consumer_info": null,
+  "link_settings": null,
+  "merchant_country": "US",
+  "merchant_currency": "usd",
+  "merchant_id": "acct_1HvTI7Lu5o3P18Zp",
+  "meta_pay_signed_container_context": null,
+  "order": null,
+  "ordered_payment_method_types_and_wallets": [
+    "card"
+  ],
+  "customer": {
+    "payment_methods": [],
+    "customer_session": {
+      "id": "cuss_654321",
+      "livemode": false,
+      "api_key": "ek_12345",
+      "api_key_expiry": 1899787184,
+      "customer": "cus_12345",
+      "components": {
+        "payment_sheet": {
+          "enabled": true,
+          "features": {
+            "payment_method_save": "enabled",
+            "payment_method_remove": "enabled",
+            "payment_method_save_allow_redisplay_override": null
+          }
+        },
+        "customer_sheet": {
+          "enabled": false,
+          "features": null
+        }
+      }
+    },
+    "default_payment_method": null
+  },
+  "payment_method_preference": {
+    "object": "payment_method_preference",
+    "country_code": "US",
+    "ordered_payment_method_types": [
+      "card"
+    ],
+    "setup_intent": {
+      "id": "si_example",
+      "object": "setup_intent",
+      "amount": 5099,
+      "amount_details": {
+        "tip": {}
+      },
+      "automatic_payment_methods": {
+        "enabled": true
+      },
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "client_secret": "seti_example_secret_example",
+      "confirmation_method": "automatic",
+      "created": 1674750417,
+      "currency": "usd",
+      "description": null,
+      "last_payment_error": null,
+      "livemode": false,
+      "next_action": null,
+      "payment_method": null,
+      "payment_method_options": {
+        "us_bank_account": {
+          "verification_method": "automatic"
+        }
+      },
+      "payment_method_types": [
+        "card"
+      ],
+      "processing": null,
+      "receipt_email": null,
+      "shipping": null,
+      "source": null,
+      "status": "requires_payment_method",
+      "usage": "off_session"
+    },
+    "type": "setup_intent"
+  },
+  "payment_method_specs": [
+    {
+      "async": false,
+      "fields": [],
+      "type": "card"
+    }
+  ],
+  "paypal_express_config": {
+    "client_id": null,
+    "paypal_merchant_id": null
+  },
+  "shipping_address_settings": {
+    "autocomplete_allowed": true
+  },
+  "unactivated_payment_method_types": []
+}


### PR DESCRIPTION
# Summary
Add initial network tests for `CustomerSession` for `PaymentSheet`

# Motivation
Ensures `CustomerSession` behavior is maintained in `PaymentSheet`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified