### PR TITLE
In vertical mode, only open card brand choice screen if the saved PM is modifiable

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -76,7 +76,6 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     private val mostRecentlySelectedSavedPaymentMethod: StateFlow<PaymentMethod?>,
     private val providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString,
     private val canRemove: StateFlow<Boolean>,
-    private val canEdit: StateFlow<Boolean>,
     private val onEditPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
     private val onSelectSavedPaymentMethod: (PaymentMethod) -> Unit,
     private val walletsState: StateFlow<WalletsState?>,
@@ -133,7 +132,6 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                 paymentMethods = customerStateHolder.paymentMethods,
                 mostRecentlySelectedSavedPaymentMethod = customerStateHolder.mostRecentlySelectedSavedPaymentMethod,
                 providePaymentMethodName = savedPaymentMethodMutator.providePaymentMethodName,
-                canEdit = viewModel.savedPaymentMethodMutator.canEdit,
                 canRemove = viewModel.savedPaymentMethodMutator.canRemove,
                 onEditPaymentMethod = { savedPaymentMethodMutator.modifyPaymentMethod(it.paymentMethod) },
                 onSelectSavedPaymentMethod = {
@@ -171,13 +169,11 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     private val availableSavedPaymentMethodAction = combineAsStateFlow(
         paymentMethods,
         displayedSavedPaymentMethod,
-        canEdit,
         canRemove,
-    ) { paymentMethods, displayedSavedPaymentMethod, canEdit, canRemove ->
+    ) { paymentMethods, displayedSavedPaymentMethod, canRemove ->
         getAvailableSavedPaymentMethodAction(
             paymentMethods = paymentMethods,
             savedPaymentMethod = displayedSavedPaymentMethod,
-            canEdit = canEdit,
             canRemove = canRemove
         )
     }
@@ -284,7 +280,6 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     private fun getAvailableSavedPaymentMethodAction(
         paymentMethods: List<PaymentMethod>?,
         savedPaymentMethod: DisplayableSavedPaymentMethod?,
-        canEdit: Boolean,
         canRemove: Boolean,
     ): PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction {
         if (paymentMethods == null || savedPaymentMethod == null) {
@@ -296,7 +291,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
             1 -> {
                 getSavedPaymentMethodActionForOnePaymentMethod(
                     canRemove = canRemove,
-                    canEdit = canEdit,
+                    savedPaymentMethod = savedPaymentMethod,
                 )
             }
             else ->
@@ -306,9 +301,9 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
 
     private fun getSavedPaymentMethodActionForOnePaymentMethod(
         canRemove: Boolean,
-        canEdit: Boolean,
+        savedPaymentMethod: DisplayableSavedPaymentMethod?,
     ): PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction {
-        return if (canEdit) {
+        return if (savedPaymentMethod?.isModifiable() == true) {
             // Edit screen handles both canRemove variants.
             PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.EDIT_CARD_BRAND
         } else if (canRemove) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -111,7 +111,6 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             initialPaymentMethods = PaymentMethodFixtures.createCards(3),
         ) {
             canRemove.value = true
-            canEdit.value = true
 
             interactor.state.test {
                 awaitItem().run {
@@ -129,7 +128,6 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             initialPaymentMethods = PaymentMethodFixtures.createCards(3),
         ) {
             canRemove.value = false
-            canEdit.value = false
 
             interactor.state.test {
                 awaitItem().run {
@@ -144,10 +142,9 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     @Test
     fun `state has edit_card_brand saved PM action when one saved PM, can edit, and can remove`() {
         runScenario(
-            initialPaymentMethods = PaymentMethodFactory.cards(1),
+            initialPaymentMethods = listOf(PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD),
         ) {
             canRemove.value = true
-            canEdit.value = true
 
             interactor.state.test {
                 awaitItem().run {
@@ -162,10 +159,9 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     @Test
     fun `state has edit card brand saved payment method action when one saved PM, can edit, and cannot remove`() {
         runScenario(
-            initialPaymentMethods = PaymentMethodFactory.cards(1),
+            initialPaymentMethods = listOf(PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD),
         ) {
             canRemove.value = false
-            canEdit.value = true
 
             interactor.state.test {
                 awaitItem().run {
@@ -178,12 +174,28 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
+    fun `state has manage one saved payment method action when one saved PM, cannot edit, and can remove`() {
+        runScenario(
+            initialPaymentMethods = PaymentMethodFactory.cards(1), // Creates a non-modifiable card
+        ) {
+            canRemove.value = true
+
+            interactor.state.test {
+                awaitItem().run {
+                    assertThat(availableSavedPaymentMethodAction).isEqualTo(
+                        PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ONE
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
     fun `state has no saved payment method action when one saved PM, cannot edit, and cannot remove`() {
         runScenario(
-            initialPaymentMethods = PaymentMethodFactory.cards(1),
+            initialPaymentMethods = PaymentMethodFactory.cards(1), // Creates a non-modifiable card
         ) {
             canRemove.value = false
-            canEdit.value = false
 
             interactor.state.test {
                 awaitItem().run {
@@ -196,12 +208,11 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
-    fun `state has no saved payment method action when multiple saved PMs, cannot edit, and cannot remove`() {
+    fun `state has no saved payment method action when multiple saved PMs and cannot remove`() {
         runScenario(
             initialPaymentMethods = PaymentMethodFactory.cards(1),
         ) {
             canRemove.value = false
-            canEdit.value = false
 
             interactor.state.test {
                 awaitItem().run {
@@ -972,7 +983,6 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         val mostRecentlySelectedSavedPaymentMethod: MutableStateFlow<PaymentMethod?> =
             MutableStateFlow(initialMostRecentlySelectedSavedPaymentMethod)
         val walletsState = MutableStateFlow<WalletsState?>(null)
-        val canEdit = MutableStateFlow(true)
         val canRemove = MutableStateFlow(true)
         val isCurrentScreen: MutableStateFlow<Boolean> = MutableStateFlow(initialIsCurrentScreen)
         val dispatcher = StandardTestDispatcher()
@@ -998,7 +1008,6 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             updateSelection = updateSelection,
             isCurrentScreen = isCurrentScreen,
             dispatcher = dispatcher,
-            canEdit = canEdit,
             canRemove = canRemove,
             isLiveMode = true,
         )
@@ -1012,7 +1021,6 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             walletsState = walletsState,
             interactor = interactor,
             canRemove = canRemove,
-            canEdit = canEdit,
             dispatcher = dispatcher,
         ).apply {
             runTest {
@@ -1029,7 +1037,6 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         val paymentMethodsSource: MutableStateFlow<List<PaymentMethod>>,
         val walletsState: MutableStateFlow<WalletsState?>,
         val canRemove: MutableStateFlow<Boolean>,
-        val canEdit: MutableStateFlow<Boolean>,
         val interactor: PaymentMethodVerticalLayoutInteractor,
         val dispatcher: TestDispatcher,
     )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
In vertical mode, when there is one saved PM, check if the saved PM is modifiable before opening the edit card brand screen

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We should only open the card brand choice screen if the saved PM has multiple card brands

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified

# Screenshots
Before:

https://github.com/user-attachments/assets/fc261435-926d-4023-ae9b-fba93e9a1412



After:

https://github.com/user-attachments/assets/b2afc357-a500-4b12-b4d2-910a8fc6d1cb



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
