### PR TITLE
Fix `3DS` tests by waiting for complete button

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -1035,7 +1035,11 @@ internal class PlaygroundTestDriver(
 
                     is AuthorizeAction.Authorize3ds2 -> {
                         closeButton.wait(5000)
-                        UiAutomatorText("COMPLETE", device = device).click()
+
+                        val completeButton = UiAutomatorText("COMPLETE", device = device)
+
+                        completeButton.wait(5000)
+                        completeButton.click()
                     }
                     is AuthorizeAction.AuthorizePayment -> {}
                     is AuthorizeAction.PollingSucceedsAfterDelay -> {


### PR DESCRIPTION
# Summary
Fix `3DS` tests by waiting for complete button

# Motivation
Fix `3DS` tests by waiting for complete button

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
