### PR TITLE
Native Link Skeleton

### DIFF
--- a/link/src/main/java/com/stripe/android/link/LinkScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkScreen.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.link
+
+internal sealed interface LinkScreen {
+    data object Verification : LinkScreen
+    data object Wallet : LinkScreen
+    data object PaymentMethod : LinkScreen
+    data object CardEdit : LinkScreen
+    data object SignUp : LinkScreen
+}

--- a/link/src/main/java/com/stripe/android/link/ui/cardedit/CardEditScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/cardedit/CardEditScreen.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.link.ui.cardedit
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+internal fun CardEditScreen() {
+    Text(text = "CardEditScreen")
+}

--- a/link/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodScreen.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.link.ui.paymentmenthod
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+internal fun PaymentMethodScreen() {
+    Text(text = "PaymentMethodScreen")
+}

--- a/link/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.link.ui.signup
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+internal fun SignUpScreen() {
+    Text(text = "SignUpScreen")
+}

--- a/link/src/main/java/com/stripe/android/link/ui/verification/VerificationScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/verification/VerificationScreen.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.link.ui.verification
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+internal fun VerificationScreen() {
+    Text(text = "VerificationScreen")
+}

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.link.ui.wallet
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+internal fun WalletScreen() {
+    Text(text = "WalletScreen")
+}


### PR DESCRIPTION
# Summary
Skeleton for Native link screens. This will re-introduce all the link screens.

Delete Link Screens can be found [here](https://github.com/stripe/stripe-android/blob/811d48d4ba28f59ee2be49bc122d1df5d19de6e0/link/src/main/java/com/stripe/android/link/LinkScreen.kt). Missing parameters will be added as needed. I left them out because some of the screens will follow [this pattern](https://trailhead.corp.stripe.com/docs/mobile-sdk/payment-android-sdk-ui-expectations#architecture), and more modern practices liked [type-safe navigation](https://developer.android.com/guide/navigation/design/type-safety) etc.

### Next Step:
* Introduce LinkActivity & navigator ([JIRA](https://jira.corp.stripe.com/browse/MOBILESDK-2499))

# Motivation

[JIRA](https://jira.corp.stripe.com/browse/MOBILESDK-2498)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
