### PR TITLE
Add Automatic as a PaymentMethodLayout enum option.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestVerticalMode.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestVerticalMode.kt
@@ -9,6 +9,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Layout
 import com.stripe.android.paymentsheet.example.playground.settings.LayoutSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
 import com.stripe.android.test.core.TestParameters
@@ -24,7 +25,7 @@ internal class TestVerticalMode : BasePlaygroundTest() {
     ).copy(
         saveForFutureUseCheckboxVisible = true,
     ).copyPlaygroundSettings { settings ->
-        settings[LayoutSettingsDefinition] = true
+        settings[LayoutSettingsDefinition] = Layout.VERTICAL
     }
 
     private val cashAppTestParameters = TestParameters.create(
@@ -37,7 +38,7 @@ internal class TestVerticalMode : BasePlaygroundTest() {
             PaymentMethod.Type.Card,
             PaymentMethod.Type.CashAppPay
         ).joinToString(",")
-        settings[LayoutSettingsDefinition] = true
+        settings[LayoutSettingsDefinition] = Layout.VERTICAL
     }
 
     @Test

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -43,6 +43,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
+import com.stripe.android.paymentsheet.example.playground.settings.Layout
 import com.stripe.android.paymentsheet.example.playground.settings.LayoutSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundConfigurationData
 import com.stripe.android.paymentsheet.example.playground.settings.RequireCvcRecollectionDefinition
@@ -503,7 +504,7 @@ internal class PlaygroundTestDriver(
         setup(testParameters)
         launchComplete()
 
-        if (testParameters.playgroundSettingsSnapshot[LayoutSettingsDefinition]) {
+        if (testParameters.playgroundSettingsSnapshot[LayoutSettingsDefinition] != Layout.HORIZONTAL) {
             selectLpmInVerticalMode(testParameters.paymentMethodCode)
         } else {
             clickPaymentSelection()

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LayoutSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LayoutSettingsDefinition.kt
@@ -3,29 +3,52 @@ package com.stripe.android.paymentsheet.example.playground.settings
 import com.stripe.android.paymentsheet.ExperimentalPaymentMethodLayoutApi
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
+import java.util.Locale
 
-internal object LayoutSettingsDefinition : BooleanSettingsDefinition(
-    key = "layout",
-    displayName = "Vertical Mode",
-    defaultValue = false,
-) {
+@OptIn(ExperimentalPaymentMethodLayoutApi::class)
+internal object LayoutSettingsDefinition :
+    PlaygroundSettingDefinition<Layout>,
+    PlaygroundSettingDefinition.Saveable<Layout> by EnumSaveable(
+        key = "layout",
+        values = Layout.entries.toTypedArray(),
+        defaultValue = Layout.HORIZONTAL,
+    ),
+    PlaygroundSettingDefinition.Displayable<Layout> {
+    override val displayName: String = "Payment Method Layout"
+
+    override fun createOptions(
+        configurationData: PlaygroundConfigurationData
+    ): List<PlaygroundSettingDefinition.Displayable.Option<Layout>> {
+        return Layout.entries.map { layout ->
+            option(
+                layout.value.replaceFirstChar {
+                    if (it.isLowerCase()) {
+                        it.titlecase(Locale.getDefault())
+                    } else {
+                        it.toString()
+                    }
+                },
+                layout
+            )
+        }
+    }
+
     override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
         return configurationData.integrationType.isPaymentFlow()
     }
 
-    @OptIn(ExperimentalPaymentMethodLayoutApi::class)
     override fun configure(
-        value: Boolean,
+        value: Layout,
         configurationBuilder: PaymentSheet.Configuration.Builder,
         playgroundState: PlaygroundState.Payment,
         configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData
     ) {
-        configurationBuilder.paymentMethodLayout(
-            if (value) {
-                PaymentSheet.PaymentMethodLayout.Vertical
-            } else {
-                PaymentSheet.PaymentMethodLayout.Horizontal
-            }
-        )
+        configurationBuilder.paymentMethodLayout(value.paymentMethodLayout)
     }
+}
+
+enum class Layout(override val value: String, val paymentMethodLayout: PaymentSheet.PaymentMethodLayout) : ValueEnum {
+    HORIZONTAL("horizontal", PaymentSheet.PaymentMethodLayout.Horizontal),
+    VERTICAL("vertical", PaymentSheet.PaymentMethodLayout.Vertical),
+    AUTOMATIC("automatic", PaymentSheet.PaymentMethodLayout.Automatic),
 }

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1086,6 +1086,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfigurat
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$PaymentMethodLayout : java/lang/Enum {
+	public static final field Automatic Lcom/stripe/android/paymentsheet/PaymentSheet$PaymentMethodLayout;
 	public static final field Horizontal Lcom/stripe/android/paymentsheet/PaymentSheet$PaymentMethodLayout;
 	public static final field Vertical Lcom/stripe/android/paymentsheet/PaymentSheet$PaymentMethodLayout;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/MandateHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/MandateHandler.kt
@@ -53,7 +53,7 @@ internal class MandateHandler(
                 coroutineScope = viewModel.viewModelScope,
                 selection = viewModel.selection,
                 merchantDisplayName = viewModel.config.merchantDisplayName,
-                isVerticalMode = viewModel.config.paymentMethodLayout == PaymentMethodLayout.Vertical,
+                isVerticalMode = viewModel.config.paymentMethodLayout != PaymentMethodLayout.Horizontal,
                 isSetupFlowProvider = { viewModel.paymentMethodMetadata.value?.stripeIntent is SetupIntent },
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -295,7 +295,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
         paymentMethodMetadata: PaymentMethodMetadata,
         customerStateHolder: CustomerStateHolder,
     ): List<PaymentSheetScreen> {
-        if (config.paymentMethodLayout == PaymentSheet.PaymentMethodLayout.Vertical) {
+        if (config.paymentMethodLayout != PaymentSheet.PaymentMethodLayout.Horizontal) {
             return VerticalModeInitialScreenFactory.create(
                 viewModel = this,
                 paymentMethodMetadata = paymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -886,7 +886,12 @@ class PaymentSheet internal constructor(
          * Payment methods are arranged vertically.
          * Users can scroll up or down to navigate through different payment methods.
          */
-        Vertical;
+        Vertical,
+
+        /**
+         * This lets Stripe choose the best layout for payment methods in the sheet.
+         */
+        Automatic;
 
         internal companion object {
             internal val default: PaymentMethodLayout = Horizontal

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -680,7 +680,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         paymentMethodMetadata: PaymentMethodMetadata,
         customerStateHolder: CustomerStateHolder,
     ): List<PaymentSheetScreen> {
-        if (config.paymentMethodLayout == PaymentSheet.PaymentMethodLayout.Vertical) {
+        if (config.paymentMethodLayout != PaymentSheet.PaymentMethodLayout.Horizontal) {
             return VerticalModeInitialScreenFactory.create(
                 viewModel = this,
                 paymentMethodMetadata = paymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModelCvcHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModelCvcHelper.kt
@@ -4,14 +4,14 @@ import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 
 internal fun PaymentSheetViewModel.shouldLaunchCvcRecollectionScreen(): Boolean {
     return requiresCvcRecollection {
-        config.paymentMethodLayout == PaymentSheet.PaymentMethodLayout.Vertical &&
+        config.paymentMethodLayout != PaymentSheet.PaymentMethodLayout.Horizontal &&
             navigationHandler.currentScreen.value !is PaymentSheetScreen.CvcRecollection
     }
 }
 
 internal fun PaymentSheetViewModel.shouldAttachCvc(): Boolean {
     return requiresCvcRecollection {
-        config.paymentMethodLayout != PaymentSheet.PaymentMethodLayout.Vertical
+        config.paymentMethodLayout == PaymentSheet.PaymentMethodLayout.Horizontal
     }
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -345,6 +345,72 @@ internal class PaymentOptionsViewModelTest {
         }
 
     @Test
+    fun `currentScreen is Form if payment methods is empty and supportedPaymentMethods contains one in automatic`() =
+        runTest {
+            val viewModel = createViewModel(
+                args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(
+                    config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY.copy(
+                        paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Automatic,
+                    ),
+                    paymentMethods = listOf(),
+                    isGooglePayReady = false,
+                    linkState = null,
+                    stripeIntent = PaymentIntentFixtures.PI_WITH_PAYMENT_METHOD!!.copy(
+                        paymentMethodTypes = listOf("card")
+                    ),
+                )
+            )
+
+            viewModel.navigationHandler.currentScreen.test {
+                assertThat(awaitItem()).isInstanceOf<PaymentSheetScreen.VerticalModeForm>()
+            }
+        }
+
+    @Test
+    fun `currentScreen is VerticalMode if payment methods is not empty in automatic`() =
+        runTest {
+            val viewModel = createViewModel(
+                args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(
+                    config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY.copy(
+                        paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Automatic,
+                    ),
+                    paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+                    isGooglePayReady = false,
+                    linkState = null,
+                    stripeIntent = PaymentIntentFixtures.PI_WITH_PAYMENT_METHOD!!.copy(
+                        paymentMethodTypes = listOf("card")
+                    ),
+                )
+            )
+
+            viewModel.navigationHandler.currentScreen.test {
+                assertThat(awaitItem()).isInstanceOf<PaymentSheetScreen.VerticalMode>()
+            }
+        }
+
+    @Test
+    fun `currentScreen is VerticalMode if supportedPaymentMethods is greater than 1 in Automatic`() =
+        runTest {
+            val viewModel = createViewModel(
+                args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(
+                    config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY.copy(
+                        paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Automatic,
+                    ),
+                    paymentMethods = listOf(),
+                    isGooglePayReady = false,
+                    linkState = null,
+                    stripeIntent = PaymentIntentFixtures.PI_WITH_PAYMENT_METHOD!!.copy(
+                        paymentMethodTypes = listOf("card", "cashapp")
+                    ),
+                )
+            )
+
+            viewModel.navigationHandler.currentScreen.test {
+                assertThat(awaitItem()).isInstanceOf<PaymentSheetScreen.VerticalMode>()
+            }
+        }
+
+    @Test
     fun `onError updates error`() = runTest {
         val viewModel = createViewModel()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1460,6 +1460,48 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
+    fun `launched with correct screen when in horizontal mode`() = runTest {
+        val viewModel = createViewModel(
+            args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
+                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal
+                )
+            ),
+        )
+        viewModel.navigationHandler.currentScreen.test {
+            assertThat(awaitItem()).isInstanceOf<SelectSavedPaymentMethods>()
+        }
+    }
+
+    @Test
+    fun `launched with correct screen when in vertical mode`() = runTest {
+        val viewModel = createViewModel(
+            args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
+                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical
+                )
+            ),
+        )
+        viewModel.navigationHandler.currentScreen.test {
+            assertThat(awaitItem()).isInstanceOf<PaymentSheetScreen.VerticalMode>()
+        }
+    }
+
+    @Test
+    fun `launched with correct screen when in automatic mode`() = runTest {
+        val viewModel = createViewModel(
+            args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
+                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Automatic
+                )
+            ),
+        )
+        viewModel.navigationHandler.currentScreen.test {
+            assertThat(awaitItem()).isInstanceOf<PaymentSheetScreen.VerticalMode>()
+        }
+    }
+
+    @Test
     fun `handleBackPressed is consumed when processing is true`() = runTest {
         val viewModel = createViewModel(customer = EMPTY_CUSTOMER_STATE)
         viewModel.savedStateHandle[SAVE_PROCESSING] = true
@@ -2754,11 +2796,64 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
+    fun `requiresCvcRecollection should return correct value in automatic mode`() {
+        var viewModel = createViewModel(
+            args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
+                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Automatic
+                )
+            )
+        )
+
+        cvcRecollectionHandler.requiresCVCRecollection = true
+        assertThat(viewModel.shouldLaunchCvcRecollectionScreen()).isTrue()
+        assertThat(viewModel.shouldAttachCvc()).isFalse()
+
+        viewModel.checkout()
+        assertThat(viewModel.shouldLaunchCvcRecollectionScreen()).isFalse()
+        assertThat(viewModel.shouldAttachCvc()).isFalse()
+
+        cvcRecollectionHandler.requiresCVCRecollection = false
+        assertThat(viewModel.shouldAttachCvc()).isFalse()
+        assertThat(viewModel.shouldLaunchCvcRecollectionScreen()).isFalse()
+
+        viewModel = createViewModel()
+
+        cvcRecollectionHandler.requiresCVCRecollection = true
+        assertThat(viewModel.shouldLaunchCvcRecollectionScreen()).isFalse()
+        assertThat(viewModel.shouldAttachCvc()).isTrue()
+
+        cvcRecollectionHandler.requiresCVCRecollection = false
+        assertThat(viewModel.shouldAttachCvc()).isFalse()
+        assertThat(viewModel.shouldLaunchCvcRecollectionScreen()).isFalse()
+    }
+
+    @Test
     fun `CvcRecollection screen should be displayed on checkout when required in vertical mode`() = runTest {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
                 config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
                     paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical
+                )
+            ),
+        )
+
+        cvcRecollectionHandler.requiresCVCRecollection = true
+        cvcRecollectionHandler.cvcRecollectionEnabled = true
+        viewModel.checkout()
+
+        viewModel.navigationHandler.currentScreen.test {
+            val screen = awaitItem()
+            assertThat(screen).isInstanceOf<PaymentSheetScreen.CvcRecollection>()
+        }
+    }
+
+    @Test
+    fun `CvcRecollection screen should be displayed on checkout when required in automatic mode`() = runTest {
+        val viewModel = createViewModel(
+            args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
+                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Automatic
                 )
             ),
         )
@@ -2819,7 +2914,11 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `CvcRecollection screen should not be displayed on checkout when not required in vertical mode`() = runTest {
         val viewModel = createViewModel(
-            args = ARGS_CUSTOMER_WITH_GOOGLEPAY
+            args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
+                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical
+                )
+            ),
         )
 
         cvcRecollectionHandler.requiresCVCRecollection = false
@@ -2828,7 +2927,27 @@ internal class PaymentSheetViewModelTest {
 
         viewModel.navigationHandler.currentScreen.test {
             val screen = awaitItem()
-            assertThat(screen).isInstanceOf<SelectSavedPaymentMethods>()
+            assertThat(screen).isInstanceOf<PaymentSheetScreen.VerticalMode>()
+        }
+    }
+
+    @Test
+    fun `CvcRecollection screen should not be displayed on checkout when not required in automatic mode`() = runTest {
+        val viewModel = createViewModel(
+            args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
+                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Automatic
+                )
+            ),
+        )
+
+        cvcRecollectionHandler.requiresCVCRecollection = false
+        cvcRecollectionHandler.cvcRecollectionEnabled = true
+        viewModel.checkout()
+
+        viewModel.navigationHandler.currentScreen.test {
+            val screen = awaitItem()
+            assertThat(screen).isInstanceOf<PaymentSheetScreen.VerticalMode>()
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Adds automatic as another option to PaymentMethodLayout. Right now it maps directly to vertical. But in the future we can do A/B tests, or optimize based on SPMs + Wallets, etc.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2527

