### PR TITLE
Tweak navigation in Instant Debits flow

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandler.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandler.kt
@@ -8,10 +8,10 @@ import com.stripe.android.financialconnections.domain.AttachConsumerToLinkAccoun
 import com.stripe.android.financialconnections.domain.GetCachedAccounts
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.GetOrFetchSync.RefetchCondition.Always
+import com.stripe.android.financialconnections.domain.HandleError
 import com.stripe.android.financialconnections.domain.SaveAccountToLink
 import com.stripe.android.financialconnections.features.common.isDataFlow
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
-import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane.LINK_ACCOUNT_PICKER
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane.LINK_LOGIN
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane.NETWORKING_LINK_SIGNUP_PANE
 import com.stripe.android.financialconnections.navigation.Destination.NetworkingLinkVerification
@@ -28,9 +28,8 @@ internal interface LinkSignupHandler {
     ): Pane
 
     fun handleSignupFailure(
-        state: NetworkingLinkSignupState,
         error: Throwable,
-    ): NetworkingLinkSignupState
+    )
 
     fun navigateToVerification()
 }
@@ -40,8 +39,7 @@ internal class LinkSignupHandlerForInstantDebits @Inject constructor(
     private val attachConsumerToLinkAccountSession: AttachConsumerToLinkAccountSession,
     private val getOrFetchSync: GetOrFetchSync,
     private val navigationManager: NavigationManager,
-    private val eventTracker: FinancialConnectionsAnalyticsTracker,
-    private val logger: Logger,
+    private val handleError: HandleError,
 ) : LinkSignupHandler {
 
     override suspend fun performSignup(
@@ -59,29 +57,21 @@ internal class LinkSignupHandlerForInstantDebits @Inject constructor(
             consumerSessionClientSecret = signup.consumerSession.clientSecret,
         )
 
-        getOrFetchSync(refetchCondition = Always)
-
-        return LINK_ACCOUNT_PICKER
+        val manifest = getOrFetchSync(refetchCondition = Always).manifest
+        return manifest.nextPane
     }
 
     override fun navigateToVerification() {
         navigationManager.tryNavigateTo(NetworkingLinkVerification(referrer = LINK_LOGIN))
     }
 
-    override fun handleSignupFailure(
-        state: NetworkingLinkSignupState,
-        error: Throwable,
-    ): NetworkingLinkSignupState {
-        eventTracker.logError(
+    override fun handleSignupFailure(error: Throwable) {
+        handleError(
             extraMessage = "Error creating a Link account",
             error = error,
-            logger = logger,
             pane = LINK_LOGIN,
+            displayErrorScreen = true,
         )
-
-        // TODO(tillh-stripe) Display error inline
-
-        return state
     }
 }
 
@@ -117,10 +107,7 @@ internal class LinkSignupHandlerForNetworking @Inject constructor(
         navigationManager.tryNavigateTo(NetworkingSaveToLinkVerification(referrer = NETWORKING_LINK_SIGNUP_PANE))
     }
 
-    override fun handleSignupFailure(
-        state: NetworkingLinkSignupState,
-        error: Throwable,
-    ): NetworkingLinkSignupState {
+    override fun handleSignupFailure(error: Throwable) {
         eventTracker.logError(
             extraMessage = "Error saving account to Link",
             error = error,
@@ -129,6 +116,5 @@ internal class LinkSignupHandlerForNetworking @Inject constructor(
         )
 
         navigationManager.tryNavigateTo(Success(referrer = NETWORKING_LINK_SIGNUP_PANE))
-        return state
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
@@ -152,11 +152,7 @@ internal class NetworkingLinkSignupViewModel @AssistedInject constructor(
                 val destination = nextPane.destination(referrer = pane)
                 navigationManager.tryNavigateTo(destination)
             },
-            onFail = { error ->
-                setState {
-                    linkSignupHandler.handleSignupFailure(state = this, error)
-                }
-            },
+            onFail = linkSignupHandler::handleSignupFailure,
         )
     }
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.LookupAccount
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.SaveAccountToLink
+import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane.LINK_LOGIN
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane.NETWORKING_LINK_SIGNUP_PANE
 import com.stripe.android.financialconnections.model.LinkLoginPane
@@ -28,6 +29,7 @@ import com.stripe.android.financialconnections.navigation.Destination.Networking
 import com.stripe.android.financialconnections.navigation.NavigationIntent
 import com.stripe.android.financialconnections.navigation.NavigationManagerImpl
 import com.stripe.android.financialconnections.repository.FinancialConnectionsConsumerSessionRepository
+import com.stripe.android.financialconnections.utils.TestHandleError
 import com.stripe.android.financialconnections.utils.UriUtils
 import com.stripe.android.model.ConsumerSessionLookup
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -51,6 +53,7 @@ class NetworkingLinkSignupViewModelTest {
     private val navigationManager = NavigationManagerImpl()
     private val lookupAccount = mock<LookupAccount>()
     private val nativeAuthFlowCoordinator = NativeAuthFlowCoordinator()
+    private val handleError = TestHandleError()
 
     private fun buildViewModel(
         state: NetworkingLinkSignupState,
@@ -370,7 +373,7 @@ class NetworkingLinkSignupViewModelTest {
 
             assertThat(awaitItem()).isEqualTo(
                 NavigationIntent.NavigateTo(
-                    route = Destination.LinkAccountPicker(referrer = LINK_LOGIN),
+                    route = Destination.InstitutionPicker(referrer = LINK_LOGIN),
                     popUpTo = null,
                     isSingleTop = true,
                 )
@@ -486,7 +489,8 @@ class NetworkingLinkSignupViewModelTest {
     ): LinkSignupHandler {
         val manifest = sessionManifest().copy(
             businessName = "Business",
-            accountholderCustomerEmailAddress = "test@test.com"
+            accountholderCustomerEmailAddress = "test@test.com",
+            nextPane = Pane.INSTITUTION_PICKER,
         )
 
         val getOrFetchSync = mock<GetOrFetchSync> {
@@ -515,9 +519,8 @@ class NetworkingLinkSignupViewModelTest {
             attachConsumerToLinkAccountSession = {
                 // Mock a successful attach
             },
-            eventTracker = eventTracker,
             navigationManager = navigationManager,
-            logger = Logger.noop(),
+            handleError = handleError,
         )
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request tweaks navigation in the Instant Debits flow in two scenarios:

- It now uses the `manifest.nextPane` after successful signup to determine the next destination.
- It now shows a terminal error if signing up to Link fails.
- It now shows a terminal error if attaching the consumer fails after verification.

This aligns us with iOS and Web. (cc @mats-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
