### PR TITLE
Add tests to verify recollected CVC is added to PaymentMethodOptionParams

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -494,11 +494,13 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             val paymentMethodOptionsParams =
                 (paymentSelection.paymentMethodOptionsParams as? PaymentMethodOptionsParams.Card)
                     ?: PaymentMethodOptionsParams.Card()
-            paymentSelection.copy(
+            val newSelection = paymentSelection.copy(
                 paymentMethodOptionsParams = paymentMethodOptionsParams.copy(
                     cvc = cvcControllerFlow.value.fieldValue.value
                 )
             )
+            updateSelection(newSelection)
+            newSelection
         } else {
             paymentSelection
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -440,6 +440,7 @@ internal class DefaultFlowController @Inject internal constructor(
                                     cvc = result.cvc,
                                 )
                             )
+                            viewModel.paymentSelection = selection
                             confirmPaymentSelection(selection, state)
                         } ?: paymentResultCallback.onPaymentSheetResult(
                             PaymentSheetResult.Failed(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update `DefaultFlowController` and `PaymentSheetViewModel` to update selection with recollected CVC
Add tests to verify

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Test Coverage

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified
