### PR TITLE
Update new PMs shown, select PM, and form shown analytics for vertical mode

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -128,9 +128,9 @@ internal class DefaultEventReporter @Inject internal constructor(
         )
     }
 
-    override fun onShowNewPaymentOptionForm() {
+    override fun onShowNewPaymentOptions() {
         fireEvent(
-            PaymentSheetEvent.ShowNewPaymentOptionForm(
+            PaymentSheetEvent.ShowNewPaymentOptions(
                 mode = mode,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -57,9 +57,9 @@ internal interface EventReporter {
     fun onShowExistingPaymentOptions()
 
     /**
-     * PaymentSheet is now being displayed and its first screen shows the payment method form.
+     * PaymentSheet is now being displayed and its first screen shows new payment methods.
      */
-    fun onShowNewPaymentOptionForm()
+    fun onShowNewPaymentOptions()
 
     /**
      * The customer has selected one of the available payment methods in the payment method form.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsListener.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsListener.kt
@@ -80,9 +80,12 @@ internal class PaymentSheetAnalyticsListener(
                 previouslyShownForm = null
                 previouslyInteractedForm = null
             }
-            is AddFirstPaymentMethod, is AddAnotherPaymentMethod, is PaymentSheetScreen.VerticalMode -> {
+            is PaymentSheetScreen.VerticalMode -> {
+                eventReporter.onShowNewPaymentOptions()
+            }
+            is AddFirstPaymentMethod, is AddAnotherPaymentMethod -> {
                 reportFormShown(currentPaymentMethodTypeProvider())
-                eventReporter.onShowNewPaymentOptionForm()
+                eventReporter.onShowNewPaymentOptions()
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -152,7 +152,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         override val additionalParams: Map<String, Any> = emptyMap()
     }
 
-    class ShowNewPaymentOptionForm(
+    class ShowNewPaymentOptions(
         mode: EventReporter.Mode,
         currency: String?,
         override val isDeferred: Boolean,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -83,6 +83,8 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     private val onMandateTextUpdated: (ResolvableString?) -> Unit,
     private val updateSelection: (PaymentSelection?) -> Unit,
     private val isCurrentScreen: StateFlow<Boolean>,
+    private val reportPaymentMethodTypeSelected: (PaymentMethodCode) -> Unit,
+    private val reportFormShown: (PaymentMethodCode) -> Unit,
     override val isLiveMode: Boolean,
     dispatcher: CoroutineContext = Dispatchers.Default,
 ) : PaymentMethodVerticalLayoutInteractor {
@@ -146,6 +148,8 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                 onMandateTextUpdated = {
                     viewModel.mandateHandler.updateMandateText(mandateText = it, showAbove = true)
                 },
+                reportPaymentMethodTypeSelected = viewModel.eventReporter::onSelectPaymentMethod,
+                reportFormShown = viewModel.eventReporter::onPaymentMethodFormShown,
                 isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
             )
         }
@@ -316,7 +320,10 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     override fun handleViewAction(viewAction: ViewAction) {
         when (viewAction) {
             is ViewAction.PaymentMethodSelected -> {
+                reportPaymentMethodTypeSelected(viewAction.selectedPaymentMethodCode)
+
                 if (requiresFormScreen(viewAction.selectedPaymentMethodCode)) {
+                    reportFormShown(viewAction.selectedPaymentMethodCode)
                     transitionTo(formScreenFactory(viewAction.selectedPaymentMethodCode))
                 } else {
                     updateSelectedPaymentMethod(viewAction.selectedPaymentMethodCode)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -185,7 +185,7 @@ internal class PaymentOptionsViewModelTest {
         viewModel.navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isInstanceOf<PaymentSheetScreen.AddAnotherPaymentMethod>()
 
-            verify(eventReporter).onShowNewPaymentOptionForm()
+            verify(eventReporter).onShowNewPaymentOptions()
 
             viewModel.handleBackPressed()
             assertThat(awaitItem()).isInstanceOf<SelectSavedPaymentMethods>()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1521,7 +1521,7 @@ internal class PaymentSheetViewModelTest {
         turbineScope {
             val receiver = viewModel.navigationHandler.currentScreen.testIn(this)
 
-            verify(eventReporter).onShowNewPaymentOptionForm()
+            verify(eventReporter).onShowNewPaymentOptions()
 
             receiver.cancelAndIgnoreRemainingEvents()
         }
@@ -1543,7 +1543,7 @@ internal class PaymentSheetViewModelTest {
         turbineScope {
             val receiver = viewModel.navigationHandler.currentScreen.testIn(this)
 
-            verify(eventReporter).onShowNewPaymentOptionForm()
+            verify(eventReporter).onShowNewPaymentOptions()
 
             receiver.cancelAndIgnoreRemainingEvents()
         }
@@ -1565,7 +1565,7 @@ internal class PaymentSheetViewModelTest {
         turbineScope {
             val receiver = viewModel.navigationHandler.currentScreen.testIn(this)
 
-            verify(eventReporter).onShowNewPaymentOptionForm()
+            verify(eventReporter).onShowNewPaymentOptions()
 
             receiver.cancelAndIgnoreRemainingEvents()
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -126,12 +126,12 @@ class DefaultEventReporterTest {
     }
 
     @Test
-    fun `onShowNewPaymentOptionForm() should fire analytics request with expected event value`() {
+    fun `onShowNewPaymentOptions() should fire analytics request with expected event value`() {
         val completeEventReporter = createEventReporter(EventReporter.Mode.Complete) {
             simulateSuccessfulSetup(linkEnabled = false, googlePayReady = false)
         }
 
-        completeEventReporter.onShowNewPaymentOptionForm()
+        completeEventReporter.onShowNewPaymentOptions()
 
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsListenerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsListenerTest.kt
@@ -85,7 +85,7 @@ class PaymentSheetAnalyticsListenerTest {
             testScheduler.advanceUntilIdle()
         }
 
-        verify(eventReporter, times(screenTypes.size)).onShowNewPaymentOptionForm()
+        verify(eventReporter, times(screenTypes.size)).onShowNewPaymentOptions()
         // Only once since it didn't change.
         verify(eventReporter).onPaymentMethodFormShown(eq("card"))
     }
@@ -94,7 +94,7 @@ class PaymentSheetAnalyticsListenerTest {
     fun `debounced analytics are re-emitted after navigating to SelectSavedPaymentMethods`() = runScenario {
         currentScreen.value = mock<PaymentSheetScreen.AddAnotherPaymentMethod>()
         testScheduler.advanceUntilIdle()
-        verify(eventReporter).onShowNewPaymentOptionForm()
+        verify(eventReporter).onShowNewPaymentOptions()
         verify(eventReporter).onPaymentMethodFormShown(eq("card"))
         analyticsListener.reportFieldInteraction("card")
         verify(eventReporter).onPaymentMethodFormInteraction(eq("card"))
@@ -109,7 +109,7 @@ class PaymentSheetAnalyticsListenerTest {
 
         currentScreen.value = mock<PaymentSheetScreen.AddAnotherPaymentMethod>()
         testScheduler.advanceUntilIdle()
-        verify(eventReporter).onShowNewPaymentOptionForm()
+        verify(eventReporter).onShowNewPaymentOptions()
         verify(eventReporter).onPaymentMethodFormShown(eq("card"))
         analyticsListener.reportFieldInteraction("card")
         verify(eventReporter).onPaymentMethodFormInteraction(eq("card"))

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -429,7 +429,8 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
                 }
                 assertThat(selectedPaymentMethodCode).isEqualTo("cashapp")
                 onFormFieldValuesChangedCalled = true
-            }
+            },
+            reportPaymentMethodTypeSelected = {},
         ) {
             val paymentMethod = interactor.state.value.displayablePaymentMethods.first { it.code == "cashapp" }
             paymentMethod.onClick()
@@ -610,6 +611,8 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     fun handleViewAction_PaymentMethodSelected_transitionsToFormScreen_whenFieldsAllowUserInteraction() {
         var calledFormScreenFactory = false
         var calledTransitionTo = false
+        var reportedSelectedPaymentMethodType: PaymentMethodCode? = null
+        var reportFormShownForPm: PaymentMethodCode? = null
         runScenario(
             formElementsForCode = {
                 formFieldsWhichRequireUserInteraction
@@ -620,11 +623,15 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             },
             transitionTo = {
                 calledTransitionTo = true
-            }
+            },
+            reportPaymentMethodTypeSelected = { reportedSelectedPaymentMethodType = it },
+            reportFormShown = { reportFormShownForPm = it }
         ) {
             interactor.handleViewAction(ViewAction.PaymentMethodSelected("card"))
             assertThat(calledFormScreenFactory).isTrue()
             assertThat(calledTransitionTo).isTrue()
+            assertThat(reportedSelectedPaymentMethodType).isEqualTo("card")
+            assertThat(reportFormShownForPm).isEqualTo("card")
         }
     }
 
@@ -642,7 +649,9 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             },
             transitionTo = {
                 calledTransitionTo = true
-            }
+            },
+            reportPaymentMethodTypeSelected = {},
+            reportFormShown = {},
         ) {
             interactor.handleViewAction(ViewAction.PaymentMethodSelected("us_bank_account"))
             assertThat(calledFormScreenFactory).isTrue()
@@ -664,7 +673,9 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             },
             transitionTo = {
                 calledTransitionTo = true
-            }
+            },
+            reportPaymentMethodTypeSelected = {},
+            reportFormShown = {},
         ) {
             interactor.handleViewAction(ViewAction.PaymentMethodSelected("link"))
             assertThat(calledFormScreenFactory).isTrue()
@@ -675,6 +686,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     @Test
     fun handleViewAction_PaymentMethodSelected_updatesSelectedLPM() {
         var onFormFieldValuesChangedCalled = false
+        var reportedSelectedPaymentMethodType: PaymentMethodCode? = null
         runScenario(
             formElementsForCode = {
                 listOf()
@@ -686,10 +698,12 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
                 }
                 assertThat(selectedPaymentMethodCode).isEqualTo("cashapp")
                 onFormFieldValuesChangedCalled = true
-            }
+            },
+            reportPaymentMethodTypeSelected = { reportedSelectedPaymentMethodType = it }
         ) {
             interactor.handleViewAction(ViewAction.PaymentMethodSelected("cashapp"))
             assertThat(onFormFieldValuesChangedCalled).isTrue()
+            assertThat(reportedSelectedPaymentMethodType).isEqualTo("cashapp")
         }
     }
 
@@ -724,6 +738,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
                 onFormFieldValuesChangedCalled = true
             },
             onMandateTextUpdated = { mostRecentMandate = it },
+            reportPaymentMethodTypeSelected = {}
         ) {
             assertThat(mostRecentMandate).isNull()
             interactor.handleViewAction(ViewAction.PaymentMethodSelected("cashapp"))
@@ -755,7 +770,8 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             onFormFieldValuesChanged = { _, selectedPaymentMethodCode ->
                 currentlySelectedPaymentMethodCode = selectedPaymentMethodCode
             },
-            formElementsForCode = { _ -> emptyList() }
+            formElementsForCode = { _ -> emptyList() },
+            reportPaymentMethodTypeSelected = {},
         ) {
             interactor.handleViewAction(ViewAction.PaymentMethodSelected("cashapp"))
             interactor.state.test {
@@ -975,6 +991,8 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         isFlowController: Boolean = false,
         updateSelection: (PaymentSelection?) -> Unit = { notImplemented() },
         onMandateTextUpdated: (ResolvableString?) -> Unit = { notImplemented() },
+        reportPaymentMethodTypeSelected: (PaymentMethodCode) -> Unit = { notImplemented() },
+        reportFormShown: (PaymentMethodCode) -> Unit = { notImplemented() },
         testBlock: suspend TestParams.() -> Unit
     ) {
         val processing: MutableStateFlow<Boolean> = MutableStateFlow(initialProcessing)
@@ -1009,6 +1027,8 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             isCurrentScreen = isCurrentScreen,
             dispatcher = dispatcher,
             canRemove = canRemove,
+            reportPaymentMethodTypeSelected = reportPaymentMethodTypeSelected,
+            reportFormShown = reportFormShown,
             isLiveMode = true,
         )
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update new PMs shown, select PM, and form shown analytics for vertical mode

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Ensure we have the analytic events listed [here](https://docs.google.com/document/d/1ClD6VsUQLxVbR7VpnHNEO327EZeQntcX9iURavC-BP4/edit#heading=h.jr59x3s7pwy8) for vertical mode. This PR doesn't cover all of the info there, but ensures we send mc_carousel_payment_method_tapped, mc_{complete/custom}_sheet_new_pm_show, and mc_form_shown from the correct places.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

Manually verified with debugger
