### PR TITLE
Add `CustomerSessionIntentDataSource`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionIntentDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionIntentDataSource.kt
@@ -1,11 +1,20 @@
 package com.stripe.android.customersheet.data
 
+import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
 import javax.inject.Inject
 
-internal class CustomerSessionIntentDataSource @Inject constructor() : CustomerSheetIntentDataSource {
+@OptIn(ExperimentalCustomerSheetApi::class, ExperimentalCustomerSessionApi::class)
+internal class CustomerSessionIntentDataSource @Inject constructor(
+    private val elementsSessionManager: CustomerSessionElementsSessionManager,
+    private val customerSessionProvider: CustomerSheet.CustomerSessionProvider,
+) : CustomerSheetIntentDataSource {
     override val canCreateSetupIntents: Boolean = true
 
     override suspend fun retrieveSetupIntentClientSecret(): CustomerSheetDataResult<String> {
-        throw NotImplementedError("Not implemented yet!")
+        return elementsSessionManager.fetchCustomerSessionEphemeralKey().mapCatching { ephemeralKey ->
+            customerSessionProvider.provideSetupIntentClientSecret(ephemeralKey.customerId).getOrThrow()
+        }.toCustomerSheetDataResult()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionIntentDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionIntentDataSourceTest.kt
@@ -1,0 +1,95 @@
+package com.stripe.android.customersheet.data
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.customersheet.utils.FakeCustomerSessionProvider
+import com.stripe.android.isInstanceOf
+import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalCustomerSheetApi::class, ExperimentalCustomerSessionApi::class)
+class CustomerSessionIntentDataSourceTest {
+    @Test
+    fun `on can create setup intents, should return true`() {
+        val dataSource = createIntentDataSource()
+
+        assertThat(dataSource.canCreateSetupIntents).isTrue()
+    }
+
+    @Test
+    fun `on provide setup intent secret, should return secret from customer session provider`() = runTest {
+        val dataSource = createIntentDataSource(
+            customerSessionProvider = FakeCustomerSessionProvider(
+                onProvideSetupIntentClientSecret = {
+                    Result.success("seti_123_secret_123")
+                }
+            ),
+        )
+
+        val result = dataSource.retrieveSetupIntentClientSecret()
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<String>>()
+
+        val successResult = result.asSuccess()
+
+        assertThat(successResult.value).isEqualTo("seti_123_secret_123")
+    }
+
+    @Test
+    fun `on provide setup intent client secret, should fail if secret retrieval from provider fails`() = runTest {
+        val exception = IllegalStateException("Failed to provide secret!")
+        val dataSource = createIntentDataSource(
+            customerSessionProvider = FakeCustomerSessionProvider(
+                onProvideSetupIntentClientSecret = {
+                    Result.failure(exception)
+                }
+            ),
+        )
+
+        val result = dataSource.retrieveSetupIntentClientSecret()
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<String>>()
+
+        val failedResult = result.asFailure()
+
+        assertThat(failedResult.cause).isEqualTo(exception)
+    }
+
+    @Test
+    fun `on provide setup intent client secret, should fail if ephemeral key fetch fails`() = runTest {
+        val exception = IllegalStateException("Failed to provide ephemeral key!")
+        val dataSource = createIntentDataSource(
+            elementsSessionManager = FakeCustomerSessionElementsSessionManager(
+                ephemeralKey = Result.failure(exception)
+            )
+        )
+
+        val result = dataSource.retrieveSetupIntentClientSecret()
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<String>>()
+
+        val failedResult = result.asFailure()
+
+        assertThat(failedResult.cause).isEqualTo(exception)
+    }
+
+    private fun createIntentDataSource(
+        elementsSessionManager: CustomerSessionElementsSessionManager = FakeCustomerSessionElementsSessionManager(),
+        customerSessionProvider: CustomerSheet.CustomerSessionProvider = FakeCustomerSessionProvider()
+    ): CustomerSheetIntentDataSource {
+        return CustomerSessionIntentDataSource(
+            elementsSessionManager = elementsSessionManager,
+            customerSessionProvider = customerSessionProvider,
+        )
+    }
+
+    private fun <T> CustomerSheetDataResult<T>.asSuccess(): CustomerSheetDataResult.Success<T> {
+        return this as CustomerSheetDataResult.Success<T>
+    }
+
+    private fun <T> CustomerSheetDataResult<T>.asFailure(): CustomerSheetDataResult.Failure<T> {
+        return this as CustomerSheetDataResult.Failure<T>
+    }
+}


### PR DESCRIPTION
# Summary
Add `CustomerSessionIntentDataSource`

# Motivation
Allows for intents to be created with `CustomerSheet` when using `CustomerSession`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
