### PR TITLE
Add call to `share_payment_details` for Link card brand

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/CreateInstantDebitsResult.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/CreateInstantDebitsResult.kt
@@ -1,10 +1,12 @@
 package com.stripe.android.financialconnections.domain
 
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext
 import com.stripe.android.financialconnections.launcher.InstantDebitsResult
 import com.stripe.android.financialconnections.repository.ConsumerSessionProvider
 import com.stripe.android.financialconnections.repository.FinancialConnectionsConsumerSessionRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsRepository
 import com.stripe.android.model.ConsumerPaymentDetails.BankAccount
+import com.stripe.android.model.LinkMode
 import javax.inject.Inject
 
 internal fun interface CreateInstantDebitsResult {
@@ -17,6 +19,7 @@ internal class RealCreateInstantDebitsResult @Inject constructor(
     private val consumerRepository: FinancialConnectionsConsumerSessionRepository,
     private val repository: FinancialConnectionsRepository,
     private val consumerSessionProvider: ConsumerSessionProvider,
+    private val elementsSessionContext: ElementsSessionContext?,
 ) : CreateInstantDebitsResult {
 
     override suspend fun invoke(
@@ -34,13 +37,21 @@ internal class RealCreateInstantDebitsResult @Inject constructor(
 
         val paymentDetails = response.paymentDetails.filterIsInstance<BankAccount>().first()
 
-        val paymentMethod = repository.createPaymentMethod(
-            paymentDetailsId = paymentDetails.id,
-            consumerSessionClientSecret = clientSecret,
-        )
+        val paymentMethodId = if (elementsSessionContext?.linkMode == LinkMode.LinkCardBrand) {
+            consumerRepository.sharePaymentDetails(
+                paymentDetailsId = paymentDetails.id,
+                consumerSessionClientSecret = clientSecret,
+                expectedPaymentMethodType = "card",
+            ).paymentMethodId
+        } else {
+            repository.createPaymentMethod(
+                paymentDetailsId = paymentDetails.id,
+                consumerSessionClientSecret = clientSecret,
+            ).id
+        }
 
         return InstantDebitsResult(
-            paymentMethodId = paymentMethod.id,
+            paymentMethodId = paymentMethodId,
             bankName = paymentDetails.bankName,
             last4 = paymentDetails.last4,
         )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
@@ -12,6 +12,7 @@ import com.stripe.android.model.ConsumerSessionLookup
 import com.stripe.android.model.ConsumerSessionSignup
 import com.stripe.android.model.ConsumerSignUpConsentAction.EnteredPhoneNumberClickedSaveToLink
 import com.stripe.android.model.CustomEmailType
+import com.stripe.android.model.SharePaymentDetails
 import com.stripe.android.model.VerificationType
 import com.stripe.android.repository.ConsumersApiService
 import kotlinx.coroutines.sync.Mutex
@@ -55,6 +56,12 @@ internal interface FinancialConnectionsConsumerSessionRepository {
         bankAccountId: String,
         consumerSessionClientSecret: String,
     ): ConsumerPaymentDetails
+
+    suspend fun sharePaymentDetails(
+        paymentDetailsId: String,
+        consumerSessionClientSecret: String,
+        expectedPaymentMethodType: String,
+    ): SharePaymentDetails
 
     companion object {
         operator fun invoke(
@@ -186,6 +193,20 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
             ),
             requestSurface = requestSurface,
             requestOptions = provideApiRequestOptions(useConsumerPublishableKey = true),
+        ).getOrThrow()
+    }
+
+    override suspend fun sharePaymentDetails(
+        paymentDetailsId: String,
+        consumerSessionClientSecret: String,
+        expectedPaymentMethodType: String
+    ): SharePaymentDetails {
+        return consumersApiService.sharePaymentDetails(
+            consumerSessionClientSecret = consumerSessionClientSecret,
+            paymentDetailsId = paymentDetailsId,
+            expectedPaymentMethodType = expectedPaymentMethodType,
+            requestSurface = requestSurface,
+            requestOptions = provideApiRequestOptions(useConsumerPublishableKey = false),
         ).getOrThrow()
     }
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/RealCreateInstantDebitsResultTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/RealCreateInstantDebitsResultTest.kt
@@ -1,0 +1,130 @@
+package com.stripe.android.financialconnections.domain
+
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext
+import com.stripe.android.financialconnections.model.PaymentMethod
+import com.stripe.android.financialconnections.repository.CachedConsumerSession
+import com.stripe.android.financialconnections.repository.FinancialConnectionsConsumerSessionRepository
+import com.stripe.android.financialconnections.repository.FinancialConnectionsRepository
+import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.LinkMode
+import com.stripe.android.model.SharePaymentDetails
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+
+class RealCreateInstantDebitsResultTest {
+
+    @Test
+    fun `Calls correct endpoint for Link card brand`() = runTest {
+        val consumerRepository = makeConsumerSessionRepository()
+        val repository = makeRepository()
+
+        val createInstantDebitResult = RealCreateInstantDebitsResult(
+            consumerRepository = consumerRepository,
+            repository = repository,
+            consumerSessionProvider = { makeCachedConsumerSession() },
+            elementsSessionContext = ElementsSessionContext(
+                linkMode = LinkMode.LinkCardBrand,
+            ),
+        )
+
+        createInstantDebitResult("bank_account_id_001")
+
+        verify(consumerRepository).sharePaymentDetails(
+            paymentDetailsId = "ba_1234",
+            consumerSessionClientSecret = "clientSecret",
+            expectedPaymentMethodType = "card",
+        )
+
+        verifyNoInteractions(repository)
+    }
+
+    @Test
+    fun `Calls correct endpoint for Instant Debits`() = runTest {
+        val consumerRepository = makeConsumerSessionRepository()
+        val repository = makeRepository()
+
+        val createInstantDebitResult = RealCreateInstantDebitsResult(
+            consumerRepository = consumerRepository,
+            repository = repository,
+            consumerSessionProvider = { makeCachedConsumerSession() },
+            elementsSessionContext = ElementsSessionContext(
+                linkMode = LinkMode.LinkPaymentMethod,
+            ),
+        )
+
+        createInstantDebitResult("bank_account_id_001")
+
+        verify(repository).createPaymentMethod(
+            paymentDetailsId = "ba_1234",
+            consumerSessionClientSecret = "clientSecret",
+        )
+    }
+
+    @Test
+    fun `Calls correct endpoint if no Link mode available`() = runTest {
+        val consumerRepository = makeConsumerSessionRepository()
+        val repository = makeRepository()
+
+        val createInstantDebitResult = RealCreateInstantDebitsResult(
+            consumerRepository = consumerRepository,
+            repository = repository,
+            consumerSessionProvider = { makeCachedConsumerSession() },
+            elementsSessionContext = ElementsSessionContext(
+                linkMode = null,
+            ),
+        )
+
+        createInstantDebitResult("bank_account_id_001")
+
+        verify(repository).createPaymentMethod(
+            paymentDetailsId = "ba_1234",
+            consumerSessionClientSecret = "clientSecret",
+        )
+    }
+
+    private fun makeConsumerSessionRepository(): FinancialConnectionsConsumerSessionRepository {
+        val consumerPaymentDetails = ConsumerPaymentDetails(
+            paymentDetails = listOf(
+                ConsumerPaymentDetails.BankAccount(
+                    id = "ba_1234",
+                    bankName = "Stripe Bank",
+                    last4 = "4242",
+                )
+            )
+        )
+
+        val sharePaymentDetails = SharePaymentDetails(
+            paymentMethodId = "pm_1234",
+        )
+
+        return mock<FinancialConnectionsConsumerSessionRepository> {
+            onBlocking { createPaymentDetails(any(), any()) } doReturn consumerPaymentDetails
+            onBlocking { sharePaymentDetails(any(), any(), any()) } doReturn sharePaymentDetails
+        }
+    }
+
+    private fun makeRepository(): FinancialConnectionsRepository {
+        val paymentMethod = PaymentMethod(
+            id = "pm_1234",
+        )
+
+        return mock<FinancialConnectionsRepository> {
+            onBlocking { createPaymentMethod(any(), any()) } doReturn paymentMethod
+        }
+    }
+
+    private fun makeCachedConsumerSession(): CachedConsumerSession {
+        return CachedConsumerSession(
+            clientSecret = "clientSecret",
+            emailAddress = "test@test.com",
+            phoneNumber = "(***) *** **12",
+            isVerified = true,
+            publishableKey = "pk_123",
+        )
+    }
+}

--- a/payments-model/api/payments-model.api
+++ b/payments-model/api/payments-model.api
@@ -362,6 +362,14 @@ public final class com/stripe/android/model/ConsumerSessionSignup$Creator : andr
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/model/SharePaymentDetails$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/SharePaymentDetails;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/SharePaymentDetails;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public abstract interface class com/stripe/android/model/StripeParamsModel : android/os/Parcelable {
 	public abstract fun toParamMap ()Ljava/util/Map;
 }

--- a/payments-model/src/main/java/com/stripe/android/model/SharePaymentDetails.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/SharePaymentDetails.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.model
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.core.model.StripeModel
+import kotlinx.parcelize.Parcelize
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Parcelize
+data class SharePaymentDetails(
+    val paymentMethodId: String,
+) : StripeModel

--- a/payments-model/src/main/java/com/stripe/android/model/parsers/SharePaymentDetailsJsonParser.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/parsers/SharePaymentDetailsJsonParser.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.model.parsers
+
+import com.stripe.android.core.model.StripeJsonUtils.optString
+import com.stripe.android.core.model.parsers.ModelJsonParser
+import com.stripe.android.model.SharePaymentDetails
+import org.json.JSONObject
+
+internal object SharePaymentDetailsJsonParser : ModelJsonParser<SharePaymentDetails> {
+
+    override fun parse(json: JSONObject): SharePaymentDetails? {
+        val paymentMethodId = optString(json, "payment_method") ?: return null
+
+        return SharePaymentDetails(
+            paymentMethodId = paymentMethodId,
+        )
+    }
+}

--- a/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
+++ b/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
@@ -16,12 +16,14 @@ import com.stripe.android.model.ConsumerSessionLookup
 import com.stripe.android.model.ConsumerSessionSignup
 import com.stripe.android.model.ConsumerSignUpConsentAction
 import com.stripe.android.model.CustomEmailType
+import com.stripe.android.model.SharePaymentDetails
 import com.stripe.android.model.VerificationType
 import com.stripe.android.model.parsers.AttachConsumerToLinkAccountSessionJsonParser
 import com.stripe.android.model.parsers.ConsumerPaymentDetailsJsonParser
 import com.stripe.android.model.parsers.ConsumerSessionJsonParser
 import com.stripe.android.model.parsers.ConsumerSessionLookupJsonParser
 import com.stripe.android.model.parsers.ConsumerSessionSignupJsonParser
+import com.stripe.android.model.parsers.SharePaymentDetailsJsonParser
 import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
@@ -75,6 +77,14 @@ interface ConsumersApiService {
         requestSurface: String,
         requestOptions: ApiRequest.Options,
     ): Result<ConsumerPaymentDetails>
+
+    suspend fun sharePaymentDetails(
+        consumerSessionClientSecret: String,
+        paymentDetailsId: String,
+        expectedPaymentMethodType: String,
+        requestSurface: String,
+        requestOptions: ApiRequest.Options,
+    ): Result<SharePaymentDetails>
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
@@ -262,6 +272,32 @@ class ConsumersApiServiceImpl(
         )
     }
 
+    override suspend fun sharePaymentDetails(
+        consumerSessionClientSecret: String,
+        paymentDetailsId: String,
+        expectedPaymentMethodType: String,
+        requestSurface: String,
+        requestOptions: ApiRequest.Options
+    ): Result<SharePaymentDetails> {
+        return executeRequestWithResultParser(
+            stripeErrorJsonParser = stripeErrorJsonParser,
+            stripeNetworkClient = stripeNetworkClient,
+            request = apiRequestFactory.createPost(
+                url = sharePaymentDetails,
+                options = requestOptions,
+                params = mapOf(
+                    "request_surface" to requestSurface,
+                    "id" to paymentDetailsId,
+                    "expected_payment_method_type" to expectedPaymentMethodType,
+                    "credentials" to mapOf(
+                        "consumer_session_client_secret" to consumerSessionClientSecret
+                    ),
+                )
+            ),
+            responseJsonParser = SharePaymentDetailsJsonParser,
+        )
+    }
+
     internal companion object {
 
         /**
@@ -298,6 +334,11 @@ class ConsumersApiServiceImpl(
          * @return `https://api.stripe.com/v1/consumers/payment_details`
          */
         private val createPaymentDetails: String = getApiUrl("consumers/payment_details")
+
+        /**
+         * @return `https://api.stripe.com/v1/consumers/payment_details/share`
+         */
+        private val sharePaymentDetails: String = getApiUrl("consumers/payment_details/share")
 
         private fun getApiUrl(path: String): String {
             return "${ApiRequest.API_HOST}/v1/$path"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds a call to `/share` in the Instant Debits flow when using the Link card brand.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[BANKCON-14532](https://jira.corp.stripe.com/browse/BANKCON-14532)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
