### PR TITLE
3DS2 Req 70 Implementation

### DIFF
--- a/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/views/ChallengeActivityViewModel.kt
+++ b/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/views/ChallengeActivityViewModel.kt
@@ -47,6 +47,7 @@ internal class ChallengeActivityViewModel(
     val nextScreen: LiveData<ChallengeResponseData> = _nextScreen
 
     var shouldRefreshUi: Boolean = false
+    var shouldAutoSubmitOOB: Boolean = false
 
     internal val transactionTimerJob: Job
 


### PR DESCRIPTION
# Summary
Auto submits the CReq if the currently displayed UI is out of band and the user returns to the app from the background.

<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Implements a new requirement from the 2.2 spec as follows:
> [Req 70] During Out-of-Band (OOB) authentication, when the 3DS Requestor App comes to
the foreground, the CReq shall automatically be submitted to the ACS and the value of the
OOB Continuation Indicator field shall be set to true.

# Testing
Manually verified using the playground.

<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified