### PR TITLE
Fix a bug where isLiveMode would be false for setup intents using a publishable key without live/test with deferred intents.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/parsers/DeferredSetupIntentJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/DeferredSetupIntentJsonParser.kt
@@ -38,7 +38,7 @@ class DeferredSetupIntentJsonParser(
             countryCode = countryCode,
             linkFundingSources = linkFundingSources,
             unactivatedPaymentMethods = unactivatedPaymentMethods,
-            isLiveMode = apiKey.contains("live"),
+            isLiveMode = !apiKey.contains("test"),
             nextActionData = null,
             paymentMethodId = null,
             created = timeProvider(),

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -404,6 +404,51 @@ class ElementsSessionJsonParserTest {
     }
 
     @Test
+    fun `Test deferred livemode=true when publishable key does not have test or live for setup mode`() {
+        val data = ElementsSessionJsonParser(
+            ElementsSessionParams.DeferredIntentType(
+                deferredIntentParams = DeferredIntentParams(
+                    mode = DeferredIntentParams.Mode.Setup(
+                        currency = "usd",
+                        setupFutureUsage = StripeIntent.Usage.OffSession,
+                    ),
+                    paymentMethodTypes = emptyList(),
+                    paymentMethodConfigurationId = null,
+                    onBehalfOf = null,
+                ),
+                externalPaymentMethods = emptyList(),
+            ),
+            apiKey = "pk_foobar",
+            timeProvider = { 1 }
+        ).parse(
+            ElementsSessionFixtures.DEFERRED_INTENT_JSON
+        )
+
+        val deferredIntent = data?.stripeIntent
+
+        assertThat(deferredIntent).isNotNull()
+        assertThat(deferredIntent).isEqualTo(
+            SetupIntent(
+                id = "elements_session_1t6ejApXCS5",
+                clientSecret = null,
+                cancellationReason = null,
+                description = null,
+                nextActionData = null,
+                paymentMethodId = null,
+                paymentMethod = null,
+                status = null,
+                countryCode = "CA",
+                created = 1,
+                isLiveMode = true,
+                usage = StripeIntent.Usage.OffSession,
+                unactivatedPaymentMethods = listOf(),
+                paymentMethodTypes = listOf("card", "link", "cashapp"),
+                linkFundingSources = listOf("card")
+            )
+        )
+    }
+
+    @Test
     fun `Test deferred SetupIntent`() {
         val data = ElementsSessionJsonParser(
             ElementsSessionParams.DeferredIntentType(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I fixed this for deferred payment intents in #9202, but didn't realize we have a separate parser for setup intents.
