### PR TITLE
Add `CustomerSession` implementation for `CustomerSheet` playground

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -113,9 +113,10 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity(), ExternalPay
             var showCustomEndpointDialog by remember { mutableStateOf(false) }
             val endpoint = playgroundState?.endpoint
 
-            val customerSheet = if (playgroundState?.asCustomerState()?.isUsingCustomerSession == true) {
-                val customerSessionProvider = remember(playgroundState) {
-                    viewModel.createCustomerSessionProvider()
+            val customerPlaygroundState = playgroundState?.asCustomerState()
+            val customerSheet = if (customerPlaygroundState?.isUsingCustomerSession == true) {
+                val customerSessionProvider = remember(customerPlaygroundState) {
+                    viewModel.createCustomerSessionProvider(customerPlaygroundState)
                 }
 
                 rememberCustomerSheet(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCustomerModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCustomerModel.kt
@@ -32,10 +32,29 @@ class CustomerEphemeralKeyRequest private constructor(
 
     class Builder {
         private var customerType: String? = null
+        private var customerKeyType: CustomerKeyType = CustomerKeyType.Legacy
         private var merchantCountryCode: String? = null
+        private var paymentMethodRemoveFeature: FeatureState = FeatureState.Enabled
+        private var paymentMethodRedisplayFilters: List<AllowRedisplayFilter> = listOf(
+            AllowRedisplayFilter.Unspecified,
+            AllowRedisplayFilter.Limited,
+            AllowRedisplayFilter.Always,
+        )
 
         fun customerType(customerType: String) = apply {
             this.customerType = customerType
+        }
+
+        fun customerKeyType(customerKeyType: CustomerKeyType) = apply {
+            this.customerKeyType = customerKeyType
+        }
+
+        fun paymentMethodRemoveFeature(state: FeatureState) {
+            this.paymentMethodRemoveFeature = state
+        }
+
+        fun paymentMethodRedisplayFilters(filters: List<AllowRedisplayFilter>) {
+            this.paymentMethodRedisplayFilters = filters
         }
 
         fun merchantCountryCode(merchantCountryCode: String?) = apply {
@@ -45,10 +64,10 @@ class CustomerEphemeralKeyRequest private constructor(
         fun build(): CustomerEphemeralKeyRequest {
             return CustomerEphemeralKeyRequest(
                 customerType = customerType,
-                customerKeyType = CustomerKeyType.Legacy,
+                customerKeyType = customerKeyType,
                 merchantCountryCode = merchantCountryCode,
                 paymentMethodSaveFeature = FeatureState.Enabled,
-                paymentMethodRemoveFeature = FeatureState.Enabled,
+                paymentMethodRemoveFeature = paymentMethodRemoveFeature,
                 paymentMethodRedisplayFeature = FeatureState.Enabled,
                 paymentMethodRedisplayFilters = listOf(
                     AllowRedisplayFilter.Unspecified,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionRedisplayFiltersSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionRedisplayFiltersSettingsDefinition.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.example.playground.settings
 
 import com.stripe.android.paymentsheet.example.playground.model.AllowRedisplayFilter
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
+import com.stripe.android.paymentsheet.example.playground.model.CustomerEphemeralKeyRequest
 
 internal object CustomerSessionRedisplayFiltersSettingsDefinition :
     PlaygroundSettingDefinition<CustomerSessionRedisplayFiltersSettingsDefinition.RedisplayFilterType>,
@@ -26,6 +27,13 @@ internal object CustomerSessionRedisplayFiltersSettingsDefinition :
 
     override fun configure(value: RedisplayFilterType, checkoutRequestBuilder: CheckoutRequest.Builder) {
         checkoutRequestBuilder.paymentMethodRedisplayFilters(value.filters)
+    }
+
+    override fun configure(
+        value: RedisplayFilterType,
+        customerEphemeralKeyRequestBuilder: CustomerEphemeralKeyRequest.Builder
+    ) {
+        customerEphemeralKeyRequestBuilder.paymentMethodRedisplayFilters(value.filters)
     }
 
     enum class RedisplayFilterType(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionRemoveSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionRemoveSettingsDefinition.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.example.playground.settings
 
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
+import com.stripe.android.paymentsheet.example.playground.model.CustomerEphemeralKeyRequest
 import com.stripe.android.paymentsheet.example.playground.model.FeatureState
 
 internal object CustomerSessionRemoveSettingsDefinition : BooleanSettingsDefinition(
@@ -20,6 +21,17 @@ internal object CustomerSessionRemoveSettingsDefinition : BooleanSettingsDefinit
             checkoutRequestBuilder.paymentMethodRemoveFeature(FeatureState.Enabled)
         } else {
             checkoutRequestBuilder.paymentMethodRemoveFeature(FeatureState.Disabled)
+        }
+    }
+
+    override fun configure(
+        value: Boolean,
+        customerEphemeralKeyRequestBuilder: CustomerEphemeralKeyRequest.Builder
+    ) {
+        if (value) {
+            customerEphemeralKeyRequestBuilder.paymentMethodRemoveFeature(FeatureState.Enabled)
+        } else {
+            customerEphemeralKeyRequestBuilder.paymentMethodRemoveFeature(FeatureState.Disabled)
         }
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSettingsDefinition.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.example.playground.settings
 
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
+import com.stripe.android.paymentsheet.example.playground.model.CustomerEphemeralKeyRequest
 
 internal object CustomerSessionSettingsDefinition : BooleanSettingsDefinition(
     defaultValue = false,
@@ -12,6 +13,21 @@ internal object CustomerSessionSettingsDefinition : BooleanSettingsDefinition(
             checkoutRequestBuilder.customerKeyType(CheckoutRequest.CustomerKeyType.CustomerSession)
         } else {
             checkoutRequestBuilder.customerKeyType(CheckoutRequest.CustomerKeyType.Legacy)
+        }
+    }
+
+    override fun configure(
+        value: Boolean,
+        customerEphemeralKeyRequestBuilder: CustomerEphemeralKeyRequest.Builder
+    ) {
+        if (value) {
+            customerEphemeralKeyRequestBuilder.customerKeyType(
+                CustomerEphemeralKeyRequest.CustomerKeyType.CustomerSession
+            )
+        } else {
+            customerEphemeralKeyRequestBuilder.customerKeyType(
+                CustomerEphemeralKeyRequest.CustomerKeyType.Legacy
+            )
         }
     }
 }


### PR DESCRIPTION
# Summary
Add `CustomerSession` implementation for `CustomerSheet` playground

# Motivation
Allows fetching `CustomerSessionClientSecret` & `SetupIntentClientSecret` for usage with `CustomerSession` on `CustomerSheet`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
