### PR TITLE
Use the actually entered email in FC playground

### DIFF
--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.stripe.android.financialconnections.example.settings.EmailSetting
 import com.stripe.android.financialconnections.example.settings.PlaygroundSettings
 import com.stripe.android.financialconnections.example.settings.SettingsUi
 import com.stripe.android.financialconnections.rememberFinancialConnectionsSheet
@@ -119,6 +120,8 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
                     }
 
                     is FinancialConnectionsPlaygroundViewEffect.OpenForPaymentIntent -> {
+                        val email = state.settings.get<EmailSetting>().selectedOption
+
                         collectBankAccountLauncher.presentWithPaymentIntent(
                             publishableKey = it.publishableKey,
                             stripeAccountId = null,
@@ -127,12 +130,12 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
                                 Experience.FinancialConnections -> {
                                     CollectBankAccountConfiguration.USBankAccount(
                                         name = "Sample name",
-                                        email = "sampleEmail@test.com"
+                                        email = email,
                                     )
                                 }
                                 Experience.InstantDebits -> {
                                     CollectBankAccountConfiguration.InstantDebits(
-                                        email = "sampleEmail@test.com",
+                                        email = email,
                                     )
                                 }
                             }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request removes the hard-coded `sampleEmail@test.com` from our playground.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
