### PR TITLE
Refresh payment methods after attaching in `CustomerSheet`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -96,6 +96,9 @@ interface ErrorReporter {
         CUSTOMER_SHEET_PAYMENT_METHODS_LOAD_FAILURE(
             eventName = "elements.customer_sheet.payment_methods.load_failure"
         ),
+        CUSTOMER_SHEET_PAYMENT_METHODS_REFRESH_FAILURE(
+            eventName = "elements.customer_sheet.payment_methods.refresh_failure"
+        ),
         CUSTOMER_SHEET_ADAPTER_NOT_FOUND(
             eventName = "elements.customer_sheet.customer_adapter.not_found"
         ),

--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -227,6 +227,9 @@ interface ErrorReporter {
         LINK_LOG_OUT_SUCCESS(
             eventName = "link.log_out.success"
         ),
+        CUSTOMER_SHEET_PAYMENT_METHODS_REFRESH_SUCCESS(
+            eventName = "elements.customer_sheet.payment_methods.refresh_success"
+        ),
         EXTERNAL_PAYMENT_METHODS_LAUNCH_SUCCESS(
             eventName = "paymentsheet.external_payment_method.launch_success"
         ),

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
@@ -61,19 +61,7 @@ internal class CustomerSheetTest {
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }
 
-        networkRule.enqueue(
-            retrievePaymentMethodsRequest(),
-            cardPaymentMethodsParams(),
-        ) { response ->
-            response.testBodyFromFile("payment-methods-get-success-empty.json")
-        }
-
-        networkRule.enqueue(
-            retrievePaymentMethodsRequest(),
-            usBankAccountPaymentMethodsParams(),
-        ) { response ->
-            response.testBodyFromFile("payment-methods-get-success-empty.json")
-        }
+        networkRule.enqueueFetchRequests(withCards = false)
 
         context.presentCustomerSheet()
 
@@ -87,6 +75,7 @@ internal class CustomerSheetTest {
             response.testBodyFromFile("payment-methods-create.json")
         }
 
+        networkRule.enqueueFetchRequests(withCards = true)
         networkRule.enqueueAttachRequests(customerSheetTestType)
 
         page.clickSaveButton()
@@ -123,19 +112,7 @@ internal class CustomerSheetTest {
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }
 
-        networkRule.enqueue(
-            retrievePaymentMethodsRequest(),
-            cardPaymentMethodsParams(),
-        ) { response ->
-            response.testBodyFromFile("payment-methods-get-success.json")
-        }
-
-        networkRule.enqueue(
-            retrievePaymentMethodsRequest(),
-            usBankAccountPaymentMethodsParams(),
-        ) { response ->
-            response.testBodyFromFile("payment-methods-get-success-empty.json")
-        }
+        networkRule.enqueueFetchRequests(withCards = true)
 
         context.presentCustomerSheet()
 
@@ -173,19 +150,7 @@ internal class CustomerSheetTest {
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }
 
-        networkRule.enqueue(
-            retrievePaymentMethodsRequest(),
-            cardPaymentMethodsParams(),
-        ) { response ->
-            response.testBodyFromFile("payment-methods-get-success.json")
-        }
-
-        networkRule.enqueue(
-            retrievePaymentMethodsRequest(),
-            usBankAccountPaymentMethodsParams(),
-        ) { response ->
-            response.testBodyFromFile("payment-methods-get-success-empty.json")
-        }
+        networkRule.enqueueFetchRequests(withCards = true)
 
         context.presentCustomerSheet()
 
@@ -232,19 +197,7 @@ internal class CustomerSheetTest {
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }
 
-        networkRule.enqueue(
-            retrievePaymentMethodsRequest(),
-            cardPaymentMethodsParams(),
-        ) { response ->
-            response.testBodyFromFile("payment-methods-get-success-empty.json")
-        }
-
-        networkRule.enqueue(
-            retrievePaymentMethodsRequest(),
-            usBankAccountPaymentMethodsParams(),
-        ) { response ->
-            response.testBodyFromFile("payment-methods-get-success-empty.json")
-        }
+        networkRule.enqueueFetchRequests(withCards = false)
 
         context.presentCustomerSheet()
 
@@ -262,6 +215,7 @@ internal class CustomerSheetTest {
             response.testBodyFromFile("payment-methods-create.json")
         }
 
+        networkRule.enqueueFetchRequests(withCards = true)
         networkRule.enqueueAttachRequests(customerSheetTestType)
 
         page.clickSaveButton()
@@ -286,19 +240,7 @@ internal class CustomerSheetTest {
             response.testBodyFromFile("elements-sessions-requires_payment_method_with_cbc.json")
         }
 
-        networkRule.enqueue(
-            retrievePaymentMethodsRequest(),
-            cardPaymentMethodsParams(),
-        ) { response ->
-            response.testBodyFromFile("payment-methods-get-success-empty.json")
-        }
-
-        networkRule.enqueue(
-            retrievePaymentMethodsRequest(),
-            usBankAccountPaymentMethodsParams(),
-        ) { response ->
-            response.testBodyFromFile("payment-methods-get-success-empty.json")
-        }
+        networkRule.enqueueFetchRequests(withCards = false)
 
         context.presentCustomerSheet()
 
@@ -320,6 +262,7 @@ internal class CustomerSheetTest {
             response.testBodyFromFile("payment-methods-create.json")
         }
 
+        networkRule.enqueueFetchRequests(withCards = true)
         networkRule.enqueueAttachRequests(customerSheetTestType)
 
         page.clickSaveButton()
@@ -341,19 +284,7 @@ internal class CustomerSheetTest {
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }
 
-        networkRule.enqueue(
-            retrievePaymentMethodsRequest(),
-            cardPaymentMethodsParams(),
-        ) { response ->
-            response.testBodyFromFile("payment-methods-get-success-empty.json")
-        }
-
-        networkRule.enqueue(
-            retrievePaymentMethodsRequest(),
-            usBankAccountPaymentMethodsParams(),
-        ) { response ->
-            response.testBodyFromFile("payment-methods-get-success-empty.json")
-        }
+        networkRule.enqueueFetchRequests(withCards = false)
 
         context.presentCustomerSheet()
 
@@ -387,6 +318,28 @@ internal class CustomerSheetTest {
         page.waitForText("Your card's security code is incorrect.")
 
         context.markTestSucceeded()
+    }
+
+    private fun NetworkRule.enqueueFetchRequests(withCards: Boolean) {
+        enqueue(
+            retrievePaymentMethodsRequest(),
+            cardPaymentMethodsParams(),
+        ) { response ->
+            val file = if (withCards) {
+                "payment-methods-get-success.json"
+            } else {
+                "payment-methods-get-success-empty.json"
+            }
+
+            response.testBodyFromFile(file)
+        }
+
+        enqueue(
+            retrievePaymentMethodsRequest(),
+            usBankAccountPaymentMethodsParams(),
+        ) { response ->
+            response.testBodyFromFile("payment-methods-get-success-empty.json")
+        }
     }
 
     private fun NetworkRule.enqueueAttachRequests(customerSheetTestType: CustomerSheetTestType) {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/util/CustomerSheetUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/util/CustomerSheetUtils.kt
@@ -1,0 +1,25 @@
+package com.stripe.android.customersheet.util
+
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.model.PaymentSelection
+
+internal fun sortPaymentMethods(
+    paymentMethods: List<PaymentMethod>,
+    selection: PaymentSelection.Saved?,
+): List<PaymentMethod> {
+    return selection?.let { savedSelection ->
+        val selectedPaymentMethod = savedSelection.paymentMethod
+
+        // The order of the payment methods should be selected PM and then any additional PMs
+        // The carousel always starts with Add and Google Pay (if enabled)
+        paymentMethods.sortedWith { left, right ->
+            // We only care to move the selected payment method, all others stay in the
+            // order they were before
+            when {
+                left.id == selectedPaymentMethod.id -> -1
+                right.id == selectedPaymentMethod.id -> 1
+                else -> 0
+            }
+        }
+    } ?: paymentMethods
+}

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -750,15 +750,11 @@ class CustomerSheetViewModelTest {
 
     @Test
     fun `After attaching payment method with setup intent, methods are refreshed`() = runTest(testDispatcher) {
+        val errorReporter = FakeErrorReporter()
         val viewModel = retrieveViewModelForAttaching(
             attachWithSetupIntent = true,
             shouldFailRefresh = false,
-        )
-
-        viewModel.handleViewAction(
-            CustomerSheetViewAction.OnFormFieldValuesCompleted(
-                formFieldValues = TEST_FORM_VALUES,
-            )
+            errorReporter = errorReporter,
         )
 
         viewModel.viewState.test {
@@ -773,6 +769,9 @@ class CustomerSheetViewModelTest {
             assertThat(newViewState.isProcessing).isFalse()
             assertThat(newViewState.savedPaymentMethods).contains(CARD_PAYMENT_METHOD)
         }
+
+        assertThat(errorReporter.getLoggedErrors())
+            .contains(ErrorReporter.SuccessEvent.CUSTOMER_SHEET_PAYMENT_METHODS_REFRESH_SUCCESS.eventName)
     }
 
     @Test
@@ -803,9 +802,11 @@ class CustomerSheetViewModelTest {
 
     @Test
     fun `After attaching payment method without setup intent, methods are refreshed`() = runTest(testDispatcher) {
+        val errorReporter = FakeErrorReporter()
         val viewModel = retrieveViewModelForAttaching(
             attachWithSetupIntent = false,
             shouldFailRefresh = false,
+            errorReporter = errorReporter,
         )
 
         viewModel.viewState.test {
@@ -820,6 +821,9 @@ class CustomerSheetViewModelTest {
             assertThat(newViewState.isProcessing).isFalse()
             assertThat(newViewState.savedPaymentMethods).contains(CARD_PAYMENT_METHOD)
         }
+
+        assertThat(errorReporter.getLoggedErrors())
+            .contains(ErrorReporter.SuccessEvent.CUSTOMER_SHEET_PAYMENT_METHODS_REFRESH_SUCCESS.eventName)
     }
 
     @Test
@@ -830,12 +834,6 @@ class CustomerSheetViewModelTest {
                 attachWithSetupIntent = false,
                 errorReporter = errorReporter,
                 shouldFailRefresh = true,
-            )
-
-            viewModel.handleViewAction(
-                CustomerSheetViewAction.OnFormFieldValuesCompleted(
-                    formFieldValues = TEST_FORM_VALUES,
-                )
             )
 
             viewModel.viewState.test {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -25,6 +25,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAvailable
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncher
@@ -88,6 +89,7 @@ internal object CustomerSheetTestHelper {
         ),
         editInteractorFactory: ModifiableEditPaymentMethodViewInteractor.Factory =
             createModifiableEditPaymentMethodViewInteractorFactory(),
+        errorReporter: ErrorReporter = FakeErrorReporter(),
     ): CustomerSheetViewModel {
         return CustomerSheetViewModel(
             application = application,
@@ -135,7 +137,7 @@ internal object CustomerSheetTestHelper {
             customerSheetLoader = customerSheetLoader,
             isFinancialConnectionsAvailable = isFinancialConnectionsAvailable,
             editInteractorFactory = editInteractorFactory,
-            errorReporter = FakeErrorReporter(),
+            errorReporter = errorReporter,
         ).apply {
             registerFromActivity(DummyActivityResultCaller(), TestLifecycleOwner())
         }


### PR DESCRIPTION
# Summary
Refresh payment methods after attaching in `CustomerSheet`

# Motivation
We should be refetching payment methods from the adapter rather than simply adding it to the list of pre-existing payment methods.
- It could be that merchants may do some filtering logic in `CustomerAdapter`.
- Setups for `CustomerSession` which does deduping filtering logic.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
