### PR TITLE
Add explicit dependency on material icons for modules that use it.

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation libs.compose.activity
     implementation libs.compose.liveData
     implementation libs.compose.material
+    implementation libs.compose.materialIcons
     implementation libs.gson
     implementation libs.kotlin.coroutines
     implementation libs.kotlin.coroutinesAndroid

--- a/example/dependencies/dependencies.txt
+++ b/example/dependencies/dependencies.txt
@@ -559,6 +559,7 @@
 |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.25 (*)
 |    |    |    |         +--- androidx.compose.material:material-icons-core:1.5.4 (c)
 |    |    |    |         \--- androidx.compose.material:material-ripple:1.5.4 (c)
+|    |    |    +--- androidx.compose.material:material-icons-core:1.5.4 (*)
 |    |    |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4
 |    |    |    |    \--- androidx.compose.ui:ui-tooling-preview-android:1.5.4
@@ -973,6 +974,7 @@
 |    +--- androidx.activity:activity-compose:1.8.2 (*)
 |    +--- androidx.compose.foundation:foundation:1.5.4 (*)
 |    +--- androidx.compose.material:material:1.5.4 (*)
+|    +--- androidx.compose.material:material-icons-core:1.5.4 (*)
 |    +--- androidx.navigation:navigation-compose:2.7.6 (*)
 |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)
@@ -1017,6 +1019,7 @@
 +--- androidx.activity:activity-compose:1.8.2 (*)
 +--- androidx.compose.runtime:runtime-livedata:1.5.4 (*)
 +--- androidx.compose.material:material:1.5.4 (*)
++--- androidx.compose.material:material-icons-core:1.5.4 (*)
 +--- com.google.code.gson:gson:2.10.1
 +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
 +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 (*)

--- a/financial-connections-example/build.gradle
+++ b/financial-connections-example/build.gradle
@@ -74,6 +74,7 @@ dependencies {
     implementation libs.androidx.workManager
     implementation libs.compose.activity
     implementation libs.compose.material
+    implementation libs.compose.materialIcons
     implementation libs.compose.liveData
     implementation libs.compose.ui
     implementation libs.compose.uiToolingPreview

--- a/financial-connections-example/dependencies/dependencies.txt
+++ b/financial-connections-example/dependencies/dependencies.txt
@@ -454,6 +454,7 @@
 |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.24 (*)
 |    |    |         +--- androidx.compose.material:material-icons-core:1.5.4 (c)
 |    |    |         \--- androidx.compose.material:material-ripple:1.5.4 (c)
+|    |    +--- androidx.compose.material:material-icons-core:1.5.4 (*)
 |    |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4
 |    |    |    \--- androidx.compose.ui:ui-tooling-preview-android:1.5.4
@@ -596,6 +597,7 @@
 |    |    \--- androidx.activity:activity-ktx:1.8.2 (c)
 |    +--- androidx.compose.foundation:foundation:1.5.4 (*)
 |    +--- androidx.compose.material:material:1.5.4 (*)
+|    +--- androidx.compose.material:material-icons-core:1.5.4 (*)
 |    +--- androidx.navigation:navigation-compose:2.7.6
 |    |    +--- androidx.activity:activity-compose:1.7.0 -> 1.8.2 (*)
 |    |    +--- androidx.compose.animation:animation:1.5.1 -> 1.5.4 (*)
@@ -1046,6 +1048,7 @@
 |    \--- androidx.work:work-runtime:2.9.0 (c)
 +--- androidx.activity:activity-compose:1.8.2 (*)
 +--- androidx.compose.material:material:1.5.4 (*)
++--- androidx.compose.material:material-icons-core:1.5.4 (*)
 +--- androidx.compose.runtime:runtime-livedata:1.5.4 (*)
 +--- androidx.compose.ui:ui:1.5.4 (*)
 +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)

--- a/financial-connections/build.gradle
+++ b/financial-connections/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation libs.compose.activity
     implementation libs.compose.foundation
     implementation libs.compose.material
+    implementation libs.compose.materialIcons
     implementation libs.compose.navigation
     implementation libs.compose.ui
     implementation libs.compose.uiToolingPreview

--- a/financial-connections/dependencies/dependencies.txt
+++ b/financial-connections/dependencies/dependencies.txt
@@ -400,6 +400,7 @@
 |    |         |    \--- androidx.compose.material:material-icons-core-android:1.5.4
 |    |         |         +--- androidx.compose.ui:ui:1.5.4 (*)
 |    |         |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.21 -> 1.9.24 (*)
+|    |         |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.24 (*)
 |    |         |         +--- androidx.compose.material:material:1.5.4 (c)
 |    |         |         \--- androidx.compose.material:material-ripple:1.5.4 (c)
 |    |         +--- androidx.compose.material:material-ripple:1.5.4
@@ -420,6 +421,7 @@
 |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.24 (*)
 |    |         +--- androidx.compose.material:material-icons-core:1.5.4 (c)
 |    |         \--- androidx.compose.material:material-ripple:1.5.4 (c)
+|    +--- androidx.compose.material:material-icons-core:1.5.4 (*)
 |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4
 |    |    \--- androidx.compose.ui:ui-tooling-preview-android:1.5.4
@@ -552,6 +554,7 @@
 |    \--- androidx.activity:activity-ktx:1.8.2 (c)
 +--- androidx.compose.foundation:foundation:1.5.4 (*)
 +--- androidx.compose.material:material:1.5.4 (*)
++--- androidx.compose.material:material-icons-core:1.5.4 (*)
 +--- androidx.navigation:navigation-compose:2.7.6
 |    +--- androidx.activity:activity-compose:1.7.0 -> 1.8.2 (*)
 |    +--- androidx.compose.animation:animation:1.5.1 -> 1.5.4 (*)

--- a/identity-example/build.gradle
+++ b/identity-example/build.gradle
@@ -73,6 +73,7 @@ dependencies {
     implementation libs.compose.activity
     implementation libs.compose.liveData
     implementation libs.compose.material
+    implementation libs.compose.materialIcons
     implementation libs.compose.ui
     implementation libs.compose.viewModels
     implementation libs.fuel

--- a/identity/dependencies/dependencies.txt
+++ b/identity/dependencies/dependencies.txt
@@ -582,6 +582,7 @@
 |    |         |    \--- androidx.compose.material:material-icons-core-android:1.5.4
 |    |         |         +--- androidx.compose.ui:ui:1.5.4 (*)
 |    |         |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.21 -> 1.9.24 (*)
+|    |         |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.24 (*)
 |    |         |         +--- androidx.compose.material:material:1.5.4 (c)
 |    |         |         \--- androidx.compose.material:material-ripple:1.5.4 (c)
 |    |         +--- androidx.compose.material:material-ripple:1.5.4
@@ -602,6 +603,7 @@
 |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.24 (*)
 |    |         +--- androidx.compose.material:material-icons-core:1.5.4 (c)
 |    |         \--- androidx.compose.material:material-ripple:1.5.4 (c)
+|    +--- androidx.compose.material:material-icons-core:1.5.4 (*)
 |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4
 |    |    \--- androidx.compose.ui:ui-tooling-preview-android:1.5.4

--- a/link/dependencies/dependencies.txt
+++ b/link/dependencies/dependencies.txt
@@ -551,6 +551,7 @@
 |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.24 (*)
 |    |    |         +--- androidx.compose.material:material-icons-core:1.5.4 (c)
 |    |    |         \--- androidx.compose.material:material-ripple:1.5.4 (c)
+|    |    +--- androidx.compose.material:material-icons-core:1.5.4 (*)
 |    |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4
 |    |    |    \--- androidx.compose.ui:ui-tooling-preview-android:1.5.4

--- a/network-testing/dependencies/dependencies.txt
+++ b/network-testing/dependencies/dependencies.txt
@@ -538,6 +538,7 @@
 |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.24 (*)
 |    |    |         +--- androidx.compose.material:material-icons-core:1.5.4 (c)
 |    |    |         \--- androidx.compose.material:material-ripple:1.5.4 (c)
+|    |    +--- androidx.compose.material:material-icons-core:1.5.4 (*)
 |    |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4
 |    |    |    \--- androidx.compose.ui:ui-tooling-preview-android:1.5.4

--- a/payment-method-messaging/dependencies/dependencies.txt
+++ b/payment-method-messaging/dependencies/dependencies.txt
@@ -550,6 +550,7 @@
 |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.24 (*)
 |    |    |         +--- androidx.compose.material:material-icons-core:1.5.4 (c)
 |    |    |         \--- androidx.compose.material:material-ripple:1.5.4 (c)
+|    |    +--- androidx.compose.material:material-icons-core:1.5.4 (*)
 |    |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4
 |    |    |    \--- androidx.compose.ui:ui-tooling-preview-android:1.5.4

--- a/payments-core-testing/dependencies/dependencies.txt
+++ b/payments-core-testing/dependencies/dependencies.txt
@@ -526,6 +526,7 @@
 |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.24 (*)
 |    |    |         +--- androidx.compose.material:material-icons-core:1.5.4 (c)
 |    |    |         \--- androidx.compose.material:material-ripple:1.5.4 (c)
+|    |    +--- androidx.compose.material:material-icons-core:1.5.4 (*)
 |    |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4
 |    |    |    \--- androidx.compose.ui:ui-tooling-preview-android:1.5.4

--- a/payments-core/dependencies/dependencies.txt
+++ b/payments-core/dependencies/dependencies.txt
@@ -526,6 +526,7 @@
 |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.24 (*)
 |    |         +--- androidx.compose.material:material-icons-core:1.5.4 (c)
 |    |         \--- androidx.compose.material:material-ripple:1.5.4 (c)
+|    +--- androidx.compose.material:material-icons-core:1.5.4 (*)
 |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4
 |    |    \--- androidx.compose.ui:ui-tooling-preview-android:1.5.4

--- a/payments-ui-core/dependencies/dependencies.txt
+++ b/payments-ui-core/dependencies/dependencies.txt
@@ -530,6 +530,7 @@
 |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.24 (*)
 |    |    |         +--- androidx.compose.material:material-icons-core:1.5.4 (c)
 |    |    |         \--- androidx.compose.material:material-ripple:1.5.4 (c)
+|    |    +--- androidx.compose.material:material-icons-core:1.5.4 (*)
 |    |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4
 |    |    |    \--- androidx.compose.ui:ui-tooling-preview-android:1.5.4

--- a/payments/dependencies/dependencies.txt
+++ b/payments/dependencies/dependencies.txt
@@ -556,6 +556,7 @@
 |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.24 (*)
 |    |    |         +--- androidx.compose.material:material-icons-core:1.5.4 (c)
 |    |    |         \--- androidx.compose.material:material-ripple:1.5.4 (c)
+|    |    +--- androidx.compose.material:material-icons-core:1.5.4 (*)
 |    |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4
 |    |    |    \--- androidx.compose.ui:ui-tooling-preview-android:1.5.4

--- a/paymentsheet-example/dependencies/dependencies.txt
+++ b/paymentsheet-example/dependencies/dependencies.txt
@@ -574,6 +574,7 @@
 |    |    |    |         +--- androidx.compose.material:material-icons-core:1.5.4 (c)
 |    |    |    |         +--- androidx.compose.material:material-icons-extended:1.5.4 (c)
 |    |    |    |         \--- androidx.compose.material:material-ripple:1.5.4 (c)
+|    |    |    +--- androidx.compose.material:material-icons-core:1.5.4 (*)
 |    |    |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4
 |    |    |    |    \--- androidx.compose.ui:ui-tooling-preview-android:1.5.4
@@ -1102,6 +1103,7 @@
 |    +--- androidx.activity:activity-compose:1.8.2 (*)
 |    +--- androidx.compose.foundation:foundation:1.5.4 (*)
 |    +--- androidx.compose.material:material:1.5.4 (*)
+|    +--- androidx.compose.material:material-icons-core:1.5.4 (*)
 |    +--- androidx.navigation:navigation-compose:2.7.6 (*)
 |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4 (*)

--- a/paymentsheet/dependencies/dependencies.txt
+++ b/paymentsheet/dependencies/dependencies.txt
@@ -556,6 +556,7 @@
 |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.24 (*)
 |    |    |         +--- androidx.compose.material:material-icons-core:1.5.4 (c)
 |    |    |         \--- androidx.compose.material:material-ripple:1.5.4 (c)
+|    |    +--- androidx.compose.material:material-icons-core:1.5.4 (*)
 |    |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4
 |    |    |    \--- androidx.compose.ui:ui-tooling-preview-android:1.5.4

--- a/screenshot-testing/dependencies/dependencies.txt
+++ b/screenshot-testing/dependencies/dependencies.txt
@@ -474,6 +474,7 @@
 |    |         |    \--- androidx.compose.material:material-icons-core-android:1.5.4
 |    |         |         +--- androidx.compose.ui:ui:1.5.4 (*)
 |    |         |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.21 -> 1.9.24 (*)
+|    |         |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.24 (*)
 |    |         |         +--- androidx.compose.material:material:1.5.4 (c)
 |    |         |         \--- androidx.compose.material:material-ripple:1.5.4 (c)
 |    |         +--- androidx.compose.material:material-ripple:1.5.4
@@ -494,6 +495,7 @@
 |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.24 (*)
 |    |         +--- androidx.compose.material:material-icons-core:1.5.4 (c)
 |    |         \--- androidx.compose.material:material-ripple:1.5.4 (c)
+|    +--- androidx.compose.material:material-icons-core:1.5.4 (*)
 |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4
 |    |    \--- androidx.compose.ui:ui-tooling-preview-android:1.5.4

--- a/stripe-test-e2e/dependencies/dependencies.txt
+++ b/stripe-test-e2e/dependencies/dependencies.txt
@@ -558,6 +558,7 @@
      |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.24 (*)
      |    |    |         +--- androidx.compose.material:material-icons-core:1.5.4 (c)
      |    |    |         \--- androidx.compose.material:material-ripple:1.5.4 (c)
+     |    |    +--- androidx.compose.material:material-icons-core:1.5.4 (*)
      |    |    +--- androidx.compose.ui:ui:1.5.4 (*)
      |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4
      |    |    |    \--- androidx.compose.ui:ui-tooling-preview-android:1.5.4

--- a/stripe-ui-core/build.gradle
+++ b/stripe-ui-core/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation libs.androidx.coreKtx
     implementation libs.compose.foundation
     implementation libs.compose.material
+    implementation libs.compose.materialIcons
     implementation libs.compose.ui
     implementation libs.compose.uiToolingPreview
     implementation libs.diskLruCache

--- a/stripe-ui-core/dependencies/dependencies.txt
+++ b/stripe-ui-core/dependencies/dependencies.txt
@@ -359,6 +359,7 @@
 |         |    \--- androidx.compose.material:material-icons-core-android:1.5.4
 |         |         +--- androidx.compose.ui:ui:1.5.4 (*)
 |         |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.21 -> 1.9.24 (*)
+|         |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.24 (*)
 |         |         +--- androidx.compose.material:material:1.5.4 (c)
 |         |         \--- androidx.compose.material:material-ripple:1.5.4 (c)
 |         +--- androidx.compose.material:material-ripple:1.5.4
@@ -379,6 +380,7 @@
 |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.24 (*)
 |         +--- androidx.compose.material:material-icons-core:1.5.4 (c)
 |         \--- androidx.compose.material:material-ripple:1.5.4 (c)
++--- androidx.compose.material:material-icons-core:1.5.4 (*)
 +--- androidx.compose.ui:ui:1.5.4 (*)
 +--- androidx.compose.ui:ui-tooling-preview:1.5.4
 |    \--- androidx.compose.ui:ui-tooling-preview-android:1.5.4

--- a/wechatpay/dependencies/dependencies.txt
+++ b/wechatpay/dependencies/dependencies.txt
@@ -528,6 +528,7 @@
 |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.24 (*)
 |    |    |         +--- androidx.compose.material:material-icons-core:1.5.4 (c)
 |    |    |         \--- androidx.compose.material:material-ripple:1.5.4 (c)
+|    |    +--- androidx.compose.material:material-icons-core:1.5.4 (*)
 |    |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4
 |    |    |    \--- androidx.compose.ui:ui-tooling-preview-android:1.5.4


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
All these modules reference `implementation libs.compose.materialIcons`, but didn't already have a declared dependency on it.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Working on getting some pre work done for upgrading compose.
