### PR TITLE
Move from `payment_sheet` to `mobile_payment_element` component

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -2677,19 +2677,19 @@ public final class com/stripe/android/model/ElementsSession$Customer$Components$
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/model/ElementsSession$Customer$Components$PaymentSheet$Disabled$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/ElementsSession$Customer$Components$MobilePaymentElement$Disabled$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ElementsSession$Customer$Components$PaymentSheet$Disabled;
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ElementsSession$Customer$Components$MobilePaymentElement$Disabled;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/model/ElementsSession$Customer$Components$PaymentSheet$Disabled;
+	public final fun newArray (I)[Lcom/stripe/android/model/ElementsSession$Customer$Components$MobilePaymentElement$Disabled;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/model/ElementsSession$Customer$Components$PaymentSheet$Enabled$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/ElementsSession$Customer$Components$MobilePaymentElement$Enabled$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ElementsSession$Customer$Components$PaymentSheet$Enabled;
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ElementsSession$Customer$Components$MobilePaymentElement$Enabled;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/model/ElementsSession$Customer$Components$PaymentSheet$Enabled;
+	public final fun newArray (I)[Lcom/stripe/android/model/ElementsSession$Customer$Components$MobilePaymentElement$Enabled;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -78,14 +78,14 @@ data class ElementsSession(
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @Parcelize
         data class Components(
-            val paymentSheet: PaymentSheet,
+            val mobilePaymentElement: MobilePaymentElement,
             val customerSheet: CustomerSheet,
         ) : StripeModel {
             @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-            sealed interface PaymentSheet : StripeModel {
+            sealed interface MobilePaymentElement : StripeModel {
                 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
                 @Parcelize
-                data object Disabled : PaymentSheet
+                data object Disabled : MobilePaymentElement
 
                 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
                 @Parcelize
@@ -93,7 +93,7 @@ data class ElementsSession(
                     val isPaymentMethodSaveEnabled: Boolean,
                     val isPaymentMethodRemoveEnabled: Boolean,
                     val allowRedisplayOverride: PaymentMethod.AllowRedisplay?
-                ) : PaymentSheet
+                ) : MobilePaymentElement
             }
 
             @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
@@ -198,18 +198,20 @@ internal class ElementsSessionJsonParser(
             return null
         }
 
-        val paymentSheetComponent = parsePaymentSheetComponent(json.optJSONObject(FIELD_PAYMENT_SHEET))
+        val paymentElementComponent = parsePaymentElementComponent(json.optJSONObject(FIELD_MOBILE_PAYMENT_ELEMENT))
             ?: return null
         val customerSheetComponent = parseCustomerSheetComponent(json.optJSONObject(FIELD_CUSTOMER_SHEET))
             ?: return null
 
         return ElementsSession.Customer.Components(
-            paymentSheet = paymentSheetComponent,
+            mobilePaymentElement = paymentElementComponent,
             customerSheet = customerSheetComponent
         )
     }
 
-    private fun parsePaymentSheetComponent(json: JSONObject?): ElementsSession.Customer.Components.PaymentSheet? {
+    private fun parsePaymentElementComponent(
+        json: JSONObject?
+    ): ElementsSession.Customer.Components.MobilePaymentElement? {
         if (json == null) {
             return null
         }
@@ -228,13 +230,13 @@ internal class ElementsSessionJsonParser(
                 allowRedisplay.value == allowRedisplayOverrideValue
             }
 
-            ElementsSession.Customer.Components.PaymentSheet.Enabled(
+            ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
                 isPaymentMethodSaveEnabled = paymentMethodSaveFeature == VALUE_ENABLED,
                 isPaymentMethodRemoveEnabled = paymentMethodRemoveFeature == VALUE_ENABLED,
                 allowRedisplayOverride = allowRedisplayOverride,
             )
         } else {
-            ElementsSession.Customer.Components.PaymentSheet.Disabled
+            ElementsSession.Customer.Components.MobilePaymentElement.Disabled
         }
     }
 
@@ -304,7 +306,7 @@ internal class ElementsSessionJsonParser(
         private const val FIELD_CUSTOMER_API_KEY_EXPIRY = "api_key_expiry"
         private const val FIELD_CUSTOMER_NAME = "customer"
         private const val FIELD_COMPONENTS = "components"
-        private const val FIELD_PAYMENT_SHEET = "payment_sheet"
+        private const val FIELD_MOBILE_PAYMENT_ELEMENT = "mobile_payment_element"
         private const val FIELD_CUSTOMER_SHEET = "customer_sheet"
         private const val FIELD_ENABLED = "enabled"
         private const val FIELD_FEATURES = "features"

--- a/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
@@ -246,7 +246,7 @@ internal object ElementsSessionFixtures {
                       "enabled": false,
                       "features": null
                     },
-                    "payment_sheet": {
+                    "mobile_payment_element": {
                       "enabled": true,
                       "features": {
                         "payment_method_remove": "enabled",
@@ -377,7 +377,7 @@ internal object ElementsSessionFixtures {
                   "enabled": false,
                   "features": null
                 },
-                "payment_sheet": {
+                "mobile_payment_element": {
                   "enabled": false,
                   "features": null
                 },

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -508,7 +508,7 @@ class ElementsSessionJsonParserTest {
                     customerId = "cus_1",
                     liveMode = false,
                     components = ElementsSession.Customer.Components(
-                        paymentSheet = ElementsSession.Customer.Components.PaymentSheet.Enabled(
+                        mobilePaymentElement = ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
                             isPaymentMethodSaveEnabled = false,
                             isPaymentMethodRemoveEnabled = true,
                             allowRedisplayOverride = PaymentMethod.AllowRedisplay.LIMITED,
@@ -604,7 +604,7 @@ class ElementsSessionJsonParserTest {
                     customerId = "cus_1",
                     liveMode = false,
                     components = ElementsSession.Customer.Components(
-                        paymentSheet = ElementsSession.Customer.Components.PaymentSheet.Disabled,
+                        mobilePaymentElement = ElementsSession.Customer.Components.MobilePaymentElement.Disabled,
                         customerSheet = ElementsSession.Customer.Components.CustomerSheet.Enabled(
                             isPaymentMethodRemoveEnabled = true
                         ),
@@ -681,9 +681,10 @@ class ElementsSessionJsonParserTest {
         val intent = createPaymentIntentWithCustomerSession(allowRedisplay = rawAllowRedisplayValue)
         val elementsSession = parser.parse(intent)
 
-        val paymentSheetComponent = elementsSession?.customer?.session?.components?.paymentSheet
+        val mobilePaymentElementComponent = elementsSession?.customer?.session?.components?.mobilePaymentElement
 
-        val enabledComponent = paymentSheetComponent as? ElementsSession.Customer.Components.PaymentSheet.Enabled
+        val enabledComponent = mobilePaymentElementComponent as?
+            ElementsSession.Customer.Components.MobilePaymentElement.Enabled
 
         assertThat(enabledComponent?.allowRedisplayOverride).isEqualTo(allowRedisplay)
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -32,6 +32,8 @@ class CheckoutRequest private constructor(
     val paymentMethodConfigurationId: String?,
     @SerialName("require_cvc_recollection")
     val requireCvcRecollection: Boolean?,
+    @SerialName("customer_session_component_name")
+    val customerSessionComponentName: String,
     @SerialName("customer_session_payment_method_save")
     val paymentMethodSaveFeature: FeatureState?,
     @SerialName("customer_session_payment_method_remove")
@@ -157,6 +159,7 @@ class CheckoutRequest private constructor(
                 supportedPaymentMethods = supportedPaymentMethods,
                 paymentMethodConfigurationId = paymentMethodConfigurationId,
                 requireCvcRecollection = requireCvcRecollection,
+                customerSessionComponentName = "mobile_payment_element",
                 paymentMethodSaveFeature = paymentMethodSaveFeature,
                 paymentMethodRemoveFeature = paymentMethodRemoveFeature,
                 paymentMethodRedisplayFeature = paymentMethodRedisplayFeature,

--- a/paymentsheet/src/androidTest/resources/elements-sessions-requires_pm_with_ps_pi_cs.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-requires_pm_with_ps_pi_cs.json
@@ -18,7 +18,7 @@
       "api_key_expiry": 1899787184,
       "customer": "cus_12345",
       "components": {
-        "payment_sheet": {
+        "mobile_payment_element": {
           "enabled": true,
           "features": {
             "payment_method_save": "enabled",

--- a/paymentsheet/src/androidTest/resources/elements-sessions-requires_pm_with_ps_si_cs.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-requires_pm_with_ps_si_cs.json
@@ -21,7 +21,7 @@
       "api_key_expiry": 1899787184,
       "customer": "cus_12345",
       "components": {
-        "payment_sheet": {
+        "mobile_payment_element": {
           "enabled": true,
           "features": {
             "payment_method_save": "enabled",

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataKtx.kt
@@ -3,18 +3,18 @@ package com.stripe.android.lpmfoundations.paymentmethod
 import com.stripe.android.model.ElementsSession
 
 internal fun ElementsSession.toPaymentSheetSaveConsentBehavior(): PaymentMethodSaveConsentBehavior {
-    return when (val paymentSheetComponent = customer?.session?.components?.paymentSheet) {
-        is ElementsSession.Customer.Components.PaymentSheet.Enabled -> {
-            if (paymentSheetComponent.isPaymentMethodSaveEnabled) {
+    return when (val mobilePaymentElementComponent = customer?.session?.components?.mobilePaymentElement) {
+        is ElementsSession.Customer.Components.MobilePaymentElement.Enabled -> {
+            if (mobilePaymentElementComponent.isPaymentMethodSaveEnabled) {
                 PaymentMethodSaveConsentBehavior.Enabled
             } else {
                 PaymentMethodSaveConsentBehavior.Disabled(
-                    overrideAllowRedisplay = paymentSheetComponent.allowRedisplayOverride
+                    overrideAllowRedisplay = mobilePaymentElementComponent.allowRedisplayOverride
                 )
             }
         }
         // Unless the merchant explicitly defines the consent behavior, always use the legacy behavior
-        is ElementsSession.Customer.Components.PaymentSheet.Disabled,
+        is ElementsSession.Customer.Components.MobilePaymentElement.Disabled,
         null -> PaymentMethodSaveConsentBehavior.Legacy
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
@@ -32,11 +32,11 @@ internal data class CustomerState(
             supportedSavedPaymentMethodTypes: List<PaymentMethod.Type>,
         ): CustomerState {
             val canRemovePaymentMethods = when (
-                val paymentSheetComponent = customer.session.components.paymentSheet
+                val mobilePaymentElementComponent = customer.session.components.mobilePaymentElement
             ) {
-                is ElementsSession.Customer.Components.PaymentSheet.Enabled ->
-                    paymentSheetComponent.isPaymentMethodRemoveEnabled
-                is ElementsSession.Customer.Components.PaymentSheet.Disabled -> false
+                is ElementsSession.Customer.Components.MobilePaymentElement.Enabled ->
+                    mobilePaymentElementComponent.isPaymentMethodRemoveEnabled
+                is ElementsSession.Customer.Components.MobilePaymentElement.Disabled -> false
             }
 
             return CustomerState(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -854,7 +854,7 @@ internal class PaymentMethodMetadataTest {
     @Test
     fun `consent behavior should be Always for Payment Sheet is customer session save is enabled`() {
         val metadata = createPaymentMethodMetadataForPaymentSheet(
-            paymentSheetComponent = ElementsSession.Customer.Components.PaymentSheet.Enabled(
+            mobilePaymentElementComponent = ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
                 isPaymentMethodSaveEnabled = true,
                 isPaymentMethodRemoveEnabled = true,
                 allowRedisplayOverride = null,
@@ -867,7 +867,7 @@ internal class PaymentMethodMetadataTest {
     @Test
     fun `consent behavior should be Disabled for Payment Sheet is customer session save is disabled`() {
         val metadata = createPaymentMethodMetadataForPaymentSheet(
-            paymentSheetComponent = ElementsSession.Customer.Components.PaymentSheet.Enabled(
+            mobilePaymentElementComponent = ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
                 isPaymentMethodSaveEnabled = false,
                 isPaymentMethodRemoveEnabled = true,
                 allowRedisplayOverride = null,
@@ -885,7 +885,7 @@ internal class PaymentMethodMetadataTest {
     @Test
     fun `consent behavior should be Legacy for Payment Sheet if payment sheet component is disabled`() {
         val metadata = createPaymentMethodMetadataForPaymentSheet(
-            paymentSheetComponent = ElementsSession.Customer.Components.PaymentSheet.Disabled,
+            mobilePaymentElementComponent = ElementsSession.Customer.Components.MobilePaymentElement.Disabled,
         )
 
         assertThat(metadata.paymentMethodSaveConsentBehavior).isEqualTo(PaymentMethodSaveConsentBehavior.Legacy)
@@ -894,18 +894,18 @@ internal class PaymentMethodMetadataTest {
     @Test
     fun `consent behavior should be Legacy for Payment Sheet if no customer session provided`() {
         val metadata = createPaymentMethodMetadataForPaymentSheet(
-            paymentSheetComponent = null,
+            mobilePaymentElementComponent = null,
         )
 
         assertThat(metadata.paymentMethodSaveConsentBehavior).isEqualTo(PaymentMethodSaveConsentBehavior.Legacy)
     }
 
     private fun createPaymentMethodMetadataForPaymentSheet(
-        paymentSheetComponent: ElementsSession.Customer.Components.PaymentSheet?,
+        mobilePaymentElementComponent: ElementsSession.Customer.Components.MobilePaymentElement?,
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata.create(
             elementsSession = createElementsSession(
-                paymentSheetComponent = paymentSheetComponent
+                mobilePaymentElementComponent = mobilePaymentElementComponent
             ),
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER,
             sharedDataSpecs = listOf(),
@@ -918,14 +918,14 @@ internal class PaymentMethodMetadataTest {
     private fun createElementsSession(
         intent: StripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
         isEligibleForCardBrandChoice: Boolean = true,
-        paymentSheetComponent: ElementsSession.Customer.Components.PaymentSheet? = null
+        mobilePaymentElementComponent: ElementsSession.Customer.Components.MobilePaymentElement? = null
     ): ElementsSession {
         return ElementsSession(
             stripeIntent = intent,
             isEligibleForCardBrandChoice = isEligibleForCardBrandChoice,
             merchantCountry = null,
             isGooglePayEnabled = false,
-            customer = paymentSheetComponent?.let { component ->
+            customer = mobilePaymentElementComponent?.let { component ->
                 ElementsSession.Customer(
                     paymentMethods = listOf(),
                     session = ElementsSession.Customer.Session(
@@ -935,7 +935,7 @@ internal class PaymentMethodMetadataTest {
                         apiKey = "123",
                         apiKeyExpiry = 999999999,
                         components = ElementsSession.Customer.Components(
-                            paymentSheet = component,
+                            mobilePaymentElement = component,
                             customerSheet = ElementsSession.Customer.Components.CustomerSheet.Disabled,
                         )
                     ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CustomerSessionPaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CustomerSessionPaymentSheetActivityTest.kt
@@ -340,7 +340,7 @@ internal class CustomerSessionPaymentSheetActivityTest {
                       "api_key_expiry": 1899787184,
                       "customer": "cus_12345",
                       "components": {
-                        "payment_sheet": {
+                        "mobile_payment_element": {
                           "enabled": true,
                           "features": {
                             "payment_method_save": "enabled",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
@@ -17,7 +17,7 @@ class CustomerStateTest {
             customerId = "cus_1",
             ephemeralKeySecret = "ek_1",
             paymentMethods = paymentMethods,
-            paymentSheetComponent = ElementsSession.Customer.Components.PaymentSheet.Disabled
+            mobilePaymentElementComponent = ElementsSession.Customer.Components.MobilePaymentElement.Disabled
         )
 
         val customerState = CustomerState.createForCustomerSession(
@@ -46,7 +46,7 @@ class CustomerStateTest {
             customerId = "cus_1",
             ephemeralKeySecret = "ek_1",
             paymentMethods = paymentMethods,
-            paymentSheetComponent = ElementsSession.Customer.Components.PaymentSheet.Enabled(
+            mobilePaymentElementComponent = ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
                 isPaymentMethodSaveEnabled = false,
                 isPaymentMethodRemoveEnabled = true,
                 allowRedisplayOverride = null,
@@ -79,7 +79,7 @@ class CustomerStateTest {
             customerId = "cus_3",
             ephemeralKeySecret = "ek_3",
             paymentMethods = paymentMethods,
-            paymentSheetComponent = ElementsSession.Customer.Components.PaymentSheet.Enabled(
+            mobilePaymentElementComponent = ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
                 isPaymentMethodSaveEnabled = false,
                 isPaymentMethodRemoveEnabled = false,
                 allowRedisplayOverride = null,
@@ -142,7 +142,7 @@ class CustomerStateTest {
                     PaymentMethodFixtures.LINK_PAYMENT_METHOD,
                     PaymentMethodFixtures.AU_BECS_DEBIT,
                 ),
-                paymentSheetComponent = ElementsSession.Customer.Components.PaymentSheet.Enabled(
+                mobilePaymentElementComponent = ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
                     isPaymentMethodSaveEnabled = false,
                     isPaymentMethodRemoveEnabled = false,
                     allowRedisplayOverride = null,
@@ -161,7 +161,7 @@ class CustomerStateTest {
         customerId: String = "cus_1",
         ephemeralKeySecret: String = "ek_1",
         paymentMethods: List<PaymentMethod>,
-        paymentSheetComponent: ElementsSession.Customer.Components.PaymentSheet
+        mobilePaymentElementComponent: ElementsSession.Customer.Components.MobilePaymentElement
     ): ElementsSession.Customer {
         return ElementsSession.Customer(
             paymentMethods = paymentMethods,
@@ -174,7 +174,7 @@ class CustomerStateTest {
                 liveMode = false,
                 components = ElementsSession.Customer.Components(
                     customerSheet = ElementsSession.Customer.Components.CustomerSheet.Disabled,
-                    paymentSheet = paymentSheetComponent
+                    mobilePaymentElement = mobilePaymentElementComponent
                 )
             ),
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -1277,7 +1277,7 @@ internal class DefaultPaymentSheetLoaderTest {
                         apiKey = "ek_123",
                         apiKeyExpiry = 555555555,
                         components = ElementsSession.Customer.Components(
-                            paymentSheet = ElementsSession.Customer.Components.PaymentSheet.Disabled,
+                            mobilePaymentElement = ElementsSession.Customer.Components.MobilePaymentElement.Disabled,
                             customerSheet = ElementsSession.Customer.Components.CustomerSheet.Disabled,
                         ),
                     ),
@@ -1322,7 +1322,7 @@ internal class DefaultPaymentSheetLoaderTest {
                 customer = ElementsSession.Customer(
                     paymentMethods = PaymentMethodFactory.cards(4),
                     session = createElementsSessionCustomerSession(
-                        ElementsSession.Customer.Components.PaymentSheet.Enabled(
+                        ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
                             isPaymentMethodRemoveEnabled = true,
                             isPaymentMethodSaveEnabled = false,
                             allowRedisplayOverride = null,
@@ -1362,7 +1362,7 @@ internal class DefaultPaymentSheetLoaderTest {
                 customer = ElementsSession.Customer(
                     paymentMethods = PaymentMethodFactory.cards(4),
                     session = createElementsSessionCustomerSession(
-                        ElementsSession.Customer.Components.PaymentSheet.Enabled(
+                        ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
                             isPaymentMethodRemoveEnabled = false,
                             isPaymentMethodSaveEnabled = false,
                             allowRedisplayOverride = null,
@@ -1402,7 +1402,7 @@ internal class DefaultPaymentSheetLoaderTest {
                 customer = ElementsSession.Customer(
                     paymentMethods = PaymentMethodFactory.cards(4),
                     session = createElementsSessionCustomerSession(
-                        ElementsSession.Customer.Components.PaymentSheet.Enabled(
+                        ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
                             isPaymentMethodRemoveEnabled = false,
                             isPaymentMethodSaveEnabled = false,
                             allowRedisplayOverride = null,
@@ -1603,7 +1603,7 @@ internal class DefaultPaymentSheetLoaderTest {
                     apiKey = "ek_123",
                     apiKeyExpiry = 555555555,
                     components = ElementsSession.Customer.Components(
-                        paymentSheet = ElementsSession.Customer.Components.PaymentSheet.Disabled,
+                        mobilePaymentElement = ElementsSession.Customer.Components.MobilePaymentElement.Disabled,
                         customerSheet = ElementsSession.Customer.Components.CustomerSheet.Disabled,
                     ),
                 ),
@@ -1694,7 +1694,7 @@ internal class DefaultPaymentSheetLoaderTest {
                         apiKey = "ek_123",
                         apiKeyExpiry = 555555555,
                         components = ElementsSession.Customer.Components(
-                            paymentSheet = ElementsSession.Customer.Components.PaymentSheet.Disabled,
+                            mobilePaymentElement = ElementsSession.Customer.Components.MobilePaymentElement.Disabled,
                             customerSheet = ElementsSession.Customer.Components.CustomerSheet.Disabled,
                         ),
                     ),
@@ -1959,7 +1959,7 @@ internal class DefaultPaymentSheetLoaderTest {
     }
 
     private fun createElementsSessionCustomerSession(
-        paymentSheetComponent: ElementsSession.Customer.Components.PaymentSheet,
+        mobilePaymentElementComponent: ElementsSession.Customer.Components.MobilePaymentElement,
     ): ElementsSession.Customer.Session {
         return ElementsSession.Customer.Session(
             id = "cuss_1",
@@ -1968,7 +1968,7 @@ internal class DefaultPaymentSheetLoaderTest {
             apiKey = "ek_123",
             apiKeyExpiry = 555555555,
             components = ElementsSession.Customer.Components(
-                paymentSheet = paymentSheetComponent,
+                mobilePaymentElement = mobilePaymentElementComponent,
                 customerSheet = ElementsSession.Customer.Components.CustomerSheet.Disabled,
             ),
         )
@@ -1977,13 +1977,14 @@ internal class DefaultPaymentSheetLoaderTest {
     private fun createElementsSessionCustomer(
         paymentMethods: List<PaymentMethod> = PaymentMethodFactory.cards(1),
         isPaymentMethodSaveEnabled: Boolean? = null,
-        paymentSheetComponent: ElementsSession.Customer.Components.PaymentSheet = isPaymentMethodSaveEnabled?.let {
-            ElementsSession.Customer.Components.PaymentSheet.Enabled(
-                isPaymentMethodSaveEnabled = it,
-                isPaymentMethodRemoveEnabled = true,
-                allowRedisplayOverride = null,
-            )
-        } ?: ElementsSession.Customer.Components.PaymentSheet.Disabled
+        mobilePaymentElementComponent: ElementsSession.Customer.Components.MobilePaymentElement =
+            isPaymentMethodSaveEnabled?.let {
+                ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
+                    isPaymentMethodSaveEnabled = it,
+                    isPaymentMethodRemoveEnabled = true,
+                    allowRedisplayOverride = null,
+                )
+            } ?: ElementsSession.Customer.Components.MobilePaymentElement.Disabled
     ): ElementsSession.Customer {
         return ElementsSession.Customer(
             paymentMethods = paymentMethods,
@@ -1994,7 +1995,7 @@ internal class DefaultPaymentSheetLoaderTest {
                 apiKey = "ek_123",
                 apiKeyExpiry = 555555555,
                 components = ElementsSession.Customer.Components(
-                    paymentSheet = paymentSheetComponent,
+                    mobilePaymentElement = mobilePaymentElementComponent,
                     customerSheet = ElementsSession.Customer.Components.CustomerSheet.Disabled,
                 ),
             ),


### PR DESCRIPTION
# Summary
Move from `payment_sheet` to `mobile_payment_element` component.

# Motivation
Conforms to new component for `PaymentSheet` which makes it easier to differentiate between future `PaymentSheet` variants.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified
