### PR TITLE
Add a delay when selecting rows in vertical mode.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/NavigationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/NavigationHandler.kt
@@ -1,14 +1,22 @@
 package com.stripe.android.paymentsheet.navigation
 
 import com.stripe.android.uicore.utils.mapAsStateFlow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import java.io.Closeable
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.milliseconds
 
 internal class NavigationHandler(
+    private val coroutineScope: CoroutineScope,
     private val poppedScreenHandler: (PaymentSheetScreen) -> Unit,
 ) {
+    private val isTransitioning = AtomicBoolean(false)
+
     private val backStack = MutableStateFlow<List<PaymentSheetScreen>>(
         value = listOf(PaymentSheetScreen.Loading),
     )
@@ -20,22 +28,44 @@ internal class NavigationHandler(
         get() = backStack.value.size > 1
 
     fun transitionTo(target: PaymentSheetScreen) {
+        if (!isTransitioning.get()) {
+            transitionToInternal(target)
+        }
+    }
+
+    fun transitionToWithDelay(target: PaymentSheetScreen) {
+        navigateWithDelay { transitionToInternal(target) }
+    }
+
+    private fun transitionToInternal(target: PaymentSheetScreen) {
         backStack.update { (it - PaymentSheetScreen.Loading) + target }
     }
 
     fun resetTo(screens: List<PaymentSheetScreen>) {
-        val previousBackStack = backStack.value
+        if (!isTransitioning.get()) {
+            val previousBackStack = backStack.value
 
-        backStack.value = screens
+            backStack.value = screens
 
-        previousBackStack.forEach { oldScreen ->
-            if (oldScreen !in screens) {
-                oldScreen.onClose()
+            previousBackStack.forEach { oldScreen ->
+                if (oldScreen !in screens) {
+                    oldScreen.onClose()
+                }
             }
         }
     }
 
     fun pop() {
+        if (!isTransitioning.get()) {
+            popInternal()
+        }
+    }
+
+    fun popWithDelay() {
+        navigateWithDelay { pop() }
+    }
+
+    private fun popInternal() {
         backStack.update { screens ->
             val modifiableScreens = screens.toMutableList()
 
@@ -59,6 +89,17 @@ internal class NavigationHandler(
         when (this) {
             is Closeable -> close()
             else -> Unit
+        }
+    }
+
+    private fun navigateWithDelay(action: () -> Unit) {
+        if (!isTransitioning.getAndSet(true)) {
+            // Introduce a delay to show ripple.
+            coroutineScope.launch {
+                delay(250.milliseconds)
+                action()
+                isTransitioning.set(false)
+            }
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
@@ -152,7 +152,7 @@ internal class DefaultManageScreenInteractor(
                 },
                 onDeletePaymentMethod = { savedPaymentMethodMutator.removePaymentMethod(it.paymentMethod) },
                 onEditPaymentMethod = { savedPaymentMethodMutator.modifyPaymentMethod(it.paymentMethod) },
-                navigateBack = viewModel::handleBackPressed,
+                navigateBack = viewModel.navigationHandler::popWithDelay,
                 isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -101,7 +101,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                 processing = viewModel.processing,
                 selection = viewModel.selection,
                 formElementsForCode = formHelper::formElementsForCode,
-                transitionTo = viewModel.navigationHandler::transitionTo,
+                transitionTo = viewModel.navigationHandler::transitionToWithDelay,
                 onFormFieldValuesChanged = formHelper::onFormFieldValuesChanged,
                 manageScreenFactory = {
                     val interactor = DefaultManageScreenInteractor.create(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -58,7 +58,7 @@ internal abstract class BaseSheetViewModel(
     private val _paymentMethodMetadata = MutableStateFlow<PaymentMethodMetadata?>(null)
     internal val paymentMethodMetadata: StateFlow<PaymentMethodMetadata?> = _paymentMethodMetadata
 
-    val navigationHandler: NavigationHandler = NavigationHandler { poppedScreen ->
+    val navigationHandler: NavigationHandler = NavigationHandler(viewModelScope) { poppedScreen ->
         analyticsListener.reportPaymentSheetHidden(poppedScreen)
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/NavigationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/NavigationHandlerTest.kt
@@ -2,17 +2,19 @@ package com.stripe.android.paymentsheet.navigation
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import java.io.Closeable
+import kotlin.time.Duration.Companion.milliseconds
 
 internal class NavigationHandlerTest {
     @Test
     fun `currentScreen is initialized to Loading`() = runTest {
-        val navigationHandler = NavigationHandler {}
+        val navigationHandler = NavigationHandler(this) {}
         navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
             assertThat(navigationHandler.canGoBack).isFalse()
@@ -21,7 +23,7 @@ internal class NavigationHandlerTest {
 
     @Test
     fun `transitionTo removes Loading`() = runTest {
-        val navigationHandler = NavigationHandler {}
+        val navigationHandler = NavigationHandler(this) {}
         navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
             val newScreen = mock<PaymentSheetScreen>()
@@ -33,7 +35,7 @@ internal class NavigationHandlerTest {
 
     @Test
     fun `transitionTo keeps backstack`() = runTest {
-        val navigationHandler = NavigationHandler {}
+        val navigationHandler = NavigationHandler(this) {}
         navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
             val screenOne = mock<PaymentSheetScreen>()
@@ -47,8 +49,68 @@ internal class NavigationHandlerTest {
     }
 
     @Test
+    fun `transitionToWithDelay transitions to target screen`() = runTest {
+        val testScope = TestScope()
+        val navigationHandler = NavigationHandler(testScope) {}
+        navigationHandler.currentScreen.test {
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
+            val screenOne = mock<PaymentSheetScreen>()
+            navigationHandler.transitionTo(screenOne)
+            assertThat(awaitItem()).isEqualTo(screenOne)
+            val screenTwo = mock<PaymentSheetScreen>()
+            navigationHandler.transitionToWithDelay(screenTwo)
+            testScope.testScheduler.advanceTimeBy(250.milliseconds)
+            ensureAllEventsConsumed()
+            testScope.testScheduler.advanceTimeBy(1.milliseconds)
+            assertThat(awaitItem()).isEqualTo(screenTwo)
+            assertThat(navigationHandler.canGoBack).isTrue()
+        }
+    }
+
+    @Test
+    fun `transitionToWithDelay allows future transitions`() = runTest {
+        val testScope = TestScope()
+        val navigationHandler = NavigationHandler(testScope) {}
+        navigationHandler.currentScreen.test {
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
+            val screenOne = mock<PaymentSheetScreen>()
+            navigationHandler.transitionTo(screenOne)
+            assertThat(awaitItem()).isEqualTo(screenOne)
+            val screenTwo = mock<PaymentSheetScreen>()
+            navigationHandler.transitionToWithDelay(screenTwo)
+            testScope.testScheduler.advanceTimeBy(251.milliseconds)
+            assertThat(awaitItem()).isEqualTo(screenTwo)
+            val screenThree = mock<PaymentSheetScreen>()
+            navigationHandler.transitionTo(screenThree)
+            assertThat(awaitItem()).isEqualTo(screenThree)
+            assertThat(navigationHandler.canGoBack).isTrue()
+        }
+    }
+
+    @Test
+    fun `transitionToWithDelay prevents other navigation actions during delay`() = runTest {
+        val testScope = TestScope()
+        val navigationHandler = NavigationHandler(testScope) {}
+        navigationHandler.currentScreen.test {
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
+            val screenOne = mock<PaymentSheetScreen>()
+            navigationHandler.transitionTo(screenOne)
+            assertThat(awaitItem()).isEqualTo(screenOne)
+            val screenTwo = mock<PaymentSheetScreen>()
+            navigationHandler.transitionToWithDelay(screenTwo)
+            val screenThree = mock<PaymentSheetScreen>()
+            navigationHandler.transitionTo(screenThree)
+            navigationHandler.pop()
+            navigationHandler.resetTo(listOf(screenThree))
+            testScope.testScheduler.advanceTimeBy(251.milliseconds)
+            assertThat(awaitItem()).isEqualTo(screenTwo)
+            assertThat(navigationHandler.canGoBack).isTrue()
+        }
+    }
+
+    @Test
     fun `resetTo resets backstack`() = runTest {
-        val navigationHandler = NavigationHandler {}
+        val navigationHandler = NavigationHandler(this) {}
         navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
             val screenOne = mock<PaymentSheetScreen>()
@@ -67,7 +129,7 @@ internal class NavigationHandlerTest {
 
     @Test
     fun `resetTo calls close on removed screens`() = runTest {
-        val navigationHandler = NavigationHandler {}
+        val navigationHandler = NavigationHandler(this) {}
         navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
             val screenOne = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
@@ -88,7 +150,7 @@ internal class NavigationHandlerTest {
 
     @Test
     fun `resetTo only calls close on removed screens`() = runTest {
-        val navigationHandler = NavigationHandler {}
+        val navigationHandler = NavigationHandler(this) {}
         navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
             val screenOne = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
@@ -112,7 +174,7 @@ internal class NavigationHandlerTest {
         val screenOne = mock<PaymentSheetScreen>()
         val screenTwo = mock<PaymentSheetScreen>()
 
-        val navigationHandler = NavigationHandler {
+        val navigationHandler = NavigationHandler(this) {
             calledPopHandler = true
             assertThat(it).isEqualTo(screenTwo)
         }
@@ -141,7 +203,7 @@ internal class NavigationHandlerTest {
         val screenOne = mock<PaymentSheetScreen>()
         val screenTwo = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
 
-        val navigationHandler = NavigationHandler {
+        val navigationHandler = NavigationHandler(this) {
             calledPopHandler = true
             assertThat(it).isEqualTo(screenTwo)
         }
@@ -166,7 +228,7 @@ internal class NavigationHandlerTest {
 
     @Test
     fun `closeScreens calls close on all closable screens in the backstack`() = runTest {
-        val navigationHandler = NavigationHandler {}
+        val navigationHandler = NavigationHandler(this) {}
         navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
             val screenOne = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This makes it so we can see the ripple of the action (similar to what the Android settings app does).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2276

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
https://github.com/user-attachments/assets/de5d35fb-ff9b-45a9-ae67-9cc6e8b2f041

