### PR TITLE
Enable `Customer Session` for `PaymentSheet`

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -812,6 +812,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$CustomerAccessTy
 public final class com/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
@@ -824,6 +825,10 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$CustomerConfigur
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration$Companion {
+	public final fun createWithCustomerSession (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration$Creator : android/os/Parcelable$Creator {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -1551,10 +1551,8 @@ class PaymentSheet internal constructor(
             accessType = CustomerAccessType.LegacyCustomerEphemeralKey(ephemeralKeySecret)
         )
 
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         companion object {
             @ExperimentalCustomerSessionApi
-            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             fun createWithCustomerSession(
                 id: String,
                 clientSecret: String


### PR DESCRIPTION
# Summary
Enable `Customer Session` for `PaymentSheet`

# Motivation
Allow merchants to use `Customer Session` features with `PaymentSheet` in experimental mode.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
