### PR TITLE
[Connect SDK] Initial API shape

### DIFF
--- a/stripe-connect-example/src/main/java/com/stripe/android/connectsdk/example/MainActivity.kt
+++ b/stripe-connect-example/src/main/java/com/stripe/android/connectsdk/example/MainActivity.kt
@@ -4,14 +4,66 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material.Text
+import com.stripe.android.connectsdk.EmbeddedComponentManager
+import com.stripe.android.connectsdk.FetchClientSecretCallback
+import com.stripe.android.connectsdk.FetchClientSecretCallback.ClientSecretResultCallback
+import com.stripe.android.connectsdk.PrivateBetaConnectSDK
 
+@OptIn(PrivateBetaConnectSDK::class)
 class MainActivity : ComponentActivity() {
+
+    private lateinit var embeddedComponentManager: EmbeddedComponentManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        embeddedComponentManager = EmbeddedComponentManager(
+            activity = this,
+            configuration = EmbeddedComponentManager.Configuration(
+                publishableKey = "<publishable key here>"
+            ),
+            fetchClientSecret = object : FetchClientSecretCallback {
+                override fun fetchClientSecret(resultCallback: ClientSecretResultCallback) {
+                    // Make a network call to fetch your client secret here
+                    resultCallback.onResult("<client secret here>")
+                }
+            }
+        )
+
         setContent {
             Text("Not yet built...")
         }
+    }
+
+    fun launchPayouts() {
+        // launch the payouts activity
+        embeddedComponentManager.presentPayouts()
+    }
+
+    fun launchAccountOnboardingActivity() {
+        // launch the account onboarding activity
+        embeddedComponentManager.presentAccountOnboarding()
+    }
+
+    fun updateAppearance() {
+        // update the appearance
+        embeddedComponentManager.update(
+            EmbeddedComponentManager.Appearance(
+                typography = EmbeddedComponentManager.Appearance.Typography(),
+                colors = EmbeddedComponentManager.Appearance.Colors(),
+                buttonPrimary = EmbeddedComponentManager.Appearance.Button(),
+                buttonSecondary = EmbeddedComponentManager.Appearance.Button(),
+                badgeNeutral = EmbeddedComponentManager.Appearance.Badge(),
+                badgeSuccess = EmbeddedComponentManager.Appearance.Badge(),
+                badgeWarning = EmbeddedComponentManager.Appearance.Badge(),
+                badgeDanger = EmbeddedComponentManager.Appearance.Badge(),
+                cornerRadius = EmbeddedComponentManager.Appearance.CornerRadius()
+            )
+        )
+    }
+
+    fun logout() {
+        // log out the user
+        embeddedComponentManager.logout()
     }
 }

--- a/stripe-connect/src/main/java/com/stripe/android/connectsdk/EmbeddedComponentManager.kt
+++ b/stripe-connect/src/main/java/com/stripe/android/connectsdk/EmbeddedComponentManager.kt
@@ -1,7 +1,145 @@
 package com.stripe.android.connectsdk
 
+import android.os.Parcelable
+import androidx.activity.ComponentActivity
+import androidx.annotation.ColorInt
 import androidx.annotation.RestrictTo
+import kotlinx.parcelize.Parcelize
 
 @PrivateBetaConnectSDK
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class EmbeddedComponentManager internal constructor()
+class EmbeddedComponentManager internal constructor() {
+    constructor(
+        activity: ComponentActivity,
+        configuration: Configuration,
+        fetchClientSecret: FetchClientSecretCallback,
+    ) : this() {
+        throw NotImplementedError("Not yet implemented")
+    }
+
+    @PrivateBetaConnectSDK
+    fun presentAccountOnboarding() {
+        throw NotImplementedError("Not yet implemented")
+    }
+
+    @PrivateBetaConnectSDK
+    fun presentPayouts() {
+        throw NotImplementedError("Not yet implemented")
+    }
+
+    @PrivateBetaConnectSDK
+    fun update(appearance: Appearance) {
+        throw NotImplementedError("Not yet implemented")
+    }
+
+    @PrivateBetaConnectSDK
+    fun logout() {
+        throw NotImplementedError("Not yet implemented")
+    }
+
+    // Configuration
+
+    @Parcelize
+    data class Configuration(
+        val publishableKey: String,
+    ) : Parcelable
+
+    // Appearance classes
+
+    @Parcelize
+    data class Appearance(
+        val typography: Typography,
+        val colors: Colors,
+        val spacingUnit: Float? = null,
+        val buttonPrimary: Button,
+        val buttonSecondary: Button,
+        val badgeNeutral: Badge,
+        val badgeSuccess: Badge,
+        val badgeWarning: Badge,
+        val badgeDanger: Badge,
+        val cornerRadius: CornerRadius
+    ): Parcelable {
+        companion object {
+            val default = Appearance(
+                typography = Typography(),
+                colors = Colors(),
+                spacingUnit = null,
+                buttonPrimary = Button(),
+                buttonSecondary = Button(),
+                badgeNeutral = Badge(),
+                badgeSuccess = Badge(),
+                badgeWarning = Badge(),
+                badgeDanger = Badge(),
+                cornerRadius = CornerRadius()
+            )
+        }
+
+        @Parcelize
+        data class Typography(
+            val font: String? = null,
+            val fontSizeBase: Float? = null,
+            val bodyMd: Style = Style(),
+            val bodySm: Style = Style(),
+            val headingXl: Style = Style(),
+            val headingLg: Style = Style(),
+            val headingMd: Style = Style(),
+            val headingSm: Style = Style(),
+            val headingXs: Style = Style(),
+            val labelMd: Style = Style(),
+            val labelSm: Style = Style()
+        ): Parcelable {
+            @Parcelize
+            data class Style(
+                val fontSize: Float? = null,
+                val weight: String? = null,
+                val textTransform: TextTransform? = null
+            ): Parcelable
+        }
+
+        enum class TextTransform {
+            NONE,
+            UPPERCASE,
+            LOWERCASE,
+            CAPITALIZE
+        }
+
+        @Parcelize
+        data class Colors(
+            @ColorInt val primary: Int? = null,
+            @ColorInt val text: Int? = null,
+            @ColorInt val danger: Int? = null,
+            @ColorInt val background: Int? = null,
+            @ColorInt val secondaryText: Int? = null,
+            @ColorInt val border: Int? = null,
+            @ColorInt val actionPrimaryText: Int? = null,
+            @ColorInt val actionSecondaryText: Int? = null,
+            @ColorInt val offsetBackground: Int? = null,
+            @ColorInt val formBackground: Int? = null,
+            @ColorInt val formHighlightBorder: Int? = null,
+            @ColorInt val formAccent: Int? = null
+        ): Parcelable
+
+        @Parcelize
+        data class Button(
+            @ColorInt val colorBackground: Int? = null,
+            @ColorInt val colorBorder: Int? = null,
+            @ColorInt val colorText: Int? = null
+        ): Parcelable
+
+        @Parcelize
+        data class Badge(
+            @ColorInt val colorBackground: Int? = null,
+            @ColorInt val colorText: Int? = null,
+            @ColorInt val colorBorder: Int? = null
+        ): Parcelable
+
+        @Parcelize
+        data class CornerRadius(
+            val base: Float? = null,
+            val form: Float? = null,
+            val button: Float? = null,
+            val badge: Float? = null,
+            val overlay: Float? = null
+        ): Parcelable
+    }
+}

--- a/stripe-connect/src/main/java/com/stripe/android/connectsdk/FetchClientSecretCallback.kt
+++ b/stripe-connect/src/main/java/com/stripe/android/connectsdk/FetchClientSecretCallback.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.connectsdk
+
+@PrivateBetaConnectSDK
+interface FetchClientSecretCallback {
+    fun fetchClientSecret(resultCallback: ClientSecretResultCallback)
+
+    interface ClientSecretResultCallback {
+        fun onResult(secret: String)
+        fun onError()
+    }
+}


### PR DESCRIPTION
# Summary
Add the initial API shape, mirroring much of iOS here: https://docs.google.com/document/d/195BaU6k2J-2CAs9anNE6e4OlZO34N-e2HTYc6pacpTw/edit#heading=h.dqbdoct8funi

Note that this is still hidden behind private beta flag and is scoped to the library.

# Motivation
This PR builds out the scaffold for the Connect SDK, which allows us to implement the methods in parallel from there (and test incrementally as we do it).

# Testing
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified