### PR TITLE
Add error code to payment failure analytic event

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetConfirmationError.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetConfirmationError.kt
@@ -5,25 +5,33 @@ import com.stripe.android.core.exception.StripeException
 internal sealed class PaymentSheetConfirmationError : Throwable() {
 
     abstract val analyticsValue: String
+    abstract val errorCode: String?
 
     data class Stripe(override val cause: Throwable) : PaymentSheetConfirmationError() {
+        private val stripeException = StripeException.create(cause)
+
+        override val errorCode: String? = stripeException.stripeError?.code
 
         override val analyticsValue: String
-            get() = StripeException.create(cause).analyticsValue()
+            get() = stripeException.analyticsValue()
     }
 
-    data class GooglePay(val errorCode: Int) : PaymentSheetConfirmationError() {
+    data class GooglePay(val errorCodeInt: Int) : PaymentSheetConfirmationError() {
+        override val errorCode = errorCodeInt.toString()
 
         override val analyticsValue: String
             get() = "googlePay_$errorCode"
     }
 
     data object ExternalPaymentMethod : PaymentSheetConfirmationError() {
+        override val errorCode: String? = null
+
         override val analyticsValue: String
             get() = "externalPaymentMethodError"
     }
 
     object InvalidState : PaymentSheetConfirmationError() {
+        override val errorCode: String? = null
 
         override val analyticsValue: String
             get() = "invalidState"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -277,7 +277,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
             mapOf(
                 FIELD_DURATION to duration?.asSeconds,
                 FIELD_CURRENCY to currency,
-            ) + buildDeferredIntentConfirmationType() + paymentSelection.paymentMethodInfo() + errorMessage()
+            ) + buildDeferredIntentConfirmationType() + paymentSelection.paymentMethodInfo() + errorInfo()
 
         private fun buildDeferredIntentConfirmationType(): Map<String, String> {
             return deferredIntentConfirmationType?.let {
@@ -285,10 +285,13 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
             }.orEmpty()
         }
 
-        private fun errorMessage(): Map<String, String> {
+        private fun errorInfo(): Map<String, String> {
             return when (result) {
                 is Result.Success -> emptyMap()
-                is Result.Failure -> mapOf(FIELD_ERROR_MESSAGE to result.error.analyticsValue)
+                is Result.Failure -> mapOf(
+                    FIELD_ERROR_MESSAGE to result.error.analyticsValue,
+                    FIELD_ERROR_CODE to result.error.errorCode,
+                ).filterNotNullValues()
             }
         }
 
@@ -476,6 +479,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_CURRENCY = "currency"
         const val FIELD_SELECTED_LPM = "selected_lpm"
         const val FIELD_ERROR_MESSAGE = "error_message"
+        const val FIELD_ERROR_CODE = "error_code"
         const val FIELD_CBC_EVENT_SOURCE = "cbc_event_source"
         const val FIELD_SELECTED_CARD_BRAND = "selected_card_brand"
         const val FIELD_LINK_CONTEXT = "link_context"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add error code to payment failure analytic event

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Parity with iOS. Adding as part of ensuring vertical mode analytics are complete.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified