### PR TITLE
Show `CardBrand` in Basic Integration `PaymentMethods` screen.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/MaskedCardView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/MaskedCardView.kt
@@ -63,8 +63,14 @@ internal class MaskedCardView @JvmOverloads constructor(
     }
 
     fun setPaymentMethod(paymentMethod: PaymentMethod) {
-        cardBrand = paymentMethod.card?.brand ?: CardBrand.Unknown
-        last4 = paymentMethod.card?.last4
+        val card = paymentMethod.card
+
+        cardBrand = CardBrand.fromCode(card?.displayBrand).takeIf { brand ->
+            brand != CardBrand.Unknown
+        } ?: card?.brand ?: CardBrand.Unknown
+
+        last4 = card?.last4
+
         updateUi()
     }
 

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
@@ -376,6 +376,8 @@ internal object PaymentMethodFixtures {
         """.trimIndent()
     )
 
+    internal val CARD_WITH_DISPLAY_BRAND = PaymentMethodJsonParser().parse(CARD_WITH_DISPLAY_BRAND_JSON)
+
     val IDEAL_JSON = JSONObject(
         """
             {

--- a/payments-core/src/test/java/com/stripe/android/view/MaskedCardViewTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/MaskedCardViewTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.view.View
 import android.widget.ImageView
 import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethodFixtures
 import org.junit.runner.RunWith
@@ -64,5 +65,11 @@ class MaskedCardViewTest {
     @Test
     fun whenTypeNotCard_doesNotCrash() {
         maskedCardView.setPaymentMethod(PaymentMethodFixtures.FPX_PAYMENT_METHOD)
+    }
+
+    @Test
+    fun whenDisplayBrandIsDifferentThanBrand_shouldUseDisplayBrand() {
+        maskedCardView.setPaymentMethod(PaymentMethodFixtures.CARD_WITH_DISPLAY_BRAND)
+        assertThat(maskedCardView.cardBrand).isEqualTo(CardBrand.CartesBancaires)
     }
 }


### PR DESCRIPTION
# Summary
Show `CardBrand` in Basic Integration `PaymentMethods` screen.

# Motivation
Resolves https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3339

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified