### PR TITLE
Update saved card description to use displayed brand

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet
 
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 
 internal data class DisplayableSavedPaymentMethod(
@@ -18,11 +19,14 @@ internal data class DisplayableSavedPaymentMethod(
     }
 
     fun getDescription() = when (paymentMethod.type) {
-        PaymentMethod.Type.Card -> resolvableString(
-            com.stripe.android.R.string.stripe_card_ending_in,
-            paymentMethod.card?.brand,
-            paymentMethod.card?.last4
-        )
+        PaymentMethod.Type.Card -> {
+            val brand = CardBrand.fromCode(paymentMethod.card?.displayBrand).displayName
+            resolvableString(
+                com.stripe.android.R.string.stripe_card_ending_in,
+                brand,
+                paymentMethod.card?.last4
+            )
+        }
         PaymentMethod.Type.SepaDebit -> resolvableString(
             R.string.stripe_bank_account_ending_in,
             paymentMethod.sepaDebit?.last4

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
@@ -20,10 +20,11 @@ internal data class DisplayableSavedPaymentMethod(
 
     fun getDescription() = when (paymentMethod.type) {
         PaymentMethod.Type.Card -> {
-            val brand = CardBrand.fromCode(paymentMethod.card?.displayBrand).displayName
+            val brand = paymentMethod.card?.displayBrand?.let { CardBrand.fromCode(it) }
+                ?: paymentMethod.card?.brand
             resolvableString(
                 com.stripe.android.R.string.stripe_card_ending_in,
-                brand,
+                brand?.displayName,
                 paymentMethod.card?.last4
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethodTest.kt
@@ -29,5 +29,4 @@ class DisplayableSavedPaymentMethodTest {
 
         assertThat(description).isEqualTo("Cartes Bancaires ending in 4242")
     }
-
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethodTest.kt
@@ -1,0 +1,33 @@
+package com.stripe.android.paymentsheet
+
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.PaymentMethodFixtures
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.Test
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.Q])
+class DisplayableSavedPaymentMethodTest {
+
+    val context: Context = getApplicationContext()
+
+    @Test
+    fun getDescription_usesDisplayedCardBrand() {
+        val visaCardUsingCartesBancaires = PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD
+        val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod(
+            displayName = "unused".resolvableString,
+            paymentMethod = visaCardUsingCartesBancaires
+        )
+
+        val description = displayableSavedPaymentMethod.getDescription().resolve(context)
+
+        assertThat(description).isEqualTo("Cartes Bancaires ending in 4242")
+    }
+
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethodTest.kt
@@ -15,7 +15,7 @@ import kotlin.test.Test
 @Config(sdk = [Build.VERSION_CODES.Q])
 class DisplayableSavedPaymentMethodTest {
 
-    val context: Context = getApplicationContext()
+    private val context: Context = getApplicationContext()
 
     @Test
     fun getDescription_usesDisplayedCardBrand() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethodTest.kt
@@ -29,4 +29,19 @@ class DisplayableSavedPaymentMethodTest {
 
         assertThat(description).isEqualTo("Cartes Bancaires ending in 4242")
     }
+
+    @Test
+    fun getDescription_usesBrandIfDisplayBrandIsUnknown() {
+        val cardWithoutDisplayBrand = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
+            card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.card?.copy(displayBrand = null)
+        )
+        val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod(
+            displayName = "unused".resolvableString,
+            paymentMethod = cardWithoutDisplayBrand
+        )
+
+        val description = displayableSavedPaymentMethod.getDescription().resolve(context)
+
+        assertThat(description).isEqualTo("Visa ending in 4242")
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update saved card description to use displayed brand

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2164

Before: For co-branded cards, this description would read as e.g. "Visa ending in 1001" even when the display brand (shown to the user) was Cartes Bancaires. This was misleading when using TalkBack -- the icon would be for CB, but the description was for Visa. 

Now: The description will read as "Cartes Bancaires ending in 1001" in the example above.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified
