### PR TITLE
Use data sources in `CustomerSheetViewModel`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -19,8 +19,16 @@ import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.requireApplication
-import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
+import com.stripe.android.customersheet.data.CustomerSheetDataResult
+import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
+import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSource
+import com.stripe.android.customersheet.data.CustomerSheetSavedSelectionDataSource
+import com.stripe.android.customersheet.data.failureOrNull
+import com.stripe.android.customersheet.data.fold
+import com.stripe.android.customersheet.data.mapCatching
+import com.stripe.android.customersheet.data.onFailure
+import com.stripe.android.customersheet.data.onSuccess
 import com.stripe.android.customersheet.injection.CustomerSheetViewModelScope
 import com.stripe.android.customersheet.injection.DaggerCustomerSheetViewModelComponent
 import com.stripe.android.customersheet.util.CustomerSheetHacks
@@ -48,6 +56,8 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.SavedSelection
+import com.stripe.android.paymentsheet.model.toSavedSelection
 import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
 import com.stripe.android.paymentsheet.ui.EditPaymentMethodViewInteractor
@@ -81,7 +91,9 @@ internal class CustomerSheetViewModel(
     application: Application, // TODO (jameswoo) remove application
     private var originalPaymentSelection: PaymentSelection?,
     private val paymentConfigurationProvider: Provider<PaymentConfiguration>,
-    private val customerAdapterProvider: Deferred<CustomerAdapter>,
+    private val paymentMethodDataSourceProvider: Deferred<CustomerSheetPaymentMethodDataSource>,
+    private val intentDataSourceProvider: Deferred<CustomerSheetIntentDataSource>,
+    private val savedSelectionDataSourceProvider: Deferred<CustomerSheetSavedSelectionDataSource>,
     private val configuration: CustomerSheet.Configuration,
     private val logger: Logger,
     private val stripeRepository: StripeRepository,
@@ -114,7 +126,9 @@ internal class CustomerSheetViewModel(
         application = application,
         originalPaymentSelection = originalPaymentSelection,
         paymentConfigurationProvider = paymentConfigurationProvider,
-        customerAdapterProvider = CustomerSheetHacks.adapter,
+        paymentMethodDataSourceProvider = CustomerSheetHacks.paymentMethodDataSource,
+        intentDataSourceProvider = CustomerSheetHacks.intentDataSource,
+        savedSelectionDataSourceProvider = CustomerSheetHacks.savedSelectionDataSource,
         configuration = configuration,
         logger = logger,
         stripeRepository = stripeRepository,
@@ -493,8 +507,8 @@ internal class CustomerSheetViewModel(
         }
     }
 
-    private suspend fun removePaymentMethod(paymentMethod: PaymentMethod): CustomerAdapter.Result<PaymentMethod> {
-        return awaitCustomerAdapter().detachPaymentMethod(
+    private suspend fun removePaymentMethod(paymentMethod: PaymentMethod): CustomerSheetDataResult<PaymentMethod> {
+        return awaitPaymentMethodDataSource().detachPaymentMethod(
             paymentMethodId = paymentMethod.id!!,
         ).onSuccess {
             eventReporter.onRemovePaymentMethodSucceeded()
@@ -510,8 +524,8 @@ internal class CustomerSheetViewModel(
     private suspend fun modifyCardPaymentMethod(
         paymentMethod: PaymentMethod,
         brand: CardBrand
-    ): CustomerAdapter.Result<PaymentMethod> {
-        return awaitCustomerAdapter().updatePaymentMethod(
+    ): CustomerSheetDataResult<PaymentMethod> {
+        return awaitPaymentMethodDataSource().updatePaymentMethod(
             paymentMethodId = paymentMethod.id!!,
             params = PaymentMethodUpdateParams.createCard(
                 networks = PaymentMethodUpdateParams.Card.Networks(
@@ -584,8 +598,8 @@ internal class CustomerSheetViewModel(
                     },
                     updateExecutor = { method, brand ->
                         when (val result = modifyCardPaymentMethod(method, brand)) {
-                            is CustomerAdapter.Result.Success -> Result.success(result.value)
-                            is CustomerAdapter.Result.Failure -> Result.failure(result.cause)
+                            is CustomerSheetDataResult.Success -> Result.success(result.value)
+                            is CustomerSheetDataResult.Failure -> Result.failure(result.cause)
                         }
                     },
                     canRemove = customerState.canRemove,
@@ -935,7 +949,7 @@ internal class CustomerSheetViewModel(
 
     private fun attachPaymentMethodToCustomer(paymentMethod: PaymentMethod) {
         viewModelScope.launch(workContext) {
-            if (awaitCustomerAdapter().canCreateSetupIntents) {
+            if (awaitIntentDataSource().canCreateSetupIntents) {
                 attachWithSetupIntent(paymentMethod = paymentMethod)
             } else {
                 attachPaymentMethod(id = paymentMethod.id!!)
@@ -944,7 +958,7 @@ internal class CustomerSheetViewModel(
     }
 
     private suspend fun attachWithSetupIntent(paymentMethod: PaymentMethod) {
-        awaitCustomerAdapter().setupIntentClientSecretForCustomerAttach()
+        awaitIntentDataSource().retrieveSetupIntentClientSecret()
             .mapCatching { clientSecret ->
                 val intent = stripeRepository.retrieveSetupIntent(
                     clientSecret = clientSecret,
@@ -1035,7 +1049,7 @@ internal class CustomerSheetViewModel(
     }
 
     private suspend fun attachPaymentMethod(id: String) {
-        awaitCustomerAdapter().attachPaymentMethod(id)
+        awaitPaymentMethodDataSource().attachPaymentMethod(id)
             .onSuccess { attachedPaymentMethod ->
                 eventReporter.onAttachPaymentMethodSucceeded(
                     style = CustomerSheetEventReporter.AddPaymentMethodStyle.CreateAttach
@@ -1062,7 +1076,7 @@ internal class CustomerSheetViewModel(
     private suspend fun refreshAndUpdatePaymentMethods(
         newPaymentMethod: PaymentMethod
     ) {
-        awaitCustomerAdapter().retrievePaymentMethods().onSuccess { paymentMethods ->
+        awaitPaymentMethodDataSource().retrievePaymentMethods().onSuccess { paymentMethods ->
             errorReporter.report(
                 ErrorReporter.SuccessEvent.CUSTOMER_SHEET_PAYMENT_METHODS_REFRESH_SUCCESS,
             )
@@ -1092,8 +1106,8 @@ internal class CustomerSheetViewModel(
 
     private fun selectSavedPaymentMethod(savedPaymentSelection: PaymentSelection.Saved?) {
         viewModelScope.launch(workContext) {
-            awaitCustomerAdapter().setSelectedPaymentOption(
-                savedPaymentSelection?.toPaymentOption()
+            awaitSavedSelectionDataSource().setSavedSelection(
+                savedPaymentSelection?.toSavedSelection()
             ).onSuccess {
                 confirmPaymentSelection(
                     paymentSelection = savedPaymentSelection,
@@ -1112,7 +1126,7 @@ internal class CustomerSheetViewModel(
 
     private fun selectGooglePay() {
         viewModelScope.launch(workContext) {
-            awaitCustomerAdapter().setSelectedPaymentOption(CustomerAdapter.PaymentOption.GooglePay)
+            awaitSavedSelectionDataSource().setSavedSelection(SavedSelection.GooglePay)
                 .onSuccess {
                     confirmPaymentSelection(
                         paymentSelection = PaymentSelection.GooglePay,
@@ -1189,8 +1203,16 @@ internal class CustomerSheetViewModel(
         }
     }
 
-    private suspend fun awaitCustomerAdapter(): CustomerAdapter {
-        return customerAdapterProvider.await()
+    private suspend fun awaitPaymentMethodDataSource(): CustomerSheetPaymentMethodDataSource {
+        return paymentMethodDataSourceProvider.await()
+    }
+
+    private suspend fun awaitIntentDataSource(): CustomerSheetIntentDataSource {
+        return intentDataSourceProvider.await()
+    }
+
+    private suspend fun awaitSavedSelectionDataSource(): CustomerSheetSavedSelectionDataSource {
+        return savedSelectionDataSourceProvider.await()
     }
 
     private val CustomerSheetViewState.eventReporterScreen: CustomerSheetEventReporter.Screen?

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
@@ -1,23 +1,52 @@
 package com.stripe.android.customersheet.data
 
 import com.stripe.android.customersheet.CustomerAdapter
+import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.customersheet.map
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.paymentsheet.model.SavedSelection
 import javax.inject.Inject
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 internal class CustomerAdapterDataSource @Inject constructor(
     private val customerAdapter: CustomerAdapter,
-) : CustomerSheetSavedSelectionDataSource, CustomerSheetPaymentMethodDataSource {
+) : CustomerSheetSavedSelectionDataSource,
+    CustomerSheetPaymentMethodDataSource,
+    CustomerSheetIntentDataSource {
+    override val canCreateSetupIntents: Boolean = customerAdapter.canCreateSetupIntents
+
     override suspend fun retrievePaymentMethods(): CustomerSheetDataResult<List<PaymentMethod>> {
         return customerAdapter.retrievePaymentMethods().toCustomerSheetDataResult()
+    }
+
+    override suspend fun updatePaymentMethod(
+        paymentMethodId: String,
+        params: PaymentMethodUpdateParams,
+    ): CustomerSheetDataResult<PaymentMethod> {
+        return customerAdapter.updatePaymentMethod(paymentMethodId, params).toCustomerSheetDataResult()
+    }
+
+    override suspend fun attachPaymentMethod(paymentMethodId: String): CustomerSheetDataResult<PaymentMethod> {
+        return customerAdapter.attachPaymentMethod(paymentMethodId).toCustomerSheetDataResult()
+    }
+
+    override suspend fun detachPaymentMethod(paymentMethodId: String): CustomerSheetDataResult<PaymentMethod> {
+        return customerAdapter.detachPaymentMethod(paymentMethodId).toCustomerSheetDataResult()
     }
 
     override suspend fun retrieveSavedSelection(): CustomerSheetDataResult<SavedSelection?> {
         return customerAdapter.retrieveSelectedPaymentOption().map { result ->
             result?.toSavedSelection()
         }.toCustomerSheetDataResult()
+    }
+
+    override suspend fun setSavedSelection(selection: SavedSelection?): CustomerSheetDataResult<Unit> {
+        return customerAdapter.setSelectedPaymentOption(selection?.toPaymentOption()).toCustomerSheetDataResult()
+    }
+
+    override suspend fun retrieveSetupIntentClientSecret(): CustomerSheetDataResult<String> {
+        return customerAdapter.setupIntentClientSecretForCustomerAttach().toCustomerSheetDataResult()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetDataResultKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetDataResultKtx.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.customersheet.data
 
+import com.stripe.android.core.exception.StripeException
 import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 
@@ -12,4 +13,77 @@ internal fun <T> CustomerAdapter.Result<T>.toCustomerSheetDataResult(): Customer
             displayMessage = displayMessage,
         )
     }
+}
+
+internal inline fun <R, T> CustomerSheetDataResult<T>.map(
+    transform: (value: T) -> R
+): CustomerSheetDataResult<R> {
+    return when (this) {
+        is CustomerSheetDataResult.Success -> CustomerSheetDataResult.success(transform(this.value))
+        is CustomerSheetDataResult.Failure -> CustomerSheetDataResult.failure(
+            cause = this.cause,
+            displayMessage = this.displayMessage
+        )
+    }
+}
+
+internal inline fun <R, T> CustomerSheetDataResult<T>.mapCatching(
+    transform: (value: T) -> R
+): CustomerSheetDataResult<R> {
+    return when (this) {
+        is CustomerSheetDataResult.Success -> runCatching { transform(this.value) }
+        is CustomerSheetDataResult.Failure -> CustomerSheetDataResult.failure(
+            cause = this.cause,
+            displayMessage = this.displayMessage
+        )
+    }
+}
+
+internal inline fun <R, T> CustomerSheetDataResult<T>.onSuccess(
+    action: (value: T) -> R
+): CustomerSheetDataResult<T> {
+    if (this is CustomerSheetDataResult.Success) {
+        action(this.value)
+    }
+    return this
+}
+
+internal inline fun <R, T> CustomerSheetDataResult<T>.onFailure(
+    action: (cause: Throwable, displayMessage: String?) -> R
+): CustomerSheetDataResult<T> {
+    failureOrNull()?.let {
+        val displayMessage = it.displayMessage
+            ?: (it.cause as? StripeException)?.stripeError?.message
+        action(it.cause, displayMessage)
+    }
+    return this
+}
+
+internal inline fun <R, T> CustomerSheetDataResult<T>.fold(
+    onSuccess: (value: T) -> R,
+    onFailure: (cause: Throwable, displayMessage: String?) -> R
+): R {
+    return when (this) {
+        is CustomerSheetDataResult.Failure -> {
+            onFailure(this.cause, this.displayMessage)
+        }
+        is CustomerSheetDataResult.Success -> {
+            onSuccess(this.value)
+        }
+    }
+}
+
+internal fun<T> CustomerSheetDataResult<T>.failureOrNull(): CustomerSheetDataResult.Failure<T>? =
+    when (this) {
+        is CustomerSheetDataResult.Failure -> this
+        else -> null
+    }
+
+private inline fun <R, T> T.runCatching(block: T.() -> R): CustomerSheetDataResult<R> {
+    return kotlin.runCatching {
+        CustomerSheetDataResult.success(block())
+    }.fold(
+        onSuccess = { it },
+        onFailure = { CustomerSheetDataResult.failure(it, null) }
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetIntentDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetIntentDataSource.kt
@@ -1,0 +1,7 @@
+package com.stripe.android.customersheet.data
+
+internal interface CustomerSheetIntentDataSource {
+    val canCreateSetupIntents: Boolean
+
+    suspend fun retrieveSetupIntentClientSecret(): CustomerSheetDataResult<String>
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetPaymentMethodDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetPaymentMethodDataSource.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.data
 
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodUpdateParams
 
 /**
  * [CustomerSheetPaymentMethodDataSource] defines a set of operations for managing saved payment methods within a
@@ -13,4 +14,13 @@ internal interface CustomerSheetPaymentMethodDataSource {
      * @return a result containing the list of payment methods if operation was successful
      */
     suspend fun retrievePaymentMethods(): CustomerSheetDataResult<List<PaymentMethod>>
+
+    suspend fun updatePaymentMethod(
+        paymentMethodId: String,
+        params: PaymentMethodUpdateParams,
+    ): CustomerSheetDataResult<PaymentMethod>
+
+    suspend fun attachPaymentMethod(paymentMethodId: String): CustomerSheetDataResult<PaymentMethod>
+
+    suspend fun detachPaymentMethod(paymentMethodId: String): CustomerSheetDataResult<PaymentMethod>
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetSavedSelectionDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetSavedSelectionDataSource.kt
@@ -13,4 +13,6 @@ internal interface CustomerSheetSavedSelectionDataSource {
      * @return a result containing the saved selection if operation was successful
      */
     suspend fun retrieveSavedSelection(): CustomerSheetDataResult<SavedSelection?>
+
+    suspend fun setSavedSelection(selection: SavedSelection?): CustomerSheetDataResult<Unit>
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/util/CustomerSheetHacks.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/util/CustomerSheetHacks.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.customersheet.data.CustomerAdapterDataSource
+import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
 import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSource
 import com.stripe.android.customersheet.data.CustomerSheetSavedSelectionDataSource
 import kotlinx.coroutines.CompletableDeferred
@@ -33,6 +34,9 @@ internal object CustomerSheetHacks {
         get() = _dataSource.asDeferred()
 
     val savedSelectionDataSource: Deferred<CustomerSheetSavedSelectionDataSource>
+        get() = _dataSource.asDeferred()
+
+    val intentDataSource: Deferred<CustomerSheetIntentDataSource>
         get() = _dataSource.asDeferred()
 
     fun initialize(
@@ -63,9 +67,11 @@ internal object CustomerSheetHacks {
 
     private class CombinedDataSource<T>(dataSource: T) :
         CustomerSheetSavedSelectionDataSource by dataSource,
-        CustomerSheetPaymentMethodDataSource by dataSource
+        CustomerSheetPaymentMethodDataSource by dataSource,
+        CustomerSheetIntentDataSource by dataSource
         where T : CustomerSheetSavedSelectionDataSource,
-              T : CustomerSheetPaymentMethodDataSource
+              T : CustomerSheetPaymentMethodDataSource,
+              T : CustomerSheetIntentDataSource
 
     fun clear() {
         _adapter.value = null

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
@@ -6,6 +6,7 @@ import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.customersheet.FakeCustomerAdapter
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.testing.PaymentMethodFactory
 import kotlinx.coroutines.test.runTest
@@ -87,6 +88,248 @@ class CustomerAdapterDataSourceTest {
         val result = dataSource.retrieveSavedSelection()
 
         assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<SavedSelection?>>()
+
+        val failedResult = result.asFailure()
+
+        assertThat(failedResult.cause).isInstanceOf(IllegalStateException::class.java)
+        assertThat(failedResult.cause.message).isEqualTo("Failed to retrieve!")
+        assertThat(failedResult.displayMessage).isEqualTo("Something went wrong!")
+    }
+
+    @Test
+    fun `on set saved selection, should complete successfully from adapter`() = runTest {
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                onSetSelectedPaymentOption = {
+                    CustomerAdapter.Result.success(Unit)
+                }
+            ),
+        )
+
+        val result = dataSource.setSavedSelection(SavedSelection.GooglePay)
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<SavedSelection?>>()
+    }
+
+    @Test
+    fun `on set saved selection, should fail from adapter`() = runTest {
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                onSetSelectedPaymentOption = {
+                    CustomerAdapter.Result.failure(
+                        cause = IllegalStateException("Failed to retrieve!"),
+                        displayMessage = "Something went wrong!",
+                    )
+                }
+            )
+        )
+
+        val result = dataSource.setSavedSelection(SavedSelection.GooglePay)
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<SavedSelection?>>()
+
+        val failedResult = result.asFailure()
+
+        assertThat(failedResult.cause).isInstanceOf(IllegalStateException::class.java)
+        assertThat(failedResult.cause.message).isEqualTo("Failed to retrieve!")
+        assertThat(failedResult.displayMessage).isEqualTo("Something went wrong!")
+    }
+
+    @Test
+    fun `on attach payment method, should complete successfully from adapter`() = runTest {
+        val paymentMethod = PaymentMethodFactory.card(id = "pm_1")
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                onAttachPaymentMethod = {
+                    CustomerAdapter.Result.success(paymentMethod)
+                }
+            ),
+        )
+
+        val result = dataSource.attachPaymentMethod(paymentMethodId = "pm_1")
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<PaymentMethod>>()
+
+        val successResult = result.asSuccess()
+
+        assertThat(successResult.value).isEqualTo(paymentMethod)
+    }
+
+    @Test
+    fun `on attach payment method, should fail from adapter`() = runTest {
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                onAttachPaymentMethod = {
+                    CustomerAdapter.Result.failure(
+                        cause = IllegalStateException("Failed to retrieve!"),
+                        displayMessage = "Something went wrong!",
+                    )
+                }
+            )
+        )
+
+        val result = dataSource.attachPaymentMethod(paymentMethodId = "pm_1")
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<PaymentMethod>>()
+
+        val failedResult = result.asFailure()
+
+        assertThat(failedResult.cause).isInstanceOf(IllegalStateException::class.java)
+        assertThat(failedResult.cause.message).isEqualTo("Failed to retrieve!")
+        assertThat(failedResult.displayMessage).isEqualTo("Something went wrong!")
+    }
+
+    @Test
+    fun `on detach payment method, should complete successfully from adapter`() = runTest {
+        val paymentMethod = PaymentMethodFactory.card(id = "pm_1")
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                onDetachPaymentMethod = {
+                    CustomerAdapter.Result.success(paymentMethod)
+                },
+            ),
+        )
+
+        val result = dataSource.detachPaymentMethod(paymentMethodId = "pm_1")
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<PaymentMethod>>()
+
+        val successResult = result.asSuccess()
+
+        assertThat(successResult.value).isEqualTo(paymentMethod)
+    }
+
+    @Test
+    fun `on detach payment method, should fail from adapter`() = runTest {
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                onDetachPaymentMethod = {
+                    CustomerAdapter.Result.failure(
+                        cause = IllegalStateException("Failed to retrieve!"),
+                        displayMessage = "Something went wrong!",
+                    )
+                }
+            )
+        )
+
+        val result = dataSource.detachPaymentMethod(paymentMethodId = "pm_1")
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<PaymentMethod>>()
+
+        val failedResult = result.asFailure()
+
+        assertThat(failedResult.cause).isInstanceOf(IllegalStateException::class.java)
+        assertThat(failedResult.cause.message).isEqualTo("Failed to retrieve!")
+        assertThat(failedResult.displayMessage).isEqualTo("Something went wrong!")
+    }
+
+    @Test
+    fun `on update payment method, should complete successfully from adapter`() = runTest {
+        val paymentMethod = PaymentMethodFactory.card(id = "pm_1")
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                onUpdatePaymentMethod = { _, _ ->
+                    CustomerAdapter.Result.success(paymentMethod)
+                },
+            ),
+        )
+
+        val result = dataSource.updatePaymentMethod(
+            paymentMethodId = "pm_1",
+            params = PaymentMethodUpdateParams.createCard(expiryYear = 2028, expiryMonth = 7),
+        )
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<PaymentMethod>>()
+
+        val successResult = result.asSuccess()
+
+        assertThat(successResult.value).isEqualTo(paymentMethod)
+    }
+
+    @Test
+    fun `on update payment method, should fail from adapter`() = runTest {
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                onUpdatePaymentMethod = { _, _ ->
+                    CustomerAdapter.Result.failure(
+                        cause = IllegalStateException("Failed to retrieve!"),
+                        displayMessage = "Something went wrong!",
+                    )
+                }
+            )
+        )
+
+        val result = dataSource.updatePaymentMethod(
+            paymentMethodId = "pm_1",
+            params = PaymentMethodUpdateParams.createCard(expiryYear = 2028, expiryMonth = 7),
+        )
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<PaymentMethod>>()
+
+        val failedResult = result.asFailure()
+
+        assertThat(failedResult.cause).isInstanceOf(IllegalStateException::class.java)
+        assertThat(failedResult.cause.message).isEqualTo("Failed to retrieve!")
+        assertThat(failedResult.displayMessage).isEqualTo("Something went wrong!")
+    }
+
+    @Test
+    fun `on can create setup intents, should return true from adapter`() = runTest {
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                canCreateSetupIntents = true,
+            )
+        )
+
+        assertThat(dataSource.canCreateSetupIntents).isTrue()
+    }
+
+    @Test
+    fun `on can create setup intents, should return false from adapter`() = runTest {
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                canCreateSetupIntents = false,
+            )
+        )
+
+        assertThat(dataSource.canCreateSetupIntents).isFalse()
+    }
+
+    @Test
+    fun `on fetch setup intent client secret, should complete successfully from adapter`() = runTest {
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                onSetupIntentClientSecretForCustomerAttach = {
+                    CustomerAdapter.Result.success("seti_example")
+                }
+            )
+        )
+
+        val result = dataSource.retrieveSetupIntentClientSecret()
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<String>>()
+
+        val successResult = result.asSuccess()
+
+        assertThat(successResult.value).isEqualTo("seti_example")
+    }
+
+    @Test
+    fun `on fetch setup intent client secret, should fail from adapter`() = runTest {
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                onSetupIntentClientSecretForCustomerAttach = {
+                    CustomerAdapter.Result.failure(
+                        cause = IllegalStateException("Failed to retrieve!"),
+                        displayMessage = "Something went wrong!",
+                    )
+                }
+            )
+        )
+
+        val result = dataSource.retrieveSetupIntentClientSecret()
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<String>>()
 
         val failedResult = result.asFailure()
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -18,6 +18,7 @@ import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.customersheet.FakeCustomerAdapter
 import com.stripe.android.customersheet.FakeStripeRepository
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
+import com.stripe.android.customersheet.data.CustomerAdapterDataSource
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
@@ -99,12 +100,20 @@ internal object CustomerSheetTestHelper {
             createModifiableEditPaymentMethodViewInteractorFactory(),
         errorReporter: ErrorReporter = FakeErrorReporter(),
     ): CustomerSheetViewModel {
+        val dataSourceProvider = CompletableDeferred(
+            CustomerAdapterDataSource(
+                customerAdapter = customerAdapter
+            )
+        )
+
         return CustomerSheetViewModel(
             application = application,
             workContext = workContext,
             originalPaymentSelection = savedPaymentSelection,
             paymentConfigurationProvider = { paymentConfiguration },
-            customerAdapterProvider = CompletableDeferred(customerAdapter),
+            paymentMethodDataSourceProvider = dataSourceProvider,
+            intentDataSourceProvider = dataSourceProvider,
+            savedSelectionDataSourceProvider = dataSourceProvider,
             stripeRepository = stripeRepository,
             configuration = configuration,
             isLiveModeProvider = { isLiveMode },


### PR DESCRIPTION
# Summary
Uses `CustomerSheetPaymentMethodDataSource` and `CustomerSheetSavedSelectionDataSource` in `CustomerSheetViewModel`. Also add `CustomerSheetIntentDataSource` as well.

# Motivation
Helps move `CustomerSheet` to new data source architecture which will allow for `CustomerSession` to be built into it.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
