### PR TITLE
Update wallets divider text styling

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletsDivider.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletsDivider.kt
@@ -12,8 +12,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.stripe.android.uicore.shouldUseDarkDynamicColor
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.stripeShapes
@@ -30,9 +30,9 @@ internal fun WalletsDivider(text: String) {
 
         Text(
             text = text,
-            style = MaterialTheme.typography.body1,
+            style = MaterialTheme.typography.caption,
             color = MaterialTheme.stripeColors.subtitle,
-            fontSize = 12.sp,
+            fontWeight = FontWeight.Normal,
             modifier = Modifier.padding(horizontal = 8.dp),
         )
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update wallets divider text styling

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix issue found in bug bash: Wallets divider text doesn't change size when appearance API scale factor changes

https://jira.corp.stripe.com/browse/MOBILESDK-2475

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

We have screenshot tests that cover this, but I guess the default case looks exactly the same as before, because none of them updated!

WalletsDividerScreenshotTest didn't require any updates surprisingly -- these tests don't seem to capture our appearance API changes, but I am planning to fix that soon: https://jira.corp.stripe.com/browse/MOBILESDK-2474 

# Screenshots
Before:
![wallets divider - before](https://github.com/user-attachments/assets/e7fe5653-d92d-437a-8cb2-00fe9639812b)


After:
![wallets divider - after](https://github.com/user-attachments/assets/39cafe78-43e2-4c1f-bbd8-74c65fa31a21)


