### PR TITLE
Add `ElementsSessionContext` to Instant Debits flows

### DIFF
--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
@@ -174,6 +174,7 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
                 clientSecret = paymentIntentSecret,
                 configuration = CollectBankAccountConfiguration.InstantDebits(
                     email = email,
+                    elementsContext = elementsContext,
                 )
             )
         }

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
@@ -174,7 +174,7 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
                 clientSecret = paymentIntentSecret,
                 configuration = CollectBankAccountConfiguration.InstantDebits(
                     email = email,
-                    elementsContext = elementsContext,
+                    elementsSessionContext = elementsSessionContext,
                 )
             )
         }

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -11,7 +11,7 @@ import com.stripe.android.Stripe
 import com.stripe.android.confirmPaymentIntent
 import com.stripe.android.financialconnections.FinancialConnections
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
-import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsContext
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext
 import com.stripe.android.financialconnections.FinancialConnectionsSheetForTokenResult
 import com.stripe.android.financialconnections.FinancialConnectionsSheetResult
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent
@@ -125,7 +125,7 @@ internal class FinancialConnectionsPlaygroundViewModel(
                             publishableKey = it.publishableKey,
                             ephemeralKey = it.ephemeralKey,
                             customerId = it.customerId,
-                            elementsContext = ElementsContext(
+                            elementsSessionContext = ElementsSessionContext(
                                 linkMode = LinkMode.LinkPaymentMethod,
                             ),
                             experience = settings.get<ExperienceSetting>().selectedOption,
@@ -485,7 +485,7 @@ sealed class FinancialConnectionsPlaygroundViewEffect {
         val publishableKey: String,
         val experience: Experience,
         val integrationType: IntegrationType,
-        val elementsContext: ElementsContext,
+        val elementsSessionContext: ElementsSessionContext,
     ) : FinancialConnectionsPlaygroundViewEffect()
 }
 

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -11,6 +11,7 @@ import com.stripe.android.Stripe
 import com.stripe.android.confirmPaymentIntent
 import com.stripe.android.financialconnections.FinancialConnections
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsContext
 import com.stripe.android.financialconnections.FinancialConnectionsSheetForTokenResult
 import com.stripe.android.financialconnections.FinancialConnectionsSheetResult
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent
@@ -24,6 +25,7 @@ import com.stripe.android.financialconnections.example.settings.IntegrationTypeS
 import com.stripe.android.financialconnections.example.settings.PlaygroundSettings
 import com.stripe.android.financialconnections.example.settings.StripeAccountIdSetting
 import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountForInstantDebitsResult
@@ -123,6 +125,9 @@ internal class FinancialConnectionsPlaygroundViewModel(
                             publishableKey = it.publishableKey,
                             ephemeralKey = it.ephemeralKey,
                             customerId = it.customerId,
+                            elementsContext = ElementsContext(
+                                linkMode = LinkMode.LinkPaymentMethod,
+                            ),
                             experience = settings.get<ExperienceSetting>().selectedOption,
                             integrationType = settings.get<IntegrationTypeSetting>().selectedOption,
                         )
@@ -480,6 +485,7 @@ sealed class FinancialConnectionsPlaygroundViewEffect {
         val publishableKey: String,
         val experience: Experience,
         val integrationType: IntegrationType,
+        val elementsContext: ElementsContext,
     ) : FinancialConnectionsPlaygroundViewEffect()
 }
 

--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -145,6 +145,14 @@ public final class com/stripe/android/financialconnections/FinancialConnectionsS
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsContext$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsContext;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsContext;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/financialconnections/FinancialConnectionsSheetComposeKt {
 	public static final fun rememberFinancialConnectionsSheet (Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)Lcom/stripe/android/financialconnections/FinancialConnectionsSheet;
 	public static final fun rememberFinancialConnectionsSheetForToken (Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)Lcom/stripe/android/financialconnections/FinancialConnectionsSheet;

--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -145,11 +145,11 @@ public final class com/stripe/android/financialconnections/FinancialConnectionsS
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsContext$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsContext;
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsContext;
+	public final fun newArray (I)[Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheet.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheet.kt
@@ -2,10 +2,12 @@ package com.stripe.android.financialconnections
 
 import android.os.Parcelable
 import androidx.activity.ComponentActivity
+import androidx.annotation.RestrictTo
 import androidx.fragment.app.Fragment
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetForDataLauncher
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetForTokenLauncher
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetLauncher
+import com.stripe.android.model.LinkMode
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -33,6 +35,17 @@ class FinancialConnectionsSheet internal constructor(
     ) : Parcelable
 
     /**
+     * Context for sessions created from Stripe Elements. This isn't intended to be
+     * part of the public API, but solely to be used by the Mobile Payment Element and
+     * CustomerSheet.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @Parcelize
+    data class ElementsContext(
+        val linkMode: LinkMode?,
+    ) : Parcelable
+
+    /**
      * Present the [FinancialConnectionsSheet].
      *
      * @param configuration the [FinancialConnectionsSheet] configuration
@@ -40,7 +53,10 @@ class FinancialConnectionsSheet internal constructor(
     fun present(
         configuration: Configuration
     ) {
-        financialConnectionsSheetLauncher.present(configuration)
+        financialConnectionsSheetLauncher.present(
+            configuration = configuration,
+            elementsContext = null,
+        )
     }
 
     companion object {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheet.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheet.kt
@@ -41,7 +41,7 @@ class FinancialConnectionsSheet internal constructor(
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
-    data class ElementsContext(
+    data class ElementsSessionContext(
         val linkMode: LinkMode?,
     ) : Parcelable
 
@@ -55,7 +55,7 @@ class FinancialConnectionsSheet internal constructor(
     ) {
         financialConnectionsSheetLauncher.present(
             configuration = configuration,
-            elementsContext = null,
+            elementsSessionContext = null,
         )
     }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetActivity.kt
@@ -151,7 +151,8 @@ internal class FinancialConnectionsSheetActivity : AppCompatActivity() {
                 context = this,
                 args = FinancialConnectionsSheetNativeActivityArgs(
                     initialSyncResponse = viewEffect.initialSyncResponse,
-                    configuration = viewEffect.configuration
+                    configuration = viewEffect.configuration,
+                    elementsContext = viewEffect.elementsContext,
                 )
             )
         )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetActivity.kt
@@ -152,7 +152,7 @@ internal class FinancialConnectionsSheetActivity : AppCompatActivity() {
                 args = FinancialConnectionsSheetNativeActivityArgs(
                     initialSyncResponse = viewEffect.initialSyncResponse,
                     configuration = viewEffect.configuration,
-                    elementsContext = viewEffect.elementsContext,
+                    elementsSessionContext = viewEffect.elementsSessionContext,
                 )
             )
         )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetState.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetState.kt
@@ -88,7 +88,7 @@ internal sealed class FinancialConnectionsSheetViewEffect {
     data class OpenNativeAuthFlow(
         val configuration: FinancialConnectionsSheet.Configuration,
         val initialSyncResponse: SynchronizeSessionResponse,
-        val elementsContext: FinancialConnectionsSheet.ElementsContext?,
+        val elementsSessionContext: FinancialConnectionsSheet.ElementsSessionContext?,
     ) : FinancialConnectionsSheetViewEffect()
 
     /**

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetState.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetState.kt
@@ -87,7 +87,8 @@ internal sealed class FinancialConnectionsSheetViewEffect {
      */
     data class OpenNativeAuthFlow(
         val configuration: FinancialConnectionsSheet.Configuration,
-        val initialSyncResponse: SynchronizeSessionResponse
+        val initialSyncResponse: SynchronizeSessionResponse,
+        val elementsContext: FinancialConnectionsSheet.ElementsContext?,
     ) : FinancialConnectionsSheetViewEffect()
 
     /**

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.stripe.android.core.Logger
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsContext
 import com.stripe.android.financialconnections.FinancialConnectionsSheetActivity.Companion.getArgs
 import com.stripe.android.financialconnections.FinancialConnectionsSheetState.AuthFlowStatus
 import com.stripe.android.financialconnections.FinancialConnectionsSheetViewEffect.FinishWithResult
@@ -144,7 +145,11 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
                     copy(
                         manifest = manifest,
                         webAuthFlowStatus = AuthFlowStatus.NONE,
-                        viewEffect = OpenNativeAuthFlow(initialArgs.configuration, sync)
+                        viewEffect = OpenNativeAuthFlow(
+                            configuration = initialArgs.configuration,
+                            initialSyncResponse = sync,
+                            elementsContext = initialArgs.retrieveElementsContext(),
+                        )
                     )
                 }
             } else {
@@ -539,4 +544,8 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
     override fun updateTopAppBar(state: FinancialConnectionsSheetState): TopAppBarStateUpdate? {
         return null
     }
+}
+
+private fun FinancialConnectionsSheetActivityArgs.retrieveElementsContext(): ElementsContext? {
+    return (this as? ForInstantDebits)?.elementsContext
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -14,7 +14,6 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.stripe.android.core.Logger
-import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsContext
 import com.stripe.android.financialconnections.FinancialConnectionsSheetActivity.Companion.getArgs
 import com.stripe.android.financialconnections.FinancialConnectionsSheetState.AuthFlowStatus
 import com.stripe.android.financialconnections.FinancialConnectionsSheetViewEffect.FinishWithResult
@@ -148,7 +147,7 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
                         viewEffect = OpenNativeAuthFlow(
                             configuration = initialArgs.configuration,
                             initialSyncResponse = sync,
-                            elementsContext = initialArgs.retrieveElementsContext(),
+                            elementsSessionContext = initialArgs.elementsSessionContext,
                         )
                     )
                 }
@@ -544,8 +543,4 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
     override fun updateTopAppBar(state: FinancialConnectionsSheetState): TopAppBarStateUpdate? {
         return null
     }
-}
-
-private fun FinancialConnectionsSheetActivityArgs.retrieveElementsContext(): ElementsContext? {
-    return (this as? ForInstantDebits)?.elementsContext
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
@@ -7,6 +7,7 @@ import com.stripe.android.core.Logger
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.StripeNetworkClient
 import com.stripe.android.core.version.StripeSdkVersion
+import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.domain.AttachConsumerToLinkAccountSession
 import com.stripe.android.financialconnections.domain.CreateInstantDebitsResult
 import com.stripe.android.financialconnections.domain.HandleError
@@ -23,6 +24,7 @@ import com.stripe.android.financialconnections.model.SynchronizeSessionResponse
 import com.stripe.android.financialconnections.navigation.NavigationManager
 import com.stripe.android.financialconnections.navigation.NavigationManagerImpl
 import com.stripe.android.financialconnections.network.FinancialConnectionsRequestExecutor
+import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeState
 import com.stripe.android.financialconnections.repository.ConsumerSessionRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsAccountsRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsConsumerSessionRepository
@@ -183,6 +185,13 @@ internal interface FinancialConnectionsSheetNativeModule {
             } else {
                 linkSignupHandlerForNetworking.get()
             }
+        }
+
+        @Provides
+        internal fun provideElementsContext(
+            initialState: FinancialConnectionsSheetNativeState,
+        ): FinancialConnectionsSheet.ElementsContext? {
+            return initialState.elementsContext
         }
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
@@ -188,10 +188,10 @@ internal interface FinancialConnectionsSheetNativeModule {
         }
 
         @Provides
-        internal fun provideElementsContext(
+        internal fun provideElementsSessionContext(
             initialState: FinancialConnectionsSheetNativeState,
-        ): FinancialConnectionsSheet.ElementsContext? {
-            return initialState.elementsContext
+        ): FinancialConnectionsSheet.ElementsSessionContext? {
+            return initialState.elementsSessionContext
         }
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetActivityArgs.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetActivityArgs.kt
@@ -11,30 +11,30 @@ import java.security.InvalidParameterException
  * [com.stripe.android.financialconnections.FinancialConnectionsSheetActivity] and
  * instances of [com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetLauncher].
  */
-
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 sealed class FinancialConnectionsSheetActivityArgs(
-    open val configuration: FinancialConnectionsSheet.Configuration
+    open val configuration: FinancialConnectionsSheet.Configuration,
+    open val elementsSessionContext: FinancialConnectionsSheet.ElementsSessionContext?,
 ) : Parcelable {
 
     @Parcelize
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class ForData(
         override val configuration: FinancialConnectionsSheet.Configuration
-    ) : FinancialConnectionsSheetActivityArgs(configuration)
+    ) : FinancialConnectionsSheetActivityArgs(configuration, elementsSessionContext = null)
 
     @Parcelize
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class ForToken(
         override val configuration: FinancialConnectionsSheet.Configuration
-    ) : FinancialConnectionsSheetActivityArgs(configuration)
+    ) : FinancialConnectionsSheetActivityArgs(configuration, elementsSessionContext = null)
 
     @Parcelize
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class ForInstantDebits(
         override val configuration: FinancialConnectionsSheet.Configuration,
-        internal val elementsContext: FinancialConnectionsSheet.ElementsContext? = null,
-    ) : FinancialConnectionsSheetActivityArgs(configuration)
+        override val elementsSessionContext: FinancialConnectionsSheet.ElementsSessionContext? = null,
+    ) : FinancialConnectionsSheetActivityArgs(configuration, elementsSessionContext)
 
     internal fun validate() {
         if (configuration.financialConnectionsSessionClientSecret.isBlank()) {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetActivityArgs.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetActivityArgs.kt
@@ -32,7 +32,8 @@ sealed class FinancialConnectionsSheetActivityArgs(
     @Parcelize
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class ForInstantDebits(
-        override val configuration: FinancialConnectionsSheet.Configuration
+        override val configuration: FinancialConnectionsSheet.Configuration,
+        internal val elementsContext: FinancialConnectionsSheet.ElementsContext? = null,
     ) : FinancialConnectionsSheetActivityArgs(configuration)
 
     internal fun validate() {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForDataLauncher.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForDataLauncher.kt
@@ -52,7 +52,7 @@ class FinancialConnectionsSheetForDataLauncher(
 
     override fun present(
         configuration: FinancialConnectionsSheet.Configuration,
-        elementsContext: FinancialConnectionsSheet.ElementsContext?
+        elementsSessionContext: FinancialConnectionsSheet.ElementsSessionContext?
     ) {
         activityResultLauncher.launch(
             FinancialConnectionsSheetActivityArgs.ForData(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForDataLauncher.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForDataLauncher.kt
@@ -50,7 +50,10 @@ class FinancialConnectionsSheetForDataLauncher(
         }
     )
 
-    override fun present(configuration: FinancialConnectionsSheet.Configuration) {
+    override fun present(
+        configuration: FinancialConnectionsSheet.Configuration,
+        elementsContext: FinancialConnectionsSheet.ElementsContext?
+    ) {
         activityResultLauncher.launch(
             FinancialConnectionsSheetActivityArgs.ForData(
                 configuration

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForInstantDebitsLauncher.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForInstantDebitsLauncher.kt
@@ -39,10 +39,10 @@ class FinancialConnectionsSheetForInstantDebitsLauncher(
 
     override fun present(
         configuration: FinancialConnectionsSheet.Configuration,
-        elementsContext: FinancialConnectionsSheet.ElementsContext?
+        elementsSessionContext: FinancialConnectionsSheet.ElementsSessionContext?
     ) {
         activityResultLauncher.launch(
-            FinancialConnectionsSheetActivityArgs.ForInstantDebits(configuration, elementsContext)
+            FinancialConnectionsSheetActivityArgs.ForInstantDebits(configuration, elementsSessionContext)
         )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForInstantDebitsLauncher.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForInstantDebitsLauncher.kt
@@ -37,11 +37,12 @@ class FinancialConnectionsSheetForInstantDebitsLauncher(
         )
     )
 
-    override fun present(configuration: FinancialConnectionsSheet.Configuration) {
+    override fun present(
+        configuration: FinancialConnectionsSheet.Configuration,
+        elementsContext: FinancialConnectionsSheet.ElementsContext?
+    ) {
         activityResultLauncher.launch(
-            FinancialConnectionsSheetActivityArgs.ForInstantDebits(
-                configuration
-            )
+            FinancialConnectionsSheetActivityArgs.ForInstantDebits(configuration, elementsContext)
         )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForTokenLauncher.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForTokenLauncher.kt
@@ -50,7 +50,7 @@ internal class FinancialConnectionsSheetForTokenLauncher(
 
     override fun present(
         configuration: FinancialConnectionsSheet.Configuration,
-        elementsContext: FinancialConnectionsSheet.ElementsContext?
+        elementsSessionContext: FinancialConnectionsSheet.ElementsSessionContext?
     ) {
         activityResultLauncher.launch(
             FinancialConnectionsSheetActivityArgs.ForToken(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForTokenLauncher.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForTokenLauncher.kt
@@ -48,7 +48,10 @@ internal class FinancialConnectionsSheetForTokenLauncher(
         }
     )
 
-    override fun present(configuration: FinancialConnectionsSheet.Configuration) {
+    override fun present(
+        configuration: FinancialConnectionsSheet.Configuration,
+        elementsContext: FinancialConnectionsSheet.ElementsContext?
+    ) {
         activityResultLauncher.launch(
             FinancialConnectionsSheetActivityArgs.ForToken(
                 configuration

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetLauncher.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetLauncher.kt
@@ -5,5 +5,8 @@ import com.stripe.android.financialconnections.FinancialConnectionsSheet
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface FinancialConnectionsSheetLauncher {
-    fun present(configuration: FinancialConnectionsSheet.Configuration)
+    fun present(
+        configuration: FinancialConnectionsSheet.Configuration,
+        elementsContext: FinancialConnectionsSheet.ElementsContext? = null,
+    )
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetLauncher.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetLauncher.kt
@@ -7,6 +7,6 @@ import com.stripe.android.financialconnections.FinancialConnectionsSheet
 interface FinancialConnectionsSheetLauncher {
     fun present(
         configuration: FinancialConnectionsSheet.Configuration,
-        elementsContext: FinancialConnectionsSheet.ElementsContext? = null,
+        elementsSessionContext: FinancialConnectionsSheet.ElementsSessionContext? = null,
     )
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetNativeActivityArgs.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetNativeActivityArgs.kt
@@ -8,5 +8,6 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 internal data class FinancialConnectionsSheetNativeActivityArgs constructor(
     val configuration: FinancialConnectionsSheet.Configuration,
-    val initialSyncResponse: SynchronizeSessionResponse
+    val initialSyncResponse: SynchronizeSessionResponse,
+    val elementsContext: FinancialConnectionsSheet.ElementsContext? = null,
 ) : Parcelable

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetNativeActivityArgs.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetNativeActivityArgs.kt
@@ -9,5 +9,5 @@ import kotlinx.parcelize.Parcelize
 internal data class FinancialConnectionsSheetNativeActivityArgs constructor(
     val configuration: FinancialConnectionsSheet.Configuration,
     val initialSyncResponse: SynchronizeSessionResponse,
-    val elementsContext: FinancialConnectionsSheet.ElementsContext? = null,
+    val elementsSessionContext: FinancialConnectionsSheet.ElementsSessionContext? = null,
 ) : Parcelable

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -16,7 +16,7 @@ import androidx.navigation.compose.NavHost
 import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.FinancialConnections
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
-import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsContext
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.AppBackgrounded
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.ClickNavBarBack
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.ClickNavBarClose
@@ -514,7 +514,7 @@ internal data class FinancialConnectionsSheetNativeState(
     val initialPane: Pane,
     val theme: Theme,
     val isLinkWithStripe: Boolean,
-    val elementsContext: ElementsContext?,
+    val elementsSessionContext: ElementsSessionContext?,
 ) {
 
     /**
@@ -535,7 +535,7 @@ internal data class FinancialConnectionsSheetNativeState(
         theme = args.initialSyncResponse.manifest.theme?.toLocalTheme() ?: Theme.default,
         viewEffect = null,
         isLinkWithStripe = args.initialSyncResponse.manifest.isLinkWithStripe ?: false,
-        elementsContext = args.elementsContext,
+        elementsSessionContext = args.elementsSessionContext,
     )
 
     companion object {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -16,6 +16,7 @@ import androidx.navigation.compose.NavHost
 import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.FinancialConnections
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsContext
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.AppBackgrounded
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.ClickNavBarBack
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.ClickNavBarClose
@@ -513,6 +514,7 @@ internal data class FinancialConnectionsSheetNativeState(
     val initialPane: Pane,
     val theme: Theme,
     val isLinkWithStripe: Boolean,
+    val elementsContext: ElementsContext?,
 ) {
 
     /**
@@ -533,6 +535,7 @@ internal data class FinancialConnectionsSheetNativeState(
         theme = args.initialSyncResponse.manifest.theme?.toLocalTheme() ?: Theme.default,
         viewEffect = null,
         isLinkWithStripe = args.initialSyncResponse.manifest.isLinkWithStripe ?: false,
+        elementsContext = args.elementsContext,
     )
 
     companion object {

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModelTest.kt
@@ -313,7 +313,7 @@ internal class FinancialConnectionsSheetNativeViewModelTest {
             initialPane = FinancialConnectionsSessionManifest.Pane.CONSENT,
             theme = Theme.LinkLight,
             isLinkWithStripe = true,
-            elementsContext = null,
+            elementsSessionContext = null,
         )
 
         val viewModel = createViewModel(
@@ -367,7 +367,7 @@ internal class FinancialConnectionsSheetNativeViewModelTest {
             initialPane = FinancialConnectionsSessionManifest.Pane.CONSENT,
             theme = Theme.LinkLight,
             isLinkWithStripe = true,
-            elementsContext = null,
+            elementsSessionContext = null,
         )
 
         val viewModel = createViewModel(
@@ -419,7 +419,7 @@ internal class FinancialConnectionsSheetNativeViewModelTest {
             initialPane = FinancialConnectionsSessionManifest.Pane.CONSENT,
             theme = Theme.LinkLight,
             isLinkWithStripe = true,
-            elementsContext = null,
+            elementsSessionContext = null,
         )
 
         val viewModel = createViewModel(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModelTest.kt
@@ -313,6 +313,7 @@ internal class FinancialConnectionsSheetNativeViewModelTest {
             initialPane = FinancialConnectionsSessionManifest.Pane.CONSENT,
             theme = Theme.LinkLight,
             isLinkWithStripe = true,
+            elementsContext = null,
         )
 
         val viewModel = createViewModel(
@@ -366,6 +367,7 @@ internal class FinancialConnectionsSheetNativeViewModelTest {
             initialPane = FinancialConnectionsSessionManifest.Pane.CONSENT,
             theme = Theme.LinkLight,
             isLinkWithStripe = true,
+            elementsContext = null,
         )
 
         val viewModel = createViewModel(
@@ -417,6 +419,7 @@ internal class FinancialConnectionsSheetNativeViewModelTest {
             initialPane = FinancialConnectionsSessionManifest.Pane.CONSENT,
             theme = Theme.LinkLight,
             isLinkWithStripe = true,
+            elementsContext = null,
         )
 
         val viewModel = createViewModel(

--- a/payments-core/src/main/java/com/stripe/android/model/LinkMode.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/LinkMode.kt
@@ -2,13 +2,6 @@ package com.stripe.android.model
 
 import androidx.annotation.RestrictTo
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-enum class LinkMode(val value: String) {
-    Passthrough("PASSTHROUGH"),
-    LinkPaymentMethod("LINK_PAYMENT_METHOD"),
-    LinkCardBrand("LINK_CARD_BRAND"),
-}
-
 /**
  * Needed for backwards compatibility, as Elements uses these values for
  * analytics instead of the strings coming from the API.

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
@@ -6,6 +6,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.ActivityResultRegistryOwner
 import androidx.annotation.RestrictTo
 import androidx.fragment.app.Fragment
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsContext
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResult
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResultInternal
@@ -137,6 +138,7 @@ sealed interface CollectBankAccountConfiguration : Parcelable {
     @Parcelize
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class InstantDebits(
-        val email: String?
+        val email: String?,
+        val elementsContext: ElementsContext?,
     ) : Parcelable, CollectBankAccountConfiguration
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
@@ -6,7 +6,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.ActivityResultRegistryOwner
 import androidx.annotation.RestrictTo
 import androidx.fragment.app.Fragment
-import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsContext
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResult
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResultInternal
@@ -129,6 +129,7 @@ interface CollectBankAccountLauncher {
 }
 
 sealed interface CollectBankAccountConfiguration : Parcelable {
+
     @Parcelize
     data class USBankAccount(
         val name: String,
@@ -139,6 +140,6 @@ sealed interface CollectBankAccountConfiguration : Parcelable {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class InstantDebits(
         val email: String?,
-        val elementsContext: ElementsContext?,
+        val elementsSessionContext: ElementsSessionContext?,
     ) : Parcelable, CollectBankAccountConfiguration
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountActivity.kt
@@ -68,7 +68,8 @@ internal class CollectBankAccountActivity : AppCompatActivity() {
         financialConnectionsPaymentsProxy.present(
             financialConnectionsSessionClientSecret = financialConnectionsSessionSecret,
             publishableKey = publishableKey,
-            stripeAccountId = stripeAccountId
+            stripeAccountId = stripeAccountId,
+            elementsContext = elementsContext,
         )
     }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountActivity.kt
@@ -69,7 +69,7 @@ internal class CollectBankAccountActivity : AppCompatActivity() {
             financialConnectionsSessionClientSecret = financialConnectionsSessionSecret,
             publishableKey = publishableKey,
             stripeAccountId = stripeAccountId,
-            elementsContext = elementsContext,
+            elementsSessionContext = elementsSessionContext,
         )
     }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewEffect.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewEffect.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.payments.bankaccount.ui
 
-import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsContext
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResultInternal
 
 /**
@@ -18,7 +18,7 @@ internal sealed class CollectBankAccountViewEffect {
         val publishableKey: String,
         val financialConnectionsSessionSecret: String,
         val stripeAccountId: String?,
-        val elementsContext: ElementsContext?,
+        val elementsSessionContext: ElementsSessionContext?,
     ) : CollectBankAccountViewEffect()
 
     /**

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewEffect.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewEffect.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.payments.bankaccount.ui
 
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsContext
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResultInternal
 
 /**
@@ -16,7 +17,8 @@ internal sealed class CollectBankAccountViewEffect {
     data class OpenConnectionsFlow(
         val publishableKey: String,
         val financialConnectionsSessionSecret: String,
-        val stripeAccountId: String?
+        val stripeAccountId: String?,
+        val elementsContext: ElementsContext?,
     ) : CollectBankAccountViewEffect()
 
     /**

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
@@ -8,7 +8,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.core.Logger
 import com.stripe.android.core.utils.requireApplication
-import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsContext
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext
 import com.stripe.android.financialconnections.FinancialConnectionsSheetResult
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetInstantDebitsResult
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
@@ -109,13 +109,13 @@ internal class CollectBankAccountViewModel @Inject constructor(
                 logger.debug("Bank account session created! $financialConnectionsSessionSecret.")
                 hasLaunched = true
 
-                val elementsContext = args.configuration.retrieveElementsContext()
+                val elementsSessionContext = args.configuration.retrieveElementsSessionContext()
                 _viewEffect.emit(
                     OpenConnectionsFlow(
                         financialConnectionsSessionSecret = financialConnectionsSessionSecret,
                         publishableKey = args.publishableKey,
                         stripeAccountId = args.stripeAccountId,
-                        elementsContext = elementsContext,
+                        elementsSessionContext = elementsSessionContext,
                     )
                 )
             }
@@ -279,6 +279,6 @@ internal class CollectBankAccountViewModel @Inject constructor(
     }
 }
 
-private fun CollectBankAccountConfiguration.retrieveElementsContext(): ElementsContext? {
-    return (this as? InstantDebits)?.elementsContext
+private fun CollectBankAccountConfiguration.retrieveElementsSessionContext(): ElementsSessionContext? {
+    return (this as? InstantDebits)?.elementsSessionContext
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
@@ -8,10 +8,13 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.core.Logger
 import com.stripe.android.core.utils.requireApplication
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsContext
 import com.stripe.android.financialconnections.FinancialConnectionsSheetResult
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetInstantDebitsResult
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.payments.bankaccount.CollectBankAccountConfiguration
+import com.stripe.android.payments.bankaccount.CollectBankAccountConfiguration.InstantDebits
 import com.stripe.android.payments.bankaccount.di.DaggerCollectBankAccountComponent
 import com.stripe.android.payments.bankaccount.domain.AttachFinancialConnectionsSession
 import com.stripe.android.payments.bankaccount.domain.CreateFinancialConnectionsSession
@@ -105,11 +108,14 @@ internal class CollectBankAccountViewModel @Inject constructor(
             .onSuccess { financialConnectionsSessionSecret: String ->
                 logger.debug("Bank account session created! $financialConnectionsSessionSecret.")
                 hasLaunched = true
+
+                val elementsContext = args.configuration.retrieveElementsContext()
                 _viewEffect.emit(
                     OpenConnectionsFlow(
                         financialConnectionsSessionSecret = financialConnectionsSessionSecret,
                         publishableKey = args.publishableKey,
-                        stripeAccountId = args.stripeAccountId
+                        stripeAccountId = args.stripeAccountId,
+                        elementsContext = elementsContext,
                     )
                 )
             }
@@ -271,4 +277,8 @@ internal class CollectBankAccountViewModel @Inject constructor(
     companion object {
         private const val KEY_HAS_LAUNCHED = "key_has_launched"
     }
+}
+
+private fun CollectBankAccountConfiguration.retrieveElementsContext(): ElementsContext? {
+    return (this as? InstantDebits)?.elementsContext
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/financialconnections/FinancialConnectionsPaymentsProxy.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/financialconnections/FinancialConnectionsPaymentsProxy.kt
@@ -3,6 +3,7 @@ package com.stripe.android.payments.financialconnections
 import androidx.appcompat.app.AppCompatActivity
 import com.stripe.android.BuildConfig
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext
 import com.stripe.android.financialconnections.FinancialConnectionsSheetResult
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetForDataLauncher
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetForInstantDebitsLauncher
@@ -18,7 +19,7 @@ internal interface FinancialConnectionsPaymentsProxy {
         financialConnectionsSessionClientSecret: String,
         publishableKey: String,
         stripeAccountId: String?,
-        elementsContext: FinancialConnectionsSheet.ElementsContext?,
+        elementsSessionContext: ElementsSessionContext?,
     )
 
     companion object {
@@ -72,7 +73,7 @@ internal class FinancialConnectionsLauncherProxy<T : FinancialConnectionsSheetLa
         financialConnectionsSessionClientSecret: String,
         publishableKey: String,
         stripeAccountId: String?,
-        elementsContext: FinancialConnectionsSheet.ElementsContext?,
+        elementsSessionContext: ElementsSessionContext?,
     ) {
         launcher.present(
             configuration = FinancialConnectionsSheet.Configuration(
@@ -80,7 +81,7 @@ internal class FinancialConnectionsLauncherProxy<T : FinancialConnectionsSheetLa
                 publishableKey,
                 stripeAccountId,
             ),
-            elementsContext = elementsContext,
+            elementsSessionContext = elementsSessionContext,
         )
     }
 }
@@ -90,7 +91,7 @@ internal class UnsupportedFinancialConnectionsPaymentsProxy : FinancialConnectio
         financialConnectionsSessionClientSecret: String,
         publishableKey: String,
         stripeAccountId: String?,
-        elementsContext: FinancialConnectionsSheet.ElementsContext?,
+        elementsSessionContext: ElementsSessionContext?,
     ) {
         if (BuildConfig.DEBUG) {
             throw IllegalStateException(

--- a/payments-core/src/main/java/com/stripe/android/payments/financialconnections/FinancialConnectionsPaymentsProxy.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/financialconnections/FinancialConnectionsPaymentsProxy.kt
@@ -17,7 +17,8 @@ internal interface FinancialConnectionsPaymentsProxy {
     fun present(
         financialConnectionsSessionClientSecret: String,
         publishableKey: String,
-        stripeAccountId: String?
+        stripeAccountId: String?,
+        elementsContext: FinancialConnectionsSheet.ElementsContext?,
     )
 
     companion object {
@@ -70,14 +71,16 @@ internal class FinancialConnectionsLauncherProxy<T : FinancialConnectionsSheetLa
     override fun present(
         financialConnectionsSessionClientSecret: String,
         publishableKey: String,
-        stripeAccountId: String?
+        stripeAccountId: String?,
+        elementsContext: FinancialConnectionsSheet.ElementsContext?,
     ) {
         launcher.present(
-            FinancialConnectionsSheet.Configuration(
+            configuration = FinancialConnectionsSheet.Configuration(
                 financialConnectionsSessionClientSecret,
                 publishableKey,
-                stripeAccountId
-            )
+                stripeAccountId,
+            ),
+            elementsContext = elementsContext,
         )
     }
 }
@@ -86,7 +89,8 @@ internal class UnsupportedFinancialConnectionsPaymentsProxy : FinancialConnectio
     override fun present(
         financialConnectionsSessionClientSecret: String,
         publishableKey: String,
-        stripeAccountId: String?
+        stripeAccountId: String?,
+        elementsContext: FinancialConnectionsSheet.ElementsContext?,
     ) {
         if (BuildConfig.DEBUG) {
             throw IllegalStateException(

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
@@ -73,7 +73,8 @@ class CollectBankAccountViewModelTest {
                 OpenConnectionsFlow(
                     publishableKey = publishableKey,
                     financialConnectionsSessionSecret = financialConnectionsSession.clientSecret!!,
-                    stripeAccountId = stripeAccountId
+                    stripeAccountId = stripeAccountId,
+                    elementsContext = null,
                 )
             )
         }
@@ -94,7 +95,8 @@ class CollectBankAccountViewModelTest {
                 OpenConnectionsFlow(
                     publishableKey = publishableKey,
                     financialConnectionsSessionSecret = financialConnectionsSession.clientSecret!!,
-                    stripeAccountId = stripeAccountId
+                    stripeAccountId = stripeAccountId,
+                    elementsContext = null,
                 )
             )
         }
@@ -117,7 +119,8 @@ class CollectBankAccountViewModelTest {
                 OpenConnectionsFlow(
                     publishableKey = publishableKey,
                     financialConnectionsSessionSecret = financialConnectionsSession.clientSecret!!,
-                    stripeAccountId = stripeAccountId
+                    stripeAccountId = stripeAccountId,
+                    elementsContext = null,
                 )
             )
         }
@@ -140,7 +143,8 @@ class CollectBankAccountViewModelTest {
                 OpenConnectionsFlow(
                     publishableKey = publishableKey,
                     financialConnectionsSessionSecret = financialConnectionsSession.clientSecret!!,
-                    stripeAccountId = stripeAccountId
+                    stripeAccountId = stripeAccountId,
+                    elementsContext = null,
                 )
             )
         }

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
@@ -74,7 +74,7 @@ class CollectBankAccountViewModelTest {
                     publishableKey = publishableKey,
                     financialConnectionsSessionSecret = financialConnectionsSession.clientSecret!!,
                     stripeAccountId = stripeAccountId,
-                    elementsContext = null,
+                    elementsSessionContext = null,
                 )
             )
         }
@@ -96,7 +96,7 @@ class CollectBankAccountViewModelTest {
                     publishableKey = publishableKey,
                     financialConnectionsSessionSecret = financialConnectionsSession.clientSecret!!,
                     stripeAccountId = stripeAccountId,
-                    elementsContext = null,
+                    elementsSessionContext = null,
                 )
             )
         }
@@ -120,7 +120,7 @@ class CollectBankAccountViewModelTest {
                     publishableKey = publishableKey,
                     financialConnectionsSessionSecret = financialConnectionsSession.clientSecret!!,
                     stripeAccountId = stripeAccountId,
-                    elementsContext = null,
+                    elementsSessionContext = null,
                 )
             )
         }
@@ -144,7 +144,7 @@ class CollectBankAccountViewModelTest {
                     publishableKey = publishableKey,
                     financialConnectionsSessionSecret = financialConnectionsSession.clientSecret!!,
                     stripeAccountId = stripeAccountId,
-                    elementsContext = null,
+                    elementsSessionContext = null,
                 )
             )
         }

--- a/payments-core/src/test/java/com/stripe/android/payments/financialconnections/FinancialConnectionsPaymentsProxyTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/financialconnections/FinancialConnectionsPaymentsProxyTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.payments.financialconnections
 
 import androidx.appcompat.app.AppCompatActivity
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsContext
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -22,7 +23,8 @@ class FinancialConnectionsPaymentsProxyTest {
         override fun present(
             financialConnectionsSessionClientSecret: String,
             publishableKey: String,
-            stripeAccountId: String?
+            stripeAccountId: String?,
+            elementsContext: ElementsContext?,
         ) {
             // noop
         }
@@ -62,7 +64,8 @@ class FinancialConnectionsPaymentsProxyTest {
             ).present(
                 financialConnectionsSessionClientSecret = "",
                 publishableKey = "",
-                stripeAccountId = null
+                stripeAccountId = null,
+                elementsContext = null,
             )
         }
     }

--- a/payments-core/src/test/java/com/stripe/android/payments/financialconnections/FinancialConnectionsPaymentsProxyTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/financialconnections/FinancialConnectionsPaymentsProxyTest.kt
@@ -2,7 +2,7 @@ package com.stripe.android.payments.financialconnections
 
 import androidx.appcompat.app.AppCompatActivity
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
-import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsContext
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -24,7 +24,7 @@ class FinancialConnectionsPaymentsProxyTest {
             financialConnectionsSessionClientSecret: String,
             publishableKey: String,
             stripeAccountId: String?,
-            elementsContext: ElementsContext?,
+            elementsSessionContext: ElementsSessionContext?,
         ) {
             // noop
         }
@@ -65,7 +65,7 @@ class FinancialConnectionsPaymentsProxyTest {
                 financialConnectionsSessionClientSecret = "",
                 publishableKey = "",
                 stripeAccountId = null,
-                elementsContext = null,
+                elementsSessionContext = null,
             )
         }
     }

--- a/payments-model/src/main/java/com/stripe/android/model/LinkMode.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/LinkMode.kt
@@ -1,0 +1,10 @@
+package com.stripe.android.model
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class LinkMode(val value: String) {
+    Passthrough("PASSTHROUGH"),
+    LinkPaymentMethod("LINK_PAYMENT_METHOD"),
+    LinkCardBrand("LINK_CARD_BRAND"),
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -836,6 +836,7 @@ internal class CustomerSheetViewModel(
     private fun createDefaultUsBankArguments(stripeIntent: StripeIntent?): USBankAccountFormArguments {
         return USBankAccountFormArguments(
             instantDebits = false,
+            linkMode = null,
             showCheckbox = false,
             onBehalfOf = null,
             isCompleteFlow = false,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
@@ -62,6 +62,7 @@ internal fun USBankAccountForm(
         factory = USBankAccountFormViewModel.Factory {
             USBankAccountFormViewModel.Args(
                 instantDebits = usBankAccountFormArgs.instantDebits,
+                linkMode = usBankAccountFormArgs.linkMode,
                 formArgs = formArgs,
                 hostedSurface = usBankAccountFormArgs.hostedSurface,
                 showCheckbox = usBankAccountFormArgs.showCheckbox,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.paymentdatacollection.ach
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.lpmfoundations.luxe.isSaveForFutureUseValueChangeable
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResultInternal
@@ -38,6 +39,7 @@ import kotlinx.coroutines.flow.update
  */
 internal class USBankAccountFormArguments(
     val instantDebits: Boolean,
+    val linkMode: LinkMode?,
     val onBehalfOf: String?,
     val showCheckbox: Boolean,
     val isCompleteFlow: Boolean,
@@ -81,6 +83,7 @@ internal class USBankAccountFormArguments(
                     instantDebits.not(),
                 hostedSurface = hostedSurface,
                 instantDebits = instantDebits,
+                linkMode = paymentMethodMetadata.linkMode,
                 onBehalfOf = onBehalfOf,
                 isCompleteFlow = viewModel.isCompleteFlow,
                 isPaymentFlow = stripeIntent is PaymentIntent,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -13,7 +13,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.requireApplication
-import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsContext
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext
 import com.stripe.android.financialconnections.model.BankAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
 import com.stripe.android.model.Address
@@ -472,7 +472,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         val configuration = if (args.instantDebits) {
             CollectBankAccountConfiguration.InstantDebits(
                 email = email.value,
-                elementsContext = ElementsContext(
+                elementsSessionContext = ElementsSessionContext(
                     linkMode = args.linkMode,
                 ),
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -13,9 +13,11 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.requireApplication
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsContext
 import com.stripe.android.financialconnections.model.BankAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
 import com.stripe.android.model.Address
+import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodOptionsParams
@@ -470,6 +472,9 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         val configuration = if (args.instantDebits) {
             CollectBankAccountConfiguration.InstantDebits(
                 email = email.value,
+                elementsContext = ElementsContext(
+                    linkMode = args.linkMode,
+                ),
             )
         } else {
             CollectBankAccountConfiguration.USBankAccount(
@@ -668,6 +673,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
 
     data class Args(
         val instantDebits: Boolean,
+        val linkMode: LinkMode?,
         val formArgs: FormArguments,
         val showCheckbox: Boolean,
         val isCompleteFlow: Boolean,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -40,6 +40,7 @@ internal class CustomerSheetScreenshotTest {
     private val usBankAccountFormArguments = USBankAccountFormArguments(
         showCheckbox = false,
         instantDebits = false,
+        linkMode = null,
         onBehalfOf = null,
         isCompleteFlow = false,
         isPaymentFlow = false,
@@ -47,7 +48,7 @@ internal class CustomerSheetScreenshotTest {
         clientSecret = null,
         shippingDetails = null,
         draftPaymentSelection = null,
-        hostedSurface = CollectBankAccountLauncher.HOSTED_SURFACE_PAYMENT_ELEMENT,
+        hostedSurface = CollectBankAccountLauncher.HOSTED_SURFACE_CUSTOMER_SHEET,
         onMandateTextChanged = { _, _ -> },
         onConfirmUSBankAccount = { },
         onCollectBankAccountResult = { },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -1078,7 +1078,7 @@ class USBankAccountFormViewModelTest {
             configuration = eq(
                 CollectBankAccountConfiguration.InstantDebits(
                     email = "email@email.com",
-                    elementsContext = FinancialConnectionsSheet.ElementsContext(
+                    elementsSessionContext = FinancialConnectionsSheet.ElementsSessionContext(
                         linkMode = LinkMode.LinkCardBrand,
                     ),
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -14,6 +14,7 @@ import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.Address
 import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodOptionsParams
@@ -1057,7 +1058,10 @@ class USBankAccountFormViewModelTest {
     @Test
     fun `Uses CollectBankAccountLauncher for Instant Debits when in Instant Debits flow`() {
         val viewModel = createViewModel(
-            args = defaultArgs.copy(instantDebits = true),
+            args = defaultArgs.copy(
+                instantDebits = true,
+                linkMode = LinkMode.LinkCardBrand,
+            ),
         ).apply {
             this.collectBankAccountLauncher = mockCollectBankAccountLauncher
         }
@@ -1075,7 +1079,7 @@ class USBankAccountFormViewModelTest {
                 CollectBankAccountConfiguration.InstantDebits(
                     email = "email@email.com",
                     elementsContext = FinancialConnectionsSheet.ElementsContext(
-                        linkMode = null,
+                        linkMode = LinkMode.LinkCardBrand,
                     ),
                 )
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -7,6 +7,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.model.BankAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
@@ -69,6 +70,7 @@ class USBankAccountFormViewModelTest {
         savedPaymentMethod = null,
         shippingDetails = null,
         hostedSurface = CollectBankAccountLauncher.HOSTED_SURFACE_PAYMENT_ELEMENT,
+        linkMode = null,
     )
 
     private val mockCollectBankAccountLauncher = mock<CollectBankAccountLauncher>()
@@ -1072,6 +1074,9 @@ class USBankAccountFormViewModelTest {
             configuration = eq(
                 CollectBankAccountConfiguration.InstantDebits(
                     email = "email@email.com",
+                    elementsContext = FinancialConnectionsSheet.ElementsContext(
+                        linkMode = null,
+                    ),
                 )
             ),
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds an `ElementsContext` struct to the Instant Debits flow, allowing us to pass in information from the hosting surface.

Right now, this is only used with the `LinkMode` in Instant Debits flow, but can be extended to more properties and to the ACH flow.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[BANKCON-14527](https://jira.corp.stripe.com/browse/BANKCON-14527)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
