### PR TITLE
Navigate back to vertical mode list after removing the last saved payment method.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
@@ -46,7 +46,7 @@ internal interface ManageScreenInteractor {
 }
 
 internal class DefaultManageScreenInteractor(
-    private val paymentMethods: StateFlow<List<PaymentMethod>?>,
+    private val paymentMethods: StateFlow<List<PaymentMethod>>,
     private val paymentMethodMetadata: PaymentMethodMetadata,
     private val selection: StateFlow<PaymentSelection?>,
     private val editing: StateFlow<Boolean>,
@@ -68,9 +68,9 @@ internal class DefaultManageScreenInteractor(
 
     private val displayableSavedPaymentMethods: StateFlow<List<DisplayableSavedPaymentMethod>> =
         paymentMethods.mapAsStateFlow { paymentMethods ->
-            paymentMethods?.map {
+            paymentMethods.map {
                 it.toDisplayableSavedPaymentMethod(providePaymentMethodName, paymentMethodMetadata)
-            } ?: emptyList()
+            }
         }
 
     override val state = combineAsStateFlow(
@@ -100,6 +100,14 @@ internal class DefaultManageScreenInteractor(
             state.collect { state ->
                 if (!state.isEditing && !state.canEdit && state.paymentMethods.size == 1) {
                     handlePaymentMethodSelected(state.paymentMethods.first())
+                    safeNavigateBack()
+                }
+            }
+        }
+
+        coroutineScope.launch {
+            paymentMethods.collect { paymentMethods ->
+                if (paymentMethods.isEmpty()) {
                     safeNavigateBack()
                 }
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
@@ -199,6 +199,29 @@ class DefaultManageScreenInteractorTest {
     }
 
     @Test
+    fun `removing the last payment methods navigates back`() {
+        var backPressed = false
+        fun handleBackPressed() {
+            backPressed = true
+        }
+
+        val paymentMethods = PaymentMethodFactory.cards(2)
+        runScenario(
+            initialPaymentMethods = paymentMethods,
+            currentSelection = PaymentSelection.Saved(paymentMethods[0]),
+            onSelectPaymentMethod = {},
+            isEditing = true,
+            handleBackPressed = ::handleBackPressed,
+        ) {
+            assertThat(backPressed).isFalse()
+
+            paymentMethodsSource.value = listOf()
+
+            assertThat(backPressed).isTrue()
+        }
+    }
+
+    @Test
     fun `handleViewAction ToggleEdit calls toggleEdit`() {
         var hasCalledToggleEdit = false
         val initialPaymentMethods = PaymentMethodFixtures.createCards(2)
@@ -215,7 +238,7 @@ class DefaultManageScreenInteractorTest {
     private val notImplemented: () -> Nothing = { throw AssertionError("Not implemented") }
 
     private fun runScenario(
-        initialPaymentMethods: List<PaymentMethod>?,
+        initialPaymentMethods: List<PaymentMethod>,
         currentSelection: PaymentSelection?,
         isEditing: Boolean = false,
         toggleEdit: () -> Unit = { notImplemented() },
@@ -265,7 +288,7 @@ class DefaultManageScreenInteractorTest {
 
     private data class TestParams(
         val interactor: ManageScreenInteractor,
-        val paymentMethodsSource: MutableStateFlow<List<PaymentMethod>?>,
+        val paymentMethodsSource: MutableStateFlow<List<PaymentMethod>>,
         val editingSource: MutableStateFlow<Boolean>,
         val canEditSource: MutableStateFlow<Boolean>,
         val canRemoveSource: MutableStateFlow<Boolean,>


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Previously deleting the last saved payment method would leave you on an empty screen. Now you're returned to the main vertical mode list.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2372

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

