### PR TITLE
Disable 3DS2 docs.

### DIFF
--- a/3ds2sdk/gradle.properties
+++ b/3ds2sdk/gradle.properties
@@ -1,3 +1,4 @@
 # Update SdkVersion when publishing a new release
 VERSION_NAME=6.1.8
 STRIPE_ANDROID_NAMESPACE=com.stripe.android.stripe3ds2
+skip_dokka=true

--- a/build-configuration/android-library.gradle
+++ b/build-configuration/android-library.gradle
@@ -5,7 +5,9 @@
  */
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
-apply plugin: "org.jetbrains.dokka"
+if (!project.hasProperty("skip_dokka")) {
+    apply plugin: "org.jetbrains.dokka"
+}
 
 apply from: rootProject.file('build-configuration/detekt.gradle')
 apply from: rootProject.file('build-configuration/ktlint.gradle')
@@ -61,8 +63,10 @@ android {
         disable 'MissingTranslation'
     }
 
-    dokkaHtml {
-        outputDirectory = new File("${project.rootDir}/docs/$project.name")
+    if (!project.hasProperty("skip_dokka")) {
+        dokkaHtml {
+            outputDirectory = new File("${project.rootDir}/docs/$project.name")
+        }
     }
 
     compileOptions {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We've been manually removing these docs. We don't want manual processes. This disabled the generation of the docs.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2355