### PR TITLE
Allow testing Link Card Brand in FC Playground

### DIFF
--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
@@ -48,6 +48,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.example.Experience.FinancialConnections
 import com.stripe.android.financialconnections.example.Experience.InstantDebits
+import com.stripe.android.financialconnections.example.Experience.LinkCardBrand
 import com.stripe.android.financialconnections.example.FinancialConnectionsPlaygroundViewEffect.OpenForData
 import com.stripe.android.financialconnections.example.FinancialConnectionsPlaygroundViewEffect.OpenForPaymentIntent
 import com.stripe.android.financialconnections.example.FinancialConnectionsPlaygroundViewEffect.OpenForToken
@@ -146,13 +147,14 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
         state: FinancialConnectionsPlaygroundState,
         paymentSheet: PaymentSheet
     ) {
+        val email = state.settings.get<EmailSetting>().selectedOption
+
         when (integrationType) {
             IntegrationType.Standalone -> {
-                val email = state.settings.get<EmailSetting>().selectedOption
                 launchStandaloneIntegration(email)
             }
             IntegrationType.PaymentElement -> {
-                launchPaymentSheet(paymentSheet)
+                launchPaymentSheet(paymentSheet, email)
             }
         }
     }
@@ -168,7 +170,8 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
                     email = email,
                 )
             )
-            InstantDebits -> collectBankAccountForInstantDebitsLauncher.presentWithPaymentIntent(
+            InstantDebits,
+            LinkCardBrand -> collectBankAccountForInstantDebitsLauncher.presentWithPaymentIntent(
                 publishableKey = publishableKey,
                 stripeAccountId = null,
                 clientSecret = paymentIntentSecret,
@@ -182,21 +185,28 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
 
     private fun OpenForPaymentIntent.launchPaymentSheet(
         paymentSheet: PaymentSheet,
+        email: String,
     ) {
         PaymentConfiguration.init(
             context = this@FinancialConnectionsPlaygroundActivity,
             publishableKey = publishableKey
         )
+
+        val config = PaymentSheet.Configuration(
+            allowsDelayedPaymentMethods = true,
+            merchantDisplayName = "Example, Inc.",
+            customer = PaymentSheet.CustomerConfiguration(
+                id = requireNotNull(customerId),
+                ephemeralKeySecret = requireNotNull(ephemeralKey),
+            ),
+            defaultBillingDetails = PaymentSheet.BillingDetails(
+                email = email.takeIf { it.isNotBlank() },
+            ),
+        )
+
         paymentSheet.presentWithPaymentIntent(
             paymentIntentClientSecret = paymentIntentSecret,
-            configuration = PaymentSheet.Configuration(
-                allowsDelayedPaymentMethods = true,
-                merchantDisplayName = "Example, Inc.",
-                customer = PaymentSheet.CustomerConfiguration(
-                    id = requireNotNull(customerId),
-                    ephemeralKeySecret = requireNotNull(ephemeralKey),
-                )
-            )
+            configuration = config,
         )
     }
 

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -92,6 +92,9 @@ internal class FinancialConnectionsPlaygroundViewModel(
             Experience.InstantDebits -> {
                 startWithPaymentIntent(this, experience = Experience.InstantDebits)
             }
+            Experience.LinkCardBrand -> {
+                startWithPaymentIntent(this, experience = Experience.LinkCardBrand)
+            }
         }
     }
 
@@ -103,7 +106,9 @@ internal class FinancialConnectionsPlaygroundViewModel(
             showLoadingWithMessage("Fetching link account session from example backend!")
             kotlin.runCatching {
                 repository.createPaymentIntent(
-                    settings.paymentIntentRequest(forceInstantDebits = experience == Experience.InstantDebits)
+                    settings.paymentIntentRequest(
+                        linkMode = experience.linkMode,
+                    )
                 )
             }
                 // Success creating session: open the financial connections sheet with received secret
@@ -459,6 +464,14 @@ enum class Experience(
 ) {
     FinancialConnections("Financial Connections"),
     InstantDebits("Instant Debits"),
+    LinkCardBrand("Link Card Brand");
+
+    val linkMode: String?
+        get() = when (this) {
+            FinancialConnections -> null
+            InstantDebits -> "instant_debits"
+            LinkCardBrand -> "link_card_brand"
+        }
 }
 
 enum class NativeOverride(val apiValue: String) {

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/model/PaymentIntentBody.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/model/PaymentIntentBody.kt
@@ -29,6 +29,6 @@ data class PaymentIntentBody(
     val testMode: Boolean? = null,
     @SerialName("stripe_account_id")
     val stripeAccountId: String? = null,
-    @SerialName("force_instant_debits")
-    val forceInstantDebits: Boolean = false,
+    @SerialName("link_mode")
+    val linkMode: String? = null,
 )

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/ConfirmIntentSetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/ConfirmIntentSetting.kt
@@ -34,7 +34,9 @@ data class ConfirmIntentSetting(
         flow: Flow,
         experience: Experience,
     ): Boolean {
-        return experience == Experience.InstantDebits || flow == Flow.PaymentIntent
+        return experience == Experience.InstantDebits ||
+            experience == Experience.LinkCardBrand ||
+            flow == Flow.PaymentIntent
     }
 
     override fun convertToValue(value: String): Boolean = value.toBoolean()

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PlaygroundSettings.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PlaygroundSettings.kt
@@ -48,14 +48,14 @@ internal data class PlaygroundSettings(
     ) { acc, setting: Setting<*> -> setting.lasRequest(acc) }
 
     fun paymentIntentRequest(
-        forceInstantDebits: Boolean = false,
+        linkMode: String? = null,
     ): PaymentIntentBody {
         return settings.toList().fold(
             PaymentIntentBody(testEnvironment = BuildConfig.TEST_ENVIRONMENT)
         ) { acc, setting: Setting<*> ->
             setting.paymentIntentRequest(acc)
         }.copy(
-            forceInstantDebits = forceInstantDebits,
+            linkMode = linkMode,
         )
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds support for testing Link Card Brand payments through PaymentSheet.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
