### PR TITLE
Make FlowController tests use Turbine for validating configure.

### DIFF
--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -107,6 +107,7 @@ dependencies {
     androidTestImplementation testLibs.leakCanaryInstrumentation
     androidTestImplementation testLibs.testParameterInjector
     androidTestImplementation testLibs.truth
+    androidTestImplementation testLibs.turbine
 
     androidTestUtil testLibs.testOrchestrator
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -48,9 +48,6 @@ internal class FlowControllerTest {
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        paymentOptionCallback = { paymentOption ->
-            assertThat(paymentOption?.label).endsWith("4242")
-        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -90,9 +87,6 @@ internal class FlowControllerTest {
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        paymentOptionCallback = { paymentOption ->
-            assertThat(paymentOption?.label).endsWith("4242")
-        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -133,15 +127,10 @@ internal class FlowControllerTest {
     fun testCardRelaunchesIntoFormPage(
         @TestParameter integrationType: IntegrationType,
     ) {
-        val paymentOptionCallbackCountDownLatch = CountDownLatch(1)
         runFlowControllerTest(
             networkRule = networkRule,
             integrationType = integrationType,
             callConfirmOnPaymentOptionCallback = false,
-            paymentOptionCallback = { paymentOption ->
-                assertThat(paymentOption?.label).endsWith("4242")
-                paymentOptionCallbackCountDownLatch.countDown()
-            },
             resultCallback = ::assertCompleted,
         ) { testContext ->
             networkRule.enqueue(
@@ -169,7 +158,7 @@ internal class FlowControllerTest {
             page.fillOutCardDetails()
 
             page.clickPrimaryButton()
-            assertThat(paymentOptionCallbackCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
+            assertThat(testContext.configureCallbackTurbine.awaitItem()?.label).endsWith("4242")
             composeTestRule.waitForIdle()
 
             testContext.flowController.presentPaymentOptions()
@@ -184,15 +173,10 @@ internal class FlowControllerTest {
     fun testCashappRelaunchesIntoListPageWithCashappSelected(
         @TestParameter integrationType: IntegrationType,
     ) {
-        var paymentOptionCallbackCountDownLatch = CountDownLatch(1)
         runFlowControllerTest(
             networkRule = networkRule,
             integrationType = integrationType,
             callConfirmOnPaymentOptionCallback = false,
-            paymentOptionCallback = { paymentOption ->
-                assertThat(paymentOption?.label).isEqualTo("Cash App Pay")
-                paymentOptionCallbackCountDownLatch.countDown()
-            },
             resultCallback = ::assertCompleted,
         ) { testContext ->
             networkRule.enqueue(
@@ -220,15 +204,14 @@ internal class FlowControllerTest {
             page.assertLpmSelected("cashapp")
 
             page.clickPrimaryButton()
-            assertThat(paymentOptionCallbackCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
+            assertThat(testContext.configureCallbackTurbine.awaitItem()?.label).endsWith("Cash App Pay")
             composeTestRule.waitForIdle()
 
             testContext.flowController.presentPaymentOptions()
 
             page.assertLpmSelected("cashapp")
-            paymentOptionCallbackCountDownLatch = CountDownLatch(1)
             page.clickPrimaryButton()
-            assertThat(paymentOptionCallbackCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
+            assertThat(testContext.configureCallbackTurbine.awaitItem()?.label).endsWith("Cash App Pay")
 
             testContext.markTestSucceeded()
         }
@@ -240,9 +223,6 @@ internal class FlowControllerTest {
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        paymentOptionCallback = { paymentOption ->
-            assertThat(paymentOption?.label).endsWith("4242")
-        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -290,9 +270,6 @@ internal class FlowControllerTest {
         runFlowControllerTest(
             networkRule = networkRule,
             integrationType = integrationType,
-            paymentOptionCallback = { paymentOption ->
-                assertThat(paymentOption?.label).endsWith("4242")
-            },
             resultCallback = ::assertFailed,
         ) { testContext ->
             networkRule.enqueue(
@@ -467,9 +444,6 @@ internal class FlowControllerTest {
         networkRule = networkRule,
         integrationType = integrationType,
         createIntentCallback = { _, _ -> CreateIntentResult.Success("pi_example_secret_example") },
-        paymentOptionCallback = { paymentOption ->
-            assertThat(paymentOption?.label).endsWith("4242")
-        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -544,9 +518,6 @@ internal class FlowControllerTest {
                 displayMessage = "We don't accept visa"
             )
         },
-        paymentOptionCallback = { paymentOption ->
-            assertThat(paymentOption?.label).endsWith("4242")
-        },
         resultCallback = { result ->
             assertThat(result).isInstanceOf(PaymentSheetResult.Failed::class.java)
             assertThat((result as PaymentSheetResult.Failed).error.message)
@@ -603,9 +574,6 @@ internal class FlowControllerTest {
         createIntentCallback = { _, _ ->
             CreateIntentResult.Success(PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT)
         },
-        paymentOptionCallback = { paymentOption ->
-            assertThat(paymentOption?.label).endsWith("4242")
-        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -655,9 +623,6 @@ internal class FlowControllerTest {
         networkRule = networkRule,
         integrationType = integrationType,
         createIntentCallback = { _, _ -> CreateIntentResult.Success("pi_example_secret_example") },
-        paymentOptionCallback = { paymentOption ->
-            assertThat(paymentOption?.label).endsWith("4242")
-        },
         resultCallback = { result ->
             val failureResult = result as? PaymentSheetResult.Failed
             assertThat(failureResult?.error?.message).isEqualTo(
@@ -721,9 +686,6 @@ internal class FlowControllerTest {
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        paymentOptionCallback = { paymentOption ->
-            assertThat(paymentOption?.label).endsWith("4242")
-        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -778,5 +740,7 @@ internal class FlowControllerTest {
         composeTestRule
             .onNodeWithText("Confirm")
             .performClick()
+
+        assertThat(testContext.configureCallbackTurbine.awaitItem()?.label).endsWith("4242")
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.closeSoftKeyboard
-import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.stripe.android.core.utils.urlEncode
@@ -48,9 +47,6 @@ internal class LinkTest {
     fun testSuccessfulCardPaymentWithLinkSignUp() = runProductIntegrationTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        paymentOptionCallback = { paymentOption ->
-            assertThat(paymentOption?.label).endsWith("4242")
-        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -132,12 +128,6 @@ internal class LinkTest {
         runProductIntegrationTest(
             networkRule = networkRule,
             integrationType = integrationType,
-            paymentOptionCallback = { paymentOption ->
-                assertThat(paymentOption?.label).endsWith("4242")
-
-                @Suppress("DEPRECATION")
-                assertThat(paymentOption?.drawableResourceId).isEqualTo(R.drawable.stripe_ic_paymentsheet_link)
-            },
             resultCallback = ::assertCompleted,
         ) { testContext ->
             networkRule.enqueue(
@@ -240,9 +230,6 @@ internal class LinkTest {
     fun testSuccessfulCardPaymentWithLinkSignUpAndCardBrandChoice() = runProductIntegrationTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        paymentOptionCallback = { paymentOption ->
-            assertThat(paymentOption?.label).endsWith("4242")
-        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -328,12 +315,6 @@ internal class LinkTest {
     fun testSuccessfulCardPaymentWithLinkSignUpAndLinkPassthroughMode() = runProductIntegrationTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        paymentOptionCallback = { paymentOption ->
-            assertThat(paymentOption?.label).endsWith("4242")
-
-            @Suppress("DEPRECATION")
-            assertThat(paymentOption?.drawableResourceId).isEqualTo(R.drawable.stripe_ic_paymentsheet_link)
-        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -427,12 +408,6 @@ internal class LinkTest {
         runProductIntegrationTest(
             networkRule = networkRule,
             integrationType = integrationType,
-            paymentOptionCallback = { paymentOption ->
-                assertThat(paymentOption?.label).endsWith("4242")
-
-                @Suppress("DEPRECATION")
-                assertThat(paymentOption?.drawableResourceId).isEqualTo(R.drawable.stripe_ic_paymentsheet_link)
-            },
             resultCallback = ::assertCompleted,
         ) { testContext ->
             networkRule.enqueue(
@@ -542,12 +517,6 @@ internal class LinkTest {
     fun testSuccessfulCardPaymentWithLinkSignUpPassthroughModeAndCardBrandChoice() = runProductIntegrationTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        paymentOptionCallback = { paymentOption ->
-            assertThat(paymentOption?.label).endsWith("1001")
-
-            @Suppress("DEPRECATION")
-            assertThat(paymentOption?.drawableResourceId).isEqualTo(R.drawable.stripe_ic_paymentsheet_link)
-        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -645,9 +614,6 @@ internal class LinkTest {
     fun testSuccessfulCardPaymentWithLinkSignUpFailure() = runProductIntegrationTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        paymentOptionCallback = { paymentOption ->
-            assertThat(paymentOption?.label).endsWith("4242")
-        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -704,9 +670,6 @@ internal class LinkTest {
     fun testSuccessfulCardPaymentWithLinkSignUpFailureInPassthroughMode() = runProductIntegrationTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        paymentOptionCallback = { paymentOption ->
-            assertThat(paymentOption?.label).endsWith("4242")
-        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -763,9 +726,6 @@ internal class LinkTest {
     fun testSuccessfulCardPaymentWithLinkSignUpShareFailureInPassthroughMode() = runProductIntegrationTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        paymentOptionCallback = { paymentOption ->
-            assertThat(paymentOption?.label).endsWith("4242")
-        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -829,9 +789,6 @@ internal class LinkTest {
     fun testSuccessfulCardPaymentWithExistingLinkEmailUsed() = runProductIntegrationTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        paymentOptionCallback = { paymentOption ->
-            assertThat(paymentOption?.label).endsWith("4242")
-        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -880,9 +837,6 @@ internal class LinkTest {
     fun testSuccessfulCardPaymentWithLinkPreviouslyUsed() = runProductIntegrationTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        paymentOptionCallback = { paymentOption ->
-            assertThat(paymentOption?.label).endsWith("4242")
-        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -914,9 +868,6 @@ internal class LinkTest {
     fun testLogoutAfterLinkTransaction() = runProductIntegrationTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        paymentOptionCallback = { paymentOption ->
-            assertThat(paymentOption?.label).endsWith("4242")
-        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -996,9 +947,6 @@ internal class LinkTest {
     fun testSuccessfulCardPaymentWithLinkSignUpWithAlbaniaPhoneNumber() = runProductIntegrationTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        paymentOptionCallback = { paymentOption ->
-            assertThat(paymentOption?.label).endsWith("4242")
-        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
@@ -120,9 +120,6 @@ internal class PaymentSheetAnalyticsTest {
     @Test
     fun testSuccessfulCardPaymentInFlowController() = runFlowControllerTest(
         networkRule = networkRule,
-        paymentOptionCallback = { paymentOption ->
-            assertThat(paymentOption?.label).endsWith("4242")
-        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -247,9 +244,6 @@ internal class PaymentSheetAnalyticsTest {
     @Test
     fun testSuccessfulCardPaymentInFlowControllerInVerticalMode() = runFlowControllerTest(
         networkRule = networkRule,
-        paymentOptionCallback = { paymentOption ->
-            assertThat(paymentOption?.label).endsWith("4242")
-        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestFactory.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestFactory.kt
@@ -2,17 +2,18 @@ package com.stripe.android.paymentsheet.utils
 
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import app.cash.turbine.Turbine
 import com.stripe.android.paymentsheet.CreateIntentCallback
-import com.stripe.android.paymentsheet.PaymentOptionCallback
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
+import com.stripe.android.paymentsheet.model.PaymentOption
 import com.stripe.android.paymentsheet.rememberPaymentSheetFlowController
 
 internal class FlowControllerTestFactory(
     private val callConfirmOnPaymentOptionCallback: Boolean,
     private val integrationType: IntegrationType,
     private val createIntentCallback: CreateIntentCallback? = null,
-    private val paymentOptionCallback: PaymentOptionCallback,
+    private val configureCallbackTurbine: Turbine<PaymentOption?>,
     private val resultCallback: PaymentSheetResultCallback,
 ) {
 
@@ -29,7 +30,7 @@ internal class FlowControllerTestFactory(
             PaymentSheet.FlowController.create(
                 activity = activity,
                 paymentOptionCallback = { paymentOption ->
-                    paymentOptionCallback.onPaymentOption(paymentOption)
+                    configureCallbackTurbine.add(paymentOption)
                     if (callConfirmOnPaymentOptionCallback) {
                         flowController.confirm()
                     }
@@ -41,7 +42,7 @@ internal class FlowControllerTestFactory(
             PaymentSheet.FlowController.create(
                 activity = activity,
                 paymentOptionCallback = { paymentOption ->
-                    paymentOptionCallback.onPaymentOption(paymentOption)
+                    configureCallbackTurbine.add(paymentOption)
                     if (callConfirmOnPaymentOptionCallback) {
                         flowController.confirm()
                     }
@@ -59,7 +60,7 @@ internal class FlowControllerTestFactory(
                 rememberPaymentSheetFlowController(
                     createIntentCallback = createIntentCallback,
                     paymentOptionCallback = { paymentOption ->
-                        paymentOptionCallback.onPaymentOption(paymentOption)
+                        configureCallbackTurbine.add(paymentOption)
                         if (callConfirmOnPaymentOptionCallback) {
                             flowController.confirm()
                         }
@@ -69,7 +70,7 @@ internal class FlowControllerTestFactory(
             } else {
                 rememberPaymentSheetFlowController(
                     paymentOptionCallback = { paymentOption ->
-                        paymentOptionCallback.onPaymentOption(paymentOption)
+                        configureCallbackTurbine.add(paymentOption)
                         if (callConfirmOnPaymentOptionCallback) {
                             flowController.confirm()
                         }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ProductIntegrationTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ProductIntegrationTestRunner.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet.utils
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.paymentsheet.CreateIntentCallback
-import com.stripe.android.paymentsheet.PaymentOptionCallback
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
 
@@ -11,7 +10,6 @@ internal fun runProductIntegrationTest(
     networkRule: NetworkRule,
     integrationType: ProductIntegrationType,
     createIntentCallback: CreateIntentCallback? = null,
-    paymentOptionCallback: PaymentOptionCallback,
     resultCallback: PaymentSheetResultCallback,
     block: (ProductIntegrationTestRunnerContext) -> Unit,
 ) {
@@ -31,7 +29,6 @@ internal fun runProductIntegrationTest(
                 networkRule = networkRule,
                 integrationType = IntegrationType.Compose,
                 createIntentCallback = createIntentCallback,
-                paymentOptionCallback = paymentOptionCallback,
                 resultCallback = resultCallback,
                 block = { context ->
                     block(ProductIntegrationTestRunnerContext.WithFlowController(context))
@@ -69,7 +66,7 @@ internal sealed interface ProductIntegrationTestRunnerContext {
     }
 
     class WithFlowController(
-        private val context: FlowControllerTestRunnerContext
+        val context: FlowControllerTestRunnerContext
     ) : ProductIntegrationTestRunnerContext {
         override fun launch(configuration: PaymentSheet.Configuration) {
             context.configureFlowController {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
These tests were quite confusing before, acting like they were validating the configure callback was indeed called, when in fact it wouldn't be.

I'm trying to add some more tests in #9359 where using a turbine would be a much cleaner solution. So doing this as pre work for that.
