### PR TITLE
Return `CustomerEphemeralKey.Available` directly rather than have consumers handle it.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CachedCustomerEphemeralKey.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CachedCustomerEphemeralKey.kt
@@ -23,14 +23,3 @@ internal sealed interface CachedCustomerEphemeralKey {
         }
     }
 }
-
-internal fun <T> Result<CachedCustomerEphemeralKey>.mapWithEphemeralKeyCatching(
-    mapper: (customerId: String, ephemeralKey: String) -> T
-): Result<T> {
-    return mapCatching { cachedKey ->
-        when (cachedKey) {
-            is CachedCustomerEphemeralKey.Available -> mapper(cachedKey.customerId, cachedKey.ephemeralKey)
-            is CachedCustomerEphemeralKey.None -> throw IllegalStateException("No ephemeral key was available!")
-        }
-    }
-}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
@@ -42,8 +42,8 @@ internal class CustomerSessionSavedSelectionDataSource @Inject constructor(
     }
 
     private suspend fun createPrefsRepository(): CustomerSheetDataResult<PrefsRepository> {
-        return elementsSessionManager.fetchCustomerSessionEphemeralKey().mapWithEphemeralKeyCatching { customerId, _ ->
-            prefsRepositoryFactory(customerId)
+        return elementsSessionManager.fetchCustomerSessionEphemeralKey().mapCatching { ephemeralKey ->
+            prefsRepositoryFactory(ephemeralKey.customerId)
         }.toCustomerSheetDataResult()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSessionElementsSessionManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSessionElementsSessionManager.kt
@@ -3,7 +3,7 @@ package com.stripe.android.customersheet.data
 import com.stripe.android.model.ElementsSession
 
 internal class FakeCustomerSessionElementsSessionManager(
-    private val ephemeralKey: Result<CachedCustomerEphemeralKey> = Result.success(
+    private val ephemeralKey: Result<CachedCustomerEphemeralKey.Available> = Result.success(
         CachedCustomerEphemeralKey.Available(
             customerId = "cus_1",
             ephemeralKey = "ek_123",
@@ -11,7 +11,7 @@ internal class FakeCustomerSessionElementsSessionManager(
         )
     ),
 ) : CustomerSessionElementsSessionManager {
-    override suspend fun fetchCustomerSessionEphemeralKey(): Result<CachedCustomerEphemeralKey> {
+    override suspend fun fetchCustomerSessionEphemeralKey(): Result<CachedCustomerEphemeralKey.Available> {
         return ephemeralKey
     }
 


### PR DESCRIPTION
# Summary
Return `CustomerEphemeralKey.Available` directly rather than have consumers handle it in `CachedCustomerEphemeralKey`

# Motivation
Ensures only an available key is returned to the caller.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
