### PR TITLE
Move intent confirmation logic into `IntentConfirmationDefinition`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationDefinition.kt
@@ -1,0 +1,143 @@
+package com.stripe.android.paymentsheet
+
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
+import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.ConfirmSetupIntentParams
+import com.stripe.android.model.ConfirmStripeIntentParams
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
+import com.stripe.android.payments.paymentlauncher.PaymentLauncher
+import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
+
+internal class IntentConfirmationDefinition(
+    private val intentConfirmationInterceptor: IntentConfirmationInterceptor,
+    private val paymentLauncherFactory: (ActivityResultLauncher<PaymentLauncherContract.Args>) -> PaymentLauncher,
+) : PaymentConfirmationDefinition<
+    PaymentConfirmationOption.PaymentMethod,
+    PaymentLauncher,
+    IntentConfirmationDefinition.Args,
+    InternalPaymentResult
+    > {
+    override suspend fun action(
+        confirmationOption: PaymentConfirmationOption.PaymentMethod,
+        intent: StripeIntent
+    ): PaymentConfirmationDefinition.ConfirmationAction<Args> {
+        val nextStep = intentConfirmationInterceptor.intercept(confirmationOption = confirmationOption)
+
+        val deferredIntentConfirmationType = nextStep.deferredIntentConfirmationType
+
+        return when (nextStep) {
+            is IntentConfirmationInterceptor.NextStep.HandleNextAction -> {
+                PaymentConfirmationDefinition.ConfirmationAction.Launch(
+                    launcherArguments = Args.NextAction(nextStep.clientSecret),
+                    deferredIntentConfirmationType = deferredIntentConfirmationType,
+                )
+            }
+            is IntentConfirmationInterceptor.NextStep.Confirm -> {
+                PaymentConfirmationDefinition.ConfirmationAction.Launch(
+                    launcherArguments = Args.Confirm(nextStep.confirmParams),
+                    deferredIntentConfirmationType = deferredIntentConfirmationType,
+                )
+            }
+            is IntentConfirmationInterceptor.NextStep.Fail -> {
+                PaymentConfirmationDefinition.ConfirmationAction.Fail(
+                    cause = nextStep.cause,
+                    message = nextStep.message,
+                    errorType = PaymentConfirmationErrorType.Internal,
+                )
+            }
+            is IntentConfirmationInterceptor.NextStep.Complete -> {
+                PaymentConfirmationDefinition.ConfirmationAction.Complete(
+                    intent = intent,
+                    confirmationOption = confirmationOption,
+                    deferredIntentConfirmationType = deferredIntentConfirmationType,
+                )
+            }
+        }
+    }
+
+    override fun createLauncher(
+        activityResultCaller: ActivityResultCaller,
+        onResult: (InternalPaymentResult) -> Unit
+    ): PaymentLauncher {
+        return paymentLauncherFactory(
+            activityResultCaller.registerForActivityResult(
+                PaymentLauncherContract(),
+                onResult
+            )
+        )
+    }
+
+    override fun launch(
+        launcher: PaymentLauncher,
+        arguments: Args,
+        confirmationOption: PaymentConfirmationOption.PaymentMethod,
+        intent: StripeIntent,
+    ) {
+        when (arguments) {
+            is Args.Confirm -> launchConfirm(launcher, arguments.confirmNextParams)
+            is Args.NextAction -> launchNextAction(launcher, arguments.clientSecret, intent)
+        }
+    }
+
+    override fun toPaymentConfirmationResult(
+        confirmationOption: PaymentConfirmationOption.PaymentMethod,
+        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        intent: StripeIntent,
+        result: InternalPaymentResult
+    ): PaymentConfirmationResult {
+        return when (result) {
+            is InternalPaymentResult.Completed -> PaymentConfirmationResult.Succeeded(
+                intent = result.intent,
+                deferredIntentConfirmationType = deferredIntentConfirmationType,
+            )
+            is InternalPaymentResult.Failed -> PaymentConfirmationResult.Failed(
+                cause = result.throwable,
+                message = result.throwable.stripeErrorMessage(),
+                type = PaymentConfirmationErrorType.Payment,
+            )
+            is InternalPaymentResult.Canceled -> PaymentConfirmationResult.Canceled(
+                action = PaymentCancellationAction.InformCancellation
+            )
+        }
+    }
+
+    private fun launchNextAction(
+        launcher: PaymentLauncher,
+        clientSecret: String,
+        intent: StripeIntent,
+    ) {
+        when (intent) {
+            is PaymentIntent -> {
+                launcher.handleNextActionForPaymentIntent(clientSecret)
+            }
+            is SetupIntent -> {
+                launcher.handleNextActionForSetupIntent(clientSecret)
+            }
+        }
+    }
+
+    private fun launchConfirm(
+        launcher: PaymentLauncher,
+        confirmStripeIntentParams: ConfirmStripeIntentParams
+    ) {
+        when (confirmStripeIntentParams) {
+            is ConfirmPaymentIntentParams -> {
+                launcher.confirm(confirmStripeIntentParams)
+            }
+            is ConfirmSetupIntentParams -> {
+                launcher.confirm(confirmStripeIntentParams)
+            }
+        }
+    }
+
+    sealed interface Args {
+        data class NextAction(val clientSecret: String) : Args
+
+        data class Confirm(val confirmNextParams: ConfirmStripeIntentParams) : Args
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationHandler.kt
@@ -17,9 +17,6 @@ import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
-import com.stripe.android.model.ConfirmPaymentIntentParams
-import com.stripe.android.model.ConfirmSetupIntentParams
-import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
@@ -61,6 +58,11 @@ internal class IntentConfirmationHandler(
     private val errorReporter: ErrorReporter,
     private val logger: UserFacingLogger?,
 ) {
+    private val intentConfirmationDefinition = IntentConfirmationDefinition(
+        intentConfirmationInterceptor,
+        paymentLauncherFactory
+    )
+
     private var paymentLauncher: PaymentLauncher? = null
     private var externalPaymentMethodLauncher: ActivityResultLauncher<ExternalPaymentMethodInput>? = null
     private var bacsMandateConfirmationLauncher: BacsMandateConfirmationLauncher? = null
@@ -121,11 +123,9 @@ internal class IntentConfirmationHandler(
      * @param lifecycleOwner a class tied to an Android [Lifecycle]
      */
     fun register(activityResultCaller: ActivityResultCaller, lifecycleOwner: LifecycleOwner) {
-        paymentLauncher = paymentLauncherFactory(
-            activityResultCaller.registerForActivityResult(
-                PaymentLauncherContract(),
-                ::onPaymentResult
-            )
+        paymentLauncher = intentConfirmationDefinition.createLauncher(
+            activityResultCaller,
+            ::onPaymentResult
         )
 
         externalPaymentMethodLauncher = activityResultCaller.registerForActivityResult(
@@ -226,6 +226,8 @@ internal class IntentConfirmationHandler(
     private suspend fun confirm(
         arguments: Args
     ) {
+        currentArguments = arguments
+
         _state.value = State.Confirming
 
         val confirmationOption = arguments.confirmationOption
@@ -262,75 +264,35 @@ internal class IntentConfirmationHandler(
         paymentMethod: PaymentConfirmationOption.PaymentMethod,
         intent: StripeIntent,
     ) {
-        val nextStep = intentConfirmationInterceptor.intercept(confirmationOption = paymentMethod)
+        when (val action = intentConfirmationDefinition.action(paymentMethod, intent)) {
+            is PaymentConfirmationDefinition.ConfirmationAction.Launch -> withPaymentLauncher { launcher ->
+                deferredIntentConfirmationType = action.deferredIntentConfirmationType
 
-        deferredIntentConfirmationType = nextStep.deferredIntentConfirmationType
+                storeIsAwaitingForPaymentResult()
 
-        when (nextStep) {
-            is IntentConfirmationInterceptor.NextStep.HandleNextAction -> {
-                handleNextAction(
-                    clientSecret = nextStep.clientSecret,
-                    stripeIntent = intent,
+                intentConfirmationDefinition.launch(
+                    launcher = launcher,
+                    arguments = action.launcherArguments,
+                    confirmationOption = paymentMethod,
+                    intent = intent,
                 )
             }
-            is IntentConfirmationInterceptor.NextStep.Confirm -> {
-                confirmStripeIntent(nextStep.confirmParams)
-            }
-            is IntentConfirmationInterceptor.NextStep.Fail -> {
+            is PaymentConfirmationDefinition.ConfirmationAction.Fail -> {
                 onIntentResult(
                     PaymentConfirmationResult.Failed(
-                        cause = nextStep.cause,
-                        message = nextStep.message,
+                        cause = action.cause,
+                        message = action.message,
                         type = PaymentConfirmationErrorType.Payment,
                     )
                 )
             }
-            is IntentConfirmationInterceptor.NextStep.Complete -> {
+            is PaymentConfirmationDefinition.ConfirmationAction.Complete -> {
                 onIntentResult(
                     PaymentConfirmationResult.Succeeded(
                         intent = intent,
-                        deferredIntentConfirmationType = nextStep.deferredIntentConfirmationType,
+                        deferredIntentConfirmationType = action.deferredIntentConfirmationType,
                     )
                 )
-            }
-        }
-    }
-
-    private fun handleNextAction(
-        clientSecret: String,
-        stripeIntent: StripeIntent,
-    ) = withPaymentLauncher { launcher ->
-        /*
-         * In case of process death, we should store that we waiting for a payment result to return from a
-         * payment confirmation activity
-         */
-        storeIsAwaitingForPaymentResult()
-
-        when (stripeIntent) {
-            is PaymentIntent -> {
-                launcher.handleNextActionForPaymentIntent(clientSecret)
-            }
-            is SetupIntent -> {
-                launcher.handleNextActionForSetupIntent(clientSecret)
-            }
-        }
-    }
-
-    private fun confirmStripeIntent(
-        confirmStripeIntentParams: ConfirmStripeIntentParams
-    ) = withPaymentLauncher { launcher ->
-        /*
-         * In case of process death, we should store that we waiting for a payment result to return from a
-         * payment confirmation activity
-         */
-        storeIsAwaitingForPaymentResult()
-
-        when (confirmStripeIntentParams) {
-            is ConfirmPaymentIntentParams -> {
-                launcher.confirm(confirmStripeIntentParams)
-            }
-            is ConfirmSetupIntentParams -> {
-                launcher.confirm(confirmStripeIntentParams)
             }
         }
     }
@@ -492,18 +454,25 @@ internal class IntentConfirmationHandler(
     }
 
     private fun onPaymentResult(result: InternalPaymentResult) {
-        val intentResult = when (result) {
-            is InternalPaymentResult.Completed -> PaymentConfirmationResult.Succeeded(
-                intent = result.intent,
-                deferredIntentConfirmationType = deferredIntentConfirmationType
+        val intentResult = runCatching {
+            val arguments = currentArguments ?: throw IllegalStateException(
+                "Arguments should have been initialized before handling payment result!"
             )
-            is InternalPaymentResult.Failed -> PaymentConfirmationResult.Failed(
-                cause = result.throwable,
-                message = result.throwable.stripeErrorMessage(),
-                type = PaymentConfirmationErrorType.Payment,
+
+            val intentConfirmationOption = arguments.confirmationOption as? PaymentConfirmationOption.PaymentMethod
+                ?: throw IllegalStateException("Cannot confirm intent with non payment method confirmation option")
+
+            intentConfirmationDefinition.toPaymentConfirmationResult(
+                confirmationOption = intentConfirmationOption,
+                intent = arguments.intent,
+                result = result,
+                deferredIntentConfirmationType = deferredIntentConfirmationType,
             )
-            is InternalPaymentResult.Canceled -> PaymentConfirmationResult.Canceled(
-                action = PaymentCancellationAction.InformCancellation
+        }.getOrElse { cause ->
+            PaymentConfirmationResult.Failed(
+                cause = cause,
+                message = cause.stripeErrorMessage(),
+                type = PaymentConfirmationErrorType.ExternalPaymentMethod,
             )
         }
 
@@ -552,7 +521,7 @@ internal class IntentConfirmationHandler(
             when (result) {
                 is PaymentResult.Completed -> PaymentConfirmationResult.Succeeded(
                     intent = arguments.intent,
-                    deferredIntentConfirmationType = null
+                    deferredIntentConfirmationType = null,
                 )
                 is PaymentResult.Failed -> PaymentConfirmationResult.Failed(
                     cause = result.throwable,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationHandler.kt
@@ -472,7 +472,7 @@ internal class IntentConfirmationHandler(
             PaymentConfirmationResult.Failed(
                 cause = cause,
                 message = cause.stripeErrorMessage(),
-                type = PaymentConfirmationErrorType.ExternalPaymentMethod,
+                type = PaymentConfirmationErrorType.Internal,
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationDefinition.kt
@@ -1,0 +1,56 @@
+package com.stripe.android.paymentsheet
+
+import android.os.Parcelable
+import androidx.activity.result.ActivityResultCaller
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.model.StripeIntent
+
+internal interface PaymentConfirmationDefinition<
+    TConfirmationOption : PaymentConfirmationOption,
+    TLauncher,
+    TLauncherArgs,
+    TLauncherResult : Parcelable
+    > {
+    suspend fun action(
+        confirmationOption: TConfirmationOption,
+        intent: StripeIntent,
+    ): ConfirmationAction<TLauncherArgs>
+
+    fun launch(
+        launcher: TLauncher,
+        arguments: TLauncherArgs,
+        confirmationOption: TConfirmationOption,
+        intent: StripeIntent,
+    )
+
+    fun createLauncher(
+        activityResultCaller: ActivityResultCaller,
+        onResult: (TLauncherResult) -> Unit,
+    ): TLauncher
+
+    fun toPaymentConfirmationResult(
+        confirmationOption: TConfirmationOption,
+        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        intent: StripeIntent,
+        result: TLauncherResult,
+    ): PaymentConfirmationResult
+
+    sealed interface ConfirmationAction<TLauncherArgs> {
+        data class Complete<TLauncherArgs>(
+            val intent: StripeIntent,
+            val confirmationOption: PaymentConfirmationOption,
+            val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        ) : ConfirmationAction<TLauncherArgs>
+
+        data class Fail<TLauncherArgs>(
+            val cause: Throwable,
+            val message: ResolvableString,
+            val errorType: PaymentConfirmationErrorType,
+        ) : ConfirmationAction<TLauncherArgs>
+
+        data class Launch<TLauncherArgs>(
+            val launcherArguments: TLauncherArgs,
+            val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        ) : ConfirmationAction<TLauncherArgs>
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeStripeRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeStripeRepository.kt
@@ -4,11 +4,13 @@ import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.StripeIntent
 import com.stripe.android.testing.AbsFakeStripeRepository
 
 class FakeStripeRepository(
     private val createPaymentMethodResult: Result<PaymentMethod> = Result.failure(NotImplementedError()),
-    private val retrieveSetupIntent: Result<SetupIntent> = Result.failure(NotImplementedError())
+    private val retrieveSetupIntent: Result<SetupIntent> = Result.failure(NotImplementedError()),
+    private val retrieveIntent: Result<StripeIntent> = Result.failure(NotImplementedError()),
 ) : AbsFakeStripeRepository() {
 
     override suspend fun createPaymentMethod(
@@ -24,5 +26,13 @@ class FakeStripeRepository(
         expandFields: List<String>
     ): Result<SetupIntent> {
         return retrieveSetupIntent
+    }
+
+    override suspend fun retrieveStripeIntent(
+        clientSecret: String,
+        options: ApiRequest.Options,
+        expandFields: List<String>
+    ): Result<StripeIntent> {
+        return retrieveIntent
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationDefinitionTest.kt
@@ -1,0 +1,406 @@
+package com.stripe.android.paymentsheet
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.ConfirmSetupIntentParams
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParamsFixtures
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.PaymentMethodOptionsParams
+import com.stripe.android.model.SetupIntentFixtures
+import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
+import com.stripe.android.payments.paymentlauncher.PaymentLauncher
+import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
+import com.stripe.android.testing.FakePaymentLauncher
+import com.stripe.android.utils.FakeIntentConfirmationInterceptor
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+class IntentConfirmationDefinitionTest {
+    @Test
+    fun `'createLauncher' should call factory when creating launcher`() {
+        val launcher = FakePaymentLauncher()
+
+        val definition = createIntentConfirmationDefinition(
+            paymentLauncher = launcher,
+        )
+
+        val createdLauncher = definition.createLauncher(
+            activityResultCaller = mock {
+                on {
+                    registerForActivityResult<PaymentLauncherContract.Args, InternalPaymentResult>(any(), any())
+                } doReturn mock()
+            },
+            onResult = {}
+        )
+
+        assertThat(createdLauncher).isEqualTo(launcher)
+    }
+
+    @Test
+    fun `On 'action' with new payment method, should call 'IntentConfirmationInterceptor' with expected params`() =
+        runTest {
+            val intentConfirmationInterceptor = FakeIntentConfirmationInterceptor().apply {
+                enqueueCompleteStep()
+            }
+
+            val definition = createIntentConfirmationDefinition(
+                intentConfirmationInterceptor = intentConfirmationInterceptor,
+            )
+
+            definition.action(
+                confirmationOption = PaymentConfirmationOption.PaymentMethod.New(
+                    initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                        clientSecret = "pi_123"
+                    ),
+                    createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                    optionsParams = null,
+                    shippingDetails = AddressDetails(name = "John Doe"),
+                    shouldSave = true,
+                ),
+                intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            )
+
+            assertThat(intentConfirmationInterceptor.calls.awaitItem()).isEqualTo(
+                FakeIntentConfirmationInterceptor.InterceptCall.WithNewPaymentMethod(
+                    initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                        clientSecret = "pi_123"
+                    ),
+                    paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                    paymentMethodOptionsParams = null,
+                    shippingValues = AddressDetails(name = "John Doe").toConfirmPaymentIntentShipping(),
+                    customerRequestedSave = true,
+                )
+            )
+        }
+
+    @Test
+    fun `On 'action' with saved payment method, should call 'IntentConfirmationInterceptor' with expected params`() =
+        runTest {
+            val intentConfirmationInterceptor = FakeIntentConfirmationInterceptor().apply {
+                enqueueCompleteStep()
+            }
+
+            val definition = createIntentConfirmationDefinition(
+                intentConfirmationInterceptor = intentConfirmationInterceptor,
+            )
+
+            definition.action(
+                confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+                intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            )
+
+            assertThat(intentConfirmationInterceptor.calls.awaitItem()).isEqualTo(
+                FakeIntentConfirmationInterceptor.InterceptCall.WithExistingPaymentMethod(
+                    initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                        clientSecret = "pi_123"
+                    ),
+                    paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                    paymentMethodOptionsParams = PaymentMethodOptionsParams.Card(
+                        cvc = "505",
+                    ),
+                    shippingValues = AddressDetails(name = "John Doe").toConfirmPaymentIntentShipping(),
+                )
+            )
+        }
+
+    @Test
+    fun `On 'IntentConfirmationInterceptor' complete, should return 'Complete' confirmation action`() = runTest {
+        val intentConfirmationInterceptor = FakeIntentConfirmationInterceptor().apply {
+            enqueueCompleteStep()
+        }
+
+        val definition = createIntentConfirmationDefinition(
+            intentConfirmationInterceptor = intentConfirmationInterceptor,
+        )
+
+        val action = definition.action(
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+        )
+
+        assertThat(action).isEqualTo(
+            PaymentConfirmationDefinition.ConfirmationAction.Complete<IntentConfirmationDefinition.Args>(
+                intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+                confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+                deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+            )
+        )
+    }
+
+    @Test
+    fun `On 'IntentConfirmationInterceptor' failure, should return 'Fail' confirmation action`() = runTest {
+        val message = "Failed!"
+        val cause = IllegalStateException("Failed with exception!")
+
+        val intentConfirmationInterceptor = FakeIntentConfirmationInterceptor().apply {
+            enqueueFailureStep(
+                cause = cause,
+                message = message
+            )
+        }
+
+        val definition = createIntentConfirmationDefinition(
+            intentConfirmationInterceptor = intentConfirmationInterceptor,
+        )
+
+        val action = definition.action(
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+        )
+
+        assertThat(action).isEqualTo(
+            PaymentConfirmationDefinition.ConfirmationAction.Fail<IntentConfirmationDefinition.Args>(
+                cause = cause,
+                message = message.resolvableString,
+                errorType = PaymentConfirmationErrorType.Internal,
+            )
+        )
+    }
+
+    @Test
+    fun `On 'IntentConfirmationInterceptor' next step, should return 'Launch' confirmation action`() = runTest {
+        val intentConfirmationInterceptor = FakeIntentConfirmationInterceptor().apply {
+            enqueueNextActionStep(clientSecret = "pi_123")
+        }
+
+        val definition = createIntentConfirmationDefinition(
+            intentConfirmationInterceptor = intentConfirmationInterceptor,
+        )
+
+        val action = definition.action(
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+        )
+
+        assertThat(action).isEqualTo(
+            PaymentConfirmationDefinition.ConfirmationAction.Launch<IntentConfirmationDefinition.Args>(
+                launcherArguments = IntentConfirmationDefinition.Args.NextAction(
+                    clientSecret = "pi_123"
+                ),
+                deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+            )
+        )
+    }
+
+    @Test
+    fun `On 'IntentConfirmationInterceptor' confirm, should return 'Launch' confirmation action`() = runTest {
+        val confirmParams = ConfirmSetupIntentParams.create(
+            clientSecret = "pi_1234",
+            paymentMethodType = PaymentMethod.Type.Card
+        )
+
+        val intentConfirmationInterceptor = FakeIntentConfirmationInterceptor().apply {
+            enqueueConfirmStep(confirmParams = confirmParams)
+        }
+
+        val definition = createIntentConfirmationDefinition(
+            intentConfirmationInterceptor = intentConfirmationInterceptor,
+        )
+
+        val action = definition.action(
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+            intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+        )
+
+        assertThat(action).isEqualTo(
+            PaymentConfirmationDefinition.ConfirmationAction.Launch<IntentConfirmationDefinition.Args>(
+                launcherArguments = IntentConfirmationDefinition.Args.Confirm(
+                    confirmNextParams = confirmParams,
+                ),
+                deferredIntentConfirmationType = null,
+            )
+        )
+    }
+
+    @Test
+    fun `On launch with confirm action and 'SetupIntent' params, should launch with expected params`() = runTest {
+        val confirmParams = ConfirmSetupIntentParams.create(
+            clientSecret = "pi_1234",
+            paymentMethodType = PaymentMethod.Type.Card
+        )
+
+        val launcher = FakePaymentLauncher()
+
+        val definition = createIntentConfirmationDefinition(
+            paymentLauncher = launcher,
+        )
+
+        definition.launch(
+            launcher = launcher,
+            arguments = IntentConfirmationDefinition.Args.Confirm(confirmParams),
+            intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+        )
+
+        assertThat(launcher.calls.awaitItem()).isEqualTo(
+            FakePaymentLauncher.Call.Confirm.SetupIntent(confirmParams)
+        )
+    }
+
+    @Test
+    fun `On launch with next step action and 'SetupIntent', should launch with expected params`() = runTest {
+        val launcher = FakePaymentLauncher()
+
+        val definition = createIntentConfirmationDefinition(
+            paymentLauncher = launcher,
+        )
+
+        definition.launch(
+            launcher = launcher,
+            arguments = IntentConfirmationDefinition.Args.NextAction(clientSecret = "si_123"),
+            intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+        )
+
+        assertThat(launcher.calls.awaitItem()).isEqualTo(
+            FakePaymentLauncher.Call.HandleNextAction.SetupIntent(clientSecret = "si_123")
+        )
+    }
+
+    @Test
+    fun `On launch with confirm action and 'PaymentIntent' params, should launch with expected params`() = runTest {
+        val confirmParams = ConfirmPaymentIntentParams.create(
+            clientSecret = "pi_1234",
+            paymentMethodType = PaymentMethod.Type.Card
+        )
+
+        val launcher = FakePaymentLauncher()
+
+        val definition = createIntentConfirmationDefinition(
+            paymentLauncher = launcher,
+        )
+
+        definition.launch(
+            launcher = launcher,
+            arguments = IntentConfirmationDefinition.Args.Confirm(confirmParams),
+            intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+        )
+
+        assertThat(launcher.calls.awaitItem()).isEqualTo(
+            FakePaymentLauncher.Call.Confirm.PaymentIntent(confirmParams)
+        )
+    }
+
+    @Test
+    fun `On launch with next step action and 'PaymentIntent', should launch with expected params`() = runTest {
+        val launcher = FakePaymentLauncher()
+
+        val definition = createIntentConfirmationDefinition(
+            paymentLauncher = launcher,
+        )
+
+        definition.launch(
+            launcher = launcher,
+            arguments = IntentConfirmationDefinition.Args.NextAction(clientSecret = "pi_123"),
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+        )
+
+        assertThat(launcher.calls.awaitItem()).isEqualTo(
+            FakePaymentLauncher.Call.HandleNextAction.PaymentIntent(clientSecret = "pi_123")
+        )
+    }
+
+    @Test
+    fun `On 'Completed' payment result, should return successful confirmation result`() {
+        val launcher = FakePaymentLauncher()
+
+        val definition = createIntentConfirmationDefinition(
+            paymentLauncher = launcher,
+        )
+
+        val result = definition.toPaymentConfirmationResult(
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+            result = InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED),
+        )
+
+        assertThat(result).isEqualTo(
+            PaymentConfirmationResult.Succeeded(
+                intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+            ),
+        )
+    }
+
+    @Test
+    fun `On 'Failed' payment result, should return failed confirmation result`() {
+        val launcher = FakePaymentLauncher()
+
+        val definition = createIntentConfirmationDefinition(
+            paymentLauncher = launcher,
+        )
+
+        val exception = IllegalStateException("Failed!")
+
+        val result = definition.toPaymentConfirmationResult(
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            deferredIntentConfirmationType = null,
+            result = InternalPaymentResult.Failed(exception),
+        )
+
+        assertThat(result).isEqualTo(
+            PaymentConfirmationResult.Failed(
+                cause = exception,
+                message = R.string.stripe_something_went_wrong.resolvableString,
+                type = PaymentConfirmationErrorType.Payment,
+            ),
+        )
+    }
+
+    @Test
+    fun `On 'Canceled' payment result, should return canceled confirmation result`() {
+        val launcher = FakePaymentLauncher()
+
+        val definition = createIntentConfirmationDefinition(
+            paymentLauncher = launcher,
+        )
+
+        val result = definition.toPaymentConfirmationResult(
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            deferredIntentConfirmationType = null,
+            result = InternalPaymentResult.Canceled,
+        )
+
+        assertThat(result).isEqualTo(
+            PaymentConfirmationResult.Canceled(
+                action = PaymentCancellationAction.InformCancellation,
+            ),
+        )
+    }
+
+    private fun createIntentConfirmationDefinition(
+        intentConfirmationInterceptor: IntentConfirmationInterceptor = FakeIntentConfirmationInterceptor(),
+        paymentLauncher: PaymentLauncher = FakePaymentLauncher()
+    ): IntentConfirmationDefinition {
+        return IntentConfirmationDefinition(
+            intentConfirmationInterceptor = intentConfirmationInterceptor,
+            paymentLauncherFactory = { paymentLauncher }
+        )
+    }
+
+    private companion object {
+        private val SAVED_PAYMENT_CONFIRMATION_OPTION = PaymentConfirmationOption.PaymentMethod.Saved(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123"
+            ),
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            optionsParams = PaymentMethodOptionsParams.Card(
+                cvc = "505",
+            ),
+            shippingDetails = AddressDetails(name = "John Doe"),
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationFlowTest.kt
@@ -1,0 +1,272 @@
+package com.stripe.android.paymentsheet
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.customersheet.FakeStripeRepository
+import com.stripe.android.model.Address
+import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.ConfirmSetupIntentParams
+import com.stripe.android.model.ConfirmStripeIntentParams
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParamsFixtures
+import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
+import com.stripe.android.model.SetupIntentFixtures
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.testing.FakePaymentLauncher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+internal class IntentConfirmationFlowTest {
+    @Test
+    fun `On payment intent, action should be to confirm intent`() = runTest {
+        val intentConfirmationDefinition = createIntentConfirmationDefinition()
+
+        val action = intentConfirmationDefinition.action(
+            confirmationOption = PaymentConfirmationOption.PaymentMethod.New(
+                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                    clientSecret = "pi_123_secret_123",
+                ),
+                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                optionsParams = null,
+                shouldSave = false,
+                shippingDetails = AddressDetails(
+                    name = "John Doe",
+                    phoneNumber = "1234567890"
+                ),
+            ),
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+        )
+
+        val launchAction = action.asLaunch()
+
+        assertThat(launchAction.launcherArguments).isEqualTo(
+            IntentConfirmationDefinition.Args.Confirm(
+                confirmNextParams = ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
+                    paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                    clientSecret = "pi_123_secret_123",
+                    shipping = ConfirmPaymentIntentParams.Shipping(
+                        name = "John Doe",
+                        phone = "1234567890",
+                        address = Address(),
+                    ),
+                    savePaymentMethod = null,
+                    setupFutureUsage = null,
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `On setup intent, action should be to confirm intent`() = runTest {
+        val intentConfirmationDefinition = createIntentConfirmationDefinition()
+
+        val action = intentConfirmationDefinition.action(
+            confirmationOption = PaymentConfirmationOption.PaymentMethod.New(
+                initializationMode = PaymentSheet.InitializationMode.SetupIntent(
+                    clientSecret = "pi_123_secret_123",
+                ),
+                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                optionsParams = null,
+                shouldSave = false,
+                shippingDetails = AddressDetails(
+                    name = "John Doe",
+                    phoneNumber = "1234567890"
+                ),
+            ),
+            intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+        )
+
+        val launchAction = action.asLaunch()
+
+        assertThat(launchAction.launcherArguments).isEqualTo(
+            IntentConfirmationDefinition.Args.Confirm(
+                confirmNextParams = ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
+                    paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                    clientSecret = "pi_123_secret_123",
+                    shipping = ConfirmPaymentIntentParams.Shipping(
+                        name = "John Doe",
+                        phone = "1234567890",
+                        address = Address(),
+                    ),
+                    savePaymentMethod = null,
+                    setupFutureUsage = null,
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `On deferred intent, action should be complete if completing without confirming`() = runTest {
+        val intentConfirmationDefinition = createIntentConfirmationDefinition()
+
+        IntentConfirmationInterceptor.createIntentCallback = CreateIntentCallback { _, _ ->
+            CreateIntentResult.Success(
+                clientSecret = "COMPLETE_WITHOUT_CONFIRMING_INTENT"
+            )
+        }
+
+        val confirmationOption = createDeferredConfirmationOption()
+
+        val action = intentConfirmationDefinition.action(
+            confirmationOption = confirmationOption,
+            intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+        )
+
+        val completeAction = action.asComplete()
+
+        assertThat(completeAction.intent).isEqualTo(SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD)
+        assertThat(completeAction.confirmationOption).isEqualTo(confirmationOption)
+        assertThat(completeAction.deferredIntentConfirmationType)
+            .isEqualTo(DeferredIntentConfirmationType.None)
+    }
+
+    @Test
+    fun `On deferred intent, action should be confirm if completing intent`() = runTest {
+        val intentConfirmationDefinition = createIntentConfirmationDefinition()
+
+        IntentConfirmationInterceptor.createIntentCallback = CreateIntentCallback { _, _ ->
+            CreateIntentResult.Success(
+                clientSecret = "seti_123_secret_123"
+            )
+        }
+
+        val confirmationOption = createDeferredConfirmationOption()
+
+        val action = intentConfirmationDefinition.action(
+            confirmationOption = confirmationOption.copy(
+                shouldSave = true,
+            ),
+            intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+        )
+
+        val launchAction = action.asLaunch()
+        val confirmArguments = launchAction.launcherArguments.asConfirm()
+        val setupIntentParams = confirmArguments.confirmNextParams.asSetup()
+
+        assertThat(setupIntentParams.clientSecret).isEqualTo("seti_123_secret_123")
+        assertThat(launchAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
+    }
+
+    @Test
+    fun `On deferred intent, action should be fail if failed to create payment method`() = runTest {
+        val intentConfirmationDefinition = createIntentConfirmationDefinition(
+            createPaymentMethodResult = Result.failure(IllegalStateException("An error occurred!"))
+        )
+
+        IntentConfirmationInterceptor.createIntentCallback = CreateIntentCallback { _, _ ->
+            CreateIntentResult.Success(
+                clientSecret = "COMPLETE_WITHOUT_CONFIRMING_INTENT"
+            )
+        }
+
+        val confirmationOption = createDeferredConfirmationOption()
+
+        val action = intentConfirmationDefinition.action(
+            confirmationOption = confirmationOption,
+            intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+        )
+
+        val failAction = action.asFail()
+
+        assertThat(failAction.cause).isInstanceOf(IllegalStateException::class.java)
+        assertThat(failAction.cause.message).isEqualTo("An error occurred!")
+        assertThat(failAction.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
+        assertThat(failAction.errorType).isEqualTo(PaymentConfirmationErrorType.Internal)
+    }
+
+    @Test
+    fun `On deferred intent, action should be fail if failed to retrieve intent`() = runTest {
+        val intentConfirmationDefinition = createIntentConfirmationDefinition(
+            intentResult = Result.failure(IllegalStateException("An error occurred!"))
+        )
+
+        IntentConfirmationInterceptor.createIntentCallback = CreateIntentCallback { _, _ ->
+            CreateIntentResult.Success(
+                clientSecret = "si_123_secret_123"
+            )
+        }
+
+        val confirmationOption = createDeferredConfirmationOption()
+
+        val action = intentConfirmationDefinition.action(
+            confirmationOption = confirmationOption,
+            intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+        )
+
+        val failAction = action.asFail()
+
+        assertThat(failAction.cause).isInstanceOf(IllegalStateException::class.java)
+        assertThat(failAction.cause.message).isEqualTo("An error occurred!")
+        assertThat(failAction.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
+        assertThat(failAction.errorType).isEqualTo(PaymentConfirmationErrorType.Internal)
+    }
+
+    private fun createDeferredConfirmationOption(): PaymentConfirmationOption.PaymentMethod.New {
+        return PaymentConfirmationOption.PaymentMethod.New(
+            initializationMode = PaymentSheet.InitializationMode.DeferredIntent(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Setup(
+                        currency = "USD",
+                    )
+                )
+            ),
+            createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+            optionsParams = null,
+            shouldSave = false,
+            shippingDetails = AddressDetails(
+                name = "John Doe",
+                phoneNumber = "1234567890"
+            ),
+        )
+    }
+
+    private fun createIntentConfirmationDefinition(
+        createPaymentMethodResult: Result<PaymentMethod> = Result.success(CARD_PAYMENT_METHOD),
+        intentResult: Result<StripeIntent> =
+            Result.success(SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD),
+    ): IntentConfirmationDefinition {
+        return IntentConfirmationDefinition(
+            intentConfirmationInterceptor = DefaultIntentConfirmationInterceptor(
+                isFlowController = false,
+                publishableKeyProvider = {
+                    "pk_123"
+                },
+                stripeAccountIdProvider = {
+                    "acct_123"
+                },
+                stripeRepository = FakeStripeRepository(
+                    createPaymentMethodResult = createPaymentMethodResult,
+                    retrieveIntent = intentResult,
+                ),
+            ),
+            paymentLauncherFactory = {
+                FakePaymentLauncher()
+            }
+        )
+    }
+
+    private fun ConfirmStripeIntentParams.asSetup(): ConfirmSetupIntentParams {
+        return this as ConfirmSetupIntentParams
+    }
+
+    private fun IntentConfirmationDefinition.Args.asConfirm(): IntentConfirmationDefinition.Args.Confirm {
+        return this as IntentConfirmationDefinition.Args.Confirm
+    }
+
+    private fun <TLauncherArgs> PaymentConfirmationDefinition.ConfirmationAction<TLauncherArgs>.asFail():
+        PaymentConfirmationDefinition.ConfirmationAction.Fail<TLauncherArgs> {
+        return this as PaymentConfirmationDefinition.ConfirmationAction.Fail<TLauncherArgs>
+    }
+
+    private fun <TLauncherArgs> PaymentConfirmationDefinition.ConfirmationAction<TLauncherArgs>.asComplete():
+        PaymentConfirmationDefinition.ConfirmationAction.Complete<TLauncherArgs> {
+        return this as PaymentConfirmationDefinition.ConfirmationAction.Complete<TLauncherArgs>
+    }
+
+    private fun <TLauncherArgs> PaymentConfirmationDefinition.ConfirmationAction<TLauncherArgs>.asLaunch():
+        PaymentConfirmationDefinition.ConfirmationAction.Launch<TLauncherArgs> {
+        return this as PaymentConfirmationDefinition.ConfirmationAction.Launch<TLauncherArgs>
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
@@ -795,6 +795,30 @@ class IntentConfirmationHandlerTest {
     }
 
     @Test
+    fun `On init with 'SavedStateHandle' with incorrect option, error should be internal`() = runTest {
+        val savedStateHandle = SavedStateHandle().apply {
+            set("AwaitingPaymentResult", true)
+            set("IntentConfirmationArguments", DEFAULT_ARGUMENTS.copy(confirmationOption = EXTERNAL_PAYMENT_METHOD))
+        }
+
+        val intentConfirmationHandler = createIntentConfirmationHandler(
+            savedStateHandle = savedStateHandle,
+        )
+
+        val paymentResultCallbackHandler = FakeResultHandler<InternalPaymentResult>()
+
+        intentConfirmationHandler.registerWithCallbacks(
+            paymentResultCallbackHandler = paymentResultCallbackHandler
+        )
+
+        paymentResultCallbackHandler.onResult(InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED))
+
+        val failedResult = intentConfirmationHandler.awaitIntentResult().asFailed()
+
+        assertThat(failedResult.type).isEqualTo(PaymentConfirmationErrorType.Internal)
+    }
+
+    @Test
     fun `On init with 'SavedStateHandle', should receive result through 'awaitIntentResult'`() = runTest {
         val savedStateHandle = SavedStateHandle().apply {
             set("AwaitingPaymentResult", true)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
@@ -798,6 +798,7 @@ class IntentConfirmationHandlerTest {
     fun `On init with 'SavedStateHandle', should receive result through 'awaitIntentResult'`() = runTest {
         val savedStateHandle = SavedStateHandle().apply {
             set("AwaitingPaymentResult", true)
+            set("IntentConfirmationArguments", DEFAULT_ARGUMENTS)
         }
 
         val intentConfirmationHandler = createIntentConfirmationHandler(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -2802,7 +2802,20 @@ internal class PaymentSheetViewModelTest {
 
     private suspend fun testProcessDeathRestorationAfterPaymentSuccess(loadStateBeforePaymentResult: Boolean) {
         val stripeIntent = PaymentIntentFactory.create(status = StripeIntent.Status.Succeeded)
-        val savedStateHandle = SavedStateHandle(initialState = mapOf("AwaitingPaymentResult" to true))
+        val savedStateHandle = SavedStateHandle(
+            initialState = mapOf(
+                "AwaitingPaymentResult" to true,
+                "IntentConfirmationArguments" to IntentConfirmationHandler.Args(
+                    intent = PAYMENT_INTENT,
+                    confirmationOption = PaymentConfirmationOption.PaymentMethod.Saved(
+                        initializationMode = ARGS_CUSTOMER_WITH_GOOGLEPAY.initializationMode,
+                        paymentMethod = CARD_PAYMENT_METHOD,
+                        optionsParams = null,
+                        shippingDetails = null,
+                    )
+                )
+            )
+        )
         val paymentSheetLoader = RelayingPaymentSheetLoader()
 
         val viewModel = createViewModel(


### PR DESCRIPTION
# Summary
Move intent confirmation logic into `IntentConfirmationDefinition`

# Motivation
Move intent confirmation logic into `IntentConfirmationDefinition`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
