### PR TITLE
Fail payment attempt where merchant attempted to use the same intent in `createIntentCallback`

### DIFF
--- a/paymentsheet/res/values/donottranslate.xml
+++ b/paymentsheet/res/values/donottranslate.xml
@@ -14,4 +14,6 @@
     <string name="stripe_paymentsheet_bacs_support_default_email">support@stripe.com</string>
     <string name="stripe_paymentsheet_bacs_support_default_address_line_one">Stripe, 7th Floor The Bower Warehouse</string>
     <string name="stripe_paymentsheet_bacs_support_default_address_line_two">207–211 Old St, London EC1V 9NR</string>
+
+    <string name="stripe_paymentsheet_invalid_deferred_intent_usage">Place user error message here</string>
 </resources>

--- a/paymentsheet/res/values/donottranslate.xml
+++ b/paymentsheet/res/values/donottranslate.xml
@@ -15,5 +15,5 @@
     <string name="stripe_paymentsheet_bacs_support_default_address_line_one">Stripe, 7th Floor The Bower Warehouse</string>
     <string name="stripe_paymentsheet_bacs_support_default_address_line_two">207–211 Old St, London EC1V 9NR</string>
 
-    <string name="stripe_paymentsheet_invalid_deferred_intent_usage">Place user error message here</string>
+    <string name="stripe_paymentsheet_invalid_deferred_intent_usage">It appears you are reusing an intent on every `createIntentCallback` call. You should either create a brand new intent in `createIntentCallback` or update the existing intent with the new payment method ID.</string>
 </resources>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationHandler.kt
@@ -281,7 +281,7 @@ internal class IntentConfirmationHandler(
                     PaymentConfirmationResult.Failed(
                         cause = nextStep.cause,
                         message = nextStep.message,
-                        type = PaymentConfirmationErrorType.Internal,
+                        type = PaymentConfirmationErrorType.Payment,
                     )
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptor.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet
 
 import com.stripe.android.ConfirmStripeIntentParamsFactory
+import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.networking.ApiRequest
@@ -86,6 +87,15 @@ internal enum class DeferredIntentConfirmationType(val value: String) {
     Client("client"),
     Server("server"),
     None("none")
+}
+
+internal class InvalidDeferredIntentUsageException : StripeException() {
+    override fun analyticsValue(): String = "invalidDeferredIntentUsage"
+
+    override val message: String = """
+        It appears you are reusing an intent on every `createIntentCallback` call. You should either create a brand
+        new intent in `createIntentCallback` or update the existing intent with the new payment method ID.
+    """.trimIndent()
 }
 
 internal class DefaultIntentConfirmationInterceptor @Inject constructor(
@@ -300,7 +310,16 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
             if (intent.isConfirmed) {
                 NextStep.Complete(isForceSuccess = false)
             } else if (intent.requiresAction()) {
-                NextStep.HandleNextAction(clientSecret)
+                val attachedPaymentMethodId = intent.paymentMethodId
+
+                if (attachedPaymentMethodId != null && attachedPaymentMethodId != paymentMethod.id) {
+                    NextStep.Fail(
+                        cause = InvalidDeferredIntentUsageException(),
+                        message = resolvableString(R.string.stripe_paymentsheet_invalid_deferred_intent_usage),
+                    )
+                } else {
+                    NextStep.HandleNextAction(clientSecret)
+                }
             } else {
                 DeferredIntentValidator.validate(intent, intentConfiguration, isFlowController)
                 createConfirmStep(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
@@ -1,10 +1,9 @@
 package com.stripe.android.paymentsheet
 
-import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
 
 internal suspend fun IntentConfirmationInterceptor.intercept(
-    confirmationOption: PaymentConfirmationOption.PaymentMethod?,
+    confirmationOption: PaymentConfirmationOption.PaymentMethod,
 ): IntentConfirmationInterceptor.NextStep {
     return when (confirmationOption) {
         is PaymentConfirmationOption.PaymentMethod.New -> {
@@ -22,12 +21,6 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
                 paymentMethod = confirmationOption.paymentMethod,
                 paymentMethodOptionsParams = confirmationOption.optionsParams,
                 shippingValues = confirmationOption.shippingDetails?.toConfirmPaymentIntentShipping(),
-            )
-        }
-        null -> {
-            IntentConfirmationInterceptor.NextStep.Fail(
-                cause = IllegalStateException("Nothing selected."),
-                message = resolvableString(R.string.stripe_something_went_wrong),
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -704,8 +704,8 @@ internal class DefaultFlowController @Inject internal constructor(
         cause: Throwable
     ): PaymentSheetConfirmationError? {
         return when (this) {
-            PaymentConfirmationErrorType.ExternalPaymentMethod -> PaymentSheetConfirmationError.Stripe(cause)
-            PaymentConfirmationErrorType.Payment -> PaymentSheetConfirmationError.ExternalPaymentMethod
+            PaymentConfirmationErrorType.ExternalPaymentMethod -> PaymentSheetConfirmationError.ExternalPaymentMethod
+            PaymentConfirmationErrorType.Payment -> PaymentSheetConfirmationError.Stripe(cause)
             is PaymentConfirmationErrorType.GooglePay -> PaymentSheetConfirmationError.GooglePay(errorCode)
             PaymentConfirmationErrorType.Internal,
             PaymentConfirmationErrorType.MerchantIntegration,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.paymentsheet.analytics
 
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentMethodCode
@@ -8,7 +10,10 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 
 @Suppress("EmptyFunctionBlock")
-internal class NoOpEventReporter : EventReporter {
+internal class FakeEventReporter : EventReporter {
+    private val _paymentFailureCalls = Turbine<PaymentFailureCall>()
+    val paymentFailureCalls: ReceiveTurbine<PaymentFailureCall> = _paymentFailureCalls
+
     override fun onInit(configuration: PaymentSheet.Configuration, isDeferred: Boolean) {
     }
 
@@ -64,7 +69,16 @@ internal class NoOpEventReporter : EventReporter {
     ) {
     }
 
-    override fun onPaymentFailure(paymentSelection: PaymentSelection?, error: PaymentSheetConfirmationError) {
+    override fun onPaymentFailure(
+        paymentSelection: PaymentSelection?,
+        error: PaymentSheetConfirmationError
+    ) {
+        _paymentFailureCalls.add(
+            PaymentFailureCall(
+                paymentSelection = paymentSelection,
+                error = error,
+            )
+        )
     }
 
     override fun onLpmSpecFailure(errorMessage: String?) {
@@ -96,4 +110,9 @@ internal class NoOpEventReporter : EventReporter {
 
     override fun onCannotProperlyReturnFromLinkAndOtherLPMs() {
     }
+
+    data class PaymentFailureCall(
+        val paymentSelection: PaymentSelection?,
+        val error: PaymentSheetConfirmationError
+    )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/FakeBaseSheetViewModel.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/FakeBaseSheetViewModel.kt
@@ -8,7 +8,7 @@ import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.NewOrExternalPaymentSelection
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.analytics.NoOpEventReporter
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.state.WalletsProcessingState
@@ -40,7 +40,7 @@ internal class FakeBaseSheetViewModel private constructor(
     paymentMethodMetadata: PaymentMethodMetadata,
 ) : BaseSheetViewModel(
     config = PaymentSheet.Configuration.Builder("Example, Inc.").build(),
-    eventReporter = NoOpEventReporter(),
+    eventReporter = FakeEventReporter(),
     customerRepository = FakeCustomerRepository(),
     workContext = Dispatchers.IO,
     savedStateHandle = savedStateHandle,


### PR DESCRIPTION
# Summary
Fail & log payment attempt in deferred intent mode where merchant attempted to use the same intent in `createIntentCallback`

# Motivation
Allows us to better view merchant integration errors with deferred intent.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Video
https://github.com/user-attachments/assets/50c2e39a-c64a-400e-a80c-b55f78b22b4d