### PR TITLE
Decouple `LinkSignupMode` from `LinkConfiguration`.

### DIFF
--- a/link/src/main/java/com/stripe/android/link/LinkConfiguration.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkConfiguration.kt
@@ -2,7 +2,6 @@ package com.stripe.android.link
 
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
-import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.uicore.elements.IdentifierSpec
 import kotlinx.parcelize.Parcelize
@@ -11,7 +10,6 @@ import kotlinx.parcelize.Parcelize
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class LinkConfiguration(
     val stripeIntent: StripeIntent,
-    val signupMode: LinkSignupMode?,
     val merchantName: String,
     val merchantCountryCode: String?,
     val customerInfo: CustomerInfo,
@@ -19,10 +17,6 @@ data class LinkConfiguration(
     val passthroughModeEnabled: Boolean,
     val flags: Map<String, Boolean>,
 ) : Parcelable {
-
-    val showOptionalLabel: Boolean
-        get() = signupMode == LinkSignupMode.AlongsideSaveForFutureUse
-
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     data class CustomerInfo(

--- a/link/src/main/java/com/stripe/android/link/injection/LinkComponent.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/LinkComponent.kt
@@ -4,7 +4,6 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.account.LinkAccountManager
-import com.stripe.android.link.ui.inline.InlineSignupViewModel
 import dagger.BindsInstance
 import dagger.Subcomponent
 import javax.inject.Scope
@@ -27,7 +26,7 @@ internal annotation class LinkScope
 abstract class LinkComponent {
     internal abstract val linkAccountManager: LinkAccountManager
     internal abstract val configuration: LinkConfiguration
-    internal abstract val inlineSignupViewModel: InlineSignupViewModel
+    internal abstract val inlineSignupViewModelFactory: LinkInlineSignupAssistedViewModelFactory
 
     @Subcomponent.Builder
     internal interface Builder {

--- a/link/src/main/java/com/stripe/android/link/injection/LinkInlineSignupAssistedViewModelFactory.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/LinkInlineSignupAssistedViewModelFactory.kt
@@ -1,0 +1,10 @@
+package com.stripe.android.link.injection
+
+import com.stripe.android.link.ui.inline.InlineSignupViewModel
+import com.stripe.android.link.ui.inline.LinkSignupMode
+import dagger.assisted.AssistedFactory
+
+@AssistedFactory
+internal interface LinkInlineSignupAssistedViewModelFactory {
+    fun create(signupMode: LinkSignupMode): InlineSignupViewModel
+}

--- a/link/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewState.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewState.kt
@@ -48,8 +48,11 @@ constructor(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
 
-        fun create(config: LinkConfiguration): InlineSignupViewState {
-            val isAlternativeFlow = config.signupMode == LinkSignupMode.AlongsideSaveForFutureUse
+        fun create(
+            signupMode: LinkSignupMode,
+            config: LinkConfiguration
+        ): InlineSignupViewState {
+            val isAlternativeFlow = signupMode == LinkSignupMode.AlongsideSaveForFutureUse
             val customer = config.customerInfo
 
             val fields = buildList {
@@ -72,7 +75,7 @@ constructor(
                 }
             }
 
-            val prefillEligibleFields = when (config.signupMode) {
+            val prefillEligibleFields = when (signupMode) {
                 LinkSignupMode.InsteadOfSaveForFutureUse -> {
                     fields.toSet()
                 }
@@ -81,15 +84,12 @@ constructor(
                     // user consent. We don't prefill the first field in this case.
                     fields.toSet() - fields.first()
                 }
-                null -> {
-                    emptySet()
-                }
             }
 
             return InlineSignupViewState(
                 userInput = null,
                 merchantName = config.merchantName,
-                signupMode = config.signupMode!!,
+                signupMode = signupMode,
                 fields = fields,
                 prefillEligibleFields = prefillEligibleFields,
             )

--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkElement.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkElement.kt
@@ -1,0 +1,56 @@
+@file:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+
+package com.stripe.android.link.ui.inline
+
+import androidx.annotation.RestrictTo
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.stripe.android.link.LinkConfigurationCoordinator
+
+@Composable
+fun LinkElement(
+    linkConfigurationCoordinator: LinkConfigurationCoordinator?,
+    linkSignupMode: LinkSignupMode?,
+    enabled: Boolean,
+    horizontalPadding: Dp,
+    onLinkSignupStateChanged: (InlineSignupViewState) -> Unit,
+) {
+    val component = linkConfigurationCoordinator?.component
+
+    if (component != null && linkSignupMode != null) {
+        val viewModel: InlineSignupViewModel = viewModel(
+            factory = InlineSignupViewModel.Factory(
+                signupMode = linkSignupMode,
+                linkComponent = component,
+            )
+        )
+
+        when (viewModel.signupMode) {
+            LinkSignupMode.InsteadOfSaveForFutureUse -> {
+                LinkInlineSignup(
+                    viewModel = viewModel,
+                    enabled = enabled,
+                    onStateChanged = onLinkSignupStateChanged,
+                    modifier = Modifier
+                        .padding(horizontal = horizontalPadding, vertical = 6.dp)
+                        .fillMaxWidth(),
+                )
+            }
+            LinkSignupMode.AlongsideSaveForFutureUse -> {
+                LinkOptionalInlineSignup(
+                    viewModel = viewModel,
+                    enabled = enabled,
+                    onStateChanged = onLinkSignupStateChanged,
+                    modifier = Modifier
+                        .padding(horizontal = horizontalPadding, vertical = 6.dp)
+                        .fillMaxWidth(),
+                )
+            }
+        }
+    }
+}

--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
@@ -39,8 +39,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
-import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.R
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.ui.ErrorMessage
@@ -62,50 +60,44 @@ import kotlinx.coroutines.launch
 internal const val ProgressIndicatorTestTag = "CircularProgressIndicator"
 
 @Composable
-fun LinkInlineSignup(
-    linkConfigurationCoordinator: LinkConfigurationCoordinator,
+internal fun LinkInlineSignup(
+    viewModel: InlineSignupViewModel,
     enabled: Boolean,
     onStateChanged: (InlineSignupViewState) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    linkConfigurationCoordinator.component?.let { component ->
-        val viewModel: InlineSignupViewModel = viewModel(
-            factory = InlineSignupViewModel.Factory(component)
-        )
+    val viewState by viewModel.viewState.collectAsState()
+    val errorMessage by viewModel.errorMessage.collectAsState()
 
-        val viewState by viewModel.viewState.collectAsState()
-        val errorMessage by viewModel.errorMessage.collectAsState()
-
-        LaunchedEffect(viewState) {
-            onStateChanged(viewState)
-        }
-
-        val focusManager = LocalFocusManager.current
-        val textInputService = LocalTextInputService.current
-
-        LaunchedEffect(viewState.signUpState) {
-            if (viewState.signUpState == SignUpState.InputtingPrimaryField && viewState.userInput != null) {
-                focusManager.clearFocus(true)
-                @Suppress("DEPRECATION")
-                textInputService?.hideSoftwareKeyboard()
-            }
-        }
-
-        LinkInlineSignup(
-            merchantName = viewState.merchantName,
-            sectionController = viewModel.sectionController,
-            emailController = viewModel.emailController,
-            phoneNumberController = viewModel.phoneController,
-            nameController = viewModel.nameController,
-            signUpState = viewState.signUpState,
-            enabled = enabled,
-            expanded = viewState.isExpanded,
-            requiresNameCollection = viewModel.requiresNameCollection,
-            errorMessage = errorMessage,
-            toggleExpanded = viewModel::toggleExpanded,
-            modifier = modifier
-        )
+    LaunchedEffect(viewState) {
+        onStateChanged(viewState)
     }
+
+    val focusManager = LocalFocusManager.current
+    val textInputService = LocalTextInputService.current
+
+    LaunchedEffect(viewState.signUpState) {
+        if (viewState.signUpState == SignUpState.InputtingPrimaryField && viewState.userInput != null) {
+            focusManager.clearFocus(true)
+            @Suppress("DEPRECATION")
+            textInputService?.hideSoftwareKeyboard()
+        }
+    }
+
+    LinkInlineSignup(
+        merchantName = viewState.merchantName,
+        sectionController = viewModel.sectionController,
+        emailController = viewModel.emailController,
+        phoneNumberController = viewModel.phoneController,
+        nameController = viewModel.nameController,
+        signUpState = viewState.signUpState,
+        enabled = enabled,
+        expanded = viewState.isExpanded,
+        requiresNameCollection = viewModel.requiresNameCollection,
+        errorMessage = errorMessage,
+        toggleExpanded = viewModel::toggleExpanded,
+        modifier = modifier
+    )
 }
 
 @OptIn(ExperimentalFoundationApi::class)

--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkOptionalInlineSignup.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkOptionalInlineSignup.kt
@@ -36,8 +36,6 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
-import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.R
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.ui.ErrorMessage
@@ -56,48 +54,42 @@ import com.stripe.android.uicore.utils.collectAsState
 import kotlinx.coroutines.job
 
 @Composable
-fun LinkOptionalInlineSignup(
-    linkConfigurationCoordinator: LinkConfigurationCoordinator,
+internal fun LinkOptionalInlineSignup(
+    viewModel: InlineSignupViewModel,
     enabled: Boolean,
     onStateChanged: (InlineSignupViewState) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    linkConfigurationCoordinator.component?.let { component ->
-        val viewModel: InlineSignupViewModel = viewModel(
-            factory = InlineSignupViewModel.Factory(component)
-        )
+    val viewState by viewModel.viewState.collectAsState()
+    val errorMessage by viewModel.errorMessage.collectAsState()
 
-        val viewState by viewModel.viewState.collectAsState()
-        val errorMessage by viewModel.errorMessage.collectAsState()
-
-        LaunchedEffect(viewState) {
-            onStateChanged(viewState)
-        }
-
-        val focusManager = LocalFocusManager.current
-        val textInputService = LocalTextInputService.current
-
-        LaunchedEffect(viewState.signUpState) {
-            if (viewState.signUpState == SignUpState.InputtingPrimaryField && viewState.userInput != null) {
-                focusManager.clearFocus(true)
-                @Suppress("DEPRECATION")
-                textInputService?.hideSoftwareKeyboard()
-            }
-        }
-
-        LinkOptionalInlineSignup(
-            sectionController = viewModel.sectionController,
-            emailController = viewModel.emailController,
-            phoneNumberController = viewModel.phoneController,
-            nameController = viewModel.nameController,
-            signUpState = viewState.signUpState,
-            isShowingPhoneFirst = viewState.isShowingPhoneFirst,
-            enabled = enabled,
-            requiresNameCollection = viewModel.requiresNameCollection,
-            errorMessage = errorMessage,
-            modifier = modifier
-        )
+    LaunchedEffect(viewState) {
+        onStateChanged(viewState)
     }
+
+    val focusManager = LocalFocusManager.current
+    val textInputService = LocalTextInputService.current
+
+    LaunchedEffect(viewState.signUpState) {
+        if (viewState.signUpState == SignUpState.InputtingPrimaryField && viewState.userInput != null) {
+            focusManager.clearFocus(true)
+            @Suppress("DEPRECATION")
+            textInputService?.hideSoftwareKeyboard()
+        }
+    }
+
+    LinkOptionalInlineSignup(
+        sectionController = viewModel.sectionController,
+        emailController = viewModel.emailController,
+        phoneNumberController = viewModel.phoneController,
+        nameController = viewModel.nameController,
+        signUpState = viewState.signUpState,
+        isShowingPhoneFirst = viewState.isShowingPhoneFirst,
+        enabled = enabled,
+        requiresNameCollection = viewModel.requiresNameCollection,
+        errorMessage = errorMessage,
+        modifier = modifier
+    )
 }
 
 @OptIn(ExperimentalFoundationApi::class)

--- a/link/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
@@ -4,7 +4,6 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.link.model.StripeIntentFixtures
-import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.networking.StripeRepository
 import org.junit.After
 import org.junit.Before
@@ -44,7 +43,6 @@ class LinkActivityContractTest {
                 billingCountryCode = "US",
             ),
             shippingValues = null,
-            signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
             passthroughModeEnabled = false,
             flags = emptyMap(),
         )

--- a/link/src/test/java/com/stripe/android/link/LinkConfigurationCoordinatorTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkConfigurationCoordinatorTest.kt
@@ -5,7 +5,6 @@ import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.injection.LinkComponent
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.model.StripeIntentFixtures
-import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.link.utils.FakeAndroidKeyStore
 import kotlinx.coroutines.flow.flowOf
@@ -33,7 +32,6 @@ class LinkConfigurationCoordinatorTest {
             billingCountryCode = CUSTOMER_BILLING_COUNTRY_CODE,
         ),
         shippingValues = null,
-        signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
         passthroughModeEnabled = false,
         flags = emptyMap(),
     )

--- a/link/src/test/java/com/stripe/android/link/account/LinkAccountManagerTest.kt
+++ b/link/src/test/java/com/stripe/android/link/account/LinkAccountManagerTest.kt
@@ -8,7 +8,6 @@ import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.analytics.LinkEventsReporter
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.repositories.LinkRepository
-import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.CardParams
@@ -490,7 +489,6 @@ class LinkAccountManagerTest {
             merchantName = "Merchant",
             merchantCountryCode = "US",
             shippingValues = null,
-            signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
             passthroughModeEnabled = passthroughModeEnabled,
             flags = emptyMap(),
         ),

--- a/link/src/test/java/com/stripe/android/link/serialization/PopupPayloadTest.kt
+++ b/link/src/test/java/com/stripe/android/link/serialization/PopupPayloadTest.kt
@@ -6,7 +6,6 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.link.LinkConfiguration
-import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.SetupIntentFactory
@@ -199,7 +198,6 @@ internal class PopupPayloadTest {
             flags = emptyMap(),
             passthroughModeEnabled = true,
             shippingValues = emptyMap(),
-            signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
             stripeIntent = intent
         )
     }

--- a/link/src/test/java/com/stripe/android/link/ui/inline/InlineSignupViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/inline/InlineSignupViewModelTest.kt
@@ -60,13 +60,13 @@ class InlineSignupViewModelTest {
                         billingCountryCode = CUSTOMER_BILLING_COUNTRY_CODE,
                     ),
                     shippingValues = null,
-                    signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
                     passthroughModeEnabled = false,
                     flags = emptyMap(),
                 ),
+                signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
                 linkAccountManager = linkAccountManager,
                 linkEventsReporter = linkEventsReporter,
-                logger = Logger.noop()
+                logger = Logger.noop(),
             )
 
             whenever(linkAccountManager.lookupConsumer(any(), any()))
@@ -429,13 +429,13 @@ class InlineSignupViewModelTest {
                 billingCountryCode = null,
             ),
             shippingValues = null,
-            signupMode = signupMode,
             passthroughModeEnabled = false,
             flags = emptyMap(),
         ),
+        signupMode = signupMode,
         linkAccountManager = linkAccountManager,
         linkEventsReporter = linkEventsReporter,
-        logger = Logger.noop()
+        logger = Logger.noop(),
     )
 
     private fun mockConsumerSessionWithVerificationSession(

--- a/link/src/test/java/com/stripe/android/link/ui/inline/InlineSignupViewStateTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/inline/InlineSignupViewStateTest.kt
@@ -11,10 +11,12 @@ class InlineSignupViewStateTest {
     fun `Allows full prefill if showing instead of save-for-future-use for US customers`() {
         val linkConfig = createLinkConfig(
             countryCode = "US",
-            signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
         )
 
-        val viewState = InlineSignupViewState.create(linkConfig)
+        val viewState = InlineSignupViewState.create(
+            signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
+            config = linkConfig
+        )
 
         assertThat(viewState.prefillEligibleFields).containsExactly(
             LinkSignupField.Email,
@@ -26,10 +28,12 @@ class InlineSignupViewStateTest {
     fun `Allows full prefill if showing instead of save-for-future-use for non-US customers`() {
         val linkConfig = createLinkConfig(
             countryCode = "CA",
-            signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
         )
 
-        val viewState = InlineSignupViewState.create(linkConfig)
+        val viewState = InlineSignupViewState.create(
+            signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
+            config = linkConfig
+        )
 
         assertThat(viewState.prefillEligibleFields).containsExactly(
             LinkSignupField.Email,
@@ -42,10 +46,12 @@ class InlineSignupViewStateTest {
     fun `Limits prefill if showing alongside save-for-future-use if all fields have prefills`() {
         val linkConfig = createLinkConfig(
             countryCode = "CA",
-            signupMode = LinkSignupMode.AlongsideSaveForFutureUse,
         )
 
-        val viewState = InlineSignupViewState.create(linkConfig)
+        val viewState = InlineSignupViewState.create(
+            signupMode = LinkSignupMode.AlongsideSaveForFutureUse,
+            config = linkConfig
+        )
 
         assertThat(viewState.prefillEligibleFields).containsExactly(
             LinkSignupField.Email,
@@ -57,11 +63,13 @@ class InlineSignupViewStateTest {
     fun `Correct prefill if showing alongside save-for-future-use if not all fields have prefills`() {
         val linkConfig = createLinkConfig(
             countryCode = "CA",
-            signupMode = LinkSignupMode.AlongsideSaveForFutureUse,
             email = null,
         )
 
-        val viewState = InlineSignupViewState.create(linkConfig)
+        val viewState = InlineSignupViewState.create(
+            signupMode = LinkSignupMode.AlongsideSaveForFutureUse,
+            config = linkConfig
+        )
 
         assertThat(viewState.prefillEligibleFields).containsExactly(
             LinkSignupField.Phone,
@@ -71,12 +79,10 @@ class InlineSignupViewStateTest {
 
     private fun createLinkConfig(
         countryCode: String,
-        signupMode: LinkSignupMode,
         email: String? = "john@doe.ca",
     ): LinkConfiguration {
         return LinkConfiguration(
             stripeIntent = PaymentIntentFactory.create(countryCode = countryCode),
-            signupMode = signupMode,
             merchantName = "Merchant, Inc.",
             merchantCountryCode = "usd",
             customerInfo = LinkConfiguration.CustomerInfo(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LinkState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LinkState.kt
@@ -2,12 +2,14 @@ package com.stripe.android.paymentsheet.state
 
 import android.os.Parcelable
 import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.ui.inline.LinkSignupMode
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class LinkState(
     val configuration: LinkConfiguration,
     val loginState: LoginState,
+    val signupMode: LinkSignupMode?,
 ) : Parcelable {
 
     enum class LoginState {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
@@ -20,8 +20,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.ui.inline.InlineSignupViewState
-import com.stripe.android.link.ui.inline.LinkInlineSignup
-import com.stripe.android.link.ui.inline.LinkOptionalInlineSignup
+import com.stripe.android.link.ui.inline.LinkElement
 import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.PaymentMethod.Type.Link
@@ -150,40 +149,6 @@ internal fun FormElement(
                 formElements = formElements,
                 modifier = Modifier.padding(horizontal = horizontalPadding)
             )
-        }
-    }
-}
-
-@Composable
-internal fun LinkElement(
-    linkConfigurationCoordinator: LinkConfigurationCoordinator?,
-    linkSignupMode: LinkSignupMode?,
-    enabled: Boolean,
-    horizontalPadding: Dp,
-    onLinkSignupStateChanged: (InlineSignupViewState) -> Unit,
-) {
-    if (linkConfigurationCoordinator != null && linkSignupMode != null) {
-        when (linkSignupMode) {
-            LinkSignupMode.InsteadOfSaveForFutureUse -> {
-                LinkInlineSignup(
-                    linkConfigurationCoordinator = linkConfigurationCoordinator,
-                    enabled = enabled,
-                    onStateChanged = onLinkSignupStateChanged,
-                    modifier = Modifier
-                        .padding(horizontal = horizontalPadding, vertical = 6.dp)
-                        .fillMaxWidth(),
-                )
-            }
-            LinkSignupMode.AlongsideSaveForFutureUse -> {
-                LinkOptionalInlineSignup(
-                    linkConfigurationCoordinator = linkConfigurationCoordinator,
-                    enabled = enabled,
-                    onStateChanged = onLinkSignupStateChanged,
-                    modifier = Modifier
-                        .padding(horizontal = horizontalPadding, vertical = 6.dp)
-                        .fillMaxWidth(),
-                )
-            }
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUI.kt
@@ -19,10 +19,10 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.stripe.android.link.ui.inline.LinkElement
 import com.stripe.android.lpmfoundations.FormHeaderInformation
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.ui.FormElement
-import com.stripe.android.paymentsheet.ui.LinkElement
 import com.stripe.android.paymentsheet.ui.PaymentMethodIcon
 import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.uicore.strings.resolve

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/LinkHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/LinkHandlerTest.kt
@@ -52,7 +52,7 @@ class LinkHandlerTest {
     @Test
     fun `Prepares state correctly for logged out user`() = runLinkTest {
         accountStatusFlow.emit(AccountStatus.SignedOut)
-        handler.setupLink(LinkState(configuration, LinkState.LoginState.LoggedOut))
+        handler.setupLink(createLinkState(LinkState.LoginState.LoggedOut))
         assertThat(handler.isLinkEnabled.first()).isTrue()
         assertThat(accountStatusTurbine.awaitItem()).isEqualTo(AccountStatus.SignedOut)
         assertThat(savedStateHandle.get<PaymentSelection>(SAVE_SELECTION)).isNull()
@@ -61,7 +61,7 @@ class LinkHandlerTest {
     @Test
     fun `Completed result sets processing state to Completed`() = runLinkTest {
         handler.setupLink(
-            LinkState(configuration, LinkState.LoginState.LoggedIn),
+            createLinkState(LinkState.LoginState.LoggedIn),
         )
         handler.launchLink()
         assertThat(processingStateTurbine.awaitItem()).isEqualTo(LinkHandler.ProcessingState.Launched)
@@ -76,7 +76,7 @@ class LinkHandlerTest {
     @Test
     fun `Back pressed result sets processing state to Cancelled`() = runLinkTest {
         handler.setupLink(
-            LinkState(configuration, LinkState.LoginState.LoggedIn),
+            createLinkState(LinkState.LoginState.LoggedIn),
         )
         handler.launchLink()
         assertThat(processingStateTurbine.awaitItem()).isEqualTo(LinkHandler.ProcessingState.Launched)
@@ -87,7 +87,7 @@ class LinkHandlerTest {
     @Test
     fun `Cancelled result sets processing state to Cancelled`() = runLinkTest {
         handler.setupLink(
-            LinkState(configuration, LinkState.LoginState.LoggedIn),
+            createLinkState(LinkState.LoginState.LoggedIn),
         )
         handler.launchLink()
         assertThat(processingStateTurbine.awaitItem()).isEqualTo(LinkHandler.ProcessingState.Launched)
@@ -100,7 +100,7 @@ class LinkHandlerTest {
     @Test
     fun `exception causes processing state to be CompletedWithPaymentResult`() = runLinkTest {
         handler.setupLink(
-            LinkState(configuration, LinkState.LoginState.LoggedIn),
+            createLinkState(LinkState.LoginState.LoggedIn),
         )
         handler.launchLink()
         assertThat(processingStateTurbine.awaitItem()).isEqualTo(LinkHandler.ProcessingState.Launched)
@@ -119,9 +119,8 @@ class LinkHandlerTest {
         val userInput = UserInput.SignIn("example@example.com")
 
         handler.setupLink(
-            state = LinkState(
+            state = createLinkState(
                 loginState = LinkState.LoginState.LoggedIn,
-                configuration = configuration,
             )
         )
 
@@ -153,9 +152,8 @@ class LinkHandlerTest {
         val userInput = UserInput.SignIn("example@example.com")
 
         handler.setupLink(
-            state = LinkState(
+            state = createLinkState(
                 loginState = LinkState.LoginState.NeedsVerification,
-                configuration = configuration,
             )
         )
 
@@ -186,9 +184,8 @@ class LinkHandlerTest {
         val userInput = UserInput.SignIn("example@example.com")
 
         handler.setupLink(
-            state = LinkState(
+            state = createLinkState(
                 loginState = LinkState.LoginState.LoggedOut,
-                configuration = configuration,
             )
         )
 
@@ -218,9 +215,8 @@ class LinkHandlerTest {
 
         accountStatusTurbine.ensureAllEventsConsumed()
         handler.setupLink(
-            state = LinkState(
+            state = createLinkState(
                 loginState = LinkState.LoginState.LoggedOut,
-                configuration = configuration,
             )
         )
 
@@ -255,9 +251,8 @@ class LinkHandlerTest {
 
         accountStatusTurbine.ensureAllEventsConsumed()
         handler.setupLink(
-            state = LinkState(
+            state = createLinkState(
                 loginState = LinkState.LoginState.LoggedOut,
-                configuration = configuration,
             )
         )
 
@@ -361,9 +356,8 @@ class LinkHandlerTest {
 
         accountStatusTurbine.ensureAllEventsConsumed()
         handler.setupLink(
-            state = LinkState(
+            state = createLinkState(
                 loginState = LinkState.LoginState.LoggedOut,
-                configuration = configuration,
             )
         )
 
@@ -412,9 +406,8 @@ class LinkHandlerTest {
         val userInput = UserInput.SignIn(email = "example@example.com")
 
         handler.setupLink(
-            state = LinkState(
+            state = createLinkState(
                 loginState = LinkState.LoginState.LoggedOut,
-                configuration = configuration,
             )
         )
 
@@ -450,9 +443,8 @@ class LinkHandlerTest {
         )
 
         handler.setupLink(
-            state = LinkState(
+            state = createLinkState(
                 loginState = LinkState.LoginState.LoggedOut,
-                configuration = configuration,
             )
         )
 
@@ -480,9 +472,8 @@ class LinkHandlerTest {
     @Test
     fun `payWithLinkInline fails for signedOut user without userInput`() = runLinkInlineTest {
         handler.setupLink(
-            state = LinkState(
+            state = createLinkState(
                 loginState = LinkState.LoginState.LoggedOut,
-                configuration = configuration,
             )
         )
 
@@ -512,9 +503,8 @@ class LinkHandlerTest {
         ),
     ) {
         handler.setupLink(
-            state = LinkState(
+            state = createLinkState(
                 loginState = LinkState.LoginState.LoggedOut,
-                configuration = configuration,
             )
         )
 
@@ -530,9 +520,8 @@ class LinkHandlerTest {
     @Test
     fun `Hides Link inline signup if user already has an account`() = runLinkInlineTest {
         handler.setupLink(
-            state = LinkState(
+            state = createLinkState(
                 loginState = LinkState.LoginState.NeedsVerification,
-                configuration = configuration,
             )
         )
 
@@ -548,9 +537,8 @@ class LinkHandlerTest {
     @Test
     fun `Shows Link inline signup if user has no account`() = runLinkInlineTest {
         handler.setupLink(
-            state = LinkState(
+            state = createLinkState(
                 loginState = LinkState.LoginState.LoggedOut,
-                configuration = configuration,
             )
         )
 
@@ -565,9 +553,8 @@ class LinkHandlerTest {
 
     private suspend fun LinkInlineTestData.setupBasicLink() {
         handler.setupLink(
-            state = LinkState(
+            state = createLinkState(
                 loginState = LinkState.LoginState.LoggedIn,
-                configuration = configuration,
             )
         )
 
@@ -687,6 +674,16 @@ private fun runLinkTest(
     }
 }
 
+private fun LinkTestData.createLinkState(
+    loginState: LinkState.LoginState,
+): LinkState {
+    return LinkState(
+        loginState = loginState,
+        signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
+        configuration = configuration,
+    )
+}
+
 private fun defaultLinkConfiguration(
     linkFundingSources: List<String> = emptyList(),
 ): LinkConfiguration {
@@ -694,7 +691,6 @@ private fun defaultLinkConfiguration(
         stripeIntent = PaymentIntentFactory.create(
             linkFundingSources = linkFundingSources,
         ),
-        signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
         merchantName = "Merchant, Inc",
         merchantCountryCode = "US",
         customerInfo = LinkConfiguration.CustomerInfo(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -213,6 +213,7 @@ internal class PaymentOptionsViewModelTest {
         val viewModel = createViewModel(
             linkState = LinkState(
                 configuration = mock(),
+                signupMode = null,
                 loginState = LinkState.LoginState.LoggedOut,
             ),
         )
@@ -681,6 +682,7 @@ internal class PaymentOptionsViewModelTest {
         val args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(
             linkState = LinkState(
                 configuration = mock(),
+                signupMode = null,
                 loginState = LinkState.LoginState.NeedsVerification,
             ),
             isGooglePayReady = false,
@@ -746,6 +748,7 @@ internal class PaymentOptionsViewModelTest {
         return createViewModel(
             linkState = LinkState(
                 configuration = LinkTestUtils.createLinkConfiguration(),
+                signupMode = null,
                 loginState = LinkState.LoginState.LoggedOut
             ),
             linkConfigurationCoordinator = linkConfigurationCoordinator,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -1098,6 +1098,7 @@ internal class PaymentSheetActivityTest {
                     linkState = LinkState(
                         configuration = mock(),
                         loginState = LinkState.LoginState.LoggedOut,
+                        signupMode = null,
                     ).takeIf { isLinkAvailable },
                     delay = loadDelay,
                     paymentSelection = initialPaymentSelection,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -678,6 +678,7 @@ internal class PaymentSheetViewModelTest {
             linkState = LinkState(
                 configuration = mock(),
                 loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
             ),
         )
 
@@ -781,11 +782,13 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `On inline link payment, should process with primary button`() = runTest {
         val linkConfiguration = LinkTestUtils.createLinkConfiguration()
+        val signupMode = LinkSignupMode.InsteadOfSaveForFutureUse
 
         val viewModel = createViewModel(
             linkState = LinkState(
                 configuration = linkConfiguration,
-                loginState = LinkState.LoginState.LoggedOut
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = signupMode,
             )
         )
 
@@ -809,6 +812,7 @@ internal class PaymentSheetViewModelTest {
             val linkInlineHandler = LinkInlineHandler.create(viewModel, viewModel.viewModelScope)
             linkInlineHandler.onStateUpdated(
                 InlineSignupViewState.create(
+                    signupMode = signupMode,
                     config = linkConfiguration
                 ).copy(
                     userInput = UserInput.SignUp(
@@ -900,7 +904,6 @@ internal class PaymentSheetViewModelTest {
                     PaymentMethod.Type.Card.code
                 )
             },
-            signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
             customerInfo = LinkConfiguration.CustomerInfo(null, null, null, null),
             flags = mapOf(),
             merchantName = "Test merchant inc.",
@@ -912,7 +915,8 @@ internal class PaymentSheetViewModelTest {
         val viewModel = createViewModel(
             linkState = LinkState(
                 configuration = linkConfiguration,
-                loginState = LinkState.LoginState.LoggedOut
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
             )
         )
 
@@ -1526,6 +1530,7 @@ internal class PaymentSheetViewModelTest {
             linkState = LinkState(
                 configuration = mock(),
                 loginState = LinkState.LoginState.NeedsVerification,
+                signupMode = null,
             ),
             customer = null,
             customerRepository = FakeCustomerRepository(PAYMENT_METHODS)
@@ -1547,6 +1552,7 @@ internal class PaymentSheetViewModelTest {
             linkState = LinkState(
                 configuration = mock(),
                 loginState = LinkState.LoginState.LoggedIn,
+                signupMode = null,
             ),
             customer = null,
             customerRepository = FakeCustomerRepository(PAYMENT_METHODS)
@@ -1667,6 +1673,7 @@ internal class PaymentSheetViewModelTest {
             linkState = LinkState(
                 configuration = mock(),
                 loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
             ),
         )
 
@@ -1683,6 +1690,7 @@ internal class PaymentSheetViewModelTest {
             linkState = LinkState(
                 configuration = mock(),
                 loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
             )
         )
 
@@ -2336,11 +2344,12 @@ internal class PaymentSheetViewModelTest {
 
             val interceptor = spy(FakeIntentConfirmationInterceptor())
 
+            val signupMode = LinkSignupMode.InsteadOfSaveForFutureUse
             val viewModel = spy(
                 createViewModel(
                     customer = EMPTY_CUSTOMER_STATE,
                     intentConfirmationInterceptor = interceptor,
-                    linkState = LinkState(LINK_CONFIG, LinkState.LoginState.LoggedOut)
+                    linkState = LinkState(LINK_CONFIG, LinkState.LoginState.LoggedOut, signupMode)
                 )
             )
 
@@ -2366,7 +2375,10 @@ internal class PaymentSheetViewModelTest {
 
                 val linkInlineHandler = LinkInlineHandler.create(viewModel, viewModel.viewModelScope)
                 linkInlineHandler.onStateUpdated(
-                    InlineSignupViewState.create(config = LINK_CONFIG).copy(
+                    InlineSignupViewState.create(
+                        signupMode = signupMode,
+                        config = LINK_CONFIG,
+                    ).copy(
                         isExpanded = true,
                         userInput = UserInput.SignUp(
                             name = "John Doe",
@@ -2892,7 +2904,8 @@ internal class PaymentSheetViewModelTest {
             intentConfirmationInterceptor = intentConfirmationInterceptor,
             linkState = LinkState(
                 configuration = LinkTestUtils.createLinkConfiguration(),
-                loginState = LinkState.LoginState.LoggedOut
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
             )
         )
     }
@@ -3031,7 +3044,6 @@ internal class PaymentSheetViewModelTest {
 
         private val LINK_CONFIG = LinkConfiguration(
             stripeIntent = PAYMENT_INTENT,
-            signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
             merchantName = "Merchant, Inc.",
             merchantCountryCode = "US",
             customerInfo = LinkConfiguration.CustomerInfo(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -2189,6 +2189,7 @@ internal class DefaultFlowControllerTest {
         linkState: LinkState? = LinkState(
             configuration = mock(),
             loginState = LinkState.LoginState.LoggedIn,
+            signupMode = null,
         ),
         viewModel: FlowControllerViewModel = createViewModel(),
         bacsMandateConfirmationLauncherFactory: BacsMandateConfirmationLauncherFactory = mock(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
@@ -523,6 +523,7 @@ class FlowControllerConfigurationHandlerTest {
             linkState = LinkState(
                 configuration = mock(),
                 loginState = LinkState.LoginState.LoggedIn,
+                signupMode = null,
             ),
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -557,7 +557,6 @@ internal class DefaultPaymentSheetLoaderTest {
 
         val expectedLinkConfig = LinkConfiguration(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-            signupMode = InsteadOfSaveForFutureUse,
             merchantName = "Merchant",
             merchantCountryCode = null,
             customerInfo = LinkConfiguration.CustomerInfo(
@@ -678,7 +677,7 @@ internal class DefaultPaymentSheetLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.configuration?.signupMode).isNull()
+        assertThat(result.linkState?.signupMode).isNull()
     }
 
     @Test
@@ -699,7 +698,7 @@ internal class DefaultPaymentSheetLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.configuration?.signupMode).isNull()
+        assertThat(result.linkState?.signupMode).isNull()
     }
 
     @Test
@@ -994,7 +993,7 @@ internal class DefaultPaymentSheetLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.configuration?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
+        assertThat(result.linkState?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
     }
 
     @Test
@@ -1017,7 +1016,7 @@ internal class DefaultPaymentSheetLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.configuration?.signupMode).isEqualTo(AlongsideSaveForFutureUse)
+        assertThat(result.linkState?.signupMode).isEqualTo(AlongsideSaveForFutureUse)
     }
 
     @Test
@@ -1034,7 +1033,7 @@ internal class DefaultPaymentSheetLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.configuration?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
+        assertThat(result.linkState?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
     }
 
     @Test
@@ -1051,7 +1050,7 @@ internal class DefaultPaymentSheetLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.configuration?.signupMode).isEqualTo(AlongsideSaveForFutureUse)
+        assertThat(result.linkState?.signupMode).isEqualTo(AlongsideSaveForFutureUse)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet.utils
 
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkPaymentDetails
-import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.PaymentMethod
 import org.mockito.kotlin.doReturn
@@ -33,7 +32,6 @@ object LinkTestUtils {
                     PaymentMethod.Type.Card.code
                 )
             },
-            signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
             customerInfo = LinkConfiguration.CustomerInfo(null, null, null, null),
             flags = mapOf(),
             merchantName = "Test merchant inc.",


### PR DESCRIPTION
# Summary
Decouple `LinkSignupMode` from `LinkConfiguration`.

# Motivation
We don't really calculate `LinkSignupMode` properly with the `LinkConfiguration`. It's also nullable in places where it should not be such as `InlineSignupViewModel`.

Decoupling it allows us to calculate the actual inline signup value after fetching the account status since we need the config to get the account status.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
