### PR TITLE
Add `LinkFormElement` to `CardDefinition`

### DIFF
--- a/link/src/test/java/com/stripe/android/link/LinkConfigurationCoordinatorTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkConfigurationCoordinatorTest.kt
@@ -66,17 +66,20 @@ class LinkConfigurationCoordinatorTest {
 
     @Test
     fun `verify component is reused for same configuration`() = runTest {
+        val component = linkConfigurationCoordinator.getComponent(config)
+
         linkConfigurationCoordinator.getAccountStatusFlow(config)
-        val component = linkConfigurationCoordinator.component
         linkConfigurationCoordinator.signInWithUserInput(config, mock<UserInput.SignIn>())
-        assertThat(linkConfigurationCoordinator.component).isEqualTo(component)
+
+        assertThat(linkConfigurationCoordinator.getComponent(config)).isEqualTo(component)
     }
 
     @Test
     fun `verify component is recreated for different configuration`() {
-        val component = linkConfigurationCoordinator.component
-        linkConfigurationCoordinator.getAccountStatusFlow(config.copy(merchantName = "anotherName"))
-        assertThat(linkConfigurationCoordinator.component).isNotEqualTo(component)
+        val component = linkConfigurationCoordinator.getComponent(config)
+
+        assertThat(linkConfigurationCoordinator.getComponent(config.copy(merchantName = "anotherName")))
+            .isNotEqualTo(component)
     }
 
     companion object {

--- a/payments-ui-core/detekt-baseline.xml
+++ b/payments-ui-core/detekt-baseline.xml
@@ -5,7 +5,6 @@
     <ID>ConstructorParameterNaming:CardNumberElement.kt$CardNumberElement$val _identifier: IdentifierSpec</ID>
     <ID>ConstructorParameterNaming:CvcElement.kt$CvcElement$val _identifier: IdentifierSpec</ID>
     <ID>CyclomaticComplexMethod:FormItemSpec.kt$FormItemSpecSerializer$override fun selectDeserializer(element: JsonElement): DeserializationStrategy&lt;FormItemSpec></ID>
-    <ID>CyclomaticComplexMethod:FormUI.kt$@Composable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun FormUI( hiddenIdentifiers: Set&lt;IdentifierSpec>, enabled: Boolean, elements: List&lt;FormElement>, lastTextFieldIdentifier: IdentifierSpec?, modifier: Modifier = Modifier )</ID>
     <ID>CyclomaticComplexMethod:TransformGoogleToStripeAddress.kt$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun Place.transformGoogleToStripeAddress( context: Context ): com.stripe.android.model.Address</ID>
     <ID>ForbiddenComment:Menu.kt$// TODO: Make sure this gets the rounded corner values</ID>
     <ID>LongMethod:Menu.kt$@Suppress("ModifierParameter") @Composable internal fun DropdownMenuContent( expandedStates: MutableTransitionState&lt;Boolean>, transformOriginState: MutableState&lt;TransformOrigin>, initialFirstVisibleItemIndex: Int, modifier: Modifier = Modifier, content: LazyListScope.() -> Unit )</ID>

--- a/payments-ui-core/detekt-baseline.xml
+++ b/payments-ui-core/detekt-baseline.xml
@@ -5,6 +5,7 @@
     <ID>ConstructorParameterNaming:CardNumberElement.kt$CardNumberElement$val _identifier: IdentifierSpec</ID>
     <ID>ConstructorParameterNaming:CvcElement.kt$CvcElement$val _identifier: IdentifierSpec</ID>
     <ID>CyclomaticComplexMethod:FormItemSpec.kt$FormItemSpecSerializer$override fun selectDeserializer(element: JsonElement): DeserializationStrategy&lt;FormItemSpec></ID>
+    <ID>CyclomaticComplexMethod:FormUI.kt$@Composable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun FormUI( hiddenIdentifiers: Set&lt;IdentifierSpec>, enabled: Boolean, elements: List&lt;FormElement>, lastTextFieldIdentifier: IdentifierSpec?, modifier: Modifier = Modifier )</ID>
     <ID>CyclomaticComplexMethod:TransformGoogleToStripeAddress.kt$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun Place.transformGoogleToStripeAddress( context: Context ): com.stripe.android.model.Address</ID>
     <ID>ForbiddenComment:Menu.kt$// TODO: Make sure this gets the rounded corner values</ID>
     <ID>LongMethod:Menu.kt$@Suppress("ModifierParameter") @Composable internal fun DropdownMenuContent( expandedStates: MutableTransitionState&lt;Boolean>, transformOriginState: MutableState&lt;TransformOrigin>, initialFirstVisibleItemIndex: Int, modifier: Modifier = Modifier, content: LazyListScope.() -> Unit )</ID>

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
@@ -72,38 +72,53 @@ fun FormUI(
     ) {
         elements.forEachIndexed { _, element ->
             if (!hiddenIdentifiers.contains(element.identifier)) {
-                when (element) {
-                    is SectionElement -> SectionElementUI(
-                        enabled,
-                        element,
-                        hiddenIdentifiers,
-                        lastTextFieldIdentifier
-                    )
-                    is CheckboxFieldElement -> CheckboxFieldUI(
-                        controller = element.controller,
-                        enabled = enabled
-                    )
-                    is StaticTextElement -> StaticTextElementUI(element)
-                    is SaveForFutureUseElement -> SaveForFutureUseElementUI(enabled, element)
-                    is AfterpayClearpayHeaderElement -> AfterpayClearpayElementUI(
-                        enabled,
-                        element
-                    )
-                    is AuBecsDebitMandateTextElement -> AuBecsDebitMandateElementUI(element)
-                    is AffirmHeaderElement -> AffirmElementUI()
-                    is MandateTextElement -> MandateTextUI(element)
-                    is CardDetailsSectionElement -> CardDetailsSectionElementUI(
-                        enabled,
-                        element.controller,
-                        hiddenIdentifiers,
-                        lastTextFieldIdentifier
-                    )
-                    is BsbElement -> BsbElementUI(enabled, element, lastTextFieldIdentifier)
-                    is OTPElement -> OTPElementUI(enabled, element)
-                    is RenderableFormElement -> element.ComposeUI(enabled)
-                    is EmptyFormElement -> {}
-                }
+                FormUIElement(
+                    element = element,
+                    enabled = enabled,
+                    lastTextFieldIdentifier = lastTextFieldIdentifier,
+                    hiddenIdentifiers = hiddenIdentifiers,
+                )
             }
         }
+    }
+}
+
+@Composable
+private fun FormUIElement(
+    element: FormElement,
+    enabled: Boolean,
+    hiddenIdentifiers: Set<IdentifierSpec>,
+    lastTextFieldIdentifier: IdentifierSpec?,
+) {
+    when (element) {
+        is SectionElement -> SectionElementUI(
+            enabled,
+            element,
+            hiddenIdentifiers,
+            lastTextFieldIdentifier
+        )
+        is CheckboxFieldElement -> CheckboxFieldUI(
+            controller = element.controller,
+            enabled = enabled
+        )
+        is StaticTextElement -> StaticTextElementUI(element)
+        is SaveForFutureUseElement -> SaveForFutureUseElementUI(enabled, element)
+        is AfterpayClearpayHeaderElement -> AfterpayClearpayElementUI(
+            enabled,
+            element
+        )
+        is AuBecsDebitMandateTextElement -> AuBecsDebitMandateElementUI(element)
+        is AffirmHeaderElement -> AffirmElementUI()
+        is MandateTextElement -> MandateTextUI(element)
+        is CardDetailsSectionElement -> CardDetailsSectionElementUI(
+            enabled,
+            element.controller,
+            hiddenIdentifiers,
+            lastTextFieldIdentifier
+        )
+        is BsbElement -> BsbElementUI(enabled, element, lastTextFieldIdentifier)
+        is OTPElement -> OTPElementUI(enabled, element)
+        is RenderableFormElement -> element.ComposeUI(enabled)
+        is EmptyFormElement -> {}
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
@@ -19,6 +19,7 @@ import com.stripe.android.ui.core.elements.CardDetailsSectionElementUI
 import com.stripe.android.ui.core.elements.EmptyFormElement
 import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.ui.core.elements.MandateTextUI
+import com.stripe.android.ui.core.elements.RenderableFormElement
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.elements.SaveForFutureUseElementUI
 import com.stripe.android.ui.core.elements.StaticTextElement
@@ -99,6 +100,7 @@ fun FormUI(
                     )
                     is BsbElement -> BsbElementUI(enabled, element, lastTextFieldIdentifier)
                     is OTPElement -> OTPElementUI(enabled, element)
+                    is RenderableFormElement -> element.ComposeUI(enabled)
                     is EmptyFormElement -> {}
                 }
             }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/RenderableFormElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/RenderableFormElement.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+import androidx.compose.runtime.Composable
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.uicore.elements.Controller
+import com.stripe.android.uicore.elements.FormElement
+import com.stripe.android.uicore.elements.IdentifierSpec
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+abstract class RenderableFormElement(
+    override val identifier: IdentifierSpec,
+    override val allowsUserInteraction: Boolean,
+) : FormElement {
+    override val controller: Controller? = null
+    override val mandateText: ResolvableString? = null
+
+    @Composable
+    abstract fun ComposeUI(enabled: Boolean)
+}

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -246,6 +246,14 @@ public final class com/stripe/android/lpmfoundations/paymentmethod/PaymentMethod
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/lpmfoundations/paymentmethod/link/LinkInlineConfiguration$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/lpmfoundations/paymentmethod/link/LinkInlineConfiguration;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/lpmfoundations/paymentmethod/link/LinkInlineConfiguration;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/paymentsheet/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
 	public static final field DEBUG Z

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -353,6 +353,16 @@ internal class CustomerSheetViewModel(
                     code = paymentMethod.code,
                     uiDefinitionFactoryArgumentsFactory = UiDefinitionFactory.Arguments.Factory.Default(
                         cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
+                        /*
+                         * `CustomerSheet` does not implement `Link` so we don't need a coordinator or callback.
+                         */
+                        linkConfigurationCoordinator = null,
+                        onLinkInlineSignupStateChanged = {
+                            throw IllegalStateException(
+                                "`CustomerSheet` does not implement `Link` and should not " +
+                                    "receive `InlineSignUpViewState` updates"
+                            )
+                        }
                     ),
                 ) ?: listOf(),
                 primaryButtonLabel = if (
@@ -720,6 +730,16 @@ internal class CustomerSheetViewModel(
             code = selectedPaymentMethod.code,
             uiDefinitionFactoryArgumentsFactory = UiDefinitionFactory.Arguments.Factory.Default(
                 cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
+                /*
+                 * `CustomerSheet` does not implement `Link` so we don't need a coordinator or callback.
+                 */
+                linkConfigurationCoordinator = null,
+                onLinkInlineSignupStateChanged = {
+                    throw IllegalStateException(
+                        "`CustomerSheet` does not implement `Link` and should not " +
+                            "receive `InlineSignUpViewState` updates"
+                    )
+                }
             )
         ) ?: emptyList()
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -219,12 +219,9 @@ internal fun AddPaymentMethod(
                 supportedPaymentMethods = viewState.supportedPaymentMethods,
                 selectedItemCode = viewState.paymentMethodCode,
                 formElements = viewState.formElements,
-                linkSignupMode = null,
-                linkConfigurationCoordinator = null,
                 onItemSelectedListener = {
                     viewActionHandler(CustomerSheetViewAction.OnAddPaymentMethodItemChanged(it))
                 },
-                onLinkSignupStateChanged = { _ -> },
                 formArguments = viewState.formArguments,
                 usBankAccountFormArguments = viewState.usBankAccountFormArguments,
                 onFormFieldValuesChanged = {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -6,6 +6,7 @@ import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.lpmfoundations.FormHeaderInformation
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.ExternalPaymentMethodUiDefinitionFactory
+import com.stripe.android.lpmfoundations.paymentmethod.link.LinkInlineConfiguration
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
@@ -42,6 +43,7 @@ internal data class PaymentMethodMetadata(
     val externalPaymentMethodSpecs: List<ExternalPaymentMethodSpec>,
     val hasCustomerConfiguration: Boolean,
     val isGooglePayReady: Boolean,
+    val linkInlineConfiguration: LinkInlineConfiguration?,
     val paymentMethodSaveConsentBehavior: PaymentMethodSaveConsentBehavior,
     val financialConnectionsAvailable: Boolean = DefaultIsFinancialConnectionsAvailable(),
 ) : Parcelable {
@@ -249,6 +251,7 @@ internal data class PaymentMethodMetadata(
             sharedDataSpecs: List<SharedDataSpec>,
             externalPaymentMethodSpecs: List<ExternalPaymentMethodSpec>,
             isGooglePayReady: Boolean,
+            linkInlineConfiguration: LinkInlineConfiguration?,
         ): PaymentMethodMetadata {
             return PaymentMethodMetadata(
                 stripeIntent = elementsSession.stripeIntent,
@@ -268,6 +271,7 @@ internal data class PaymentMethodMetadata(
                 sharedDataSpecs = sharedDataSpecs,
                 externalPaymentMethodSpecs = externalPaymentMethodSpecs,
                 paymentMethodSaveConsentBehavior = elementsSession.toPaymentSheetSaveConsentBehavior(),
+                linkInlineConfiguration = linkInlineConfiguration,
                 isGooglePayReady = isGooglePayReady,
             )
         }
@@ -296,6 +300,7 @@ internal data class PaymentMethodMetadata(
                 hasCustomerConfiguration = true,
                 sharedDataSpecs = sharedDataSpecs,
                 isGooglePayReady = isGooglePayReady,
+                linkInlineConfiguration = null,
                 financialConnectionsAvailable = isFinancialConnectionsAvailable(),
                 paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
                 externalPaymentMethodSpecs = emptyList(),

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.lpmfoundations.paymentmethod
 
 import com.stripe.android.cards.CardAccountRangeRepository
+import com.stripe.android.link.LinkConfigurationCoordinator
+import com.stripe.android.link.ui.inline.InlineSignupViewState
 import com.stripe.android.lpmfoundations.FormHeaderInformation
 import com.stripe.android.lpmfoundations.luxe.InitialValuesFactory
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
@@ -18,6 +20,7 @@ import com.stripe.android.uicore.elements.IdentifierSpec
 internal sealed interface UiDefinitionFactory {
     class Arguments(
         val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
+        val linkConfigurationCoordinator: LinkConfigurationCoordinator?,
         val initialValues: Map<IdentifierSpec, String?>,
         val shippingValues: Map<IdentifierSpec, String?>?,
         val amount: Amount?,
@@ -26,6 +29,7 @@ internal sealed interface UiDefinitionFactory {
         val cbcEligibility: CardBrandChoiceEligibility,
         val billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration,
         val requiresMandate: Boolean,
+        val onLinkInlineSignupStateChanged: (InlineSignupViewState) -> Unit,
     ) {
         interface Factory {
             fun create(
@@ -37,6 +41,8 @@ internal sealed interface UiDefinitionFactory {
                 private val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
                 private val paymentMethodCreateParams: PaymentMethodCreateParams? = null,
                 private val paymentMethodExtraParams: PaymentMethodExtraParams? = null,
+                private val linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
+                private val onLinkInlineSignupStateChanged: (InlineSignupViewState) -> Unit = {}
             ) : Factory {
                 override fun create(
                     metadata: PaymentMethodMetadata,
@@ -44,6 +50,7 @@ internal sealed interface UiDefinitionFactory {
                 ): Arguments {
                     return Arguments(
                         cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
+                        linkConfigurationCoordinator = linkConfigurationCoordinator,
                         amount = metadata.amount(),
                         merchantName = metadata.merchantName,
                         cbcEligibility = metadata.cbcEligibility,
@@ -56,6 +63,7 @@ internal sealed interface UiDefinitionFactory {
                         saveForFutureUseInitialValue = false,
                         billingDetailsCollectionConfiguration = metadata.billingDetailsCollectionConfiguration,
                         requiresMandate = requiresMandate,
+                        onLinkInlineSignupStateChanged = onLinkInlineSignupStateChanged,
                     )
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
@@ -39,10 +39,10 @@ internal sealed interface UiDefinitionFactory {
 
             class Default(
                 private val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
+                private val linkConfigurationCoordinator: LinkConfigurationCoordinator?,
+                private val onLinkInlineSignupStateChanged: (InlineSignupViewState) -> Unit,
                 private val paymentMethodCreateParams: PaymentMethodCreateParams? = null,
                 private val paymentMethodExtraParams: PaymentMethodExtraParams? = null,
-                private val linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
-                private val onLinkInlineSignupStateChanged: (InlineSignupViewState) -> Unit = {}
             ) : Factory {
                 override fun create(
                     metadata: PaymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -9,6 +9,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequireme
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
+import com.stripe.android.lpmfoundations.paymentmethod.link.LinkFormElement
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
@@ -105,6 +106,16 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
                 )
             ) {
                 add(SaveForFutureUseElement(arguments.saveForFutureUseInitialValue, arguments.merchantName))
+            }
+
+            if (metadata.linkInlineConfiguration != null && arguments.linkConfigurationCoordinator != null) {
+                add(
+                    LinkFormElement(
+                        configuration = metadata.linkInlineConfiguration,
+                        linkConfigurationCoordinator = arguments.linkConfigurationCoordinator,
+                        onLinkInlineSignupStateChanged = arguments.onLinkInlineSignupStateChanged,
+                    )
+                )
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElement.kt
@@ -1,0 +1,35 @@
+package com.stripe.android.lpmfoundations.paymentmethod.link
+
+import androidx.compose.runtime.Composable
+import com.stripe.android.link.LinkConfigurationCoordinator
+import com.stripe.android.link.ui.inline.InlineSignupViewState
+import com.stripe.android.link.ui.inline.LinkElement
+import com.stripe.android.ui.core.elements.RenderableFormElement
+import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.forms.FormFieldEntry
+import com.stripe.android.uicore.utils.stateFlowOf
+import kotlinx.coroutines.flow.StateFlow
+
+internal class LinkFormElement(
+    private val configuration: LinkInlineConfiguration,
+    private val linkConfigurationCoordinator: LinkConfigurationCoordinator,
+    private val onLinkInlineSignupStateChanged: (InlineSignupViewState) -> Unit,
+) : RenderableFormElement(
+    allowsUserInteraction = true,
+    identifier = IdentifierSpec.Generic("link_form")
+) {
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
+        return stateFlowOf(listOf())
+    }
+
+    @Composable
+    override fun ComposeUI(enabled: Boolean) {
+        LinkElement(
+            linkConfigurationCoordinator = linkConfigurationCoordinator,
+            linkSignupMode = configuration.signupMode,
+            configuration = configuration.linkConfiguration,
+            enabled = enabled,
+            onLinkSignupStateChanged = onLinkInlineSignupStateChanged,
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkInlineConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkInlineConfiguration.kt
@@ -1,0 +1,12 @@
+package com.stripe.android.lpmfoundations.paymentmethod.link
+
+import android.os.Parcelable
+import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.ui.inline.LinkSignupMode
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+internal data class LinkInlineConfiguration(
+    val signupMode: LinkSignupMode,
+    val linkConfiguration: LinkConfiguration,
+) : Parcelable

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormHelper.kt
@@ -2,6 +2,8 @@ package com.stripe.android.paymentsheet
 
 import android.content.Context
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
+import com.stripe.android.link.LinkConfigurationCoordinator
+import com.stripe.android.link.ui.inline.InlineSignupViewState
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
@@ -19,15 +21,23 @@ internal class FormHelper(
     private val paymentMethodMetadata: PaymentMethodMetadata,
     private val newPaymentSelectionProvider: () -> NewOrExternalPaymentSelection?,
     private val selectionUpdater: (PaymentSelection?) -> Unit,
+    private val linkConfigurationCoordinator: LinkConfigurationCoordinator,
+    private val onLinkInlineSignupStateChanged: (InlineSignupViewState) -> Unit,
 ) {
     companion object {
-        fun create(viewModel: BaseSheetViewModel, paymentMethodMetadata: PaymentMethodMetadata): FormHelper {
+        fun create(
+            viewModel: BaseSheetViewModel,
+            linkInlineHandler: LinkInlineHandler,
+            paymentMethodMetadata: PaymentMethodMetadata
+        ): FormHelper {
             return FormHelper(
                 context = viewModel.getApplication(),
                 paymentMethodMetadata = paymentMethodMetadata,
                 newPaymentSelectionProvider = {
                     viewModel.newPaymentSelection
                 },
+                linkConfigurationCoordinator = viewModel.linkConfigurationCoordinator,
+                onLinkInlineSignupStateChanged = linkInlineHandler::onStateUpdated,
                 selectionUpdater = {
                     viewModel.updateSelection(it)
                 }
@@ -44,6 +54,8 @@ internal class FormHelper(
             code = code,
             uiDefinitionFactoryArgumentsFactory = UiDefinitionFactory.Arguments.Factory.Default(
                 cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
+                linkConfigurationCoordinator = linkConfigurationCoordinator,
+                onLinkInlineSignupStateChanged = onLinkInlineSignupStateChanged,
                 paymentMethodCreateParams = currentSelection?.getPaymentMethodCreateParams(),
                 paymentMethodExtraParams = currentSelection?.getPaymentMethodExtraParams(),
             ),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
@@ -11,7 +11,6 @@ import com.stripe.android.link.account.LinkStore
 import com.stripe.android.link.analytics.LinkAnalyticsHelper
 import com.stripe.android.link.injection.LinkAnalyticsComponent
 import com.stripe.android.link.model.AccountStatus
-import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentMethod
@@ -72,9 +71,6 @@ internal class LinkHandler @Inject constructor(
     private val _linkConfiguration = MutableStateFlow<LinkConfiguration?>(null)
     private val linkConfiguration: StateFlow<LinkConfiguration?> = _linkConfiguration.asStateFlow()
 
-    private val _linkSignupMode = MutableStateFlow<LinkSignupMode?>(null)
-    val linkSignupMode: StateFlow<LinkSignupMode?> = _linkSignupMode.asStateFlow()
-
     private val linkAnalyticsHelper: LinkAnalyticsHelper by lazy {
         linkAnalyticsComponentBuilder.build().linkAnalyticsHelper
     }
@@ -95,9 +91,7 @@ internal class LinkHandler @Inject constructor(
 
         if (state == null) return
 
-        linkConfigurationCoordinator.setConfiguration(state.configuration)
         _linkConfiguration.value = state.configuration
-        _linkSignupMode.value = state.signupMode
     }
 
     suspend fun payWithLinkInline(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/FormControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/FormControllerModule.kt
@@ -43,8 +43,16 @@ internal object FormControllerModule {
             cbcEligibility = CardBrandChoiceEligibility.Ineligible,
             billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
             requiresMandate = false,
+            /*
+             * `FormController` is only used by `AddressElement` now so it does not require a
+             * `LinkConfigurationCoordinator` instance or a callback for reacting to `InlineSignUpViewState` changes.
+             */
             linkConfigurationCoordinator = null,
-            onLinkInlineSignupStateChanged = {}
+            onLinkInlineSignupStateChanged = {
+                throw IllegalStateException(
+                    "`InlineSignUpViewState` updates should not be received by `FormController`!"
+                )
+            },
         )
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/FormControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/FormControllerModule.kt
@@ -43,6 +43,8 @@ internal object FormControllerModule {
             cbcEligibility = CardBrandChoiceEligibility.Ineligible,
             billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
             requiresMandate = false,
+            linkConfigurationCoordinator = null,
+            onLinkInlineSignupStateChanged = {}
         )
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -14,6 +14,7 @@ import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.lpmfoundations.luxe.isSaveForFutureUseValueChangeable
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.link.LinkInlineConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.toPaymentSheetSaveConsentBehavior
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
@@ -102,30 +103,12 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
 
         val isGooglePayReady = isGooglePayReady(paymentSheetConfiguration, elementsSession)
 
-        val metadata = createPaymentMethodMetadata(
-            paymentSheetConfiguration = paymentSheetConfiguration,
-            elementsSession = elementsSession,
-            isGooglePayReady = isGooglePayReady,
-        )
-
         val savedSelection = async {
             retrieveSavedSelection(
                 config = paymentSheetConfiguration,
                 isGooglePayReady = isGooglePayReady,
                 elementsSession = elementsSession
             )
-        }
-
-        val customer = async {
-            createCustomerState(
-                customerInfo = customerInfo,
-                metadata = metadata,
-                savedSelection = savedSelection,
-            )
-        }
-
-        val initialPaymentSelection = async {
-            retrieveInitialPaymentSelection(savedSelection, customer)
         }
 
         val linkState = async {
@@ -136,22 +119,45 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             )
         }
 
+        val metadata = async {
+            createPaymentMethodMetadata(
+                paymentSheetConfiguration = paymentSheetConfiguration,
+                elementsSession = elementsSession,
+                isGooglePayReady = isGooglePayReady,
+                linkState = linkState.await(),
+            )
+        }
+
+        val customer = async {
+            createCustomerState(
+                customerInfo = customerInfo,
+                metadata = metadata.await(),
+                savedSelection = savedSelection,
+            )
+        }
+
+        val initialPaymentSelection = async {
+            retrieveInitialPaymentSelection(savedSelection, customer)
+        }
+
         val stripeIntent = elementsSession.stripeIntent
+        val paymentMethodMetadata = metadata.await()
 
         warnUnactivatedIfNeeded(stripeIntent)
 
-        if (!supportsIntent(metadata)) {
+        if (!supportsIntent(paymentMethodMetadata)) {
             val requested = stripeIntent.paymentMethodTypes.joinToString(separator = ", ")
             throw PaymentSheetLoadingException.NoPaymentMethodTypesAvailable(requested)
         }
 
+        val fetchedLinkState = linkState.await()
         val state = PaymentSheetState.Full(
             config = paymentSheetConfiguration,
             customer = customer.await(),
-            linkState = linkState.await(),
+            linkState = fetchedLinkState,
             paymentSelection = initialPaymentSelection.await(),
             validationError = stripeIntent.validate(),
-            paymentMethodMetadata = metadata,
+            paymentMethodMetadata = paymentMethodMetadata,
         )
 
         reportSuccessfulLoad(
@@ -182,6 +188,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
     private fun createPaymentMethodMetadata(
         paymentSheetConfiguration: PaymentSheet.Configuration,
         elementsSession: ElementsSession,
+        linkState: LinkState?,
         isGooglePayReady: Boolean,
     ): PaymentMethodMetadata {
         val sharedDataSpecsResult = lpmRepository.getSharedDataSpecs(
@@ -208,6 +215,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             sharedDataSpecs = sharedDataSpecsResult.sharedDataSpecs,
             externalPaymentMethodSpecs = externalPaymentMethodSpecs,
             isGooglePayReady = isGooglePayReady,
+            linkInlineConfiguration = createLinkInlineConfiguration(linkState),
         )
     }
 
@@ -515,6 +523,17 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             isGooglePayAvailable = isGooglePayReady,
             isLinkAvailable = isLinkAvailable,
         )
+    }
+
+    private fun createLinkInlineConfiguration(state: LinkState?): LinkInlineConfiguration? {
+        return state?.run {
+            signupMode?.let { linkSignupMode ->
+                LinkInlineConfiguration(
+                    linkConfiguration = configuration,
+                    signupMode = linkSignupMode,
+                )
+            }
+        }
     }
 
     private fun warnUnactivatedIfNeeded(stripeIntent: StripeIntent) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -150,11 +150,10 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             throw PaymentSheetLoadingException.NoPaymentMethodTypesAvailable(requested)
         }
 
-        val fetchedLinkState = linkState.await()
         val state = PaymentSheetState.Full(
             config = paymentSheetConfiguration,
             customer = customer.await(),
-            linkState = fetchedLinkState,
+            linkState = linkState.await(),
             paymentSelection = initialPaymentSelection.await(),
             validationError = stripeIntent.validate(),
             paymentMethodMetadata = paymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -29,18 +29,11 @@ internal fun AddPaymentMethod(
         supportedPaymentMethods = state.supportedPaymentMethods,
         selectedItemCode = state.selectedPaymentMethodCode,
         formElements = state.formElements,
-        linkSignupMode = state.linkInlineSignupMode,
-        linkConfigurationCoordinator = state.linkConfigurationCoordinator,
         onItemSelectedListener = { selectedLpm ->
             interactor.handleViewAction(
                 AddPaymentMethodInteractor.ViewAction.OnPaymentMethodSelected(
                     selectedLpm.code
                 )
-            )
-        },
-        onLinkSignupStateChanged = {
-            interactor.handleViewAction(
-                AddPaymentMethodInteractor.ViewAction.OnLinkSignUpStateUpdated(it)
             )
         },
         formArguments = state.arguments,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
@@ -18,10 +18,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.stripe.android.link.LinkConfigurationCoordinator
-import com.stripe.android.link.ui.inline.InlineSignupViewState
-import com.stripe.android.link.ui.inline.LinkElement
-import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.PaymentMethod.Type.Link
 import com.stripe.android.model.PaymentMethod.Type.USBankAccount
@@ -41,10 +37,7 @@ internal fun PaymentElement(
     supportedPaymentMethods: List<SupportedPaymentMethod>,
     selectedItemCode: PaymentMethodCode,
     formElements: List<FormElement>,
-    linkSignupMode: LinkSignupMode?,
-    linkConfigurationCoordinator: LinkConfigurationCoordinator?,
     onItemSelectedListener: (SupportedPaymentMethod) -> Unit,
-    onLinkSignupStateChanged: (InlineSignupViewState) -> Unit,
     formArguments: FormArguments,
     usBankAccountFormArguments: USBankAccountFormArguments,
     onFormFieldValuesChanged: (FormFieldValues?) -> Unit,
@@ -88,14 +81,6 @@ internal fun PaymentElement(
             horizontalPadding = horizontalPadding,
             onFormFieldValuesChanged = onFormFieldValuesChanged,
             onInteractionEvent = onInteractionEvent,
-        )
-
-        LinkElement(
-            linkConfigurationCoordinator = linkConfigurationCoordinator,
-            linkSignupMode = linkSignupMode,
-            enabled = enabled,
-            horizontalPadding = horizontalPadding,
-            onLinkSignupStateChanged = onLinkSignupStateChanged,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.verticalmode
 
+import androidx.lifecycle.viewModelScope
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -8,6 +9,7 @@ import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.FormHelper
+import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
 import com.stripe.android.paymentsheet.analytics.code
@@ -94,7 +96,8 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
             customerStateHolder: CustomerStateHolder,
             savedPaymentMethodMutator: SavedPaymentMethodMutator,
         ): PaymentMethodVerticalLayoutInteractor {
-            val formHelper = FormHelper.create(viewModel = viewModel, paymentMethodMetadata = paymentMethodMetadata)
+            val linkInlineHandler = LinkInlineHandler.create(viewModel, viewModel.viewModelScope)
+            val formHelper = FormHelper.create(viewModel, linkInlineHandler, paymentMethodMetadata)
             return DefaultPaymentMethodVerticalLayoutInteractor(
                 paymentMethodMetadata = paymentMethodMetadata,
                 processing = viewModel.processing,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
@@ -1,11 +1,7 @@
 package com.stripe.android.paymentsheet.verticalmode
 
-import com.stripe.android.link.LinkConfigurationCoordinator
-import com.stripe.android.link.ui.inline.InlineSignupViewState
-import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.lpmfoundations.FormHeaderInformation
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.FormHelper
@@ -15,7 +11,7 @@ import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.utils.combineAsStateFlow
+import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -39,23 +35,17 @@ internal interface VerticalModeFormInteractor {
         val usBankAccountFormArguments: USBankAccountFormArguments,
         val formArguments: FormArguments,
         val formElements: List<FormElement>,
-        val linkSignupMode: LinkSignupMode?,
-        val linkConfigurationCoordinator: LinkConfigurationCoordinator,
         val headerInformation: FormHeaderInformation?,
     )
 
     sealed interface ViewAction {
         data object FieldInteraction : ViewAction
         data class FormFieldValuesChanged(val formValues: FormFieldValues?) : ViewAction
-        data class LinkSignupStateChanged(val linkInlineSignupViewState: InlineSignupViewState) : ViewAction
     }
 }
 
 internal class DefaultVerticalModeFormInteractor(
     private val selectedPaymentMethodCode: String,
-    private val linkConfigurationCoordinator: LinkConfigurationCoordinator,
-    private val onLinkInlineStateUpdated: (InlineSignupViewState) -> Unit,
-    private val linkSignupMode: StateFlow<LinkSignupMode?>,
     private val formArguments: FormArguments,
     private val formElements: List<FormElement>,
     private val onFormFieldValuesChanged: (formValues: FormFieldValues?, selectedPaymentMethodCode: String) -> Unit,
@@ -67,18 +57,13 @@ internal class DefaultVerticalModeFormInteractor(
     processing: StateFlow<Boolean>,
     private val coroutineScope: CoroutineScope,
 ) : VerticalModeFormInteractor {
-    override val state: StateFlow<VerticalModeFormInteractor.State> = combineAsStateFlow(
-        processing,
-        linkSignupMode,
-    ) { isProcessing, linkSignupMode ->
+    override val state: StateFlow<VerticalModeFormInteractor.State> = processing.mapAsStateFlow { isProcessing ->
         VerticalModeFormInteractor.State(
             selectedPaymentMethodCode = selectedPaymentMethodCode,
             isProcessing = isProcessing,
             usBankAccountFormArguments = usBankAccountArguments,
             formArguments = formArguments,
             formElements = formElements,
-            linkSignupMode = linkSignupMode.takeIf { selectedPaymentMethodCode == PaymentMethod.Type.Card.code },
-            linkConfigurationCoordinator = linkConfigurationCoordinator,
             headerInformation = headerInformation,
         )
     }
@@ -90,9 +75,6 @@ internal class DefaultVerticalModeFormInteractor(
             }
             is VerticalModeFormInteractor.ViewAction.FormFieldValuesChanged -> {
                 onFormFieldValuesChanged(viewAction.formValues, selectedPaymentMethodCode)
-            }
-            is VerticalModeFormInteractor.ViewAction.LinkSignupStateChanged -> {
-                onLinkInlineStateUpdated(viewAction.linkInlineSignupViewState)
             }
         }
     }
@@ -113,12 +95,13 @@ internal class DefaultVerticalModeFormInteractor(
             customerStateHolder: CustomerStateHolder,
         ): VerticalModeFormInteractor {
             val coroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
-            val formHelper = FormHelper.create(viewModel = viewModel, paymentMethodMetadata = paymentMethodMetadata)
+            val formHelper = FormHelper.create(
+                viewModel = viewModel,
+                linkInlineHandler = LinkInlineHandler.create(viewModel, coroutineScope),
+                paymentMethodMetadata = paymentMethodMetadata
+            )
             return DefaultVerticalModeFormInteractor(
                 selectedPaymentMethodCode = selectedPaymentMethodCode,
-                linkConfigurationCoordinator = viewModel.linkConfigurationCoordinator,
-                onLinkInlineStateUpdated = LinkInlineHandler.create(viewModel, coroutineScope)::onStateUpdated,
-                linkSignupMode = viewModel.linkHandler.linkSignupMode,
                 formArguments = formHelper.createFormArguments(selectedPaymentMethodCode),
                 formElements = formHelper.formElementsForCode(selectedPaymentMethodCode),
                 onFormFieldValuesChanged = formHelper::onFormFieldValuesChanged,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUI.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.stripe.android.link.ui.inline.LinkElement
 import com.stripe.android.lpmfoundations.FormHeaderInformation
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.ui.FormElement
@@ -64,16 +63,6 @@ internal fun VerticalModeFormUI(interactor: VerticalModeFormInteractor) {
                     interactor.handleViewAction(VerticalModeFormInteractor.ViewAction.FieldInteraction)
                     hasSentInteractionEvent = true
                 }
-            },
-        )
-
-        LinkElement(
-            linkConfigurationCoordinator = state.linkConfigurationCoordinator,
-            linkSignupMode = state.linkSignupMode,
-            enabled = enabled,
-            horizontalPadding = horizontalPadding,
-            onLinkSignupStateChanged = {
-                interactor.handleViewAction(VerticalModeFormInteractor.ViewAction.LinkSignupStateChanged(it))
             },
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
@@ -109,7 +109,7 @@ class FormElementsBuilderTest {
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
             requiresMandate = false,
             linkConfigurationCoordinator = null,
-            onLinkInlineSignupStateChanged = {},
+            onLinkInlineSignupStateChanged = { throw AssertionError("Not implemented") },
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
@@ -108,6 +108,8 @@ class FormElementsBuilderTest {
             cbcEligibility = CardBrandChoiceEligibility.Ineligible,
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
             requiresMandate = false,
+            linkConfigurationCoordinator = null,
+            onLinkInlineSignupStateChanged = {},
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
@@ -387,6 +387,8 @@ private object TransformSpecToElementsFactory {
                 cbcEligibility = CardBrandChoiceEligibility.Ineligible,
                 billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
                 requiresMandate = requiresMandate,
+                linkConfigurationCoordinator = null,
+                onLinkInlineSignupStateChanged = {},
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
@@ -388,7 +388,7 @@ private object TransformSpecToElementsFactory {
                 billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
                 requiresMandate = requiresMandate,
                 linkConfigurationCoordinator = null,
-                onLinkInlineSignupStateChanged = {},
+                onLinkInlineSignupStateChanged = { throw AssertionError("Not implemented") },
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.lpmfoundations.paymentmethod
 
+import com.stripe.android.lpmfoundations.paymentmethod.link.LinkInlineConfiguration
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -26,6 +27,7 @@ internal object PaymentMethodMetadataFactory {
         externalPaymentMethodSpecs: List<ExternalPaymentMethodSpec> = emptyList(),
         isGooglePayReady: Boolean = false,
         paymentMethodSaveConsentBehavior: PaymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+        linkInlineConfiguration: LinkInlineConfiguration? = null,
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,
@@ -43,6 +45,7 @@ internal object PaymentMethodMetadataFactory {
             paymentMethodSaveConsentBehavior = paymentMethodSaveConsentBehavior,
             externalPaymentMethodSpecs = externalPaymentMethodSpecs,
             isGooglePayReady = isGooglePayReady,
+            linkInlineConfiguration = linkInlineConfiguration,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -4,8 +4,11 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.AffirmDefinition
+import com.stripe.android.lpmfoundations.paymentmethod.link.LinkInlineConfiguration
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentIntentFixtures
@@ -737,9 +740,9 @@ internal class PaymentMethodMetadataTest {
             address = PaymentSheet.Address(line1 = "123 Apple Street")
         )
 
-        val shippingDetails = AddressDetails(
-            address = PaymentSheet.Address(line1 = "123 Pear Street")
-        )
+        val shippingDetails = AddressDetails(address = PaymentSheet.Address(line1 = "123 Pear Street"))
+
+        val linkInlineConfiguration = createLinkInlineConfiguration()
 
         val metadata = PaymentMethodMetadata.create(
             elementsSession = createElementsSession(
@@ -763,6 +766,7 @@ internal class PaymentMethodMetadataTest {
             sharedDataSpecs = listOf(SharedDataSpec("card")),
             externalPaymentMethodSpecs = listOf(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC),
             isGooglePayReady = false,
+            linkInlineConfiguration = linkInlineConfiguration,
         )
 
         assertThat(metadata).isEqualTo(
@@ -783,6 +787,7 @@ internal class PaymentMethodMetadataTest {
                 hasCustomerConfiguration = true,
                 paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
                 isGooglePayReady = false,
+                linkInlineConfiguration = linkInlineConfiguration,
             )
         )
     }
@@ -841,6 +846,7 @@ internal class PaymentMethodMetadataTest {
                 isGooglePayReady = true,
                 paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
                 financialConnectionsAvailable = false,
+                linkInlineConfiguration = null,
             )
         )
     }
@@ -905,6 +911,7 @@ internal class PaymentMethodMetadataTest {
             sharedDataSpecs = listOf(),
             externalPaymentMethodSpecs = listOf(),
             isGooglePayReady = false,
+            linkInlineConfiguration = null,
         )
     }
 
@@ -1239,4 +1246,24 @@ internal class PaymentMethodMetadataTest {
                 )
             ).isEqualTo(PaymentMethod.AllowRedisplay.UNSPECIFIED)
         }
+
+    private fun createLinkInlineConfiguration(): LinkInlineConfiguration {
+        return LinkInlineConfiguration(
+            signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
+            linkConfiguration = LinkConfiguration(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+                customerInfo = LinkConfiguration.CustomerInfo(
+                    email = "john@email.com",
+                    name = "John Doe",
+                    billingCountryCode = "CA",
+                    phone = "1234567890"
+                ),
+                merchantName = "Merchant Inc.",
+                merchantCountryCode = "CA",
+                shippingValues = mapOf(),
+                flags = mapOf(),
+                passthroughModeEnabled = false,
+            ),
+        )
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/TestUiDefinitionFactoryArgumentsFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/TestUiDefinitionFactoryArgumentsFactory.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.cards.CardNumber
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
+import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.model.AccountRange
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
@@ -17,6 +18,7 @@ internal object TestUiDefinitionFactoryArgumentsFactory {
     fun create(
         paymentMethodCreateParams: PaymentMethodCreateParams? = null,
         paymentMethodExtraParams: PaymentMethodExtraParams? = null,
+        linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
     ): UiDefinitionFactory.Arguments.Factory {
         val context: Context? = try {
             ApplicationProvider.getApplicationContext<Application>()
@@ -27,6 +29,7 @@ internal object TestUiDefinitionFactoryArgumentsFactory {
             cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory(context),
             paymentMethodCreateParams = paymentMethodCreateParams,
             paymentMethodExtraParams = paymentMethodExtraParams,
+            linkConfigurationCoordinator = linkConfigurationCoordinator,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/TestUiDefinitionFactoryArgumentsFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/TestUiDefinitionFactoryArgumentsFactory.kt
@@ -30,6 +30,7 @@ internal object TestUiDefinitionFactoryArgumentsFactory {
             paymentMethodCreateParams = paymentMethodCreateParams,
             paymentMethodExtraParams = paymentMethodExtraParams,
             linkConfigurationCoordinator = linkConfigurationCoordinator,
+            onLinkInlineSignupStateChanged = { throw AssertionError("Not implemented") },
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionTestHelper.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.lpmfoundations.paymentmethod
 
+import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.uicore.elements.FormElement
@@ -8,6 +9,7 @@ internal fun PaymentMethodDefinition.formElements(
     metadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
     paymentMethodCreateParams: PaymentMethodCreateParams? = null,
     paymentMethodExtraParams: PaymentMethodExtraParams? = null,
+    linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
 ): List<FormElement> {
     return requireNotNull(
         metadata.formElementsForCode(
@@ -15,6 +17,7 @@ internal fun PaymentMethodDefinition.formElements(
             uiDefinitionFactoryArgumentsFactory = TestUiDefinitionFactoryArgumentsFactory.create(
                 paymentMethodCreateParams = paymentMethodCreateParams,
                 paymentMethodExtraParams = paymentMethodExtraParams,
+                linkConfigurationCoordinator = linkConfigurationCoordinator,
             )
         )
     )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
@@ -1,11 +1,17 @@
 package com.stripe.android.lpmfoundations.paymentmethod.definitions
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.formElements
+import com.stripe.android.lpmfoundations.paymentmethod.link.LinkFormElement
+import com.stripe.android.lpmfoundations.paymentmethod.link.LinkInlineConfiguration
+import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.uicore.elements.SectionElement
+import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -86,5 +92,39 @@ class CardDefinitionTest {
         assertThat(formElements).hasSize(2)
         assertThat(formElements[0].identifier.v1).isEqualTo("card_details")
         assertThat(formElements[1].identifier.v1).isEqualTo("save_for_future_use")
+    }
+
+    @Test
+    fun `createFormElements returns link_form`() {
+        val formElements = CardDefinition.formElements(
+            PaymentMethodMetadataFactory.create(
+                linkInlineConfiguration = LinkInlineConfiguration(
+                    signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
+                    linkConfiguration = createLinkConfiguration()
+                )
+            ),
+            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+        )
+
+        assertThat(formElements).hasSize(3)
+        assertThat(formElements[2].identifier.v1).isEqualTo("link_form")
+        assertThat(formElements[2]).isInstanceOf(LinkFormElement::class.java)
+    }
+
+    private fun createLinkConfiguration(): LinkConfiguration {
+        return LinkConfiguration(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            merchantCountryCode = "Merchant, Inc.",
+            merchantName = "John Doe",
+            customerInfo = LinkConfiguration.CustomerInfo(
+                name = "John Doe",
+                email = "email@email.com",
+                billingCountryCode = "CA",
+                phone = "1234567890"
+            ),
+            flags = mapOf(),
+            passthroughModeEnabled = false,
+            shippingValues = mapOf()
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UiDefinitionTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UiDefinitionTestHelper.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.lpmfoundations.paymentmethod.definitions
 
 import androidx.compose.runtime.Composable
+import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.formElements
@@ -13,11 +14,13 @@ internal fun PaymentMethodDefinition.CreateFormUi(
     metadata: PaymentMethodMetadata,
     paymentMethodCreateParams: PaymentMethodCreateParams? = null,
     paymentMethodExtraParams: PaymentMethodExtraParams? = null,
+    linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
 ) {
     val formElements = formElements(
         metadata = metadata,
         paymentMethodCreateParams = paymentMethodCreateParams,
         paymentMethodExtraParams = paymentMethodExtraParams,
+        linkConfigurationCoordinator = linkConfigurationCoordinator,
     )
     FormUI(
         hiddenIdentifiers = emptySet(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry
+import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -166,6 +167,8 @@ internal class FormHelperTest {
             context = ApplicationProvider.getApplicationContext(),
             paymentMethodMetadata = paymentMethodMetadata,
             newPaymentSelectionProvider = newPaymentSelectionProvider,
+            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+            onLinkInlineSignupStateChanged = {},
             selectionUpdater = selectionUpdater,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
@@ -168,7 +168,7 @@ internal class FormHelperTest {
             paymentMethodMetadata = paymentMethodMetadata,
             newPaymentSelectionProvider = newPaymentSelectionProvider,
             linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
-            onLinkInlineSignupStateChanged = {},
+            onLinkInlineSignupStateChanged = { throw AssertionError("Not implemented") },
             selectionUpdater = selectionUpdater,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/LinkHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/LinkHandlerTest.kt
@@ -59,8 +59,6 @@ class LinkHandlerTest {
             )
         )
         assertThat(handler.isLinkEnabled.first()).isTrue()
-        verify(linkConfigurationCoordinator).setConfiguration(configuration)
-        assertThat(handler.linkSignupMode.value).isEqualTo(LinkSignupMode.InsteadOfSaveForFutureUse)
         assertThat(savedStateHandle.get<PaymentSelection>(SAVE_SELECTION)).isNull()
     }
 
@@ -74,8 +72,6 @@ class LinkHandlerTest {
             )
         )
         assertThat(handler.isLinkEnabled.first()).isTrue()
-        verify(linkConfigurationCoordinator).setConfiguration(configuration)
-        assertThat(handler.linkSignupMode.value).isEqualTo(LinkSignupMode.AlongsideSaveForFutureUse)
         assertThat(savedStateHandle.get<PaymentSelection>(SAVE_SELECTION)).isNull()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1490,6 +1490,7 @@ internal class PaymentSheetViewModelTest {
 
         val observedArgs = FormHelper.create(
             viewModel = viewModel,
+            linkInlineHandler = LinkInlineHandler.create(viewModel, viewModel.viewModelScope),
             paymentMethodMetadata = requireNotNull(viewModel.paymentMethodMetadata.value),
         ).createFormArguments(
             paymentMethodCode = LpmRepositoryTestHelpers.card.code,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FormControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FormControllerTest.kt
@@ -45,7 +45,7 @@ class FormControllerTest {
             billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
             requiresMandate = false,
             linkConfigurationCoordinator = null,
-            onLinkInlineSignupStateChanged = {},
+            onLinkInlineSignupStateChanged = { throw AssertionError("Not implemented") },
         )
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FormControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FormControllerTest.kt
@@ -44,6 +44,8 @@ class FormControllerTest {
             cbcEligibility = CardBrandChoiceEligibility.Ineligible,
             billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
             requiresMandate = false,
+            linkConfigurationCoordinator = null,
+            onLinkInlineSignupStateChanged = {},
         )
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenAddAnotherPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenAddAnotherPaymentMethodTest.kt
@@ -75,11 +75,8 @@ internal class PaymentSheetScreenAddAnotherPaymentMethodTest {
             arguments = mock(),
             formElements = emptyList(),
             paymentSelection = null,
-            linkSignupMode = null,
-            linkInlineSignupMode = null,
             processing = false,
             usBankAccountFormArguments = mock(),
-            linkConfigurationCoordinator = mock(),
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenAddFirstPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenAddFirstPaymentMethodTest.kt
@@ -76,11 +76,8 @@ internal class PaymentSheetScreenAddFirstPaymentMethodTest {
             arguments = mock(),
             formElements = emptyList(),
             paymentSelection = null,
-            linkSignupMode = null,
-            linkInlineSignupMode = null,
             processing = false,
             usBankAccountFormArguments = mock(),
-            linkConfigurationCoordinator = mock(),
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -642,18 +642,18 @@ internal class DefaultPaymentSheetLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.configuration?.flags).containsExactlyEntriesIn(
-            mapOf(
-                "link_authenticated_change_event_enabled" to false,
-                "link_bank_incentives_enabled" to false,
-                "link_bank_onboarding_enabled" to false,
-                "link_email_verification_login_enabled" to false,
-                "link_financial_incentives_experiment_enabled" to false,
-                "link_local_storage_login_enabled" to true,
-                "link_only_for_payment_method_types_enabled" to false,
-                "link_passthrough_mode_enabled" to true,
-            )
+        val expectedFlags = mapOf(
+            "link_authenticated_change_event_enabled" to false,
+            "link_bank_incentives_enabled" to false,
+            "link_bank_onboarding_enabled" to false,
+            "link_email_verification_login_enabled" to false,
+            "link_financial_incentives_experiment_enabled" to false,
+            "link_local_storage_login_enabled" to true,
+            "link_only_for_payment_method_types_enabled" to false,
+            "link_passthrough_mode_enabled" to true,
         )
+
+        assertThat(result.linkState?.configuration?.flags).containsExactlyEntriesIn(expectedFlags)
     }
 
     @Test
@@ -678,6 +678,7 @@ internal class DefaultPaymentSheetLoaderTest {
         ).getOrThrow()
 
         assertThat(result.linkState?.signupMode).isNull()
+        assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode).isNull()
     }
 
     @Test
@@ -699,6 +700,7 @@ internal class DefaultPaymentSheetLoaderTest {
         ).getOrThrow()
 
         assertThat(result.linkState?.signupMode).isNull()
+        assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode).isNull()
     }
 
     @Test
@@ -717,6 +719,7 @@ internal class DefaultPaymentSheetLoaderTest {
         ).getOrThrow()
 
         assertThat(result.linkState?.signupMode).isNull()
+        assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode).isNull()
     }
 
     @Test
@@ -732,6 +735,7 @@ internal class DefaultPaymentSheetLoaderTest {
         ).getOrThrow()
 
         assertThat(result.linkState?.signupMode).isNull()
+        assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode).isNull()
     }
 
     @Test
@@ -747,6 +751,7 @@ internal class DefaultPaymentSheetLoaderTest {
         ).getOrThrow()
 
         assertThat(result.linkState?.signupMode).isNull()
+        assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode).isNull()
     }
 
     @Test
@@ -762,6 +767,7 @@ internal class DefaultPaymentSheetLoaderTest {
         ).getOrThrow()
 
         assertThat(result.linkState?.signupMode).isNull()
+        assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode).isNull()
     }
 
     @Test
@@ -780,6 +786,8 @@ internal class DefaultPaymentSheetLoaderTest {
         ).getOrThrow()
 
         assertThat(result.linkState?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
+        assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode)
+            .isEqualTo(InsteadOfSaveForFutureUse)
     }
 
     @Test
@@ -795,6 +803,8 @@ internal class DefaultPaymentSheetLoaderTest {
         ).getOrThrow()
 
         assertThat(result.linkState?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
+        assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode)
+            .isEqualTo(InsteadOfSaveForFutureUse)
     }
 
     @Test
@@ -1090,6 +1100,8 @@ internal class DefaultPaymentSheetLoaderTest {
         ).getOrThrow()
 
         assertThat(result.linkState?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
+        assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode)
+            .isEqualTo(InsteadOfSaveForFutureUse)
     }
 
     @Test
@@ -1113,6 +1125,8 @@ internal class DefaultPaymentSheetLoaderTest {
         ).getOrThrow()
 
         assertThat(result.linkState?.signupMode).isEqualTo(AlongsideSaveForFutureUse)
+        assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode)
+            .isEqualTo(AlongsideSaveForFutureUse)
     }
 
     @Test
@@ -1131,6 +1145,8 @@ internal class DefaultPaymentSheetLoaderTest {
         ).getOrThrow()
 
         assertThat(result.linkState?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
+        assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode)
+            .isEqualTo(InsteadOfSaveForFutureUse)
     }
 
     @Test
@@ -1149,6 +1165,8 @@ internal class DefaultPaymentSheetLoaderTest {
         ).getOrThrow()
 
         assertThat(result.linkState?.signupMode).isEqualTo(AlongsideSaveForFutureUse)
+        assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode)
+            .isEqualTo(AlongsideSaveForFutureUse)
     }
 
     @Test
@@ -1169,6 +1187,7 @@ internal class DefaultPaymentSheetLoaderTest {
         ).getOrThrow()
 
         assertThat(result.linkState).isNull()
+        assertThat(result.paymentMethodMetadata.linkInlineConfiguration).isNull()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.PaymentIntentFixtures
@@ -25,7 +24,6 @@ import com.stripe.android.uicore.elements.CheckboxFieldElement
 import com.stripe.android.uicore.elements.DEFAULT_CHECKBOX_TEST_TAG
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry
-import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runTest
@@ -251,11 +249,8 @@ internal class AddPaymentMethodTest {
                 )
             ),
             paymentSelection = null,
-            linkSignupMode = LinkSignupMode.AlongsideSaveForFutureUse,
-            linkInlineSignupMode = null,
             processing = false,
             usBankAccountFormArguments = mock(),
-            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
         )
 
         val viewActionRecorder = ViewActionRecorder<AddPaymentMethodInteractor.ViewAction>()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultAddPaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultAddPaymentMethodInteractorTest.kt
@@ -2,9 +2,6 @@ package com.stripe.android.paymentsheet.ui
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.link.LinkConfigurationCoordinator
-import com.stripe.android.link.ui.inline.InlineSignupViewState
-import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
@@ -15,7 +12,6 @@ import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFo
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -27,35 +23,6 @@ import org.mockito.Mockito.mock
 import kotlin.test.Test
 
 class DefaultAddPaymentMethodInteractorTest {
-
-    @Test
-    fun handleViewAction_OnLinkSignUpStateUpdated_updatesLinkState() {
-        var updatedLinkSignupState: InlineSignupViewState? = null
-        fun onLinkSignupStateUpdated(inlineSignupViewState: InlineSignupViewState) {
-            updatedLinkSignupState = inlineSignupViewState
-        }
-
-        val inlineSignUpState = InlineSignupViewState(
-            userInput = null,
-            merchantName = "Example merchant",
-            signupMode = LinkSignupMode.AlongsideSaveForFutureUse,
-            fields = emptyList(),
-            prefillEligibleFields = emptySet(),
-        )
-
-        runScenario(
-            onLinkSignUpStateUpdated = ::onLinkSignupStateUpdated,
-        ) {
-            interactor.handleViewAction(
-                AddPaymentMethodInteractor.ViewAction.OnLinkSignUpStateUpdated(
-                    inlineSignUpState
-                )
-            )
-
-            assertThat(updatedLinkSignupState).isEqualTo(inlineSignUpState)
-        }
-    }
-
     @Test
     fun handleViewAction_ReportFieldInteraction_reportsFieldInteraction() {
         var latestCodeWithInteraction: PaymentMethodCode? = null
@@ -157,7 +124,6 @@ class DefaultAddPaymentMethodInteractorTest {
         val expectedSelection = PaymentSelection.Saved(
             paymentMethod = PaymentMethodFactory.usBankAccount(),
         )
-        val expectedLinkSignupMode = LinkSignupMode.AlongsideSaveForFutureUse
         val expectedProcessing = false
 
         var formArgumentsCreatedForCode: PaymentMethodCode? = null
@@ -175,7 +141,6 @@ class DefaultAddPaymentMethodInteractorTest {
         runScenario(
             initiallySelectedPaymentMethodType = expectedSelectedPaymentMethodCode,
             selection = MutableStateFlow(expectedSelection),
-            linkSignupMode = MutableStateFlow(expectedLinkSignupMode),
             processing = MutableStateFlow(expectedProcessing),
             createFormArguments = ::createFormArguments,
             formElementsForCode = ::formElementsForCode,
@@ -184,7 +149,6 @@ class DefaultAddPaymentMethodInteractorTest {
                 awaitItem().run {
                     assertThat(selectedPaymentMethodCode).isEqualTo(expectedSelectedPaymentMethodCode)
                     assertThat(paymentSelection).isEqualTo(expectedSelection)
-                    assertThat(linkSignupMode).isEqualTo(expectedLinkSignupMode)
                     assertThat(processing).isEqualTo(expectedProcessing)
 
                     assertThat(formArgumentsCreatedForCode).isEqualTo(expectedSelectedPaymentMethodCode)
@@ -236,38 +200,6 @@ class DefaultAddPaymentMethodInteractorTest {
     }
 
     @Test
-    fun linkInlineSignupMode_existsIfSelectedPaymentMethodIsCard() {
-        val expectedLinkInlineSignupMode = LinkSignupMode.AlongsideSaveForFutureUse
-        runScenario(
-            initiallySelectedPaymentMethodType = PaymentMethod.Type.Card.code,
-            linkSignupMode = MutableStateFlow(expectedLinkInlineSignupMode),
-        ) {
-            interactor.state.test {
-                awaitItem().run {
-                    assertThat(linkSignupMode).isEqualTo(expectedLinkInlineSignupMode)
-                    assertThat(linkInlineSignupMode).isEqualTo(expectedLinkInlineSignupMode)
-                }
-            }
-        }
-    }
-
-    @Test
-    fun linkInlineSignupMode_nullIfSelectedPaymentMethodIsNotCard() {
-        val expectedLinkSignupMode = LinkSignupMode.AlongsideSaveForFutureUse
-        runScenario(
-            initiallySelectedPaymentMethodType = PaymentMethod.Type.CashAppPay.code,
-            linkSignupMode = MutableStateFlow(expectedLinkSignupMode),
-        ) {
-            interactor.state.test {
-                awaitItem().run {
-                    assertThat(linkSignupMode).isEqualTo(expectedLinkSignupMode)
-                    assertThat(linkInlineSignupMode).isEqualTo(null)
-                }
-            }
-        }
-    }
-
-    @Test
     fun changingSelectedPaymentMethod_clearsErrorMessages() {
         var errorMessagesHaveBeenCleared = false
         fun clearErrorMessages() {
@@ -295,9 +227,7 @@ class DefaultAddPaymentMethodInteractorTest {
 
     private fun runScenario(
         initiallySelectedPaymentMethodType: PaymentMethodCode = PaymentMethod.Type.Card.code,
-        linkConfigurationCoordinator: LinkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
         selection: StateFlow<PaymentSelection?> = MutableStateFlow(null),
-        linkSignupMode: StateFlow<LinkSignupMode?> = MutableStateFlow(null),
         processing: StateFlow<Boolean> = MutableStateFlow(false),
         supportedPaymentMethods: List<SupportedPaymentMethod> = emptyList(),
         createFormArguments: (PaymentMethodCode) -> FormArguments = {
@@ -312,7 +242,6 @@ class DefaultAddPaymentMethodInteractorTest {
         },
         formElementsForCode: (PaymentMethodCode) -> List<FormElement> = { emptyList() },
         clearErrorMessages: () -> Unit = { notImplemented() },
-        onLinkSignUpStateUpdated: (InlineSignupViewState) -> Unit = { notImplemented() },
         reportFieldInteraction: (PaymentMethodCode) -> Unit = { notImplemented() },
         onFormFieldValuesChanged: (FormFieldValues?, String) -> Unit = { _, _ -> notImplemented() },
         reportPaymentMethodTypeSelected: (PaymentMethodCode) -> Unit = { notImplemented() },
@@ -323,15 +252,12 @@ class DefaultAddPaymentMethodInteractorTest {
 
         val interactor = DefaultAddPaymentMethodInteractor(
             initiallySelectedPaymentMethodType = initiallySelectedPaymentMethodType,
-            linkConfigurationCoordinator = linkConfigurationCoordinator,
             selection = selection,
-            linkSignupMode = linkSignupMode,
             processing = processing,
             supportedPaymentMethods = supportedPaymentMethods,
             createFormArguments = createFormArguments,
             formElementsForCode = formElementsForCode,
             clearErrorMessages = clearErrorMessages,
-            onLinkSignUpStateUpdated = onLinkSignUpStateUpdated,
             reportFieldInteraction = reportFieldInteraction,
             onFormFieldValuesChanged = onFormFieldValuesChanged,
             reportPaymentMethodTypeSelected = reportPaymentMethodTypeSelected,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -669,6 +669,8 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
                     cardAccountRangeRepositoryFactory = mock(),
                     paymentMethodCreateParams = null,
                     paymentMethodExtraParams = null,
+                    linkConfigurationCoordinator = null,
+                    onLinkInlineSignupStateChanged = { throw AssertionError("Not implemented") },
                 )
                 paymentMethodMetadata.formElementsForCode(it, uiDefinitionFactoryArgumentsFactory)!!
             },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
@@ -24,7 +24,6 @@ import com.stripe.android.paymentsheet.ui.FORM_ELEMENT_TEST_TAG
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventReporter
-import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.junit.Rule
@@ -149,8 +148,6 @@ internal class VerticalModeFormUITest {
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
             ),
             formElements = CardDefinition.formElements(),
-            linkSignupMode = null,
-            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
             headerInformation = headerInformation,
         )
     }
@@ -178,8 +175,6 @@ internal class VerticalModeFormUITest {
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
             ),
             formElements = emptyList(),
-            linkSignupMode = null,
-            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
             headerInformation = headerInformation,
         )
     }
@@ -211,8 +206,6 @@ internal class VerticalModeFormUITest {
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
             ),
             formElements = KlarnaDefinition.formElements(paymentMethodMetadata),
-            linkSignupMode = null,
-            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
             headerInformation = headerInformation,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeLinkConfigurationCoordinator.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeLinkConfigurationCoordinator.kt
@@ -29,14 +29,11 @@ class FakeLinkConfigurationCoordinator(
     private val accountStatus: AccountStatus = AccountStatus.SignedOut,
 ) : LinkConfigurationCoordinator {
 
-    override val component: LinkComponent
-        get() = mock()
-
     override val emailFlow: StateFlow<String?>
         get() = stateFlowOf(null)
 
-    override fun setConfiguration(configuration: LinkConfiguration) {
-        // No-op
+    override fun getComponent(configuration: LinkConfiguration): LinkComponent {
+        return mock()
     }
 
     override fun getAccountStatusFlow(configuration: LinkConfiguration): Flow<AccountStatus> {


### PR DESCRIPTION
# Summary
Adds a `LinkFormElement` to `CardDefinition` while providing all the necessary elements for `Link` through the metadata or definition arguments.

# Motivation
Attempt to clean up usage of `Link` in multiple places and centralize it in `CardDefinition`. This should allow us to consolidate `Link` rendering and logic as well as allow for adding or removing additional elements above and below `Link` without hassle.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
