### PR TITLE
Uncouple `SaveForFutureUsageHelper` from `PaymentMethodMetadata`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelper.kt
@@ -1,27 +1,29 @@
 package com.stripe.android.lpmfoundations.luxe
 
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.StripeIntent
 
 internal fun isSaveForFutureUseValueChangeable(
     code: PaymentMethodCode,
-    metadata: PaymentMethodMetadata,
+    paymentMethodSaveConsentBehavior: PaymentMethodSaveConsentBehavior,
+    intent: StripeIntent,
+    hasCustomerConfiguration: Boolean,
 ): Boolean {
-    return when (metadata.paymentMethodSaveConsentBehavior) {
+    return when (paymentMethodSaveConsentBehavior) {
         is PaymentMethodSaveConsentBehavior.Disabled -> false
-        is PaymentMethodSaveConsentBehavior.Enabled -> metadata.hasCustomerConfiguration
+        is PaymentMethodSaveConsentBehavior.Enabled -> hasCustomerConfiguration
         is PaymentMethodSaveConsentBehavior.Legacy -> {
-            when (metadata.stripeIntent) {
+            when (intent) {
                 is PaymentIntent -> {
-                    val isSetupFutureUsageSet = metadata.stripeIntent.isSetupFutureUsageSet(code)
+                    val isSetupFutureUsageSet = intent.isSetupFutureUsageSet(code)
 
                     if (isSetupFutureUsageSet) {
                         false
                     } else {
-                        metadata.hasCustomerConfiguration
+                        hasCustomerConfiguration
                     }
                 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -99,7 +99,9 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
             if (
                 isSaveForFutureUseValueChangeable(
                     code = PaymentMethod.Type.Card.code,
-                    metadata = metadata,
+                    intent = metadata.stripeIntent,
+                    paymentMethodSaveConsentBehavior = metadata.paymentMethodSaveConsentBehavior,
+                    hasCustomerConfiguration = metadata.hasCustomerConfiguration,
                 )
             ) {
                 add(SaveForFutureUseElement(arguments.saveForFutureUseInitialValue, arguments.merchantName))

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
@@ -63,7 +63,9 @@ internal class USBankAccountFormArguments(
         ): USBankAccountFormArguments {
             val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
                 code = selectedPaymentMethodCode,
-                metadata = paymentMethodMetadata,
+                intent = paymentMethodMetadata.stripeIntent,
+                paymentMethodSaveConsentBehavior = paymentMethodMetadata.paymentMethodSaveConsentBehavior,
+                hasCustomerConfiguration = paymentMethodMetadata.hasCustomerConfiguration,
             )
             val instantDebits = selectedPaymentMethodCode == PaymentMethod.Type.Link.code
             val initializationMode = (viewModel as? PaymentSheetViewModel)

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelperKtTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelperKtTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.lpmfoundations.luxe
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
@@ -14,11 +13,9 @@ class SaveForFutureUseHelperKtTest {
     fun `isSaveForFutureUseValueChangeable returns false for SI if behavior is Legacy`() {
         val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
             code = PaymentMethod.Type.Card.code,
-            metadata = PaymentMethodMetadataFactory.create(
-                stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
-                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
-                hasCustomerConfiguration = true,
-            ),
+            intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+            hasCustomerConfiguration = true,
         )
 
         assertThat(isSaveForFutureUseValueChangeable).isFalse()
@@ -28,13 +25,11 @@ class SaveForFutureUseHelperKtTest {
     fun `isSaveForFutureUseValueChangeable returns false for PI with SFU and no customer if behavior is Legacy`() {
         val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
             code = PaymentMethod.Type.Card.code,
-            metadata = PaymentMethodMetadataFactory.create(
-                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                    setupFutureUsage = StripeIntent.Usage.OnSession,
-                ),
-                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
-                hasCustomerConfiguration = false,
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                setupFutureUsage = StripeIntent.Usage.OnSession,
             ),
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+            hasCustomerConfiguration = false,
         )
 
         assertThat(isSaveForFutureUseValueChangeable).isFalse()
@@ -44,13 +39,11 @@ class SaveForFutureUseHelperKtTest {
     fun `isSaveForFutureUseValueChangeable returns false for PI with SFU and has customer if behavior is Legacy`() {
         val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
             code = PaymentMethod.Type.Card.code,
-            metadata = PaymentMethodMetadataFactory.create(
-                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                    setupFutureUsage = StripeIntent.Usage.OnSession,
-                ),
-                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
-                hasCustomerConfiguration = true,
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                setupFutureUsage = StripeIntent.Usage.OnSession,
             ),
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+            hasCustomerConfiguration = true,
         )
 
         assertThat(isSaveForFutureUseValueChangeable).isFalse()
@@ -60,13 +53,11 @@ class SaveForFutureUseHelperKtTest {
     fun `isSaveForFutureUseValueChangeable returns true for PI without SFU and has customer if behavior is Legacy`() {
         val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
             code = PaymentMethod.Type.Card.code,
-            metadata = PaymentMethodMetadataFactory.create(
-                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                    setupFutureUsage = null,
-                ),
-                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
-                hasCustomerConfiguration = true,
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                setupFutureUsage = null,
             ),
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+            hasCustomerConfiguration = true,
         )
 
         assertThat(isSaveForFutureUseValueChangeable).isTrue()
@@ -76,11 +67,9 @@ class SaveForFutureUseHelperKtTest {
     fun `isSaveForFutureUseValueChangeable returns true if consent behavior is Enabled and has customer`() {
         val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
             code = PaymentMethod.Type.Card.code,
-            metadata = PaymentMethodMetadataFactory.create(
-                stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
-                hasCustomerConfiguration = true,
-                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Enabled,
-            ),
+            intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            hasCustomerConfiguration = true,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Enabled,
         )
 
         assertThat(isSaveForFutureUseValueChangeable).isTrue()
@@ -90,11 +79,9 @@ class SaveForFutureUseHelperKtTest {
     fun `isSaveForFutureUseValueChangeable returns false if consent behavior is Enabled and no customer`() {
         val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
             code = PaymentMethod.Type.Card.code,
-            metadata = PaymentMethodMetadataFactory.create(
-                stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
-                hasCustomerConfiguration = false,
-                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Enabled,
-            ),
+            intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            hasCustomerConfiguration = false,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Enabled,
         )
 
         assertThat(isSaveForFutureUseValueChangeable).isFalse()
@@ -104,12 +91,10 @@ class SaveForFutureUseHelperKtTest {
     fun `isSaveForFutureUseValueChangeable returns false if consent behavior is Disabled`() {
         val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
             code = PaymentMethod.Type.Card.code,
-            metadata = PaymentMethodMetadataFactory.create(
-                stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
-                hasCustomerConfiguration = true,
-                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Disabled(
-                    overrideAllowRedisplay = null,
-                ),
+            intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            hasCustomerConfiguration = true,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Disabled(
+                overrideAllowRedisplay = null,
             ),
         )
 


### PR DESCRIPTION
# Summary
Uncouple `SaveForFutureUsageHelper` from `PaymentMethodMetadata`.

# Motivation
Allows `SaveForFutureUsageHelper` to be used outside of `PaymentMethodMetadata` context. This allows for decoupling `LinkConfiguration` initialization from requiring `PaymentMethodMetadata`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
