### PR TITLE
Add `CustomerSession` skeleton API for `CustomerSheet`

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -44,6 +44,7 @@ import com.stripe.android.customersheet.CustomerSheetResult
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.customersheet.rememberCustomerSheet
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
 import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressLauncher
@@ -83,7 +84,7 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity(), ExternalPay
         )
     }
 
-    @OptIn(ExperimentalCustomerSheetApi::class)
+    @OptIn(ExperimentalCustomerSheetApi::class, ExperimentalCustomerSessionApi::class)
     @Suppress("LongMethod")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -112,14 +113,25 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity(), ExternalPay
             var showCustomEndpointDialog by remember { mutableStateOf(false) }
             val endpoint = playgroundState?.endpoint
 
-            val adapter = remember(playgroundState) {
-                viewModel.createCustomerAdapter(playgroundState)
-            }
+            val customerSheet = if (playgroundState?.asCustomerState()?.isUsingCustomerSession == true) {
+                val customerSessionProvider = remember(playgroundState) {
+                    viewModel.createCustomerSessionProvider()
+                }
 
-            val customerSheet = rememberCustomerSheet(
-                customerAdapter = adapter,
-                callback = viewModel::onCustomerSheetCallback
-            )
+                rememberCustomerSheet(
+                    customerSessionProvider = customerSessionProvider,
+                    callback = viewModel::onCustomerSheetCallback
+                )
+            } else {
+                val adapter = remember(playgroundState) {
+                    viewModel.createCustomerAdapter(playgroundState)
+                }
+
+                rememberCustomerSheet(
+                    customerAdapter = adapter,
+                    callback = viewModel::onCustomerSheetCallback
+                )
+            }
 
             if (showCustomEndpointDialog) {
                 CustomEndpointDialog(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
@@ -16,11 +16,13 @@ import com.github.kittinunf.result.Result
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.CustomerEphemeralKey
+import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetResult
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.DelicatePaymentSheetApi
+import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.addresselement.AddressLauncherResult
@@ -51,7 +53,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import java.io.IOException
 
-@OptIn(ExperimentalCustomerSheetApi::class)
+@OptIn(ExperimentalCustomerSheetApi::class, ExperimentalCustomerSessionApi::class)
 internal class PaymentSheetPlaygroundViewModel(
     application: Application,
     private val savedStateHandle: SavedStateHandle,
@@ -190,6 +192,22 @@ internal class PaymentSheetPlaygroundViewModel(
                 null
             }
         )
+    }
+
+    fun createCustomerSessionProvider(): CustomerSheet.CustomerSessionProvider {
+        return object : CustomerSheet.CustomerSessionProvider() {
+            override suspend fun provideSetupIntentClientSecret(
+                customerId: String
+            ): kotlin.Result<String> {
+                throw NotImplementedError("Not implemented yet!")
+            }
+
+            override suspend fun providesCustomerSessionClientSecret(): kotlin.Result<
+                CustomerSheet.CustomerSessionClientSecret
+                > {
+                throw NotImplementedError("Not implemented yet!")
+            }
+        }
     }
 
     @OptIn(ExperimentalCustomerSheetApi::class)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PlaygroundState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PlaygroundState.kt
@@ -13,6 +13,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomEndpointDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomerSessionSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSheetPaymentMethodModeDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
@@ -87,6 +88,9 @@ internal sealed interface PlaygroundState : Parcelable {
 
         val isNewCustomer
             get() = snapshot[CustomerSettingsDefinition] == CustomerType.NEW
+
+        val isUsingCustomerSession
+            get() = snapshot[CustomerSessionSettingsDefinition]
 
         val inSetupMode
             get() = snapshot[CustomerSheetPaymentMethodModeDefinition] ==

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionRedisplayFiltersSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionRedisplayFiltersSettingsDefinition.kt
@@ -14,10 +14,6 @@ internal object CustomerSessionRedisplayFiltersSettingsDefinition :
     PlaygroundSettingDefinition.Displayable<CustomerSessionRedisplayFiltersSettingsDefinition.RedisplayFilterType> {
     override val displayName: String = "Customer Session Allow Redisplay Filters"
 
-    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
-        return configurationData.integrationType.isPaymentFlow()
-    }
-
     override fun createOptions(
         configurationData: PlaygroundConfigurationData
     ) = listOf(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionRemoveSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionRemoveSettingsDefinition.kt
@@ -8,10 +8,6 @@ internal object CustomerSessionRemoveSettingsDefinition : BooleanSettingsDefinit
     displayName = "Customer Session Remove",
     key = "customer_session_payment_method_remove"
 ) {
-    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
-        return configurationData.integrationType.isPaymentFlow()
-    }
-
     override fun createOptions(
         configurationData: PlaygroundConfigurationData
     ) = listOf(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSettingsDefinition.kt
@@ -7,10 +7,6 @@ internal object CustomerSessionSettingsDefinition : BooleanSettingsDefinition(
     displayName = "Use Customer Session",
     key = "customer_session_enabled"
 ) {
-    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
-        return configurationData.integrationType.isPaymentFlow()
-    }
-
     override fun configure(value: Boolean, checkoutRequestBuilder: CheckoutRequest.Builder) {
         if (value) {
             checkoutRequestBuilder.customerKeyType(CheckoutRequest.CustomerKeyType.CustomerSession)

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetCompose.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetCompose.kt
@@ -1,10 +1,12 @@
 package com.stripe.android.customersheet
 
 import androidx.activity.compose.LocalActivityResultRegistryOwner
+import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
 import com.stripe.android.utils.rememberActivity
 
 /**
@@ -21,6 +23,44 @@ fun rememberCustomerSheet(
     customerAdapter: CustomerAdapter,
     callback: CustomerSheetResultCallback,
 ): CustomerSheet {
+    return rememberCustomerSheet(
+        integrationType = remember(customerAdapter) {
+            CustomerSheetIntegrationType.Adapter(customerAdapter)
+        },
+        callback = callback,
+    )
+}
+
+/**
+* Creates a [CustomerSheet] with `CustomerSession` support that is remembered across compositions.
+*
+* This *must* be called unconditionally, as part of the initialization path.
+*
+* @param customerSessionProvider provider for providing customer session elements
+* @param callback Called with the result of the operation after [CustomerSheet] is dismissed
+*/
+@ExperimentalCustomerSheetApi
+@ExperimentalCustomerSessionApi
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Composable
+fun rememberCustomerSheet(
+    customerSessionProvider: CustomerSheet.CustomerSessionProvider,
+    callback: CustomerSheetResultCallback,
+): CustomerSheet {
+    return rememberCustomerSheet(
+        integrationType = remember(customerSessionProvider) {
+            CustomerSheetIntegrationType.CustomerSession(customerSessionProvider)
+        },
+        callback = callback,
+    )
+}
+
+@ExperimentalCustomerSheetApi
+@Composable
+private fun rememberCustomerSheet(
+    integrationType: CustomerSheetIntegrationType,
+    callback: CustomerSheetResultCallback,
+): CustomerSheet {
     val activityResultRegistryOwner = requireNotNull(LocalActivityResultRegistryOwner.current) {
         "CustomerSheet must be created with access to an ActivityResultRegistryOwner"
     }
@@ -35,7 +75,7 @@ fun rememberCustomerSheet(
     }
 
     return remember(
-        customerAdapter,
+        integrationType,
         callback,
     ) {
         CustomerSheet.getInstance(
@@ -43,7 +83,7 @@ fun rememberCustomerSheet(
             lifecycleOwner = lifecycleOwner,
             activityResultRegistryOwner = activityResultRegistryOwner,
             viewModelStoreOwner = viewModelStoreOwner,
-            customerAdapter = customerAdapter,
+            integrationType = integrationType,
             callback = callback,
             statusBarColor = { activity.window?.statusBarColor },
         )

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetIntegrationType.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetIntegrationType.kt
@@ -1,0 +1,14 @@
+package com.stripe.android.customersheet
+
+import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
+
+@OptIn(ExperimentalCustomerSheetApi::class, ExperimentalCustomerSessionApi::class)
+internal sealed interface CustomerSheetIntegrationType {
+    class Adapter(
+        val adapter: CustomerAdapter
+    ) : CustomerSheetIntegrationType
+
+    class CustomerSession(
+        val customerSessionProvider: CustomerSheet.CustomerSessionProvider
+    ) : CustomerSheetIntegrationType
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSource.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.customersheet.data
+
+import javax.inject.Inject
+
+internal class CustomerSessionInitializationDataSource @Inject constructor() : CustomerSheetInitializationDataSource {
+    override suspend fun loadCustomerSheetSession(): CustomerSheetDataResult<CustomerSheetSession> {
+        throw NotImplementedError("Not implemented yet!")
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionIntentDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionIntentDataSource.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.customersheet.data
+
+import javax.inject.Inject
+
+internal class CustomerSessionIntentDataSource @Inject constructor() : CustomerSheetIntentDataSource {
+    override val canCreateSetupIntents: Boolean = true
+
+    override suspend fun retrieveSetupIntentClientSecret(): CustomerSheetDataResult<String> {
+        throw NotImplementedError("Not implemented yet!")
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.customersheet.data
+
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodUpdateParams
+import javax.inject.Inject
+
+internal class CustomerSessionPaymentMethodDataSource @Inject constructor() : CustomerSheetPaymentMethodDataSource {
+    override suspend fun retrievePaymentMethods(): CustomerSheetDataResult<List<PaymentMethod>> {
+        throw NotImplementedError("Not implemented yet!")
+    }
+
+    override suspend fun updatePaymentMethod(
+        paymentMethodId: String,
+        params: PaymentMethodUpdateParams
+    ): CustomerSheetDataResult<PaymentMethod> {
+        throw NotImplementedError("Not implemented yet!")
+    }
+
+    override suspend fun attachPaymentMethod(
+        paymentMethodId: String
+    ): CustomerSheetDataResult<PaymentMethod> {
+        throw NotImplementedError("Not implemented yet!")
+    }
+
+    override suspend fun detachPaymentMethod(
+        paymentMethodId: String
+    ): CustomerSheetDataResult<PaymentMethod> {
+        throw NotImplementedError("Not implemented yet!")
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
@@ -1,0 +1,14 @@
+package com.stripe.android.customersheet.data
+
+import com.stripe.android.paymentsheet.model.SavedSelection
+import javax.inject.Inject
+
+internal class CustomerSessionSavedSelectionDataSource @Inject constructor() : CustomerSheetSavedSelectionDataSource {
+    override suspend fun retrieveSavedSelection(): CustomerSheetDataResult<SavedSelection?> {
+        throw NotImplementedError("Not implemented yet!")
+    }
+
+    override suspend fun setSavedSelection(selection: SavedSelection?): CustomerSheetDataResult<Unit> {
+        throw NotImplementedError("Not implemented yet!")
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSessionDataSourceComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSessionDataSourceComponent.kt
@@ -1,0 +1,48 @@
+package com.stripe.android.customersheet.data.injection
+
+import android.app.Application
+import com.stripe.android.core.injection.CoreCommonModule
+import com.stripe.android.core.injection.CoroutineContextModule
+import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.customersheet.data.CustomerSheetInitializationDataSource
+import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
+import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSource
+import com.stripe.android.customersheet.data.CustomerSheetSavedSelectionDataSource
+import com.stripe.android.customersheet.injection.CustomerSheetDataCommonModule
+import com.stripe.android.payments.core.injection.StripeRepositoryModule
+import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
+import dagger.BindsInstance
+import dagger.Component
+import javax.inject.Singleton
+
+@OptIn(ExperimentalCustomerSheetApi::class, ExperimentalCustomerSessionApi::class)
+@Singleton
+@Component(
+    modules = [
+        CustomerSessionDataSourceModule::class,
+        CustomerSheetDataSourceCommonModule::class,
+        CustomerSheetDataCommonModule::class,
+        StripeRepositoryModule::class,
+        CoroutineContextModule::class,
+        CoreCommonModule::class,
+    ]
+)
+internal interface CustomerSessionDataSourceComponent {
+    val customerSheetPaymentMethodDataSource: CustomerSheetPaymentMethodDataSource
+    val customerSheetSavedSelectionDataSource: CustomerSheetSavedSelectionDataSource
+    val customerSheetIntentDataSource: CustomerSheetIntentDataSource
+    val customerSheetInitializationDataSource: CustomerSheetInitializationDataSource
+
+    @Component.Builder
+    interface Builder {
+
+        @BindsInstance
+        fun application(application: Application): Builder
+
+        @BindsInstance
+        fun customerSessionProvider(customerSessionProvider: CustomerSheet.CustomerSessionProvider): Builder
+
+        fun build(): CustomerSessionDataSourceComponent
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSessionDataSourceModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSessionDataSourceModule.kt
@@ -1,0 +1,35 @@
+package com.stripe.android.customersheet.data.injection
+
+import com.stripe.android.customersheet.data.CustomerSessionInitializationDataSource
+import com.stripe.android.customersheet.data.CustomerSessionIntentDataSource
+import com.stripe.android.customersheet.data.CustomerSessionPaymentMethodDataSource
+import com.stripe.android.customersheet.data.CustomerSessionSavedSelectionDataSource
+import com.stripe.android.customersheet.data.CustomerSheetInitializationDataSource
+import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
+import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSource
+import com.stripe.android.customersheet.data.CustomerSheetSavedSelectionDataSource
+import dagger.Binds
+import dagger.Module
+
+@Module
+internal interface CustomerSessionDataSourceModule {
+    @Binds
+    fun bindsCustomerSheetPaymentMethodDataSource(
+        impl: CustomerSessionPaymentMethodDataSource
+    ): CustomerSheetPaymentMethodDataSource
+
+    @Binds
+    fun bindsCustomerSheetIntentDataSource(
+        impl: CustomerSessionIntentDataSource
+    ): CustomerSheetIntentDataSource
+
+    @Binds
+    fun bindsCustomerSheetSavedSelectionDataSource(
+        impl: CustomerSessionSavedSelectionDataSource
+    ): CustomerSheetSavedSelectionDataSource
+
+    @Binds
+    fun bindsCustomerSheetInitializationDataSource(
+        impl: CustomerSessionInitializationDataSource
+    ): CustomerSheetInitializationDataSource
+}

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetHacksTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetHacksTest.kt
@@ -8,7 +8,13 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.customersheet.CustomerSheetIntegrationType
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.customersheet.FakeCustomerAdapter
+import com.stripe.android.customersheet.data.CustomerAdapterDataSource
+import com.stripe.android.customersheet.data.CustomerSessionInitializationDataSource
+import com.stripe.android.customersheet.data.CustomerSessionIntentDataSource
+import com.stripe.android.customersheet.data.CustomerSessionPaymentMethodDataSource
+import com.stripe.android.customersheet.data.CustomerSessionSavedSelectionDataSource
 import com.stripe.android.customersheet.util.CustomerSheetHacks
+import com.stripe.android.isInstanceOf
 import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.test.runTest
@@ -36,10 +42,14 @@ class CustomerSheetHacksTest {
             integrationType = CustomerSheetIntegrationType.Adapter(FakeCustomerAdapter())
         )
 
-        assertThat(CustomerSheetHacks.initializationDataSource.awaitWithTimeout()).isNotNull()
-        assertThat(CustomerSheetHacks.intentDataSource.awaitWithTimeout()).isNotNull()
-        assertThat(CustomerSheetHacks.paymentMethodDataSource.awaitWithTimeout()).isNotNull()
-        assertThat(CustomerSheetHacks.savedSelectionDataSource.awaitWithTimeout()).isNotNull()
+        assertThat(CustomerSheetHacks.initializationDataSource.awaitWithTimeout())
+            .isInstanceOf<CustomerAdapterDataSource>()
+        assertThat(CustomerSheetHacks.intentDataSource.awaitWithTimeout())
+            .isInstanceOf<CustomerAdapterDataSource>()
+        assertThat(CustomerSheetHacks.paymentMethodDataSource.awaitWithTimeout())
+            .isInstanceOf<CustomerAdapterDataSource>()
+        assertThat(CustomerSheetHacks.savedSelectionDataSource.awaitWithTimeout())
+            .isInstanceOf<CustomerAdapterDataSource>()
     }
 
     @Test
@@ -50,10 +60,14 @@ class CustomerSheetHacksTest {
             integrationType = CustomerSheetIntegrationType.CustomerSession(FakeCustomerSessionProvider())
         )
 
-        assertThat(CustomerSheetHacks.initializationDataSource.awaitWithTimeout()).isNotNull()
-        assertThat(CustomerSheetHacks.intentDataSource.awaitWithTimeout()).isNotNull()
-        assertThat(CustomerSheetHacks.paymentMethodDataSource.awaitWithTimeout()).isNotNull()
-        assertThat(CustomerSheetHacks.savedSelectionDataSource.awaitWithTimeout()).isNotNull()
+        assertThat(CustomerSheetHacks.initializationDataSource.awaitWithTimeout())
+            .isInstanceOf<CustomerSessionInitializationDataSource>()
+        assertThat(CustomerSheetHacks.intentDataSource.awaitWithTimeout())
+            .isInstanceOf<CustomerSessionIntentDataSource>()
+        assertThat(CustomerSheetHacks.paymentMethodDataSource.awaitWithTimeout())
+            .isInstanceOf<CustomerSessionPaymentMethodDataSource>()
+        assertThat(CustomerSheetHacks.savedSelectionDataSource.awaitWithTimeout())
+            .isInstanceOf<CustomerSessionSavedSelectionDataSource>()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetHacksTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetHacksTest.kt
@@ -5,9 +5,11 @@ import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.customersheet.CustomerSheetIntegrationType
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.customersheet.FakeCustomerAdapter
 import com.stripe.android.customersheet.util.CustomerSheetHacks
+import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeoutOrNull
@@ -16,7 +18,7 @@ import org.junit.runner.RunWith
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.seconds
 
-@OptIn(ExperimentalCustomerSheetApi::class)
+@OptIn(ExperimentalCustomerSheetApi::class, ExperimentalCustomerSessionApi::class)
 @RunWith(AndroidJUnit4::class)
 class CustomerSheetHacksTest {
     private val application = ApplicationProvider.getApplicationContext<Application>()
@@ -27,8 +29,26 @@ class CustomerSheetHacksTest {
     }
 
     @Test
-    fun `on initialize, should initialize all data sources as expected`() = runTest {
-        CustomerSheetHacks.initialize(application, TestLifecycleOwner(), FakeCustomerAdapter())
+    fun `on initialize with adapter, should initialize all data sources as expected`() = runTest {
+        CustomerSheetHacks.initialize(
+            application = application,
+            lifecycleOwner = TestLifecycleOwner(),
+            integrationType = CustomerSheetIntegrationType.Adapter(FakeCustomerAdapter())
+        )
+
+        assertThat(CustomerSheetHacks.initializationDataSource.awaitWithTimeout()).isNotNull()
+        assertThat(CustomerSheetHacks.intentDataSource.awaitWithTimeout()).isNotNull()
+        assertThat(CustomerSheetHacks.paymentMethodDataSource.awaitWithTimeout()).isNotNull()
+        assertThat(CustomerSheetHacks.savedSelectionDataSource.awaitWithTimeout()).isNotNull()
+    }
+
+    @Test
+    fun `on initialize with customer session, should initialize all data sources as expected`() = runTest {
+        CustomerSheetHacks.initialize(
+            application = application,
+            lifecycleOwner = TestLifecycleOwner(),
+            integrationType = CustomerSheetIntegrationType.CustomerSession(FakeCustomerSessionProvider())
+        )
 
         assertThat(CustomerSheetHacks.initializationDataSource.awaitWithTimeout()).isNotNull()
         assertThat(CustomerSheetHacks.intentDataSource.awaitWithTimeout()).isNotNull()
@@ -38,7 +58,11 @@ class CustomerSheetHacksTest {
 
     @Test
     fun `on clear, should clear all data sources as expected`() = runTest {
-        CustomerSheetHacks.initialize(application, TestLifecycleOwner(), FakeCustomerAdapter())
+        CustomerSheetHacks.initialize(
+            application = application,
+            lifecycleOwner = TestLifecycleOwner(),
+            integrationType = CustomerSheetIntegrationType.Adapter(FakeCustomerAdapter())
+        )
         CustomerSheetHacks.clear()
 
         assertThat(CustomerSheetHacks.initializationDataSource.awaitWithTimeout()).isNull()

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSessionProvider.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSessionProvider.kt
@@ -1,0 +1,16 @@
+package com.stripe.android.customersheet.utils
+
+import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
+
+@OptIn(ExperimentalCustomerSheetApi::class, ExperimentalCustomerSessionApi::class)
+class FakeCustomerSessionProvider : CustomerSheet.CustomerSessionProvider() {
+    override suspend fun provideSetupIntentClientSecret(customerId: String): Result<String> {
+        throw NotImplementedError("Not implemented yet!")
+    }
+
+    override suspend fun providesCustomerSessionClientSecret(): Result<CustomerSheet.CustomerSessionClientSecret> {
+        throw NotImplementedError("Not implemented yet!")
+    }
+}


### PR DESCRIPTION
# Summary
Add `CustomerSession` skeleton API for `CustomerSheet`

# Motivation
Enabled adding `CustomerSession` for `CustomerSheet`

[API Review](https://docs.google.com/document/d/1B_BK0oFOYHiRjo8GTovg8UG8zwo_8tk9r2Rk6EHMa_g/edit#heading=h.570u4leviueu)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified