### PR TITLE
Remove unnecessary `expected_payment_method_type` param

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -2228,7 +2228,6 @@ public final class com/stripe/android/model/ConfirmPaymentIntentParams : com/str
 	public final fun component12 ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;
 	public final fun component13 ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;
 	public final fun component14 ()Ljava/lang/String;
-	public final fun component15 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Lcom/stripe/android/model/SourceParams;
 	public final fun component4 ()Ljava/lang/String;
@@ -2236,8 +2235,8 @@ public final class com/stripe/android/model/ConfirmPaymentIntentParams : com/str
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Ljava/lang/Boolean;
 	public final fun component9 ()Lcom/stripe/android/model/PaymentMethodOptionsParams;
-	public final fun copy (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/ConfirmPaymentIntentParams;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun copy (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/ConfirmPaymentIntentParams;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun create (Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun create (Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun create (Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
@@ -2380,9 +2379,8 @@ public final class com/stripe/android/model/ConfirmSetupIntentParams : com/strip
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Lcom/stripe/android/model/MandateDataParams;
-	public final fun component8 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLjava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/ConfirmSetupIntentParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLjava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLjava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/ConfirmSetupIntentParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLjava/lang/String;Lcom/stripe/android/model/MandateDataParams;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;

--- a/payments-core/src/main/java/com/stripe/android/ConfirmStripeIntentParamsFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/ConfirmStripeIntentParamsFactory.kt
@@ -20,7 +20,6 @@ sealed class ConfirmStripeIntentParamsFactory<out T : ConfirmStripeIntentParams>
     abstract fun create(
         paymentMethodId: String,
         paymentMethodType: PaymentMethod.Type?,
-        expectedLinkPaymentMethodType: String?,
         optionsParams: PaymentMethodOptionsParams?,
     ): T
 
@@ -36,7 +35,6 @@ sealed class ConfirmStripeIntentParamsFactory<out T : ConfirmStripeIntentParams>
         return create(
             paymentMethodId = paymentMethod.id.orEmpty(),
             paymentMethodType = paymentMethod.type,
-            expectedLinkPaymentMethodType = null,
             optionsParams = optionsParams,
         )
     }
@@ -69,7 +67,6 @@ internal class ConfirmPaymentIntentParamsFactory(
     override fun create(
         paymentMethodId: String,
         paymentMethodType: PaymentMethod.Type?,
-        expectedLinkPaymentMethodType: String?,
         optionsParams: PaymentMethodOptionsParams?,
     ): ConfirmPaymentIntentParams {
         return ConfirmPaymentIntentParams.createWithPaymentMethodId(
@@ -79,8 +76,6 @@ internal class ConfirmPaymentIntentParamsFactory(
             mandateData = MandateDataParams(MandateDataParams.Type.Online.DEFAULT)
                 .takeIf { paymentMethodType?.requiresMandate == true },
             shipping = shipping
-        ).copy(
-            expectedPaymentMethodType = expectedLinkPaymentMethodType
         )
     }
 
@@ -104,7 +99,6 @@ internal class ConfirmSetupIntentParamsFactory(
     override fun create(
         paymentMethodId: String,
         paymentMethodType: PaymentMethod.Type?,
-        expectedLinkPaymentMethodType: String?,
         optionsParams: PaymentMethodOptionsParams?,
     ): ConfirmSetupIntentParams {
         return ConfirmSetupIntentParams.create(
@@ -113,8 +107,6 @@ internal class ConfirmSetupIntentParamsFactory(
             mandateData = paymentMethodType?.requiresMandate?.let {
                 MandateDataParams(MandateDataParams.Type.Online.DEFAULT)
             }
-        ).copy(
-            expectedPaymentMethodType = expectedLinkPaymentMethodType
         )
     }
 

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
-import androidx.annotation.RestrictTo
 import com.stripe.android.model.ConfirmPaymentIntentParams.SetupFutureUsage
 import com.stripe.android.model.ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
 import com.stripe.android.model.ConfirmPaymentIntentParams.SetupFutureUsage.OnSession
@@ -118,12 +117,6 @@ data class ConfirmPaymentIntentParams internal constructor(
      * See [receipt_email](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-receipt_email).
      */
     var receiptEmail: String? = null,
-
-    /**
-     * Internal field to represent the expected payment method type when using the Link Card Brand.
-     */
-    @field:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    var expectedPaymentMethodType: String? = null,
 ) : ConfirmStripeIntentParams {
     fun shouldSavePaymentMethod(): Boolean {
         return savePaymentMethod == true

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.model
 
-import androidx.annotation.RestrictTo
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_SECRET
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_MANDATE_DATA
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_MANDATE_ID
@@ -46,12 +45,6 @@ data class ConfirmSetupIntentParams internal constructor(
      * See [mandate_data](https://stripe.com/docs/api/setup_intents/confirm#confirm_setup_intent-mandate_data).
      */
     var mandateData: MandateDataParams? = null,
-
-    /**
-     * Internal field to represent the expected payment method type when using the Link Card Brand.
-     */
-    @field:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    var expectedPaymentMethodType: String? = null,
 ) : ConfirmStripeIntentParams {
 
     override fun shouldUseStripeSdk(): Boolean {

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -322,12 +322,6 @@ data class PaymentMethodCreateParams internal constructor(
         return linkParams["payment_method_id"] as? String
     }
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    fun expectedPaymentMethodType(): String? {
-        val linkParams = (toParamMap()["link"] as? Map<*, *>) ?: return null
-        return linkParams["expected_payment_method_type"] as? String
-    }
-
     @Parcelize
     data class Card
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -1314,7 +1308,6 @@ data class PaymentMethodCreateParams internal constructor(
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet
         fun createInstantDebits(
             paymentMethodId: String,
-            expectedPaymentMethodType: String?,
             requiresMandate: Boolean,
             productUsage: Set<String>,
         ): PaymentMethodCreateParams {
@@ -1324,7 +1317,6 @@ data class PaymentMethodCreateParams internal constructor(
                 overrideParamMap = mapOf(
                     "link" to mapOf(
                         "payment_method_id" to paymentMethodId,
-                        "expected_payment_method_type" to expectedPaymentMethodType,
                     ),
                 ),
                 productUsage = productUsage,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptor.kt
@@ -385,7 +385,6 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
             paramsFactory.create(
                 paymentMethodId = linkBankPaymentMethodId,
                 paymentMethodType = PaymentMethod.Type.Link,
-                expectedLinkPaymentMethodType = paymentMethodCreateParams.expectedPaymentMethodType(),
                 optionsParams = paymentMethodOptionsParams,
             )
         } else {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -563,7 +563,6 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
             is ResultIdentifier.PaymentMethod -> {
                 PaymentMethodCreateParams.createInstantDebits(
                     paymentMethodId = resultIdentifier.id,
-                    expectedPaymentMethodType = args.linkMode?.expectedPaymentMethodType,
                     requiresMandate = true,
                     productUsage = setOf("PaymentSheet"),
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
@@ -578,7 +578,6 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethodId = paymentMethodId,
             requiresMandate = false,
             productUsage = emptySet(),
-            expectedPaymentMethodType = null,
         )
 
         val nextStep = interceptor.intercept(
@@ -619,7 +618,6 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethodId = paymentMethodId,
             requiresMandate = false,
             productUsage = emptySet(),
-            expectedPaymentMethodType = "card",
         )
 
         val nextStep = interceptor.intercept(
@@ -634,8 +632,6 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethodId = paymentMethodId,
             clientSecret = clientSecret,
             mandateData = MandateDataParams(MandateDataParams.Type.Online.DEFAULT),
-        ).copy(
-            expectedPaymentMethodType = "card",
         )
 
         assertThat(nextStep).isEqualTo(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request removes an unnecessary field added in https://github.com/stripe/stripe-android/pull/9320.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
