### PR TITLE
Improve animations for vertical mode.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -53,11 +53,17 @@ internal data class BuyButtonState(
 
 internal sealed interface PaymentSheetScreen {
 
+    enum class AnimationStyle {
+        PrimaryButtonAnchored,
+        FullPage,
+    }
+
     val buyButtonState: StateFlow<BuyButtonState>
     val showsContinueButton: Boolean
     val topContentPadding: Dp
     val bottomContentPadding: Dp
     val walletsDividerSpacing: Dp
+    val animationStyle: AnimationStyle
 
     fun topBarState(): StateFlow<PaymentSheetTopBarState?>
 
@@ -77,6 +83,7 @@ internal sealed interface PaymentSheetScreen {
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = 0.dp
         override val walletsDividerSpacing: Dp = horizontalModeWalletsDividerSpacing
+        override val animationStyle: AnimationStyle = AnimationStyle.FullPage
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(null)
@@ -113,6 +120,7 @@ internal sealed interface PaymentSheetScreen {
         override val topContentPadding: Dp = SavedPaymentMethodsTopContentPadding
         override val bottomContentPadding: Dp = 0.dp
         override val walletsDividerSpacing: Dp = horizontalModeWalletsDividerSpacing
+        override val animationStyle: AnimationStyle = AnimationStyle.PrimaryButtonAnchored
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return interactor.state.mapAsStateFlow { state ->
@@ -169,6 +177,7 @@ internal sealed interface PaymentSheetScreen {
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = horizontalModeBottomContentPadding
         override val walletsDividerSpacing: Dp = horizontalModeWalletsDividerSpacing
+        override val animationStyle: AnimationStyle = AnimationStyle.PrimaryButtonAnchored
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(
@@ -219,6 +228,7 @@ internal sealed interface PaymentSheetScreen {
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = horizontalModeBottomContentPadding
         override val walletsDividerSpacing: Dp = horizontalModeWalletsDividerSpacing
+        override val animationStyle: AnimationStyle = AnimationStyle.FullPage
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(
@@ -271,6 +281,7 @@ internal sealed interface PaymentSheetScreen {
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = 0.dp
         override val walletsDividerSpacing: Dp = horizontalModeWalletsDividerSpacing
+        override val animationStyle: AnimationStyle = AnimationStyle.FullPage
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(
@@ -309,6 +320,7 @@ internal sealed interface PaymentSheetScreen {
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = verticalModeBottomContentPadding
         override val walletsDividerSpacing: Dp = verticalModeWalletsDividerSpacing
+        override val animationStyle: AnimationStyle = AnimationStyle.FullPage
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(
@@ -354,6 +366,7 @@ internal sealed interface PaymentSheetScreen {
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = verticalModeBottomContentPadding
         override val walletsDividerSpacing: Dp = verticalModeWalletsDividerSpacing
+        override val animationStyle: AnimationStyle = AnimationStyle.FullPage
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(
@@ -391,6 +404,7 @@ internal sealed interface PaymentSheetScreen {
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = 0.dp
         override val walletsDividerSpacing: Dp = verticalModeWalletsDividerSpacing
+        override val animationStyle: AnimationStyle = AnimationStyle.FullPage
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return interactor.state.mapAsStateFlow { state ->
@@ -442,6 +456,7 @@ internal sealed interface PaymentSheetScreen {
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = 0.dp
         override val walletsDividerSpacing: Dp = verticalModeWalletsDividerSpacing
+        override val animationStyle: AnimationStyle = AnimationStyle.FullPage
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(
@@ -480,6 +495,7 @@ internal sealed interface PaymentSheetScreen {
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = verticalModeBottomContentPadding
         override val walletsDividerSpacing: Dp = verticalModeWalletsDividerSpacing
+        override val animationStyle: AnimationStyle = AnimationStyle.FullPage
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return interactor.cvcCompletionState.mapAsStateFlow { complete ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -54,7 +54,17 @@ internal data class BuyButtonState(
 internal sealed interface PaymentSheetScreen {
 
     enum class AnimationStyle {
+        /**
+         * Does not animate the PrimaryButton (it's either shown or displayed without animation).
+         * The primary button is not part of an animation block, so it helps with visual anchoring between screens.
+         */
         PrimaryButtonAnchored,
+
+        /**
+         * The full page is animated, including the primary button.
+         * Helps make it so that pages that aren't expected to have an visual anchor around the primary button to
+         * animate more smoothly.
+         */
         FullPage,
     }
 
@@ -64,6 +74,7 @@ internal sealed interface PaymentSheetScreen {
     val bottomContentPadding: Dp
     val walletsDividerSpacing: Dp
     val animationStyle: AnimationStyle
+        get() = AnimationStyle.FullPage
 
     fun topBarState(): StateFlow<PaymentSheetTopBarState?>
 
@@ -83,7 +94,6 @@ internal sealed interface PaymentSheetScreen {
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = 0.dp
         override val walletsDividerSpacing: Dp = horizontalModeWalletsDividerSpacing
-        override val animationStyle: AnimationStyle = AnimationStyle.FullPage
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(null)
@@ -228,7 +238,6 @@ internal sealed interface PaymentSheetScreen {
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = horizontalModeBottomContentPadding
         override val walletsDividerSpacing: Dp = horizontalModeWalletsDividerSpacing
-        override val animationStyle: AnimationStyle = AnimationStyle.FullPage
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(
@@ -281,7 +290,6 @@ internal sealed interface PaymentSheetScreen {
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = 0.dp
         override val walletsDividerSpacing: Dp = horizontalModeWalletsDividerSpacing
-        override val animationStyle: AnimationStyle = AnimationStyle.FullPage
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(
@@ -320,7 +328,6 @@ internal sealed interface PaymentSheetScreen {
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = verticalModeBottomContentPadding
         override val walletsDividerSpacing: Dp = verticalModeWalletsDividerSpacing
-        override val animationStyle: AnimationStyle = AnimationStyle.FullPage
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(
@@ -366,7 +373,6 @@ internal sealed interface PaymentSheetScreen {
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = verticalModeBottomContentPadding
         override val walletsDividerSpacing: Dp = verticalModeWalletsDividerSpacing
-        override val animationStyle: AnimationStyle = AnimationStyle.FullPage
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(
@@ -404,7 +410,6 @@ internal sealed interface PaymentSheetScreen {
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = 0.dp
         override val walletsDividerSpacing: Dp = verticalModeWalletsDividerSpacing
-        override val animationStyle: AnimationStyle = AnimationStyle.FullPage
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return interactor.state.mapAsStateFlow { state ->
@@ -456,7 +461,6 @@ internal sealed interface PaymentSheetScreen {
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = 0.dp
         override val walletsDividerSpacing: Dp = verticalModeWalletsDividerSpacing
-        override val animationStyle: AnimationStyle = AnimationStyle.FullPage
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(
@@ -495,7 +499,6 @@ internal sealed interface PaymentSheetScreen {
         override val topContentPadding: Dp = 0.dp
         override val bottomContentPadding: Dp = verticalModeBottomContentPadding
         override val walletsDividerSpacing: Dp = verticalModeWalletsDividerSpacing
-        override val animationStyle: AnimationStyle = AnimationStyle.FullPage
 
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return interactor.cvcCompletionState.mapAsStateFlow { complete ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -249,9 +249,46 @@ private fun PaymentSheetContent(
     currentScreen: PaymentSheetScreen,
     mandateText: MandateText?,
 ) {
+    @Composable
+    fun Content(modifier: Modifier) {
+        PaymentSheetContent(
+            viewModel = viewModel,
+            headerText = headerText,
+            walletsState = walletsState,
+            walletsProcessingState = walletsProcessingState,
+            error = error,
+            currentScreen = currentScreen,
+            mandateText = mandateText,
+            modifier = modifier
+        )
+    }
+
+    when (currentScreen.animationStyle) {
+        PaymentSheetScreen.AnimationStyle.PrimaryButtonAnchored -> {
+            Content(modifier = Modifier.animateContentSize())
+        }
+        PaymentSheetScreen.AnimationStyle.FullPage -> {
+            Column(modifier = Modifier.animateContentSize()) {
+                Content(modifier = Modifier)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PaymentSheetContent(
+    viewModel: BaseSheetViewModel,
+    headerText: ResolvableString?,
+    walletsState: WalletsState?,
+    walletsProcessingState: WalletsProcessingState?,
+    error: ResolvableString?,
+    currentScreen: PaymentSheetScreen,
+    mandateText: MandateText?,
+    modifier: Modifier,
+) {
     val horizontalPadding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
 
-    Column(modifier = Modifier.animateContentSize()) {
+    Column(modifier = modifier) {
         headerText?.let { text ->
             H4Text(
                 text = text.resolve(),
@@ -284,7 +321,9 @@ private fun PaymentSheetContent(
         if (mandateText?.showAbovePrimaryButton == true) {
             Mandate(
                 mandateText = mandateText.text?.resolve(),
-                modifier = Modifier.padding(horizontal = horizontalPadding).padding(bottom = 8.dp),
+                modifier = Modifier
+                    .padding(horizontal = horizontalPadding)
+                    .padding(bottom = 8.dp),
             )
         }
 
@@ -302,7 +341,7 @@ private fun PaymentSheetContent(
 
     PrimaryButton(viewModel)
 
-    Box(modifier = Modifier.animateContentSize()) {
+    Box(modifier = modifier) {
         if (mandateText?.showAbovePrimaryButton == false) {
             Mandate(
                 mandateText = mandateText.text?.resolve(),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -250,7 +250,7 @@ private fun PaymentSheetContent(
     mandateText: MandateText?,
 ) {
     @Composable
-    fun Content(modifier: Modifier) {
+    fun Content(modifierProvider: () -> Modifier) {
         PaymentSheetContent(
             viewModel = viewModel,
             headerText = headerText,
@@ -259,17 +259,17 @@ private fun PaymentSheetContent(
             error = error,
             currentScreen = currentScreen,
             mandateText = mandateText,
-            modifier = modifier
+            modifierProvider = modifierProvider
         )
     }
 
     when (currentScreen.animationStyle) {
         PaymentSheetScreen.AnimationStyle.PrimaryButtonAnchored -> {
-            Content(modifier = Modifier.animateContentSize())
+            Content(modifierProvider = { Modifier.animateContentSize() })
         }
         PaymentSheetScreen.AnimationStyle.FullPage -> {
             Column(modifier = Modifier.animateContentSize()) {
-                Content(modifier = Modifier)
+                Content(modifierProvider = { Modifier })
             }
         }
     }
@@ -284,11 +284,11 @@ private fun PaymentSheetContent(
     error: ResolvableString?,
     currentScreen: PaymentSheetScreen,
     mandateText: MandateText?,
-    modifier: Modifier,
+    modifierProvider: () -> Modifier,
 ) {
     val horizontalPadding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
 
-    Column(modifier = modifier) {
+    Column(modifier = modifierProvider()) {
         headerText?.let { text ->
             H4Text(
                 text = text.resolve(),
@@ -341,7 +341,7 @@ private fun PaymentSheetContent(
 
     PrimaryButton(viewModel)
 
-    Box(modifier = modifier) {
+    Box(modifier = modifierProvider()) {
         if (mandateText?.showAbovePrimaryButton == false) {
             Mandate(
                 mandateText = mandateText.text?.resolve(),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -250,7 +250,7 @@ private fun PaymentSheetContent(
     mandateText: MandateText?,
 ) {
     @Composable
-    fun Content(modifierProvider: () -> Modifier) {
+    fun Content(modifier: Modifier) {
         PaymentSheetContent(
             viewModel = viewModel,
             headerText = headerText,
@@ -259,17 +259,17 @@ private fun PaymentSheetContent(
             error = error,
             currentScreen = currentScreen,
             mandateText = mandateText,
-            modifierProvider = modifierProvider
+            modifier = modifier
         )
     }
 
     when (currentScreen.animationStyle) {
         PaymentSheetScreen.AnimationStyle.PrimaryButtonAnchored -> {
-            Content(modifierProvider = { Modifier.animateContentSize() })
+            Content(modifier = Modifier.animateContentSize())
         }
         PaymentSheetScreen.AnimationStyle.FullPage -> {
             Column(modifier = Modifier.animateContentSize()) {
-                Content(modifierProvider = { Modifier })
+                Content(modifier = Modifier)
             }
         }
     }
@@ -284,11 +284,11 @@ private fun PaymentSheetContent(
     error: ResolvableString?,
     currentScreen: PaymentSheetScreen,
     mandateText: MandateText?,
-    modifierProvider: () -> Modifier,
+    modifier: Modifier,
 ) {
     val horizontalPadding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
 
-    Column(modifier = modifierProvider()) {
+    Column(modifier = modifier) {
         headerText?.let { text ->
             H4Text(
                 text = text.resolve(),
@@ -341,7 +341,7 @@ private fun PaymentSheetContent(
 
     PrimaryButton(viewModel)
 
-    Box(modifier = modifierProvider()) {
+    Box(modifier = modifier) {
         if (mandateText?.showAbovePrimaryButton == false) {
             Mandate(
                 mandateText = mandateText.text?.resolve(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/MandateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/MandateTest.kt
@@ -14,7 +14,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.Q])
+@Config(sdk = [Build.VERSION_CODES.S])
 internal class MandateTest {
     @get:Rule
     val composeRule = createComposeRule()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsTest.kt
@@ -24,7 +24,7 @@ import org.robolectric.annotation.Config
 import kotlin.math.roundToInt
 
 @RunWith(AndroidJUnit4::class)
-@Config(sdk = [Build.VERSION_CODES.Q])
+@Config(sdk = [Build.VERSION_CODES.S])
 class PaymentOptionsTest {
 
     @get:Rule


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Vertical mode doesn't have the same primary button anchor desire that horizontal mode has.

This intends to fix issues where animating content size, but not animating the primary button in was causing weird looking animations.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2410

## Before


https://github.com/user-attachments/assets/82df12ce-c473-476c-aae7-a22a05f6b36c



## After


https://github.com/user-attachments/assets/cb1f40c2-24c4-459f-8b7c-2ac93f253294


