### PR TITLE
Fix more R8 issues.

### DIFF
--- a/paymentsheet/consumer-rules.txt
+++ b/paymentsheet/consumer-rules.txt
@@ -1,2 +1,0 @@
--if class com.stripe.android.paymentsheet.PaymentSheet$FlowController
--keep class com.stripe.android.paymentsheet.PaymentOptionContract

--- a/stripe-core/consumer-rules.txt
+++ b/stripe-core/consumer-rules.txt
@@ -1,1 +1,4 @@
 -dontwarn io.grpc.internal.**
+
+# Ideally we could only keep the contracts that are used, but there isn't a way to do that.
+-keep class * extends androidx.activity.result.contract.ActivityResultContract


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Other contracts were having the same issue, so let's just keep them all.

The original issue was with FlowController selections. But now we can't pay in release mode either.