### PR TITLE
Add `Google Pay` availability tests

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayAvailabilityClient.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayAvailabilityClient.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.googlepaylauncher
+
+import androidx.annotation.RestrictTo
+import com.google.android.gms.wallet.IsReadyToPayRequest
+import com.google.android.gms.wallet.PaymentsClient
+import kotlinx.coroutines.tasks.await
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+interface GooglePayAvailabilityClient {
+    suspend fun isReady(request: IsReadyToPayRequest): Boolean
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    interface Factory {
+        fun create(paymentsClient: PaymentsClient): GooglePayAvailabilityClient
+    }
+}
+
+internal class DefaultGooglePayAvailabilityClient internal constructor(
+    private val paymentsClient: PaymentsClient
+) : GooglePayAvailabilityClient {
+    override suspend fun isReady(request: IsReadyToPayRequest): Boolean {
+        return paymentsClient.isReadyToPay(request).await()
+    }
+
+    class Factory : GooglePayAvailabilityClient.Factory {
+        override fun create(paymentsClient: PaymentsClient): GooglePayAvailabilityClient {
+            return DefaultGooglePayAvailabilityClient(paymentsClient)
+        }
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayRepository.kt
@@ -21,9 +21,14 @@ fun interface GooglePayRepository {
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
+        private val defaultFactory = DefaultGooglePayAvailabilityClient.Factory()
+
         @Volatile
-        var googlePayAvailabilityClientFactory: GooglePayAvailabilityClient.Factory =
-            DefaultGooglePayAvailabilityClient.Factory()
+        var googlePayAvailabilityClientFactory: GooglePayAvailabilityClient.Factory = defaultFactory
+
+        fun resetFactory() {
+            googlePayAvailabilityClientFactory = defaultFactory
+        }
     }
 }
 

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayRepository.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.googlepaylauncher
 
 import android.content.Context
+import androidx.annotation.RestrictTo
 import com.google.android.gms.wallet.IsReadyToPayRequest
 import com.google.android.gms.wallet.PaymentsClient
 import com.stripe.android.GooglePayJsonFactory
@@ -8,7 +9,6 @@ import com.stripe.android.core.Logger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -17,6 +17,13 @@ fun interface GooglePayRepository {
 
     object Disabled : GooglePayRepository {
         override fun isReady(): Flow<Boolean> = flowOf(false)
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    companion object {
+        @Volatile
+        var googlePayAvailabilityClientFactory: GooglePayAvailabilityClient.Factory =
+            DefaultGooglePayAvailabilityClient.Factory()
     }
 }
 
@@ -52,8 +59,10 @@ internal class DefaultGooglePayRepository(
 
     private val googlePayJsonFactory = GooglePayJsonFactory(context)
 
-    private val paymentsClient: PaymentsClient by lazy {
-        paymentsClientFactory.create(environment)
+    private val googlePayAvailabilityClient: GooglePayAvailabilityClient by lazy {
+        GooglePayRepository.googlePayAvailabilityClientFactory.create(
+            paymentsClient = paymentsClientFactory.create(environment)
+        )
     }
 
     /**
@@ -83,7 +92,7 @@ internal class DefaultGooglePayRepository(
         }
 
         val isReady = runCatching {
-            paymentsClient.isReadyToPay(request).await()
+            googlePayAvailabilityClient.isReady(request)
         }.onFailure {
             // TODO (samer-stripe): Add error event here
             logger.error("Google Pay check failed.", it)

--- a/payments-core/src/test/java/com/stripe/android/DefaultGooglePayAvailabilityClientTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/DefaultGooglePayAvailabilityClientTest.kt
@@ -1,0 +1,62 @@
+package com.stripe.android
+
+import com.google.android.gms.tasks.Tasks
+import com.google.android.gms.wallet.IsReadyToPayRequest
+import com.google.android.gms.wallet.PaymentsClient
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.googlepaylauncher.DefaultGooglePayAvailabilityClient
+import kotlinx.coroutines.test.runTest
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import kotlin.test.Test
+
+class DefaultGooglePayAvailabilityClientTest {
+    @Test
+    fun `On is ready, should call payments client`() = runTest {
+        val paymentsClient = createPaymentsClient()
+
+        val client = DefaultGooglePayAvailabilityClient(
+            paymentsClient = paymentsClient,
+        )
+
+        val isReadyToPayRequest = createIsReadyToPayRequest()
+
+        client.isReady(isReadyToPayRequest)
+
+        verify(paymentsClient).isReadyToPay(isReadyToPayRequest)
+    }
+
+    @Test
+    fun `On is ready is true from payments client, should return true`() = runTest {
+        val paymentsClient = createPaymentsClient(isReady = true)
+
+        val client = DefaultGooglePayAvailabilityClient(
+            paymentsClient = paymentsClient,
+        )
+
+        assertThat(client.isReady(createIsReadyToPayRequest())).isTrue()
+    }
+
+    @Test
+    fun `On is ready is false from payments client, should return false`() = runTest {
+        val paymentsClient = createPaymentsClient(isReady = false)
+
+        val client = DefaultGooglePayAvailabilityClient(
+            paymentsClient = paymentsClient,
+        )
+
+        assertThat(client.isReady(createIsReadyToPayRequest())).isFalse()
+    }
+
+    private fun createPaymentsClient(isReady: Boolean = false): PaymentsClient {
+        return mock<PaymentsClient> {
+            on { isReadyToPay(any()) } doReturn Tasks.forResult(isReady)
+        }
+    }
+
+    private fun createIsReadyToPayRequest(): IsReadyToPayRequest {
+        return mock<IsReadyToPayRequest>()
+    }
+}

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestGooglePayAvailabilityClient.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestGooglePayAvailabilityClient.kt
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith
     "Only testable on devices with a Google Play account & payment methods " +
         "available. Run these before releasing or making changes to Google Pay flow"
 )
-internal class TestGooglePay : BasePlaygroundTest() {
+internal class TestGooglePayAvailabilityClient : BasePlaygroundTest() {
     @Test
     fun testUnitedStates() {
         testDriver.confirmWithGooglePay(Country.US)

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/GooglePayTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/GooglePayTest.kt
@@ -1,0 +1,176 @@
+package com.stripe.android.paymentsheet
+
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import com.google.android.gms.wallet.IsReadyToPayRequest
+import com.google.android.gms.wallet.PaymentsClient
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.googlepaylauncher.GooglePayRepository
+import com.stripe.android.googlepaylauncher.GooglePayAvailabilityClient
+import com.stripe.android.networktesting.RequestMatchers.host
+import com.stripe.android.networktesting.RequestMatchers.method
+import com.stripe.android.networktesting.RequestMatchers.path
+import com.stripe.android.networktesting.ResponseReplacement
+import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.paymentsheet.ui.GOOGLE_PAY_BUTTON_TEST_TAG
+import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_FORM_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_METHOD_CARD_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG
+import com.stripe.android.paymentsheet.utils.ProductIntegrationType
+import com.stripe.android.paymentsheet.utils.ProductIntegrationTypeProvider
+import com.stripe.android.paymentsheet.utils.TestRules
+import com.stripe.android.paymentsheet.utils.expectNoResult
+import com.stripe.android.paymentsheet.utils.runProductIntegrationTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(TestParameterInjector::class)
+internal class GooglePayTest {
+    @TestParameter(valuesProvider = ProductIntegrationTypeProvider::class)
+    lateinit var integrationType: ProductIntegrationType
+
+    @get:Rule
+    val testRules: TestRules = TestRules.create()
+
+    private val composeTestRule = testRules.compose
+
+    @Test
+    fun googlePayIsShownWhenFullyEnabled() = runGooglePayTest(
+        isGooglePayReady = true,
+        isGooglePayEnabledInElementsSession = true,
+        hasGooglePayConfig = true,
+    ) {
+        composeTestRule.onGooglePayOption().assertExists()
+    }
+
+    @Test
+    fun googlePayIsNotShownWhenNotReady() = runGooglePayTest(
+        isGooglePayReady = false,
+        isGooglePayEnabledInElementsSession = true,
+        hasGooglePayConfig = true,
+    ) {
+        composeTestRule.onGooglePayOption().assertDoesNotExist()
+    }
+
+    @Test
+    fun googlePayIsNotShownWhenNotEnabledInElementsSession() = runGooglePayTest(
+        isGooglePayReady = true,
+        isGooglePayEnabledInElementsSession = false,
+        hasGooglePayConfig = true,
+    ) {
+        composeTestRule.onGooglePayOption().assertDoesNotExist()
+    }
+
+    @Test
+    fun googlePayIsNotShownWhenGooglePayConfigIsNotProvided() = runGooglePayTest(
+        isGooglePayReady = true,
+        isGooglePayEnabledInElementsSession = true,
+        hasGooglePayConfig = false,
+    ) {
+        composeTestRule.onGooglePayOption().assertDoesNotExist()
+    }
+
+    private fun runGooglePayTest(
+        isGooglePayReady: Boolean,
+        isGooglePayEnabledInElementsSession: Boolean,
+        hasGooglePayConfig: Boolean,
+        test: () -> Unit,
+    ) {
+        GooglePayRepository.googlePayAvailabilityClientFactory =
+            FakeGooglePayAvailabilityClient.Factory(isGooglePayReady)
+
+        enqueueElementsSession(isGooglePayEnabledInElementsSession)
+
+        runProductIntegrationTest(
+            networkRule = testRules.networkRule,
+            integrationType = integrationType,
+            resultCallback = ::expectNoResult,
+            paymentOptionCallback = {}
+        ) { context ->
+            val configBuilder = PaymentSheet.Configuration.Builder(merchantDisplayName = "Merchant, Inc.")
+
+            if (hasGooglePayConfig) {
+                configBuilder.googlePay(
+                    PaymentSheet.GooglePayConfiguration(
+                        environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                        countryCode = "USD",
+                    )
+                )
+            }
+
+            context.launch(configBuilder.build())
+
+            waitUntilLoaded()
+
+            test()
+
+            context.markTestSucceeded()
+        }
+    }
+
+    private fun enqueueElementsSession(isGooglePayEnabledInElementsSession: Boolean) {
+        testRules.networkRule.enqueue(
+            host("api.stripe.com"),
+            method("GET"),
+            path("/v1/elements/sessions"),
+        ) { response ->
+            val replacements = if (isGooglePayEnabledInElementsSession) {
+                listOf()
+            } else {
+                listOf(
+                    ResponseReplacement(
+                        original = """
+                                "google_pay_preference": "enabled"
+                            """.trimIndent(),
+                        new = """
+                                "google_pay_preference": "disabled"
+                            """.trimIndent(),
+                    )
+                )
+            }
+
+            response.testBodyFromFile("elements-sessions-requires_payment_method.json", replacements)
+        }
+    }
+
+    private fun waitUntilLoaded() {
+        composeTestRule.waitUntil(UI_TIMEOUT) {
+            composeTestRule
+                .onAllNodes(
+                    hasTestTag(PAYMENT_SHEET_FORM_TEST_TAG)
+                        .or(hasTestTag(SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG))
+                )
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isNotEmpty()
+        }
+    }
+
+    private fun ComposeTestRule.onGooglePayOption(): SemanticsNodeInteraction {
+        return when (integrationType) {
+            ProductIntegrationType.PaymentSheet -> onNode(hasTestTag(GOOGLE_PAY_BUTTON_TEST_TAG))
+            ProductIntegrationType.FlowController -> onNode(hasTestTag(GOOGLE_PAY_SAVED_OPTION_TEST_TAG))
+        }
+    }
+
+    private class FakeGooglePayAvailabilityClient(
+        private val isReady: Boolean,
+    ) : GooglePayAvailabilityClient {
+        override suspend fun isReady(request: IsReadyToPayRequest): Boolean {
+            return isReady
+        }
+
+        class Factory(private val isReady: Boolean) : GooglePayAvailabilityClient.Factory {
+            override fun create(paymentsClient: PaymentsClient): GooglePayAvailabilityClient {
+                return FakeGooglePayAvailabilityClient(isReady)
+            }
+        }
+    }
+
+    private companion object {
+        const val GOOGLE_PAY_SAVED_OPTION_TEST_TAG = "${SAVED_PAYMENT_METHOD_CARD_TEST_TAG}_Google Pay"
+        const val UI_TIMEOUT = 5000L
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/GooglePayTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/GooglePayTest.kt
@@ -23,6 +23,7 @@ import com.stripe.android.paymentsheet.utils.ProductIntegrationTypeProvider
 import com.stripe.android.paymentsheet.utils.TestRules
 import com.stripe.android.paymentsheet.utils.expectNoResult
 import com.stripe.android.paymentsheet.utils.runProductIntegrationTest
+import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -36,6 +37,11 @@ internal class GooglePayTest {
     val testRules: TestRules = TestRules.create()
 
     private val composeTestRule = testRules.compose
+
+    @After
+    fun teardown() {
+        GooglePayRepository.resetFactory()
+    }
 
     @Test
     fun googlePayIsShownWhenFullyEnabled() = runGooglePayTest(

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ProductIntegrationTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ProductIntegrationTestRunner.kt
@@ -49,6 +49,8 @@ internal sealed interface ProductIntegrationTestRunnerContext {
         )
     )
 
+    fun markTestSucceeded()
+
     class WithPaymentSheet(
         private val context: PaymentSheetTestRunnerContext
     ) : ProductIntegrationTestRunnerContext {
@@ -59,6 +61,10 @@ internal sealed interface ProductIntegrationTestRunnerContext {
                     configuration = configuration,
                 )
             }
+        }
+
+        override fun markTestSucceeded() {
+            context.markTestSucceeded()
         }
     }
 
@@ -77,6 +83,10 @@ internal sealed interface ProductIntegrationTestRunnerContext {
                     },
                 )
             }
+        }
+
+        override fun markTestSucceeded() {
+            context.markTestSucceeded()
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -1,8 +1,11 @@
 package com.stripe.android.paymentsheet.ui
 
+import androidx.annotation.RestrictTo
+import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.CardBrand
@@ -46,7 +49,7 @@ internal fun AddPaymentMethod(
                 )
             )
         },
-        modifier = modifier,
+        modifier = modifier.testTag(PAYMENT_SHEET_FORM_TEST_TAG),
         onInteractionEvent = {
             interactor.handleViewAction(
                 AddPaymentMethodInteractor.ViewAction.ReportFieldInteraction(
@@ -125,3 +128,7 @@ internal fun FormFieldValues.transformToPaymentSelection(
         )
     }
 }
+
+@VisibleForTesting
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val PAYMENT_SHEET_FORM_TEST_TAG = "PaymentSheetAddPaymentMethodForm"


### PR DESCRIPTION
# Summary
Add `Google Pay` tests that determine that Google Pay is available when expected.

# Motivation
Ensures Google Pay availability is well tested in `PaymentSheet`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
