### PR TITLE
Allow testing MPE with Instant Debits in FC playground

### DIFF
--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
@@ -48,8 +48,6 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.example.Experience.FinancialConnections
 import com.stripe.android.financialconnections.example.Experience.InstantDebits
-import com.stripe.android.financialconnections.example.Experience.PaymentElement
-import com.stripe.android.financialconnections.example.Experience.PaymentElementWithInstantDebits
 import com.stripe.android.financialconnections.example.FinancialConnectionsPlaygroundViewEffect.OpenForData
 import com.stripe.android.financialconnections.example.FinancialConnectionsPlaygroundViewEffect.OpenForPaymentIntent
 import com.stripe.android.financialconnections.example.FinancialConnectionsPlaygroundViewEffect.OpenForToken
@@ -128,7 +126,7 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
         FinancialConnectionsContent(
             state = state,
             onSettingsChanged = viewModel::onSettingsChanged,
-            onButtonClick = viewModel::startFinancialConnectionsSession
+            onButtonClick = viewModel::connectAccounts
         )
     }
 
@@ -148,7 +146,18 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
         state: FinancialConnectionsPlaygroundState,
         paymentSheet: PaymentSheet
     ) {
-        val email = state.settings.get<EmailSetting>().selectedOption
+        when (integrationType) {
+            IntegrationType.Standalone -> {
+                val email = state.settings.get<EmailSetting>().selectedOption
+                launchStandaloneIntegration(email)
+            }
+            IntegrationType.PaymentElement -> {
+                launchPaymentSheet(paymentSheet)
+            }
+        }
+    }
+
+    private fun OpenForPaymentIntent.launchStandaloneIntegration(email: String) {
         when (experience) {
             FinancialConnections -> collectBankAccountForAchLauncher.presentWithPaymentIntent(
                 publishableKey = publishableKey,
@@ -167,25 +176,27 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
                     email = email,
                 )
             )
-            PaymentElement,
-            PaymentElementWithInstantDebits -> {
-                PaymentConfiguration.init(
-                    context = this@FinancialConnectionsPlaygroundActivity,
-                    publishableKey = publishableKey
-                )
-                paymentSheet.presentWithPaymentIntent(
-                    paymentIntentClientSecret = paymentIntentSecret,
-                    configuration = PaymentSheet.Configuration(
-                        allowsDelayedPaymentMethods = true,
-                        merchantDisplayName = "Example, Inc.",
-                        customer = PaymentSheet.CustomerConfiguration(
-                            id = requireNotNull(customerId),
-                            ephemeralKeySecret = requireNotNull(ephemeralKey)
-                        )
-                    )
-                )
-            }
         }
+    }
+
+    private fun OpenForPaymentIntent.launchPaymentSheet(
+        paymentSheet: PaymentSheet,
+    ) {
+        PaymentConfiguration.init(
+            context = this@FinancialConnectionsPlaygroundActivity,
+            publishableKey = publishableKey
+        )
+        paymentSheet.presentWithPaymentIntent(
+            paymentIntentClientSecret = paymentIntentSecret,
+            configuration = PaymentSheet.Configuration(
+                allowsDelayedPaymentMethods = true,
+                merchantDisplayName = "Example, Inc.",
+                customer = PaymentSheet.CustomerConfiguration(
+                    id = requireNotNull(customerId),
+                    ephemeralKeySecret = requireNotNull(ephemeralKey),
+                )
+            )
+        )
     }
 
     @Composable

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
@@ -49,6 +49,7 @@ import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.example.Experience.FinancialConnections
 import com.stripe.android.financialconnections.example.Experience.InstantDebits
 import com.stripe.android.financialconnections.example.Experience.PaymentElement
+import com.stripe.android.financialconnections.example.Experience.PaymentElementWithInstantDebits
 import com.stripe.android.financialconnections.example.FinancialConnectionsPlaygroundViewEffect.OpenForData
 import com.stripe.android.financialconnections.example.FinancialConnectionsPlaygroundViewEffect.OpenForPaymentIntent
 import com.stripe.android.financialconnections.example.FinancialConnectionsPlaygroundViewEffect.OpenForToken
@@ -166,7 +167,8 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
                     email = email,
                 )
             )
-            PaymentElement -> {
+            PaymentElement,
+            PaymentElementWithInstantDebits -> {
                 PaymentConfiguration.init(
                     context = this@FinancialConnectionsPlaygroundActivity,
                     publishableKey = publishableKey

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -20,6 +20,7 @@ import com.stripe.android.financialconnections.example.settings.ConfirmIntentSet
 import com.stripe.android.financialconnections.example.settings.ExperienceSetting
 import com.stripe.android.financialconnections.example.settings.FinancialConnectionsPlaygroundUrlHelper
 import com.stripe.android.financialconnections.example.settings.FlowSetting
+import com.stripe.android.financialconnections.example.settings.IntegrationTypeSetting
 import com.stripe.android.financialconnections.example.settings.PlaygroundSettings
 import com.stripe.android.financialconnections.example.settings.StripeAccountIdSetting
 import com.stripe.android.model.ConfirmPaymentIntentParams
@@ -65,7 +66,7 @@ internal class FinancialConnectionsPlaygroundViewModel(
         }
     }
 
-    fun startFinancialConnectionsSession() = with(state.value.settings) {
+    fun connectAccounts() = with(state.value.settings) {
         _state.update {
             it.copy(
                 status = emptyList(),
@@ -83,30 +84,24 @@ internal class FinancialConnectionsPlaygroundViewModel(
                 when (state.value.flow) {
                     Flow.Data -> startForData(this)
                     Flow.Token -> startForToken(this)
-                    Flow.PaymentIntent -> startWithPaymentIntent(this)
+                    Flow.PaymentIntent -> startWithPaymentIntent(this, experience = Experience.FinancialConnections)
                 }
             }
             Experience.InstantDebits -> {
-                startWithPaymentIntent(this)
-            }
-            Experience.PaymentElement -> {
-                startWithPaymentIntent(this)
-            }
-            Experience.PaymentElementWithInstantDebits -> {
-                startWithPaymentIntent(this, forceInstantDebits = true)
+                startWithPaymentIntent(this, experience = Experience.InstantDebits)
             }
         }
     }
 
     private fun startWithPaymentIntent(
         settings: PlaygroundSettings,
-        forceInstantDebits: Boolean = false,
+        experience: Experience,
     ) {
         viewModelScope.launch {
             showLoadingWithMessage("Fetching link account session from example backend!")
             kotlin.runCatching {
                 repository.createPaymentIntent(
-                    settings.paymentIntentRequest(forceInstantDebits = forceInstantDebits)
+                    settings.paymentIntentRequest(forceInstantDebits = experience == Experience.InstantDebits)
                 )
             }
                 // Success creating session: open the financial connections sheet with received secret
@@ -129,6 +124,7 @@ internal class FinancialConnectionsPlaygroundViewModel(
                             ephemeralKey = it.ephemeralKey,
                             customerId = it.customerId,
                             experience = settings.get<ExperienceSetting>().selectedOption,
+                            integrationType = settings.get<IntegrationTypeSetting>().selectedOption,
                         )
                     )
                 }
@@ -446,13 +442,18 @@ enum class Flow(val apiValue: String) {
     }
 }
 
+enum class IntegrationType(
+    val displayName: String,
+) {
+    Standalone("Standalone"),
+    PaymentElement("Payment Element"),
+}
+
 enum class Experience(
     val displayName: String,
 ) {
     FinancialConnections("Financial Connections"),
     InstantDebits("Instant Debits"),
-    PaymentElement("Payment Element"),
-    PaymentElementWithInstantDebits("Payment Element w/ Instant Debits"),
 }
 
 enum class NativeOverride(val apiValue: String) {
@@ -478,6 +479,7 @@ sealed class FinancialConnectionsPlaygroundViewEffect {
         val customerId: String?,
         val publishableKey: String,
         val experience: Experience,
+        val integrationType: IntegrationType,
     ) : FinancialConnectionsPlaygroundViewEffect()
 }
 

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -92,15 +92,21 @@ internal class FinancialConnectionsPlaygroundViewModel(
             Experience.PaymentElement -> {
                 startWithPaymentIntent(this)
             }
+            Experience.PaymentElementWithInstantDebits -> {
+                startWithPaymentIntent(this, forceInstantDebits = true)
+            }
         }
     }
 
-    private fun startWithPaymentIntent(settings: PlaygroundSettings) {
+    private fun startWithPaymentIntent(
+        settings: PlaygroundSettings,
+        forceInstantDebits: Boolean = false,
+    ) {
         viewModelScope.launch {
             showLoadingWithMessage("Fetching link account session from example backend!")
             kotlin.runCatching {
                 repository.createPaymentIntent(
-                    settings.paymentIntentRequest()
+                    settings.paymentIntentRequest(forceInstantDebits = forceInstantDebits)
                 )
             }
                 // Success creating session: open the financial connections sheet with received secret
@@ -445,7 +451,8 @@ enum class Experience(
 ) {
     FinancialConnections("Financial Connections"),
     InstantDebits("Instant Debits"),
-    PaymentElement("Payment Element")
+    PaymentElement("Payment Element"),
+    PaymentElementWithInstantDebits("Payment Element w/ Instant Debits"),
 }
 
 enum class NativeOverride(val apiValue: String) {

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/model/PaymentIntentBody.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/model/PaymentIntentBody.kt
@@ -29,4 +29,6 @@ data class PaymentIntentBody(
     val testMode: Boolean? = null,
     @SerialName("stripe_account_id")
     val stripeAccountId: String? = null,
+    @SerialName("force_instant_debits")
+    val forceInstantDebits: Boolean = false,
 )

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/IntegrationTypeSetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/IntegrationTypeSetting.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.financialconnections.example.settings
+
+import com.stripe.android.financialconnections.example.IntegrationType
+import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
+import com.stripe.android.financialconnections.example.data.model.PaymentIntentBody
+
+data class IntegrationTypeSetting(
+    override val selectedOption: IntegrationType = IntegrationType.Standalone,
+    override val key: String = "integration_type",
+) : Saveable<IntegrationType>, SingleChoiceSetting<IntegrationType>(
+    displayName = "Integration Type",
+    options = IntegrationType.entries.map { Option(it.displayName, it) },
+    selectedOption = selectedOption,
+) {
+    override fun lasRequest(body: LinkAccountSessionBody): LinkAccountSessionBody = body
+
+    override fun paymentIntentRequest(body: PaymentIntentBody): PaymentIntentBody = body
+
+    override fun convertToString(value: IntegrationType): String {
+        return value.name
+    }
+
+    override fun convertToValue(value: String): IntegrationType {
+        return IntegrationType.entries.find { it.name == value } ?: IntegrationType.Standalone
+    }
+
+    override fun valueUpdated(currentSettings: List<Setting<*>>, value: IntegrationType): List<Setting<*>> {
+        return replace(currentSettings, this.copy(selectedOption = value))
+    }
+}

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PlaygroundSettings.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PlaygroundSettings.kt
@@ -167,6 +167,7 @@ internal data class PlaygroundSettings(
         }
 
         private val allSettings: List<Setting<*>> = listOfNotNull(
+            IntegrationTypeSetting(),
             ExperienceSetting(),
             MerchantSetting(),
             PublicKeySetting(),

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PlaygroundSettings.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PlaygroundSettings.kt
@@ -47,9 +47,17 @@ internal data class PlaygroundSettings(
         LinkAccountSessionBody(testEnvironment = BuildConfig.TEST_ENVIRONMENT)
     ) { acc, setting: Setting<*> -> setting.lasRequest(acc) }
 
-    fun paymentIntentRequest(): PaymentIntentBody = settings.toList().fold(
-        PaymentIntentBody(testEnvironment = BuildConfig.TEST_ENVIRONMENT)
-    ) { acc, setting: Setting<*> -> setting.paymentIntentRequest(acc) }
+    fun paymentIntentRequest(
+        forceInstantDebits: Boolean = false,
+    ): PaymentIntentBody {
+        return settings.toList().fold(
+            PaymentIntentBody(testEnvironment = BuildConfig.TEST_ENVIRONMENT)
+        ) { acc, setting: Setting<*> ->
+            setting.paymentIntentRequest(acc)
+        }.copy(
+            forceInstantDebits = forceInstantDebits,
+        )
+    }
 
     fun asJsonString(): String {
         val json = settings

--- a/maestro/financial-connections/Livemode-Data-Finbank.yaml
+++ b/maestro/financial-connections/Livemode-Data-Finbank.yaml
@@ -5,7 +5,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/livemode-data-finbank-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?experience=FinancialConnections&flow=Data&financial_connections_override_native=native&merchant=live_testing&financial_connections_test_mode=false
+- openLink: stripeconnectionsexample://playground?integration_type=Standalone&experience=FinancialConnections&flow=Data&financial_connections_override_native=native&merchant=live_testing&financial_connections_test_mode=false
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible

--- a/maestro/financial-connections/Livemode-Data-MXBank.yaml
+++ b/maestro/financial-connections/Livemode-Data-MXBank.yaml
@@ -5,7 +5,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/livemode-data-mxbank-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?experience=FinancialConnections&flow=Data&financial_connections_override_native=native&merchant=live_testing&financial_connections_test_mode=false
+- openLink: stripeconnectionsexample://playground?integration_type=Standalone&experience=FinancialConnections&flow=Data&financial_connections_override_native=native&merchant=live_testing&financial_connections_test_mode=false
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible

--- a/maestro/financial-connections/Testmode-Data-TestOauthInstitution-Connected.yaml
+++ b/maestro/financial-connections/Testmode-Data-TestOauthInstitution-Connected.yaml
@@ -6,7 +6,8 @@ tags:
 - startRecording: ${'/tmp/test_results/testmode-data-testoauthinstitution-connected-' + new Date().getTime()}
 - clearState
 - openLink: "stripeconnectionsexample://playground\
-    ?experience=FinancialConnections\
+    ?integration_type=Standalone\
+    &experience=FinancialConnections\
     &flow=Data\
     &financial_connections_override_native=native\
     &merchant=networking\

--- a/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
+++ b/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
@@ -6,7 +6,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/testmode-data-testoauthinstitution-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?experience=FinancialConnections&flow=Data&financial_connections_override_native=native&merchant=testmode&financial_connections_test_mode=true
+- openLink: stripeconnectionsexample://playground?integration_type=Standalone&experience=FinancialConnections&flow=Data&financial_connections_override_native=native&merchant=testmode&financial_connections_test_mode=true
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-InstantDebits.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-InstantDebits.yaml
@@ -6,7 +6,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-instantdebits-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?experience=InstantDebits&flow=PaymentIntent&financial_connections_override_native=native&merchant=networking&financial_connections_test_mode=true&permissions=transactions,payment_method&financial_connections_confirm_intent=false
+- openLink: stripeconnectionsexample://playground?integration_type=Standalone&experience=InstantDebits&flow=PaymentIntent&financial_connections_override_native=native&merchant=networking&financial_connections_test_mode=true&permissions=transactions,payment_method&financial_connections_confirm_intent=false
 - tapOn:
     id: "Customer email setting"
 - inputRandomEmail

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking.yaml
@@ -6,7 +6,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-networking-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?experience=FinancialConnections&flow=PaymentIntent&financial_connections_override_native=native&merchant=networking&financial_connections_test_mode=true&permissions=transactions,payment_method&financial_connections_confirm_intent=true
+- openLink: stripeconnectionsexample://playground?integration_type=Standalone&experience=FinancialConnections&flow=PaymentIntent&financial_connections_override_native=native&merchant=networking&financial_connections_test_mode=true&permissions=transactions,payment_method&financial_connections_confirm_intent=true
 - tapOn:
     id: "Customer email setting"
 - inputRandomEmail

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
@@ -6,7 +6,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-networking-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?experience=FinancialConnections&flow=PaymentIntent&financial_connections_override_native=native&financial_connections_test_mode=true&merchant=testmode&permissions=payment_method
+- openLink: stripeconnectionsexample://playground?integration_type=Standalone&experience=FinancialConnections&flow=PaymentIntent&financial_connections_override_native=native&financial_connections_test_mode=true&merchant=testmode&permissions=payment_method
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
@@ -6,7 +6,7 @@ tags:
 ---
 #- startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?experience=FinancialConnections&flow=PaymentIntent&financial_connections_override_native=native&merchant=testmode&permissions=payment_method&financial_connections_test_mode=true&financial_connections_confirm_intent=true
+- openLink: stripeconnectionsexample://playground?integration_type=Standalone&experience=FinancialConnections&flow=PaymentIntent&financial_connections_override_native=native&merchant=testmode&permissions=payment_method&financial_connections_test_mode=true&financial_connections_confirm_intent=true
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible

--- a/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
+++ b/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
@@ -6,7 +6,7 @@ tags:
 ---
 - startRecording: ${'/tmp/test_results/testmode-token_manualentry-' + new Date().getTime()}
 - clearState
-- openLink: stripeconnectionsexample://playground?experience=FinancialConnections&flow=Token&financial_connections_override_native=native&financial_connections_test_mode=true&merchant=testmode&permissions=balances,payment_method
+- openLink: stripeconnectionsexample://playground?integration_type=Standalone&experience=FinancialConnections&flow=Token&financial_connections_override_native=native&financial_connections_test_mode=true&merchant=testmode&permissions=balances,payment_method
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request allows testing MPE with Instant Debits from within the Financial Connections playground. Previously, we could only test MPE with US bank account.

It separates integration type and experience, allowing us to test all combinations of `Standalone vs. MPE` and `Financial Connections vs. Instant Debits`.

![Screenshot_20240906_105450](https://github.com/user-attachments/assets/c2332e73-e916-4c2e-aadc-d673f35cfb08)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Easier testing.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
