### PR TITLE
Disable CVC when processing.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -39,7 +39,7 @@ import com.stripe.android.paymentsheet.model.isLink
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.Args
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcCompletionState
-import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionInteractorFactory
+import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionInteractor
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetState
@@ -85,7 +85,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     editInteractorFactory: ModifiableEditPaymentMethodViewInteractor.Factory,
     private val errorReporter: ErrorReporter,
     internal val cvcRecollectionHandler: CvcRecollectionHandler,
-    private val cvcRecollectionInteractorFactory: CvcRecollectionInteractorFactory
+    private val cvcRecollectionInteractorFactory: CvcRecollectionInteractor.Factory
 ) : BaseSheetViewModel(
     config = args.config,
     eventReporter = eventReporter,
@@ -432,8 +432,11 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 args = Args(
                     lastFour = cvcRecollectionData.lastFour ?: "",
                     cardBrand = cvcRecollectionData.brand,
+                    cvc = "",
                     isTestMode = paymentMethodMetadata.value?.stripeIntent?.isLiveMode?.not() ?: false,
-                )
+                ),
+                processing = processing,
+                coroutineScope = viewModelScope,
             )
             viewModelScope.launch {
                 interactor.cvcCompletionState.collectLatest(::handleCvcCompletionState)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -35,7 +35,7 @@ import com.stripe.android.paymentsheet.flowcontroller.DefaultPaymentSelectionUpd
 import com.stripe.android.paymentsheet.flowcontroller.PaymentSelectionUpdater
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncherFactory
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.DefaultBacsMandateConfirmationLauncherFactory
-import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionInteractorFactory
+import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionInteractor
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionLauncherFactory
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.DefaultCvcRecollectionInteractor
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.DefaultCvcRecollectionLauncherFactory
@@ -197,9 +197,8 @@ internal abstract class PaymentSheetCommonModule {
         )
 
         @Provides
-        @Singleton
-        fun providesCvcRecollectionInteractorFactory(): CvcRecollectionInteractorFactory {
-            return DefaultCvcRecollectionInteractor.Factory()
+        fun providesCvcRecollectionInteractorFactory(): CvcRecollectionInteractor.Factory {
+            return DefaultCvcRecollectionInteractor.Factory
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/Args.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/Args.kt
@@ -5,6 +5,6 @@ import com.stripe.android.model.CardBrand
 internal data class Args(
     val lastFour: String,
     val cardBrand: CardBrand,
-    val cvc: String? = null,
+    val cvc: String,
     val isTestMode: Boolean
 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionInteractor.kt
@@ -1,33 +1,61 @@
 package com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection
 
+import com.stripe.android.model.CardBrand
 import com.stripe.android.uicore.utils.mapAsStateFlow
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 internal interface CvcRecollectionInteractor {
     val viewState: StateFlow<CvcRecollectionViewState>
     val cvcCompletionState: StateFlow<CvcCompletionState>
 
     fun onCvcChanged(cvc: String)
+
+    interface Factory {
+        fun create(
+            args: Args,
+            processing: StateFlow<Boolean>,
+            coroutineScope: CoroutineScope,
+        ): CvcRecollectionInteractor
+    }
 }
 
 internal class DefaultCvcRecollectionInteractor(
-    args: Args,
+    private val lastFour: String,
+    private val cardBrand: CardBrand,
+    private val cvc: String,
+    private val isTestMode: Boolean,
+    private val processing: StateFlow<Boolean>,
+    coroutineScope: CoroutineScope,
 ) : CvcRecollectionInteractor {
-
     private val _viewState = MutableStateFlow(
         CvcRecollectionViewState(
-            lastFour = args.lastFour,
-            isTestMode = args.isTestMode,
+            lastFour = lastFour,
+            isTestMode = isTestMode,
             cvcState = CvcState(
-                cvc = args.cvc ?: "",
-                cardBrand = args.cardBrand
-            )
+                cvc = cvc,
+                cardBrand = cardBrand,
+            ),
+            isEnabled = !processing.value,
         )
     )
     override val viewState = _viewState.asStateFlow()
+
+    init {
+        coroutineScope.launch {
+            processing.collect { processing ->
+                _viewState.update { oldState ->
+                    oldState.copy(
+                        isEnabled = !processing
+                    )
+                }
+            }
+        }
+    }
 
     override val cvcCompletionState = _viewState.mapAsStateFlow { state ->
         if (state.cvcState.isValid) {
@@ -45,9 +73,20 @@ internal class DefaultCvcRecollectionInteractor(
         }
     }
 
-    internal class Factory : CvcRecollectionInteractorFactory {
-        override fun create(args: Args): CvcRecollectionInteractor {
-            return DefaultCvcRecollectionInteractor(args)
+    internal object Factory : CvcRecollectionInteractor.Factory {
+        override fun create(
+            args: Args,
+            processing: StateFlow<Boolean>,
+            coroutineScope: CoroutineScope,
+        ): CvcRecollectionInteractor {
+            return DefaultCvcRecollectionInteractor(
+                lastFour = args.lastFour,
+                cardBrand = args.cardBrand,
+                cvc = args.cvc,
+                isTestMode = args.isTestMode,
+                processing = processing,
+                coroutineScope = coroutineScope,
+            )
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionInteractorFactory.kt
@@ -1,5 +1,0 @@
-package com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection
-
-internal interface CvcRecollectionInteractorFactory {
-    fun create(args: Args): CvcRecollectionInteractor
-}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionScreen.kt
@@ -75,6 +75,7 @@ internal fun CvcRecollectionScreen(
             CvcRecollectionTitle()
             CvcRecollectionField(
                 lastFour = lastFour,
+                enabled = true,
                 cvcState = cvcState,
                 onValueChanged = {
                     viewActionHandler(CvcRecollectionViewAction.OnCvcChanged(it))
@@ -102,8 +103,9 @@ internal fun CvcRecollectionPaymentSheetScreen(
             CvcRecollectionTitle()
             CvcRecollectionField(
                 lastFour = state.lastFour,
+                enabled = state.isEnabled,
                 cvcState = state.cvcState,
-                onValueChanged = interactor::onCvcChanged
+                onValueChanged = interactor::onCvcChanged,
             )
         }
     }
@@ -114,6 +116,7 @@ internal fun CvcRecollectionPaymentSheetScreen(
 @Composable
 internal fun CvcRecollectionField(
     lastFour: String,
+    enabled: Boolean,
     cvcState: CvcState,
     onValueChanged: (String) -> Unit
 ) {
@@ -182,6 +185,7 @@ internal fun CvcRecollectionField(
                     .fillMaxWidth()
                     .weight(.5f, true)
                     .focusRequester(focusRequester),
+                enabled = enabled,
                 value = cvcState.cvc,
                 onValueChange = onValueChanged,
                 shape = MaterialTheme.shapes.large,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionViewModel.kt
@@ -24,7 +24,8 @@ internal class CvcRecollectionViewModel(args: Args) : ViewModel() {
             cvcState = CvcState(
                 cvc = args.cvc ?: "",
                 cardBrand = args.cardBrand
-            )
+            ),
+            isEnabled = true,
         )
     )
     val viewState: StateFlow<CvcRecollectionViewState>
@@ -70,8 +71,8 @@ internal class CvcRecollectionViewModel(args: Args) : ViewModel() {
                 args = Args(
                     lastFour = args.lastFour,
                     cardBrand = args.cardBrand,
-                    cvc = null,
-                    isTestMode = args.isTestMode
+                    cvc = "",
+                    isTestMode = args.isTestMode,
                 )
             ) as T
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionViewModel.kt
@@ -22,7 +22,7 @@ internal class CvcRecollectionViewModel(args: Args) : ViewModel() {
             lastFour = args.lastFour,
             isTestMode = args.isTestMode,
             cvcState = CvcState(
-                cvc = args.cvc ?: "",
+                cvc = args.cvc,
                 cardBrand = args.cardBrand
             ),
             isEnabled = true,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionViewState.kt
@@ -3,5 +3,6 @@ package com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection
 internal data class CvcRecollectionViewState(
     val lastFour: String,
     val isTestMode: Boolean,
-    val cvcState: CvcState
+    val cvcState: CvcState,
+    val isEnabled: Boolean,
 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FakeCvcRecollectionInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FakeCvcRecollectionInteractor.kt
@@ -16,7 +16,8 @@ internal class FakeCvcRecollectionInteractor : CvcRecollectionInteractor {
             cvcState = CvcState(
                 cvc = "",
                 cardBrand = CardBrand.Visa
-            )
+            ),
+            isEnabled = true,
         )
     )
     override val viewState: StateFlow<CvcRecollectionViewState> = _viewState

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -62,7 +62,7 @@ import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddAnotherP
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.FakeBacsMandateConfirmationLauncher
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.Args
-import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionInteractorFactory
+import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionInteractor
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.WalletsProcessingState
 import com.stripe.android.paymentsheet.ui.GOOGLE_PAY_BUTTON_TEST_TAG
@@ -88,6 +88,7 @@ import com.stripe.android.utils.TestUtils.viewModelFactoryFor
 import com.stripe.android.utils.injectableActivityScenario
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -1127,8 +1128,14 @@ internal class PaymentSheetActivityTest {
                 editInteractorFactory = FakeEditPaymentMethodInteractor.Factory(),
                 errorReporter = FakeErrorReporter(),
                 cvcRecollectionHandler = cvcRecollectionHandler,
-                cvcRecollectionInteractorFactory = object : CvcRecollectionInteractorFactory {
-                    override fun create(args: Args) = FakeCvcRecollectionInteractor()
+                cvcRecollectionInteractorFactory = object : CvcRecollectionInteractor.Factory {
+                    override fun create(
+                        args: Args,
+                        processing: StateFlow<Boolean>,
+                        coroutineScope: CoroutineScope,
+                    ): CvcRecollectionInteractor {
+                        return FakeCvcRecollectionInteractor()
+                    }
                 }
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -87,7 +87,7 @@ import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateCon
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateData
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.Args
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcCompletionState
-import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionInteractorFactory
+import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionInteractor
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.LinkState
@@ -115,7 +115,9 @@ import com.stripe.android.utils.FakePaymentSheetLoader
 import com.stripe.android.utils.IntentConfirmationInterceptorTestRule
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import com.stripe.android.utils.RelayingPaymentSheetLoader
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -2995,8 +2997,14 @@ internal class PaymentSheetViewModelTest {
                 editInteractorFactory = fakeEditPaymentMethodInteractorFactory,
                 errorReporter = errorReporter,
                 cvcRecollectionHandler = cvcRecollectionHandler,
-                cvcRecollectionInteractorFactory = object : CvcRecollectionInteractorFactory {
-                    override fun create(args: Args) = cvcRecollectionInteractor
+                cvcRecollectionInteractorFactory = object : CvcRecollectionInteractor.Factory {
+                    override fun create(
+                        args: Args,
+                        processing: StateFlow<Boolean>,
+                        coroutineScope: CoroutineScope,
+                    ): CvcRecollectionInteractor {
+                        return cvcRecollectionInteractor
+                    }
                 }
             ).apply {
                 if (shouldRegister) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionFieldScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionFieldScreenshotTest.kt
@@ -21,11 +21,12 @@ class CvcRecollectionFieldScreenshotTest {
         paparazziRule.snapshot {
             CvcRecollectionField(
                 lastFour = "4242",
+                enabled = true,
                 cvcState = CvcState(
                     cardBrand = CardBrand.Visa,
                     cvc = ""
                 ),
-                onValueChanged = {}
+                onValueChanged = {},
             )
         }
     }
@@ -35,6 +36,7 @@ class CvcRecollectionFieldScreenshotTest {
         paparazziRule.snapshot {
             CvcRecollectionField(
                 lastFour = "4242",
+                enabled = true,
                 cvcState = CvcState(
                     cardBrand = CardBrand.Visa,
                     cvc = "424"

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionScreenScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionScreenScreenshotTest.kt
@@ -4,7 +4,10 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
 import com.stripe.android.screenshottesting.SystemAppearance
+import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Rule
 import org.junit.Test
 
@@ -16,14 +19,14 @@ class CvcRecollectionScreenScreenshotTest {
         FontSize.entries
     )
 
-    private fun interactor(cvc: String? = null, isTestMode: Boolean = true): CvcRecollectionInteractor {
+    private fun interactor(cvc: String = "", isTestMode: Boolean = true): CvcRecollectionInteractor {
         return DefaultCvcRecollectionInteractor(
-            args = Args(
-                lastFour = "4242",
-                cardBrand = CardBrand.Visa,
-                cvc = cvc,
-                isTestMode = isTestMode
-            ),
+            lastFour = "4242",
+            cardBrand = CardBrand.Visa,
+            cvc = cvc,
+            isTestMode = isTestMode,
+            processing = stateFlowOf(false),
+            coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionViewModelTest.kt
@@ -3,28 +3,17 @@ package com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.CardBrand
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.resetMain
+import com.stripe.android.testing.CoroutineTestRule
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
 class CvcRecollectionViewModelTest {
 
-    @Before
-    fun setup() {
-        Dispatchers.setMain(UnconfinedTestDispatcher())
-    }
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
 
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    private fun createViewModel(cvc: String? = null): CvcRecollectionViewModel {
+    private fun createViewModel(cvc: String = ""): CvcRecollectionViewModel {
         return CvcRecollectionViewModel(
             args = Args(
                 lastFour = "4242",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/DefaultCvcRecollectionInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/DefaultCvcRecollectionInteractorTest.kt
@@ -3,19 +3,26 @@ package com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.CardBrand
+import com.stripe.android.uicore.utils.stateFlowOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 class DefaultCvcRecollectionInteractorTest {
 
-    private fun createInteractor(): DefaultCvcRecollectionInteractor {
+    private fun createInteractor(
+        processing: StateFlow<Boolean> = stateFlowOf(false)
+    ): DefaultCvcRecollectionInteractor {
         return DefaultCvcRecollectionInteractor(
-            args = Args(
-                lastFour = "4242",
-                cardBrand = CardBrand.Visa,
-                cvc = null,
-                isTestMode = true
-            ),
+            lastFour = "4242",
+            cardBrand = CardBrand.Visa,
+            cvc = "",
+            isTestMode = true,
+            processing = processing,
+            coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
         )
     }
 
@@ -28,6 +35,31 @@ class DefaultCvcRecollectionInteractorTest {
             assertThat(viewState.lastFour).isEqualTo("4242")
             assertThat(viewState.cvcState).isEqualTo(CvcState(cvc = "", cardBrand = CardBrand.Visa))
             assertThat(viewState.isTestMode).isEqualTo(true)
+        }
+    }
+
+    @Test
+    fun `view state updated with CVC onCvcChanged`() = runTest {
+        val interactor = createInteractor()
+
+        interactor.viewState.test {
+            assertThat(awaitItem().cvcState.cvc).isEqualTo("")
+            interactor.onCvcChanged("444")
+            assertThat(awaitItem().cvcState.cvc).isEqualTo("444")
+        }
+    }
+
+    @Test
+    fun `view state updated with enabled when processing changes`() = runTest {
+        val processingSource = MutableStateFlow(false)
+        val interactor = createInteractor(processing = processingSource)
+
+        interactor.viewState.test {
+            assertThat(awaitItem().isEnabled).isTrue()
+            processingSource.value = true
+            assertThat(awaitItem().isEnabled).isFalse()
+            processingSource.value = false
+            assertThat(awaitItem().isEnabled).isTrue()
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We were seeing the keyboard reappear due to the field continuing to have focus throughout the checkout flow. But in reality we just wanted to disable the field to remove focus, which prevents the keyboard from re-appearing when processing is complete.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2451

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
