### PR TITLE
Fix issue where custom endpoint wasn’t saved in playground

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -128,7 +128,7 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity(), ExternalPay
 
             if (showCustomEndpointDialog) {
                 CustomEndpointDialog(
-                    endpoint.orEmpty(),
+                    currentUrl = endpoint,
                     onConfirm = { backendUrl ->
                         viewModel.onCustomUrlUpdated(backendUrl)
                         showCustomEndpointDialog = false

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomEndpointDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomEndpointDefinition.kt
@@ -8,5 +8,5 @@ internal object CustomEndpointDefinition :
     override val defaultValue: String? = null
 
     override fun convertToValue(value: String): String? = value.takeUnless { it.isBlank() }
-    override fun convertToString(value: String?): String = ""
+    override fun convertToString(value: String?): String = value.orEmpty()
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the custom endpoint defined in the PaymentSheet playground wasn’t saved correctly. This also prevented it from being included in any JSON encoding of the current settings.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Easier bug bashes with custom endpoints!

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
