### PR TITLE
Remove delay when navigating back after removing the last SPM.

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
@@ -82,7 +82,9 @@ class DefaultManageScreenInteractorTest {
     @Test
     fun cannotRemoveOrEdit_multiplePaymentsMethods_shouldNotNavigateBack() {
         var backPressed = false
-        fun handleBackPressed() {
+        fun handleBackPressed(withDelay: Boolean) {
+            assertThat(withDelay).isTrue()
+            assertThat(backPressed).isFalse()
             backPressed = true
         }
 
@@ -105,7 +107,9 @@ class DefaultManageScreenInteractorTest {
     @Test
     fun cannotRemoveButCanEdit_hidesDeleteButton() {
         var backPressed = false
-        fun handleBackPressed() {
+        fun handleBackPressed(withDelay: Boolean) {
+            assertThat(withDelay).isTrue()
+            assertThat(backPressed).isFalse()
             backPressed = true
         }
 
@@ -136,7 +140,9 @@ class DefaultManageScreenInteractorTest {
     @Test
     fun cannotRemoveOrEdit_removesAllButLastPaymentMethod_navsBackWhenEditingFinishes() {
         var backPressed = false
-        fun handleBackPressed() {
+        fun handleBackPressed(withDelay: Boolean) {
+            assertThat(withDelay).isTrue()
+            assertThat(backPressed).isFalse()
             backPressed = true
         }
 
@@ -174,7 +180,9 @@ class DefaultManageScreenInteractorTest {
     @Test
     fun canRemove_doesNotNavBackWhenEditingFinishes() {
         var backPressed = false
-        fun handleBackPressed() {
+        fun handleBackPressed(withDelay: Boolean) {
+            assertThat(withDelay).isTrue()
+            assertThat(backPressed).isFalse()
             backPressed = true
         }
 
@@ -199,9 +207,11 @@ class DefaultManageScreenInteractorTest {
     }
 
     @Test
-    fun `removing the last payment methods navigates back`() {
+    fun `removing the last payment methods navigates back without delay`() {
         var backPressed = false
-        fun handleBackPressed() {
+        fun handleBackPressed(withDelay: Boolean) {
+            assertThat(withDelay).isFalse()
+            assertThat(backPressed).isFalse()
             backPressed = true
         }
 
@@ -243,7 +253,7 @@ class DefaultManageScreenInteractorTest {
         isEditing: Boolean = false,
         toggleEdit: () -> Unit = { notImplemented() },
         onSelectPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit = { notImplemented() },
-        handleBackPressed: () -> Unit = { notImplemented() },
+        handleBackPressed: (withDelay: Boolean) -> Unit = { notImplemented() },
         testBlock: suspend TestParams.() -> Unit
     ) {
         val paymentMethods = MutableStateFlow(initialPaymentMethods)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This is a UX optimization so we don't see an extraneous title change when removing the last SPM.

Now we see a reasonable transition when removing the last SPM.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

