### PR TITLE
Handle `institution_picker` next pane on update required modal

### DIFF
--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -611,19 +611,19 @@ public final class com/stripe/android/financialconnections/features/notice/Notic
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/financialconnections/features/notice/NoticeSheetState$NoticeSheetContent$UpdateRequired$Type$PartnerAuth$Creator : android/os/Parcelable$Creator {
-	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/features/notice/NoticeSheetState$NoticeSheetContent$UpdateRequired$Type$PartnerAuth;
-	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/financialconnections/features/notice/NoticeSheetState$NoticeSheetContent$UpdateRequired$Type$PartnerAuth;
-	public synthetic fun newArray (I)[Ljava/lang/Object;
-}
-
 public final class com/stripe/android/financialconnections/features/notice/NoticeSheetState$NoticeSheetContent$UpdateRequired$Type$Repair$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/features/notice/NoticeSheetState$NoticeSheetContent$UpdateRequired$Type$Repair;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/financialconnections/features/notice/NoticeSheetState$NoticeSheetContent$UpdateRequired$Type$Repair;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/financialconnections/features/notice/NoticeSheetState$NoticeSheetContent$UpdateRequired$Type$Supportability$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/features/notice/NoticeSheetState$NoticeSheetContent$UpdateRequired$Type$Supportability;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/financialconnections/features/notice/NoticeSheetState$NoticeSheetContent$UpdateRequired$Type$Supportability;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountupdate/AccountUpdateRequiredModal.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountupdate/AccountUpdateRequiredModal.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.NavBackStackEntry
 import com.stripe.android.financialconnections.features.common.GenericBottomSheetContent
 import com.stripe.android.financialconnections.features.notice.NoticeSheetState.NoticeSheetContent.UpdateRequired
-import com.stripe.android.financialconnections.features.notice.NoticeSheetState.NoticeSheetContent.UpdateRequired.Type.PartnerAuth
+import com.stripe.android.financialconnections.features.notice.NoticeSheetState.NoticeSheetContent.UpdateRequired.Type.Supportability
 import com.stripe.android.financialconnections.model.Image
 import com.stripe.android.financialconnections.presentation.paneViewModel
 import com.stripe.android.financialconnections.ui.FinancialConnectionsPreview
@@ -88,7 +88,7 @@ internal fun AccountUpdateRequiredModalPreview() {
                         verticalAlignment = VerticalAlignment.Default
                     )
                 ),
-                type = PartnerAuth(
+                type = Supportability(
                     institution = null,
                 ),
             ),

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountupdate/AccountUpdateRequiredViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountupdate/AccountUpdateRequiredViewModel.kt
@@ -13,9 +13,11 @@ import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.UpdateLocalManifest
 import com.stripe.android.financialconnections.exception.UnclassifiedError
 import com.stripe.android.financialconnections.features.notice.NoticeSheetState.NoticeSheetContent.UpdateRequired
+import com.stripe.android.financialconnections.features.notice.NoticeSheetState.NoticeSheetContent.UpdateRequired.Type
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.navigation.Destination
+import com.stripe.android.financialconnections.navigation.Destination.InstitutionPicker
 import com.stripe.android.financialconnections.navigation.NavigationManager
 import com.stripe.android.financialconnections.navigation.topappbar.TopAppBarStateUpdate
 import com.stripe.android.financialconnections.presentation.Async
@@ -57,10 +59,10 @@ internal class AccountUpdateRequiredViewModel @AssistedInject constructor(
             val state = stateFlow.value
             val referrer = state.referrer
             when (val type = requireNotNull(state.payload()?.type)) {
-                is UpdateRequired.Type.Repair -> {
+                is Type.Repair -> {
                     handleUnsupportedRepairAction(referrer)
                 }
-                is UpdateRequired.Type.PartnerAuth -> {
+                is Type.Supportability -> {
                     openPartnerAuth(type.institution, referrer)
                 }
             }
@@ -75,7 +77,7 @@ internal class AccountUpdateRequiredViewModel @AssistedInject constructor(
             pane = PANE,
         )
         // Fall back to the institution picker for now
-        navigationManager.tryNavigateTo(Destination.InstitutionPicker(referrer))
+        navigationManager.tryNavigateTo(InstitutionPicker(referrer))
     }
 
     private fun openPartnerAuth(
@@ -89,7 +91,7 @@ internal class AccountUpdateRequiredViewModel @AssistedInject constructor(
             navigationManager.tryNavigateTo(Destination.PartnerAuth(referrer))
         } else {
             // Fall back to the institution picker
-            navigationManager.tryNavigateTo(Destination.InstitutionPicker(referrer))
+            navigationManager.tryNavigateTo(InstitutionPicker(referrer))
         }
     }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
@@ -30,13 +30,15 @@ import com.stripe.android.financialconnections.features.notice.NoticeSheetState
 import com.stripe.android.financialconnections.features.notice.NoticeSheetState.NoticeSheetContent.DataAccess
 import com.stripe.android.financialconnections.features.notice.NoticeSheetState.NoticeSheetContent.Generic
 import com.stripe.android.financialconnections.features.notice.NoticeSheetState.NoticeSheetContent.UpdateRequired
-import com.stripe.android.financialconnections.features.notice.NoticeSheetState.NoticeSheetContent.UpdateRequired.Type.PartnerAuth
+import com.stripe.android.financialconnections.features.notice.NoticeSheetState.NoticeSheetContent.UpdateRequired.Type
 import com.stripe.android.financialconnections.features.notice.NoticeSheetState.NoticeSheetContent.UpdateRequired.Type.Repair
+import com.stripe.android.financialconnections.features.notice.NoticeSheetState.NoticeSheetContent.UpdateRequired.Type.Supportability
 import com.stripe.android.financialconnections.features.notice.PresentSheet
 import com.stripe.android.financialconnections.model.AddNewAccount
 import com.stripe.android.financialconnections.model.DataAccessNotice
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane.BANK_AUTH_REPAIR
+import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane.INSTITUTION_PICKER
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane.PARTNER_AUTH
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane.SUCCESS
 import com.stripe.android.financialconnections.model.Image
@@ -377,8 +379,14 @@ internal class LinkAccountPickerViewModel @AssistedInject constructor(
                     )
                     PARTNER_AUTH -> UpdateRequired(
                         generic = genericContent,
-                        type = PartnerAuth(
+                        type = Supportability(
                             institution = institution,
+                        ),
+                    )
+                    INSTITUTION_PICKER -> UpdateRequired(
+                        generic = genericContent,
+                        type = Supportability(
+                            institution = null,
                         ),
                     )
                     else -> null
@@ -396,9 +404,9 @@ internal class LinkAccountPickerViewModel @AssistedInject constructor(
         presentSheet(this, referrer = PANE)
     }
 
-    private fun logUpdateRequired(type: UpdateRequired.Type) {
+    private fun logUpdateRequired(type: Type) {
         val eventName = when (type) {
-            is PartnerAuth -> "click.supportability_account"
+            is Supportability -> "click.supportability_account"
             is Repair -> "click.repair_accounts"
         }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/notice/NoticeSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/notice/NoticeSheetViewModel.kt
@@ -147,7 +147,7 @@ internal data class NoticeSheetState(
                 data class Repair(val authorization: String?) : Type
 
                 @Parcelize
-                data class PartnerAuth(val institution: FinancialConnectionsInstitution?) : Type
+                data class Supportability(val institution: FinancialConnectionsInstitution?) : Type
             }
         }
     }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModelTest.kt
@@ -15,7 +15,9 @@ import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.SelectNetworkedAccounts
 import com.stripe.android.financialconnections.domain.UpdateCachedAccounts
-import com.stripe.android.financialconnections.features.notice.NoticeSheetState
+import com.stripe.android.financialconnections.features.notice.NoticeSheetState.NoticeSheetContent.Generic
+import com.stripe.android.financialconnections.features.notice.NoticeSheetState.NoticeSheetContent.UpdateRequired
+import com.stripe.android.financialconnections.features.notice.NoticeSheetState.NoticeSheetContent.UpdateRequired.Type.Supportability
 import com.stripe.android.financialconnections.features.notice.PresentSheet
 import com.stripe.android.financialconnections.model.AddNewAccount
 import com.stripe.android.financialconnections.model.DataAccessNotice
@@ -58,7 +60,6 @@ class LinkAccountPickerViewModelTest {
     private val selectNetworkedAccounts = mock<SelectNetworkedAccounts>()
     private val eventTracker = TestFinancialConnectionsAnalyticsTracker()
     private val nativeAuthFlowCoordinator = NativeAuthFlowCoordinator()
-    private val presentUpdateRequiredSheet = mock<PresentSheet>()
     private val presentSheet = mock<PresentSheet>()
 
     private fun buildViewModel(
@@ -395,8 +396,80 @@ class LinkAccountPickerViewModelTest {
         viewModel.onAccountClick(selectedAccount)
 
         verifyNoInteractions(presentSheet)
-        verifyNoInteractions(presentUpdateRequiredSheet)
     }
+
+    @Test
+    fun `onAccountClick - presents supportability drawer with no institution if next pane is institution_picker`() =
+        runTest {
+            val noticeContent = FinancialConnectionsGenericInfoScreen(id = "id")
+            val accounts = NetworkedAccountsList(
+                acquireConsentOnPrimaryCtaClick = false,
+                data = listOf(
+                    partnerAccount().copy(id = "id1", nextPaneOnSelection = Pane.INSTITUTION_PICKER)
+                ),
+                display = display(
+                    listOf(
+                        NetworkedAccount(
+                            id = "id1",
+                            allowSelection = true,
+                            drawerOnSelection = noticeContent
+                        )
+                    )
+                )
+            )
+            val selectedAccount = accounts.data.first()
+            whenever(getSync()).thenReturn(syncResponse())
+            whenever(getCachedConsumerSession()).thenReturn(consumerSession())
+            whenever(fetchNetworkedAccounts(any())).thenReturn(accounts)
+
+            val viewModel = buildViewModel(LinkAccountPickerState())
+
+            viewModel.onAccountClick(selectedAccount)
+
+            verify(presentSheet).invoke(
+                eq(UpdateRequired(generic = noticeContent, type = Supportability(null))),
+                eq(Pane.LINK_ACCOUNT_PICKER),
+            )
+        }
+
+    @Test
+    fun `onAccountClick - presents supportability drawer with institution if next pane is partner_auth`() =
+        runTest {
+            val noticeContent = FinancialConnectionsGenericInfoScreen(id = "id")
+            val institution = institution()
+            val accounts = NetworkedAccountsList(
+                acquireConsentOnPrimaryCtaClick = false,
+                data = listOf(
+                    partnerAccount().copy(
+                        id = "id1",
+                        nextPaneOnSelection = Pane.PARTNER_AUTH,
+                        institution = institution
+                    )
+                ),
+                display = display(
+                    listOf(
+                        NetworkedAccount(
+                            id = "id1",
+                            allowSelection = true,
+                            drawerOnSelection = noticeContent,
+                        )
+                    )
+                )
+            )
+            val selectedAccount = accounts.data.first()
+            whenever(getSync()).thenReturn(syncResponse())
+            whenever(getCachedConsumerSession()).thenReturn(consumerSession())
+            whenever(fetchNetworkedAccounts(any())).thenReturn(accounts)
+
+            val viewModel = buildViewModel(LinkAccountPickerState())
+
+            viewModel.onAccountClick(selectedAccount)
+
+            verify(presentSheet).invoke(
+                eq(UpdateRequired(generic = noticeContent, type = Supportability(institution = institution))),
+                eq(Pane.LINK_ACCOUNT_PICKER),
+            )
+        }
 
     @Test
     fun `onAccountClick - present drawer on click if acquireConsentOnCta is false`() = runTest {
@@ -426,10 +499,9 @@ class LinkAccountPickerViewModelTest {
         viewModel.onAccountClick(selectedAccount)
 
         verify(presentSheet).invoke(
-            eq(NoticeSheetState.NoticeSheetContent.Generic(drawerOnSelection)),
+            eq(Generic(drawerOnSelection)),
             eq(Pane.LINK_ACCOUNT_PICKER),
         )
-        verifyNoInteractions(presentUpdateRequiredSheet)
     }
 
     private fun twoAccounts() = NetworkedAccountsList(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/partnerauth/SupportabilityViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/partnerauth/SupportabilityViewModelTest.kt
@@ -42,7 +42,7 @@ import kotlin.test.assertEquals
 
 @Suppress("MaxLineLength")
 @ExperimentalCoroutinesApi
-internal class PartnerAuthViewModelTest {
+internal class SupportabilityViewModelTest {
 
     @get:Rule
     val testRule = CoroutineTestRule()


### PR DESCRIPTION
# Summary
We're not properly handling `institution_picker`  as `next_pane_on_selection` on `update required` modals. We've [specific code](https://github.com/stripe/stripe-android/blob/92c77e9ebc2f54763d604066fc89e7de900dfc26/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt#L370-L390) that decides wether to treat the modal as a notice _dumb_ modal (CTAs just close the modal) or an actual update required modal. That check just considers partner_auth and repair panes, not institution_picker.

This happens when we don't know the bank of the account to be updated.  

# Motivation
[BANKCON-11863](https://jira.corp.stripe.com/browse/BANKCON-11863)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |