### PR TITLE
Fix a bug where a newly added payment method that is filtered out by `CustomerSheet` is made the new selection

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -1082,12 +1082,16 @@ internal class CustomerSheetViewModel(
                 ErrorReporter.SuccessEvent.CUSTOMER_SHEET_PAYMENT_METHODS_REFRESH_SUCCESS,
             )
 
-            val selection = PaymentSelection.Saved(newPaymentMethod)
-
             setCustomerState { state ->
+                val selection = paymentMethods.find { paymentMethod ->
+                    newPaymentMethod.id == paymentMethod.id
+                }?.let {
+                    PaymentSelection.Saved(it)
+                } ?: state.currentSelection
+
                 state.copy(
-                    paymentMethods = sortPaymentMethods(paymentMethods, selection),
-                    currentSelection = PaymentSelection.Saved(newPaymentMethod),
+                    paymentMethods = sortPaymentMethods(paymentMethods, selection as? PaymentSelection.Saved),
+                    currentSelection = selection,
                 )
             }
 


### PR DESCRIPTION
# Summary
Fix a bug where a newly added payment method that is filtered out by `CustomerSheet` is made the new selection

# Motivation
`CustomerSession` will filter out cards that have the same fingerprint (indicating they are the same card).

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
