### PR TITLE
Add analytics for tracking `CustomerSession` usage.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -26,6 +26,7 @@ import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
 import com.stripe.android.uicore.PRIMARY_BUTTON_SUCCESS_BACKGROUND_COLOR
 import com.stripe.android.uicore.StripeThemeDefaults
 import com.stripe.android.uicore.getRawValueFromDimenResource
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -1511,11 +1512,19 @@ class PaymentSheet internal constructor(
     }
 
     internal sealed interface CustomerAccessType : Parcelable {
-        @Parcelize
-        data class LegacyCustomerEphemeralKey(val ephemeralKeySecret: String) : CustomerAccessType
+        val analyticsValue: String
 
         @Parcelize
-        data class CustomerSession(val customerSessionClientSecret: String) : CustomerAccessType
+        data class LegacyCustomerEphemeralKey(val ephemeralKeySecret: String) : CustomerAccessType {
+            @IgnoredOnParcel
+            override val analyticsValue: String = "legacy"
+        }
+
+        @Parcelize
+        data class CustomerSession(val customerSessionClientSecret: String) : CustomerAccessType {
+            @IgnoredOnParcel
+            override val analyticsValue: String = "customer_session"
+        }
     }
 
     @Parcelize

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -127,6 +127,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
                 @Suppress("DEPRECATION")
                 val configurationMap = mapOf(
                     FIELD_CUSTOMER to (configuration.customer != null),
+                    FIELD_CUSTOMER_ACCESS_PROVIDER to (configuration.customer?.accessType?.analyticsValue),
                     FIELD_GOOGLE_PAY to (configuration.googlePay != null),
                     FIELD_PRIMARY_BUTTON_COLOR to (configuration.primaryButtonColor != null),
                     FIELD_BILLING to (configuration.defaultBillingDetails?.isFilledOut() == true),
@@ -463,6 +464,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         }
 
         const val FIELD_CUSTOMER = "customer"
+        const val FIELD_CUSTOMER_ACCESS_PROVIDER = "customer_access_provider"
         const val FIELD_GOOGLE_PAY = "googlepay"
         const val FIELD_GOOGLE_PAY_ENABLED = "google_pay_enabled"
         const val FIELD_PRIMARY_BUTTON_COLOR = "primary_button_color"


### PR DESCRIPTION
# Summary
Add analytics for tracking `CustomerSession` usage.

# Motivation
Allows us to track `CustomerSession` usage in the SDK.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
