### PR TITLE
Persist `CustomerSheetConfigureRequest` to view model

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -136,6 +136,14 @@ public final class com/stripe/android/customersheet/CustomerSheetComposeKt {
 	public static final fun rememberCustomerSheet (Lcom/stripe/android/customersheet/CustomerAdapter;Lcom/stripe/android/customersheet/CustomerSheetResultCallback;Landroidx/compose/runtime/Composer;I)Lcom/stripe/android/customersheet/CustomerSheet;
 }
 
+public final class com/stripe/android/customersheet/CustomerSheetConfigureRequest$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/customersheet/CustomerSheetConfigureRequest;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/customersheet/CustomerSheetConfigureRequest;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/customersheet/CustomerSheetContract$Args$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/customersheet/CustomerSheetContract$Args;

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetCompose.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetCompose.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.LocalActivityResultRegistryOwner
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import com.stripe.android.utils.rememberActivity
 
 /**
@@ -29,6 +30,10 @@ fun rememberCustomerSheet(
         "CustomerSheet must be created in the context of an Activity"
     }
 
+    val viewModelStoreOwner = requireNotNull(LocalViewModelStoreOwner.current) {
+        "CustomerSheet must be created with access to a ViewModelStoreOwner"
+    }
+
     return remember(
         customerAdapter,
         callback,
@@ -37,6 +42,7 @@ fun rememberCustomerSheet(
             application = activity.application,
             lifecycleOwner = lifecycleOwner,
             activityResultRegistryOwner = activityResultRegistryOwner,
+            viewModelStoreOwner = viewModelStoreOwner,
             customerAdapter = customerAdapter,
             callback = callback,
             statusBarColor = { activity.window?.statusBarColor },

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetConfigViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetConfigViewModel.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.customersheet
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewmodel.CreationExtras
+
+internal class CustomerSheetConfigViewModel(
+    private val savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+    var configureRequest: CustomerSheetConfigureRequest?
+        set(value) {
+            savedStateHandle[CUSTOMER_SHEET_CONFIGURE_REQUEST_KEY] = value
+        }
+        get() = savedStateHandle[CUSTOMER_SHEET_CONFIGURE_REQUEST_KEY]
+
+    object Factory : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+            @Suppress("UNCHECKED_CAST")
+            return CustomerSheetConfigViewModel(
+                savedStateHandle = extras.createSavedStateHandle(),
+            ) as T
+        }
+    }
+
+    private companion object {
+        private const val CUSTOMER_SHEET_CONFIGURE_REQUEST_KEY = "CustomerSheetConfigureRequest"
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetConfigureRequest.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetConfigureRequest.kt
@@ -1,0 +1,10 @@
+package com.stripe.android.customersheet
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+@Parcelize
+internal data class CustomerSheetConfigureRequest(
+    val configuration: CustomerSheet.Configuration,
+) : Parcelable

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetConfigViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetConfigViewModelTest.kt
@@ -1,0 +1,51 @@
+package com.stripe.android.customersheet
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.Test
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+class CustomerSheetConfigViewModelTest {
+    @Test
+    fun `On set configure request, should be able to retrieve the same request`() {
+        val viewModel = CustomerSheetConfigViewModel(
+            savedStateHandle = SavedStateHandle(),
+        )
+
+        val request = CustomerSheetConfigureRequest(
+            configuration = CustomerSheet.Configuration.builder(
+                merchantDisplayName = "Merchant, Inc.",
+            )
+                .googlePayEnabled(googlePayConfiguration = true)
+                .build()
+        )
+
+        viewModel.configureRequest = request
+
+        assertThat(viewModel.configureRequest).isEqualTo(request)
+    }
+
+    @Test
+    fun `On init with 'SavedStateHandle', should be able to retrieve the saved request`() {
+        val handle = SavedStateHandle()
+        val viewModel = CustomerSheetConfigViewModel(
+            savedStateHandle = handle,
+        )
+
+        val request = CustomerSheetConfigureRequest(
+            configuration = CustomerSheet.Configuration.builder(
+                merchantDisplayName = "Merchant, Inc.",
+            )
+                .googlePayEnabled(googlePayConfiguration = true)
+                .build()
+        )
+
+        viewModel.configureRequest = request
+
+        val recreatedViewModel = CustomerSheetConfigViewModel(
+            savedStateHandle = handle
+        )
+
+        assertThat(recreatedViewModel.configureRequest).isEqualTo(request)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTest.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.Intents.times
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.espresso.intent.rule.IntentsRule
@@ -142,6 +143,37 @@ class CustomerSheetTest {
             assertThat(selectedResult.selection).isNull()
         }
 
+    @Test
+    fun `On configure, should persist on config changes & process death`() = runTestActivityTest {
+        val customerSheet = CustomerSheet.create(
+            activity = activity,
+            customerAdapter = FakeCustomerAdapter(),
+            callback = {},
+        )
+
+        customerSheet.configure(
+            configuration = CustomerSheet.Configuration
+                .builder(merchantDisplayName = "Merchant, Inc.")
+                .build()
+        )
+
+        customerSheet.present()
+
+        activityScenario.recreate()
+
+        val recreatedCustomerSheet = CustomerSheet.create(
+            activity = activity,
+            customerAdapter = FakeCustomerAdapter(),
+            callback = {},
+        )
+
+        recreatedCustomerSheet.present()
+
+        intended(hasComponent(CustomerSheetActivity::class.java.name), times(2))
+
+        completeTest()
+    }
+
     private fun runPaymentOptionTest(
         configuration: CustomerSheet.Configuration?,
         paymentOption: CustomerAdapter.PaymentOption? = null,
@@ -176,6 +208,7 @@ class CustomerSheetTest {
 
             scenario.onActivity {
                 Scenario(
+                    activityScenario = scenario,
                     activity = it,
                     completeTest = countDownLatch::countDown,
                 ).test()
@@ -194,6 +227,7 @@ class CustomerSheetTest {
     }
 
     private class Scenario(
+        val activityScenario: ActivityScenario<TestActivity>,
         val activity: TestActivity,
         val completeTest: () -> Unit,
     )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTest.kt
@@ -144,7 +144,7 @@ class CustomerSheetTest {
         }
 
     @Test
-    fun `On configure, should persist on config changes & process death`() = runTestActivityTest {
+    fun `On configure, should persist on config changes`() = runTestActivityTest {
         val customerSheet = CustomerSheet.create(
             activity = activity,
             customerAdapter = FakeCustomerAdapter(),


### PR DESCRIPTION
# Summary
Persist `CustomerSheetConfigureRequest` to view model

# Motivation
There's a chance merchants don't re-call `configure` on every `onCreate` of an activity. We should account for this by persisting the configuration on config changes & process death.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified