### PR TITLE
[Connect SDK] UI for Connect SDK Example App

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,23 +1,33 @@
+## For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+#
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. For more details, visit
+# https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
+# org.gradle.parallel=true
+#Fri Sep 13 16:29:14 EDT 2024
 GROUP=com.stripe
-
-POM_URL=https://github.com/stripe/stripe-android
-POM_SCM_URL=https://github.com/stripe/stripe-android
-POM_SCM_CONNECTION=scm:git@github.com/stripe/stripe-android.git
-POM_SCM_DEV_CONNECTION=scm:git@github.com/stripe/stripe-android.git
-POM_LICENCE_NAME=The MIT License
-POM_LICENCE_URL=https://raw.githubusercontent.com/stripe/stripe-android/master/LICENSE
-POM_LICENCE_DIST=repo
+POM_DEVELOPER_EMAIL=support+android@stripe.com
 POM_DEVELOPER_ID=stripe
 POM_DEVELOPER_NAME=Stripe
-POM_DEVELOPER_EMAIL=support+android@stripe.com
-
+POM_LICENCE_DIST=repo
+POM_LICENCE_NAME=The MIT License
+POM_LICENCE_URL=https\://raw.githubusercontent.com/stripe/stripe-android/master/LICENSE
+POM_SCM_CONNECTION=scm\:git@github.com/stripe/stripe-android.git
+POM_SCM_DEV_CONNECTION=scm\:git@github.com/stripe/stripe-android.git
+POM_SCM_URL=https\://github.com/stripe/stripe-android
+POM_URL=https\://github.com/stripe/stripe-android
+VERSION_NAME=20.48.6
 android.defaults.buildfeatures.buildconfig=true
 android.enableJetifier=false
 android.enableR8.fullMode=true
+android.experimental.androidTest.numManagedDeviceShards=3
 android.nonFinalResIds=true
 android.nonTransitiveRClass=true
 android.useAndroidX=true
-android.experimental.androidTest.numManagedDeviceShards=3
-
-# Update StripeSdkVersion.VERSION_NAME when publishing a new release
-VERSION_NAME=20.48.6
+org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"

--- a/stripe-connect-example/build.gradle
+++ b/stripe-connect-example/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation libs.compose.activity
     implementation libs.compose.navigation
     implementation libs.accompanist.systemUiController
+    implementation 'androidx.compose.ui:ui-tooling-preview-android:1.7.1'
 
     // Test
     testImplementation testLibs.androidx.archCore
@@ -74,6 +75,7 @@ dependencies {
     androidTestImplementation testLibs.truth
 
     androidTestUtil testLibs.testOrchestrator
+    debugImplementation 'androidx.compose.ui:ui-tooling:1.7.1'
 }
 
 android {

--- a/stripe-connect-example/src/main/AndroidManifest.xml
+++ b/stripe-connect-example/src/main/AndroidManifest.xml
@@ -1,14 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
     <application>
         <activity
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".ui.accountonboarding.AccountOnboardingExampleActivity"
+            android:exported="false"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
+        <activity
+            android:name=".ui.payouts.PayoutsExampleActivity"
+            android:exported="false"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
     </application>
 </manifest>

--- a/stripe-connect-example/src/main/java/com/stripe/android/connectsdk/example/MainActivity.kt
+++ b/stripe-connect-example/src/main/java/com/stripe/android/connectsdk/example/MainActivity.kt
@@ -1,69 +1,177 @@
 package com.stripe.android.connectsdk.example
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyItemScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
 import androidx.compose.material.Text
-import com.stripe.android.connectsdk.EmbeddedComponentManager
-import com.stripe.android.connectsdk.FetchClientSecretCallback
-import com.stripe.android.connectsdk.FetchClientSecretCallback.ClientSecretResultCallback
-import com.stripe.android.connectsdk.PrivateBetaConnectSDK
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.LineHeightStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.stripe.android.connectsdk.example.ui.accountonboarding.AccountOnboardingExampleActivity
+import com.stripe.android.connectsdk.example.ui.payouts.PayoutsExampleActivity
 
-@OptIn(PrivateBetaConnectSDK::class)
 class MainActivity : ComponentActivity() {
 
-    private lateinit var embeddedComponentManager: EmbeddedComponentManager
+    private data class MenuItem(
+        val title: String,
+        val subtitle: String,
+        val activity: Class<out ComponentActivity>,
+        val isBeta: Boolean = false,
+    )
+
+    private val menuItems = listOf(
+        MenuItem(
+            title = "Account Onboarding",
+            subtitle = "Show a localized onboarding form that validates data",
+            activity = AccountOnboardingExampleActivity::class.java,
+            isBeta = true,
+        ),
+        MenuItem(
+            title = "Payouts",
+            subtitle = "Show payout information and allow your users to perform payouts",
+            activity = PayoutsExampleActivity::class.java,
+            isBeta = true,
+        ),
+    )
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        embeddedComponentManager = EmbeddedComponentManager(
-            activity = this,
-            configuration = EmbeddedComponentManager.Configuration(
-                publishableKey = "<publishable key here>"
-            ),
-            fetchClientSecret = object : FetchClientSecretCallback {
-                override fun fetchClientSecret(resultCallback: ClientSecretResultCallback) {
-                    // Make a network call to fetch your client secret here
-                    resultCallback.onResult("<client secret here>")
+        setContent {
+            ConnectSdkExampleTheme {
+                MainContent(title = "Connect SDK Example") {
+                    ComponentList(menuItems)
                 }
             }
-        )
-
-        setContent {
-            Text("Not yet built...")
         }
     }
 
-    fun launchPayouts() {
-        // launch the payouts activity
-        embeddedComponentManager.presentPayouts()
+    @Composable
+    private fun ComponentList(components: List<MenuItem>) {
+        LazyColumn {
+            items(components) { menuItem ->
+                MenuRowItem(menuItem)
+            }
+        }
     }
 
-    fun launchAccountOnboardingActivity() {
-        // launch the account onboarding activity
-        embeddedComponentManager.presentAccountOnboarding()
-    }
+    @Composable
+    private fun LazyItemScope.MenuRowItem(menuItem: MenuItem) {
+        val context = LocalContext.current
+        Row(
+            modifier = Modifier
+                .fillParentMaxWidth()
+                .clickable { context.startActivity(Intent(context, menuItem.activity)) },
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Column(modifier = Modifier.padding(8.dp)) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Text(
+                            text = menuItem.title,
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        if (menuItem.isBeta) {
+                            BetaBadge()
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
 
-    fun updateAppearance() {
-        // update the appearance
-        embeddedComponentManager.update(
-            EmbeddedComponentManager.Appearance(
-                typography = EmbeddedComponentManager.Appearance.Typography(),
-                colors = EmbeddedComponentManager.Appearance.Colors(),
-                buttonPrimary = EmbeddedComponentManager.Appearance.Button(),
-                buttonSecondary = EmbeddedComponentManager.Appearance.Button(),
-                badgeNeutral = EmbeddedComponentManager.Appearance.Badge(),
-                badgeSuccess = EmbeddedComponentManager.Appearance.Badge(),
-                badgeWarning = EmbeddedComponentManager.Appearance.Badge(),
-                badgeDanger = EmbeddedComponentManager.Appearance.Badge(),
-                cornerRadius = EmbeddedComponentManager.Appearance.CornerRadius()
+                        text = menuItem.subtitle,
+                        fontSize = 16.sp,
+                    )
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Divider()
+            }
+
+            Icon(
+                modifier = Modifier
+                    .size(36.dp)
+                    .padding(start = 8.dp),
+                contentDescription = null,
+                imageVector = Icons.Default.KeyboardArrowRight,
             )
+        }
+    }
+
+    @Composable
+    private fun BetaBadge() {
+        val borderColor = Color(0xffa7e7fc) // none
+        val backgroundColor = Color(0xffcbf5fd) // Color(0xff051a4c)
+        val textColor = Color(0xff045ad0) // none
+        val shape = RoundedCornerShape(4.dp)
+        val labelMediumEmphasized = TextStyle.Default.copy(
+            fontSize = 14.sp,
+            fontWeight = FontWeight.SemiBold,
+            lineHeight = 20.sp,
+            lineHeightStyle = LineHeightStyle(
+                alignment = LineHeightStyle.Alignment.Center,
+                trim = LineHeightStyle.Trim.None
+            )
+        )
+        Text(
+            modifier = Modifier
+                .border(1.dp, borderColor, shape)
+                .background(
+                    color = backgroundColor,
+                    shape = shape
+                )
+                .padding(horizontal = 6.dp, vertical = 1.dp),
+            color = textColor,
+            fontSize = 12.sp,
+            lineHeight = 16.sp,
+            style = labelMediumEmphasized,
+            text = "BETA"
         )
     }
 
-    fun logout() {
-        // log out the user
-        embeddedComponentManager.logout()
+    @Composable
+    @Preview(showBackground = true)
+    fun ComponentListPreview() {
+        ConnectSdkExampleTheme {
+            ComponentList(menuItems)
+        }
+    }
+
+    @Composable
+    @Preview(showBackground = true)
+    fun BetaBadgePreview() {
+        ConnectSdkExampleTheme {
+            BetaBadge()
+        }
     }
 }

--- a/stripe-connect-example/src/main/java/com/stripe/android/connectsdk/example/Theme.kt
+++ b/stripe-connect-example/src/main/java/com/stripe/android/connectsdk/example/Theme.kt
@@ -1,0 +1,56 @@
+package com.stripe.android.connectsdk.example
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.darkColors
+import androidx.compose.material.lightColors
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun ConnectSdkExampleTheme(
+    content: @Composable () -> Unit,
+) {
+    MaterialTheme(
+        colors = if (isSystemInDarkTheme()) darkColors() else lightColors(),
+        content = content,
+    )
+}
+
+@Composable
+fun MainContent(
+    title: String,
+    content: @Composable () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            Column {
+                Text(
+                    modifier = Modifier.padding(8.dp),
+                    text = title,
+                    fontSize = 24.sp,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Divider()
+            }
+        }
+    ) { contentPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(contentPadding),
+        ) {
+            content()
+        }
+    }
+}

--- a/stripe-connect-example/src/main/java/com/stripe/android/connectsdk/example/networking/EmbeddedComponentService.kt
+++ b/stripe-connect-example/src/main/java/com/stripe/android/connectsdk/example/networking/EmbeddedComponentService.kt
@@ -1,0 +1,10 @@
+package com.stripe.android.connectsdk.example.networking
+
+import kotlinx.coroutines.delay
+
+class EmbeddedComponentService {
+    suspend fun fetchClientSecret(): String? {
+        delay(3000)
+        return null
+    }
+}

--- a/stripe-connect-example/src/main/java/com/stripe/android/connectsdk/example/ui/accountonboarding/AccountOnboardingExampleActivity.kt
+++ b/stripe-connect-example/src/main/java/com/stripe/android/connectsdk/example/ui/accountonboarding/AccountOnboardingExampleActivity.kt
@@ -1,0 +1,52 @@
+package com.stripe.android.connectsdk.example.ui.accountonboarding
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.stripe.android.connectsdk.EmbeddedComponentManager
+import com.stripe.android.connectsdk.PrivateBetaConnectSDK
+import com.stripe.android.connectsdk.example.ConnectSdkExampleTheme
+import com.stripe.android.connectsdk.example.MainContent
+
+class AccountOnboardingExampleActivity : ComponentActivity() {
+
+    @OptIn(PrivateBetaConnectSDK::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            ConnectSdkExampleTheme {
+                val viewModel: AccountOnboardingExampleViewModel = viewModel()
+                val embeddedComponentManager = remember {
+                    EmbeddedComponentManager(
+                        activity = this@AccountOnboardingExampleActivity,
+                        configuration = EmbeddedComponentManager.Configuration(""),
+                        fetchClientSecret = viewModel::fetchClientSecret,
+                    )
+                }
+
+                MainContent(title = "Account Onboarding Example") {
+
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Button(
+                            onClick = embeddedComponentManager::presentAccountOnboarding,
+                        ) {
+                            Text("Launch onboarding")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/stripe-connect-example/src/main/java/com/stripe/android/connectsdk/example/ui/accountonboarding/AccountOnboardingExampleViewModel.kt
+++ b/stripe-connect-example/src/main/java/com/stripe/android/connectsdk/example/ui/accountonboarding/AccountOnboardingExampleViewModel.kt
@@ -1,0 +1,25 @@
+package com.stripe.android.connectsdk.example.ui.accountonboarding
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.stripe.android.connectsdk.FetchClientSecretCallback.ClientSecretResultCallback
+import com.stripe.android.connectsdk.PrivateBetaConnectSDK
+import com.stripe.android.connectsdk.example.networking.EmbeddedComponentService
+import kotlinx.coroutines.launch
+
+class AccountOnboardingExampleViewModel(
+    private val embeddedComponentService: EmbeddedComponentService = EmbeddedComponentService(),
+): ViewModel() {
+
+    @OptIn(PrivateBetaConnectSDK::class)
+    fun fetchClientSecret(resultCallback: ClientSecretResultCallback) {
+        viewModelScope.launch {
+            val clientSecret = embeddedComponentService.fetchClientSecret()
+            if (clientSecret != null) {
+                resultCallback.onResult(clientSecret)
+            } else {
+                resultCallback.onError()
+            }
+        }
+    }
+}

--- a/stripe-connect-example/src/main/java/com/stripe/android/connectsdk/example/ui/payouts/PayoutsExampleActivity.kt
+++ b/stripe-connect-example/src/main/java/com/stripe/android/connectsdk/example/ui/payouts/PayoutsExampleActivity.kt
@@ -1,0 +1,51 @@
+package com.stripe.android.connectsdk.example.ui.payouts
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.stripe.android.connectsdk.EmbeddedComponentManager
+import com.stripe.android.connectsdk.PrivateBetaConnectSDK
+import com.stripe.android.connectsdk.example.ConnectSdkExampleTheme
+import com.stripe.android.connectsdk.example.MainContent
+
+@OptIn(PrivateBetaConnectSDK::class)
+class PayoutsExampleActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            ConnectSdkExampleTheme {
+                val viewModel: PayoutsExampleViewModel = viewModel()
+                val embeddedComponentManager = remember {
+                    EmbeddedComponentManager(
+                        activity = this@PayoutsExampleActivity,
+                        configuration = EmbeddedComponentManager.Configuration(""),
+                        fetchClientSecret = viewModel::fetchClientSecret,
+                    )
+                }
+
+                MainContent(title = "Payouts Example") {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Button(
+                            onClick = embeddedComponentManager::presentPayouts,
+                        ) {
+                            Text("Launch payouts")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/stripe-connect-example/src/main/java/com/stripe/android/connectsdk/example/ui/payouts/PayoutsExampleViewModel.kt
+++ b/stripe-connect-example/src/main/java/com/stripe/android/connectsdk/example/ui/payouts/PayoutsExampleViewModel.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.connectsdk.example.ui.payouts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.stripe.android.connectsdk.FetchClientSecretCallback.ClientSecretResultCallback
+import com.stripe.android.connectsdk.PrivateBetaConnectSDK
+import com.stripe.android.connectsdk.example.networking.EmbeddedComponentService
+import kotlinx.coroutines.launch
+
+class PayoutsExampleViewModel(
+    private val embeddedComponentService: EmbeddedComponentService = EmbeddedComponentService(),
+): ViewModel() {
+
+    @OptIn(PrivateBetaConnectSDK::class)
+    fun fetchClientSecret(resultCallback: ClientSecretResultCallback) {
+        viewModelScope.launch {
+            @OptIn(PrivateBetaConnectSDK::class)
+            fun fetchClientSecret(resultCallback: ClientSecretResultCallback) {
+                viewModelScope.launch {
+                    val clientSecret = embeddedComponentService.fetchClientSecret()
+                    if (clientSecret != null) {
+                        resultCallback.onResult(clientSecret)
+                    } else {
+                        resultCallback.onError()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/stripe-connect/src/main/java/com/stripe/android/connectsdk/FetchClientSecretCallback.kt
+++ b/stripe-connect/src/main/java/com/stripe/android/connectsdk/FetchClientSecretCallback.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.connectsdk
 
 @PrivateBetaConnectSDK
-interface FetchClientSecretCallback {
+fun interface FetchClientSecretCallback {
     fun fetchClientSecret(resultCallback: ClientSecretResultCallback)
 
     interface ClientSecretResultCallback {


### PR DESCRIPTION
# Summary
This adds the UI for the Connect SDK example app. It's mirrored off of the other example apps in this repo (ex. PaymentSheetExample and FinancialConnectionsExample).

The app has UI for both components in the Connect SDK: AccountOnboarding and Payouts. Both are currently Beta and more can be added easily in the UI as the Connect SDK evolves.

# Motivation
This is meant to:
1. show off the capabilities of the SDK and
2. demonstrate a canonical integration of the SDK to integrators

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
![screen-1726357536](https://github.com/user-attachments/assets/181826c5-8d0f-4924-8df0-50dbcfdf9cb6)


