### PR TITLE
3DS2 Req 71 Implementation

### DIFF
--- a/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/transactions/ChallengeRequestData.kt
+++ b/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/transactions/ChallengeRequestData.kt
@@ -41,7 +41,13 @@ data class ChallengeRequestData constructor(
                 json.put(FIELD_CHALLENGE_CANCEL, cancelReason.code)
             }
 
-            if (challengeDataEntry != null) {
+            // [Req 40] ...if the cardholder has submitted the response without entering any data in the UI,
+            // the Challenge Data Entry field shall not be present in the CReq message.
+            // [Req 71] If the Cardholder does not enter any data in the UI, the Challenge No Entry field
+            // shall be sent in the CReq message with the value ”Y.”
+            if (challengeDataEntry.isNullOrEmpty()) {
+                json.put(FIELD_CHALLENGE_NO_ENTRY, "Y")
+            } else {
                 json.put(FIELD_CHALLENGE_DATA_ENTRY, challengeDataEntry)
             }
 
@@ -90,6 +96,7 @@ data class ChallengeRequestData constructor(
         internal const val FIELD_3DS_SERVER_TRANS_ID: String = "threeDSServerTransID"
         internal const val FIELD_CHALLENGE_CANCEL: String = "challengeCancel"
         internal const val FIELD_CHALLENGE_DATA_ENTRY: String = "challengeDataEntry"
+        internal const val FIELD_CHALLENGE_NO_ENTRY: String = "challengeNoEntry"
         internal const val FIELD_CHALLENGE_HTML_DATA_ENTRY: String = "challengeHTMLDataEntry"
         internal const val FIELD_MESSAGE_EXTENSION: String = "messageExtensions"
         internal const val FIELD_MESSAGE_TYPE: String = "messageType"

--- a/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/transactions/ChallengeRequestData.kt
+++ b/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/transactions/ChallengeRequestData.kt
@@ -46,7 +46,7 @@ data class ChallengeRequestData constructor(
             // [Req 71] If the Cardholder does not enter any data in the UI, the Challenge No Entry field
             // shall be sent in the CReq message with the value ”Y.”
             if (challengeDataEntry.isNullOrEmpty()) {
-                json.put(FIELD_CHALLENGE_NO_ENTRY, "Y")
+                json.put(FIELD_CHALLENGE_NO_ENTRY, YES_VALUE)
             } else {
                 json.put(FIELD_CHALLENGE_DATA_ENTRY, challengeDataEntry)
             }
@@ -106,5 +106,6 @@ data class ChallengeRequestData constructor(
         internal const val FIELD_SDK_TRANS_ID: String = "sdkTransID"
 
         internal const val MESSAGE_TYPE: String = "CReq"
+        internal const val YES_VALUE: String = "Y"
     }
 }

--- a/3ds2sdk/src/test/kotlin/com/stripe/android/stripe3ds2/transactions/ChallengeRequestDataTest.kt
+++ b/3ds2sdk/src/test/kotlin/com/stripe/android/stripe3ds2/transactions/ChallengeRequestDataTest.kt
@@ -50,6 +50,7 @@ class ChallengeRequestDataTest {
             creqJson.getString(ChallengeRequestData.FIELD_RESEND_CHALLENGE)
         )
         assertFalse(creqJson.has(ChallengeRequestData.FIELD_CHALLENGE_DATA_ENTRY))
+        assertEquals("Y", creqJson.getString(ChallengeRequestData.FIELD_CHALLENGE_NO_ENTRY))
         assertFalse(creqJson.has(ChallengeRequestData.FIELD_CHALLENGE_HTML_DATA_ENTRY))
 
         assertEquals(


### PR DESCRIPTION
# Summary
Adds a new `challengeNoEntry` field for the `CReq` set to `Y` when the `challengeDataEntry` is null or empty.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
To conform to the follow requirement of the 2.2 spec:
> [Req 71] If the Cardholder does not enter any data in the UI, the Challenge No Entry field
shall be sent in the CReq message with the value ”Y.”

# Testing
<!-- How was the code tested? Be as specific as possible. -->
Updated tests to confirm that the JSON is as expected.
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified
