### PR TITLE
Announce error messages in TalkBack

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/ErrorMessage.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/ErrorMessage.kt
@@ -8,6 +8,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.core.content.res.ResourcesCompat
@@ -41,6 +44,8 @@ internal fun ErrorMessage(
         fontSize = fontSize,
         color = MaterialTheme.colors.error,
         fontFamily = FontFamily(typeface),
-        modifier = modifier,
+        modifier = modifier.semantics {
+            this.liveRegion = LiveRegionMode.Assertive
+        },
     )
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Announce error messages in TalkBack

Previously, the error message would not be focused on or read to users. Now, whenever an error message appears, it will be read out to the user, so they know why their PM failed.

Affects PaymentSheet (all variants) + CustomerSheet

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2164

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified