### PR TITLE
Remove Android framework usage in `network-testing`

### DIFF
--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.networktesting
 
-import android.os.SystemClock
 import com.stripe.android.networktesting.RequestMatchers.composite
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
@@ -74,7 +73,7 @@ internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dis
         var timeWaited = 0.milliseconds
         val sleepDuration = 100.milliseconds
         while (enqueuedResponses.size != 0 && timeWaited < validationTimeout) {
-            SystemClock.sleep(sleepDuration.inWholeMilliseconds)
+            Thread.sleep(sleepDuration.inWholeMilliseconds)
             timeWaited = timeWaited.plus(sleepDuration)
         }
         return enqueuedResponses.size != 0

--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.networktesting
 
 import android.os.SystemClock
-import android.util.Log
 import com.stripe.android.networktesting.RequestMatchers.composite
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
@@ -101,7 +100,7 @@ internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dis
         }
 
         val exception = RequestNotFoundException("$request not mocked\n${testRequest.bodyText}")
-        Log.d("NetworkDispatcher", "Request not found.", exception)
+        println(exception)
 
         extraRequests.add(request)
 

--- a/network-testing/src/main/java/com/stripe/android/networktesting/TestMockWebServer.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/TestMockWebServer.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.networktesting
 
-import android.annotation.SuppressLint
 import okhttp3.HttpUrl
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.tls.HandshakeCertificates
@@ -40,7 +39,7 @@ internal class TestMockWebServer(validationTimeout: Duration?) {
         return serverCertificates.sslSocketFactory()
     }
 
-    @SuppressLint("CustomX509TrustManager", "TrustAllX509TrustManager")
+    @Suppress("CustomX509TrustManager", "TrustAllX509TrustManager")
     fun clientSocketFactory(
         trustAll: Boolean = false,
     ): SSLSocketFactory {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request removes Android framework usages from `network-testing`. The main one is replacing `Log.d` with `println`, as the usage of the former caused issues when using `NetworkRule` in unit tests.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
