### PR TITLE
Add `CustomerSessionInitializationDataSource`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSource.kt
@@ -1,9 +1,50 @@
 package com.stripe.android.customersheet.data
 
+import com.stripe.android.core.injection.IOContext
+import com.stripe.android.customersheet.CustomerPermissions
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
+import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.PaymentMethod
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
 
-internal class CustomerSessionInitializationDataSource @Inject constructor() : CustomerSheetInitializationDataSource {
+internal class CustomerSessionInitializationDataSource @Inject constructor(
+    private val elementsSessionManager: CustomerSessionElementsSessionManager,
+    private val savedSelectionDataSource: CustomerSheetSavedSelectionDataSource,
+    @IOContext private val workContext: CoroutineContext,
+) : CustomerSheetInitializationDataSource {
     override suspend fun loadCustomerSheetSession(): CustomerSheetDataResult<CustomerSheetSession> {
-        throw NotImplementedError("Not implemented yet!")
+        return withContext(workContext) {
+            elementsSessionManager.fetchElementsSession().mapCatching { customerSessionElementsSession ->
+                val savedSelection = savedSelectionDataSource
+                    .retrieveSavedSelection()
+                    .toResult()
+                    .getOrThrow()
+
+                val customer = customerSessionElementsSession.customer
+
+                CustomerSheetSession(
+                    elementsSession = customerSessionElementsSession.elementsSession,
+                    paymentMethods = customer.paymentMethods,
+                    /*
+                     * `CustomerSession` on `CustomerSheet` never shows the checkbox but always assumes any PMs
+                     * saved through it are meant to be re-shown since `CustomerSheet` acts as a wallet version
+                     * of `PaymentSheet` hence the override.
+                     */
+                    paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Disabled(
+                        overrideAllowRedisplay = PaymentMethod.AllowRedisplay.ALWAYS,
+                    ),
+                    savedSelection = savedSelection,
+                    permissions = CustomerPermissions(
+                        canRemovePaymentMethods = when (val component = customer.session.components.customerSheet) {
+                            is ElementsSession.Customer.Components.CustomerSheet.Enabled ->
+                                component.isPaymentMethodRemoveEnabled
+                            is ElementsSession.Customer.Components.CustomerSheet.Disabled -> false
+                        }
+                    )
+                )
+            }.toCustomerSheetDataResult()
+        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSourceTest.kt
@@ -1,0 +1,138 @@
+package com.stripe.android.customersheet.data
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
+import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.model.SavedSelection
+import com.stripe.android.testing.PaymentMethodFactory
+import com.stripe.android.testing.SetupIntentFactory
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.coroutines.coroutineContext
+
+class CustomerSessionInitializationDataSourceTest {
+    @Test
+    fun `on load, should return expected successful state`() = runTest {
+        val paymentMethods = PaymentMethodFactory.cards(size = 6)
+        val intent = SetupIntentFactory.create()
+
+        val dataSource = createInitializationDataSource(
+            elementsSessionManager = FakeCustomerSessionElementsSessionManager(
+                intent = intent,
+                paymentMethods = paymentMethods,
+                customerSheetComponent = ElementsSession.Customer.Components.CustomerSheet.Enabled(
+                    isPaymentMethodRemoveEnabled = true,
+                )
+            ),
+            savedSelectionDataSource = FakeCustomerSheetSavedSelectionDataSource(
+                savedSelection = CustomerSheetDataResult.success(
+                    SavedSelection.PaymentMethod(id = "pm_1")
+                )
+            )
+        )
+
+        val result = dataSource.loadCustomerSheetSession()
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<CustomerSheetSession>>()
+
+        val customerSheetSession = result.asSuccess().value
+
+        assertThat(customerSheetSession.elementsSession.stripeIntent).isEqualTo(intent)
+        assertThat(customerSheetSession.savedSelection).isEqualTo(SavedSelection.PaymentMethod(id = "pm_1"))
+        assertThat(customerSheetSession.paymentMethods).isEqualTo(paymentMethods)
+        assertThat(customerSheetSession.paymentMethodSaveConsentBehavior).isEqualTo(
+            PaymentMethodSaveConsentBehavior.Disabled(
+                overrideAllowRedisplay = PaymentMethod.AllowRedisplay.ALWAYS,
+            )
+        )
+        assertThat(customerSheetSession.permissions.canRemovePaymentMethods).isTrue()
+    }
+
+    @Test
+    fun `on load, should have no remove permissions if component has no remove permissions`() = runTest {
+        val dataSource = createInitializationDataSource(
+            elementsSessionManager = FakeCustomerSessionElementsSessionManager(
+                customerSheetComponent = ElementsSession.Customer.Components.CustomerSheet.Enabled(
+                    isPaymentMethodRemoveEnabled = false,
+                ),
+            ),
+        )
+
+        val result = dataSource.loadCustomerSheetSession()
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<CustomerSheetSession>>()
+
+        val customerSheetSession = result.asSuccess().value
+
+        assertThat(customerSheetSession.permissions.canRemovePaymentMethods).isFalse()
+    }
+
+    @Test
+    fun `on load, should have no remove permissions if component is disabled`() = runTest {
+        val dataSource = createInitializationDataSource(
+            elementsSessionManager = FakeCustomerSessionElementsSessionManager(
+                customerSheetComponent = ElementsSession.Customer.Components.CustomerSheet.Disabled,
+            ),
+        )
+
+        val result = dataSource.loadCustomerSheetSession()
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<CustomerSheetSession>>()
+
+        val customerSheetSession = result.asSuccess().value
+
+        assertThat(customerSheetSession.permissions.canRemovePaymentMethods).isFalse()
+    }
+
+    @Test
+    fun `on load, should fail if we cannot retrieve elements session`() = runTest {
+        val exception = IllegalStateException("Failed to load!")
+        val dataSource = createInitializationDataSource(
+            elementsSessionManager = FakeCustomerSessionElementsSessionManager(
+                elementsSession = Result.failure(exception)
+            ),
+        )
+
+        val result = dataSource.loadCustomerSheetSession()
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<CustomerSheetSession>>()
+
+        val returnedCause = result.asFailure().cause
+
+        assertThat(returnedCause).isEqualTo(exception)
+    }
+
+    @Test
+    fun `on load, should fail if we cannot retrieve saved selection`() = runTest {
+        val exception = IllegalStateException("Failed to retrieve!")
+        val dataSource = createInitializationDataSource(
+            savedSelectionDataSource = FakeCustomerSheetSavedSelectionDataSource(
+                savedSelection = CustomerSheetDataResult.failure(
+                    cause = exception,
+                    displayMessage = null,
+                )
+            )
+        )
+
+        val result = dataSource.loadCustomerSheetSession()
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<CustomerSheetSession>>()
+
+        val returnedCause = result.asFailure().cause
+
+        assertThat(returnedCause).isEqualTo(exception)
+    }
+
+    private suspend fun createInitializationDataSource(
+        elementsSessionManager: CustomerSessionElementsSessionManager = FakeCustomerSessionElementsSessionManager(),
+        savedSelectionDataSource: CustomerSheetSavedSelectionDataSource = FakeCustomerSheetSavedSelectionDataSource(),
+    ): CustomerSheetInitializationDataSource {
+        return CustomerSessionInitializationDataSource(
+            elementsSessionManager = elementsSessionManager,
+            savedSelectionDataSource = savedSelectionDataSource,
+            workContext = coroutineContext,
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSessionElementsSessionManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSessionElementsSessionManager.kt
@@ -2,6 +2,7 @@ package com.stripe.android.customersheet.data
 
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.StripeIntent
 import com.stripe.android.testing.SetupIntentFactory
 
 internal class FakeCustomerSessionElementsSessionManager(
@@ -12,6 +13,7 @@ internal class FakeCustomerSessionElementsSessionManager(
             expiresAt = 999999,
         )
     ),
+    private val intent: StripeIntent = SetupIntentFactory.create(),
     private val paymentMethods: List<PaymentMethod> = listOf(),
     private val customerSheetComponent: ElementsSession.Customer.Components.CustomerSheet =
         ElementsSession.Customer.Components.CustomerSheet.Enabled(
@@ -37,7 +39,7 @@ internal class FakeCustomerSessionElementsSessionManager(
             elementsSession = ElementsSession(
                 linkSettings = null,
                 paymentMethodSpecs = null,
-                stripeIntent = SetupIntentFactory.create(),
+                stripeIntent = intent,
                 merchantCountry = null,
                 isGooglePayEnabled = true,
                 sessionsError = null,


### PR DESCRIPTION
# Summary
Add `CustomerSessionInitializationDataSource`

# Motivation
Allows for `CustomerSheet` to be initialized with `CustomerSession`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
