### PR TITLE
Refactor DefaultFlowController to use CvcRecollectionHandler.requiresCVCRecollection

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -371,7 +371,6 @@ internal class DefaultFlowController @Inject internal constructor(
                     appearance = getPaymentAppearance(),
                     isLiveMode = state.stripeIntent.isLiveMode
                 )
-
             }
         } else {
             confirmPaymentSelection(paymentSelection, state)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -67,6 +67,7 @@ import com.stripe.android.paymentsheet.addresselement.AddressElementActivityCont
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
+import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandlerImpl
 import com.stripe.android.paymentsheet.model.PaymentOptionFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
@@ -2349,6 +2350,7 @@ internal class DefaultFlowControllerTest {
         initializedViaCompose = false,
         workContext = testScope.coroutineContext,
         logger = FakeUserFacingLogger(),
+        cvcRecollectionHandler = CvcRecollectionHandlerImpl()
     )
 
     private fun createViewModel(): FlowControllerViewModel {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Refactor DefaultFlowController to use CvcRecollectionHandler.requiresCVCRecollection

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Align `DefaultFlowController` and `PaymentSheetViewModel` CVC recollection required logic
[MOBILESDK-2459](https://jira.corp.stripe.com/browse/MOBILESDK-2459)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [X] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
