### PR TITLE
On manage one PM screen, don't display the saved PM as selected

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageOneSavedPaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageOneSavedPaymentMethodUI.kt
@@ -17,7 +17,7 @@ internal fun ManageOneSavedPaymentMethodUI(interactor: ManageOneSavedPaymentMeth
     SavedPaymentMethodRowButton(
         displayableSavedPaymentMethod = paymentMethod,
         isEnabled = true,
-        isSelected = true,
+        isSelected = false,
         trailingContent = {
             DeleteIcon(
                 paymentMethod = paymentMethod,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/VerticalModePaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/VerticalModePaymentSheetActivityTest.kt
@@ -220,7 +220,6 @@ internal class VerticalModePaymentSheetActivityTest {
 
         verticalModePage.clickEdit()
         managePage.waitUntilRemoveVisible("pm_12345")
-        verticalModePage.assertHasSelectedSavedPaymentMethod("pm_12345")
         managePage.clickRemove("pm_12345")
 
         verticalModePage.waitUntilVisible()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
On manage one PM screen, don't display the saved PM as selected

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Bug bash feedback: [here](https://docs.google.com/document/d/1nBu2ot6iswjt3L6D4UozoGpOR3EEJDiHWKOROx5nKGY/edit#bookmark=id.9t8boyrw3oee)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screenshots
Before:
![manage one bfore](https://github.com/user-attachments/assets/b84e3244-be76-44c6-b3e8-ba710c106028)


After:
![manage one after](https://github.com/user-attachments/assets/ce137cbf-3318-4a0b-b118-c81fc7a959e5)

