### PR TITLE
Fix a bug where updating a card brand wouldn't update it on the vertical mode list

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -256,6 +256,7 @@ internal class SavedPaymentMethodMutator(
                 productUsageTokens = setOf("PaymentSheet"),
             )
         ).onSuccess { updatedMethod ->
+            customerStateHolder.updateMostRecentlySelectedSavedPaymentMethod(updatedMethod)
             customerStateHolder.setCustomerState(
                 currentCustomer.copy(
                     paymentMethods = currentCustomer.paymentMethods.map { savedMethod ->


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Before updating a card brand wouldn't update it on the list page when navigating back.

We don't have great tests for this area of code, and it's next to impossible to test this specific code path. I'll make a note to write an end to end or network test for this scenario in that jira.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2384

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
