### PR TITLE
Only push specific tag.

### DIFF
--- a/scripts/deploy/create_github_release.rb
+++ b/scripts/deploy/create_github_release.rb
@@ -65,7 +65,7 @@ private def tag_release
 
     # There's no way to create a "draft" tag, so we skip pushing tags if this is a dry run.
     if(!@is_dry_run)
-        execute_or_fail("git push --tags")
+        execute_or_fail("git push --tag origin #{tag_name}")
     end
 end
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We've had a few issues during release that this command failed due to duplicate (previous) tags.
By isolating the push to a single tag, we should avoid that issue in the future.
