### PR TITLE
Improve accessibility on vertical mode manage screen

### DIFF
--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -5,7 +5,7 @@
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay. -->
   <string name="stripe_afterpay_subtitle">Buy now or pay later with Afterpay</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
-  <string name="stripe_bank_account_ending_in">Remove bank account ending in %s</string>
+  <string name="stripe_bank_account_ending_in">Bank account ending in %s</string>
   <!-- Text for alert message when user needs to confirm payment in their banking app -->
   <string name="stripe_blik_confirm_payment">Confirm the payment in your bank\'s app within %s to complete the purchase.</string>
   <!-- This shows the message on Buy Now Pay Later LPM, clearpay. -->
@@ -105,6 +105,8 @@
   <string name="stripe_paymentsheet_select_your_payment_method">Select your payment method</string>
   <!-- Label indicating the total amount that the user is authorizing (e.g. "Total: $25.00") -->
   <string name="stripe_paymentsheet_total_amount">Total: %s</string>
+  <!-- Text shown in dialog to remove a saved bank account. E.g. 'Remove bank account ending in 4242' -->
+  <string name="stripe_remove_bank_account_ending_in">Remove bank account ending in %s</string>
   <!-- Generic failure message -->
   <string name="stripe_something_went_wrong">Something went wrong</string>
   <!-- Button text on a screen asking the user to approve a payment -->

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetPage.kt
@@ -15,6 +15,7 @@ import com.stripe.android.customersheet.ui.CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_EDIT_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
 import com.stripe.android.paymentsheet.ui.TEST_TAG_REMOVE_BADGE
+import com.stripe.android.paymentsheet.ui.readNumbersAsIndividualDigits
 import com.stripe.android.paymentsheet.utils.isPlaced
 import com.stripe.android.ui.core.elements.TEST_TAG_DIALOG_CONFIRM_BUTTON
 import com.stripe.android.uicore.elements.DROPDOWN_MENU_CLICKABLE_TEST_TAG
@@ -89,7 +90,7 @@ internal class CustomerSheetPage(
 
     fun clickDeleteButton(forEndsWith: String) {
         val deleteBadgeForSavedPmMatcher = hasTestTag(TEST_TAG_REMOVE_BADGE)
-            .and(hasContentDescription(forEndsWith, substring = true))
+            .and(hasContentDescription(forEndsWith.readNumbersAsIndividualDigits(), substring = true))
 
         waitUntil(deleteBadgeForSavedPmMatcher)
         click(deleteBadgeForSavedPmMatcher)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet
 import android.content.res.Resources
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.paymentsheet.ui.readNumbersAsIndividualDigits
 
 internal data class DisplayableSavedPaymentMethod(
     val displayName: ResolvableString,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
@@ -22,15 +22,15 @@ internal data class DisplayableSavedPaymentMethod(
         PaymentMethod.Type.Card -> resources.getString(
             com.stripe.android.R.string.stripe_card_ending_in,
             paymentMethod.card?.brand,
-            paymentMethod.card?.last4?.readNumbersAsIndividualDigits()
+            paymentMethod.card?.last4
         )
         PaymentMethod.Type.SepaDebit -> resources.getString(
             R.string.stripe_bank_account_ending_in,
-            paymentMethod.sepaDebit?.last4?.readNumbersAsIndividualDigits()
+            paymentMethod.sepaDebit?.last4
         )
         PaymentMethod.Type.USBankAccount -> resources.getString(
             R.string.stripe_bank_account_ending_in,
-            paymentMethod.usBankAccount?.last4?.readNumbersAsIndividualDigits()
+            paymentMethod.usBankAccount?.last4
         )
         else -> ""
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.paymentsheet
 
-import android.content.res.Resources
 import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.PaymentMethod
 
 internal data class DisplayableSavedPaymentMethod(
@@ -17,30 +17,32 @@ internal data class DisplayableSavedPaymentMethod(
         return isCbcEligible && hasMultipleNetworks
     }
 
-    fun getDescription(resources: Resources) = when (paymentMethod.type) {
-        PaymentMethod.Type.Card -> resources.getString(
+    fun getDescription() = when (paymentMethod.type) {
+        PaymentMethod.Type.Card -> resolvableString(
             com.stripe.android.R.string.stripe_card_ending_in,
             paymentMethod.card?.brand,
             paymentMethod.card?.last4
         )
-        PaymentMethod.Type.SepaDebit -> resources.getString(
+        PaymentMethod.Type.SepaDebit -> resolvableString(
             R.string.stripe_bank_account_ending_in,
             paymentMethod.sepaDebit?.last4
         )
-        PaymentMethod.Type.USBankAccount -> resources.getString(
+        PaymentMethod.Type.USBankAccount -> resolvableString(
             R.string.stripe_bank_account_ending_in,
             paymentMethod.usBankAccount?.last4
         )
-        else -> ""
+        else -> resolvableString("")
     }
 
-    fun getModifyDescription(resources: Resources) = resources.getString(
+    fun getModifyDescription() = resolvableString(
         R.string.stripe_paymentsheet_modify_pm,
-        getDescription(resources)
+        getDescription()
     )
 
-    fun getRemoveDescription(resources: Resources) = resources.getString(
-        R.string.stripe_paymentsheet_remove_pm,
-        getDescription(resources)
-    )
+    fun getRemoveDescription(): ResolvableString {
+        return resolvableString(
+            R.string.stripe_paymentsheet_remove_pm,
+            getDescription(),
+        )
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet
 import android.content.res.Resources
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.ui.readNumbersAsIndividualDigits
 
 internal data class DisplayableSavedPaymentMethod(
     val displayName: ResolvableString,
@@ -21,16 +22,26 @@ internal data class DisplayableSavedPaymentMethod(
         PaymentMethod.Type.Card -> resources.getString(
             com.stripe.android.R.string.stripe_card_ending_in,
             paymentMethod.card?.brand,
-            paymentMethod.card?.last4
+            paymentMethod.card?.last4?.readNumbersAsIndividualDigits()
         )
         PaymentMethod.Type.SepaDebit -> resources.getString(
             R.string.stripe_bank_account_ending_in,
-            paymentMethod.sepaDebit?.last4
+            paymentMethod.sepaDebit?.last4?.readNumbersAsIndividualDigits()
         )
         PaymentMethod.Type.USBankAccount -> resources.getString(
             R.string.stripe_bank_account_ending_in,
-            paymentMethod.usBankAccount?.last4
+            paymentMethod.usBankAccount?.last4?.readNumbersAsIndividualDigits()
         )
         else -> ""
     }
+
+    fun getModifyDescription(resources: Resources) = resources.getString(
+        R.string.stripe_paymentsheet_modify_pm,
+        getDescription(resources)
+    )
+
+    fun getRemoveDescription(resources: Resources) = resources.getString(
+        R.string.stripe_paymentsheet_remove_pm,
+        getDescription(resources)
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsItem.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsItem.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet
 
-import android.content.res.Resources
 import com.stripe.android.model.PaymentMethod
 
 internal sealed class PaymentOptionsItem {
@@ -39,16 +38,6 @@ internal sealed class PaymentOptionsItem {
         override val isEnabledDuringEditing: Boolean by lazy {
             isModifiable || canRemovePaymentMethods
         }
-
-        fun getModifyDescription(resources: Resources) = resources.getString(
-            R.string.stripe_paymentsheet_modify_pm,
-            displayableSavedPaymentMethod.getDescription(resources)
-        )
-
-        fun getRemoveDescription(resources: Resources) = resources.getString(
-            R.string.stripe_paymentsheet_remove_pm,
-            displayableSavedPaymentMethod.getDescription(resources)
-        )
     }
 
     enum class ViewType {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/Accessibility.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/Accessibility.kt
@@ -1,0 +1,7 @@
+package com.stripe.android.paymentsheet.ui
+
+internal fun String.readNumbersAsIndividualDigits(): String {
+    // This makes the screen reader read out numbers digit by digit
+    // one one one one vs one thousand one hundred eleven
+    return this.replace("\\d".toRegex(), "$0 ")
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/Accessibility.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/Accessibility.kt
@@ -3,5 +3,5 @@ package com.stripe.android.paymentsheet.ui
 internal fun String.readNumbersAsIndividualDigits(): String {
     // This makes the screen reader read out numbers digit by digit
     // one one one one vs one thousand one hundred eleven
-    return this.replace("\\d".toRegex(), "$0 ")
+    return replace("\\d".toRegex(), "$0 ")
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/RemovePaymentMethodDialogUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/RemovePaymentMethodDialogUI.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.ui.core.elements.SimpleDialogElementUI
@@ -15,14 +16,28 @@ internal fun RemovePaymentMethodDialogUI(
     onConfirmListener: () -> Unit,
     onDismissListener: () -> Unit,
 ) {
+    val resources = LocalContext.current.resources
+
     val removeTitle = stringResource(
         R.string.stripe_paymentsheet_remove_pm,
         paymentMethod.displayName.resolve(),
     )
+    val messageText = when (paymentMethod.paymentMethod.type) {
+        PaymentMethod.Type.Card -> paymentMethod.getRemoveDescription(resources)
+        PaymentMethod.Type.USBankAccount -> resources.getString(
+            R.string.stripe_remove_bank_account_ending_in,
+            paymentMethod.paymentMethod.usBankAccount?.last4
+        )
+        PaymentMethod.Type.SepaDebit -> resources.getString(
+            R.string.stripe_remove_bank_account_ending_in,
+            paymentMethod.paymentMethod.sepaDebit?.last4
+        )
+        else -> ""
+    }
 
     SimpleDialogElementUI(
         titleText = removeTitle,
-        messageText = paymentMethod.getDescription(LocalContext.current.resources),
+        messageText = messageText,
         confirmText = stringResource(StripeR.string.stripe_remove),
         dismissText = stringResource(StripeR.string.stripe_cancel),
         destructive = true,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/RemovePaymentMethodDialogUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/RemovePaymentMethodDialogUI.kt
@@ -23,7 +23,7 @@ internal fun RemovePaymentMethodDialogUI(
         paymentMethod.displayName.resolve(),
     )
     val messageText = when (paymentMethod.paymentMethod.type) {
-        PaymentMethod.Type.Card -> paymentMethod.getRemoveDescription(resources)
+        PaymentMethod.Type.Card -> paymentMethod.getDescription(resources)
         PaymentMethod.Type.USBankAccount -> resources.getString(
             R.string.stripe_remove_bank_account_ending_in,
             paymentMethod.paymentMethod.usBankAccount?.last4

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/RemovePaymentMethodDialogUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/RemovePaymentMethodDialogUI.kt
@@ -23,7 +23,7 @@ internal fun RemovePaymentMethodDialogUI(
         paymentMethod.displayName.resolve(),
     )
     val messageText = when (paymentMethod.paymentMethod.type) {
-        PaymentMethod.Type.Card -> paymentMethod.getDescription(resources)
+        PaymentMethod.Type.Card -> paymentMethod.getDescription().resolve()
         PaymentMethod.Type.USBankAccount -> resources.getString(
             R.string.stripe_remove_bank_account_ending_in,
             paymentMethod.paymentMethod.usBankAccount?.last4

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTab.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTab.kt
@@ -115,7 +115,7 @@ internal fun SavedPaymentMethodTab(
                     modifier = Modifier
                         .padding(top = 4.dp, start = 6.dp, end = 6.dp)
                         .semantics {
-                            this.contentDescription = description.readNumbersAsIndividualDigits()
+                           contentDescription = description.readNumbersAsIndividualDigits()
                         }
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTab.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTab.kt
@@ -115,10 +115,7 @@ internal fun SavedPaymentMethodTab(
                     modifier = Modifier
                         .padding(top = 4.dp, start = 6.dp, end = 6.dp)
                         .semantics {
-                            // This makes the screen reader read out numbers digit by digit
-                            // one one one one vs one thousand one hundred eleven
-                            this.contentDescription =
-                                description.replace("\\d".toRegex(), "$0 ")
+                            this.contentDescription = description.readNumbersAsIndividualDigits()
                         }
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTab.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTab.kt
@@ -115,7 +115,7 @@ internal fun SavedPaymentMethodTab(
                     modifier = Modifier
                         .padding(top = 4.dp, start = 6.dp, end = 6.dp)
                         .semantics {
-                           contentDescription = description.readNumbersAsIndividualDigits()
+                            contentDescription = description.readNumbersAsIndividualDigits()
                         }
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -399,15 +399,20 @@ private fun SavedPaymentMethodTab(
             labelIcon = labelIcon,
             labelText = labelText,
             paymentMethod = paymentMethod.displayableSavedPaymentMethod,
-            description = paymentMethod.displayableSavedPaymentMethod.getDescription(context.resources),
+            description = paymentMethod
+                .displayableSavedPaymentMethod
+                .getDescription(context.resources)
+                .readNumbersAsIndividualDigits(),
             onModifyListener = { onModifyItem(paymentMethod.paymentMethod) },
             onModifyAccessibilityDescription = paymentMethod
                 .displayableSavedPaymentMethod
-                .getModifyDescription(context.resources),
+                .getModifyDescription(context.resources)
+                .readNumbersAsIndividualDigits(),
             onRemoveListener = { onItemRemoved(paymentMethod.paymentMethod) },
             onRemoveAccessibilityDescription = paymentMethod
                 .displayableSavedPaymentMethod
-                .getRemoveDescription(context.resources),
+                .getRemoveDescription(context.resources)
+                .readNumbersAsIndividualDigits(),
             onItemSelectedListener = {
                 onItemSelected(paymentMethod.toPaymentSelection())
             },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -370,7 +369,6 @@ private fun SavedPaymentMethodTab(
     onItemRemoved: (PaymentMethod) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val context = LocalContext.current
     val labelIcon = paymentMethod.paymentMethod.getLabelIcon()
     val labelText = paymentMethod.paymentMethod.getLabel()?.resolve() ?: return
 
@@ -401,17 +399,20 @@ private fun SavedPaymentMethodTab(
             paymentMethod = paymentMethod.displayableSavedPaymentMethod,
             description = paymentMethod
                 .displayableSavedPaymentMethod
-                .getDescription(context.resources)
+                .getDescription()
+                .resolve()
                 .readNumbersAsIndividualDigits(),
             onModifyListener = { onModifyItem(paymentMethod.paymentMethod) },
             onModifyAccessibilityDescription = paymentMethod
                 .displayableSavedPaymentMethod
-                .getModifyDescription(context.resources)
+                .getModifyDescription()
+                .resolve()
                 .readNumbersAsIndividualDigits(),
             onRemoveListener = { onItemRemoved(paymentMethod.paymentMethod) },
             onRemoveAccessibilityDescription = paymentMethod
                 .displayableSavedPaymentMethod
-                .getRemoveDescription(context.resources)
+                .getRemoveDescription()
+                .resolve()
                 .readNumbersAsIndividualDigits(),
             onItemSelectedListener = {
                 onItemSelected(paymentMethod.toPaymentSelection())

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -401,9 +401,13 @@ private fun SavedPaymentMethodTab(
             paymentMethod = paymentMethod.displayableSavedPaymentMethod,
             description = paymentMethod.displayableSavedPaymentMethod.getDescription(context.resources),
             onModifyListener = { onModifyItem(paymentMethod.paymentMethod) },
-            onModifyAccessibilityDescription = paymentMethod.getModifyDescription(context.resources),
+            onModifyAccessibilityDescription = paymentMethod
+                .displayableSavedPaymentMethod
+                .getModifyDescription(context.resources),
             onRemoveListener = { onItemRemoved(paymentMethod.paymentMethod) },
-            onRemoveAccessibilityDescription = paymentMethod.getRemoveDescription(context.resources),
+            onRemoveAccessibilityDescription = paymentMethod
+                .displayableSavedPaymentMethod
+                .getRemoveDescription(context.resources),
             onItemSelectedListener = {
                 onItemSelected(paymentMethod.toPaymentSelection())
             },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenIcons.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenIcons.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -25,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.ui.RemovePaymentMethodDialogUI
 import com.stripe.android.paymentsheet.ui.readNumbersAsIndividualDigits
+import com.stripe.android.uicore.strings.resolve
 
 @Composable
 internal fun DeleteIcon(
@@ -42,7 +42,8 @@ internal fun DeleteIcon(
             openRemoveDialog.value = true
         },
         contentDescription = paymentMethod
-            .getRemoveDescription(LocalContext.current.resources)
+            .getRemoveDescription()
+            .resolve()
             .readNumbersAsIndividualDigits()
     )
 
@@ -69,7 +70,8 @@ internal fun EditIcon(
         modifier = Modifier.testTag("${TEST_TAG_MANAGE_SCREEN_EDIT_ICON}_$paymentMethodId"),
         onClick = { editPaymentMethod(paymentMethod) },
         contentDescription = paymentMethod
-            .getModifyDescription(LocalContext.current.resources)
+            .getModifyDescription()
+            .resolve()
             .readNumbersAsIndividualDigits(),
     )
 }
@@ -94,9 +96,11 @@ private fun TrailingIcon(
             imageVector = icon,
             contentDescription = null,
             tint = Color.White,
-            modifier = Modifier.size(12.dp).semantics {
-                this.contentDescription = contentDescription
-            },
+            modifier = Modifier
+                .size(12.dp)
+                .semantics {
+                    this.contentDescription = contentDescription
+                },
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenIcons.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenIcons.kt
@@ -17,7 +17,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.ui.RemovePaymentMethodDialogUI
@@ -37,6 +40,7 @@ internal fun DeleteIcon(
         onClick = {
             openRemoveDialog.value = true
         },
+        contentDescription = paymentMethod.getRemoveDescription(LocalContext.current.resources)
     )
 
     if (openRemoveDialog.value) {
@@ -60,12 +64,19 @@ internal fun EditIcon(
         backgroundColor = Color.Gray,
         icon = Icons.Filled.Edit,
         modifier = Modifier.testTag("${TEST_TAG_MANAGE_SCREEN_EDIT_ICON}_$paymentMethodId"),
-        onClick = { editPaymentMethod(paymentMethod) }
+        onClick = { editPaymentMethod(paymentMethod) },
+        contentDescription = paymentMethod.getModifyDescription(LocalContext.current.resources),
     )
 }
 
 @Composable
-private fun TrailingIcon(backgroundColor: Color, icon: ImageVector, onClick: () -> Unit, modifier: Modifier) {
+private fun TrailingIcon(
+    backgroundColor: Color,
+    icon: ImageVector,
+    onClick: () -> Unit,
+    contentDescription: String,
+    modifier: Modifier,
+) {
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
@@ -78,7 +89,9 @@ private fun TrailingIcon(backgroundColor: Color, icon: ImageVector, onClick: () 
             imageVector = icon,
             contentDescription = null,
             tint = Color.White,
-            modifier = Modifier.size(12.dp),
+            modifier = Modifier.size(12.dp).semantics {
+                this.contentDescription = contentDescription
+            },
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenIcons.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenIcons.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.ui.RemovePaymentMethodDialogUI
+import com.stripe.android.paymentsheet.ui.readNumbersAsIndividualDigits
 
 @Composable
 internal fun DeleteIcon(
@@ -40,7 +41,9 @@ internal fun DeleteIcon(
         onClick = {
             openRemoveDialog.value = true
         },
-        contentDescription = paymentMethod.getRemoveDescription(LocalContext.current.resources)
+        contentDescription = paymentMethod
+            .getRemoveDescription(LocalContext.current.resources)
+            .readNumbersAsIndividualDigits()
     )
 
     if (openRemoveDialog.value) {
@@ -65,7 +68,9 @@ internal fun EditIcon(
         icon = Icons.Filled.Edit,
         modifier = Modifier.testTag("${TEST_TAG_MANAGE_SCREEN_EDIT_ICON}_$paymentMethodId"),
         onClick = { editPaymentMethod(paymentMethod) },
-        contentDescription = paymentMethod.getModifyDescription(LocalContext.current.resources),
+        contentDescription = paymentMethod
+            .getModifyDescription(LocalContext.current.resources)
+            .readNumbersAsIndividualDigits(),
     )
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowButton.kt
@@ -13,6 +13,8 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -28,6 +30,7 @@ internal fun PaymentMethodRowButton(
     title: String,
     subtitle: String?,
     onClick: () -> Unit,
+    contentDescription: String? = null,
     modifier: Modifier = Modifier,
     trailingContent: (@Composable RowScope.() -> Unit)? = null,
 ) {
@@ -52,7 +55,12 @@ internal fun PaymentMethodRowButton(
         ) {
             iconContent()
 
-            TitleContent(title = title, subtitle = subtitle, isEnabled = isEnabled)
+            TitleContent(
+                title = title,
+                subtitle = subtitle,
+                isEnabled = isEnabled,
+                contentDescription = contentDescription
+            )
 
             if (trailingContent != null) {
                 Spacer(modifier = Modifier.weight(1f))
@@ -63,7 +71,7 @@ internal fun PaymentMethodRowButton(
 }
 
 @Composable
-private fun TitleContent(title: String, subtitle: String?, isEnabled: Boolean,) {
+private fun TitleContent(title: String, subtitle: String?, isEnabled: Boolean, contentDescription: String?,) {
     val textColor = MaterialTheme.stripeColors.onComponent
 
     Column {
@@ -72,7 +80,12 @@ private fun TitleContent(title: String, subtitle: String?, isEnabled: Boolean,) 
             style = MaterialTheme.typography.body1.copy(fontWeight = FontWeight.Medium),
             color = if (isEnabled) textColor else textColor.copy(alpha = 0.6f),
             maxLines = 1,
-            overflow = TextOverflow.Ellipsis
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.semantics {
+                if (contentDescription != null) {
+                    this.contentDescription = contentDescription
+                }
+            }
         )
 
         if (subtitle != null) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -35,7 +34,8 @@ internal fun SavedPaymentMethodRowButton(
     trailingContent: (@Composable RowScope.() -> Unit)? = null,
 ) {
     val contentDescription = displayableSavedPaymentMethod
-        .getDescription(LocalContext.current.resources)
+        .getDescription()
+        .resolve()
         .readNumbersAsIndividualDigits()
     val paymentMethodTitle =
         displayableSavedPaymentMethod.paymentMethod.getLabel()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
@@ -18,6 +18,7 @@ import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.ui.PaymentMethodIconFromResource
 import com.stripe.android.paymentsheet.ui.getLabel
 import com.stripe.android.paymentsheet.ui.getSavedPaymentMethodIcon
+import com.stripe.android.paymentsheet.ui.readNumbersAsIndividualDigits
 import com.stripe.android.paymentsheet.utils.testMetadata
 import com.stripe.android.paymentsheet.verticalmode.UIConstants.iconHeight
 import com.stripe.android.paymentsheet.verticalmode.UIConstants.iconWidth
@@ -33,7 +34,9 @@ internal fun SavedPaymentMethodRowButton(
     onClick: () -> Unit = {},
     trailingContent: (@Composable RowScope.() -> Unit)? = null,
 ) {
-    val contentDescription = displayableSavedPaymentMethod.getDescription(LocalContext.current.resources)
+    val contentDescription = displayableSavedPaymentMethod
+        .getDescription(LocalContext.current.resources)
+        .readNumbersAsIndividualDigits()
     val paymentMethodTitle =
         displayableSavedPaymentMethod.paymentMethod.getLabel()
             ?: displayableSavedPaymentMethod.displayName

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -32,6 +33,7 @@ internal fun SavedPaymentMethodRowButton(
     onClick: () -> Unit = {},
     trailingContent: (@Composable RowScope.() -> Unit)? = null,
 ) {
+    val contentDescription = displayableSavedPaymentMethod.getDescription(LocalContext.current.resources)
     val paymentMethodTitle =
         displayableSavedPaymentMethod.paymentMethod.getLabel()
             ?: displayableSavedPaymentMethod.displayName
@@ -57,9 +59,11 @@ internal fun SavedPaymentMethodRowButton(
         title = paymentMethodTitle.resolve(),
         subtitle = null,
         onClick = onClick,
-        modifier = modifier.testTag(
-            "${TEST_TAG_SAVED_PAYMENT_METHOD_ROW_BUTTON}_$paymentMethodId"
-        ),
+        modifier = modifier
+            .testTag(
+                "${TEST_TAG_SAVED_PAYMENT_METHOD_ROW_BUTTON}_$paymentMethodId"
+            ),
+        contentDescription = contentDescription,
         trailingContent = trailingContent,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUITest.kt
@@ -2,7 +2,9 @@ package com.stripe.android.paymentsheet.verticalmode
 
 import android.os.Build
 import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertAny
 import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.hasContentDescriptionExactly
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onChild
 import androidx.compose.ui.test.onChildren
@@ -11,8 +13,10 @@ import androidx.compose.ui.test.performClick
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.PaymentMethodFixtures.toDisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.ViewActionRecorder
+import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.ui.core.elements.TEST_TAG_DIALOG_CONFIRM_BUTTON
 import com.stripe.android.ui.core.elements.TEST_TAG_DIALOG_DISMISS_BUTTON
 import com.stripe.android.ui.core.elements.TEST_TAG_SIMPLE_DIALOG
@@ -47,6 +51,28 @@ class ManageScreenUITest {
             composeRule.onNodeWithTag(
                 "${TEST_TAG_SAVED_PAYMENT_METHOD_ROW_BUTTON}_${savedPaymentMethod.paymentMethod.id}"
             ).assertExists()
+        }
+    }
+
+    @Test
+    fun savedPaymentMethod_hasCorrectContentDescription() {
+        val savedCard = PaymentMethodFactory.card(last4 = "4242", addCbcNetworks = false)
+        runScenario(
+            initialState = ManageScreenInteractor.State(
+                paymentMethods = listOf(
+                    savedCard.toDisplayableSavedPaymentMethod()
+                ),
+                currentSelection = null,
+                isEditing = false,
+                canRemove = true,
+                canEdit = true,
+            )
+        ) {
+            composeRule.onNodeWithTag(
+                "${TEST_TAG_SAVED_PAYMENT_METHOD_ROW_BUTTON}_${savedCard.id}"
+            ).onChildren().assertAny(
+                hasContentDescriptionExactly("Visa ending in 4 2 4 2")
+            )
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUITest.kt
@@ -71,7 +71,7 @@ class ManageScreenUITest {
             composeRule.onNodeWithTag(
                 "${TEST_TAG_SAVED_PAYMENT_METHOD_ROW_BUTTON}_${savedCard.id}"
             ).onChildren().assertAny(
-                hasContentDescriptionExactly("Visa ending in 4 2 4 2")
+                hasContentDescriptionExactly("Visa ending in 4 2 4 2 ")
             )
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Improve accessibility on vertical mode manage screen

Specifically:
- when focused on a saved PM row, the content description now reads as e.g. "Visa card ending in four two four two" instead of just reading as "four thousand two hundred forty-two"
- added a description to the modify and remove buttons in the manage screen

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2125

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screen recording
Before:

https://github.com/user-attachments/assets/de2137c1-ac62-45ac-9237-01462a68032f


After:

https://github.com/user-attachments/assets/584e5076-ab71-4b2d-9c49-3b189e476bac

