### PR TITLE
Add additional network tests for `CustomerSession`

### DIFF
--- a/network-testing/src/main/java/com/stripe/android/networktesting/ResponseReplacement.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/ResponseReplacement.kt
@@ -1,0 +1,6 @@
+package com.stripe.android.networktesting
+
+data class ResponseReplacement(
+    val original: String,
+    val new: String
+)

--- a/network-testing/src/main/java/com/stripe/android/networktesting/TestBodyFromFile.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/TestBodyFromFile.kt
@@ -3,6 +3,30 @@ package com.stripe.android.networktesting
 import okhttp3.mockwebserver.MockResponse
 import okio.Buffer
 
+fun MockResponse.testBodyFromFile(
+    filename: String,
+    replacements: List<ResponseReplacement>,
+): MockResponse {
+    addHeader("request-id", filename)
+
+    val inputStream = MockResponse::class.java.classLoader!!.getResourceAsStream(filename)
+    val textBuilder = StringBuilder()
+
+    val reader = inputStream.reader().buffered()
+
+    reader.forEachLine { line ->
+        val replacedText = replacements.fold(line) { acc, replacement ->
+            acc.replace(replacement.original, replacement.new)
+        }
+
+        textBuilder.append(replacedText)
+    }
+
+    setBody(textBuilder.toString())
+
+    return this
+}
+
 fun MockResponse.testBodyFromFile(filename: String): MockResponse {
     addHeader("request-id", filename)
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetCustomerSessionTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetCustomerSessionTest.kt
@@ -5,8 +5,8 @@ import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
+import com.stripe.android.networktesting.ResponseReplacement
 import com.stripe.android.networktesting.testBodyFromFile
-import com.stripe.android.paymentsheet.utils.IntegrationType
 import com.stripe.android.paymentsheet.utils.PaymentSheetTestRunnerContext
 import com.stripe.android.paymentsheet.utils.TestRules
 import com.stripe.android.paymentsheet.utils.assertCompleted
@@ -59,7 +59,6 @@ class PaymentSheetCustomerSessionTest {
     @Test
     fun allowRedisplayIsLimitedWhenNotSavingWithSetupIntent() = runPaymentSheetTest(
         networkRule = networkRule,
-        integrationType = IntegrationType.Compose,
         resultCallback = ::assertCompleted,
     ) { testContext ->
         enqueueElementsSessionWithSetupIntentAndCustomerSession()
@@ -90,12 +89,98 @@ class PaymentSheetCustomerSessionTest {
         page.clickPrimaryButton()
     }
 
-    private fun enqueueElementsSessionWithPaymentIntentAndCustomerSession() {
-        enqueueElementsSession("elements-sessions-requires_pm_with_ps_pi_cs.json")
+    @Test
+    fun allowRedisplayIsUnspecifiedWhenSaveIsDisabledWithPaymentIntent() = runPaymentSheetTest(
+        networkRule = networkRule,
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
+        enqueueElementsSessionWithPaymentIntentAndCustomerSession(
+            isSaveEnabled = false,
+        )
+
+        testContext.presentWithPaymentIntent()
+
+        page.fillOutCardDetails()
+
+        enqueuePaymentIntentConfirmWithExpectedAllowRedisplay(allowRedisplay = "unspecified")
+
+        page.clickPrimaryButton()
     }
 
-    private fun enqueueElementsSessionWithSetupIntentAndCustomerSession() {
-        enqueueElementsSession("elements-sessions-requires_pm_with_ps_si_cs.json")
+    @Test
+    fun allowRedisplayIsLimitedWhenSaveIsDisabledWithSetupIntent() = runPaymentSheetTest(
+        networkRule = networkRule,
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
+        enqueueElementsSessionWithSetupIntentAndCustomerSession(
+            isSaveEnabled = false,
+        )
+
+        testContext.presentWithSetupIntent()
+
+        page.fillOutCardDetails()
+
+        enqueueSetupIntentConfirmWithExpectedAllowRedisplay(allowRedisplay = "limited")
+
+        page.clickPrimaryButton()
+    }
+
+    @Test
+    fun allowRedisplayIsUnspecifiedWhenOverrideIsUnspecifiedWithSetupIntent() = runPaymentSheetTest(
+        networkRule = networkRule,
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
+        enqueueElementsSessionWithSetupIntentAndCustomerSession(
+            isSaveEnabled = false,
+            allowRedisplayOverride = "unspecified",
+        )
+
+        testContext.presentWithSetupIntent()
+
+        page.fillOutCardDetails()
+
+        enqueueSetupIntentConfirmWithExpectedAllowRedisplay(allowRedisplay = "unspecified")
+
+        page.clickPrimaryButton()
+    }
+
+    @Test
+    fun allowRedisplayIsAlwaysWhenOverrideIsAlwaysWithSetupIntent() = runPaymentSheetTest(
+        networkRule = networkRule,
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
+        enqueueElementsSessionWithSetupIntentAndCustomerSession(
+            isSaveEnabled = false,
+            allowRedisplayOverride = "always",
+        )
+
+        testContext.presentWithSetupIntent()
+
+        page.fillOutCardDetails()
+
+        enqueueSetupIntentConfirmWithExpectedAllowRedisplay(allowRedisplay = "always")
+
+        page.clickPrimaryButton()
+    }
+
+    private fun enqueueElementsSessionWithPaymentIntentAndCustomerSession(
+        isSaveEnabled: Boolean = true,
+        allowRedisplayOverride: String? = null,
+    ) {
+        enqueueElementsSession(
+            responseFilePath = "elements-sessions-requires_pm_with_ps_pi_cs.json",
+            replacements = createReplacements(isSaveEnabled, allowRedisplayOverride),
+        )
+    }
+
+    private fun enqueueElementsSessionWithSetupIntentAndCustomerSession(
+        isSaveEnabled: Boolean = true,
+        allowRedisplayOverride: String? = null,
+    ) {
+        enqueueElementsSession(
+            responseFilePath = "elements-sessions-requires_pm_with_ps_si_cs.json",
+            replacements = createReplacements(isSaveEnabled, allowRedisplayOverride),
+        )
     }
 
     private fun enqueuePaymentIntentConfirmWithExpectedAllowRedisplay(allowRedisplay: String) {
@@ -118,13 +203,16 @@ class PaymentSheetCustomerSessionTest {
         }
     }
 
-    private fun enqueueElementsSession(responseFilePath: String) {
+    private fun enqueueElementsSession(
+        responseFilePath: String,
+        replacements: List<ResponseReplacement> = listOf()
+    ) {
         networkRule.enqueue(
             host("api.stripe.com"),
             method("GET"),
             path("/v1/elements/sessions"),
         ) { response ->
-            response.testBodyFromFile(responseFilePath)
+            response.testBodyFromFile(responseFilePath, replacements)
         }
     }
 
@@ -162,5 +250,32 @@ class PaymentSheetCustomerSessionTest {
                 ),
             )
         }
+    }
+
+    private fun createReplacements(
+        isSaveEnabled: Boolean,
+        allowRedisplayOverride: String?
+    ): List<ResponseReplacement> {
+        val replacements = mutableListOf<ResponseReplacement>()
+
+        if (!isSaveEnabled) {
+            replacements.add(
+                ResponseReplacement(
+                    original = "\"payment_method_save\": \"enabled\"",
+                    new = "\"payment_method_save\": \"disabled\"",
+                )
+            )
+        }
+
+        allowRedisplayOverride?.let {
+            replacements.add(
+                ResponseReplacement(
+                    original = "\"payment_method_save_allow_redisplay_override\": null",
+                    new = "\"payment_method_save_allow_redisplay_override\": \"$it\"",
+                )
+            )
+        }
+
+        return replacements
     }
 }


### PR DESCRIPTION
# Summary
Add additional network tests for `CustomerSession`

# Motivation
Ensures that `CustomerSession` behavior is maintained in `PaymentSheet`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
