### PR TITLE
Add remove activity tests for `CustomerSession`

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentConfigurationTestRule.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentConfigurationTestRule.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.testing
+
+import android.content.Context
+import com.stripe.android.PaymentConfiguration
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+class PaymentConfigurationTestRule(
+    private val context: Context,
+    private val publishableKey: String = "pk_123"
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        PaymentConfiguration.init(context, publishableKey)
+        super.starting(description)
+    }
+
+    override fun finished(description: Description) {
+        super.finished(description)
+        PaymentConfiguration.clearInstance()
+    }
+}

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -54,6 +54,7 @@ dependencies {
 
     testImplementation project(':link')
     testImplementation project(':financial-connections')
+    testImplementation project(':network-testing')
     testImplementation project(':payments-core-testing')
     testImplementation project(':screenshot-testing')
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditPaymentMethod.kt
@@ -190,6 +190,7 @@ private fun RemoveButton(
     ) {
         Box(
             modifier = Modifier
+                .testTag(PAYMENT_SHEET_EDIT_SCREEN_REMOVE_BUTTON)
                 .fillMaxWidth()
                 .padding(
                     start = 8.dp,
@@ -328,3 +329,5 @@ private fun EditPaymentMethodPreview() {
         )
     }
 }
+
+internal const val PAYMENT_SHEET_EDIT_SCREEN_REMOVE_BUTTON = "PaymentSheetEditScreenRemoveButton"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.disabled
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
@@ -106,7 +107,7 @@ internal fun SavedPaymentMethodTabLayoutUI(
                 SelectSavedPaymentMethodsInteractor.ViewAction.DeletePaymentMethod(it)
             )
         },
-        modifier = modifier,
+        modifier = modifier.testTag(SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG),
     )
 
     if (
@@ -378,6 +379,10 @@ private fun SavedPaymentMethodTab(
             testTag = SAVED_PAYMENT_OPTION_TEST_TAG
             selected = isSelected
             text = AnnotatedString(labelText)
+
+            if (!isEnabled) {
+                disabled()
+            }
         }
     ) {
         SavedPaymentMethodTab(
@@ -474,6 +479,8 @@ internal fun CvcRecollectionField(
         }
     }
 }
+
+internal const val SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG = "PaymentSheetSavedPaymentOptionTabLayout"
 
 @VisibleForTesting
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CustomerSessionPaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CustomerSessionPaymentSheetActivityTest.kt
@@ -1,0 +1,473 @@
+package com.stripe.android.paymentsheet
+
+import android.app.Application
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasAnyDescendant
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.RequestMatchers
+import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_EDIT_BUTTON_TEST_TAG
+import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_EDIT_SCREEN_REMOVE_BUTTON
+import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
+import com.stripe.android.paymentsheet.ui.TEST_TAG_MODIFY_BADGE
+import com.stripe.android.testing.PaymentConfigurationTestRule
+import com.stripe.android.testing.PaymentMethodFactory
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@OptIn(ExperimentalCustomerSessionApi::class)
+@RunWith(RobolectricTestRunner::class)
+internal class CustomerSessionPaymentSheetActivityTest {
+    private val applicationContext = ApplicationProvider.getApplicationContext<Application>()
+
+    private val composeTestRule = createAndroidComposeRule<PaymentSheetActivity>()
+    private val networkRule = NetworkRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(composeTestRule)
+        .around(networkRule)
+        .around(PaymentConfigurationTestRule(applicationContext))
+
+    @Test
+    fun `When multiple PMs with remove permissions and can remove last PM, should all be enabled when editing`() =
+        runTest(
+            cards = listOf(
+                createCard(last4 = "4242"),
+                createCard(last4 = "5544", addCbcNetworks = true),
+            ),
+            isPaymentMethodRemoveEnabled = true,
+            allowsRemovalOfLastSavedPaymentMethod = true,
+        ) {
+            composeTestRule.onEditButton().performClick()
+
+            composeTestRule.onSavedPaymentMethod(last4 = "4242").assertIsEnabled()
+            composeTestRule.onSavedPaymentMethod(last4 = "5544").assertIsEnabled()
+        }
+
+    @Test
+    fun `When single PM with remove permissions and can remove last PM, should be enabled when editing`() =
+        runTest(
+            cards = listOf(
+                createCard(last4 = "4242"),
+            ),
+            isPaymentMethodRemoveEnabled = true,
+            allowsRemovalOfLastSavedPaymentMethod = true,
+        ) {
+            composeTestRule.onEditButton().performClick()
+
+            composeTestRule.onSavedPaymentMethod(last4 = "4242").assertIsEnabled()
+        }
+
+    @Test
+    fun `When single PM with remove permissions but cannot remove last PM, edit button should not be displayed`() =
+        runTest(
+            cards = listOf(
+                createCard(last4 = "4242"),
+            ),
+            isPaymentMethodRemoveEnabled = true,
+            allowsRemovalOfLastSavedPaymentMethod = false,
+        ) {
+            composeTestRule.onEditButton().assertDoesNotExist()
+        }
+
+    @Test
+    fun `When multiple PMs but no remove permissions, edit button should not be displayed`() =
+        runTest(
+            cards = listOf(
+                createCard(last4 = "4242"),
+                createCard(last4 = "5544"),
+            ),
+            isPaymentMethodRemoveEnabled = false,
+            allowsRemovalOfLastSavedPaymentMethod = true,
+        ) {
+            composeTestRule.onEditButton().assertDoesNotExist()
+        }
+
+    @Test
+    fun `When multiple PMs with CBC card but no remove permissions, should allow editing CBC card and disable rest`() =
+        runTest(
+            cards = listOf(
+                createCard(last4 = "4242", addCbcNetworks = true),
+                createCard(last4 = "5544"),
+            ),
+            isPaymentMethodRemoveEnabled = false,
+            allowsRemovalOfLastSavedPaymentMethod = true,
+        ) {
+            composeTestRule.onEditButton().performClick()
+
+            composeTestRule.onSavedPaymentMethod(last4 = "5544").assertIsNotEnabled()
+
+            val cbcCard = composeTestRule.onSavedPaymentMethod(last4 = "4242")
+
+            cbcCard.assertIsEnabled()
+            cbcCard.assertHasModifyBadge()
+        }
+
+    @Test
+    fun `When multiple PMs with CBC card and has remove permissions, should be able to remove and edit CBC card`() =
+        runTest(
+            cards = listOf(
+                createCard(last4 = "4242", addCbcNetworks = true),
+                createCard(last4 = "5544"),
+            ),
+            isPaymentMethodRemoveEnabled = true,
+            allowsRemovalOfLastSavedPaymentMethod = true,
+        ) {
+            composeTestRule.onEditButton().performClick()
+
+            composeTestRule.onSavedPaymentMethod(last4 = "5544").assertIsEnabled()
+
+            val cbcCard = composeTestRule.onSavedPaymentMethod(last4 = "4242")
+
+            cbcCard.assertIsEnabled()
+            cbcCard.assertHasModifyBadge()
+
+            composeTestRule.onModifyBadgeFor(last4 = "4242").performClick()
+
+            composeTestRule.onEditScreenRemoveButton().assertIsEnabled()
+        }
+
+    @Test
+    fun `When single CBC card, has remove permissions, and can remove last PM, should be able to remove and edit`() =
+        runTest(
+            cards = listOf(
+                createCard(last4 = "4242", addCbcNetworks = true),
+            ),
+            isPaymentMethodRemoveEnabled = true,
+            allowsRemovalOfLastSavedPaymentMethod = true,
+        ) {
+            composeTestRule.onEditButton().performClick()
+
+            val cbcCard = composeTestRule.onSavedPaymentMethod(last4 = "4242")
+
+            cbcCard.assertIsEnabled()
+            cbcCard.assertHasModifyBadge()
+
+            composeTestRule.onModifyBadgeFor(last4 = "4242").performClick()
+
+            composeTestRule.onEditScreenRemoveButton().assertIsEnabled()
+        }
+
+    @Test
+    fun `When single CBC card but no remove permissions, can edit but not remove CBC card`() =
+        runTest(
+            cards = listOf(
+                createCard(last4 = "4242", addCbcNetworks = true),
+            ),
+            isPaymentMethodRemoveEnabled = false,
+            allowsRemovalOfLastSavedPaymentMethod = true,
+        ) {
+            composeTestRule.onEditButton().performClick()
+
+            val cbcCard = composeTestRule.onSavedPaymentMethod(last4 = "4242")
+
+            cbcCard.assertIsEnabled()
+            cbcCard.assertHasModifyBadge()
+
+            composeTestRule.onModifyBadgeFor(last4 = "4242").performClick()
+
+            composeTestRule.onEditScreenRemoveButton().assertDoesNotExist()
+        }
+
+    @Test
+    fun `When single CBC card has remove permissions but cannot remove last, can edit but not remove CBC card`() =
+        runTest(
+            cards = listOf(
+                createCard(last4 = "4242", addCbcNetworks = true),
+            ),
+            isPaymentMethodRemoveEnabled = true,
+            allowsRemovalOfLastSavedPaymentMethod = false,
+        ) {
+            composeTestRule.onEditButton().performClick()
+
+            val cbcCard = composeTestRule.onSavedPaymentMethod(last4 = "4242")
+
+            cbcCard.assertIsEnabled()
+            cbcCard.assertHasModifyBadge()
+
+            composeTestRule.onModifyBadgeFor(last4 = "4242").performClick()
+
+            composeTestRule.onEditScreenRemoveButton().assertDoesNotExist()
+        }
+
+    private fun runTest(
+        cards: List<PaymentMethod>,
+        isPaymentMethodRemoveEnabled: Boolean,
+        allowsRemovalOfLastSavedPaymentMethod: Boolean,
+        test: (PaymentSheetActivity) -> Unit,
+    ) {
+        networkRule.enqueue(
+            RequestMatchers.host("api.stripe.com"),
+            RequestMatchers.method("GET"),
+            RequestMatchers.path("/v1/elements/sessions"),
+        ) { response ->
+            response.setBody(createElementsSessionResponse(cards, isPaymentMethodRemoveEnabled))
+        }
+
+        val countDownLatch = CountDownLatch(1)
+
+        ActivityScenario.launch<PaymentSheetActivity>(
+            PaymentSheetContractV2().createIntent(
+                ApplicationProvider.getApplicationContext(),
+                PaymentSheetContractV2.Args(
+                    initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                        clientSecret = "pi_1234_secret_5678",
+                    ),
+                    config = PaymentSheet.Configuration(
+                        merchantDisplayName = "Merchant, Inc.",
+                        customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
+                            id = "cus_1",
+                            clientSecret = "cuss_1",
+                        ),
+                        allowsRemovalOfLastSavedPaymentMethod = allowsRemovalOfLastSavedPaymentMethod,
+                        preferredNetworks = listOf(CardBrand.CartesBancaires, CardBrand.Visa),
+                    ),
+                    statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR,
+                )
+            )
+        ).use { scenario ->
+            scenario.onActivity { activity ->
+                composeTestRule.waitUntil(timeoutMillis = 2_000) {
+                    composeTestRule
+                        .onAllNodes(hasTestTag(SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG))
+                        .fetchSemanticsNodes()
+                        .isNotEmpty()
+                }
+
+                test(activity)
+
+                countDownLatch.countDown()
+            }
+
+            countDownLatch.await(5, TimeUnit.SECONDS)
+            networkRule.validate()
+        }
+    }
+
+    private fun ComposeTestRule.onEditButton(): SemanticsNodeInteraction {
+        return onNode(
+            hasTestTag(PAYMENT_SHEET_EDIT_BUTTON_TEST_TAG)
+        )
+    }
+
+    private fun ComposeTestRule.onEditScreenRemoveButton(): SemanticsNodeInteraction {
+        return onNode(
+            hasTestTag(PAYMENT_SHEET_EDIT_SCREEN_REMOVE_BUTTON)
+        )
+    }
+
+    private fun SemanticsNodeInteraction.assertHasModifyBadge() {
+        assert(hasAnyDescendant(hasTestTag(TEST_TAG_MODIFY_BADGE)))
+    }
+
+    private fun ComposeTestRule.onModifyBadgeFor(last4: String): SemanticsNodeInteraction {
+        return onNode(
+            hasTestTag(TEST_TAG_MODIFY_BADGE).and(hasAnyAncestor(savedPaymentMethodMatcher(last4)))
+        )
+    }
+
+    private fun ComposeTestRule.onSavedPaymentMethod(last4: String): SemanticsNodeInteraction {
+        return onNode(savedPaymentMethodMatcher(last4))
+    }
+
+    private fun savedPaymentMethodMatcher(last4: String): SemanticsMatcher {
+        return hasTestTag(SAVED_PAYMENT_OPTION_TEST_TAG).and(hasText(last4, substring = true))
+    }
+
+    private fun createCard(last4: String, addCbcNetworks: Boolean = false): PaymentMethod {
+        return PaymentMethodFactory.card(random = true).run {
+            copy(
+                card = card?.copy(
+                    last4 = last4,
+                    networks = PaymentMethod.Card.Networks(
+                        available = setOf("cartes_bancaires", "visa"),
+                        preferred = "cartes_bancaries",
+                    ).takeIf {
+                        addCbcNetworks
+                    }
+                )
+            )
+        }
+    }
+
+    private companion object {
+        @Suppress("LongMethod")
+        fun createElementsSessionResponse(
+            cards: List<PaymentMethod>,
+            isPaymentMethodRemoveEnabled: Boolean,
+        ): String {
+            val cardsArray = JSONArray()
+
+            cards.forEach { card ->
+                cardsArray.put(convertCardToJson(card))
+            }
+
+            val cardsStringified = cardsArray.toString(2)
+
+            val isPaymentMethodRemoveStringified = if (isPaymentMethodRemoveEnabled) {
+                "enabled"
+            } else {
+                "disabled"
+            }
+
+            return """
+                {
+                  "business_name": "Mobile Example Account",
+                  "google_pay_preference": "enabled",
+                  "merchant_country": "US",
+                  "merchant_currency": "usd",
+                  "merchant_id": "acct_1HvTI7Lu5o3P18Zp",
+                  "meta_pay_signed_container_context": null,
+                  "order": null,
+                  "ordered_payment_method_types_and_wallets": [
+                    "card"
+                  ],
+                  "card_brand_choice": {
+                    "eligible": true,
+                    "preferred_networks": ["cartes_bancaires"]
+                  },
+                  "customer": {
+                    "payment_methods": $cardsStringified,
+                    "customer_session": {
+                      "id": "cuss_654321",
+                      "livemode": false,
+                      "api_key": "ek_12345",
+                      "api_key_expiry": 1899787184,
+                      "customer": "cus_12345",
+                      "components": {
+                        "payment_sheet": {
+                          "enabled": true,
+                          "features": {
+                            "payment_method_save": "enabled",
+                            "payment_method_remove": "$isPaymentMethodRemoveStringified",
+                            "payment_method_save_allow_redisplay_override": null
+                          }
+                        },
+                        "customer_sheet": {
+                          "enabled": false,
+                          "features": null
+                        }
+                      }
+                    },
+                    "default_payment_method": null
+                  },
+                  "payment_method_preference": {
+                    "object": "payment_method_preference",
+                    "country_code": "US",
+                    "ordered_payment_method_types": [
+                      "card"
+                    ],
+                    "payment_intent": {
+                      "id": "pi_example",
+                      "object": "payment_intent",
+                      "amount": 5099,
+                      "amount_details": {
+                        "tip": {}
+                      },
+                      "automatic_payment_methods": {
+                        "enabled": true
+                      },
+                      "canceled_at": null,
+                      "cancellation_reason": null,
+                      "capture_method": "automatic",
+                      "client_secret": "pi_example_secret_example",
+                      "confirmation_method": "automatic",
+                      "created": 1674750417,
+                      "currency": "usd",
+                      "description": null,
+                      "last_payment_error": null,
+                      "livemode": false,
+                      "next_action": null,
+                      "payment_method": null,
+                      "payment_method_options": {
+                        "us_bank_account": {
+                          "verification_method": "automatic"
+                        }
+                      },
+                      "payment_method_types": [
+                        "card"
+                      ],
+                      "processing": null,
+                      "receipt_email": null,
+                      "setup_future_usage": null,
+                      "shipping": null,
+                      "source": null,
+                      "status": "requires_payment_method"
+                    },
+                    "type": "payment_intent"
+                  },
+                  "payment_method_specs": [
+                    {
+                      "async": false,
+                      "fields": [],
+                      "type": "card"
+                    }
+                  ],
+                  "paypal_express_config": {
+                    "client_id": null,
+                    "paypal_merchant_id": null
+                  },
+                  "shipping_address_settings": {
+                    "autocomplete_allowed": true
+                  },
+                  "unactivated_payment_method_types": []
+                }
+            """.trimIndent()
+        }
+
+        private fun convertCardToJson(paymentMethod: PaymentMethod): JSONObject {
+            val paymentMethodJson = JSONObject()
+
+            paymentMethodJson.put("id", paymentMethod.id)
+            paymentMethodJson.put("type", paymentMethod.type?.code)
+            paymentMethodJson.put("created", paymentMethod.created)
+            paymentMethodJson.put("customer", paymentMethod.customerId)
+            paymentMethodJson.put("livemode", paymentMethod.liveMode)
+
+            val card = paymentMethod.card
+            val cardJson = JSONObject()
+
+            cardJson.put("brand", card?.brand?.code)
+            cardJson.put("last4", card?.last4)
+
+            val networks = paymentMethod.card?.networks
+            val networksJson = JSONObject()
+            val availableJson = JSONArray()
+
+            networks?.available?.forEach {
+                availableJson.put(it)
+            }
+
+            networksJson.put("available", availableJson)
+            networksJson.put("preferred", networks?.preferred)
+
+            cardJson.put("networks", networksJson)
+
+            paymentMethodJson.put("card", cardJson)
+
+            return paymentMethodJson
+        }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsTest.kt
@@ -1,13 +1,22 @@
 package com.stripe.android.paymentsheet.ui
 
 import android.os.Build
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.PaymentOptionsItem
+import com.stripe.android.testing.PaymentMethodFactory
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -107,6 +116,40 @@ class PaymentOptionsTest {
     }
 
     @Test
+    fun `If saved payment methods are disabled, all tabs should be disabled as well`() {
+        composeTestRule.setContent {
+            SavedPaymentMethodTabLayoutUI(
+                paymentOptionsItems = listOf(
+                    PaymentOptionsItem.SavedPaymentMethod(
+                        displayableSavedPaymentMethod = DisplayableSavedPaymentMethod(
+                            displayName = resolvableString("4242"),
+                            paymentMethod = createCard(last4 = "4242"),
+                        ),
+                        canRemovePaymentMethods = false,
+                    ),
+                    PaymentOptionsItem.SavedPaymentMethod(
+                        displayableSavedPaymentMethod = DisplayableSavedPaymentMethod(
+                            displayName = resolvableString("5555"),
+                            paymentMethod = createCard(last4 = "5555"),
+                        ),
+                        canRemovePaymentMethods = false,
+                    )
+                ),
+                selectedPaymentOptionsItem = PaymentOptionsItem.GooglePay,
+                isEditing = true,
+                isProcessing = false,
+                onAddCardPressed = {},
+                onItemSelected = {},
+                onModifyItem = {},
+                onItemRemoved = {},
+            )
+        }
+
+        composeTestRule.onTab(last4 = "4242").assertIsNotEnabled()
+        composeTestRule.onTab(last4 = "5555").assertIsNotEnabled()
+    }
+
+    @Test
     fun `When width is 320dp, calculates item width of 114dp`() {
         composeTestRule.setContent {
             val itemWidth = rememberItemWidth(maxWidth = 320.dp)
@@ -128,5 +171,19 @@ class PaymentOptionsTest {
             val itemWidth = rememberItemWidth(maxWidth = 482.dp)
             assertThat(itemWidth.value.roundToInt()).isEqualTo(112)
         }
+    }
+
+    private fun createCard(last4: String): PaymentMethod {
+        return PaymentMethodFactory.card(random = true).run {
+            copy(
+                card = card?.copy(
+                    last4 = last4,
+                )
+            )
+        }
+    }
+
+    private fun ComposeTestRule.onTab(last4: String): SemanticsNodeInteraction {
+        return onNode(hasTestTag(SAVED_PAYMENT_OPTION_TEST_TAG).and(hasText(last4, substring = true)))
     }
 }


### PR DESCRIPTION
# Summary
Add remove tests through a new instrumented test class `CustomerSessionPaymentSheetTest` that tests all variants of removal/edit states that can occur in `PaymentSheet` with `CustomerSession`.

# Motivation
Ensures removal logic is well maintained for `CustomerSession` in `PaymentSheet`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
