### PR TITLE
Rename `canDelete` to `canRemove` to standardize naming.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
@@ -33,7 +33,7 @@ internal interface ManageScreenInteractor {
         val paymentMethods: List<DisplayableSavedPaymentMethod>,
         val currentSelection: DisplayableSavedPaymentMethod?,
         val isEditing: Boolean,
-        val canDelete: Boolean,
+        val canRemove: Boolean,
         val canEdit: Boolean,
     )
 
@@ -90,7 +90,7 @@ internal class DefaultManageScreenInteractor(
             paymentMethods = displayablePaymentMethods,
             currentSelection = currentSelection,
             isEditing = editing,
-            canDelete = canRemove,
+            canRemove = canRemove,
             canEdit = canEdit,
         )
     }
@@ -100,7 +100,7 @@ internal class DefaultManageScreenInteractor(
             state.collect { state ->
                 if (!state.canEdit) {
                     safeNavigateBack()
-                } else if (!state.isEditing && !state.canDelete && state.paymentMethods.size == 1) {
+                } else if (!state.isEditing && !state.canRemove && state.paymentMethods.size == 1) {
                     handlePaymentMethodSelected(state.paymentMethods.first())
                     safeNavigateBack()
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUI.kt
@@ -42,7 +42,7 @@ internal fun ManageScreenUI(interactor: ManageScreenInteractor) {
                         isSelected = isSelected,
                         isEditing = state.isEditing,
                         isModifiable = it.isModifiable(),
-                        canDelete = state.canDelete,
+                        canRemove = state.canRemove,
                         paymentMethod = it,
                         deletePaymentMethod = { paymentMethod ->
                             interactor.handleViewAction(
@@ -69,7 +69,7 @@ private fun TrailingContent(
     isSelected: Boolean,
     isEditing: Boolean,
     isModifiable: Boolean,
-    canDelete: Boolean,
+    canRemove: Boolean,
     paymentMethod: DisplayableSavedPaymentMethod,
     deletePaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
     editPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
@@ -77,11 +77,11 @@ private fun TrailingContent(
     if (isEditing && isModifiable) {
         Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
             EditIcon(paymentMethod, editPaymentMethod)
-            if (canDelete) {
+            if (canRemove) {
                 DeleteIcon(paymentMethod, deletePaymentMethod)
             }
         }
-    } else if (isEditing && canDelete) {
+    } else if (isEditing && canRemove) {
         DeleteIcon(paymentMethod, deletePaymentMethod)
     } else if (isSelected) {
         SelectedBadge()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenManageSavedPaymentMethodsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenManageSavedPaymentMethodsTest.kt
@@ -35,7 +35,7 @@ internal class PaymentSheetScreenManageSavedPaymentMethodsTest {
             paymentMethods = emptyList(),
             currentSelection = null,
             isEditing = isEditing,
-            canDelete = true,
+            canRemove = true,
             canEdit = true,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
@@ -127,7 +127,7 @@ class DefaultManageScreenInteractorTest {
 
             interactor.state.test {
                 awaitItem().run {
-                    assertThat(canDelete).isFalse()
+                    assertThat(canRemove).isFalse()
                 }
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeManageScreenInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeManageScreenInteractor.kt
@@ -16,7 +16,7 @@ internal class FakeManageScreenInteractor(
                 emptyList(),
                 currentSelection = null,
                 isEditing = false,
-                canDelete = true,
+                canRemove = true,
                 canEdit = true,
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUIScreenshotTest.kt
@@ -28,7 +28,7 @@ internal class ManageScreenUIScreenshotTest {
                         paymentMethods = savedPaymentMethods,
                         currentSelection = null,
                         isEditing = false,
-                        canDelete = true,
+                        canRemove = true,
                         canEdit = true,
                     )
                 ),
@@ -45,7 +45,7 @@ internal class ManageScreenUIScreenshotTest {
                         paymentMethods = savedPaymentMethods,
                         currentSelection = savedPaymentMethods[1],
                         isEditing = false,
-                        canDelete = true,
+                        canRemove = true,
                         canEdit = true,
                     )
                 ),
@@ -62,7 +62,7 @@ internal class ManageScreenUIScreenshotTest {
                         paymentMethods = savedPaymentMethods,
                         currentSelection = null,
                         isEditing = true,
-                        canDelete = true,
+                        canRemove = true,
                         canEdit = true,
                     )
                 ),
@@ -81,7 +81,7 @@ internal class ManageScreenUIScreenshotTest {
                         ),
                         currentSelection = null,
                         isEditing = true,
-                        canDelete = false,
+                        canRemove = false,
                         canEdit = true,
                     )
                 ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUITest.kt
@@ -35,7 +35,7 @@ class ManageScreenUITest {
             paymentMethods = displayableSavedPaymentMethods,
             currentSelection = null,
             isEditing = false,
-            canDelete = true,
+            canRemove = true,
             canEdit = true,
         )
     ) {
@@ -56,7 +56,7 @@ class ManageScreenUITest {
             paymentMethods = displayableSavedPaymentMethods,
             currentSelection = null,
             isEditing = true,
-            canDelete = true,
+            canRemove = true,
             canEdit = true,
         )
     ) {
@@ -78,7 +78,7 @@ class ManageScreenUITest {
                 paymentMethods = displayableSavedPaymentMethods,
                 currentSelection = null,
                 isEditing = false,
-                canDelete = true,
+                canRemove = true,
                 canEdit = true,
             )
         ) {
@@ -101,7 +101,7 @@ class ManageScreenUITest {
                 paymentMethods = displayableSavedPaymentMethods,
                 currentSelection = null,
                 isEditing = true,
-                canDelete = true,
+                canRemove = true,
                 canEdit = true,
             )
         ) {
@@ -121,7 +121,7 @@ class ManageScreenUITest {
                 paymentMethods = displayableSavedPaymentMethods,
                 currentSelection = null,
                 isEditing = true,
-                canDelete = true,
+                canRemove = true,
                 canEdit = true,
             )
         ) {
@@ -140,7 +140,7 @@ class ManageScreenUITest {
             paymentMethods = displayableSavedPaymentMethods,
             currentSelection = displayableSavedPaymentMethods[1],
             isEditing = false,
-            canDelete = true,
+            canRemove = true,
             canEdit = true,
         )
     ) {
@@ -158,7 +158,7 @@ class ManageScreenUITest {
             paymentMethods = displayableSavedPaymentMethods,
             currentSelection = null,
             isEditing = true,
-            canDelete = true,
+            canRemove = true,
             canEdit = true,
         )
     ) {
@@ -177,7 +177,7 @@ class ManageScreenUITest {
             paymentMethods = listOf(cbcEligibleSavedPaymentMethod),
             currentSelection = null,
             isEditing = true,
-            canDelete = false,
+            canRemove = false,
             canEdit = true,
         )
     ) {
@@ -191,7 +191,7 @@ class ManageScreenUITest {
             paymentMethods = displayableSavedPaymentMethods,
             currentSelection = null,
             isEditing = true,
-            canDelete = true,
+            canRemove = true,
             canEdit = true,
         )
     ) {
@@ -213,7 +213,7 @@ class ManageScreenUITest {
             paymentMethods = displayableSavedPaymentMethods,
             currentSelection = null,
             isEditing = true,
-            canDelete = true,
+            canRemove = true,
             canEdit = true,
         )
     ) {
@@ -232,7 +232,7 @@ class ManageScreenUITest {
             paymentMethods = displayableSavedPaymentMethods,
             currentSelection = null,
             isEditing = true,
-            canDelete = true,
+            canRemove = true,
             canEdit = true,
         )
     ) {


### PR DESCRIPTION
# Summary
Rename `canDelete` to `canRemove` to standardize naming.

# Motivation
Rename `canDelete` to `canRemove` to standardize naming.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
