### PR TITLE
Use the generic title "Front of identity document" instead of "Front of identity card"

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/ui/DocumentScanScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/DocumentScanScreen.kt
@@ -179,9 +179,9 @@ private fun DocumentCaptureScreen(
     }
 
     val title = if (targetScanType.isNullOrFront()) {
-        stringResource(id = R.string.stripe_front_of_id)
+        stringResource(id = R.string.stripe_front_of_id_document)
     } else {
-        stringResource(id = R.string.stripe_back_of_id)
+        stringResource(id = R.string.stripe_back_of_id_document)
     }
 
     Column(

--- a/identity/src/main/java/com/stripe/android/identity/ui/UploadScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/UploadScreen.kt
@@ -314,7 +314,7 @@ internal fun UploadImageDialog(
                         end = 24.dp
                     ),
                     text = stringResource(
-                        id = if (isFront) R.string.stripe_front_of_id else R.string.stripe_back_of_id
+                        id = if (isFront) R.string.stripe_front_of_id_document else R.string.stripe_back_of_id_document
                     ),
                     style = MaterialTheme.typography.subtitle1,
                     fontWeight = FontWeight.Bold
@@ -389,7 +389,7 @@ private fun SingleSideUploadRow(
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         Text(
-            text = stringResource(id = if (isFront) R.string.stripe_front_of_id else R.string.stripe_back_of_id),
+            text = stringResource(id = if (isFront) R.string.stripe_front_of_id_document else R.string.stripe_back_of_id_document),
             modifier = Modifier.align(CenterVertically)
         )
         when (uploadUiState) {
@@ -414,7 +414,7 @@ private fun SingleSideUploadRow(
                 Image(
                     painter = painterResource(id = R.drawable.stripe_check_mark),
                     contentDescription = stringResource(
-                        id = if (isFront) R.string.stripe_front_of_id_selected else R.string.stripe_back_of_id_selected
+                        id = if (isFront) R.string.stripe_front_of_id_document_selected else R.string.stripe_back_of_id_document_selected
                     ),
                     modifier = Modifier
                         .height(18.dp)

--- a/identity/src/test/java/com/stripe/android/identity/ui/DocumentScanScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/DocumentScanScreenTest.kt
@@ -96,7 +96,7 @@ class DocumentScanScreenTest {
         testDocumentScanScreen(
             scannerState = IdentityScanViewModel.State.Scanning(),
         ) {
-            onNodeWithTag(SCAN_TITLE_TAG).assertTextEquals(context.getString(R.string.stripe_front_of_id))
+            onNodeWithTag(SCAN_TITLE_TAG).assertTextEquals(context.getString(R.string.stripe_front_of_id_document))
             onNodeWithTag(SCAN_MESSAGE_TAG).assertTextEquals(context.getString(R.string.stripe_position_id_front))
             onNodeWithTag(CHECK_MARK_TAG).assertDoesNotExist()
             onNodeWithTag(CONTINUE_BUTTON_TAG).onChildAt(0).assertIsNotEnabled()
@@ -114,7 +114,7 @@ class DocumentScanScreenTest {
                 eq(IdentityScanState.ScanType.DOC_FRONT),
                 any()
             )
-            onNodeWithTag(SCAN_TITLE_TAG).assertTextEquals(context.getString(R.string.stripe_front_of_id))
+            onNodeWithTag(SCAN_TITLE_TAG).assertTextEquals(context.getString(R.string.stripe_front_of_id_document))
             onNodeWithTag(SCAN_MESSAGE_TAG).assertTextEquals(context.getString(R.string.stripe_hold_still))
             onNodeWithTag(CHECK_MARK_TAG).assertDoesNotExist()
             onNodeWithTag(CONTINUE_BUTTON_TAG).onChildAt(0).assertIsNotEnabled()
@@ -133,7 +133,7 @@ class DocumentScanScreenTest {
                 eq(IdentityScanState.ScanType.DOC_BACK),
                 any()
             )
-            onNodeWithTag(SCAN_TITLE_TAG).assertTextEquals(context.getString(R.string.stripe_back_of_id))
+            onNodeWithTag(SCAN_TITLE_TAG).assertTextEquals(context.getString(R.string.stripe_back_of_id_document))
             onNodeWithTag(SCAN_MESSAGE_TAG).assertTextEquals(context.getString(R.string.stripe_hold_still))
             onNodeWithTag(CHECK_MARK_TAG).assertDoesNotExist()
             onNodeWithTag(CONTINUE_BUTTON_TAG).onChildAt(0).assertIsNotEnabled()
@@ -148,7 +148,7 @@ class DocumentScanScreenTest {
             messageId = R.string.stripe_scanned
         ) {
             verify(mockDocumentScanViewModel).stopScan(any())
-            onNodeWithTag(SCAN_TITLE_TAG).assertTextEquals(context.getString(R.string.stripe_front_of_id))
+            onNodeWithTag(SCAN_TITLE_TAG).assertTextEquals(context.getString(R.string.stripe_front_of_id_document))
             onNodeWithTag(SCAN_MESSAGE_TAG).assertTextEquals(context.getString(R.string.stripe_scanned))
             onNodeWithTag(CHECK_MARK_TAG).assertExists()
             onNodeWithTag(CONTINUE_BUTTON_TAG).onChildAt(0).assertIsEnabled()


### PR DESCRIPTION
See #8511

This change is similar to:
- https://github.com/stripe/stripe-ios/pull/3632/files#diff-2a6b2ccc2c3c46f603c78f8eba3e6f982503c9f60c1731ea09926a22671beff3R17-R23

# Summary
<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Because currently the title is always "Front of identity card" regardless of what is configured in `options.document.allowed_types`, users upload their "Identity card" (German: "Personalausweis") instead of the "Driver's license" (German: Führerschein"). So the more generic term "Identity document" should be used. This approach was also changed recently in stripe-ios [here](https://github.com/stripe/stripe-ios/pull/3632/files#diff-2a6b2ccc2c3c46f603c78f8eba3e6f982503c9f60c1731ea09926a22671beff3R17-R23).

The optimal solution would be that the title corresponds exactly with `options.document.allowed_types`. This is how the web version already does it.

Example:
`options.document.allowed_types` | string used
-|-
`["driving_license"]` | `<string name="stripe_front_of_dl">Front of driver\'s license</string>`
`["id_card"]` | `<string name="stripe_front_of_id">Front of identity card</string>`
`["passport"]` | `<string name="stripe_passport">Passport</string>`
`["driving_license", "id_card", "passport"]` | `<string name="stripe_front_of_id_document">Front of identity document</string>`

I've seen that with this [commit](https://github.com/stripe/stripe-android/commit/36fd0ac19ebb0c02849c290e5e05532bc9e4c9b0#diff-1945a18d8ffb88e1fe04e8924983c36f70651e39b2c4a3e633eeeb60f57074b9R17-R112) in the PR
- https://github.com/stripe/stripe-android/pull/8671

these new translations were added:

```xml
<string name="stripe_front_of_id_document">Front of identity document</string>
<string name="stripe_back_of_id_document">Back of identity document</string>
```

but they are not used in the code yet.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
