### PR TITLE
Reset edit state when screen changes

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -113,9 +113,24 @@ internal class SavedPaymentMethodMutator(
         }
 
         coroutineScope.launch {
-            currentScreen.collect {
-                // Anytime the screen changes, editing should be reset to false.
-                _editing.value = false
+            currentScreen.collect { currentScreen ->
+                when (currentScreen) {
+                    is PaymentSheetScreen.VerticalMode -> {
+                        // When returning to the vertical mode screen, reset editing to false.
+                        _editing.value = false
+                    }
+                    is PaymentSheetScreen.ManageSavedPaymentMethods,
+                    is PaymentSheetScreen.AddAnotherPaymentMethod,
+                    is PaymentSheetScreen.AddFirstPaymentMethod,
+                    is PaymentSheetScreen.CvcRecollection,
+                    is PaymentSheetScreen.EditPaymentMethod,
+                    PaymentSheetScreen.Loading,
+                    is PaymentSheetScreen.ManageOneSavedPaymentMethod,
+                    is PaymentSheetScreen.SelectSavedPaymentMethods,
+                    is PaymentSheetScreen.VerticalModeForm -> {
+                        // Do nothing.
+                    }
+                }
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -43,6 +43,7 @@ internal class SavedPaymentMethodMutator(
     private val clearSelection: () -> Unit,
     private val isLiveModeProvider: () -> Boolean,
     private val customerStateHolder: CustomerStateHolder,
+    private val currentScreen: StateFlow<PaymentSheetScreen>,
     isCbcEligible: () -> Boolean,
     isGooglePayReady: StateFlow<Boolean>,
     isLinkEnabled: StateFlow<Boolean?>,
@@ -108,6 +109,13 @@ internal class SavedPaymentMethodMutator(
                 if (paymentMethods.isEmpty() && editing.value) {
                     _editing.value = false
                 }
+            }
+        }
+
+        coroutineScope.launch {
+            currentScreen.collect {
+                // Anytime the screen changes, editing should be reset to false.
+                _editing.value = false
             }
         }
     }
@@ -316,7 +324,8 @@ internal class SavedPaymentMethodMutator(
                 isGooglePayReady = viewModel.paymentMethodMetadata.mapAsStateFlow { it?.isGooglePayReady == true },
                 isLinkEnabled = viewModel.linkHandler.isLinkEnabled,
                 isNotPaymentFlow = !viewModel.isCompleteFlow,
-                isLiveModeProvider = { requireNotNull(viewModel.paymentMethodMetadata.value).stripeIntent.isLiveMode }
+                isLiveModeProvider = { requireNotNull(viewModel.paymentMethodMetadata.value).stripeIntent.isLiveMode },
+                currentScreen = viewModel.navigationHandler.currentScreen,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -119,15 +119,7 @@ internal class SavedPaymentMethodMutator(
                         // When returning to the vertical mode screen, reset editing to false.
                         _editing.value = false
                     }
-                    is PaymentSheetScreen.ManageSavedPaymentMethods,
-                    is PaymentSheetScreen.AddAnotherPaymentMethod,
-                    is PaymentSheetScreen.AddFirstPaymentMethod,
-                    is PaymentSheetScreen.CvcRecollection,
-                    is PaymentSheetScreen.EditPaymentMethod,
-                    PaymentSheetScreen.Loading,
-                    is PaymentSheetScreen.ManageOneSavedPaymentMethod,
-                    is PaymentSheetScreen.SelectSavedPaymentMethods,
-                    is PaymentSheetScreen.VerticalModeForm -> {
+                    else -> {
                         // Do nothing.
                     }
                 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -422,7 +422,7 @@ class SavedPaymentMethodMutatorTest {
     }
 
     @Test
-    fun `Changing the screen resets editing to false`() {
+    fun `Exiting the manage saved PMs screen resets editing to false`() {
         runScenario {
             currentScreen.value = PaymentSheetScreen.ManageSavedPaymentMethods(
                 interactor = FakeManageScreenInteractor()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -13,11 +13,14 @@ import com.stripe.android.paymentsheet.navigation.NavigationHandler
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.state.CustomerState
+import com.stripe.android.paymentsheet.verticalmode.FakeManageScreenInteractor
+import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.FakeCustomerRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -419,6 +422,38 @@ class SavedPaymentMethodMutatorTest {
     }
 
     @Test
+    fun `Changing the screen resets editing to false`() {
+        runScenario {
+            currentScreen.value = PaymentSheetScreen.ManageSavedPaymentMethods(
+                interactor = FakeManageScreenInteractor()
+            )
+
+            savedPaymentMethodMutator.toggleEditing()
+            savedPaymentMethodMutator.editing.test {
+                assertThat(awaitItem()).isTrue()
+            }
+
+            currentScreen.value = PaymentSheetScreen.VerticalMode(
+                interactor = FakePaymentMethodVerticalLayoutInteractor
+            )
+
+            savedPaymentMethodMutator.editing.test {
+                assertThat(awaitItem()).isFalse()
+            }
+        }
+    }
+
+    private object FakePaymentMethodVerticalLayoutInteractor : PaymentMethodVerticalLayoutInteractor {
+        override val isLiveMode: Boolean = false
+        override val state: StateFlow<PaymentMethodVerticalLayoutInteractor.State> = mock()
+        override val showsWalletsHeader: StateFlow<Boolean> = MutableStateFlow(false)
+
+        override fun handleViewAction(viewAction: PaymentMethodVerticalLayoutInteractor.ViewAction) {
+            // Do nothing.
+        }
+    }
+
+    @Test
     fun `On detach without remove duplicate permissions, should not attempt to remove duplicates in repository`() {
         removeDuplicatesTest(shouldRemoveDuplicates = false)
     }
@@ -484,6 +519,7 @@ class SavedPaymentMethodMutatorTest {
     ) {
         runTest {
             val selection: MutableStateFlow<PaymentSelection?> = MutableStateFlow(null)
+            val currentScreen: MutableStateFlow<PaymentSheetScreen> = MutableStateFlow(PaymentSheetScreen.Loading)
 
             val customerStateHolder = CustomerStateHolder(
                 savedStateHandle = SavedStateHandle(),
@@ -510,12 +546,14 @@ class SavedPaymentMethodMutatorTest {
                 isLinkEnabled = stateFlowOf(false),
                 isNotPaymentFlow = true,
                 isLiveModeProvider = { true },
+                currentScreen = currentScreen,
             )
             Scenario(
                 savedPaymentMethodMutator = savedPaymentMethodMutator,
                 customerStateHolder = customerStateHolder,
                 selectionSource = selection,
                 editPaymentMethodInteractorFactory = editPaymentMethodInteractorFactory,
+                currentScreen = currentScreen,
             ).apply {
                 block()
             }
@@ -527,5 +565,6 @@ class SavedPaymentMethodMutatorTest {
         val customerStateHolder: CustomerStateHolder,
         val selectionSource: MutableStateFlow<PaymentSelection?>,
         val editPaymentMethodInteractorFactory: FakeEditPaymentMethodInteractor.Factory,
+        val currentScreen: MutableStateFlow<PaymentSheetScreen>,
     )
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Reset edit state when screen changes

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Vertical mode bug bash feedback: [here](https://docs.google.com/document/d/1nBu2ot6iswjt3L6D4UozoGpOR3EEJDiHWKOROx5nKGY/edit#bookmark=id.ljboa42j33du)

Specifically, fixes an issue where the "edit" state on the manage screen is persisted across screens. It should be reset after you leave the manage screen. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screenshots
Before:


https://github.com/user-attachments/assets/f8a418e2-291b-452b-89ed-ac8898c81d34



After:

https://github.com/user-attachments/assets/a0db6c1d-3bb9-4610-bb7a-4de14da21775

