### PR TITLE
Use dependency injection for `CustomerSheet` data sources

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
@@ -8,8 +8,10 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.paymentsheet.model.SavedSelection
 import javax.inject.Inject
+import javax.inject.Singleton
 
 @OptIn(ExperimentalCustomerSheetApi::class)
+@Singleton
 internal class CustomerAdapterDataSource @Inject constructor(
     private val customerAdapter: CustomerAdapter,
 ) : CustomerSheetSavedSelectionDataSource,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceComponent.kt
@@ -7,8 +7,10 @@ import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSourc
 import com.stripe.android.customersheet.data.CustomerSheetSavedSelectionDataSource
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Singleton
 
 @OptIn(ExperimentalCustomerSheetApi::class)
+@Singleton
 @Component(
     modules = [
         CustomerAdapterDataSourceModule::class

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceComponent.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.customersheet.data.injection
+
+import com.stripe.android.customersheet.CustomerAdapter
+import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
+import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSource
+import com.stripe.android.customersheet.data.CustomerSheetSavedSelectionDataSource
+import dagger.BindsInstance
+import dagger.Component
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+@Component(
+    modules = [
+        CustomerAdapterDataSourceModule::class
+    ]
+)
+internal interface CustomerAdapterDataSourceComponent {
+    val customerSheetPaymentMethodDataSource: CustomerSheetPaymentMethodDataSource
+    val customerSheetSavedSelectionDataSource: CustomerSheetSavedSelectionDataSource
+    val customerSheetIntentDataSource: CustomerSheetIntentDataSource
+
+    @Component.Builder
+    interface Builder {
+
+        @BindsInstance
+        fun adapter(customerAdapter: CustomerAdapter): Builder
+
+        fun build(): CustomerAdapterDataSourceComponent
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceModule.kt
@@ -1,16 +1,12 @@
 package com.stripe.android.customersheet.data.injection
 
-import com.stripe.android.customersheet.CustomerAdapter
-import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.customersheet.data.CustomerAdapterDataSource
 import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
 import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSource
 import com.stripe.android.customersheet.data.CustomerSheetSavedSelectionDataSource
 import dagger.Binds
 import dagger.Module
-import dagger.Provides
 
-@OptIn(ExperimentalCustomerSheetApi::class)
 @Module
 internal interface CustomerAdapterDataSourceModule {
     @Binds
@@ -27,11 +23,4 @@ internal interface CustomerAdapterDataSourceModule {
     fun bindsCustomerSheetSavedSelectionDataSource(
         impl: CustomerAdapterDataSource
     ): CustomerSheetSavedSelectionDataSource
-
-    companion object {
-        @Provides
-        fun providesCustomerAdapterDataSource(adapter: CustomerAdapter): CustomerAdapterDataSource {
-            return CustomerAdapterDataSource(adapter)
-        }
-    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceModule.kt
@@ -1,0 +1,37 @@
+package com.stripe.android.customersheet.data.injection
+
+import com.stripe.android.customersheet.CustomerAdapter
+import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.customersheet.data.CustomerAdapterDataSource
+import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
+import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSource
+import com.stripe.android.customersheet.data.CustomerSheetSavedSelectionDataSource
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+@Module
+internal interface CustomerAdapterDataSourceModule {
+    @Binds
+    fun bindsCustomerSheetPaymentMethodDataSource(
+        impl: CustomerAdapterDataSource
+    ): CustomerSheetPaymentMethodDataSource
+
+    @Binds
+    fun bindsCustomerSheetIntentDataSource(
+        impl: CustomerAdapterDataSource
+    ): CustomerSheetIntentDataSource
+
+    @Binds
+    fun bindsCustomerSheetSavedSelectionDataSource(
+        impl: CustomerAdapterDataSource
+    ): CustomerSheetSavedSelectionDataSource
+
+    companion object {
+        @Provides
+        fun providesCustomerAdapterDataSource(adapter: CustomerAdapter): CustomerAdapterDataSource {
+            return CustomerAdapterDataSource(adapter)
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/util/CustomerSheetHacks.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/util/CustomerSheetHacks.kt
@@ -6,10 +6,10 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
-import com.stripe.android.customersheet.data.CustomerAdapterDataSource
 import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
 import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSource
 import com.stripe.android.customersheet.data.CustomerSheetSavedSelectionDataSource
+import com.stripe.android.customersheet.data.injection.DaggerCustomerAdapterDataSourceComponent
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.flow.Flow
@@ -28,23 +28,32 @@ internal object CustomerSheetHacks {
     val adapter: Deferred<CustomerAdapter>
         get() = _adapter.asDeferred()
 
-    private val _dataSource = MutableStateFlow<CombinedDataSource<*>?>(null)
-
+    private val _paymentMethodDataSource = MutableStateFlow<CustomerSheetPaymentMethodDataSource?>(null)
     val paymentMethodDataSource: Deferred<CustomerSheetPaymentMethodDataSource>
-        get() = _dataSource.asDeferred()
+        get() = _paymentMethodDataSource.asDeferred()
 
+    private val _savedSelectionDataSource = MutableStateFlow<CustomerSheetSavedSelectionDataSource?>(null)
     val savedSelectionDataSource: Deferred<CustomerSheetSavedSelectionDataSource>
-        get() = _dataSource.asDeferred()
+        get() = _savedSelectionDataSource.asDeferred()
 
+    private val _intentDataSource = MutableStateFlow<CustomerSheetIntentDataSource?>(null)
     val intentDataSource: Deferred<CustomerSheetIntentDataSource>
-        get() = _dataSource.asDeferred()
+        get() = _intentDataSource.asDeferred()
 
     fun initialize(
         lifecycleOwner: LifecycleOwner,
         adapter: CustomerAdapter,
     ) {
         _adapter.value = adapter
-        _dataSource.value = CombinedDataSource(CustomerAdapterDataSource(adapter))
+
+        val adapterDataSourceComponent = DaggerCustomerAdapterDataSourceComponent
+            .builder()
+            .adapter(adapter)
+            .build()
+
+        _paymentMethodDataSource.value = adapterDataSourceComponent.customerSheetPaymentMethodDataSource
+        _intentDataSource.value = adapterDataSourceComponent.customerSheetIntentDataSource
+        _savedSelectionDataSource.value = adapterDataSourceComponent.customerSheetSavedSelectionDataSource
 
         lifecycleOwner.lifecycle.addObserver(
             object : DefaultLifecycleObserver {
@@ -65,17 +74,11 @@ internal object CustomerSheetHacks {
         )
     }
 
-    private class CombinedDataSource<T>(dataSource: T) :
-        CustomerSheetSavedSelectionDataSource by dataSource,
-        CustomerSheetPaymentMethodDataSource by dataSource,
-        CustomerSheetIntentDataSource by dataSource
-        where T : CustomerSheetSavedSelectionDataSource,
-              T : CustomerSheetPaymentMethodDataSource,
-              T : CustomerSheetIntentDataSource
-
     fun clear() {
         _adapter.value = null
-        _dataSource.value = null
+        _paymentMethodDataSource.value = null
+        _savedSelectionDataSource.value = null
+        _intentDataSource.value = null
     }
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetHacksTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetHacksTest.kt
@@ -1,0 +1,44 @@
+package com.stripe.android.customersheet.utils
+
+import androidx.lifecycle.testing.TestLifecycleOwner
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.customersheet.FakeCustomerAdapter
+import com.stripe.android.customersheet.util.CustomerSheetHacks
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.After
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+class CustomerSheetHacksTest {
+    @After
+    fun teardown() {
+        CustomerSheetHacks.clear()
+    }
+
+    @Test
+    fun `on initialize, should initialize all data sources as expected`() = runTest {
+        CustomerSheetHacks.initialize(TestLifecycleOwner(), FakeCustomerAdapter())
+
+        assertThat(CustomerSheetHacks.intentDataSource.awaitWithTimeout()).isNotNull()
+        assertThat(CustomerSheetHacks.paymentMethodDataSource.awaitWithTimeout()).isNotNull()
+        assertThat(CustomerSheetHacks.savedSelectionDataSource.awaitWithTimeout()).isNotNull()
+    }
+
+    @Test
+    fun `on clear, should clear all data sources as expected`() = runTest {
+        CustomerSheetHacks.initialize(TestLifecycleOwner(), FakeCustomerAdapter())
+        CustomerSheetHacks.clear()
+
+        assertThat(CustomerSheetHacks.intentDataSource.awaitWithTimeout()).isNull()
+        assertThat(CustomerSheetHacks.paymentMethodDataSource.awaitWithTimeout()).isNull()
+        assertThat(CustomerSheetHacks.savedSelectionDataSource.awaitWithTimeout()).isNull()
+    }
+
+    private suspend fun <T> Deferred<T>.awaitWithTimeout(): T? {
+        return withTimeoutOrNull(1.seconds) { await() }
+    }
+}


### PR DESCRIPTION
# Summary
Use dependency injection for `CustomerSheet` data sources. It also cleans up the weird `CombinedDataSource` type in `CustomerSheetHacks`. Also added tests to validate `CustomerSheetHacks` as well.

# Motivation
We'll need `elements/session` and `ErrorReporter` dependencies when we move initialization into the data sources. Creating these beforehand will help make that process easier.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified