### PR TITLE
Add `CustomerSheetInitializationDataSource`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -218,6 +218,12 @@ interface ErrorReporter {
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     enum class SuccessEvent(override val eventName: String) : ErrorEvent {
+        CUSTOMER_SHEET_ELEMENTS_SESSION_LOAD_SUCCESS(
+            eventName = "elements.customer_sheet.elements_session.load_success"
+        ),
+        CUSTOMER_SHEET_PAYMENT_METHODS_LOAD_SUCCESS(
+            eventName = "elements.customer_sheet.payment_methods.load_success"
+        ),
         GET_SAVED_PAYMENT_METHODS_SUCCESS(
             eventName = "elements.customer_repository.get_saved_payment_methods_success"
         ),

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -395,6 +395,7 @@ class CustomerSheet internal constructor(
             callback: CustomerSheetResultCallback,
         ): CustomerSheet {
             CustomerSheetHacks.initialize(
+                application = application,
                 lifecycleOwner = lifecycleOwner,
                 adapter = customerAdapter,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -3,6 +3,8 @@ package com.stripe.android.customersheet
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.IS_LIVE_MODE
+import com.stripe.android.customersheet.data.CustomerSheetInitializationDataSource
+import com.stripe.android.customersheet.data.CustomerSheetSession
 import com.stripe.android.customersheet.util.CustomerSheetHacks
 import com.stripe.android.customersheet.util.sortPaymentMethods
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
@@ -10,17 +12,13 @@ import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAvailable
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.validate
-import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
@@ -38,10 +36,9 @@ internal interface CustomerSheetLoader {
 internal class DefaultCustomerSheetLoader(
     @Named(IS_LIVE_MODE) private val isLiveModeProvider: () -> Boolean,
     private val googlePayRepositoryFactory: @JvmSuppressWildcards (GooglePayEnvironment) -> GooglePayRepository,
-    private val elementsSessionRepository: ElementsSessionRepository,
     private val isFinancialConnectionsAvailable: IsFinancialConnectionsAvailable,
     private val lpmRepository: LpmRepository,
-    private val customerAdapterProvider: Deferred<CustomerAdapter>,
+    private val initializationDataSourceProvider: Deferred<CustomerSheetInitializationDataSource>,
     private val errorReporter: ErrorReporter,
     private val workContext: CoroutineContext
 ) : CustomerSheetLoader {
@@ -49,7 +46,6 @@ internal class DefaultCustomerSheetLoader(
     @Inject constructor(
         @Named(IS_LIVE_MODE) isLiveModeProvider: () -> Boolean,
         googlePayRepositoryFactory: @JvmSuppressWildcards (GooglePayEnvironment) -> GooglePayRepository,
-        elementsSessionRepository: ElementsSessionRepository,
         isFinancialConnectionsAvailable: IsFinancialConnectionsAvailable,
         lpmRepository: LpmRepository,
         errorReporter: ErrorReporter,
@@ -57,10 +53,9 @@ internal class DefaultCustomerSheetLoader(
     ) : this(
         isLiveModeProvider = isLiveModeProvider,
         googlePayRepositoryFactory = googlePayRepositoryFactory,
-        elementsSessionRepository = elementsSessionRepository,
         isFinancialConnectionsAvailable = isFinancialConnectionsAvailable,
         lpmRepository = lpmRepository,
-        customerAdapterProvider = CustomerSheetHacks.adapter,
+        initializationDataSourceProvider = CustomerSheetHacks.initializationDataSource,
         errorReporter = errorReporter,
         workContext = workContext,
     )
@@ -68,37 +63,26 @@ internal class DefaultCustomerSheetLoader(
     override suspend fun load(
         configuration: CustomerSheet.Configuration
     ): Result<CustomerSheetState.Full> = workContext.runCatching {
-        val customerAdapter = retrieveCustomerAdapter().getOrThrow()
-
-        val elementsSession = retrieveElementsSession(
-            customerAdapter = customerAdapter,
-        ).getOrThrow()
+        val initializationDataSource = retrieveInitializationDataSource().getOrThrow()
+        val customerSheetSession = initializationDataSource.loadCustomerSheetSession().toResult().getOrThrow()
 
         val metadata = createPaymentMethodMetadata(
             configuration = configuration,
-            elementsSession = elementsSession,
+            customerSheetSession = customerSheetSession,
         )
 
-        loadPaymentMethods(
-            customerAdapter = customerAdapter,
+        createCustomerSheetState(
+            customerSheetSession = customerSheetSession,
+            metadata = metadata,
             configuration = configuration,
-            elementsSessionWithMetadata = ElementsSessionWithMetadata(
-                elementsSession = elementsSession,
-                metadata = metadata,
-            ),
-        ).onFailure {
-            errorReporter.report(
-                errorEvent = ErrorReporter.ExpectedErrorEvent.CUSTOMER_SHEET_PAYMENT_METHODS_LOAD_FAILURE,
-                stripeException = StripeException.create(it)
-            )
-        }.getOrThrow()
+        )
     }
 
-    private suspend fun retrieveCustomerAdapter(): Result<CustomerAdapter> {
-        return customerAdapterProvider.awaitAsResult(
+    private suspend fun retrieveInitializationDataSource(): Result<CustomerSheetInitializationDataSource> {
+        return initializationDataSourceProvider.awaitAsResult(
             timeout = 5.seconds,
             error = {
-                "Couldn't find an instance of CustomerAdapter. " +
+                "Couldn't find an instance of InitializationDataSource. " +
                     "Are you instantiating CustomerSheet unconditionally in your app?"
             },
         ).onFailure {
@@ -109,33 +93,11 @@ internal class DefaultCustomerSheetLoader(
         }
     }
 
-    private suspend fun retrieveElementsSession(
-        customerAdapter: CustomerAdapter,
-    ): Result<ElementsSession> {
-        val paymentMethodTypes = createPaymentMethodTypes(customerAdapter)
-        val initializationMode = PaymentSheet.InitializationMode.DeferredIntent(
-            PaymentSheet.IntentConfiguration(
-                mode = PaymentSheet.IntentConfiguration.Mode.Setup(),
-                paymentMethodTypes = paymentMethodTypes,
-            )
-        )
-        return elementsSessionRepository.get(
-            initializationMode,
-            customer = null,
-            externalPaymentMethods = emptyList(),
-            defaultPaymentMethodId = null,
-        ).onFailure {
-            errorReporter.report(
-                errorEvent = ErrorReporter.ExpectedErrorEvent.CUSTOMER_SHEET_ELEMENTS_SESSION_LOAD_FAILURE,
-                stripeException = StripeException.create(it)
-            )
-        }
-    }
-
     private suspend fun createPaymentMethodMetadata(
         configuration: CustomerSheet.Configuration,
-        elementsSession: ElementsSession,
+        customerSheetSession: CustomerSheetSession,
     ): PaymentMethodMetadata {
+        val elementsSession = customerSheetSession.elementsSession
         val sharedDataSpecs = lpmRepository.getSharedDataSpecs(
             stripeIntent = elementsSession.stripeIntent,
             serverLpmSpecs = elementsSession.paymentMethodSpecs,
@@ -148,81 +110,53 @@ internal class DefaultCustomerSheetLoader(
         return PaymentMethodMetadata.create(
             elementsSession = elementsSession,
             configuration = configuration,
+            paymentMethodSaveConsentBehavior = customerSheetSession.paymentMethodSaveConsentBehavior,
             sharedDataSpecs = sharedDataSpecs,
             isGooglePayReady = isGooglePayReadyAndEnabled,
             isFinancialConnectionsAvailable = isFinancialConnectionsAvailable
         )
     }
 
-    private suspend fun loadPaymentMethods(
-        customerAdapter: CustomerAdapter,
+    private fun createCustomerSheetState(
+        customerSheetSession: CustomerSheetSession,
+        metadata: PaymentMethodMetadata,
         configuration: CustomerSheet.Configuration,
-        elementsSessionWithMetadata: ElementsSessionWithMetadata,
-    ) = coroutineScope {
-        val paymentMethodsResult = async {
-            customerAdapter.retrievePaymentMethods()
+    ): CustomerSheetState.Full {
+        val paymentMethods = customerSheetSession.paymentMethods
+
+        val paymentSelection = customerSheetSession.savedSelection?.let { selection ->
+            when (selection) {
+                is SavedSelection.GooglePay -> PaymentSelection.GooglePay
+                is SavedSelection.Link -> PaymentSelection.Link
+                is SavedSelection.PaymentMethod -> {
+                    paymentMethods.find { paymentMethod ->
+                        paymentMethod.id == selection.id
+                    }?.let {
+                        PaymentSelection.Saved(it)
+                    }
+                }
+                is SavedSelection.None -> null
+            }
         }
-        val selectedPaymentOption = async {
-            customerAdapter.retrieveSelectedPaymentOption()
-        }
 
-        paymentMethodsResult.await().flatMap { paymentMethods ->
-            selectedPaymentOption.await().map { paymentOption ->
-                Pair(paymentMethods, paymentOption)
-            }
-        }.map {
-            val paymentMethods = it.first
-            val paymentOption = it.second
-            val selection = paymentOption?.toPaymentSelection { id ->
-                paymentMethods.find { it.id == id }
-            }
-            Pair(paymentMethods, selection)
-        }.fold(
-            onSuccess = { result ->
-                val paymentSelection = result.second
-
-                val sortedPaymentMethods = sortPaymentMethods(
-                    paymentMethods = result.first,
-                    selection = paymentSelection as? PaymentSelection.Saved
-                )
-
-                val elementsSession = elementsSessionWithMetadata.elementsSession
-                val metadata = elementsSessionWithMetadata.metadata
-
-                val supportedPaymentMethods = metadata.sortedSupportedPaymentMethods()
-
-                val validSupportedPaymentMethods = filterSupportedPaymentMethods(supportedPaymentMethods)
-
-                Result.success(
-                    CustomerSheetState.Full(
-                        config = configuration,
-                        paymentMethodMetadata = metadata,
-                        supportedPaymentMethods = validSupportedPaymentMethods,
-                        customerPaymentMethods = sortedPaymentMethods,
-                        paymentSelection = paymentSelection,
-                        validationError = elementsSession.stripeIntent.validate(),
-                        customerPermissions = CustomerPermissions(
-                            // Should always be true for `legacy` case
-                            canRemovePaymentMethods = true,
-                        )
-                    )
-                )
-            },
-            onFailure = { cause, _ ->
-                Result.failure(cause)
-            }
+        val sortedPaymentMethods = sortPaymentMethods(
+            paymentMethods = customerSheetSession.paymentMethods,
+            selection = paymentSelection as? PaymentSelection.Saved
         )
-    }
 
-    private fun createPaymentMethodTypes(
-        customerAdapter: CustomerAdapter,
-    ): List<String> {
-        return if (customerAdapter.canCreateSetupIntents) {
-            customerAdapter.paymentMethodTypes ?: emptyList()
-        } else {
-            // We only support cards if `customerAdapter.canCreateSetupIntents` is false.
-            listOf("card")
-        }
+        val supportedPaymentMethods = metadata.sortedSupportedPaymentMethods()
+
+        val validSupportedPaymentMethods = filterSupportedPaymentMethods(supportedPaymentMethods)
+
+        return CustomerSheetState.Full(
+            config = configuration,
+            paymentMethodMetadata = metadata,
+            supportedPaymentMethods = validSupportedPaymentMethods,
+            customerPaymentMethods = sortedPaymentMethods,
+            paymentSelection = paymentSelection,
+            validationError = customerSheetSession.elementsSession.stripeIntent.validate(),
+            customerPermissions = customerSheetSession.permissions,
+        )
     }
 
     private fun filterSupportedPaymentMethods(
@@ -237,11 +171,6 @@ internal class DefaultCustomerSheetLoader(
         }
     }
 }
-
-private data class ElementsSessionWithMetadata(
-    val elementsSession: ElementsSession,
-    val metadata: PaymentMethodMetadata,
-)
 
 private suspend fun <T> Deferred<T>.awaitAsResult(
     timeout: Duration,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
@@ -1,23 +1,70 @@
 package com.stripe.android.customersheet.data
 
+import com.stripe.android.common.coroutines.runCatching
+import com.stripe.android.core.exception.StripeException
+import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
+import com.stripe.android.customersheet.CustomerPermissions
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.customersheet.map
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
+import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.SavedSelection
+import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
+import kotlinx.coroutines.async
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.CoroutineContext
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 @Singleton
 internal class CustomerAdapterDataSource @Inject constructor(
+    private val elementsSessionRepository: ElementsSessionRepository,
     private val customerAdapter: CustomerAdapter,
-) : CustomerSheetSavedSelectionDataSource,
+    private val errorReporter: ErrorReporter,
+    @IOContext private val workContext: CoroutineContext,
+) : CustomerSheetInitializationDataSource,
+    CustomerSheetSavedSelectionDataSource,
     CustomerSheetPaymentMethodDataSource,
     CustomerSheetIntentDataSource {
     override val canCreateSetupIntents: Boolean = customerAdapter.canCreateSetupIntents
+
+    override suspend fun loadCustomerSheetSession(): CustomerSheetDataResult<CustomerSheetSession> {
+        return workContext.runCatching {
+            val elementsSessionResult = async {
+                fetchElementsSession()
+            }
+
+            val paymentMethodsResult = async {
+                fetchInitialPaymentMethods()
+            }
+
+            val savedSelectionResult = async {
+                retrieveSavedSelection().toResult()
+            }
+
+            val elementsSession = elementsSessionResult.await().getOrThrow()
+            val paymentMethods = paymentMethodsResult.await().getOrThrow()
+            val savedSelection = savedSelectionResult.await().getOrThrow()
+
+            CustomerSheetSession(
+                elementsSession = elementsSession,
+                paymentMethods = paymentMethods,
+                // Always `Legacy` for adapter use case
+                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+                savedSelection = savedSelection,
+                permissions = CustomerPermissions(
+                    // Always `true` for `Adapter` use case
+                    canRemovePaymentMethods = true,
+                )
+            )
+        }.toCustomerSheetDataResult()
+    }
 
     override suspend fun retrievePaymentMethods(): CustomerSheetDataResult<List<PaymentMethod>> {
         return customerAdapter.retrievePaymentMethods().toCustomerSheetDataResult()
@@ -50,5 +97,56 @@ internal class CustomerAdapterDataSource @Inject constructor(
 
     override suspend fun retrieveSetupIntentClientSecret(): CustomerSheetDataResult<String> {
         return customerAdapter.setupIntentClientSecretForCustomerAttach().toCustomerSheetDataResult()
+    }
+
+    private suspend fun fetchElementsSession(): Result<ElementsSession> {
+        val paymentMethodTypes = createPaymentMethodTypes()
+        val initializationMode = PaymentSheet.InitializationMode.DeferredIntent(
+            PaymentSheet.IntentConfiguration(
+                mode = PaymentSheet.IntentConfiguration.Mode.Setup(),
+                paymentMethodTypes = paymentMethodTypes,
+            )
+        )
+
+        return elementsSessionRepository.get(
+            initializationMode,
+            customer = null,
+            externalPaymentMethods = emptyList(),
+            defaultPaymentMethodId = null,
+        ).onSuccess {
+            errorReporter.report(
+                errorEvent = ErrorReporter.SuccessEvent.CUSTOMER_SHEET_ELEMENTS_SESSION_LOAD_SUCCESS,
+            )
+        }.onFailure {
+            errorReporter.report(
+                errorEvent = ErrorReporter.ExpectedErrorEvent.CUSTOMER_SHEET_ELEMENTS_SESSION_LOAD_FAILURE,
+                stripeException = StripeException.create(it)
+            )
+        }
+    }
+
+    private suspend fun fetchInitialPaymentMethods(): Result<List<PaymentMethod>> {
+        return retrievePaymentMethods()
+            .onSuccess {
+                errorReporter.report(
+                    errorEvent = ErrorReporter.SuccessEvent.CUSTOMER_SHEET_PAYMENT_METHODS_LOAD_SUCCESS,
+                )
+            }
+            .onFailure { cause, _ ->
+                errorReporter.report(
+                    errorEvent = ErrorReporter.ExpectedErrorEvent.CUSTOMER_SHEET_PAYMENT_METHODS_LOAD_FAILURE,
+                    stripeException = StripeException.create(cause)
+                )
+            }
+            .toResult()
+    }
+
+    private fun createPaymentMethodTypes(): List<String> {
+        return if (customerAdapter.canCreateSetupIntents) {
+            customerAdapter.paymentMethodTypes ?: emptyList()
+        } else {
+            // We only support cards if `customerAdapter.canCreateSetupIntents` is false.
+            listOf("card")
+        }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetDataResultKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetDataResultKtx.kt
@@ -15,6 +15,17 @@ internal fun <T> CustomerAdapter.Result<T>.toCustomerSheetDataResult(): Customer
     }
 }
 
+internal fun <T> Result<T>.toCustomerSheetDataResult(): CustomerSheetDataResult<T> {
+    return fold(
+        onSuccess = {
+            CustomerSheetDataResult.success(it)
+        },
+        onFailure = {
+            CustomerSheetDataResult.failure(cause = it, displayMessage = null)
+        },
+    )
+}
+
 internal inline fun <R, T> CustomerSheetDataResult<T>.map(
     transform: (value: T) -> R
 ): CustomerSheetDataResult<R> {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetInitializationDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetInitializationDataSource.kt
@@ -1,0 +1,5 @@
+package com.stripe.android.customersheet.data
+
+internal interface CustomerSheetInitializationDataSource {
+    suspend fun loadCustomerSheetSession(): CustomerSheetDataResult<CustomerSheetSession>
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetSession.kt
@@ -1,0 +1,15 @@
+package com.stripe.android.customersheet.data
+
+import com.stripe.android.customersheet.CustomerPermissions
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
+import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.model.SavedSelection
+
+internal data class CustomerSheetSession(
+    val elementsSession: ElementsSession,
+    val paymentMethods: List<PaymentMethod>,
+    val savedSelection: SavedSelection?,
+    val paymentMethodSaveConsentBehavior: PaymentMethodSaveConsentBehavior,
+    val permissions: CustomerPermissions,
+)

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceComponent.kt
@@ -1,10 +1,16 @@
 package com.stripe.android.customersheet.data.injection
 
+import android.app.Application
+import com.stripe.android.core.injection.CoreCommonModule
+import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.customersheet.data.CustomerSheetInitializationDataSource
 import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
 import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSource
 import com.stripe.android.customersheet.data.CustomerSheetSavedSelectionDataSource
+import com.stripe.android.customersheet.injection.CustomerSheetDataCommonModule
+import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Singleton
@@ -13,16 +19,25 @@ import javax.inject.Singleton
 @Singleton
 @Component(
     modules = [
-        CustomerAdapterDataSourceModule::class
+        CustomerAdapterDataSourceModule::class,
+        CustomerSheetDataSourceCommonModule::class,
+        CustomerSheetDataCommonModule::class,
+        StripeRepositoryModule::class,
+        CoroutineContextModule::class,
+        CoreCommonModule::class,
     ]
 )
 internal interface CustomerAdapterDataSourceComponent {
     val customerSheetPaymentMethodDataSource: CustomerSheetPaymentMethodDataSource
     val customerSheetSavedSelectionDataSource: CustomerSheetSavedSelectionDataSource
     val customerSheetIntentDataSource: CustomerSheetIntentDataSource
+    val customerSheetInitializationDataSource: CustomerSheetInitializationDataSource
 
     @Component.Builder
     interface Builder {
+
+        @BindsInstance
+        fun application(application: Application): Builder
 
         @BindsInstance
         fun adapter(customerAdapter: CustomerAdapter): Builder

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceModule.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.data.injection
 
 import com.stripe.android.customersheet.data.CustomerAdapterDataSource
+import com.stripe.android.customersheet.data.CustomerSheetInitializationDataSource
 import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
 import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSource
 import com.stripe.android.customersheet.data.CustomerSheetSavedSelectionDataSource
@@ -23,4 +24,9 @@ internal interface CustomerAdapterDataSourceModule {
     fun bindsCustomerSheetSavedSelectionDataSource(
         impl: CustomerAdapterDataSource
     ): CustomerSheetSavedSelectionDataSource
+
+    @Binds
+    fun bindsCustomerSheetInitializationDataSource(
+        impl: CustomerAdapterDataSource
+    ): CustomerSheetInitializationDataSource
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSheetDataSourceCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSheetDataSourceCommonModule.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.customersheet.data.injection
+
+import android.app.Application
+import android.content.Context
+import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
+import com.stripe.android.paymentsheet.repositories.RealElementsSessionRepository
+import dagger.Binds
+import dagger.Module
+
+@Module
+internal interface CustomerSheetDataSourceCommonModule {
+    @Binds
+    fun bindsElementsSessionRepository(
+        elementsSessionRepository: RealElementsSessionRepository
+    ): ElementsSessionRepository
+
+    @Binds
+    fun bindsApplicationContext(application: Application): Context
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/util/CustomerSheetHacks.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/util/CustomerSheetHacks.kt
@@ -1,11 +1,13 @@
 package com.stripe.android.customersheet.util
 
+import android.app.Application
 import androidx.activity.ComponentActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.customersheet.data.CustomerSheetInitializationDataSource
 import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
 import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSource
 import com.stripe.android.customersheet.data.CustomerSheetSavedSelectionDataSource
@@ -23,10 +25,9 @@ import kotlinx.coroutines.flow.first
  */
 @OptIn(ExperimentalCustomerSheetApi::class)
 internal object CustomerSheetHacks {
-
-    private val _adapter = MutableStateFlow<CustomerAdapter?>(null)
-    val adapter: Deferred<CustomerAdapter>
-        get() = _adapter.asDeferred()
+    private val _initializationDataSource = MutableStateFlow<CustomerSheetInitializationDataSource?>(null)
+    val initializationDataSource: Deferred<CustomerSheetInitializationDataSource>
+        get() = _initializationDataSource.asDeferred()
 
     private val _paymentMethodDataSource = MutableStateFlow<CustomerSheetPaymentMethodDataSource?>(null)
     val paymentMethodDataSource: Deferred<CustomerSheetPaymentMethodDataSource>
@@ -41,16 +42,17 @@ internal object CustomerSheetHacks {
         get() = _intentDataSource.asDeferred()
 
     fun initialize(
+        application: Application,
         lifecycleOwner: LifecycleOwner,
         adapter: CustomerAdapter,
     ) {
-        _adapter.value = adapter
-
         val adapterDataSourceComponent = DaggerCustomerAdapterDataSourceComponent
             .builder()
+            .application(application)
             .adapter(adapter)
             .build()
 
+        _initializationDataSource.value = adapterDataSourceComponent.customerSheetInitializationDataSource
         _paymentMethodDataSource.value = adapterDataSourceComponent.customerSheetPaymentMethodDataSource
         _intentDataSource.value = adapterDataSourceComponent.customerSheetIntentDataSource
         _savedSelectionDataSource.value = adapterDataSourceComponent.customerSheetSavedSelectionDataSource
@@ -75,7 +77,7 @@ internal object CustomerSheetHacks {
     }
 
     fun clear() {
-        _adapter.value = null
+        _initializationDataSource.value = null
         _paymentMethodDataSource.value = null
         _savedSelectionDataSource.value = null
         _intentDataSource.value = null

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -292,6 +292,7 @@ internal data class PaymentMethodMetadata(
         internal fun create(
             elementsSession: ElementsSession,
             configuration: CustomerSheet.Configuration,
+            paymentMethodSaveConsentBehavior: PaymentMethodSaveConsentBehavior,
             sharedDataSpecs: List<SharedDataSpec>,
             isGooglePayReady: Boolean,
             isFinancialConnectionsAvailable: IsFinancialConnectionsAvailable,
@@ -314,7 +315,7 @@ internal data class PaymentMethodMetadata(
                 isGooglePayReady = isGooglePayReady,
                 linkInlineConfiguration = null,
                 financialConnectionsAvailable = isFinancialConnectionsAvailable(),
-                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+                paymentMethodSaveConsentBehavior = paymentMethodSaveConsentBehavior,
                 linkMode = elementsSession.linkSettings?.linkMode,
                 externalPaymentMethodSpecs = emptyList(),
             )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
@@ -5,11 +5,20 @@ import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.customersheet.FakeCustomerAdapter
 import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.SavedSelection
+import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
+import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentMethodFactory
+import com.stripe.android.testing.SetupIntentFactory
+import com.stripe.android.utils.FakeElementsSessionRepository
 import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.coroutineContext
 import kotlin.test.Test
 
 @OptIn(ExperimentalCustomerSheetApi::class)
@@ -338,12 +347,204 @@ class CustomerAdapterDataSourceTest {
         assertThat(failedResult.displayMessage).isEqualTo("Something went wrong!")
     }
 
-    private fun createCustomerAdapterDataSource(
+    @Test
+    fun `on load customer sheet session, should load properly & report success events`() = runTest {
+        val intent = SetupIntentFactory.create()
+        val elementsSessionRepository = createElementsSessionRepository(intent)
+
+        val errorReporter = FakeErrorReporter()
+        val paymentMethods = PaymentMethodFactory.cards(size = 4)
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                paymentMethods = CustomerAdapter.Result.success(paymentMethods),
+                selectedPaymentOption = CustomerAdapter.Result.success(
+                    CustomerAdapter.PaymentOption.fromId(id = "pm_1")
+                ),
+            ),
+            elementsSessionRepository = elementsSessionRepository,
+            errorReporter = errorReporter,
+        )
+
+        val result = dataSource.loadCustomerSheetSession()
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<CustomerSheetSession>>()
+
+        val customerSheetSession = result.asSuccess().value
+
+        assertThat(customerSheetSession.elementsSession.stripeIntent).isEqualTo(intent)
+        assertThat(customerSheetSession.paymentMethods).containsExactlyElementsIn(paymentMethods)
+        assertThat(customerSheetSession.savedSelection).isEqualTo(SavedSelection.PaymentMethod(id = "pm_1"))
+        assertThat(customerSheetSession.permissions.canRemovePaymentMethods).isTrue()
+        assertThat(customerSheetSession.paymentMethodSaveConsentBehavior).isEqualTo(
+            PaymentMethodSaveConsentBehavior.Legacy
+        )
+
+        assertThat(errorReporter.getLoggedErrors()).containsExactly(
+            ErrorReporter.SuccessEvent.CUSTOMER_SHEET_ELEMENTS_SESSION_LOAD_SUCCESS.eventName,
+            ErrorReporter.SuccessEvent.CUSTOMER_SHEET_PAYMENT_METHODS_LOAD_SUCCESS.eventName,
+        )
+    }
+
+    @Test
+    fun `on load with failed elements session load result, should fail to load & report properly`() = runTest {
+        val errorReporter = FakeErrorReporter()
+
+        val elementsSessionRepository = createElementsSessionRepository(
+            error = IllegalStateException("Failed to load!")
+        )
+        val dataSource = createCustomerAdapterDataSource(
+            elementsSessionRepository = elementsSessionRepository,
+            errorReporter = errorReporter,
+        )
+
+        val result = dataSource.loadCustomerSheetSession()
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<CustomerSheetSession>>()
+
+        val failureResult = result.asFailure()
+
+        assertThat(failureResult.cause).isInstanceOf<IllegalStateException>()
+        assertThat(failureResult.cause.message).isEqualTo("Failed to load!")
+        assertThat(errorReporter.getLoggedErrors()).containsExactly(
+            ErrorReporter.ExpectedErrorEvent.CUSTOMER_SHEET_ELEMENTS_SESSION_LOAD_FAILURE.eventName,
+            ErrorReporter.SuccessEvent.CUSTOMER_SHEET_PAYMENT_METHODS_LOAD_SUCCESS.eventName,
+        )
+    }
+
+    @Test
+    fun `on load with failed PMs load result, should fail to load & report properly`() = runTest {
+        val errorReporter = FakeErrorReporter()
+
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                paymentMethods = CustomerAdapter.Result.failure(
+                    cause = IllegalStateException("Failed to load!"),
+                    displayMessage = null,
+                ),
+            ),
+            errorReporter = errorReporter,
+        )
+
+        val result = dataSource.loadCustomerSheetSession()
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<CustomerSheetSession>>()
+
+        val failureResult = result.asFailure()
+
+        assertThat(failureResult.cause).isInstanceOf<IllegalStateException>()
+        assertThat(failureResult.cause.message).isEqualTo("Failed to load!")
+        assertThat(errorReporter.getLoggedErrors()).containsExactly(
+            ErrorReporter.SuccessEvent.CUSTOMER_SHEET_ELEMENTS_SESSION_LOAD_SUCCESS.eventName,
+            ErrorReporter.ExpectedErrorEvent.CUSTOMER_SHEET_PAYMENT_METHODS_LOAD_FAILURE.eventName
+        )
+    }
+
+    @Test
+    fun `on load with failed saved selection result, should fail to load`() = runTest {
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                selectedPaymentOption = CustomerAdapter.Result.failure(
+                    cause = IllegalStateException("Failed to load!"),
+                    displayMessage = null,
+                )
+            ),
+        )
+
+        val result = dataSource.loadCustomerSheetSession()
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<CustomerSheetSession>>()
+
+        val failureResult = result.asFailure()
+
+        assertThat(failureResult.cause).isInstanceOf<IllegalStateException>()
+        assertThat(failureResult.cause.message).isEqualTo("Failed to load!")
+    }
+
+    @Test
+    fun `when SI can be created, elements session repo should be called with paymentMethodTypes`() =
+        runPaymentMethodTypesTest(
+            canCreateSetupIntents = true,
+            providedPaymentMethodTypes = listOf("card", "us_bank_account", "sepa_debit"),
+            expectedPaymentMethodTypes = listOf("card", "us_bank_account", "sepa_debit"),
+        )
+
+    @Test
+    fun `when SI can be created and no paymentMethods, elements session repo should be called empty types list`() =
+        runPaymentMethodTypesTest(
+            canCreateSetupIntents = true,
+            providedPaymentMethodTypes = null,
+            expectedPaymentMethodTypes = listOf(),
+        )
+
+    @Test
+    fun `when SI cannot be created, elements session repo should be called with card PM only`() =
+        runPaymentMethodTypesTest(
+            canCreateSetupIntents = false,
+            providedPaymentMethodTypes = null,
+            expectedPaymentMethodTypes = listOf("card")
+        )
+
+    @Test
+    fun `when SI cannot be created, elements sessions is called with card only when paymentMethodTypes is set`() =
+        runPaymentMethodTypesTest(
+            canCreateSetupIntents = false,
+            providedPaymentMethodTypes = listOf("card", "us_bank_account"),
+            expectedPaymentMethodTypes = listOf("card")
+        )
+
+    private fun runPaymentMethodTypesTest(
+        canCreateSetupIntents: Boolean,
+        providedPaymentMethodTypes: List<String>?,
+        expectedPaymentMethodTypes: List<String>,
+    ) = runTest {
+        val elementsSessionRepository = createElementsSessionRepository()
+
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                canCreateSetupIntents = canCreateSetupIntents,
+                paymentMethodTypes = providedPaymentMethodTypes
+            ),
+            elementsSessionRepository = elementsSessionRepository
+        )
+
+        dataSource.loadCustomerSheetSession()
+
+        val initializationMode = elementsSessionRepository.lastParams?.initializationMode
+
+        assertThat(initializationMode).isInstanceOf<PaymentSheet.InitializationMode.DeferredIntent>()
+
+        val deferredInitializationMode = initializationMode.asDeferred()
+
+        assertThat(deferredInitializationMode.intentConfiguration.paymentMethodTypes)
+            .containsExactlyElementsIn(expectedPaymentMethodTypes)
+    }
+
+    private suspend fun createCustomerAdapterDataSource(
         adapter: CustomerAdapter = FakeCustomerAdapter(),
+        errorReporter: ErrorReporter = FakeErrorReporter(),
+        elementsSessionRepository: ElementsSessionRepository = createElementsSessionRepository(),
     ): CustomerAdapterDataSource {
         return CustomerAdapterDataSource(
             customerAdapter = adapter,
+            elementsSessionRepository = elementsSessionRepository,
+            errorReporter = errorReporter,
+            workContext = coroutineContext,
         )
+    }
+
+    private fun createElementsSessionRepository(
+        intent: StripeIntent = SetupIntentFactory.create(),
+        error: Throwable? = null,
+    ): FakeElementsSessionRepository {
+        return FakeElementsSessionRepository(
+            error = error,
+            linkSettings = null,
+            stripeIntent = intent,
+        )
+    }
+
+    private fun PaymentSheet.InitializationMode?.asDeferred(): PaymentSheet.InitializationMode.DeferredIntent {
+        return this as PaymentSheet.InitializationMode.DeferredIntent
     }
 
     private fun <T> CustomerSheetDataResult<T>.asSuccess(): CustomerSheetDataResult.Success<T> {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetHacksTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetHacksTest.kt
@@ -1,6 +1,9 @@
 package com.stripe.android.customersheet.utils
 
+import android.app.Application
 import androidx.lifecycle.testing.TestLifecycleOwner
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.customersheet.FakeCustomerAdapter
@@ -9,11 +12,15 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.After
+import org.junit.runner.RunWith
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalCustomerSheetApi::class)
+@RunWith(AndroidJUnit4::class)
 class CustomerSheetHacksTest {
+    private val application = ApplicationProvider.getApplicationContext<Application>()
+
     @After
     fun teardown() {
         CustomerSheetHacks.clear()
@@ -21,8 +28,9 @@ class CustomerSheetHacksTest {
 
     @Test
     fun `on initialize, should initialize all data sources as expected`() = runTest {
-        CustomerSheetHacks.initialize(TestLifecycleOwner(), FakeCustomerAdapter())
+        CustomerSheetHacks.initialize(application, TestLifecycleOwner(), FakeCustomerAdapter())
 
+        assertThat(CustomerSheetHacks.initializationDataSource.awaitWithTimeout()).isNotNull()
         assertThat(CustomerSheetHacks.intentDataSource.awaitWithTimeout()).isNotNull()
         assertThat(CustomerSheetHacks.paymentMethodDataSource.awaitWithTimeout()).isNotNull()
         assertThat(CustomerSheetHacks.savedSelectionDataSource.awaitWithTimeout()).isNotNull()
@@ -30,9 +38,10 @@ class CustomerSheetHacksTest {
 
     @Test
     fun `on clear, should clear all data sources as expected`() = runTest {
-        CustomerSheetHacks.initialize(TestLifecycleOwner(), FakeCustomerAdapter())
+        CustomerSheetHacks.initialize(application, TestLifecycleOwner(), FakeCustomerAdapter())
         CustomerSheetHacks.clear()
 
+        assertThat(CustomerSheetHacks.initializationDataSource.awaitWithTimeout()).isNull()
         assertThat(CustomerSheetHacks.intentDataSource.awaitWithTimeout()).isNull()
         assertThat(CustomerSheetHacks.paymentMethodDataSource.awaitWithTimeout()).isNull()
         assertThat(CustomerSheetHacks.savedSelectionDataSource.awaitWithTimeout()).isNull()

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -826,11 +826,12 @@ internal class PaymentMethodMetadataTest {
                 ),
             ),
             configuration = configuration,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Disabled(
+                overrideAllowRedisplay = PaymentMethod.AllowRedisplay.ALWAYS,
+            ),
             sharedDataSpecs = listOf(SharedDataSpec("card")),
             isGooglePayReady = true,
-            isFinancialConnectionsAvailable = {
-                false
-            }
+            isFinancialConnectionsAvailable = { false }
         )
 
         assertThat(metadata).isEqualTo(
@@ -850,7 +851,9 @@ internal class PaymentMethodMetadataTest {
                 externalPaymentMethodSpecs = listOf(),
                 hasCustomerConfiguration = true,
                 isGooglePayReady = true,
-                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Disabled(
+                    overrideAllowRedisplay = PaymentMethod.AllowRedisplay.ALWAYS,
+                ),
                 financialConnectionsAvailable = false,
                 linkInlineConfiguration = null,
                 linkMode = null,


### PR DESCRIPTION
# Summary
Add `CustomerSheetInitializationDataSource`

# Motivation
Moves initialization into a separate data source. Helps with creating custom `CustomerSession` data sources.

This is a re-merge of https://github.com/stripe/stripe-android/pull/9307 with fixes for flaky tests

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
