### PR TITLE
Remove unexpected FLOW_CONTROLLER_NO_PAYMENT_SELECTION_ON_CHECKOUT event

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -184,9 +184,6 @@ interface ErrorReporter {
         PAYMENT_SHEET_INVALID_PAYMENT_SELECTION_ON_CHECKOUT(
             partialEventName = "paymentsheet.invalid_payment_selection"
         ),
-        FLOW_CONTROLLER_NO_PAYMENT_SELECTION_ON_CHECKOUT(
-            partialEventName = "flow_controller.no_payment_selection"
-        ),
         FLOW_CONTROLLER_INVALID_PAYMENT_SELECTION_ON_CHECKOUT(
             partialEventName = "flow_controller.invalid_payment_selection"
         ),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -415,11 +415,10 @@ internal class DefaultFlowController @Inject internal constructor(
 
                 val exception = IllegalStateException(message)
 
-                val event = paymentSelection?.let {
-                    ErrorReporter.UnexpectedErrorEvent.FLOW_CONTROLLER_INVALID_PAYMENT_SELECTION_ON_CHECKOUT
-                } ?: ErrorReporter.UnexpectedErrorEvent.FLOW_CONTROLLER_NO_PAYMENT_SELECTION_ON_CHECKOUT
-
-                errorReporter.report(event, StripeException.create(exception))
+                paymentSelection?.let {
+                    val event = ErrorReporter.UnexpectedErrorEvent.FLOW_CONTROLLER_INVALID_PAYMENT_SELECTION_ON_CHECKOUT
+                    errorReporter.report(event, StripeException.create(exception))
+                }
 
                 onIntentResult(
                     PaymentConfirmationResult.Failed(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -724,7 +724,7 @@ internal class DefaultFlowControllerTest {
     }
 
     @Test
-    fun `confirmPaymentSelection() with null payment selection, should report event and return failure`() = runTest {
+    fun `confirmPaymentSelection() with null payment selection, should return failure`() = runTest {
         val errorReporter = FakeErrorReporter()
 
         val flowController = createFlowController(
@@ -739,9 +739,7 @@ internal class DefaultFlowControllerTest {
             state = PAYMENT_SHEET_STATE_FULL,
         )
 
-        assertThat(errorReporter.getLoggedErrors()).contains(
-            "unexpected_error.flow_controller.no_payment_selection"
-        )
+        assertThat(errorReporter.getLoggedErrors()).isEmpty()
 
         verify(paymentResultCallback).onPaymentSheetResult(isA<PaymentSheetResult.Failed>())
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This event isn't unexpected, and could be triggered by merchants when they don't disable the button that calls confirm when nothing is selected.
