### PR TITLE
Navigate to form screen in flow controller for current selections.

### DIFF
--- a/payments-ui-core/detekt-baseline.xml
+++ b/payments-ui-core/detekt-baseline.xml
@@ -13,8 +13,6 @@
     <ID>LongMethod:TransformGoogleToStripeAddressTest.kt$TransformGoogleToStripeAddressTest$@Test fun `test US address with sublocality`()</ID>
     <ID>LongMethod:TransformGoogleToStripeAddressTest.kt$TransformGoogleToStripeAddressTest$@Test fun `test US address without sublocality`()</ID>
     <ID>LongMethod:TransformGoogleToStripeAddressTest.kt$TransformGoogleToStripeAddressTest$@Test fun `test should not combine dependent locality - US`()</ID>
-    <ID>MagicNumber:AfterpayClearpayHeaderElement.kt$AfterpayClearpayHeaderElement$3</ID>
-    <ID>MagicNumber:AfterpayClearpayHeaderElement.kt$AfterpayClearpayHeaderElement$4</ID>
     <ID>MagicNumber:CardDetailsElement.kt$2000</ID>
     <ID>MagicNumber:CardDetailsElement.kt$4</ID>
     <ID>MagicNumber:CardNumberVisualTransformation.kt$CardNumberVisualTransformation$14</ID>

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -30,6 +30,7 @@
     <ID>LongMethod:EditPaymentMethod.kt$@Composable internal fun EditPaymentMethodUi( viewState: EditPaymentMethodViewState, viewActionHandler: (action: EditPaymentMethodViewAction) -> Unit, modifier: Modifier = Modifier )</ID>
     <ID>LongMethod:FormViewModelTest.kt$FormViewModelTest$@Test fun `Verify params are set when element address fields are complete`()</ID>
     <ID>LongMethod:FormViewModelTest.kt$FormViewModelTest$@Test fun `Verify params are set when required address fields are complete`()</ID>
+    <ID>LongMethod:PaymentMethodVerticalLayoutInteractor.kt$DefaultPaymentMethodVerticalLayoutInteractor.Companion$fun create( viewModel: BaseSheetViewModel, paymentMethodMetadata: PaymentMethodMetadata, customerStateHolder: CustomerStateHolder, ): PaymentMethodVerticalLayoutInteractor</ID>
     <ID>LongMethod:PaymentOptionFactory.kt$PaymentOptionFactory$fun create(selection: PaymentSelection): PaymentOption</ID>
     <ID>LongMethod:PaymentSheetConfigurationKtx.kt$internal fun PaymentSheet.Appearance.parseAppearance()</ID>
     <ID>LongMethod:PaymentSheetScreen.kt$@Composable private fun PaymentSheetContent( viewModel: BaseSheetViewModel, headerText: ResolvableString?, walletsState: WalletsState?, walletsProcessingState: WalletsProcessingState?, error: ResolvableString?, currentScreen: PaymentSheetScreen, mandateText: MandateText?, modifier: Modifier, )</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormHelper.kt
@@ -6,6 +6,7 @@ import com.stripe.android.link.ui.inline.InlineSignupViewState
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
 import com.stripe.android.paymentsheet.forms.FormFieldValues
@@ -74,6 +75,13 @@ internal class FormHelper(
             paymentMethodMetadata = paymentMethodMetadata,
         )
         selectionUpdater(newSelection)
+    }
+
+    fun requiresFormScreen(selectedPaymentMethodCode: String): Boolean {
+        val userInteractionAllowed = formElementsForCode(selectedPaymentMethodCode).any { it.allowsUserInteraction }
+        return userInteractionAllowed ||
+            selectedPaymentMethodCode == PaymentMethod.Type.USBankAccount.code ||
+            selectedPaymentMethodCode == PaymentMethod.Type.Link.code
     }
 
     private fun supportedPaymentMethodForCode(code: String): SupportedPaymentMethod {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -296,13 +296,10 @@ internal class PaymentOptionsViewModel @Inject constructor(
         customerStateHolder: CustomerStateHolder,
     ): List<PaymentSheetScreen> {
         if (config.paymentMethodLayout == PaymentSheet.PaymentMethodLayout.Vertical) {
-            return listOf(
-                VerticalModeInitialScreenFactory.create(
-                    viewModel = this,
-                    paymentMethodMetadata = paymentMethodMetadata,
-                    customerStateHolder = customerStateHolder,
-                    savedPaymentMethodMutator = savedPaymentMethodMutator,
-                )
+            return VerticalModeInitialScreenFactory.create(
+                viewModel = this,
+                paymentMethodMetadata = paymentMethodMetadata,
+                customerStateHolder = customerStateHolder,
             )
         }
         val target = if (args.state.showSavedPaymentMethods) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -675,13 +675,10 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         customerStateHolder: CustomerStateHolder,
     ): List<PaymentSheetScreen> {
         if (config.paymentMethodLayout == PaymentSheet.PaymentMethodLayout.Vertical) {
-            return listOf(
-                VerticalModeInitialScreenFactory.create(
-                    viewModel = this,
-                    paymentMethodMetadata = paymentMethodMetadata,
-                    customerStateHolder = customerStateHolder,
-                    savedPaymentMethodMutator = savedPaymentMethodMutator,
-                )
+            return VerticalModeInitialScreenFactory.create(
+                viewModel = this,
+                paymentMethodMetadata = paymentMethodMetadata,
+                customerStateHolder = customerStateHolder,
             )
         }
         val hasPaymentMethods = customerStateHolder.paymentMethods.value.isNotEmpty()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
@@ -1,8 +1,11 @@
 package com.stripe.android.paymentsheet.verticalmode
 
+import androidx.lifecycle.viewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
+import com.stripe.android.paymentsheet.FormHelper
+import com.stripe.android.paymentsheet.LinkInlineHandler
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 
@@ -11,27 +14,51 @@ internal object VerticalModeInitialScreenFactory {
         viewModel: BaseSheetViewModel,
         paymentMethodMetadata: PaymentMethodMetadata,
         customerStateHolder: CustomerStateHolder,
-        savedPaymentMethodMutator: SavedPaymentMethodMutator,
-    ): PaymentSheetScreen {
+    ): List<PaymentSheetScreen> {
         val supportedPaymentMethodTypes = paymentMethodMetadata.supportedPaymentMethodTypes()
 
         if (supportedPaymentMethodTypes.size == 1 && customerStateHolder.paymentMethods.value.isEmpty()) {
-            return PaymentSheetScreen.VerticalModeForm(
-                interactor = DefaultVerticalModeFormInteractor.create(
-                    selectedPaymentMethodCode = supportedPaymentMethodTypes.first(),
-                    viewModel = viewModel,
-                    paymentMethodMetadata = paymentMethodMetadata,
-                    customerStateHolder = customerStateHolder,
-                ),
-                showsWalletHeader = true,
+            return listOf(
+                PaymentSheetScreen.VerticalModeForm(
+                    interactor = DefaultVerticalModeFormInteractor.create(
+                        selectedPaymentMethodCode = supportedPaymentMethodTypes.first(),
+                        viewModel = viewModel,
+                        paymentMethodMetadata = paymentMethodMetadata,
+                        customerStateHolder = customerStateHolder,
+                    ),
+                    showsWalletHeader = true,
+                )
             )
         }
-        val interactor = DefaultPaymentMethodVerticalLayoutInteractor.create(
-            viewModel = viewModel,
-            paymentMethodMetadata = paymentMethodMetadata,
-            customerStateHolder = customerStateHolder,
-            savedPaymentMethodMutator = savedPaymentMethodMutator,
-        )
-        return PaymentSheetScreen.VerticalMode(interactor = interactor)
+
+        return buildList {
+            val interactor = DefaultPaymentMethodVerticalLayoutInteractor.create(
+                viewModel = viewModel,
+                paymentMethodMetadata = paymentMethodMetadata,
+                customerStateHolder = customerStateHolder,
+            )
+            val verticalModeScreen = PaymentSheetScreen.VerticalMode(interactor = interactor)
+            add(verticalModeScreen)
+
+            (viewModel.selection.value as? PaymentSelection.New?)?.let { newPaymentSelection ->
+                val paymentMethodCode = newPaymentSelection.paymentMethodCreateParams.typeCode
+
+                val linkInlineHandler = LinkInlineHandler.create(viewModel, viewModel.viewModelScope)
+                val formHelper = FormHelper.create(viewModel, linkInlineHandler, paymentMethodMetadata)
+
+                if (formHelper.requiresFormScreen(paymentMethodCode)) {
+                    add(
+                        PaymentSheetScreen.VerticalModeForm(
+                            interactor = DefaultVerticalModeFormInteractor.create(
+                                selectedPaymentMethodCode = paymentMethodCode,
+                                viewModel = viewModel,
+                                paymentMethodMetadata = paymentMethodMetadata,
+                                customerStateHolder = customerStateHolder,
+                            ),
+                        )
+                    )
+                }
+            }
+        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
@@ -158,6 +158,57 @@ internal class FormHelperTest {
         assertThat(hasCalledSelectionUpdater).isTrue()
     }
 
+    @Test
+    fun `requiresFormScreen returns false for an LPM with no fields`() {
+        val formHelper = createFormHelper(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    paymentMethodTypes = listOf("card", "cashapp"),
+                )
+            ),
+            newPaymentSelectionProvider = { null },
+        )
+        assertThat(formHelper.requiresFormScreen("cashapp")).isFalse()
+    }
+
+    @Test
+    fun `requiresFormScreen returns true for an LPM with no fields, but requires name`() {
+        val formHelper = createFormHelper(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    paymentMethodTypes = listOf("card", "cashapp"),
+                ),
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                ),
+            ),
+            newPaymentSelectionProvider = { null },
+        )
+        assertThat(formHelper.requiresFormScreen("cashapp")).isTrue()
+    }
+
+    @Test
+    fun `requiresFormScreen returns true for an LPM with fields`() {
+        val formHelper = createFormHelper(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    paymentMethodTypes = listOf("card", "klarna"),
+                ),
+            ),
+            newPaymentSelectionProvider = { null },
+        )
+        assertThat(formHelper.requiresFormScreen("klarna")).isTrue()
+    }
+
+    @Test
+    fun `requiresFormScreen returns true for non form field based LPM us_bank_account`() {
+        val formHelper = createFormHelper(
+            newPaymentSelectionProvider = { null },
+        )
+        assertThat(formHelper.requiresFormScreen("us_bank_account")).isTrue()
+        assertThat(formHelper.requiresFormScreen("link")).isTrue()
+    }
+
     private fun createFormHelper(
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         newPaymentSelectionProvider: () -> NewOrExternalPaymentSelection? = { throw AssertionError("Not implemented") },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -608,6 +608,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             formElementsForCode = {
                 formFieldsWhichRequireUserInteraction
             },
+            requiresFormScreen = { true },
             formScreenFactory = {
                 calledFormScreenFactory = true
                 mock()
@@ -634,6 +635,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             formElementsForCode = {
                 listOf()
             },
+            requiresFormScreen = { true },
             formScreenFactory = {
                 calledFormScreenFactory = true
                 mock()
@@ -658,6 +660,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             formElementsForCode = {
                 listOf()
             },
+            requiresFormScreen = { true },
             formScreenFactory = {
                 calledFormScreenFactory = true
                 mock()
@@ -720,6 +723,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
                 )
                 paymentMethodMetadata.formElementsForCode(it, uiDefinitionFactoryArgumentsFactory)!!
             },
+
             onFormFieldValuesChanged = { fieldValues, selectedPaymentMethodCode ->
                 fieldValues.run {
                     assertThat(fieldValuePairs).isEmpty()
@@ -836,6 +840,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             updateSelection = { verticalModeSelection = it },
         ) {
             interactor.state.test {
+                isCurrentScreenSource.value = true
                 assertThat(awaitItem().selection).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
                 assertThat(verticalModeSelection).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
                 isCurrentScreenSource.value = false
@@ -975,8 +980,9 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         ),
         initialProcessing: Boolean = false,
         initialSelection: PaymentSelection? = null,
-        initialIsCurrentScreen: Boolean = true,
+        initialIsCurrentScreen: Boolean = false,
         formElementsForCode: (code: String) -> List<FormElement> = { notImplemented() },
+        requiresFormScreen: (String) -> Boolean = { false },
         transitionTo: (screen: PaymentSheetScreen) -> Unit = { notImplemented() },
         onFormFieldValuesChanged: (formValues: FormFieldValues, selectedPaymentMethodCode: String) -> Unit = { _, _ ->
             notImplemented()
@@ -1009,6 +1015,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             processing = processing,
             selection = selection,
             formElementsForCode = formElementsForCode,
+            requiresFormScreen = requiresFormScreen,
             transitionTo = transitionTo,
             onFormFieldValuesChanged = onFormFieldValuesChanged,
             manageScreenFactory = manageScreenFactory,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
@@ -1,0 +1,98 @@
+package com.stripe.android.paymentsheet.verticalmode
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
+import com.stripe.android.paymentsheet.state.CustomerState
+import com.stripe.android.paymentsheet.viewmodels.FakeBaseSheetViewModel
+import com.stripe.android.testing.CoroutineTestRule
+import org.junit.Rule
+import kotlin.test.Test
+
+class VerticalModeInitialScreenFactoryTest {
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+
+    @Test
+    fun `returns form screen when only one payment method available`() = runScenario(
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("cashapp"),
+            )
+        )
+    ) {
+        assertThat(screens).hasSize(1)
+        assertThat(screens[0]).isInstanceOf<PaymentSheetScreen.VerticalModeForm>()
+    }
+
+    @Test
+    fun `returns list screen when only one payment method available with saved payment methods`() = runScenario(
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("cashapp"),
+            )
+        ),
+        hasSavedPaymentMethods = true
+    ) {
+        assertThat(screens).hasSize(1)
+        assertThat(screens[0]).isInstanceOf<PaymentSheetScreen.VerticalMode>()
+    }
+
+    @Test
+    fun `returns both screens when selection is new card`() = runScenario(
+        selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
+    ) {
+        assertThat(screens).hasSize(2)
+        assertThat(screens[0]).isInstanceOf<PaymentSheetScreen.VerticalMode>()
+        assertThat(screens[1]).isInstanceOf<PaymentSheetScreen.VerticalModeForm>()
+    }
+
+    private fun runScenario(
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        hasSavedPaymentMethods: Boolean = false,
+        selection: PaymentSelection? = null,
+        block: Scenario.() -> Unit,
+    ) {
+        val fakeViewModel = FakeBaseSheetViewModel.create(
+            paymentMethodMetadata = paymentMethodMetadata,
+            initialScreen = PaymentSheetScreen.Loading,
+        )
+
+        val customerStateHolder = CustomerStateHolder(SavedStateHandle(), fakeViewModel.selection)
+        if (hasSavedPaymentMethods) {
+            customerStateHolder.setCustomerState(
+                CustomerState(
+                    id = "cus_foobar",
+                    ephemeralKeySecret = "ek_123",
+                    paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+                    permissions = CustomerState.Permissions(
+                        canRemovePaymentMethods = true,
+                        canRemoveDuplicates = true,
+                    )
+                )
+            )
+        }
+
+        fakeViewModel.updateSelection(selection)
+
+        val screens = VerticalModeInitialScreenFactory.create(
+            viewModel = fakeViewModel,
+            paymentMethodMetadata = paymentMethodMetadata,
+            customerStateHolder = customerStateHolder,
+        )
+        Scenario(
+            screens = screens
+        ).apply(block)
+    }
+
+    private class Scenario(
+        val screens: List<PaymentSheetScreen>,
+    )
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We want to navigate directly into the form screen, with a back button to get back to the list in the case the user has already filled out a form in flow controller.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2443

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
