### PR TITLE
Fix a bug where using deferred intents with a publishable key that didn't have live or test in it would show as test mode.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/parsers/DeferredPaymentIntentJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/DeferredPaymentIntentJsonParser.kt
@@ -43,7 +43,7 @@ class DeferredPaymentIntentJsonParser(
             countryCode = countryCode,
             linkFundingSources = linkFundingSources,
             unactivatedPaymentMethods = unactivatedPaymentMethods,
-            isLiveMode = apiKey.contains("live"),
+            isLiveMode = !apiKey.contains("test"),
             created = timeProvider(),
             setupFutureUsage = paymentMode.setupFutureUsage,
             amount = paymentMode.amount,

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -360,6 +360,50 @@ class ElementsSessionJsonParserTest {
     }
 
     @Test
+    fun `Test deferred livemode=true when publishable key does not have test or live`() {
+        val data = ElementsSessionJsonParser(
+            ElementsSessionParams.DeferredIntentType(
+                deferredIntentParams = DeferredIntentParams(
+                    mode = DeferredIntentParams.Mode.Payment(
+                        amount = 2000,
+                        currency = "usd",
+                        captureMethod = PaymentIntent.CaptureMethod.Automatic,
+                        setupFutureUsage = null,
+                    ),
+                    paymentMethodTypes = emptyList(),
+                    paymentMethodConfigurationId = null,
+                    onBehalfOf = null,
+                ),
+                externalPaymentMethods = emptyList(),
+            ),
+            apiKey = "pk_foobar",
+            timeProvider = { 1 }
+        ).parse(
+            ElementsSessionFixtures.DEFERRED_INTENT_JSON
+        )
+
+        val deferredIntent = data?.stripeIntent
+
+        assertThat(deferredIntent).isNotNull()
+        assertThat(deferredIntent).isEqualTo(
+            PaymentIntent(
+                id = "elements_session_1t6ejApXCS5",
+                clientSecret = null,
+                amount = 2000L,
+                currency = "usd",
+                captureMethod = PaymentIntent.CaptureMethod.Automatic,
+                countryCode = "CA",
+                created = 1,
+                isLiveMode = true,
+                setupFutureUsage = null,
+                unactivatedPaymentMethods = listOf(),
+                paymentMethodTypes = listOf("card", "link", "cashapp"),
+                linkFundingSources = listOf("card")
+            )
+        )
+    }
+
+    @Test
     fun `Test deferred SetupIntent`() {
         val data = ElementsSessionJsonParser(
             ElementsSessionParams.DeferredIntentType(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Some publishable keys don't have live or test in them. We should default to livemode (as to not show the banner) in the case where we don't explicitly know.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://stripe.slack.com/archives/CFA2HJ99A/p1725636495600769?thread_ts=1725555895.395669&cid=CFA2HJ99A

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

