### PR TITLE
Add content description to card brand drop down

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditPaymentMethod.kt
@@ -39,6 +39,8 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.stripe.android.common.ui.LoadingIndicator
@@ -243,6 +245,9 @@ private fun Dropdown(
 
                     viewActionHandler.invoke(EditPaymentMethodViewAction.OnBrandChoiceOptionsShown)
                 }
+            }
+            .semantics {
+                this.contentDescription = viewState.selectedBrand.brand.displayName
             }
             .testTag(DROPDOWN_MENU_CLICKABLE_TEST_TAG)
     ) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/EditPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/EditPaymentMethodTest.kt
@@ -1,0 +1,60 @@
+package com.stripe.android.paymentsheet.ui
+
+import android.os.Build
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.CardBrand
+import com.stripe.android.uicore.elements.DROPDOWN_MENU_CLICKABLE_TEST_TAG
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.Test
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.Q])
+class EditPaymentMethodTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `Card drop down has accessibility label`() {
+        composeRule.setContent {
+            EditPaymentMethod(
+                interactor = FakeEditPaymentMethodInteractor(selectedBrand = CardBrand.Visa),
+                modifier = Modifier
+            )
+        }
+
+        composeRule.onNodeWithTag(DROPDOWN_MENU_CLICKABLE_TEST_TAG)
+            .assertContentDescriptionEquals("Visa")
+    }
+
+    private class FakeEditPaymentMethodInteractor(selectedBrand: CardBrand = CardBrand.Visa) :
+        EditPaymentMethodViewInteractor {
+        override val viewState: StateFlow<EditPaymentMethodViewState> = MutableStateFlow(
+            EditPaymentMethodViewState(
+                status = EditPaymentMethodViewState.Status.Idle,
+                last4 = "4242",
+                displayName = "Visa".resolvableString,
+                canUpdate = true,
+                selectedBrand = EditPaymentMethodViewState.CardBrandChoice(selectedBrand),
+                availableBrands = listOf(
+                    EditPaymentMethodViewState.CardBrandChoice(CardBrand.Visa),
+                    EditPaymentMethodViewState.CardBrandChoice(CardBrand.CartesBancaires)
+                ),
+                canRemove = true,
+            )
+        )
+
+        override fun handleViewAction(viewAction: EditPaymentMethodViewAction) {
+            // Do nothing.
+        }
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add content description to card brand drop down

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2419

Previously, if you used TalkBack on this screen, the dropdown description would read as "unlabeled" and would try to guess what the icon said (so for visa, it would say "text visa detected" but for e.g. Cartes Bancaires, there would be no description). Now, the label says the card brand. It also says "double tap to activate" indicating that it's clickable (though it also did that before this change)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified