### PR TITLE
Restore `PlaygroundState` after process death

### DIFF
--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -2,6 +2,7 @@ apply from: configs.androidApplication
 
 apply plugin: 'com.emergetools.android'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
+apply plugin: "org.jetbrains.kotlin.plugin.parcelize"
 apply plugin: 'shot'
 
 // Read values from gradle.properties or system environment variable

--- a/paymentsheet-example/dependencies/dependencies.txt
+++ b/paymentsheet-example/dependencies/dependencies.txt
@@ -1300,4 +1300,5 @@
 |    |    \--- com.squareup.okhttp3:okhttp:3.14.9 -> 4.12.0 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-serialization-core:1.5.0 -> 1.6.2 (*)
 |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10 -> 1.9.10 (*)
-\--- com.google.zxing:core:3.5.2
++--- com.google.zxing:core:3.5.2
+\--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.24 (*)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PlaygroundState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PlaygroundState.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.example.playground
 
+import android.os.Parcelable
 import androidx.compose.runtime.Stable
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
@@ -21,14 +22,16 @@ import com.stripe.android.paymentsheet.example.playground.settings.PaymentMethod
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundConfigurationData
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettings
 import com.stripe.android.paymentsheet.example.playground.settings.RequireCvcRecollectionDefinition
+import kotlinx.parcelize.Parcelize
 
 @Stable
-internal sealed interface PlaygroundState {
+internal sealed interface PlaygroundState : Parcelable {
     val integrationType: PlaygroundConfigurationData.IntegrationType
     val countryCode: Country
     val endpoint: String
 
     @Stable
+    @Parcelize
     data class Payment(
         private val snapshot: PlaygroundSettings.Snapshot,
         val amount: Long,
@@ -37,19 +40,29 @@ internal sealed interface PlaygroundState {
         val clientSecret: String,
         private val defaultEndpoint: String,
     ) : PlaygroundState {
-        override val integrationType = snapshot.configurationData.integrationType
-        override val countryCode = snapshot[CountrySettingsDefinition]
+        override val integrationType
+            get() = snapshot.configurationData.integrationType
 
-        val initializationType = snapshot[InitializationTypeSettingsDefinition]
-        val checkoutMode = snapshot[CheckoutModeSettingsDefinition]
-        val currencyCode = snapshot[CurrencySettingsDefinition]
-        val paymentMethodConfigurationId: String? =
-            snapshot[PaymentMethodConfigurationSettingsDefinition].ifEmpty { null }
+        override val countryCode
+            get() = snapshot[CountrySettingsDefinition]
+
+        val initializationType
+            get() = snapshot[InitializationTypeSettingsDefinition]
+
+        val checkoutMode
+            get() = snapshot[CheckoutModeSettingsDefinition]
+
+        val currencyCode
+            get() = snapshot[CurrencySettingsDefinition]
+
+        val paymentMethodConfigurationId: String?
+            get() = snapshot[PaymentMethodConfigurationSettingsDefinition].ifEmpty { null }
 
         val stripeIntentId: String
             get() = clientSecret.substringBefore("_secret_")
 
-        val requireCvcRecollectionForDeferred = snapshot[RequireCvcRecollectionDefinition]
+        val requireCvcRecollectionForDeferred
+            get() = snapshot[RequireCvcRecollectionDefinition]
 
         override val endpoint: String
             get() = snapshot[CustomEndpointDefinition] ?: defaultEndpoint
@@ -61,15 +74,23 @@ internal sealed interface PlaygroundState {
 
     @Stable
     @OptIn(ExperimentalCustomerSheetApi::class)
+    @Parcelize
     data class Customer(
         private val snapshot: PlaygroundSettings.Snapshot,
         override val endpoint: String,
     ) : PlaygroundState {
-        override val integrationType = snapshot.configurationData.integrationType
-        override val countryCode = snapshot[CountrySettingsDefinition]
+        override val integrationType
+            get() = snapshot.configurationData.integrationType
 
-        val isNewCustomer = snapshot[CustomerSettingsDefinition] == CustomerType.NEW
-        val inSetupMode = snapshot[CustomerSheetPaymentMethodModeDefinition] == PaymentMethodMode.SetupIntent
+        override val countryCode
+            get() = snapshot[CountrySettingsDefinition]
+
+        val isNewCustomer
+            get() = snapshot[CustomerSettingsDefinition] == CustomerType.NEW
+
+        val inSetupMode
+            get() = snapshot[CustomerSheetPaymentMethodModeDefinition] ==
+                PaymentMethodMode.SetupIntent
 
         fun customerSheetConfiguration(): CustomerSheet.Configuration {
             return snapshot.customerSheetConfiguration(this)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundConfigurationData.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundConfigurationData.kt
@@ -1,12 +1,15 @@
 package com.stripe.android.paymentsheet.example.playground.settings
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@Parcelize
 data class PlaygroundConfigurationData(
     val integrationType: IntegrationType = IntegrationType.PaymentSheet,
-) {
+) : Parcelable {
     @Serializable
     enum class IntegrationType {
         @SerialName("paymentSheet")


### PR DESCRIPTION
# Summary
Restore `PlaygroundState` after process death

# Motivation
We lose the playground state during process death, preventing us from being able to re-initialize `CustomerAdapter` properly. Restoring the playground state allows for re-initializing the adapter properly.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified