### PR TITLE
Remove hardcoded nature of afterpay payment calculation.

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement.kt
@@ -4,12 +4,10 @@ import android.content.res.Resources
 import androidx.annotation.RestrictTo
 import androidx.compose.ui.text.intl.Locale
 import com.stripe.android.core.strings.ResolvableString
-import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.Controller
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
-import com.stripe.android.uicore.format.CurrencyFormatter
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
@@ -17,7 +15,6 @@ import kotlinx.coroutines.flow.StateFlow
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class AfterpayClearpayHeaderElement(
     override val identifier: IdentifierSpec,
-    private val amount: Amount,
     override val controller: Controller? = null
 ) : FormElement {
     override val allowsUserInteraction: Boolean = false
@@ -33,20 +30,9 @@ data class AfterpayClearpayHeaderElement(
         locale.language.lowercase() + "_" + locale.region.uppercase()
 
     fun getLabel(resources: Resources): String {
-        val numInstallments = when (amount.currencyCode.lowercase()) {
-            "eur" -> 3
-            else -> 4
-        }
         return resources.getString(
-            R.string.stripe_afterpay_clearpay_message
-        ).replace("<num_installments/>", numInstallments.toString())
-            .replace(
-                "<installment_price/>",
-                CurrencyFormatter.format(
-                    amount.value / numInstallments,
-                    amount.currencyCode
-                )
-            )
+            R.string.stripe_afterpay_clearpay_marketing
+        )
             // The no break space will keep the afterpay logo and (i) on the same line.
             .replace(
                 "<img/>",

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayTextSpec.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
-import com.stripe.android.ui.core.Amount
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import kotlinx.parcelize.Parcelize
@@ -18,6 +17,5 @@ data class AfterpayClearpayTextSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("afterpay_text")
 ) : FormItemSpec() {
-    fun transform(amount: Amount): FormElement =
-        AfterpayClearpayHeaderElement(this.apiPath, amount)
+    fun transform(): FormElement = AfterpayClearpayHeaderElement(apiPath)
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElementTest.kt
@@ -3,7 +3,6 @@ package com.stripe.android.ui.core.elements
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.elements.AfterpayClearpayHeaderElement.Companion.isClearpay
 import com.stripe.android.uicore.elements.IdentifierSpec
 import org.junit.Test
@@ -15,56 +14,20 @@ import java.util.Locale
 class AfterpayClearpayHeaderElementTest {
 
     @Test
-    fun `Verify label is correct for USD`() {
+    fun `Verify label is correct`() {
         val element = AfterpayClearpayHeaderElement(
             IdentifierSpec.Generic("test"),
-            Amount(20000, "USD")
         )
 
         assertThat(
             element.getLabel(ApplicationProvider.getApplicationContext<Application>().resources)
-        ).isEqualTo(
-            "Pay in 4 interest-free payments of $50.00 with <img/> " +
-                "<b>ⓘ</b>"
-        )
-    }
-
-    @Test
-    fun `Verify label is correct for EUR`() {
-        val element = AfterpayClearpayHeaderElement(
-            IdentifierSpec.Generic("test"),
-            Amount(20000, "EUR")
-        )
-
-        assertThat(
-            element.getLabel(ApplicationProvider.getApplicationContext<Application>().resources)
-        ).isEqualTo(
-            "Pay in 3 interest-free payments of €66.66 with <img/> " +
-                "<b>ⓘ</b>"
-        )
-    }
-
-    @Test
-    fun `Verify label amount is localized`() {
-        Locale.setDefault(Locale.CANADA)
-        val element = AfterpayClearpayHeaderElement(
-            IdentifierSpec.Generic("test"),
-            Amount(20000, "USD")
-        )
-
-        assertThat(
-            element.getLabel(ApplicationProvider.getApplicationContext<Application>().resources)
-        ).isEqualTo(
-            "Pay in 4 interest-free payments of US$50.00 with <img/> " +
-                "<b>ⓘ</b>"
-        )
+        ).isEqualTo("Buy now or pay later with <img/> <b>ⓘ</b>")
     }
 
     @Test
     fun `Verify infoUrl is correct`() {
         val element = AfterpayClearpayHeaderElement(
             IdentifierSpec.Generic("test"),
-            Amount(123, "USD")
         )
 
         assertThat(element.infoUrl)
@@ -76,7 +39,6 @@ class AfterpayClearpayHeaderElementTest {
         Locale.setDefault(Locale.UK)
         val element = AfterpayClearpayHeaderElement(
             IdentifierSpec.Generic("test"),
-            Amount(123, "USD")
         )
 
         assertThat(element.infoUrl)
@@ -92,7 +54,6 @@ class AfterpayClearpayHeaderElementTest {
         Locale.setDefault(Locale.UK)
         val element = AfterpayClearpayHeaderElement(
             IdentifierSpec.Generic("test"),
-            Amount(123, "USD")
         )
 
         assertThat(element.infoUrl)
@@ -104,7 +65,6 @@ class AfterpayClearpayHeaderElementTest {
         Locale.setDefault(Locale.FRANCE)
         val element = AfterpayClearpayHeaderElement(
             IdentifierSpec.Generic("test"),
-            Amount(123, "USD")
         )
 
         assertThat(element.infoUrl)

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElements.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElements.kt
@@ -53,7 +53,7 @@ internal class TransformSpecToElements(
         ).mapNotNull {
             when (it) {
                 is StaticTextSpec -> it.transform()
-                is AfterpayClearpayTextSpec -> it.transform(requireNotNull(arguments.amount))
+                is AfterpayClearpayTextSpec -> it.transform()
                 is AffirmTextSpec -> it.transform()
                 is EmptyFormSpec -> EmptyFormElement()
                 is MandateTextSpec -> it.transform(arguments.merchantName)

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
@@ -11,7 +11,6 @@ import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.toIdentifierMap
-import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.SharedDataSpec
 import com.stripe.android.uicore.elements.FormElement
@@ -23,7 +22,6 @@ internal sealed interface UiDefinitionFactory {
         val linkConfigurationCoordinator: LinkConfigurationCoordinator?,
         val initialValues: Map<IdentifierSpec, String?>,
         val shippingValues: Map<IdentifierSpec, String?>?,
-        val amount: Amount?,
         val saveForFutureUseInitialValue: Boolean,
         val merchantName: String,
         val cbcEligibility: CardBrandChoiceEligibility,
@@ -51,7 +49,6 @@ internal sealed interface UiDefinitionFactory {
                     return Arguments(
                         cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
                         linkConfigurationCoordinator = linkConfigurationCoordinator,
-                        amount = metadata.amount(),
                         merchantName = metadata.merchantName,
                         cbcEligibility = metadata.cbcEligibility,
                         initialValues = InitialValuesFactory.create(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/FormControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/FormControllerModule.kt
@@ -6,10 +6,7 @@ import com.stripe.android.core.injection.INITIAL_VALUES
 import com.stripe.android.core.injection.SHIPPING_VALUES
 import com.stripe.android.lpmfoundations.luxe.TransformSpecToElements
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
-import com.stripe.android.model.PaymentIntent
-import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.IdentifierSpec
 import dagger.Module
@@ -22,21 +19,12 @@ internal object FormControllerModule {
     fun provideTransformSpecToElements(
         context: Context,
         merchantName: String,
-        stripeIntent: StripeIntent?,
         @Named(INITIAL_VALUES) initialValues: Map<IdentifierSpec, String?>,
         @Named(SHIPPING_VALUES) shippingValues: Map<IdentifierSpec, String?>?
     ) = TransformSpecToElements(
         arguments = UiDefinitionFactory.Arguments(
             initialValues = initialValues,
             shippingValues = shippingValues,
-            amount = (stripeIntent as? PaymentIntent)?.let {
-                val amount = it.amount
-                val currency = it.currency
-                if (amount != null && currency != null) {
-                    Amount(amount, currency)
-                }
-                null
-            },
             saveForFutureUseInitialValue = false,
             merchantName = merchantName,
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context.applicationContext),

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
@@ -101,7 +101,6 @@ class FormElementsBuilderTest {
         return UiDefinitionFactory.Arguments(
             initialValues = emptyMap(),
             shippingValues = emptyMap(),
-            amount = null,
             saveForFutureUseInitialValue = false,
             merchantName = "Example Inc.",
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
@@ -379,7 +379,6 @@ private object TransformSpecToElementsFactory {
         return TransformSpecToElements(
             UiDefinitionFactory.Arguments(
                 initialValues = mapOf(),
-                amount = null,
                 saveForFutureUseInitialValue = true,
                 merchantName = "Merchant, Inc.",
                 cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FormControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FormControllerTest.kt
@@ -36,7 +36,6 @@ class FormControllerTest {
     private val transformSpecToElements = TransformSpecToElements(
         UiDefinitionFactory.Arguments(
             initialValues = emptyMap(),
-            amount = null,
             saveForFutureUseInitialValue = false,
             merchantName = "Merchant",
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
The payments have changed (I think) and we don't want them hardcoded in the SDK.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3372

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

![Screenshot_20240820_070443](https://github.com/user-attachments/assets/0d3f3053-f2f8-434e-8853-dc08f94dc2f1)

