### PR TITLE
Update `download-artifact` to `v3`

### DIFF
--- a/.github/workflows/identity_pull_request.yml
+++ b/.github/workflows/identity_pull_request.yml
@@ -44,9 +44,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download APKs
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: apk
+          path: apk
+          pattern: identity-example-release-*.apk
       - name: diffuse
         id: diffuse
         uses: usefulness/diffuse-action@d816fd102c1f5f69519ee4bb8e0e12a42d005788

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download APKs
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: apk
       - name: diffuse


### PR DESCRIPTION
# Summary
Update `download-artifact` to `v3`

# Motivation
`download-artifact` v1 and v2 are now deprecated and failing on GitHub actions.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
