### PR TITLE
Add `Google Pay` intent tests

### DIFF
--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -102,6 +102,7 @@ dependencies {
     androidTestImplementation testLibs.mockito.core
     androidTestImplementation testLibs.mockito.inline
     androidTestImplementation testLibs.mockito.kotlin
+    androidTestImplementation testLibs.espresso.intents
     androidTestImplementation libs.leakCanary
     androidTestImplementation testLibs.leakCanaryInstrumentation
     androidTestImplementation testLibs.testParameterInjector

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/GooglePayTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/GooglePayTest.kt
@@ -1,12 +1,25 @@
 package com.stripe.android.paymentsheet
 
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Intent
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.performClick
+import androidx.core.os.bundleOf
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.Intents.intending
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import com.google.android.gms.wallet.IsReadyToPayRequest
 import com.google.android.gms.wallet.PaymentsClient
+import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.googlepaylauncher.GooglePayAvailabilityClient
 import com.stripe.android.networktesting.RequestMatchers.host
@@ -14,19 +27,28 @@ import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
 import com.stripe.android.networktesting.ResponseReplacement
 import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.paymentsheet.ui.GOOGLE_PAY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_FORM_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_METHOD_CARD_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG
+import com.stripe.android.paymentsheet.utils.ProductIntegrationTestRunnerContext
 import com.stripe.android.paymentsheet.utils.ProductIntegrationType
 import com.stripe.android.paymentsheet.utils.ProductIntegrationTypeProvider
 import com.stripe.android.paymentsheet.utils.TestRules
+import com.stripe.android.paymentsheet.utils.assertCompleted
+import com.stripe.android.paymentsheet.utils.assertFailed
 import com.stripe.android.paymentsheet.utils.expectNoResult
 import com.stripe.android.paymentsheet.utils.runProductIntegrationTest
+import com.stripe.android.testing.PaymentIntentFactory
+import com.stripe.android.testing.PaymentMethodFactory
 import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 @RunWith(TestParameterInjector::class)
 internal class GooglePayTest {
@@ -38,52 +60,197 @@ internal class GooglePayTest {
 
     private val composeTestRule = testRules.compose
 
+    @Before
+    fun setup() {
+        Intents.init()
+    }
+
     @After
     fun teardown() {
         GooglePayRepository.resetFactory()
+        Intents.release()
     }
 
     @Test
-    fun googlePayIsShownWhenFullyEnabled() = runGooglePayTest(
+    fun googlePayIsShownWhenFullyEnabled() = runGooglePayAvailabilityTest(
         isGooglePayReady = true,
         isGooglePayEnabledInElementsSession = true,
         hasGooglePayConfig = true,
-    ) {
-        composeTestRule.onGooglePayOption().assertExists()
-    }
+        shouldHaveGooglePayOption = true,
+    )
 
     @Test
-    fun googlePayIsNotShownWhenNotReady() = runGooglePayTest(
+    fun googlePayIsNotShownWhenNotReady() = runGooglePayAvailabilityTest(
         isGooglePayReady = false,
         isGooglePayEnabledInElementsSession = true,
         hasGooglePayConfig = true,
-    ) {
-        composeTestRule.onGooglePayOption().assertDoesNotExist()
-    }
+        shouldHaveGooglePayOption = false,
+    )
 
     @Test
-    fun googlePayIsNotShownWhenNotEnabledInElementsSession() = runGooglePayTest(
+    fun googlePayIsNotShownWhenNotEnabledInElementsSession() = runGooglePayAvailabilityTest(
         isGooglePayReady = true,
         isGooglePayEnabledInElementsSession = false,
         hasGooglePayConfig = true,
-    ) {
-        composeTestRule.onGooglePayOption().assertDoesNotExist()
-    }
+        shouldHaveGooglePayOption = false,
+    )
 
     @Test
-    fun googlePayIsNotShownWhenGooglePayConfigIsNotProvided() = runGooglePayTest(
+    fun googlePayIsNotShownWhenGooglePayConfigIsNotProvided() = runGooglePayAvailabilityTest(
         isGooglePayReady = true,
         isGooglePayEnabledInElementsSession = true,
         hasGooglePayConfig = false,
+        shouldHaveGooglePayOption = false,
+    )
+
+    @Test
+    fun googlePaySucceeds() {
+        var resultCallbackCalled = false
+
+        runGooglePayFlowTest(
+            paymentResultCallback = {
+                resultCallbackCalled = true
+
+                assertCompleted(it)
+            }
+        ) { scenario ->
+            val paymentMethod = PaymentMethodFactory.card()
+
+            intendingGooglePayToBeLaunched(GooglePayPaymentMethodLauncher.Result.Completed(paymentMethod))
+            intendingPaymentConfirmationToBeLaunched(
+                InternalPaymentResult.Completed(PaymentIntentFactory.create(paymentMethod))
+            )
+
+            scenario.confirm()
+
+            intendedGooglePayToBeLaunched()
+            intendedPaymentConfirmationToBeLaunched()
+
+            composeTestRule.waitUntil(UI_TIMEOUT) {
+                resultCallbackCalled
+            }
+        }
+    }
+
+    @Test
+    fun googlePayFailsOnGooglePaySheetFailure() = runGooglePayFlowTest(
+        paymentResultCallback = {
+            when (integrationType) {
+                ProductIntegrationType.PaymentSheet -> expectNoResult(it)
+                ProductIntegrationType.FlowController -> assertFailed(it)
+            }
+        }
+    ) { scenario ->
+        intendingGooglePayToBeLaunched(
+            GooglePayPaymentMethodLauncher.Result.Failed(
+                error = IllegalStateException("An error occurred!"),
+                errorCode = GooglePayPaymentMethodLauncher.INTERNAL_ERROR
+            )
+        )
+
+        scenario.confirm()
+
+        intendedGooglePayToBeLaunched()
+
+        when (integrationType) {
+            ProductIntegrationType.PaymentSheet -> {
+                waitForErrorMessage("An internal error occurred.")
+                scenario.markTestSucceeded()
+            }
+            ProductIntegrationType.FlowController -> assertNoErrorMessage("An internal error occurred.")
+        }
+    }
+
+    @Test
+    fun googlePayFailsOnPaymentFailure() = runGooglePayFlowTest(
+        paymentResultCallback = {
+            when (integrationType) {
+                ProductIntegrationType.PaymentSheet -> expectNoResult(it)
+                ProductIntegrationType.FlowController -> assertFailed(it)
+            }
+        }
+    ) { scenario ->
+        intendingGooglePayToBeLaunched(GooglePayPaymentMethodLauncher.Result.Completed(PaymentMethodFactory.card()))
+        intendingPaymentConfirmationToBeLaunched(
+            InternalPaymentResult.Failed(IllegalStateException("An error occurred!"))
+        )
+
+        scenario.confirm()
+
+        intendedGooglePayToBeLaunched()
+        intendedPaymentConfirmationToBeLaunched()
+
+        when (integrationType) {
+            ProductIntegrationType.PaymentSheet -> {
+                waitForErrorMessage("Something went wrong")
+                scenario.markTestSucceeded()
+            }
+            ProductIntegrationType.FlowController -> assertNoErrorMessage("Something went wrong")
+        }
+    }
+
+    private fun runGooglePayFlowTest(
+        paymentResultCallback: (PaymentSheetResult) -> Unit,
+        test: (GooglePayFlowScenario) -> Unit
     ) {
-        composeTestRule.onGooglePayOption().assertDoesNotExist()
+        val paymentOptionCountDownLatch = CountDownLatch(1)
+
+        runGooglePayTest(
+            isGooglePayReady = true,
+            isGooglePayEnabledInElementsSession = true,
+            hasGooglePayConfig = true,
+            paymentOptionCallback = {
+                paymentOptionCountDownLatch.countDown()
+            },
+            paymentResultCallback = paymentResultCallback,
+        ) { context ->
+            test(
+                GooglePayFlowScenario(context::markTestSucceeded) {
+                    Espresso.onIdle()
+                    composeTestRule.waitForIdle()
+
+                    composeTestRule.onGooglePayOption().performClick()
+
+                    if (context is ProductIntegrationTestRunnerContext.WithFlowController) {
+                        assertThat(paymentOptionCountDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
+
+                        context.confirm()
+                    }
+                }
+            )
+        }
+    }
+
+    private fun runGooglePayAvailabilityTest(
+        isGooglePayReady: Boolean,
+        isGooglePayEnabledInElementsSession: Boolean,
+        hasGooglePayConfig: Boolean,
+        shouldHaveGooglePayOption: Boolean,
+    ) = runGooglePayTest(
+        isGooglePayReady = isGooglePayReady,
+        isGooglePayEnabledInElementsSession = isGooglePayEnabledInElementsSession,
+        hasGooglePayConfig = hasGooglePayConfig,
+        paymentOptionCallback = {},
+        paymentResultCallback = ::expectNoResult
+    ) { context ->
+        composeTestRule.onGooglePayOption().run {
+            if (shouldHaveGooglePayOption) {
+                assertExists()
+            } else {
+                assertDoesNotExist()
+            }
+        }
+
+        context.markTestSucceeded()
     }
 
     private fun runGooglePayTest(
         isGooglePayReady: Boolean,
         isGooglePayEnabledInElementsSession: Boolean,
         hasGooglePayConfig: Boolean,
-        test: () -> Unit,
+        paymentOptionCallback: PaymentOptionCallback,
+        paymentResultCallback: (PaymentSheetResult) -> Unit,
+        test: (context: ProductIntegrationTestRunnerContext) -> Unit,
     ) {
         GooglePayRepository.googlePayAvailabilityClientFactory =
             FakeGooglePayAvailabilityClient.Factory(isGooglePayReady)
@@ -93,8 +260,8 @@ internal class GooglePayTest {
         runProductIntegrationTest(
             networkRule = testRules.networkRule,
             integrationType = integrationType,
-            resultCallback = ::expectNoResult,
-            paymentOptionCallback = {}
+            paymentOptionCallback = paymentOptionCallback,
+            resultCallback = paymentResultCallback,
         ) { context ->
             val configBuilder = PaymentSheet.Configuration.Builder(merchantDisplayName = "Merchant, Inc.")
 
@@ -111,9 +278,7 @@ internal class GooglePayTest {
 
             waitUntilLoaded()
 
-            test()
-
-            context.markTestSucceeded()
+            test(context)
         }
     }
 
@@ -154,6 +319,45 @@ internal class GooglePayTest {
         }
     }
 
+    private fun intendingGooglePayToBeLaunched(result: GooglePayPaymentMethodLauncher.Result) {
+        intending(hasComponent(GOOGLE_PAY_ACTIVITY_NAME)).respondWith(
+            Instrumentation.ActivityResult(
+                Activity.RESULT_OK,
+                Intent().putExtra("extra_result", result)
+            )
+        )
+    }
+
+    private fun intendingPaymentConfirmationToBeLaunched(result: InternalPaymentResult) {
+        intending(hasComponent(PAYMENT_CONFIRMATION_LAUNCHER_ACTIVITY_NAME)).respondWith(
+            Instrumentation.ActivityResult(
+                Activity.RESULT_OK,
+                Intent().putExtras(bundleOf("extra_args" to result))
+            )
+        )
+    }
+
+    private fun intendedGooglePayToBeLaunched() {
+        intended(hasComponent(GOOGLE_PAY_ACTIVITY_NAME))
+    }
+
+    private fun intendedPaymentConfirmationToBeLaunched() {
+        intended(hasComponent(PAYMENT_CONFIRMATION_LAUNCHER_ACTIVITY_NAME))
+    }
+
+    private fun waitForErrorMessage(message: String) {
+        composeTestRule.waitUntil(UI_TIMEOUT) {
+            composeTestRule
+                .onAllNodes(hasText(message))
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+    }
+
+    private fun assertNoErrorMessage(message: String) {
+        composeTestRule.onNode(hasText(message)).assertDoesNotExist()
+    }
+
     private fun ComposeTestRule.onGooglePayOption(): SemanticsNodeInteraction {
         return when (integrationType) {
             ProductIntegrationType.PaymentSheet -> onNode(hasTestTag(GOOGLE_PAY_BUTTON_TEST_TAG))
@@ -175,7 +379,18 @@ internal class GooglePayTest {
         }
     }
 
+    private class GooglePayFlowScenario(
+        val markTestSucceeded: () -> Unit,
+        val confirm: () -> Unit,
+    )
+
     private companion object {
+        const val GOOGLE_PAY_ACTIVITY_NAME =
+            "com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherActivity"
+
+        const val PAYMENT_CONFIRMATION_LAUNCHER_ACTIVITY_NAME =
+            "com.stripe.android.payments.paymentlauncher.PaymentLauncherConfirmationActivity"
+
         const val GOOGLE_PAY_SAVED_OPTION_TEST_TAG = "${SAVED_PAYMENT_METHOD_CARD_TEST_TAG}_Google Pay"
         const val UI_TIMEOUT = 5000L
     }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ProductIntegrationTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ProductIntegrationTestRunner.kt
@@ -88,5 +88,9 @@ internal sealed interface ProductIntegrationTestRunnerContext {
         override fun markTestSucceeded() {
             context.markTestSucceeded()
         }
+
+        fun confirm() {
+            context.flowController.confirm()
+        }
     }
 }


### PR DESCRIPTION
# Summary
Add `Google Pay` intent tests

# Motivation
Test that `Google Pay` succeeds and fails when expected in `PaymentSheet` and `FlowController`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified