### PR TITLE
Add `CustomerSessionClientSecret` validation & remodel `ElementsSessionManager` response.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -207,7 +207,10 @@ interface ErrorReporter {
         ),
         CUSTOMER_SHEET_ATTACH_CALLED_WITH_CUSTOMER_SESSION(
             partialEventName = "customersheet.customer_session.attach_called"
-        )
+        ),
+        CUSTOMER_SESSION_ON_CUSTOMER_SHEET_ELEMENTS_SESSION_NO_CUSTOMER_FIELD(
+            partialEventName = "customersheet.customer_session.elements_session.no_customer_field"
+        ),
         ;
 
         override val eventName: String

--- a/paymentsheet/src/main/java/com/stripe/android/common/validation/CustomerSessionClientSecretValidator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/validation/CustomerSessionClientSecretValidator.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.common.validation
+
+internal object CustomerSessionClientSecretValidator {
+    private const val EPHEMERAL_KEY_SECRET_PREFIX = "ek_"
+    private const val CUSTOMER_SESSION_CLIENT_SECRET_KEY_PREFIX = "cuss_"
+
+    sealed interface Result {
+        data object Valid : Result
+
+        sealed interface Error : Result {
+            data object Empty : Result
+
+            data object LegacyEphemeralKey : Result
+
+            data object UnknownKey : Result
+        }
+    }
+
+    fun validate(customerSessionClientSecret: String): Result {
+        return when {
+            customerSessionClientSecret.isBlank() ->
+                Result.Error.Empty
+            customerSessionClientSecret.startsWith(EPHEMERAL_KEY_SECRET_PREFIX) ->
+                Result.Error.LegacyEphemeralKey
+            !customerSessionClientSecret.startsWith(CUSTOMER_SESSION_CLIENT_SECRET_KEY_PREFIX) ->
+                Result.Error.UnknownKey
+            else -> Result.Valid
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CachedCustomerEphemeralKey.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CachedCustomerEphemeralKey.kt
@@ -3,23 +3,13 @@ package com.stripe.android.customersheet.data
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 
-internal sealed interface CachedCustomerEphemeralKey {
-    fun shouldRefresh(currentTimeInMillis: Long): Boolean
-
-    data class Available(
-        val customerId: String,
-        val ephemeralKey: String,
-        private val expiresAt: Int,
-    ) : CachedCustomerEphemeralKey {
-        override fun shouldRefresh(currentTimeInMillis: Long): Boolean {
-            val remainingTime = expiresAt - currentTimeInMillis.milliseconds.inWholeSeconds
-            return remainingTime <= 5.minutes.inWholeSeconds
-        }
-    }
-
-    data object None : CachedCustomerEphemeralKey {
-        override fun shouldRefresh(currentTimeInMillis: Long): Boolean {
-            return true
-        }
+internal data class CachedCustomerEphemeralKey(
+    val customerId: String,
+    val ephemeralKey: String,
+    private val expiresAt: Int,
+) {
+    fun shouldRefresh(currentTimeInMillis: Long): Boolean {
+        val remainingTime = expiresAt - currentTimeInMillis.milliseconds.inWholeSeconds
+        return remainingTime <= 5.minutes.inWholeSeconds
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
@@ -4,12 +4,14 @@ import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.model.ElementsSession
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import kotlinx.coroutines.withContext
+import java.lang.IllegalArgumentException
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
@@ -17,8 +19,13 @@ import kotlin.coroutines.CoroutineContext
 internal interface CustomerSessionElementsSessionManager {
     suspend fun fetchCustomerSessionEphemeralKey(): Result<CachedCustomerEphemeralKey.Available>
 
-    suspend fun fetchElementsSession(): Result<ElementsSession>
+    suspend fun fetchElementsSession(): Result<ElementsSessionWithCustomer>
 }
+
+internal data class ElementsSessionWithCustomer(
+    val elementsSession: ElementsSession,
+    val customer: ElementsSession.Customer,
+)
 
 @OptIn(ExperimentalCustomerSheetApi::class, ExperimentalCustomerSessionApi::class)
 @Singleton
@@ -26,6 +33,7 @@ internal class DefaultCustomerSessionElementsSessionManager @Inject constructor(
     private val elementsSessionRepository: ElementsSessionRepository,
     private val prefsRepositoryFactory: @JvmSuppressWildcards (String) -> PrefsRepository,
     private val customerSessionProvider: CustomerSheet.CustomerSessionProvider,
+    private val errorReporter: ErrorReporter,
     private val timeProvider: () -> Long,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSessionElementsSessionManager {
@@ -55,7 +63,7 @@ internal class DefaultCustomerSessionElementsSessionManager @Inject constructor(
         }
     }
 
-    override suspend fun fetchElementsSession(): Result<ElementsSession> {
+    override suspend fun fetchElementsSession(): Result<ElementsSessionWithCustomer> {
         return withContext(workContext) {
             runCatching {
                 val intentConfiguration = intentConfiguration
@@ -66,6 +74,8 @@ internal class DefaultCustomerSessionElementsSessionManager @Inject constructor(
                 val customerSessionClientSecret = customerSessionProvider
                     .providesCustomerSessionClientSecret()
                     .getOrThrow()
+
+                validateCustomerSessionClientSecret(customerSessionClientSecret.clientSecret)
 
                 val prefsRepository = prefsRepositoryFactory(customerSessionClientSecret.customerId)
 
@@ -87,16 +97,59 @@ internal class DefaultCustomerSessionElementsSessionManager @Inject constructor(
                         clientSecret = customerSessionClientSecret.clientSecret,
                     ),
                     externalPaymentMethods = listOf(),
-                ).onSuccess { elementsSession ->
-                    elementsSession.customer?.session?.run {
-                        cachedCustomerEphemeralKey = CachedCustomerEphemeralKey.Available(
-                            customerId = customerId,
-                            ephemeralKey = apiKey,
-                            expiresAt = apiKeyExpiry,
+                ).mapCatching { elementsSession ->
+                    val customer = elementsSession.customer ?: run {
+                        errorReporter.report(
+                            ErrorReporter
+                                .UnexpectedErrorEvent
+                                .CUSTOMER_SESSION_ON_CUSTOMER_SHEET_ELEMENTS_SESSION_NO_CUSTOMER_FIELD
+                        )
+
+                        throw IllegalStateException(
+                            "`customer` field should be available when using `CustomerSession` in elements/session!"
                         )
                     }
+
+                    ElementsSessionWithCustomer(
+                        elementsSession = elementsSession,
+                        customer = customer
+                    )
+                }.onSuccess { elementsSessionWithCustomer ->
+                    val customerSession = elementsSessionWithCustomer.customer.session
+
+                    cachedCustomerEphemeralKey = CachedCustomerEphemeralKey.Available(
+                        customerId = customerSession.customerId,
+                        ephemeralKey = customerSession.apiKey,
+                        expiresAt = customerSession.apiKeyExpiry,
+                    )
                 }.getOrThrow()
             }
         }
+    }
+
+    private fun validateCustomerSessionClientSecret(customerSessionClientSecret: String) {
+        val error = when {
+            customerSessionClientSecret.isBlank() -> {
+                "The 'customerSessionClientSecret' cannot be an empty string."
+            }
+            customerSessionClientSecret.startsWith(EPHEMERAL_KEY_SECRET_PREFIX) -> {
+                "Provided secret looks like an Ephemeral Key secret, but expecting a CustomerSession client " +
+                    "secret. See CustomerSession API: https://docs.stripe.com/api/customer_sessions/create"
+            }
+            !customerSessionClientSecret.startsWith(CUSTOMER_SESSION_CLIENT_SECRET_KEY_PREFIX) -> {
+                "Provided secret does not look like a CustomerSession client secret. " +
+                    "See CustomerSession API: https://docs.stripe.com/api/customer_sessions/create"
+            }
+            else -> null
+        }
+
+        error?.let {
+            throw IllegalArgumentException(it)
+        }
+    }
+
+    private companion object {
+        const val EPHEMERAL_KEY_SECRET_PREFIX = "ek_"
+        const val CUSTOMER_SESSION_CLIENT_SECRET_KEY_PREFIX = "cuss_"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
@@ -17,11 +17,8 @@ internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
 ) : CustomerSheetPaymentMethodDataSource {
     override suspend fun retrievePaymentMethods(): CustomerSheetDataResult<List<PaymentMethod>> {
         return withContext(workContext) {
-            elementsSessionManager.fetchElementsSession().mapCatching { elementsSession ->
-                elementsSession.customer?.paymentMethods
-                    ?: throw IllegalStateException(
-                        "`CustomerSession` should contain payment methods in `elements/session` response!"
-                    )
+            elementsSessionManager.fetchElementsSession().mapCatching { elementsSessionWithCustomer ->
+                elementsSessionWithCustomer.customer.paymentMethods
             }.toCustomerSheetDataResult()
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
@@ -2,14 +2,12 @@ package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
-import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentMethodFactory
-import com.stripe.android.testing.SetupIntentFactory
 import com.stripe.android.utils.FakeCustomerRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -32,38 +30,6 @@ class CustomerSessionPaymentMethodDataSourceTest {
         val returnedPaymentMethods = paymentMethodsResult.asSuccess().value
 
         assertThat(returnedPaymentMethods).containsExactlyElementsIn(paymentMethods)
-    }
-
-    @Test
-    fun `on fetch payment methods, should fail if elements session does not have payment methods`() = runTest {
-        val paymentMethodDataSource = createPaymentMethodDataSource(
-            elementsSessionManager = FakeCustomerSessionElementsSessionManager(
-                elementsSession = Result.success(
-                    ElementsSession(
-                        linkSettings = null,
-                        paymentMethodSpecs = null,
-                        stripeIntent = SetupIntentFactory.create(),
-                        merchantCountry = null,
-                        isGooglePayEnabled = true,
-                        sessionsError = null,
-                        externalPaymentMethodData = null,
-                        customer = null,
-                        cardBrandChoice = null,
-                    )
-                )
-            ),
-        )
-
-        val paymentMethodsResult = paymentMethodDataSource.retrievePaymentMethods()
-
-        assertThat(paymentMethodsResult).isInstanceOf<CustomerSheetDataResult.Failure<List<PaymentMethod>>>()
-
-        val failedResult = paymentMethodsResult.asFailure()
-
-        assertThat(failedResult.cause).isInstanceOf<IllegalStateException>()
-        assertThat(failedResult.cause.message).isEqualTo(
-            "`CustomerSession` should contain payment methods in `elements/session` response!"
-        )
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
@@ -86,7 +86,7 @@ class CustomerSessionPaymentMethodDataSourceTest {
             customerRepository = customerRepository,
             elementsSessionManager = FakeCustomerSessionElementsSessionManager(
                 ephemeralKey = Result.success(
-                    CachedCustomerEphemeralKey.Available(
+                    CachedCustomerEphemeralKey(
                         customerId = "cus_1",
                         ephemeralKey = "ek_123",
                         expiresAt = 999999,
@@ -169,7 +169,7 @@ class CustomerSessionPaymentMethodDataSourceTest {
             customerRepository = customerRepository,
             elementsSessionManager = FakeCustomerSessionElementsSessionManager(
                 ephemeralKey = Result.success(
-                    CachedCustomerEphemeralKey.Available(
+                    CachedCustomerEphemeralKey(
                         customerId = "cus_1",
                         ephemeralKey = "ek_123",
                         expiresAt = 999999,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/DefaultCustomerSessionElementsSessionManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/DefaultCustomerSessionElementsSessionManagerTest.kt
@@ -129,7 +129,7 @@ class DefaultCustomerSessionElementsSessionManagerTest {
 
         assertThat(result).isEqualTo(
             Result.success(
-                CachedCustomerEphemeralKey.Available(
+                CachedCustomerEphemeralKey(
                     customerId = "cus_1",
                     ephemeralKey = "ek_123",
                     expiresAt = 999999,
@@ -184,7 +184,7 @@ class DefaultCustomerSessionElementsSessionManagerTest {
         assertThat(amountOfCalls).isEqualTo(1)
         assertThat(lastResult).isEqualTo(
             Result.success(
-                CachedCustomerEphemeralKey.Available(
+                CachedCustomerEphemeralKey(
                     customerId = "cus_1",
                     ephemeralKey = "ek_123",
                     expiresAt = 999999,
@@ -223,7 +223,7 @@ class DefaultCustomerSessionElementsSessionManagerTest {
         assertThat(amountOfCalls).isEqualTo(4)
         assertThat(lastResult).isEqualTo(
             Result.success(
-                CachedCustomerEphemeralKey.Available(
+                CachedCustomerEphemeralKey(
                     customerId = "cus_1",
                     ephemeralKey = "ek_123",
                     expiresAt = 200000,
@@ -258,7 +258,7 @@ class DefaultCustomerSessionElementsSessionManagerTest {
 
         assertThat(ephemeralKey).isEqualTo(
             Result.success(
-                CachedCustomerEphemeralKey.Available(
+                CachedCustomerEphemeralKey(
                     customerId = "cus_1",
                     ephemeralKey = "ek_123",
                     expiresAt = 999999,
@@ -298,7 +298,7 @@ class DefaultCustomerSessionElementsSessionManagerTest {
     @Test
     fun `on fetch elements session, should fail if client secret is empty`() = runClientValidationErrorTest(
         invalidClientSecret = "",
-        errorMessage = "The 'customerSessionClientSecret' cannot be an empty string."
+        errorMessage = "The provided 'customerSessionClientSecret' cannot be an empty string."
     )
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSessionElementsSessionManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSessionElementsSessionManager.kt
@@ -5,8 +5,8 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.testing.SetupIntentFactory
 
 internal class FakeCustomerSessionElementsSessionManager(
-    private val ephemeralKey: Result<CachedCustomerEphemeralKey.Available> = Result.success(
-        CachedCustomerEphemeralKey.Available(
+    private val ephemeralKey: Result<CachedCustomerEphemeralKey> = Result.success(
+        CachedCustomerEphemeralKey(
             customerId = "cus_1",
             ephemeralKey = "ek_123",
             expiresAt = 999999,
@@ -32,8 +32,8 @@ internal class FakeCustomerSessionElementsSessionManager(
         defaultPaymentMethod = null,
         paymentMethods = paymentMethods,
     ),
-    private val elementsSession: Result<ElementsSessionWithCustomer> = Result.success(
-        ElementsSessionWithCustomer(
+    private val elementsSession: Result<CustomerSessionElementsSession> = Result.success(
+        CustomerSessionElementsSession(
             elementsSession = ElementsSession(
                 linkSettings = null,
                 paymentMethodSpecs = null,
@@ -46,14 +46,19 @@ internal class FakeCustomerSessionElementsSessionManager(
                 cardBrandChoice = null,
             ),
             customer = customer,
+            ephemeralKey = CachedCustomerEphemeralKey(
+                customerId = "cus_1",
+                ephemeralKey = "ek_123",
+                expiresAt = 999999,
+            ),
         )
     )
 ) : CustomerSessionElementsSessionManager {
-    override suspend fun fetchCustomerSessionEphemeralKey(): Result<CachedCustomerEphemeralKey.Available> {
+    override suspend fun fetchCustomerSessionEphemeralKey(): Result<CachedCustomerEphemeralKey> {
         return ephemeralKey
     }
 
-    override suspend fun fetchElementsSession(): Result<ElementsSessionWithCustomer> {
+    override suspend fun fetchElementsSession(): Result<CustomerSessionElementsSession> {
         return elementsSession
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSessionElementsSessionManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSessionElementsSessionManager.kt
@@ -17,31 +17,35 @@ internal class FakeCustomerSessionElementsSessionManager(
         ElementsSession.Customer.Components.CustomerSheet.Enabled(
             isPaymentMethodRemoveEnabled = true,
         ),
-    private val elementsSession: Result<ElementsSession> = Result.success(
-        ElementsSession(
-            linkSettings = null,
-            paymentMethodSpecs = null,
-            stripeIntent = SetupIntentFactory.create(),
-            merchantCountry = null,
-            isGooglePayEnabled = true,
-            sessionsError = null,
-            externalPaymentMethodData = null,
-            customer = ElementsSession.Customer(
-                session = ElementsSession.Customer.Session(
-                    id = "cuss_1",
-                    customerId = "cus_1",
-                    apiKey = "ek_123",
-                    apiKeyExpiry = 999999,
-                    components = ElementsSession.Customer.Components(
-                        mobilePaymentElement = ElementsSession.Customer.Components.MobilePaymentElement.Disabled,
-                        customerSheet = customerSheetComponent,
-                    ),
-                    liveMode = false,
-                ),
-                defaultPaymentMethod = null,
-                paymentMethods = paymentMethods,
+    private val customer: ElementsSession.Customer = ElementsSession.Customer(
+        session = ElementsSession.Customer.Session(
+            id = "cuss_1",
+            customerId = "cus_1",
+            apiKey = "ek_123",
+            apiKeyExpiry = 999999,
+            components = ElementsSession.Customer.Components(
+                mobilePaymentElement = ElementsSession.Customer.Components.MobilePaymentElement.Disabled,
+                customerSheet = customerSheetComponent,
             ),
-            cardBrandChoice = null,
+            liveMode = false,
+        ),
+        defaultPaymentMethod = null,
+        paymentMethods = paymentMethods,
+    ),
+    private val elementsSession: Result<ElementsSessionWithCustomer> = Result.success(
+        ElementsSessionWithCustomer(
+            elementsSession = ElementsSession(
+                linkSettings = null,
+                paymentMethodSpecs = null,
+                stripeIntent = SetupIntentFactory.create(),
+                merchantCountry = null,
+                isGooglePayEnabled = true,
+                sessionsError = null,
+                externalPaymentMethodData = null,
+                customer = customer,
+                cardBrandChoice = null,
+            ),
+            customer = customer,
         )
     )
 ) : CustomerSessionElementsSessionManager {
@@ -49,7 +53,7 @@ internal class FakeCustomerSessionElementsSessionManager(
         return ephemeralKey
     }
 
-    override suspend fun fetchElementsSession(): Result<ElementsSession> {
+    override suspend fun fetchElementsSession(): Result<ElementsSessionWithCustomer> {
         return elementsSession
     }
 }


### PR DESCRIPTION
# Summary
Add `CustomerSessionClientSecret` validation & remodel `ElementsSessionManager` response.

# Motivation
We validate on the client-side if the provided key is a valid customer session key for `PaymentSheet` and should do the same for `CustomerSheet`. With this validation, we can now expect `elements/session` to return a `customer` field so `ElementsSessionManager` now provides a response with `ElementsSession` and a non-null customer.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
