### PR TITLE
Add fraud detection in FC module

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.Logger
+import com.stripe.android.core.frauddetection.FraudDetectionDataRepository
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.StripeNetworkClient
 import com.stripe.android.core.version.StripeSdkVersion
@@ -125,6 +126,7 @@ internal interface FinancialConnectionsSheetNativeModule {
             locale: Locale?,
             logger: Logger,
             isLinkWithStripe: IsLinkWithStripe,
+            fraudDetectionDataRepository: FraudDetectionDataRepository,
         ) = FinancialConnectionsConsumerSessionRepository(
             financialConnectionsConsumersApiService = financialConnectionsConsumersApiService,
             provideApiRequestOptions = provideApiRequestOptions,
@@ -133,6 +135,7 @@ internal interface FinancialConnectionsSheetNativeModule {
             locale = locale ?: Locale.getDefault(),
             logger = logger,
             isLinkWithStripe = isLinkWithStripe,
+            fraudDetectionDataRepository = fraudDetectionDataRepository,
         )
 
         @Singleton

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
@@ -3,6 +3,7 @@ package com.stripe.android.financialconnections.di
 import android.app.Application
 import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.Logger
+import com.stripe.android.core.frauddetection.FraudDetectionDataRepository
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
@@ -33,6 +34,7 @@ import com.stripe.android.financialconnections.repository.ConsumerSessionReposit
 import com.stripe.android.financialconnections.repository.FinancialConnectionsRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsRepositoryImpl
 import com.stripe.android.financialconnections.repository.RealConsumerSessionRepository
+import com.stripe.android.financialconnections.utils.DefaultFraudDetectionDataRepository
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -182,6 +184,13 @@ internal interface FinancialConnectionsSheetSharedModule {
         @Singleton
         internal fun providesIoDispatcher(): CoroutineDispatcher {
             return Dispatchers.IO
+        }
+
+        @Provides
+        internal fun provideFraudDetectionDataRepository(
+            application: Application,
+        ): FraudDetectionDataRepository {
+            return DefaultFraudDetectionDataRepository(application)
         }
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/FinancialConnectionsFraudDetectionRepositoryFactory.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/FinancialConnectionsFraudDetectionRepositoryFactory.kt
@@ -1,0 +1,23 @@
+package com.stripe.android.financialconnections.utils
+
+import android.app.Application
+import com.stripe.android.core.frauddetection.DefaultFraudDetectionDataRepository
+import com.stripe.android.core.frauddetection.DefaultFraudDetectionDataRequestFactory
+import com.stripe.android.core.frauddetection.DefaultFraudDetectionDataStore
+import com.stripe.android.core.networking.DefaultStripeNetworkClient
+import kotlinx.coroutines.Dispatchers
+
+internal fun DefaultFraudDetectionDataRepository(
+    application: Application,
+): DefaultFraudDetectionDataRepository {
+    val workContext = Dispatchers.IO
+
+    return DefaultFraudDetectionDataRepository(
+        localStore = DefaultFraudDetectionDataStore(application, workContext),
+        fraudDetectionDataRequestFactory = DefaultFraudDetectionDataRequestFactory(application),
+        stripeNetworkClient = DefaultStripeNetworkClient(workContext = workContext),
+        errorReporter = { /* No-op */ },
+        workContext = workContext,
+        fraudDetectionEnabledProvider = { true },
+    )
+}

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepositoryImplTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepositoryImplTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.financialconnections.repository
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
+import com.stripe.android.core.frauddetection.FraudDetectionDataRepository
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.StripeNetworkClient
 import com.stripe.android.core.networking.StripeResponse
@@ -24,6 +25,7 @@ class FinancialConnectionsRepositoryImplTest {
 
     private val mockStripeNetworkClient = mock<StripeNetworkClient>()
     private val apiRequestFactory = ApiRequest.Factory()
+    private val fraudDetectionDataRepository = mock<FraudDetectionDataRepository>()
 
     private val financialConnectionsRepositoryImpl = FinancialConnectionsRepositoryImpl(
         requestExecutor = FinancialConnectionsRequestExecutor(
@@ -36,6 +38,7 @@ class FinancialConnectionsRepositoryImplTest {
             ApiRequest.Options(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
         },
         apiRequestFactory = apiRequestFactory,
+        fraudDetectionDataRepository = fraudDetectionDataRepository,
     )
 
     @Test

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -22,7 +22,6 @@ import com.stripe.android.core.exception.PermissionException
 import com.stripe.android.core.exception.RateLimitException
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.exception.safeAnalyticsMessage
-import com.stripe.android.core.frauddetection.DefaultFraudDetectionDataRepository
 import com.stripe.android.core.frauddetection.FraudDetectionData
 import com.stripe.android.core.frauddetection.FraudDetectionDataParamsUtils
 import com.stripe.android.core.frauddetection.FraudDetectionDataRepository

--- a/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
+++ b/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
@@ -84,6 +84,7 @@ interface ConsumersApiService {
         expectedPaymentMethodType: String,
         requestSurface: String,
         requestOptions: ApiRequest.Options,
+        extraParams: Map<String, Any?>,
     ): Result<SharePaymentDetails>
 }
 
@@ -277,7 +278,8 @@ class ConsumersApiServiceImpl(
         paymentDetailsId: String,
         expectedPaymentMethodType: String,
         requestSurface: String,
-        requestOptions: ApiRequest.Options
+        requestOptions: ApiRequest.Options,
+        extraParams: Map<String, Any?>,
     ): Result<SharePaymentDetails> {
         return executeRequestWithResultParser(
             stripeErrorJsonParser = stripeErrorJsonParser,
@@ -292,7 +294,7 @@ class ConsumersApiServiceImpl(
                     "credentials" to mapOf(
                         "consumer_session_client_secret" to consumerSessionClientSecret
                     ),
-                )
+                ) + extraParams,
             ),
             responseJsonParser = SharePaymentDetailsJsonParser,
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds fraud detection data to `PaymentMethod`-related API calls in the Financial Connections module, namely the calls to `/payment_methods` and `/payment_details/share`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[BANKCON-15002](https://jira.corp.stripe.com/browse/BANKCON-15002)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
