### PR TITLE
[Maestro] Disable StripeAccountId in edge

### DIFF
--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -490,6 +490,6 @@ internal data class FinancialConnectionsPlaygroundState(
 
     val experience: Experience = settings.get<ExperienceSetting>().selectedOption
     val flow: Flow = settings.get<FlowSetting>().selectedOption
-    val stripeAccountId: String? = settings.get<StripeAccountIdSetting>().selectedOption
-        .takeIf { it.isNotEmpty() }
+    val stripeAccountId: String? = settings.getOrNull<StripeAccountIdSetting>()?.selectedOption
+        ?.takeIf { it.isNotEmpty() }
 }

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PlaygroundSettings.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PlaygroundSettings.kt
@@ -39,6 +39,10 @@ internal data class PlaygroundSettings(
         return settings.find { it is T } as T
     }
 
+    inline fun <reified T : Setting<*>> getOrNull(): T? {
+        return settings.find { it is T } as T?
+    }
+
     fun lasRequest(): LinkAccountSessionBody = settings.toList().fold(
         LinkAccountSessionBody(testEnvironment = BuildConfig.TEST_ENVIRONMENT)
     ) { acc, setting: Setting<*> -> setting.lasRequest(acc) }
@@ -154,7 +158,7 @@ internal data class PlaygroundSettings(
             return settings
         }
 
-        private val allSettings: List<Setting<*>> = listOf(
+        private val allSettings: List<Setting<*>> = listOfNotNull(
             ExperienceSetting(),
             MerchantSetting(),
             PublicKeySetting(),
@@ -165,7 +169,7 @@ internal data class PlaygroundSettings(
             NativeSetting(),
             PermissionsSetting(),
             EmailSetting(),
-            StripeAccountIdSetting(),
+            StripeAccountIdSetting().takeIf { BuildConfig.TEST_ENVIRONMENT != "edge" },
         )
     }
 }


### PR DESCRIPTION
# Summary
- Edge merchants don't support stripe account ids 
- Disable the setting entirely when on edge environment.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
