### PR TITLE
Make FC Maestro tests more resilient

### DIFF
--- a/maestro/financial-connections/Livemode-Data-Finbank.yaml
+++ b/maestro/financial-connections/Livemode-Data-Finbank.yaml
@@ -44,6 +44,10 @@ tags:
 - assertVisible: "Your accounts were connected."
 - tapOn:
     id: "done_button"
-- assertVisible: ".*Completed!.*"
-- assertVisible: ".*FinBank.*"
+- scrollUntilVisible:
+    element:
+      text: ".*Completed!.*"
+- scrollUntilVisible:
+    element:
+      text: ".*FinBank.*"
 - stopRecording

--- a/maestro/financial-connections/Livemode-Data-MXBank.yaml
+++ b/maestro/financial-connections/Livemode-Data-MXBank.yaml
@@ -35,6 +35,10 @@ tags:
     timeout: 60000
 - tapOn:
     id: "done_button"
-- assertVisible: ".*Completed!.*"
-- assertVisible: ".*MX Bank.*"
+- scrollUntilVisible:
+    element:
+      text: ".*Completed!.*"
+- scrollUntilVisible:
+    element:
+      text: ".*MX Bank.*"
 - stopRecording

--- a/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
+++ b/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
@@ -40,5 +40,7 @@ tags:
 - scrollUntilVisible:
     element:
       text: ".*Completed!.*"
-- assertVisible: ".*StripeBank.*"
+- scrollUntilVisible:
+    element:
+      text: ".*StripeBank.*"
 - stopRecording

--- a/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
+++ b/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
@@ -40,5 +40,7 @@ tags:
 # CONFIRM AND COMPLETE
 - tapOn:
     id: "done_button"
-- assertVisible: ".*Completed!.*"
+- scrollUntilVisible:
+    element:
+      text: ".*Completed!.*"
 - stopRecording

--- a/maestro/financial-connections/disabled/Web-Testmode-Data-TestOauthInstitution.yaml
+++ b/maestro/financial-connections/disabled/Web-Testmode-Data-TestOauthInstitution.yaml
@@ -29,6 +29,10 @@ tags:
 - tapOn: "Connect accounts" # select all accounts
 # CONFIRM AND COMPLETE
 - tapOn: "Done"
-- assertVisible: ".*Completed!.*"
-- assertVisible: ".*StripeBank.*"
+- scrollUntilVisible:
+    element:
+      text: ".*Completed!.*"
+- scrollUntilVisible:
+    element:
+      text: ".*StripeBank.*"
 - stopRecording


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request attempts to make FC Maestro tests more resilient by using `scrollUntilVisible` for validating text on screen.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
