### PR TITLE
Preserve PM selection after navigating to form and back in vertical mode

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/VerticalModePage.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/VerticalModePage.kt
@@ -43,6 +43,14 @@ internal class VerticalModePage(
             .performClick()
     }
 
+    fun assertLpmIsSelected(paymentMethodCode: PaymentMethodCode) {
+        composeTestRule.onNode(
+            hasTestTag("${TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON}_$paymentMethodCode").and(
+                hasAnyDescendant(isSelected())
+            )
+        ).assertExists()
+    }
+
     fun assertPrimaryButton(matcher: SemanticsMatcher) {
         composeTestRule
             .onNode(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG).and(matcher))

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/VerticalModePaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/VerticalModePaymentSheetActivityTest.kt
@@ -293,6 +293,37 @@ internal class VerticalModePaymentSheetActivityTest {
     }
 
     @Test
+    fun `Selection is preserved after opening form`() = runTest(
+        customer = PaymentSheet.CustomerConfiguration(id = "cus_1", ephemeralKeySecret = "ek_test"),
+        networkSetup = {
+            setupElementsSessionsResponse()
+            setupV1PaymentMethodsResponse(card1, card2)
+        },
+    ) {
+        verticalModePage.assertHasSavedPaymentMethods()
+        verticalModePage.assertHasSelectedSavedPaymentMethod("pm_12345")
+        verticalModePage.assertPrimaryButton(isEnabled())
+
+        verticalModePage.clickOnNewLpm("card")
+        formPage.waitUntilVisible()
+        Espresso.pressBack()
+
+        verticalModePage.waitUntilVisible()
+        verticalModePage.assertHasSelectedSavedPaymentMethod("pm_12345")
+        verticalModePage.assertPrimaryButton(isEnabled())
+
+        verticalModePage.clickOnNewLpm("cashapp")
+        verticalModePage.assertLpmIsSelected("cashapp")
+
+        verticalModePage.clickOnNewLpm("card")
+        formPage.waitUntilVisible()
+        Espresso.pressBack()
+
+        verticalModePage.waitUntilVisible()
+        verticalModePage.assertLpmIsSelected("cashapp")
+    }
+
+    @Test
     fun `Primary button label is correctly applied`() = runTest(
         primaryButtonLabel = "Gimme money!",
         customer = PaymentSheet.CustomerConfiguration(id = "cus_1", ephemeralKeySecret = "ek_test"),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Preserve PM selection after navigating to form and back in vertical mode

This is mostly a revert of https://github.com/stripe/stripe-android/pull/9069 which is a revert of https://github.com/stripe/stripe-android/pull/8699

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2519

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screen recording
[selection behavior.webm](https://github.com/user-attachments/assets/e653dad4-ebc0-4686-b5f1-794944b72ab0)
