### PR TITLE
Increase default timeout for `VerticalMode` E2E tests

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -891,7 +891,7 @@ internal class PlaygroundTestDriver(
     }
 
     private fun selectLpmInVerticalMode(paymentMethodCode: PaymentMethodCode) {
-        composeTestRule.waitUntil {
+        composeTestRule.waitUntil(DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
             composeTestRule
                 .onAllNodes(hasTestTag(TEST_TAG_PAYMENT_METHOD_VERTICAL_LAYOUT))
                 .fetchSemanticsNodes()


### PR DESCRIPTION
# Summary
Increase default timeout for `VerticalMode` E2E tests

# Motivation
`VerticalMode` E2E tests were failing on Samsung devices because the timeout was small.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified