### PR TITLE
Remove initial back stack parameter from `CustomerSheetViewModel`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -76,7 +76,6 @@ import com.stripe.android.ui.core.R as UiCoreR
 @CustomerSheetViewModelScope
 internal class CustomerSheetViewModel(
     application: Application, // TODO (jameswoo) remove application
-    initialBackStack: @JvmSuppressWildcards List<CustomerSheetViewState>,
     private var originalPaymentSelection: PaymentSelection?,
     private val paymentConfigurationProvider: Provider<PaymentConfiguration>,
     private val customerAdapterProvider: Deferred<CustomerAdapter>,
@@ -96,7 +95,6 @@ internal class CustomerSheetViewModel(
 
     @Inject constructor(
         application: Application,
-        initialBackStack: @JvmSuppressWildcards List<CustomerSheetViewState>,
         originalPaymentSelection: PaymentSelection?,
         paymentConfigurationProvider: Provider<PaymentConfiguration>,
         resources: Resources,
@@ -113,7 +111,6 @@ internal class CustomerSheetViewModel(
         errorReporter: ErrorReporter,
     ) : this(
         application = application,
-        initialBackStack = initialBackStack,
         originalPaymentSelection = originalPaymentSelection,
         paymentConfigurationProvider = paymentConfigurationProvider,
         customerAdapterProvider = CustomerSheetHacks.adapter,
@@ -133,7 +130,13 @@ internal class CustomerSheetViewModel(
 
     private val cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(application)
 
-    private val backStack = MutableStateFlow(initialBackStack)
+    private val backStack = MutableStateFlow<List<CustomerSheetViewState>>(
+        listOf(
+            CustomerSheetViewState.Loading(
+                isLiveMode = isLiveModeProvider()
+            )
+        )
+    )
     val viewState: StateFlow<CustomerSheetViewState> = backStack.mapAsStateFlow { it.last() }
 
     private val _result = MutableStateFlow<InternalCustomerSheetResult?>(null)

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -19,7 +19,6 @@ import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.NetworkTypeDetector
 import com.stripe.android.core.utils.ContextUtils.packageInfo
 import com.stripe.android.customersheet.CustomerSheetLoader
-import com.stripe.android.customersheet.CustomerSheetViewState
 import com.stripe.android.customersheet.DefaultCustomerSheetLoader
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.analytics.DefaultCustomerSheetEventReporter
@@ -199,15 +198,6 @@ internal interface CustomerSheetViewModelModule {
         @Provides
         fun provideLocale() =
             LocaleListCompat.getAdjustedDefault().takeUnless { it.isEmpty }?.get(0)
-
-        @Provides
-        fun backstack(
-            @Named(IS_LIVE_MODE) isLiveModeProvider: () -> Boolean
-        ): List<CustomerSheetViewState> = listOf(
-            CustomerSheetViewState.Loading(
-                isLiveMode = isLiveModeProvider()
-            )
-        )
 
         @Provides
         @Named(IS_FLOW_CONTROLLER)

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
@@ -10,20 +10,12 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.utils.CustomerSheetTestHelper.createViewModel
 import com.stripe.android.isInstanceOf
-import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.lpmfoundations.paymentmethod.TestUiDefinitionFactoryArgumentsFactory
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
-import com.stripe.android.testing.FakeErrorReporter
-import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils.viewModelFactoryFor
 import com.stripe.android.utils.injectableActivityScenario
@@ -34,7 +26,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.robolectric.annotation.Config
-import java.util.Stack
 
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [Build.VERSION_CODES.Q])
@@ -99,10 +90,8 @@ internal class CustomerSheetActivityTest {
     @Test
     fun `Finish with cancel and payment selection on back press`() {
         runActivityScenario(
-            viewState = createSelectPaymentMethodViewState(
-                paymentSelection = PaymentSelection.Saved(
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD
-                )
+            paymentMethods = listOf(
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD
             ),
             savedPaymentSelection = PaymentSelection.Saved(
                 PaymentMethodFixtures.CARD_PAYMENT_METHOD
@@ -125,11 +114,7 @@ internal class CustomerSheetActivityTest {
 
     @Test
     fun `Verify bottom sheet expands on start with default title`() {
-        runActivityScenario(
-            viewState = createSelectPaymentMethodViewState(
-                title = null
-            ),
-        ) {
+        runActivityScenario {
             page.waitForText("Manage your payment methods")
         }
     }
@@ -137,10 +122,8 @@ internal class CustomerSheetActivityTest {
     @Test
     fun `When savedPaymentMethods is not empty, payment method is visible`() {
         runActivityScenario(
-            viewState = createSelectPaymentMethodViewState(
-                savedPaymentMethods = listOf(
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                )
+            paymentMethods = listOf(
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             ),
         ) {
             page.waitForText("····4242")
@@ -150,9 +133,8 @@ internal class CustomerSheetActivityTest {
     @Test
     fun `When isGooglePayEnabled is true, google pay is visible`() {
         runActivityScenario(
-            viewState = createSelectPaymentMethodViewState(
-                isGooglePayEnabled = true
-            ),
+            paymentMethods = listOf(),
+            isGooglePayAvailable = true,
         ) {
             page.waitForText("google pay")
         }
@@ -161,13 +143,8 @@ internal class CustomerSheetActivityTest {
     @Test
     fun `When payment selection is different from original, primary button is visible`() {
         runActivityScenario(
-            viewState = createSelectPaymentMethodViewState(
-                isGooglePayEnabled = true,
-                paymentSelection = null,
-                primaryButtonVisible = false,
-                savedPaymentMethods = listOf(
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                ),
+            paymentMethods = listOf(
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             ),
         ) {
             page.clickPaymentOptionItem("Google Pay")
@@ -178,7 +155,8 @@ internal class CustomerSheetActivityTest {
     @Test
     fun `When adding a payment method, title and primary button label is for adding payment method`() {
         runActivityScenario(
-            viewState = createAddPaymentMethodViewState(),
+            paymentMethods = listOf(),
+            isGooglePayAvailable = false,
         ) {
             page.waitForText("Save a new payment method")
             page.waitForTextExactly("Save")
@@ -188,13 +166,9 @@ internal class CustomerSheetActivityTest {
     @Test
     fun `When payment method available, edit mode is available`() {
         runActivityScenario(
-            viewState = createSelectPaymentMethodViewState(
-                isGooglePayEnabled = true,
-                isEditing = false,
-                savedPaymentMethods = List(3) {
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD
-                }
-            ),
+            paymentMethods = List(3) {
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD
+            },
         ) {
             page.waitForText("edit")
         }
@@ -203,14 +177,11 @@ internal class CustomerSheetActivityTest {
     @Test
     fun `When edit is pressed, payment methods enters edit mode`() {
         runActivityScenario(
-            viewState = createSelectPaymentMethodViewState(
-                isGooglePayEnabled = true,
-                isEditing = true,
-                savedPaymentMethods = List(3) {
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD
-                }
-            ),
+            paymentMethods = List(3) {
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD
+            },
         ) {
+            page.clickOnText("edit")
             page.waitForText("done")
         }
     }
@@ -220,7 +191,8 @@ internal class CustomerSheetActivityTest {
         val eventReporter: CustomerSheetEventReporter = mock()
 
         runActivityScenario(
-            viewState = createAddPaymentMethodViewState(),
+            paymentMethods = listOf(),
+            isGooglePayAvailable = false,
             eventReporter = eventReporter,
         ) {
             page.waitForText("Card number")
@@ -232,7 +204,8 @@ internal class CustomerSheetActivityTest {
         val eventReporter: CustomerSheetEventReporter = mock()
 
         runActivityScenario(
-            viewState = createAddPaymentMethodViewState(),
+            paymentMethods = listOf(),
+            isGooglePayAvailable = false,
             eventReporter = eventReporter,
         ) {
             page.waitForText("Card number")
@@ -243,16 +216,16 @@ internal class CustomerSheetActivityTest {
     }
 
     private fun activityScenario(
-        viewState: CustomerSheetViewState,
+        paymentMethods: List<PaymentMethod>,
+        isGooglePayAvailable: Boolean = true,
         savedPaymentSelection: PaymentSelection?,
         eventReporter: CustomerSheetEventReporter = mock(),
     ): InjectableActivityScenario<CustomerSheetActivity> {
         val viewModel = createViewModel(
-            initialBackStack = Stack<CustomerSheetViewState>().apply {
-                push(viewState)
-            },
             savedPaymentSelection = savedPaymentSelection,
-            eventReporter = eventReporter
+            eventReporter = eventReporter,
+            customerPaymentMethods = paymentMethods,
+            isGooglePayAvailable = isGooglePayAvailable,
         )
 
         return injectableActivityScenario {
@@ -263,15 +236,15 @@ internal class CustomerSheetActivityTest {
     }
 
     private fun runActivityScenario(
-        viewState: CustomerSheetViewState = CustomerSheetViewState.Loading(
-            isLiveMode = false,
-        ),
+        paymentMethods: List<PaymentMethod> = listOf(),
+        isGooglePayAvailable: Boolean = true,
         savedPaymentSelection: PaymentSelection? = null,
         eventReporter: CustomerSheetEventReporter = mock(),
         testBlock: CustomerSheetTestData.() -> Unit,
     ) {
         activityScenario(
-            viewState = viewState,
+            paymentMethods = paymentMethods,
+            isGooglePayAvailable = isGooglePayAvailable,
             savedPaymentSelection = savedPaymentSelection,
             eventReporter = eventReporter,
         )
@@ -288,69 +261,6 @@ internal class CustomerSheetActivityTest {
                     }
                 }
             }
-    }
-
-    private fun createSelectPaymentMethodViewState(
-        title: String? = null,
-        savedPaymentMethods: List<PaymentMethod> = listOf(),
-        paymentSelection: PaymentSelection? = null,
-        isLiveMode: Boolean = false,
-        isProcessing: Boolean = false,
-        isEditing: Boolean = false,
-        isGooglePayEnabled: Boolean = false,
-        primaryButtonVisible: Boolean = true,
-        primaryButtonLabel: String? = null,
-    ): CustomerSheetViewState.SelectPaymentMethod {
-        return CustomerSheetViewState.SelectPaymentMethod(
-            title = title,
-            savedPaymentMethods = savedPaymentMethods,
-            paymentSelection = paymentSelection,
-            isLiveMode = isLiveMode,
-            isProcessing = isProcessing,
-            isEditing = isEditing,
-            isGooglePayEnabled = isGooglePayEnabled,
-            primaryButtonVisible = primaryButtonVisible,
-            primaryButtonLabel = primaryButtonLabel,
-            cbcEligibility = CardBrandChoiceEligibility.Ineligible,
-            allowsRemovalOfLastSavedPaymentMethod = true,
-            canRemovePaymentMethods = true,
-        )
-    }
-
-    private fun createAddPaymentMethodViewState(
-        paymentMethodCode: PaymentMethodCode = PaymentMethod.Type.Card.code,
-        isLiveMode: Boolean = false,
-        enabled: Boolean = true,
-        isProcessing: Boolean = false,
-    ): CustomerSheetViewState.AddPaymentMethod {
-        val card = LpmRepositoryTestHelpers.card
-        val cardFormElements = PaymentMethodMetadataFactory.create().formElementsForCode(
-            code = "card",
-            uiDefinitionFactoryArgumentsFactory = TestUiDefinitionFactoryArgumentsFactory.create()
-        )!!
-        return CustomerSheetViewState.AddPaymentMethod(
-            paymentMethodCode = paymentMethodCode,
-            supportedPaymentMethods = listOf(card),
-            formFieldValues = null,
-            formElements = cardFormElements,
-            formArguments = FormArguments(
-                paymentMethodCode = PaymentMethod.Type.Card.code,
-                cbcEligibility = CardBrandChoiceEligibility.Ineligible,
-                merchantName = ""
-            ),
-            usBankAccountFormArguments = mock(),
-            enabled = enabled,
-            isLiveMode = isLiveMode,
-            isProcessing = isProcessing,
-            isFirstPaymentMethod = false,
-            primaryButtonLabel = "Save".resolvableString,
-            primaryButtonEnabled = false,
-            customPrimaryButtonUiState = null,
-            bankAccountResult = null,
-            draftPaymentSelection = null,
-            cbcEligibility = CardBrandChoiceEligibility.Ineligible,
-            errorReporter = FakeErrorReporter(),
-        )
     }
 
     private class CustomerSheetTestDataImpl(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetPage.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetPage.kt
@@ -11,6 +11,12 @@ import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_METHOD_CARD_TEST_TAG
 internal class CustomerSheetPage(
     private val composeTestRule: ComposeTestRule,
 ) {
+    fun clickOnText(text: String) {
+        waitForText(text)
+
+        composeTestRule.onNode(hasText(text, ignoreCase = true)).performClick()
+    }
+
     fun clickPaymentOptionItem(text: String) {
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
             composeTestRule


### PR DESCRIPTION
# Summary
Remove initial back stack parameter from `CustomerSheetViewModel`

# Motivation
`backStack` isn't used for a production code purpose and seems to only serve unit tests in an attempt to mimic `CustomerSheet` scenarios without invoking other actions to end up in the scenario.

While our classes should be unit testable, I don't think we should be writing code to make tests easier within production code unless there is no other alternative.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
