### PR TITLE
Add remove permissions in `CustomerSheet`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerPermissions.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerPermissions.kt
@@ -1,0 +1,5 @@
+package com.stripe.android.customersheet
+
+internal data class CustomerPermissions(
+    val canRemovePaymentMethods: Boolean,
+)

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -201,6 +201,10 @@ internal class DefaultCustomerSheetLoader(
                         customerPaymentMethods = sortedPaymentMethods,
                         paymentSelection = paymentSelection,
                         validationError = elementsSession.stripeIntent.validate(),
+                        customerPermissions = CustomerPermissions(
+                            // Should always be true for `legacy` case
+                            canRemovePaymentMethods = true,
+                        )
                     )
                 )
             },

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetState.kt
@@ -13,6 +13,7 @@ internal sealed interface CustomerSheetState {
         val config: CustomerSheet.Configuration,
         val paymentMethodMetadata: PaymentMethodMetadata,
         val customerPaymentMethods: List<PaymentMethod>,
+        val customerPermissions: CustomerPermissions,
         val supportedPaymentMethods: List<SupportedPaymentMethod>,
         val paymentSelection: PaymentSelection?,
         val validationError: Throwable?,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -158,6 +158,9 @@ internal class CustomerSheetViewModel(
             paymentMethods = listOf(),
             configuration = configuration,
             currentSelection = originalPaymentSelection,
+            permissions = CustomerPermissions(
+                canRemovePaymentMethods = false,
+            ),
             metadata = null,
         )
     )
@@ -337,6 +340,7 @@ internal class CustomerSheetViewModel(
                         configuration = configuration,
                         currentSelection = state.paymentSelection,
                         metadata = state.paymentMethodMetadata,
+                        permissions = state.customerPermissions,
                     )
 
                     transitionToInitialScreen()
@@ -1201,12 +1205,13 @@ internal class CustomerSheetViewModel(
         val paymentMethods: List<PaymentMethod>,
         val currentSelection: PaymentSelection?,
         val metadata: PaymentMethodMetadata?,
+        val permissions: CustomerPermissions,
         val configuration: CustomerSheet.Configuration,
     ) {
         val canRemove = when (paymentMethods.size) {
             0 -> false
-            1 -> configuration.allowsRemovalOfLastSavedPaymentMethod
-            else -> true
+            1 -> configuration.allowsRemovalOfLastSavedPaymentMethod && permissions.canRemovePaymentMethods
+            else -> permissions.canRemovePaymentMethods
         }
 
         val cbcEligibility = metadata?.cbcEligibility ?: CardBrandChoiceEligibility.Ineligible

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -3227,6 +3227,61 @@ class CustomerSheetViewModelTest {
             intentConfirmationInterceptor.calls.ensureAllEventsConsumed()
         }
 
+    @Test
+    fun `If has remove permissions, can remove should be true in state`() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            workContext = testDispatcher,
+            customerPaymentMethods = listOf(CARD_PAYMENT_METHOD),
+            customerPermissions = CustomerPermissions(
+                canRemovePaymentMethods = true,
+            ),
+        )
+
+        val selectState = viewModel.viewState.value.asSelectState()
+
+        assertThat(selectState.canRemovePaymentMethods).isTrue()
+        assertThat(selectState.canEdit).isTrue()
+        assertThat(selectState.topBarState {}.showEditMenu).isTrue()
+    }
+
+    @Test
+    fun `If has no remove permissions, can remove should be false in state`() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            workContext = testDispatcher,
+            customerPaymentMethods = listOf(CARD_PAYMENT_METHOD),
+            customerPermissions = CustomerPermissions(
+                canRemovePaymentMethods = false,
+            ),
+        )
+
+        val selectState = viewModel.viewState.value.asSelectState()
+
+        assertThat(selectState.canRemovePaymentMethods).isFalse()
+        assertThat(selectState.canEdit).isFalse()
+        assertThat(selectState.topBarState {}.showEditMenu).isFalse()
+    }
+
+    @Test
+    fun `If has no remove permissions but is CBC eligible, can remove is false but can edit is true`() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel(
+                workContext = testDispatcher,
+                customerPaymentMethods = listOf(CARD_WITH_NETWORKS_PAYMENT_METHOD),
+                cbcEligibility = CardBrandChoiceEligibility.Eligible(
+                    preferredNetworks = listOf(CardBrand.CartesBancaires),
+                ),
+                customerPermissions = CustomerPermissions(
+                    canRemovePaymentMethods = false,
+                ),
+            )
+
+            val selectState = viewModel.viewState.value.asSelectState()
+
+            assertThat(selectState.canRemovePaymentMethods).isFalse()
+            assertThat(selectState.canEdit).isTrue()
+            assertThat(selectState.topBarState {}.showEditMenu).isTrue()
+        }
+
     private fun mockUSBankAccountResult(
         isVerified: Boolean
     ): CollectBankAccountResultInternal.Completed {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -108,6 +108,7 @@ class DefaultCustomerSheetLoaderTest {
             PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             PaymentMethodFixtures.US_BANK_ACCOUNT,
         )
+        assertThat(state.customerPermissions.canRemovePaymentMethods).isTrue()
         assertThat(state.supportedPaymentMethods.map { it.code }).containsExactly("card")
         assertThat(state.paymentSelection).isEqualTo(
             PaymentSelection.Saved(
@@ -166,6 +167,7 @@ class DefaultCustomerSheetLoaderTest {
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             )
         )
+        assertThat(state.customerPermissions.canRemovePaymentMethods).isTrue()
         assertThat(state.paymentMethodMetadata.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
         assertThat(state.validationError).isNull()
 
@@ -198,6 +200,7 @@ class DefaultCustomerSheetLoaderTest {
             PaymentMethodFixtures.CARD_PAYMENT_METHOD,
         )
         assertThat(state.supportedPaymentMethods.map { it.code }).containsExactly("card")
+        assertThat(state.customerPermissions.canRemovePaymentMethods).isTrue()
         assertThat(state.paymentSelection).isNull()
         assertThat(state.paymentMethodMetadata.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
         assertThat(state.validationError).isNull()
@@ -296,6 +299,7 @@ class DefaultCustomerSheetLoaderTest {
             PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_1"),
             PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_2"),
         )
+        assertThat(state.customerPermissions.canRemovePaymentMethods).isTrue()
         assertThat(state.supportedPaymentMethods.map { it.code }).containsExactly("card")
         assertThat(state.paymentSelection).isEqualTo(
             PaymentSelection.Saved(
@@ -332,6 +336,7 @@ class DefaultCustomerSheetLoaderTest {
             PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_2"),
             PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_3"),
         )
+        assertThat(state.customerPermissions.canRemovePaymentMethods).isTrue()
         assertThat(state.supportedPaymentMethods.map { it.code }).containsExactly("card")
         assertThat(state.paymentSelection).isNull()
         assertThat(state.paymentMethodMetadata.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -10,6 +10,7 @@ import com.stripe.android.core.Logger
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.customersheet.CustomerAdapter
+import com.stripe.android.customersheet.CustomerPermissions
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetLoader
 import com.stripe.android.customersheet.CustomerSheetViewModel
@@ -41,6 +42,7 @@ import com.stripe.android.paymentsheet.ui.PaymentMethodRemoveOperation
 import com.stripe.android.paymentsheet.ui.PaymentMethodUpdateOperation
 import com.stripe.android.paymentsheet.utils.FakeUserFacingLogger
 import com.stripe.android.testing.FakeErrorReporter
+import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.utils.DummyActivityResultCaller
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor
 import kotlinx.coroutines.CompletableDeferred
@@ -60,6 +62,10 @@ internal object CustomerSheetTestHelper {
         workContext: CoroutineContext = EmptyCoroutineContext,
         isGooglePayAvailable: Boolean = true,
         customerPaymentMethods: List<PaymentMethod> = listOf(CARD_PAYMENT_METHOD),
+        customerPermissions: CustomerPermissions = CustomerPermissions(
+            canRemovePaymentMethods = true,
+        ),
+        cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
         supportedPaymentMethods: List<SupportedPaymentMethod> = listOf(
             LpmRepositoryTestHelpers.card,
             LpmRepositoryTestHelpers.usBankAccount,
@@ -86,6 +92,8 @@ internal object CustomerSheetTestHelper {
             supportedPaymentMethods = supportedPaymentMethods,
             paymentSelection = savedPaymentSelection,
             isGooglePayAvailable = isGooglePayAvailable,
+            cbcEligibility = cbcEligibility,
+            permissions = customerPermissions,
         ),
         editInteractorFactory: ModifiableEditPaymentMethodViewInteractor.Factory =
             createModifiableEditPaymentMethodViewInteractorFactory(),

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.customersheet.utils
 
+import com.stripe.android.customersheet.CustomerPermissions
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetLoader
 import com.stripe.android.customersheet.CustomerSheetState
@@ -29,6 +30,9 @@ internal class FakeCustomerSheetLoader(
     private val delay: Duration = Duration.ZERO,
     private val cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
     private val financialConnectionsAvailable: Boolean = false,
+    private val permissions: CustomerPermissions = CustomerPermissions(
+        canRemovePaymentMethods = true,
+    ),
 ) : CustomerSheetLoader {
 
     override suspend fun load(configuration: CustomerSheet.Configuration): Result<CustomerSheetState.Full> {
@@ -48,6 +52,7 @@ internal class FakeCustomerSheetLoader(
                     ),
                     supportedPaymentMethods = supportedPaymentMethods,
                     customerPaymentMethods = customerPaymentMethods,
+                    customerPermissions = permissions,
                     paymentSelection = paymentSelection,
                     validationError = null,
                 )


### PR DESCRIPTION
# Summary
Add remove permissions in `CustomerSheet`

# Motivation
Allows for controlling remove permissions in `CustomerSheetLoader`. Some preliminary work for `CustomerSession`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified