### PR TITLE
Prevent back navigation after Link signup

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavBackStackEntry
 import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.features.common.FullScreenGenericLoading
 import com.stripe.android.financialconnections.features.common.InstitutionIcon
@@ -84,8 +85,13 @@ import com.stripe.android.uicore.utils.collectAsState
 import kotlinx.coroutines.launch
 
 @Composable
-internal fun InstitutionPickerScreen() {
-    val viewModel: InstitutionPickerViewModel = paneViewModel { InstitutionPickerViewModel.factory(it) }
+internal fun InstitutionPickerScreen(
+    backStackEntry: NavBackStackEntry,
+) {
+    val viewModel: InstitutionPickerViewModel = paneViewModel {
+        InstitutionPickerViewModel.factory(parentComponent = it, backStackEntry.arguments)
+    }
+
     val state: InstitutionPickerState by viewModel.stateFlow.collectAsState()
     val listState = rememberLazyListState()
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/Destination.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/Destination.kt
@@ -95,7 +95,7 @@ internal sealed class Destination(
         route = Pane.INSTITUTION_PICKER.value,
         closeWithoutConfirmation = false,
         logPaneLaunched = true,
-        composable = { InstitutionPickerScreen() }
+        composable = { InstitutionPickerScreen(it) },
     )
 
     data object Consent : Destination(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModelTest.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.financialconnections.features.institutionpicker
 
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.ApiKeyFixtures
 import com.stripe.android.financialconnections.CoroutineTestRule
@@ -132,6 +134,68 @@ internal class InstitutionPickerViewModelTest {
                 pane = Pane.INSTITUTION_PICKER,
                 displayErrorScreen = true
             )
+        }
+    }
+
+    @Test
+    fun `init - allows back navigation if coming from screen other than signup`() = runTest {
+        val featuredResults = InstitutionResponse(
+            showManualEntry = false,
+            data = listOf(
+                FinancialConnectionsInstitution(
+                    id = "featured_id",
+                    name = "featured_name",
+                    url = "featured_url",
+                    featured = true,
+                    featuredOrder = null,
+                    mobileHandoffCapable = false
+                )
+            )
+        )
+
+        givenManifestReturns(ApiKeyFixtures.sessionManifest())
+        givenFeaturedInstitutionsReturns(featuredResults)
+
+        nativeAuthFlowCoordinator().test {
+            buildViewModel(
+                state = InstitutionPickerState(
+                    referrer = Pane.CONSENT,
+                ),
+            )
+
+            val updateMessage = expectMostRecentItem() as NativeAuthFlowCoordinator.Message.UpdateTopAppBar
+            assertThat(updateMessage.update.allowBackNavigation).isTrue()
+        }
+    }
+
+    @Test
+    fun `init - does not allow back navigation if coming from signup`() = runTest {
+        val featuredResults = InstitutionResponse(
+            showManualEntry = false,
+            data = listOf(
+                FinancialConnectionsInstitution(
+                    id = "featured_id",
+                    name = "featured_name",
+                    url = "featured_url",
+                    featured = true,
+                    featuredOrder = null,
+                    mobileHandoffCapable = false
+                )
+            )
+        )
+
+        givenManifestReturns(ApiKeyFixtures.sessionManifest())
+        givenFeaturedInstitutionsReturns(featuredResults)
+
+        nativeAuthFlowCoordinator().test {
+            buildViewModel(
+                state = InstitutionPickerState(
+                    referrer = Pane.LINK_LOGIN,
+                ),
+            )
+
+            val updateMessage = expectMostRecentItem() as NativeAuthFlowCoordinator.Message.UpdateTopAppBar
+            assertThat(updateMessage.update.allowBackNavigation).isFalse()
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request prevents back navigation in the NUX after signing up.

If the account is successfully created, we don’t want to allow back navigation, as the user might accidentally create a second account or attempt to reuse the account details with which they’re already signed up.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[BANKCON-11806](https://jira.corp.stripe.com/browse/BANKCON-11806)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
