### PR TITLE
Special case cards for vertical mode.

### DIFF
--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -117,4 +117,8 @@
   <string name="stripe_upi_polling_payment_failed_title">Payment failed</string>
   <!-- Text shown on a button that when tapped opens a user's screen with their payment methods. -->
   <string name="stripe_view_more">View more</string>
+  <!-- Title for adding a new card as a payment method -->
+  <string name="stripe_paymentsheet_new_card">New card</string>
+  <!-- Title for adding a new US bank account as a payment method -->
+  <string name="stripe_paymentsheet_new_us_bank_account">New US bank account</string>
 </resources>

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -121,4 +121,6 @@
   <string name="stripe_paymentsheet_new_card">New card</string>
   <!-- Title for adding a new US bank account as a payment method -->
   <string name="stripe_paymentsheet_new_us_bank_account">New US bank account</string>
+  <!-- Title shown above a view allowing the customer to save a US bank account. -->
+  <string name="stripe_paymentsheet_add_new_us_bank_account">Add new US bank account</string>
 </resources>

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -119,8 +119,4 @@
   <string name="stripe_view_more">View more</string>
   <!-- Title for adding a new card as a payment method -->
   <string name="stripe_paymentsheet_new_card">New card</string>
-  <!-- Title for adding a new US bank account as a payment method -->
-  <string name="stripe_paymentsheet_new_us_bank_account">New US bank account</string>
-  <!-- Title shown above a view allowing the customer to save a US bank account. -->
-  <string name="stripe_paymentsheet_add_new_us_bank_account">Add new US bank account</string>
 </resources>

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -59,6 +59,8 @@
   <string name="stripe_paymentsheet_microdeposit">Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions to complete payment to %s.</string>
   <!-- Content for alert popup prompting to confirm modifying saved payment method. -->
   <string name="stripe_paymentsheet_modify_pm">Edit %s</string>
+  <!-- Label of a button that appears on a checkout screen. When tapped, it displays a credit card form. This button is shown next to another button representing the customer's saved card; the word 'new' is meant to differentiate this button's action with the saved card button. -->
+  <string name="stripe_paymentsheet_new_card">New card</string>
   <!-- Title shown above a section containing payment methods that a customer can choose to pay with e.g. card, bank account, etc. -->
   <string name="stripe_paymentsheet_new_pm">New payment method</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
@@ -117,6 +119,4 @@
   <string name="stripe_upi_polling_payment_failed_title">Payment failed</string>
   <!-- Text shown on a button that when tapped opens a user's screen with their payment methods. -->
   <string name="stripe_view_more">View more</string>
-  <!-- Title for adding a new card as a payment method -->
-  <string name="stripe_paymentsheet_new_card">New card</string>
 </resources>

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SupportedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SupportedPaymentMethod.kt
@@ -93,8 +93,6 @@ internal data class SupportedPaymentMethod(
 
         val displayName = if (isTypeAndHasCustomerSavedPaymentMethodsOfType(PaymentMethod.Type.Card)) {
             R.string.stripe_paymentsheet_new_card.resolvableString
-        } else if (isTypeAndHasCustomerSavedPaymentMethodsOfType(PaymentMethod.Type.USBankAccount)) {
-            R.string.stripe_paymentsheet_new_us_bank_account.resolvableString
         } else {
             displayName
         }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SupportedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SupportedPaymentMethod.kt
@@ -6,7 +6,9 @@ import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.FormHeaderInformation
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.verticalmode.DisplayablePaymentMethod
 import com.stripe.android.ui.core.elements.SharedDataSpec
 
@@ -81,7 +83,22 @@ internal data class SupportedPaymentMethod(
         )
     }
 
-    fun asDisplayablePaymentMethod(onClick: () -> Unit): DisplayablePaymentMethod {
+    fun asDisplayablePaymentMethod(
+        customerSavedPaymentMethods: List<PaymentMethod>,
+        onClick: () -> Unit,
+    ): DisplayablePaymentMethod {
+        fun isTypeAndHasCustomerSavedPaymentMethodsOfType(type: PaymentMethod.Type): Boolean {
+            return customerSavedPaymentMethods.any { it.type == type } && code == type.code
+        }
+
+        val displayName = if (isTypeAndHasCustomerSavedPaymentMethodsOfType(PaymentMethod.Type.Card)) {
+            R.string.stripe_paymentsheet_new_card.resolvableString
+        } else if (isTypeAndHasCustomerSavedPaymentMethodsOfType(PaymentMethod.Type.USBankAccount)) {
+            R.string.stripe_paymentsheet_new_us_bank_account.resolvableString
+        } else {
+            displayName
+        }
+
         return DisplayablePaymentMethod(
             code = code,
             displayName = displayName,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UsBankAccountDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UsBankAccountDefinition.kt
@@ -8,9 +8,8 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.paymentsheet.R
+import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.ui.core.R as UiCoreR
 
 internal object UsBankAccountDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.USBankAccount
@@ -33,21 +32,16 @@ internal object UsBankAccountDefinition : PaymentMethodDefinition {
 private object UsBankAccountUiDefinitionFactory : UiDefinitionFactory.Simple {
     override fun createSupportedPaymentMethod(): SupportedPaymentMethod = SupportedPaymentMethod(
         code = UsBankAccountDefinition.type.code,
-        displayNameResource = UiCoreR.string.stripe_paymentsheet_payment_method_us_bank_account,
-        iconResource = UiCoreR.drawable.stripe_ic_paymentsheet_pm_bank,
+        displayNameResource = R.string.stripe_paymentsheet_payment_method_us_bank_account,
+        iconResource = R.drawable.stripe_ic_paymentsheet_pm_bank,
         iconRequiresTinting = true,
         lightThemeIconUrl = null,
         darkThemeIconUrl = null,
     )
 
     override fun createFormHeaderInformation(customerHasSavedPaymentMethods: Boolean): FormHeaderInformation {
-        val displayName = if (customerHasSavedPaymentMethods) {
-            R.string.stripe_paymentsheet_add_new_us_bank_account
-        } else {
-            UiCoreR.string.stripe_paymentsheet_add_us_bank_account
-        }
         return createSupportedPaymentMethod().asFormHeaderInformation().copy(
-            displayName = displayName.resolvableString,
+            displayName = R.string.stripe_paymentsheet_add_us_bank_account.resolvableString,
             shouldShowIcon = false,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UsBankAccountDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UsBankAccountDefinition.kt
@@ -8,8 +8,9 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.ui.core.R
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.uicore.elements.FormElement
+import com.stripe.android.ui.core.R as UiCoreR
 
 internal object UsBankAccountDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.USBankAccount
@@ -32,16 +33,21 @@ internal object UsBankAccountDefinition : PaymentMethodDefinition {
 private object UsBankAccountUiDefinitionFactory : UiDefinitionFactory.Simple {
     override fun createSupportedPaymentMethod(): SupportedPaymentMethod = SupportedPaymentMethod(
         code = UsBankAccountDefinition.type.code,
-        displayNameResource = R.string.stripe_paymentsheet_payment_method_us_bank_account,
-        iconResource = R.drawable.stripe_ic_paymentsheet_pm_bank,
+        displayNameResource = UiCoreR.string.stripe_paymentsheet_payment_method_us_bank_account,
+        iconResource = UiCoreR.drawable.stripe_ic_paymentsheet_pm_bank,
         iconRequiresTinting = true,
         lightThemeIconUrl = null,
         darkThemeIconUrl = null,
     )
 
     override fun createFormHeaderInformation(customerHasSavedPaymentMethods: Boolean): FormHeaderInformation {
+        val displayName = if (customerHasSavedPaymentMethods) {
+            R.string.stripe_paymentsheet_add_new_us_bank_account
+        } else {
+            UiCoreR.string.stripe_paymentsheet_add_us_bank_account
+        }
         return createSupportedPaymentMethod().asFormHeaderInformation().copy(
-            displayName = R.string.stripe_paymentsheet_add_us_bank_account.resolvableString,
+            displayName = displayName.resolvableString,
             shouldShowIcon = false,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -72,7 +72,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     private val manageScreenFactory: () -> PaymentSheetScreen,
     private val manageOneSavedPaymentMethodFactory: () -> PaymentSheetScreen,
     private val formScreenFactory: (selectedPaymentMethodCode: String) -> PaymentSheetScreen,
-    paymentMethods: StateFlow<List<PaymentMethod>?>,
+    paymentMethods: StateFlow<List<PaymentMethod>>,
     private val mostRecentlySelectedSavedPaymentMethod: StateFlow<PaymentMethod?>,
     private val providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString,
     private val canRemove: StateFlow<Boolean>,
@@ -182,14 +182,15 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     }
 
     override val state: StateFlow<PaymentMethodVerticalLayoutInteractor.State> = combineAsStateFlow(
+        paymentMethods,
         processing,
         selection,
         displayedSavedPaymentMethod,
         walletsState,
         availableSavedPaymentMethodAction,
-    ) { isProcessing, selection, displayedSavedPaymentMethod, walletsState, action ->
+    ) { paymentMethods, isProcessing, selection, displayedSavedPaymentMethod, walletsState, action ->
         PaymentMethodVerticalLayoutInteractor.State(
-            displayablePaymentMethods = getDisplayablePaymentMethods(walletsState),
+            displayablePaymentMethods = getDisplayablePaymentMethods(paymentMethods, walletsState),
             isProcessing = isProcessing,
             selection = selection,
             displayedSavedPaymentMethod = displayedSavedPaymentMethod,
@@ -216,9 +217,12 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         }
     }
 
-    private fun getDisplayablePaymentMethods(walletsState: WalletsState?): List<DisplayablePaymentMethod> {
+    private fun getDisplayablePaymentMethods(
+        paymentMethods: List<PaymentMethod>,
+        walletsState: WalletsState?,
+    ): List<DisplayablePaymentMethod> {
         val lpms = supportedPaymentMethods.map { supportedPaymentMethod ->
-            supportedPaymentMethod.asDisplayablePaymentMethod {
+            supportedPaymentMethod.asDisplayablePaymentMethod(paymentMethods) {
                 handleViewAction(ViewAction.PaymentMethodSelected(supportedPaymentMethod.code))
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
@@ -113,7 +113,9 @@ internal class DefaultVerticalModeFormInteractor(
                 ),
                 headerInformation = paymentMethodMetadata.formHeaderInformationForCode(
                     selectedPaymentMethodCode,
-                    customerHasSavedPaymentMethods = customerStateHolder.paymentMethods.value.isNotEmpty(),
+                    customerHasSavedPaymentMethods = customerStateHolder.paymentMethods.value.any {
+                        it.type?.code == selectedPaymentMethodCode
+                    },
                 ),
                 isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
                 canGoBackDelegate = { viewModel.navigationHandler.canGoBack },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -400,37 +400,6 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
-    fun `state has correct displayablePaymentMethods based on saved payment methods for us_bank`() {
-        runScenario(
-            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
-                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                    paymentMethodTypes = listOf("us_bank_account"),
-                    clientSecret = null,
-                ),
-                allowsDelayedPaymentMethods = true,
-            ),
-            initialPaymentMethods = listOf(PaymentMethodFixtures.US_BANK_ACCOUNT),
-            formElementsForCode = {
-                listOf()
-            },
-        ) {
-            interactor.state.test {
-                assertThat(awaitItem().displayablePaymentMethods.first().displayName)
-                    .isEqualTo(PaymentSheetR.string.stripe_paymentsheet_new_us_bank_account.resolvableString)
-                ensureAllEventsConsumed()
-
-                // The text shouldn't say new us bank account when another saved payment method type exists.
-                paymentMethodsSource.value = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
-                // Updating paymentMethodsSource causes 2 total emissions, we only care about the last one.
-                skipItems(1)
-
-                assertThat(awaitItem().displayablePaymentMethods.first().displayName)
-                    .isEqualTo(R.string.stripe_paymentsheet_payment_method_us_bank_account.resolvableString)
-            }
-        }
-    }
-
-    @Test
     fun `calling state_displayablePaymentMethods_onClick calls ViewAction_PaymentMethodSelected`() {
         var onFormFieldValuesChangedCalled = false
         runScenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/NewPaymentMethodVerticalLayoutUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/NewPaymentMethodVerticalLayoutUIScreenshotTest.kt
@@ -15,7 +15,7 @@ internal class NewPaymentMethodVerticalLayoutUIScreenshotTest {
     val paparazziRule = PaparazziRule()
 
     private val paymentMethods: List<DisplayablePaymentMethod> by lazy {
-        MockPaymentMethodsFactory.create().map { it.asDisplayablePaymentMethod { } }
+        MockPaymentMethodsFactory.create().map { it.asDisplayablePaymentMethod(emptyList()) { } }
     }
 
     @Test
@@ -37,7 +37,7 @@ internal class NewPaymentMethodVerticalLayoutUIScreenshotTest {
             displayNameResource = R.string.stripe_paymentsheet_payment_method_us_bank_account,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_bank,
             iconRequiresTinting = true
-        ).asDisplayablePaymentMethod { }
+        ).asDisplayablePaymentMethod(emptyList()) { }
         val paymentMethods = paymentMethods.toMutableList()
         paymentMethods.add(1, bankPaymentMethod)
         paparazziRule.snapshot {
@@ -68,7 +68,7 @@ internal class NewPaymentMethodVerticalLayoutUIScreenshotTest {
         val paymentMethods = listOf(
             ExternalPaymentMethodUiDefinitionFactory(
                 PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC
-            ).createSupportedPaymentMethod().asDisplayablePaymentMethod { }
+            ).createSupportedPaymentMethod().asDisplayablePaymentMethod(emptyList()) { }
         ).plus(paymentMethods)
         paparazziRule.snapshot {
             NewPaymentMethodVerticalLayoutUI(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUIScreenshotTest.kt
@@ -14,7 +14,7 @@ internal class PaymentMethodVerticalLayoutUIScreenshotTest {
     val paparazziRule = PaparazziRule()
 
     private val paymentMethods: List<DisplayablePaymentMethod> by lazy {
-        MockPaymentMethodsFactory.create().map { it.asDisplayablePaymentMethod { } }
+        MockPaymentMethodsFactory.create().map { it.asDisplayablePaymentMethod(emptyList()) { } }
     }
 
     private val savedPaymentMethod: DisplayableSavedPaymentMethod = PaymentMethodFixtures.displayableCard()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
@@ -117,7 +117,7 @@ internal class PaymentMethodVerticalLayoutUITest {
             PaymentMethodVerticalLayoutInteractor.State(
                 displayablePaymentMethods = listOf(
                     CardDefinition.uiDefinitionFactory().supportedPaymentMethod(CardDefinition, emptyList())!!
-                        .asDisplayablePaymentMethod { onClickCalled = true },
+                        .asDisplayablePaymentMethod(emptyList()) { onClickCalled = true },
                 ),
                 isProcessing = false,
                 selection = null,
@@ -165,7 +165,7 @@ internal class PaymentMethodVerticalLayoutUITest {
                 PaymentIntentFixtures.PI_WITH_PAYMENT_METHOD!!.copy(
                     paymentMethodTypes = listOf("card", "cashapp", "klarna")
                 )
-            ).sortedSupportedPaymentMethods().map { it.asDisplayablePaymentMethod { } },
+            ).sortedSupportedPaymentMethods().map { it.asDisplayablePaymentMethod(emptyList()) { } },
             isProcessing = false,
             selection = null,
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
@@ -194,7 +194,7 @@ internal class PaymentMethodVerticalLayoutUITest {
                 PaymentIntentFixtures.PI_WITH_PAYMENT_METHOD!!.copy(
                     paymentMethodTypes = listOf("card", "cashapp", "klarna")
                 )
-            ).sortedSupportedPaymentMethods().map { it.asDisplayablePaymentMethod { } },
+            ).sortedSupportedPaymentMethods().map { it.asDisplayablePaymentMethod(emptyList()) { } },
             isProcessing = false,
             selection = PaymentSelection.Saved(PaymentMethodFixtures.displayableCard().paymentMethod),
             displayedSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
@@ -234,7 +234,9 @@ internal class PaymentMethodVerticalLayoutUITest {
         )
         runScenario(
             PaymentMethodVerticalLayoutInteractor.State(
-                displayablePaymentMethods = supportedPaymentMethods.map { it.asDisplayablePaymentMethod { } },
+                displayablePaymentMethods = supportedPaymentMethods.map {
+                    it.asDisplayablePaymentMethod(emptyList()) { }
+                },
                 isProcessing = false,
                 selection = selection,
                 displayedSavedPaymentMethod = null,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I really wanted to do this "right" but it's actually quite hard to do so. See https://github.com/stripe/stripe-android/pull/9102/files

This implementation overrides the displayName for the vertical mode list.

* If the customer has a saved payment method of type card, we'll show the text as "New card" instead of "Card".

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2268

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots

![newcard](https://github.com/user-attachments/assets/e54be763-6384-4ac3-9c66-35b473f9f7c2)

