### PR TITLE
Fix emerge tools.

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
       - name: Upload Identity example release bundle to Emerge
-        run: ./gradlew :identity-example:emergeUploadReleaseAab
+        run: ./gradlew :identity-example:emergeUploadTheme1ReleaseAab
         env:
           EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
           EMERGE_TAG: push


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Emerge tools was failing on master, as well as PRs.

It was only failing on PRs because it couldn't find the app that was uploaded on master.

Master was failing with 
```
Cannot locate tasks that match ':identity-example:emergeUploadReleaseAab' as task 'emergeUploadReleaseAab' is ambiguous in project ':identity-example'. Candidates are: 'emergeUploadTheme1ReleaseAab', 'emergeUploadTheme2ReleaseAab'.
```

I updated the action that uploads the app from master to run the right command.


