### PR TITLE
Update wallets divider padding for vertical mode

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -34,6 +34,8 @@ import java.io.Closeable
 import com.stripe.android.R as PaymentsCoreR
 
 internal val verticalModeBottomContentPadding = 20.dp
+internal val horizontalModeWalletsDividerSpacing = 16.dp
+internal val verticalModeWalletsDividerSpacing = 24.dp
 
 internal sealed interface PaymentSheetScreen {
 
@@ -41,6 +43,7 @@ internal sealed interface PaymentSheetScreen {
     val showsContinueButton: Boolean
     val topContentPadding: Dp
     val bottomContentPadding: Dp
+    val walletsDividerSpacing: Dp
 
     fun topBarState(): StateFlow<PaymentSheetTopBarState?>
 
@@ -57,6 +60,7 @@ internal sealed interface PaymentSheetScreen {
         override val showsContinueButton: Boolean = false
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = 0.dp
+        override val walletsDividerSpacing: Dp = horizontalModeWalletsDividerSpacing
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(null)
@@ -90,6 +94,7 @@ internal sealed interface PaymentSheetScreen {
         override val showsContinueButton: Boolean = false
         override val topContentPadding: Dp = SavedPaymentMethodsTopContentPadding
         override val bottomContentPadding: Dp = 0.dp
+        override val walletsDividerSpacing: Dp = horizontalModeWalletsDividerSpacing
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return interactor.state.mapAsStateFlow { state ->
@@ -143,6 +148,7 @@ internal sealed interface PaymentSheetScreen {
         override val showsContinueButton: Boolean = true
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = 0.dp
+        override val walletsDividerSpacing: Dp = horizontalModeWalletsDividerSpacing
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(
@@ -190,6 +196,7 @@ internal sealed interface PaymentSheetScreen {
         override val showsContinueButton: Boolean = true
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = 0.dp
+        override val walletsDividerSpacing: Dp = horizontalModeWalletsDividerSpacing
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(
@@ -240,6 +247,7 @@ internal sealed interface PaymentSheetScreen {
         override val showsContinueButton: Boolean = false
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = 0.dp
+        override val walletsDividerSpacing: Dp = horizontalModeWalletsDividerSpacing
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(
@@ -275,6 +283,7 @@ internal sealed interface PaymentSheetScreen {
         override val showsContinueButton: Boolean = true
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = verticalModeBottomContentPadding
+        override val walletsDividerSpacing: Dp = verticalModeWalletsDividerSpacing
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(
@@ -317,6 +326,7 @@ internal sealed interface PaymentSheetScreen {
         override val showsContinueButton: Boolean = true
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = verticalModeBottomContentPadding
+        override val walletsDividerSpacing: Dp = verticalModeWalletsDividerSpacing
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(
@@ -351,6 +361,7 @@ internal sealed interface PaymentSheetScreen {
         override val showsContinueButton: Boolean = false
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = 0.dp
+        override val walletsDividerSpacing: Dp = verticalModeWalletsDividerSpacing
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return interactor.state.mapAsStateFlow { state ->
@@ -399,6 +410,7 @@ internal sealed interface PaymentSheetScreen {
         override val showsContinueButton: Boolean = false
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = 0.dp
+        override val walletsDividerSpacing: Dp = verticalModeWalletsDividerSpacing
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.disabled
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidViewBinding
 import com.stripe.android.core.strings.ResolvableString
@@ -250,12 +251,13 @@ private fun PaymentSheetContent(
         }
 
         walletsState?.let { state ->
-            val bottomSpacing = WalletDividerSpacing - currentScreen.topContentPadding
+            val bottomSpacing = currentScreen.walletsDividerSpacing - currentScreen.topContentPadding
             Wallet(
                 state = state,
                 processingState = walletsProcessingState,
                 onGooglePayPressed = state.onGooglePayPressed,
                 onLinkPressed = state.onLinkPressed,
+                dividerSpacing = currentScreen.walletsDividerSpacing,
                 modifier = Modifier.padding(bottom = bottomSpacing),
             )
         }
@@ -308,6 +310,7 @@ internal fun Wallet(
     processingState: WalletsProcessingState?,
     onGooglePayPressed: () -> Unit,
     onLinkPressed: () -> Unit,
+    dividerSpacing: Dp,
     modifier: Modifier = Modifier,
 ) {
     val padding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
@@ -346,7 +349,7 @@ internal fun Wallet(
             else -> Unit
         }
 
-        Spacer(modifier = Modifier.requiredHeight(WalletDividerSpacing))
+        Spacer(modifier = Modifier.requiredHeight(dividerSpacing))
 
         val text = stringResource(state.dividerTextResource)
         WalletsDivider(text)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletsDivider.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletsDivider.kt
@@ -18,8 +18,6 @@ import com.stripe.android.uicore.shouldUseDarkDynamicColor
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.stripeShapes
 
-internal val WalletDividerSpacing = 16.dp
-
 @Composable
 internal fun WalletsDivider(text: String) {
     Row(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update wallets divider padding for vertical mode

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Vertical mode quality review feedback: [here](https://docs.google.com/document/d/1TPfeGBQXcbCfnvwmkHN7q3kOhF143mq8y0P9_sx3Z9U/edit#bookmark=id.23nz3omn1h0n)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

We can test this when we add screenshots for the entire vertical mode screens

# Screenshots
Before: 

![wallets divider spacing - before](https://github.com/user-attachments/assets/54cb2902-ab21-4186-aa0b-47d2abac5654)
 
After:
![wallets divider spacing - after](https://github.com/user-attachments/assets/8c66a7e9-cb9f-416a-95d9-35af0f6c6335)
 

