### PR TITLE
Fix issue with resetting US bank account mandate

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -36,10 +36,10 @@
     <ID>LongMethod:PaymentSheetScreen.kt$@Composable private fun PaymentSheetContent( viewModel: BaseSheetViewModel, headerText: ResolvableString?, walletsState: WalletsState?, walletsProcessingState: WalletsProcessingState?, error: ResolvableString?, currentScreen: PaymentSheetScreen, mandateText: MandateText?, modifier: Modifier, )</ID>
     <ID>LongMethod:PaymentSheetViewModelTest.kt$PaymentSheetViewModelTest$@Test fun `Can complete payment after switching to another LPM from card selection with inline Link signup state`()</ID>
     <ID>LongMethod:PlaceholderHelperTest.kt$PlaceholderHelperTest$@Test fun `Test correct placeholder is removed for placeholder spec`()</ID>
-    <ID>LongMethod:USBankAccountEmitters.kt$@Composable internal fun USBankAccountEmitters( viewModel: USBankAccountFormViewModel, usBankAccountFormArgs: USBankAccountFormArguments, )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable internal fun BillingDetailsForm( instantDebits: Boolean, formArgs: FormArguments, isProcessing: Boolean, isPaymentFlow: Boolean, nameController: TextFieldController, emailController: TextFieldController, phoneController: PhoneNumberController, addressController: AddressController, lastTextFieldIdentifier: IdentifierSpec?, sameAsShippingElement: SameAsShippingElement?, )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable internal fun USBankAccountForm( formArgs: FormArguments, usBankAccountFormArgs: USBankAccountFormArguments, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable private fun AccountDetailsForm( showCheckbox: Boolean, isProcessing: Boolean, bankName: String?, last4: String?, saveForFutureUseElement: SaveForFutureUseElement, onRemoveAccount: () -> Unit, )</ID>
+    <ID>LongMethod:USBankAccountFormViewModelTest.kt$USBankAccountFormViewModelTest$@Test fun `Restores screen state when re-opening screen`()</ID>
     <ID>MagicNumber:BaseSheetActivity.kt$BaseSheetActivity$30</ID>
     <ID>MagicNumber:NewPaymentMethodTabLayoutUI.kt$.3f</ID>
     <ID>MagicNumber:NewPaymentMethodTabLayoutUI.kt$.4f</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/MandateHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/MandateHandler.kt
@@ -25,15 +25,10 @@ internal class MandateHandler(
     init {
         coroutineScope.launch {
             selection.collect { selection ->
-                val mandateText = if (selection is PaymentSelection.New.USBankAccount) {
-                    // Keep whatever we already show
-                    _mandateText.value?.text
-                } else {
-                    selection?.mandateText(
-                        merchantName = merchantDisplayName,
-                        isSetupFlow = isSetupFlowProvider(),
-                    )
-                }
+                val mandateText = selection?.mandateText(
+                    merchantName = merchantDisplayName,
+                    isSetupFlow = isSetupFlowProvider(),
+                )
 
                 val showAbove = (selection as? PaymentSelection.Saved?)?.showMandateAbovePrimaryButton == true
                 updateMandateText(mandateText = mandateText, showAbove = showAbove)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/MandateHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/MandateHandler.kt
@@ -25,10 +25,15 @@ internal class MandateHandler(
     init {
         coroutineScope.launch {
             selection.collect { selection ->
-                val mandateText = selection?.mandateText(
-                    merchantName = merchantDisplayName,
-                    isSetupFlow = isSetupFlowProvider(),
-                )
+                val mandateText = if (selection is PaymentSelection.New.USBankAccount) {
+                    // Keep whatever we already show
+                    _mandateText.value?.text
+                } else {
+                    selection?.mandateText(
+                        merchantName = merchantDisplayName,
+                        isSetupFlow = isSetupFlowProvider(),
+                    )
+                }
 
                 val showAbove = (selection as? PaymentSelection.Saved?)?.showMandateAbovePrimaryButton == true
                 updateMandateText(mandateText = mandateText, showAbove = showAbove)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -107,7 +107,7 @@ internal sealed class PaymentSelection : Parcelable {
         ): ResolvableString? {
             return when (paymentMethod.type) {
                 USBankAccount -> {
-                    USBankAccountTextBuilder.mandateText(
+                    USBankAccountTextBuilder.buildMandateAndMicrodepositsText(
                         merchantName = merchantName,
                         isVerifyingMicrodeposits = false,
                         isSaveForFutureUseSelected = false,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -107,8 +107,9 @@ internal sealed class PaymentSelection : Parcelable {
         ): ResolvableString? {
             return when (paymentMethod.type) {
                 USBankAccount -> {
-                    USBankAccountTextBuilder.getContinueMandateText(
+                    USBankAccountTextBuilder.mandateText(
                         merchantName = merchantName,
+                        isVerifyingMicrodeposits = false,
                         isSaveForFutureUseSelected = false,
                         isInstantDebits = false,
                         isSetupFlow = isSetupFlow,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountEmitters.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountEmitters.kt
@@ -5,16 +5,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalContext
 import com.stripe.android.uicore.utils.collectAsState
-import kotlinx.coroutines.flow.filterNot
 
 @Composable
 internal fun USBankAccountEmitters(
     viewModel: USBankAccountFormViewModel,
     usBankAccountFormArgs: USBankAccountFormArguments,
 ) {
-    val context = LocalContext.current
     val screenState by viewModel.currentScreenState.collectAsState()
     val hasRequiredFields by viewModel.requiredFields.collectAsState()
     val activityResultRegistryOwner = LocalActivityResultRegistryOwner.current
@@ -43,32 +40,10 @@ internal fun USBankAccountEmitters(
         }
     }
 
-    LaunchedEffect(Unit) {
-        viewModel.saveForFutureUse.filterNot {
-            screenState is USBankAccountFormScreenState.BillingDetailsCollection
-        }.collect { saved ->
-            val merchantName = viewModel.formattedMerchantName()
-            val mandateText = USBankAccountTextBuilder.getContinueMandateText(
-                merchantName = merchantName,
-                isSaveForFutureUseSelected = saved,
-                isInstantDebits = usBankAccountFormArgs.instantDebits,
-                isSetupFlow = !usBankAccountFormArgs.isPaymentFlow,
-            )
-            usBankAccountFormArgs.updateMandateText(
-                context = context,
-                screenState = screenState,
-                mandateText = mandateText,
-                merchantName = merchantName
-            )
-        }
-    }
-
     LaunchedEffect(screenState, hasRequiredFields) {
         usBankAccountFormArgs.handleScreenStateChanged(
-            context = context,
             screenState = screenState,
             enabled = hasRequiredFields && !screenState.isProcessing,
-            merchantName = viewModel.formattedMerchantName(),
             onPrimaryButtonClick = viewModel::handlePrimaryButtonClick,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState.kt
@@ -60,3 +60,22 @@ internal sealed class USBankAccountFormScreenState(
         data class PaymentMethod(val id: String) : ResultIdentifier
     }
 }
+
+internal fun USBankAccountFormScreenState.updateWithMandate(
+    mandate: ResolvableString?,
+): USBankAccountFormScreenState {
+    return when (this) {
+        is USBankAccountFormScreenState.BillingDetailsCollection -> {
+            this
+        }
+        is USBankAccountFormScreenState.MandateCollection -> {
+            this.copy(mandateText = mandate)
+        }
+        is USBankAccountFormScreenState.SavedAccount -> {
+            this.copy(mandateText = mandate)
+        }
+        is USBankAccountFormScreenState.VerifyWithMicrodeposits -> {
+            this.copy(mandateText = mandate)
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -632,21 +632,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
                 isVerifyWithMicrodeposits = state is USBankAccountFormScreenState.VerifyWithMicrodeposits,
                 isSaveForFutureUseSelected = saveForFutureUse,
             )
-
-            when (state) {
-                is USBankAccountFormScreenState.BillingDetailsCollection -> {
-                    state
-                }
-                is USBankAccountFormScreenState.MandateCollection -> {
-                    state.copy(mandateText = mandateText)
-                }
-                is USBankAccountFormScreenState.SavedAccount -> {
-                    state.copy(mandateText = mandateText)
-                }
-                is USBankAccountFormScreenState.VerifyWithMicrodeposits -> {
-                    state.copy(mandateText = mandateText)
-                }
-            }
+            state.updateWithMandate(mandateText)
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -51,6 +51,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -234,6 +236,12 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
             }
         }
 
+        viewModelScope.launch {
+            saveForFutureUse.onEach { saveForFutureUse ->
+                updateScreenStateWithSaveForFutureUse(saveForFutureUse)
+            }.collect()
+        }
+
         val hasDefaultName = args.formArgs.billingDetails?.name != null &&
             args.formArgs.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod
         val hasDefaultEmail = args.formArgs.billingDetails?.email != null &&
@@ -326,7 +334,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
                 last4 = result.last4,
                 intentId = result.intent.id,
                 primaryButtonText = buildPrimaryButtonText(),
-                mandateText = buildMandateText(),
+                mandateText = buildMandateText(isVerifyWithMicrodeposits = false),
             )
         }
     }
@@ -343,7 +351,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
                         financialConnectionsSessionId = usBankAccountData.financialConnectionsSession.id,
                         intentId = intentId,
                         primaryButtonText = buildPrimaryButtonText(),
-                        mandateText = buildMandateText(),
+                        mandateText = buildMandateText(isVerifyWithMicrodeposits = true),
                     )
                 }
             }
@@ -358,7 +366,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
                         last4 = paymentAccount.last4,
                         intentId = intentId,
                         primaryButtonText = buildPrimaryButtonText(),
-                        mandateText = buildMandateText(),
+                        mandateText = buildMandateText(isVerifyWithMicrodeposits = false),
                     )
                 }
             }
@@ -618,10 +626,38 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         }
     }
 
-    private fun buildMandateText(): ResolvableString {
-        return USBankAccountTextBuilder.getContinueMandateText(
+    private fun updateScreenStateWithSaveForFutureUse(saveForFutureUse: Boolean) {
+        _currentScreenState.update { state ->
+            val mandateText = buildMandateText(
+                isVerifyWithMicrodeposits = state is USBankAccountFormScreenState.VerifyWithMicrodeposits,
+                isSaveForFutureUseSelected = saveForFutureUse,
+            )
+
+            when (state) {
+                is USBankAccountFormScreenState.BillingDetailsCollection -> {
+                    state
+                }
+                is USBankAccountFormScreenState.MandateCollection -> {
+                    state.copy(mandateText = mandateText)
+                }
+                is USBankAccountFormScreenState.SavedAccount -> {
+                    state.copy(mandateText = mandateText)
+                }
+                is USBankAccountFormScreenState.VerifyWithMicrodeposits -> {
+                    state.copy(mandateText = mandateText)
+                }
+            }
+        }
+    }
+
+    private fun buildMandateText(
+        isVerifyWithMicrodeposits: Boolean,
+        isSaveForFutureUseSelected: Boolean = saveForFutureUse.value,
+    ): ResolvableString {
+        return USBankAccountTextBuilder.mandateText(
             merchantName = formattedMerchantName(),
-            isSaveForFutureUseSelected = saveForFutureUse.value,
+            isVerifyingMicrodeposits = isVerifyWithMicrodeposits,
+            isSaveForFutureUseSelected = isSaveForFutureUseSelected,
             isInstantDebits = args.instantDebits,
             isSetupFlow = !args.isPaymentFlow,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -654,7 +654,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         isVerifyWithMicrodeposits: Boolean,
         isSaveForFutureUseSelected: Boolean = saveForFutureUse.value,
     ): ResolvableString {
-        return USBankAccountTextBuilder.mandateText(
+        return USBankAccountTextBuilder.buildMandateAndMicrodepositsText(
             merchantName = formattedMerchantName(),
             isVerifyingMicrodeposits = isVerifyWithMicrodeposits,
             isSaveForFutureUseSelected = isSaveForFutureUseSelected,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountTextBuilder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountTextBuilder.kt
@@ -33,7 +33,7 @@ internal object USBankAccountTextBuilder {
         }
 
         return if (microdepositsText != null) {
-            mandateText + " ".resolvableString + microdepositsText
+            microdepositsText + " ".resolvableString + mandateText
         } else {
             mandateText
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountTextBuilder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountTextBuilder.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.paymentdatacollection.ach
 
 import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.plus
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.strings.transformations.Replace
 import com.stripe.android.paymentsheet.R
@@ -10,7 +11,34 @@ import com.stripe.android.paymentsheet.R
  */
 internal object USBankAccountTextBuilder {
 
-    fun getContinueMandateText(
+    fun mandateText(
+        merchantName: String,
+        isVerifyingMicrodeposits: Boolean,
+        isSaveForFutureUseSelected: Boolean,
+        isInstantDebits: Boolean,
+        isSetupFlow: Boolean,
+    ): ResolvableString {
+        val mandateText = getContinueMandateText(
+            merchantName = merchantName,
+            isSaveForFutureUseSelected = isSaveForFutureUseSelected,
+            isInstantDebits = isInstantDebits,
+            isSetupFlow = isSetupFlow,
+        )
+
+        val microdepositsText = if (isVerifyingMicrodeposits) {
+            resolvableString(R.string.stripe_paymentsheet_microdeposit, merchantName)
+        } else {
+            null
+        }
+
+        return if (microdepositsText != null) {
+            mandateText + " ".resolvableString + microdepositsText
+        } else {
+            mandateText
+        }
+    }
+
+    private fun getContinueMandateText(
         merchantName: String,
         isSaveForFutureUseSelected: Boolean,
         isInstantDebits: Boolean,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountTextBuilder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountTextBuilder.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.paymentdatacollection.ach
 
+import androidx.annotation.VisibleForTesting
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.plus
 import com.stripe.android.core.strings.resolvableString
@@ -11,14 +12,14 @@ import com.stripe.android.paymentsheet.R
  */
 internal object USBankAccountTextBuilder {
 
-    fun mandateText(
+    fun buildMandateAndMicrodepositsText(
         merchantName: String,
         isVerifyingMicrodeposits: Boolean,
         isSaveForFutureUseSelected: Boolean,
         isInstantDebits: Boolean,
         isSetupFlow: Boolean,
     ): ResolvableString {
-        val mandateText = getContinueMandateText(
+        val mandateText = buildMandateText(
             merchantName = merchantName,
             isSaveForFutureUseSelected = isSaveForFutureUseSelected,
             isInstantDebits = isInstantDebits,
@@ -38,7 +39,8 @@ internal object USBankAccountTextBuilder {
         }
     }
 
-    private fun getContinueMandateText(
+    @VisibleForTesting
+    fun buildMandateText(
         merchantName: String,
         isSaveForFutureUseSelected: Boolean,
         isInstantDebits: Boolean,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/UsBankAccountFormArgumentsKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/UsBankAccountFormArgumentsKtx.kt
@@ -1,17 +1,12 @@
 package com.stripe.android.paymentsheet.paymentdatacollection.ach
 
-import android.content.Context
 import com.stripe.android.core.strings.ResolvableString
-import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormScreenState.BillingDetailsCollection
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 
 internal fun USBankAccountFormArguments.handleScreenStateChanged(
-    context: Context,
     screenState: USBankAccountFormScreenState,
     enabled: Boolean,
-    merchantName: String,
     onPrimaryButtonClick: (USBankAccountFormScreenState) -> Unit,
 ) {
     screenState.error?.let {
@@ -27,12 +22,7 @@ internal fun USBankAccountFormArguments.handleScreenStateChanged(
         shouldShowProcessingWhenClicked = showProcessingWhenClicked
     )
 
-    updateMandateText(
-        context = context,
-        screenState = screenState,
-        mandateText = screenState.mandateText,
-        merchantName = merchantName,
-    )
+    onMandateTextChanged(screenState.mandateText, false)
 }
 
 private fun USBankAccountFormArguments.updatePrimaryButton(
@@ -57,28 +47,4 @@ private fun USBankAccountFormArguments.updatePrimaryButton(
             lockVisible = isCompleteFlow,
         )
     }
-}
-
-internal fun USBankAccountFormArguments.updateMandateText(
-    context: Context,
-    screenState: USBankAccountFormScreenState,
-    mandateText: ResolvableString?,
-    merchantName: String,
-) {
-    val microdepositsText =
-        if (screenState is USBankAccountFormScreenState.VerifyWithMicrodeposits) {
-            context.getString(R.string.stripe_paymentsheet_microdeposit, merchantName)
-        } else {
-            ""
-        }
-
-    val updatedText = mandateText?.let {
-        """
-            $microdepositsText
-                
-            ${mandateText.resolve(context)}
-        """.trimIndent()
-    }?.resolvableString
-
-    onMandateTextChanged(updatedText, false)
 }

--- a/stripe-core/api/stripe-core.api
+++ b/stripe-core/api/stripe-core.api
@@ -303,6 +303,14 @@ public final class com/stripe/android/core/networking/StripeRequest$MimeType : j
 	public static fun values ()[Lcom/stripe/android/core/networking/StripeRequest$MimeType;
 }
 
+public final class com/stripe/android/core/strings/ConcatenatedResolvableString$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/core/strings/ConcatenatedResolvableString;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/core/strings/ConcatenatedResolvableString;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/core/strings/IdentifierResolvableString$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/core/strings/IdentifierResolvableString;

--- a/stripe-core/src/main/java/com/stripe/android/core/strings/ConcatenatedResolvableString.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/strings/ConcatenatedResolvableString.kt
@@ -1,0 +1,14 @@
+package com.stripe.android.core.strings
+
+import android.content.Context
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+internal data class ConcatenatedResolvableString(
+    private val first: ResolvableString,
+    private val second: ResolvableString,
+) : ResolvableString {
+    override fun resolve(context: Context): String {
+        return first.resolve(context) + second.resolve(context)
+    }
+}

--- a/stripe-core/src/main/java/com/stripe/android/core/strings/ResolvableStringUtils.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/strings/ResolvableStringUtils.kt
@@ -65,3 +65,8 @@ val @receiver:StringRes Int.resolvableString: ResolvableString
 fun ResolvableString?.orEmpty(): ResolvableString {
     return this ?: "".resolvableString
 }
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+operator fun ResolvableString.plus(other: ResolvableString): ResolvableString {
+    return ConcatenatedResolvableString(this, other)
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the US Bank Account mandate resets as soon as we begin confirming the intent. ~It points to a deeper design flaw, but fixed with a little workaround for now, given that we hope to get rid of any US Bank Account particularities.~ Fixed the deeper flaw by assembling the whole (mandate + microdeposits info) in the screen state 🎉

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screen recordings

<details><summary>Before</summary>
<p>

https://github.com/user-attachments/assets/7a2d7354-2e0a-48b7-a20d-6f651056c7eb

</p>
</details>

<details><summary>After</summary>
<p>

https://github.com/user-attachments/assets/fd843d8c-5d99-409c-994e-3ef10a6d3e76

</p>
</details>

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
