### PR TITLE
Add `PaymentConfirmationMediator` & `PaymentConfirmationRegistry`

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -401,6 +401,14 @@ public final class com/stripe/android/paymentsheet/IntentConfirmationHandler$Arg
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentsheet/PaymentConfirmationMediator$Parameters$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationMediator$Parameters;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentConfirmationMediator$Parameters;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/paymentsheet/PaymentConfirmationOption$BacsPaymentMethod$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentConfirmationOption$BacsPaymentMethod;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationDefinition.kt
@@ -22,6 +22,12 @@ internal class IntentConfirmationDefinition(
     IntentConfirmationDefinition.Args,
     InternalPaymentResult
     > {
+    override val key: String = "IntentConfirmation"
+
+    override fun option(confirmationOption: PaymentConfirmationOption): PaymentConfirmationOption.PaymentMethod? {
+        return confirmationOption as? PaymentConfirmationOption.PaymentMethod
+    }
+
     override suspend fun action(
         confirmationOption: PaymentConfirmationOption.PaymentMethod,
         intent: StripeIntent
@@ -47,7 +53,7 @@ internal class IntentConfirmationDefinition(
                 PaymentConfirmationDefinition.ConfirmationAction.Fail(
                     cause = nextStep.cause,
                     message = nextStep.message,
-                    errorType = PaymentConfirmationErrorType.Internal,
+                    errorType = PaymentConfirmationErrorType.Payment,
                 )
             }
             is IntentConfirmationInterceptor.NextStep.Complete -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationDefinition.kt
@@ -11,6 +11,12 @@ internal interface PaymentConfirmationDefinition<
     TLauncherArgs,
     TLauncherResult : Parcelable
     > {
+    val key: String
+
+    fun option(
+        confirmationOption: PaymentConfirmationOption,
+    ): TConfirmationOption?
+
     suspend fun action(
         confirmationOption: TConfirmationOption,
         intent: StripeIntent,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationMediator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationMediator.kt
@@ -1,0 +1,159 @@
+package com.stripe.android.paymentsheet
+
+import android.os.Parcelable
+import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.StripeIntent
+import kotlinx.parcelize.Parcelize
+
+internal class PaymentConfirmationMediator<
+    TConfirmationOption : PaymentConfirmationOption,
+    TLauncher,
+    TLauncherArgs,
+    TLauncherResult : Parcelable
+    >(
+    private val savedStateHandle: SavedStateHandle,
+    private val definition:
+    PaymentConfirmationDefinition<TConfirmationOption, TLauncher, TLauncherArgs, TLauncherResult>,
+) {
+    private var launcher: TLauncher? = null
+
+    private val parametersKey = definition.key + PARAMETERS_POSTFIX_KEY
+    private var persistedParameters: Parameters<TConfirmationOption>?
+        get() = savedStateHandle[parametersKey]
+        set(value) {
+            savedStateHandle[parametersKey] = value
+        }
+
+    fun canConfirm(confirmationOption: PaymentConfirmationOption): Boolean {
+        return definition.option(confirmationOption) != null
+    }
+
+    fun register(
+        activityResultCaller: ActivityResultCaller,
+        onResult: (PaymentConfirmationResult) -> Unit,
+    ) {
+        launcher = definition.createLauncher(
+            activityResultCaller
+        ) { result ->
+            val confirmationResult = persistedParameters?.let { params ->
+                definition.toPaymentConfirmationResult(
+                    confirmationOption = params.confirmationOption,
+                    intent = params.intent,
+                    result = result,
+                    deferredIntentConfirmationType = params.deferredIntentConfirmationType
+                )
+            } ?: run {
+                val exception = IllegalStateException(
+                    "Arguments should have been initialized before handling result!"
+                )
+
+                PaymentConfirmationResult.Failed(
+                    cause = exception,
+                    message = exception.stripeErrorMessage(),
+                    type = PaymentConfirmationErrorType.Internal,
+                )
+            }
+
+            onResult(confirmationResult)
+        }
+    }
+
+    fun unregister() {
+        launcher = null
+    }
+
+    suspend fun action(
+        option: PaymentConfirmationOption,
+        intent: StripeIntent
+    ): Action {
+        val confirmationOption = definition.option(option)
+            ?: return Action.Fail(
+                cause = IllegalArgumentException(
+                    "Parameter type of '${option::class.simpleName}' cannot be used with " +
+                        "${this::class.simpleName} to read a result"
+                ),
+                message = R.string.stripe_something_went_wrong.resolvableString,
+                errorType = PaymentConfirmationErrorType.Internal,
+            )
+
+        return when (val action = definition.action(confirmationOption, intent)) {
+            is PaymentConfirmationDefinition.ConfirmationAction.Launch -> {
+                launcher?.let {
+                    Action.Launch(
+                        launch = {
+                            persistedParameters = Parameters(
+                                confirmationOption = confirmationOption,
+                                intent = intent,
+                                deferredIntentConfirmationType = action.deferredIntentConfirmationType,
+                            )
+
+                            definition.launch(
+                                launcher = it,
+                                arguments = action.launcherArguments,
+                                confirmationOption = confirmationOption,
+                                intent = intent,
+                            )
+                        },
+                    )
+                } ?: run {
+                    val exception = IllegalStateException(
+                        "No launcher for ${definition::class.simpleName} was found, did you call register?"
+                    )
+
+                    Action.Fail(
+                        cause = exception,
+                        message = exception.stripeErrorMessage(),
+                        errorType = PaymentConfirmationErrorType.Fatal,
+                    )
+                }
+            }
+            is PaymentConfirmationDefinition.ConfirmationAction.Complete -> {
+                Action.Complete(
+                    intent = action.intent,
+                    confirmationOption = action.confirmationOption,
+                    deferredIntentConfirmationType = action.deferredIntentConfirmationType,
+                )
+            }
+            is PaymentConfirmationDefinition.ConfirmationAction.Fail -> {
+                Action.Fail(
+                    cause = action.cause,
+                    message = action.message,
+                    errorType = action.errorType,
+                )
+            }
+        }
+    }
+
+    sealed interface Action {
+        class Launch(
+            val launch: () -> Unit,
+        ) : Action
+
+        data class Fail(
+            val cause: Throwable,
+            val message: ResolvableString,
+            val errorType: PaymentConfirmationErrorType,
+        ) : Action
+
+        data class Complete(
+            val intent: StripeIntent,
+            val confirmationOption: PaymentConfirmationOption,
+            val deferredIntentConfirmationType: DeferredIntentConfirmationType? = null,
+        ) : Action
+    }
+
+    @Parcelize
+    internal data class Parameters<TConfirmationOption : PaymentConfirmationOption>(
+        val confirmationOption: TConfirmationOption,
+        val intent: StripeIntent,
+        val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+    ) : Parcelable
+
+    private companion object {
+        private const val PARAMETERS_POSTFIX_KEY = "Parameters"
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationRegistry.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentConfirmationRegistry.kt
@@ -1,0 +1,15 @@
+package com.stripe.android.paymentsheet
+
+import androidx.lifecycle.SavedStateHandle
+
+internal class PaymentConfirmationRegistry(
+    private val confirmationDefinitions: List<PaymentConfirmationDefinition<*, *, *, *>>,
+) {
+    fun createConfirmationMediators(
+        savedStateHandle: SavedStateHandle
+    ): List<PaymentConfirmationMediator<*, *, *, *>> {
+        return confirmationDefinitions.map { definition ->
+            PaymentConfirmationMediator(savedStateHandle, definition)
+        }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationDefinitionTest.kt
@@ -156,7 +156,7 @@ class IntentConfirmationDefinitionTest {
 
         assertThat(failAction.cause).isEqualTo(cause)
         assertThat(failAction.message).isEqualTo(message.resolvableString)
-        assertThat(failAction.errorType).isEqualTo(PaymentConfirmationErrorType.Internal)
+        assertThat(failAction.errorType).isEqualTo(PaymentConfirmationErrorType.Payment)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationFlowTest.kt
@@ -173,7 +173,7 @@ internal class IntentConfirmationFlowTest {
         assertThat(failAction.cause).isInstanceOf(IllegalStateException::class.java)
         assertThat(failAction.cause.message).isEqualTo("An error occurred!")
         assertThat(failAction.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
-        assertThat(failAction.errorType).isEqualTo(PaymentConfirmationErrorType.Internal)
+        assertThat(failAction.errorType).isEqualTo(PaymentConfirmationErrorType.Payment)
     }
 
     @Test
@@ -200,7 +200,7 @@ internal class IntentConfirmationFlowTest {
         assertThat(failAction.cause).isInstanceOf(IllegalStateException::class.java)
         assertThat(failAction.cause.message).isEqualTo("An error occurred!")
         assertThat(failAction.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
-        assertThat(failAction.errorType).isEqualTo(PaymentConfirmationErrorType.Internal)
+        assertThat(failAction.errorType).isEqualTo(PaymentConfirmationErrorType.Payment)
     }
 
     private fun createDeferredConfirmationOption(): PaymentConfirmationOption.PaymentMethod.New {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/IntentConfirmationHandlerTest.kt
@@ -352,10 +352,9 @@ class IntentConfirmationHandlerTest {
 
             val failedResult = result.asFailed()
 
-            val message = "No 'PaymentLauncher' instance was created before starting confirmation. " +
-                "Did you call register?"
+            val message = "No launcher for IntentConfirmationDefinition was found, did you call register?"
 
-            assertThat(failedResult.cause).isInstanceOf(IllegalArgumentException::class.java)
+            assertThat(failedResult.cause).isInstanceOf(IllegalStateException::class.java)
             assertThat(failedResult.cause.message).isEqualTo(message)
             assertThat(failedResult.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
             assertThat(failedResult.type).isEqualTo(PaymentConfirmationErrorType.Fatal)
@@ -751,7 +750,7 @@ class IntentConfirmationHandlerTest {
 
         val savedStateHandle = SavedStateHandle().apply {
             set("AwaitingPreConfirmResult", true)
-            set("IntentConfirmationArguments", bacsArguments)
+            set("PaymentConfirmationArguments", bacsArguments)
         }
 
         val intentConfirmationHandler = createIntentConfirmationHandler(
@@ -822,7 +821,14 @@ class IntentConfirmationHandlerTest {
     fun `On init with 'SavedStateHandle', should receive result through 'awaitIntentResult'`() = runTest {
         val savedStateHandle = SavedStateHandle().apply {
             set("AwaitingPaymentResult", true)
-            set("IntentConfirmationArguments", DEFAULT_ARGUMENTS)
+            set(
+                "IntentConfirmationParameters",
+                PaymentConfirmationMediator.Parameters(
+                    confirmationOption = DEFAULT_ARGUMENTS.confirmationOption,
+                    intent = DEFAULT_ARGUMENTS.intent,
+                    deferredIntentConfirmationType = null,
+                )
+            )
         }
 
         val intentConfirmationHandler = createIntentConfirmationHandler(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentConfirmationMediatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentConfirmationMediatorTest.kt
@@ -1,0 +1,429 @@
+package com.stripe.android.paymentsheet
+
+import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.isInstanceOf
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.utils.FakePaymentConfirmationDefinition
+import com.stripe.android.testing.PaymentMethodFactory
+import com.stripe.android.testing.SetupIntentFactory
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.mock
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class PaymentConfirmationMediatorTest {
+    @Test
+    fun `On can confirm, should return true if definition is the same type`() = runTest {
+        val mediator = PaymentConfirmationMediator(
+            savedStateHandle = SavedStateHandle(),
+            definition = FakePaymentConfirmationDefinition()
+        )
+
+        val canConfirm = mediator.canConfirm(
+            confirmationOption = PaymentConfirmationOption.PaymentMethod.Saved(
+                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                    clientSecret = "pi_123_secret_123",
+                ),
+                optionsParams = null,
+                shippingDetails = null,
+                paymentMethod = PaymentMethodFactory.card(),
+            ),
+        )
+
+        assertThat(canConfirm).isTrue()
+    }
+
+    @Test
+    fun `On can confirm, should return false if definition is not the same type`() = runTest {
+        val mediator = PaymentConfirmationMediator(
+            savedStateHandle = SavedStateHandle(),
+            definition = FakePaymentConfirmationDefinition()
+        )
+
+        val canConfirm = mediator.canConfirm(
+            confirmationOption = PaymentConfirmationOption.ExternalPaymentMethod(
+                type = "paypal",
+                billingDetails = null,
+            ),
+        )
+
+        assertThat(canConfirm).isFalse()
+    }
+
+    @Test
+    fun `On register, should create launcher`() = runTest {
+        val definition = FakePaymentConfirmationDefinition()
+        val mediator = PaymentConfirmationMediator(
+            savedStateHandle = SavedStateHandle(),
+            definition = definition,
+        )
+
+        val activityResultCaller = mock<ActivityResultCaller>()
+
+        mediator.register(
+            activityResultCaller = activityResultCaller,
+            onResult = {},
+        )
+
+        val createLauncherCall = definition.createLauncherCalls.awaitItem()
+
+        assertThat(createLauncherCall.activityResultCaller).isEqualTo(activityResultCaller)
+    }
+
+    @Test
+    fun `On incorrect confirmation option provided on action, should return fail action`() = runTest {
+        val mediator = PaymentConfirmationMediator(
+            savedStateHandle = SavedStateHandle(),
+            definition = FakePaymentConfirmationDefinition()
+        )
+
+        val action = mediator.action(
+            option = PaymentConfirmationOption.ExternalPaymentMethod(
+                type = "paypal",
+                billingDetails = null,
+            ),
+            intent = PaymentIntentFixtures.PI_SUCCEEDED,
+        )
+
+        val failAction = action.asFail()
+
+        assertThat(failAction.cause).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(failAction.cause.message).isEqualTo(
+            "Parameter type of 'ExternalPaymentMethod' cannot be used with " +
+                "PaymentConfirmationMediator to read a result"
+        )
+        assertThat(failAction.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
+        assertThat(failAction.errorType).isEqualTo(PaymentConfirmationErrorType.Internal)
+    }
+
+    @Test
+    fun `On complete confirmation action, should return mediator complete action`() = runTest {
+        val definition = FakePaymentConfirmationDefinition(
+            onAction = { confirmationOption, intent ->
+                PaymentConfirmationDefinition.ConfirmationAction.Complete(
+                    confirmationOption = confirmationOption,
+                    intent = intent,
+                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+                )
+            }
+        )
+
+        val mediator = PaymentConfirmationMediator(
+            savedStateHandle = SavedStateHandle(),
+            definition = definition
+        )
+
+        val action = mediator.action(
+            option = SAVED_CONFIRMATION_OPTION,
+            intent = INTENT,
+        )
+
+        val completeAction = action.asComplete()
+
+        assertThat(completeAction.confirmationOption).isEqualTo(SAVED_CONFIRMATION_OPTION)
+        assertThat(completeAction.intent).isEqualTo(INTENT)
+        assertThat(completeAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
+    }
+
+    @Test
+    fun `On failed confirmation action, should return mediator fail action`() = runTest {
+        val exception = IllegalStateException("Failed!")
+        val message = R.string.stripe_something_went_wrong.resolvableString
+        val errorType = PaymentConfirmationErrorType.Fatal
+
+        val definition = FakePaymentConfirmationDefinition(
+            onAction = { _, _ ->
+                PaymentConfirmationDefinition.ConfirmationAction.Fail(
+                    cause = exception,
+                    message = R.string.stripe_something_went_wrong.resolvableString,
+                    errorType = errorType,
+                )
+            }
+        )
+
+        val mediator = PaymentConfirmationMediator(
+            savedStateHandle = SavedStateHandle(),
+            definition = definition
+        )
+
+        val action = mediator.action(
+            option = SAVED_CONFIRMATION_OPTION,
+            intent = INTENT,
+        )
+
+        val failAction = action.asFail()
+
+        assertThat(failAction.cause).isInstanceOf(IllegalStateException::class.java)
+        assertThat(failAction.cause.message).isEqualTo("Failed!")
+        assertThat(failAction.message).isEqualTo(message)
+        assertThat(failAction.errorType).isEqualTo(errorType)
+    }
+
+    @Test
+    fun `On launch action, should call definition launch and persist parameters`() = runTest {
+        val launcherArguments = FakePaymentConfirmationDefinition.LauncherArgs(amount = 5000)
+        val launcher = FakePaymentConfirmationDefinition.Launcher()
+
+        val definition = FakePaymentConfirmationDefinition(
+            onAction = { _, _ ->
+                PaymentConfirmationDefinition.ConfirmationAction.Launch(
+                    launcherArguments = launcherArguments,
+                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+                )
+            },
+            launcher = launcher,
+        )
+
+        val savedStateHandle = SavedStateHandle()
+
+        val mediator = PaymentConfirmationMediator(
+            savedStateHandle = savedStateHandle,
+            definition = definition
+        ).apply {
+            register(
+                activityResultCaller = mock(),
+                onResult = {}
+            )
+        }
+
+        val action = mediator.action(
+            option = SAVED_CONFIRMATION_OPTION,
+            intent = INTENT,
+        )
+
+        val launchAction = action.asLaunch()
+
+        launchAction.launch()
+
+        val launchCall = definition.launchCalls.awaitItem()
+
+        assertThat(launchCall.confirmationOption).isEqualTo(SAVED_CONFIRMATION_OPTION)
+        assertThat(launchCall.arguments).isEqualTo(launcherArguments)
+        assertThat(launchCall.intent).isEqualTo(INTENT)
+        assertThat(launchCall.launcher).isEqualTo(launcher)
+
+        val parameters = savedStateHandle
+            .get<PaymentConfirmationMediator.Parameters<PaymentConfirmationOption.PaymentMethod.Saved>>(
+                "TestParameters"
+            )
+
+        assertThat(parameters?.confirmationOption).isEqualTo(SAVED_CONFIRMATION_OPTION)
+        assertThat(parameters?.intent).isEqualTo(INTENT)
+        assertThat(parameters?.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
+    }
+
+    @Test
+    fun `On confirmation action without registering, should return fail action`() = runTest {
+        val definition = FakePaymentConfirmationDefinition(
+            onAction = { _, _ ->
+                PaymentConfirmationDefinition.ConfirmationAction.Launch(
+                    launcherArguments = FakePaymentConfirmationDefinition.LauncherArgs(amount = 5000),
+                    deferredIntentConfirmationType = null,
+                )
+            },
+        )
+
+        val mediator = PaymentConfirmationMediator(
+            savedStateHandle = SavedStateHandle(),
+            definition = definition
+        )
+
+        val action = mediator.action(
+            option = SAVED_CONFIRMATION_OPTION,
+            intent = INTENT,
+        )
+
+        val failAction = action.asFail()
+
+        assertThat(failAction.cause).isInstanceOf(IllegalStateException::class.java)
+        assertThat(failAction.cause.message).isEqualTo(
+            "No launcher for FakePaymentConfirmationDefinition was found, did you call register?"
+        )
+        assertThat(failAction.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
+        assertThat(failAction.errorType).isEqualTo(PaymentConfirmationErrorType.Fatal)
+    }
+
+    @Test
+    fun `On confirmation action after un-registering, should return fail action`() = runTest {
+        val definition = FakePaymentConfirmationDefinition(
+            onAction = { _, _ ->
+                PaymentConfirmationDefinition.ConfirmationAction.Launch(
+                    launcherArguments = FakePaymentConfirmationDefinition.LauncherArgs(amount = 5000),
+                    deferredIntentConfirmationType = null,
+                )
+            },
+        )
+
+        val mediator = PaymentConfirmationMediator(
+            savedStateHandle = SavedStateHandle(),
+            definition = definition
+        )
+
+        mediator.register(
+            activityResultCaller = mock(),
+            onResult = {}
+        )
+        mediator.unregister()
+
+        val action = mediator.action(
+            option = SAVED_CONFIRMATION_OPTION,
+            intent = INTENT,
+        )
+
+        val failAction = action.asFail()
+
+        assertThat(failAction.cause).isInstanceOf(IllegalStateException::class.java)
+        assertThat(failAction.cause.message).isEqualTo(
+            "No launcher for FakePaymentConfirmationDefinition was found, did you call register?"
+        )
+        assertThat(failAction.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
+        assertThat(failAction.errorType).isEqualTo(PaymentConfirmationErrorType.Fatal)
+    }
+
+    @Test
+    fun `On result, should attempt to convert launcher result to confirmation result and return it`() = runTest {
+        val waitForResultLatch = CountDownLatch(1)
+
+        val intent = SetupIntentFactory.create(
+            paymentMethod = PaymentMethodFactory.card(random = true)
+        )
+        val deferredIntentConfirmationType = DeferredIntentConfirmationType.Client
+        val launcherResult = FakePaymentConfirmationDefinition.LauncherResult(amount = 50)
+        val confirmationResult = PaymentConfirmationResult.Succeeded(
+            intent = intent,
+            deferredIntentConfirmationType = deferredIntentConfirmationType,
+        )
+
+        val definition = FakePaymentConfirmationDefinition(
+            confirmationResult = confirmationResult,
+            onAction = { _, _ ->
+                PaymentConfirmationDefinition.ConfirmationAction.Launch(
+                    launcherArguments = FakePaymentConfirmationDefinition.LauncherArgs(amount = 5000),
+                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+                )
+            },
+        )
+
+        val mediator = PaymentConfirmationMediator(
+            savedStateHandle = SavedStateHandle(),
+            definition = definition,
+        )
+
+        val confirmationOption = PaymentConfirmationOption.PaymentMethod.Saved(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123_secret_123",
+            ),
+            optionsParams = null,
+            shippingDetails = null,
+            paymentMethod = PaymentMethodFactory.card(),
+        )
+
+        var receivedResult: PaymentConfirmationResult? = null
+
+        mediator.register(
+            activityResultCaller = mock(),
+            onResult = { result ->
+                receivedResult = result
+
+                waitForResultLatch.countDown()
+            },
+        )
+
+        val createLauncherCall = definition.createLauncherCalls.awaitItem()
+
+        val action = mediator.action(
+            intent = intent,
+            option = confirmationOption,
+        )
+
+        assertThat(action).isInstanceOf<PaymentConfirmationMediator.Action.Launch>()
+
+        val launchAction = action.asLaunch()
+
+        launchAction.launch()
+
+        createLauncherCall.onResult(launcherResult)
+
+        waitForResultLatch.await(2, TimeUnit.SECONDS)
+
+        val toPaymentConfirmationResultCall = definition.toPaymentConfirmationResultCalls.awaitItem()
+
+        assertThat(toPaymentConfirmationResultCall.confirmationOption).isEqualTo(confirmationOption)
+        assertThat(toPaymentConfirmationResultCall.intent).isEqualTo(intent)
+        assertThat(toPaymentConfirmationResultCall.result).isEqualTo(launcherResult)
+        assertThat(toPaymentConfirmationResultCall.deferredIntentConfirmationType)
+            .isEqualTo(deferredIntentConfirmationType)
+
+        assertThat(receivedResult).isEqualTo(confirmationResult)
+    }
+
+    @Test
+    fun `On result with no persisted parameters, should return failed result`() = runTest {
+        val countDownLatch = CountDownLatch(1)
+        val definition = FakePaymentConfirmationDefinition()
+        val mediator = PaymentConfirmationMediator(
+            savedStateHandle = SavedStateHandle(),
+            definition = definition,
+        )
+
+        val activityResultCaller = mock<ActivityResultCaller>()
+
+        mediator.register(
+            activityResultCaller = activityResultCaller,
+            onResult = { result ->
+                assertThat(result).isInstanceOf<PaymentConfirmationResult.Failed>()
+
+                val failAction = result.asFailed()
+
+                assertThat(failAction.cause).isInstanceOf(IllegalStateException::class.java)
+                assertThat(failAction.cause.message).isEqualTo(
+                    "Arguments should have been initialized before handling result!"
+                )
+                assertThat(failAction.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
+                assertThat(failAction.type).isEqualTo(PaymentConfirmationErrorType.Internal)
+
+                countDownLatch.countDown()
+            },
+        )
+
+        val createLauncherCall = definition.createLauncherCalls.awaitItem()
+
+        createLauncherCall.onResult(
+            FakePaymentConfirmationDefinition.LauncherResult(amount = 50)
+        )
+
+        countDownLatch.await(2, TimeUnit.SECONDS)
+    }
+
+    private fun PaymentConfirmationResult.asFailed(): PaymentConfirmationResult.Failed {
+        return this as PaymentConfirmationResult.Failed
+    }
+
+    private fun PaymentConfirmationMediator.Action.asFail(): PaymentConfirmationMediator.Action.Fail {
+        return this as PaymentConfirmationMediator.Action.Fail
+    }
+
+    private fun PaymentConfirmationMediator.Action.asComplete(): PaymentConfirmationMediator.Action.Complete {
+        return this as PaymentConfirmationMediator.Action.Complete
+    }
+
+    private fun PaymentConfirmationMediator.Action.asLaunch(): PaymentConfirmationMediator.Action.Launch {
+        return this as PaymentConfirmationMediator.Action.Launch
+    }
+
+    private companion object {
+        private val SAVED_CONFIRMATION_OPTION = PaymentConfirmationOption.PaymentMethod.Saved(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(clientSecret = "pi_123"),
+            shippingDetails = null,
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            optionsParams = null,
+        )
+
+        private val INTENT = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -2957,14 +2957,15 @@ internal class PaymentSheetViewModelTest {
         val savedStateHandle = SavedStateHandle(
             initialState = mapOf(
                 "AwaitingPaymentResult" to true,
-                "IntentConfirmationArguments" to IntentConfirmationHandler.Args(
+                "IntentConfirmationParameters" to PaymentConfirmationMediator.Parameters(
                     intent = PAYMENT_INTENT,
                     confirmationOption = PaymentConfirmationOption.PaymentMethod.Saved(
                         initializationMode = ARGS_CUSTOMER_WITH_GOOGLEPAY.initializationMode,
                         paymentMethod = CARD_PAYMENT_METHOD,
                         optionsParams = null,
                         shippingDetails = null,
-                    )
+                    ),
+                    deferredIntentConfirmationType = null,
                 )
             )
         )
@@ -3027,11 +3028,19 @@ internal class PaymentSheetViewModelTest {
 
         val paymentResultListener = viewModel.capturePaymentResultListener()
 
+        val createParams = PaymentMethodCreateParams.create(
+            card = PaymentMethodCreateParams.Card()
+        )
         val selection = PaymentSelection.New.Card(
             brand = CardBrand.Visa,
             customerRequestedSave = customerRequestedSave,
-            paymentMethodCreateParams = PaymentMethodCreateParams.create(
-                card = PaymentMethodCreateParams.Card()
+            paymentMethodCreateParams = createParams
+        )
+
+        fakeIntentConfirmationInterceptor.enqueueConfirmStep(
+            confirmParams = ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
+                paymentMethodCreateParams = createParams,
+                clientSecret = "pi_1234"
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/FakePaymentConfirmationDefinition.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/FakePaymentConfirmationDefinition.kt
@@ -1,0 +1,142 @@
+package com.stripe.android.paymentsheet.utils
+
+import android.os.Parcelable
+import androidx.activity.result.ActivityResultCaller
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
+import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
+import com.stripe.android.paymentsheet.PaymentCancellationAction
+import com.stripe.android.paymentsheet.PaymentConfirmationDefinition
+import com.stripe.android.paymentsheet.PaymentConfirmationErrorType
+import com.stripe.android.paymentsheet.PaymentConfirmationOption
+import com.stripe.android.paymentsheet.PaymentConfirmationResult
+import kotlinx.parcelize.Parcelize
+
+internal class FakePaymentConfirmationDefinition(
+    private val onAction: (
+        confirmationOption: PaymentConfirmationOption.PaymentMethod.Saved,
+        intent: StripeIntent
+    ) -> PaymentConfirmationDefinition.ConfirmationAction<LauncherArgs> = { _, _ ->
+        val exception = IllegalStateException("Failed!")
+
+        PaymentConfirmationDefinition.ConfirmationAction.Fail(
+            cause = exception,
+            message = exception.stripeErrorMessage(),
+            errorType = PaymentConfirmationErrorType.Internal,
+        )
+    },
+    private val confirmationResult: PaymentConfirmationResult = PaymentConfirmationResult.Canceled(
+        action = PaymentCancellationAction.InformCancellation,
+    ),
+    private val launcher: Launcher = Launcher(),
+) : PaymentConfirmationDefinition<
+    PaymentConfirmationOption.PaymentMethod.Saved,
+    FakePaymentConfirmationDefinition.Launcher,
+    FakePaymentConfirmationDefinition.LauncherArgs,
+    FakePaymentConfirmationDefinition.LauncherResult
+    > {
+    private val _launchCalls = Turbine<LaunchCall>()
+    val launchCalls: ReceiveTurbine<LaunchCall> = _launchCalls
+
+    private val _createLauncherCalls = Turbine<CreateLauncherCall>()
+    val createLauncherCalls: ReceiveTurbine<CreateLauncherCall> = _createLauncherCalls
+
+    private val _toPaymentConfirmationResultCalls = Turbine<ToPaymentConfirmationResultCall>()
+    val toPaymentConfirmationResultCalls: ReceiveTurbine<ToPaymentConfirmationResultCall> =
+        _toPaymentConfirmationResultCalls
+
+    override val key: String = "Test"
+
+    override fun option(
+        confirmationOption: PaymentConfirmationOption
+    ): PaymentConfirmationOption.PaymentMethod.Saved? {
+        return confirmationOption as? PaymentConfirmationOption.PaymentMethod.Saved
+    }
+
+    override suspend fun action(
+        confirmationOption: PaymentConfirmationOption.PaymentMethod.Saved,
+        intent: StripeIntent
+    ): PaymentConfirmationDefinition.ConfirmationAction<LauncherArgs> {
+        return onAction(confirmationOption, intent)
+    }
+
+    override fun launch(
+        launcher: Launcher,
+        arguments: LauncherArgs,
+        confirmationOption: PaymentConfirmationOption.PaymentMethod.Saved,
+        intent: StripeIntent
+    ) {
+        _launchCalls.add(
+            LaunchCall(
+                launcher = launcher,
+                arguments = arguments,
+                confirmationOption = confirmationOption,
+                intent = intent,
+            )
+        )
+    }
+
+    override fun createLauncher(
+        activityResultCaller: ActivityResultCaller,
+        onResult: (LauncherResult) -> Unit
+    ): Launcher {
+        _createLauncherCalls.add(
+            CreateLauncherCall(
+                activityResultCaller = activityResultCaller,
+                onResult = onResult,
+            )
+        )
+
+        return launcher
+    }
+
+    override fun toPaymentConfirmationResult(
+        confirmationOption: PaymentConfirmationOption.PaymentMethod.Saved,
+        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        intent: StripeIntent,
+        result: LauncherResult
+    ): PaymentConfirmationResult {
+        _toPaymentConfirmationResultCalls.add(
+            ToPaymentConfirmationResultCall(
+                confirmationOption = confirmationOption,
+                deferredIntentConfirmationType = deferredIntentConfirmationType,
+                intent = intent,
+                result = result,
+            )
+        )
+
+        return confirmationResult
+    }
+
+    class LaunchCall(
+        val launcher: Launcher,
+        val arguments: LauncherArgs,
+        val confirmationOption: PaymentConfirmationOption.PaymentMethod.Saved,
+        val intent: StripeIntent
+    )
+
+    class CreateLauncherCall(
+        val activityResultCaller: ActivityResultCaller,
+        val onResult: (LauncherResult) -> Unit
+    )
+
+    class ToPaymentConfirmationResultCall(
+        val confirmationOption: PaymentConfirmationOption.PaymentMethod.Saved,
+        val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        val intent: StripeIntent,
+        val result: LauncherResult
+    )
+
+    class Launcher
+
+    data class LauncherArgs(
+        val amount: Long,
+    )
+
+    @Parcelize
+    data class LauncherResult(
+        val amount: Long,
+    ) : Parcelable
+}


### PR DESCRIPTION
# Summary
Adds `PaymentConfirmationMediator` to mediate payment confirmation types and an accompanying `PaymentConfirmationRegistry` type to define all the payment confirmation types and create mediators from.

# Motivation
Helps move all the `ConfirmationOption` and `Launcher` abstractions into a mediator to manage the definitions. Following this PR, we can start slowly moving all the internal definitions of the handler into their own definitions then make the registry a parameter of the handler.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified