### PR TITLE
Fix decoding issue in `ElementsSessionJsonParser`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/parsers/DeferredPaymentIntentJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/DeferredPaymentIntentJsonParser.kt
@@ -22,7 +22,7 @@ class DeferredPaymentIntentJsonParser(
 
         val unactivatedPaymentMethods = jsonArrayToList(
             json.optJSONArray(FIELD_UNACTIVATED_PAYMENT_METHOD_TYPES)
-        )
+        ).map { it.lowercase() }
 
         val linkFundingSources = jsonArrayToList(json.optJSONArray(FIELD_LINK_FUNDING_SOURCES))
             .map { it.lowercase() }

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/DeferredSetupIntentJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/DeferredSetupIntentJsonParser.kt
@@ -22,7 +22,7 @@ class DeferredSetupIntentJsonParser(
 
         val unactivatedPaymentMethods = jsonArrayToList(
             json.optJSONArray(FIELD_UNACTIVATED_PAYMENT_METHOD_TYPES)
-        )
+        ).map { it.lowercase() }
 
         val linkFundingSources = jsonArrayToList(json.optJSONArray(FIELD_LINK_FUNDING_SOURCES))
             .map { it.lowercase() }

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
@@ -30,9 +30,7 @@ internal class ElementsSessionJsonParser(
         }
 
         val countryCode = paymentMethodPreference.optString(FIELD_COUNTRY_CODE)
-        val unactivatedPaymentMethodTypes =
-            jsonArrayToList(json.optJSONArray(FIELD_UNACTIVATED_PAYMENT_METHOD_TYPES))
-                .map { it.lowercase() }
+        val unactivatedPaymentMethodTypes = json.optJSONArray(FIELD_UNACTIVATED_PAYMENT_METHOD_TYPES)
         val paymentMethodSpecs = json.optJSONArray(FIELD_PAYMENT_METHOD_SPECS)?.toString()
         val externalPaymentMethodData = json.optJSONArray(FIELD_EXTERNAL_PAYMENT_METHOD_DATA)?.toString()
         val linkFundingSources = json.optJSONObject(FIELD_LINK_SETTINGS)?.optJSONArray(
@@ -90,7 +88,7 @@ internal class ElementsSessionJsonParser(
         elementsSessionId: String?,
         paymentMethodPreference: JSONObject?,
         orderedPaymentMethodTypes: JSONArray?,
-        unactivatedPaymentMethodTypes: List<String>,
+        unactivatedPaymentMethodTypes: JSONArray?,
         linkFundingSources: JSONArray?,
         countryCode: String
     ): StripeIntent? {

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentIntentJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentIntentJsonParser.kt
@@ -70,7 +70,7 @@ class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
 
         val unactivatedPaymentMethods = jsonArrayToList(
             json.optJSONArray(FIELD_UNACTIVATED_PAYMENT_METHOD_TYPES)
-        )
+        ).map { it.lowercase() }
 
         val linkFundingSources = jsonArrayToList(json.optJSONArray(FIELD_LINK_FUNDING_SOURCES))
             .map { it.lowercase() }

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/SetupIntentJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/SetupIntentJsonParser.kt
@@ -25,7 +25,7 @@ class SetupIntentJsonParser : ModelJsonParser<SetupIntent> {
 
         val unactivatedPaymentMethods = jsonArrayToList(
             json.optJSONArray(FIELD_UNACTIVATED_PAYMENT_METHOD_TYPES)
-        )
+        ).map { it.lowercase() }
 
         val linkFundingSources = jsonArrayToList(json.optJSONArray(FIELD_LINK_FUNDING_SOURCES))
             .map { it.lowercase() }

--- a/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
@@ -4,76 +4,6 @@ import org.json.JSONObject
 
 @Suppress("LargeClass")
 internal object ElementsSessionFixtures {
-    val TEST = JSONObject(
-        """
-        {
-          "business_name": "Mybusiness",
-          "link_settings": {
-            "link_bank_enabled": false,
-            "link_bank_onboarding_enabled": false
-          },
-          "merchant_country": "US",
-          "payment_method_preference": {
-            "object": "payment_method_preference",
-            "country_code": "US",
-            "ordered_payment_method_types": [
-              "card",
-              "ideal",
-              "sepa_debit",
-              "bancontact",
-              "sofort"
-            ],
-            "payment_intent": {
-              "id": "pi_3JTDhYIyGgrkZxL71IDUGKps",
-              "object": "payment_intent",
-              "amount": 973,
-              "canceled_at": null,
-              "cancellation_reason": null,
-              "capture_method": "automatic",
-              "client_secret": "pi_3JTDhYIyGgrkZxL71IDUGKps_secret_aWuzwD4JvF1HM8XJTdUsXG6Za",
-              "confirmation_method": "automatic",
-              "created": 1630103948,
-              "currency": "eur",
-              "description": null,
-              "last_payment_error": null,
-              "livemode": false,
-              "next_action": null,
-              "payment_method": null,
-              "payment_method_types": [
-                "card",
-                "sepa_debit",
-                "sofort",
-                "ideal"
-              ],
-              "receipt_email": null,
-              "setup_future_usage": null,
-              "shipping": {
-                "address": {
-                  "city": "San Francisco",
-                  "country": "US",
-                  "line1": "510 Townsend St",
-                  "line2": null,
-                  "postal_code": "94102",
-                  "state": "California"
-                },
-                "carrier": null,
-                "name": "Bruno",
-                "phone": null,
-                "tracking_number": null
-              },
-              "source": null,
-              "status": "requires_payment_method"
-            },
-            "type": "payment_intent"
-          },
-          "unactivated_payment_method_types": [
-            "card"
-          ]
-        }
-        """.trimIndent()
-    )
-
-
     val EXPANDED_PAYMENT_INTENT_JSON = JSONObject(
         """
         {
@@ -986,7 +916,7 @@ internal object ElementsSessionFixtures {
                   "currency": "aud",
                   "description": null,
                   "last_payment_error": null,
-                  "livemode": false,
+                  "livemode": true,
                   "next_action": null,
                   "payment_method": null,
                   "payment_method_types": [

--- a/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
@@ -4,6 +4,76 @@ import org.json.JSONObject
 
 @Suppress("LargeClass")
 internal object ElementsSessionFixtures {
+    val TEST = JSONObject(
+        """
+        {
+          "business_name": "Mybusiness",
+          "link_settings": {
+            "link_bank_enabled": false,
+            "link_bank_onboarding_enabled": false
+          },
+          "merchant_country": "US",
+          "payment_method_preference": {
+            "object": "payment_method_preference",
+            "country_code": "US",
+            "ordered_payment_method_types": [
+              "card",
+              "ideal",
+              "sepa_debit",
+              "bancontact",
+              "sofort"
+            ],
+            "payment_intent": {
+              "id": "pi_3JTDhYIyGgrkZxL71IDUGKps",
+              "object": "payment_intent",
+              "amount": 973,
+              "canceled_at": null,
+              "cancellation_reason": null,
+              "capture_method": "automatic",
+              "client_secret": "pi_3JTDhYIyGgrkZxL71IDUGKps_secret_aWuzwD4JvF1HM8XJTdUsXG6Za",
+              "confirmation_method": "automatic",
+              "created": 1630103948,
+              "currency": "eur",
+              "description": null,
+              "last_payment_error": null,
+              "livemode": false,
+              "next_action": null,
+              "payment_method": null,
+              "payment_method_types": [
+                "card",
+                "sepa_debit",
+                "sofort",
+                "ideal"
+              ],
+              "receipt_email": null,
+              "setup_future_usage": null,
+              "shipping": {
+                "address": {
+                  "city": "San Francisco",
+                  "country": "US",
+                  "line1": "510 Townsend St",
+                  "line2": null,
+                  "postal_code": "94102",
+                  "state": "California"
+                },
+                "carrier": null,
+                "name": "Bruno",
+                "phone": null,
+                "tracking_number": null
+              },
+              "source": null,
+              "status": "requires_payment_method"
+            },
+            "type": "payment_intent"
+          },
+          "unactivated_payment_method_types": [
+            "card"
+          ]
+        }
+        """.trimIndent()
+    )
+
+
     val EXPANDED_PAYMENT_INTENT_JSON = JSONObject(
         """
         {

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -16,6 +16,22 @@ import org.json.JSONObject
 import org.junit.Test
 
 class ElementsSessionJsonParserTest {
+
+    @Test
+    fun showUnactivatedPaymentMethodsBug() {
+        val elementsSession = ElementsSessionJsonParser(
+            ElementsSessionParams.PaymentIntentType(
+                clientSecret = "secret",
+                externalPaymentMethods = emptyList(),
+            ),
+            apiKey = "test",
+        ).parse(
+            ElementsSessionFixtures.TEST
+        )
+
+        assertThat(elementsSession?.stripeIntent?.unactivatedPaymentMethods).containsExactly("card")
+    }
+
     @Test
     fun parsePaymentIntent_shouldCreateObjectWithOrderedPaymentMethods() {
         val elementsSession = ElementsSessionJsonParser(

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -18,21 +18,6 @@ import org.junit.Test
 class ElementsSessionJsonParserTest {
 
     @Test
-    fun showUnactivatedPaymentMethodsBug() {
-        val elementsSession = ElementsSessionJsonParser(
-            ElementsSessionParams.PaymentIntentType(
-                clientSecret = "secret",
-                externalPaymentMethods = emptyList(),
-            ),
-            apiKey = "test",
-        ).parse(
-            ElementsSessionFixtures.TEST
-        )
-
-        assertThat(elementsSession?.stripeIntent?.unactivatedPaymentMethods).containsExactly("card")
-    }
-
-    @Test
     fun parsePaymentIntent_shouldCreateObjectWithOrderedPaymentMethods() {
         val elementsSession = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
@@ -787,6 +772,23 @@ class ElementsSessionJsonParserTest {
         assertIsGooglePayEnabled(true) { put(ElementsSessionJsonParser.FIELD_GOOGLE_PAY_PREFERENCE, "enabled") }
         assertIsGooglePayEnabled(true) { put(ElementsSessionJsonParser.FIELD_GOOGLE_PAY_PREFERENCE, "unknown") }
         assertIsGooglePayEnabled(false) { put(ElementsSessionJsonParser.FIELD_GOOGLE_PAY_PREFERENCE, "disabled") }
+    }
+
+    @Test
+    fun parsePaymentIntent_excludesUnactivatedPaymentMethodTypesInLiveMode() {
+        val elementsSession = ElementsSessionJsonParser(
+            ElementsSessionParams.PaymentIntentType(
+                clientSecret = "secret",
+                externalPaymentMethods = emptyList(),
+            ),
+            apiKey = "pk_live_abc123",
+        ).parse(
+            JSONObject(
+                ElementsSessionFixtures.PI_WITH_CARD_AFTERPAY_AU_BECS
+            )
+        )
+
+        assertThat(elementsSession?.stripeIntent?.unactivatedPaymentMethods).containsExactly("au_becs_debit")
     }
 
     private fun allowRedisplayTest(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the `ElementsSessionJsonParser` wouldn’t correctly parse `unactivated_payment_method_types`.

This happened because of some weird JSON manipulation where the unactivated payment method types were put into the `JSONObject` as a `List`. The subsequent attempt to retrieve them as a `JSONArray` thus failed, meaning they were always empty.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
