### PR TITLE
Display intent failure errors in `PaymentSheetPlayground`

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
@@ -316,7 +316,7 @@ internal class PaymentSheetPlaygroundViewModel(
             is PaymentSheetResult.Failed -> {
                 when (paymentResult.error) {
                     is ConfirmIntentEndpointException -> {
-                        "Couldn't process your payment."
+                        "Couldn't process your payment: ${paymentResult.error.message}"
                     }
 
                     is ConfirmIntentNetworkException -> {
@@ -324,7 +324,7 @@ internal class PaymentSheetPlaygroundViewModel(
                     }
 
                     else -> {
-                        paymentResult.error.message
+                        "Something went wrong: ${paymentResult.error.message}"
                     }
                 }
             }


### PR DESCRIPTION
# Summary
Display intent failure errors in `PaymentSheetPlayground`

# Motivation
Can debug intent failures easier in the playground. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
