### PR TITLE
Add integrated `CustomerSheet` activity tests for `CustomerSession`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -106,7 +106,7 @@ internal fun SavedPaymentMethodTabLayoutUI(
                 SelectSavedPaymentMethodsInteractor.ViewAction.DeletePaymentMethod(it)
             )
         },
-        modifier = modifier.testTag(SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG),
+        modifier = modifier,
     )
 
     if (
@@ -135,7 +135,7 @@ internal fun SavedPaymentMethodTabLayoutUI(
     modifier: Modifier = Modifier,
     scrollState: LazyListState = rememberLazyListState(),
 ) {
-    BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
+    BoxWithConstraints(modifier = modifier.fillMaxWidth().testTag(SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG)) {
         val width = rememberItemWidth(maxWidth)
 
         LazyRow(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSessionCustomerSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSessionCustomerSheetActivityTest.kt
@@ -1,0 +1,517 @@
+package com.stripe.android.customersheet
+
+import android.app.Application
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.testing.TestLifecycleOwner
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.stripe.android.customersheet.util.CustomerSheetHacks
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.RequestMatchers.host
+import com.stripe.android.networktesting.RequestMatchers.method
+import com.stripe.android.networktesting.RequestMatchers.path
+import com.stripe.android.networktesting.ResponseReplacement
+import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.paymentsheet.EditPage
+import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
+import com.stripe.android.paymentsheet.PaymentSheetActivity
+import com.stripe.android.paymentsheet.PaymentSheetFixtures
+import com.stripe.android.paymentsheet.RemoveDialog
+import com.stripe.android.paymentsheet.SavedPaymentMethodsPage
+import com.stripe.android.paymentsheet.SavedPaymentMethodsPage.Companion.assertHasModifyBadge
+import com.stripe.android.paymentsheet.ui.FORM_ELEMENT_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG
+import com.stripe.android.testing.PaymentConfigurationTestRule
+import com.stripe.android.testing.PaymentMethodFactory
+import com.stripe.android.testing.PaymentMethodFactory.update
+import okhttp3.mockwebserver.MockResponse
+import org.json.JSONArray
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@OptIn(ExperimentalCustomerSheetApi::class, ExperimentalCustomerSessionApi::class)
+@RunWith(AndroidJUnit4::class)
+class CustomerSessionCustomerSheetActivityTest {
+    private val application = ApplicationProvider.getApplicationContext<Application>()
+
+    private val composeTestRule = createAndroidComposeRule<PaymentSheetActivity>()
+    private val networkRule = NetworkRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(composeTestRule)
+        .around(networkRule)
+        .around(PaymentConfigurationTestRule(application))
+
+    private val savedPaymentMethodsPage = SavedPaymentMethodsPage(composeTestRule)
+    private val editPage = EditPage(composeTestRule)
+    private val removeDialog = RemoveDialog(composeTestRule)
+
+    @After
+    fun teardown() {
+        CustomerSheetHacks.clear()
+    }
+
+    @Test
+    fun `When multiple PMs with remove permissions and can remove last PM, should all be enabled when editing`() =
+        runTest(
+            cards = listOf(
+                PaymentMethodFactory.card(last4 = "4242"),
+                PaymentMethodFactory.card(last4 = "5544", addCbcNetworks = true),
+            ),
+            isPaymentMethodRemoveEnabled = true,
+            allowsRemovalOfLastSavedPaymentMethod = true,
+        ) {
+            savedPaymentMethodsPage.onEditButton().performClick()
+
+            savedPaymentMethodsPage.onSavedPaymentMethod(last4 = "4242").assertIsEnabled()
+            savedPaymentMethodsPage.onSavedPaymentMethod(last4 = "5544").assertIsEnabled()
+        }
+
+    @Test
+    fun `When single PM with remove permissions and can remove last PM, should be enabled when editing`() =
+        runTest(
+            cards = listOf(
+                PaymentMethodFactory.card(last4 = "4242"),
+            ),
+            isPaymentMethodRemoveEnabled = true,
+            allowsRemovalOfLastSavedPaymentMethod = true,
+        ) {
+            savedPaymentMethodsPage.onEditButton().performClick()
+
+            savedPaymentMethodsPage.onSavedPaymentMethod(last4 = "4242").assertIsEnabled()
+        }
+
+    @Test
+    fun `When single PM with remove permissions but cannot remove last PM, edit button should not be displayed`() =
+        runTest(
+            cards = listOf(
+                PaymentMethodFactory.card(last4 = "4242"),
+            ),
+            isPaymentMethodRemoveEnabled = true,
+            allowsRemovalOfLastSavedPaymentMethod = false,
+        ) {
+            savedPaymentMethodsPage.onEditButton().assertDoesNotExist()
+        }
+
+    @Test
+    fun `When multiple PMs but no remove permissions, edit button should not be displayed`() =
+        runTest(
+            cards = listOf(
+                PaymentMethodFactory.card(last4 = "4242"),
+                PaymentMethodFactory.card(last4 = "5544"),
+            ),
+            isPaymentMethodRemoveEnabled = false,
+            allowsRemovalOfLastSavedPaymentMethod = true,
+        ) {
+            savedPaymentMethodsPage.onEditButton().assertDoesNotExist()
+        }
+
+    @Test
+    fun `When multiple PMs with CBC card but no remove permissions, should allow editing CBC card and disable rest`() =
+        runTest(
+            cards = listOf(
+                PaymentMethodFactory.card(last4 = "4242", addCbcNetworks = true),
+                PaymentMethodFactory.card(last4 = "5544"),
+            ),
+            isPaymentMethodRemoveEnabled = false,
+            allowsRemovalOfLastSavedPaymentMethod = true,
+        ) {
+            savedPaymentMethodsPage.onEditButton().performClick()
+
+            savedPaymentMethodsPage.onSavedPaymentMethod(last4 = "5544").assertIsNotEnabled()
+
+            val cbcCard = savedPaymentMethodsPage.onSavedPaymentMethod(last4 = "4242")
+
+            cbcCard.assertIsEnabled()
+            cbcCard.assertHasModifyBadge()
+        }
+
+    @Test
+    fun `When multiple PMs with CBC card and has remove permissions, should be able to remove and edit CBC card`() =
+        runTest(
+            cards = listOf(
+                PaymentMethodFactory.card(last4 = "4242", addCbcNetworks = true),
+                PaymentMethodFactory.card(last4 = "5544"),
+            ),
+            isPaymentMethodRemoveEnabled = true,
+            allowsRemovalOfLastSavedPaymentMethod = true,
+        ) {
+            savedPaymentMethodsPage.onEditButton().performClick()
+
+            savedPaymentMethodsPage.onSavedPaymentMethod(last4 = "5544").assertIsEnabled()
+
+            val cbcCard = savedPaymentMethodsPage.onSavedPaymentMethod(last4 = "4242")
+
+            cbcCard.assertIsEnabled()
+            cbcCard.assertHasModifyBadge()
+
+            savedPaymentMethodsPage.onModifyBadgeFor(last4 = "4242").performClick()
+
+            editPage.onRemoveButton().assertIsEnabled()
+        }
+
+    @Test
+    fun `When single CBC card, has remove permissions, and can remove last PM, should be able to remove and edit`() =
+        runTest(
+            cards = listOf(
+                PaymentMethodFactory.card(last4 = "4242", addCbcNetworks = true),
+            ),
+            isPaymentMethodRemoveEnabled = true,
+            allowsRemovalOfLastSavedPaymentMethod = true,
+        ) {
+            savedPaymentMethodsPage.onEditButton().performClick()
+
+            val cbcCard = savedPaymentMethodsPage.onSavedPaymentMethod(last4 = "4242")
+
+            cbcCard.assertIsEnabled()
+            cbcCard.assertHasModifyBadge()
+
+            savedPaymentMethodsPage.onModifyBadgeFor(last4 = "4242").performClick()
+
+            editPage.onRemoveButton().assertIsEnabled()
+        }
+
+    @Test
+    fun `When single CBC card but no remove permissions, can edit but not remove CBC card`() =
+        runTest(
+            cards = listOf(
+                PaymentMethodFactory.card(last4 = "4242", addCbcNetworks = true),
+            ),
+            isPaymentMethodRemoveEnabled = false,
+            allowsRemovalOfLastSavedPaymentMethod = true,
+        ) {
+            savedPaymentMethodsPage.onEditButton().performClick()
+
+            val cbcCard = savedPaymentMethodsPage.onSavedPaymentMethod(last4 = "4242")
+
+            cbcCard.assertIsEnabled()
+            cbcCard.assertHasModifyBadge()
+
+            savedPaymentMethodsPage.onModifyBadgeFor(last4 = "4242").performClick()
+
+            editPage.onRemoveButton().assertDoesNotExist()
+        }
+
+    @Test
+    fun `When single CBC card has remove permissions but cannot remove last, can edit but not remove CBC card`() =
+        runTest(
+            cards = listOf(
+                PaymentMethodFactory.card(last4 = "4242", addCbcNetworks = true),
+            ),
+            isPaymentMethodRemoveEnabled = true,
+            allowsRemovalOfLastSavedPaymentMethod = false,
+        ) {
+            savedPaymentMethodsPage.onEditButton().performClick()
+
+            val cbcCard = savedPaymentMethodsPage.onSavedPaymentMethod(last4 = "4242")
+
+            cbcCard.assertIsEnabled()
+            cbcCard.assertHasModifyBadge()
+
+            savedPaymentMethodsPage.onModifyBadgeFor(last4 = "4242").performClick()
+
+            editPage.onRemoveButton().assertDoesNotExist()
+        }
+
+    @Test
+    fun `On detach, should remove payment method & un-shown duplicates from saved PMs screen`() = runTest(
+        cards = listOf(
+            createDuplicateCard(id = "pm_1"),
+            PaymentMethodFactory.card(last4 = "1001"),
+        ),
+        isPaymentMethodRemoveEnabled = true,
+        allowsRemovalOfLastSavedPaymentMethod = true,
+    ) {
+        savedPaymentMethodsPage.onEditButton().performClick()
+        savedPaymentMethodsPage.onRemoveBadgeFor(last4 = "4242").performClick()
+
+        enqueuePaymentMethods(
+            cards = listOf(
+                createDuplicateCard(id = "pm_1"),
+                createDuplicateCard(id = "pm_2"),
+                createDuplicateCard(id = "pm_3"),
+                createDuplicateCard(id = "pm_4"),
+            )
+        )
+
+        enqueueDetachPaymentMethod(id = "pm_1")
+        enqueueDetachPaymentMethod(id = "pm_2")
+        enqueueDetachPaymentMethod(id = "pm_3")
+        enqueueDetachPaymentMethod(id = "pm_4")
+
+        removeDialog.confirm()
+        savedPaymentMethodsPage.waitUntilVisible()
+        savedPaymentMethodsPage.waitForSavedPaymentMethodToBeRemoved(last4 = "4242")
+    }
+
+    @Test
+    fun `On detach from edit screen, should remove payment method & un-shown duplicates from saved PMs screen`() =
+        runTest(
+            cards = listOf(
+                createDuplicateCard(id = "pm_1", addCbcNetworks = true),
+                PaymentMethodFactory.card(last4 = "1001"),
+            ),
+        ) {
+            savedPaymentMethodsPage.onEditButton().performClick()
+            savedPaymentMethodsPage.onModifyBadgeFor(last4 = "4242").performClick()
+
+            enqueuePaymentMethods(
+                cards = listOf(
+                    createDuplicateCard(id = "pm_1", addCbcNetworks = true),
+                    createDuplicateCard(id = "pm_2", addCbcNetworks = true),
+                    createDuplicateCard(id = "pm_3", addCbcNetworks = true),
+                    createDuplicateCard(id = "pm_4", addCbcNetworks = true),
+                )
+            )
+
+            enqueueDetachPaymentMethod(id = "pm_1")
+            enqueueDetachPaymentMethod(id = "pm_2")
+            enqueueDetachPaymentMethod(id = "pm_3")
+            enqueueDetachPaymentMethod(id = "pm_4")
+
+            editPage.onRemoveButton().performClick()
+            removeDialog.confirm()
+
+            savedPaymentMethodsPage.waitUntilVisible()
+            savedPaymentMethodsPage.waitForSavedPaymentMethodToBeRemoved(last4 = "4242")
+        }
+
+    @Test
+    fun `On update, should update payment method in saved payment methods screen`() =
+        runTest(
+            cards = listOf(
+                PaymentMethodFactory.card(id = "pm_1")
+                    .update(last4 = "1001", addCbcNetworks = true),
+            ),
+        ) {
+            savedPaymentMethodsPage.onEditButton().performClick()
+            savedPaymentMethodsPage.onModifyBadgeFor(last4 = "1001").performClick()
+
+            editPage.setCardBrand("Visa")
+            editPage.update()
+
+            enqueueUpdatePaymentMethod(id = "pm_1")
+
+            savedPaymentMethodsPage.waitUntilVisible()
+            savedPaymentMethodsPage.onSavedPaymentMethod(last4 = "1001").assertExists()
+        }
+
+    @OptIn(ExperimentalCustomerSessionApi::class)
+    private fun runTest(
+        cards: List<PaymentMethod> = listOf(),
+        isPaymentMethodRemoveEnabled: Boolean = true,
+        allowsRemovalOfLastSavedPaymentMethod: Boolean = true,
+        test: (CustomerSheetActivity) -> Unit,
+    ) {
+        val countDownLatch = CountDownLatch(1)
+
+        CustomerSheetHacks.initialize(
+            application = application,
+            lifecycleOwner = TestLifecycleOwner(),
+            integrationType = CustomerSheetIntegrationType.CustomerSession(
+                customerSessionProvider = object : CustomerSheet.CustomerSessionProvider() {
+                    override suspend fun providesCustomerSessionClientSecret(): Result<
+                        CustomerSheet.CustomerSessionClientSecret
+                        > {
+                        return Result.success(
+                            CustomerSheet.CustomerSessionClientSecret(
+                                customerId = "cus_1",
+                                clientSecret = "cuss_123"
+                            )
+                        )
+                    }
+
+                    override suspend fun intentConfiguration(): Result<CustomerSheet.IntentConfiguration> {
+                        return Result.success(
+                            CustomerSheet.IntentConfiguration(
+                                paymentMethodTypes = listOf("card", "us_bank_account"),
+                            )
+                        )
+                    }
+
+                    override suspend fun provideSetupIntentClientSecret(customerId: String): Result<String> {
+                        return Result.success("seti_123_secret_123")
+                    }
+                }
+            )
+        )
+
+        enqueueElementsSession(cards, isPaymentMethodRemoveEnabled)
+
+        ActivityScenario.launch<CustomerSheetActivity>(
+            CustomerSheetContract().createIntent(
+                ApplicationProvider.getApplicationContext(),
+                CustomerSheetContract.Args(
+                    configuration = CustomerSheet.Configuration(
+                        merchantDisplayName = "Merchant, Inc.",
+                        allowsRemovalOfLastSavedPaymentMethod = allowsRemovalOfLastSavedPaymentMethod,
+                        preferredNetworks = listOf(CardBrand.CartesBancaires, CardBrand.Visa),
+                    ),
+                    statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR,
+                )
+            )
+        ).use { scenario ->
+            scenario.onActivity { activity ->
+                composeTestRule.waitUntil(timeoutMillis = 5_000) {
+                    composeTestRule
+                        .onAllNodes(
+                            hasTestTag(FORM_ELEMENT_TEST_TAG)
+                                .or(hasTestTag(SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG))
+                        )
+                        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                        .isNotEmpty()
+                }
+
+                test(activity)
+
+                countDownLatch.countDown()
+            }
+
+            countDownLatch.await(5, TimeUnit.SECONDS)
+            networkRule.validate()
+        }
+    }
+
+    private fun enqueueElementsSession(
+        savedCards: List<PaymentMethod> = listOf(),
+        isPaymentMethodRemoveEnabled: Boolean
+    ) {
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("GET"),
+            path("/v1/elements/sessions"),
+        ) { response ->
+            response.createElementsSessionResponse(savedCards, isPaymentMethodRemoveEnabled)
+        }
+    }
+
+    private fun enqueuePaymentMethods(
+        cards: List<PaymentMethod> = listOf(),
+    ) {
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("GET"),
+            path("/v1/payment_methods"),
+        ) { response ->
+            response.createPaymentMethodsResponse(cards)
+        }
+    }
+
+    private fun enqueueDetachPaymentMethod(id: String) {
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("POST"),
+            path("/v1/payment_methods/$id/detach")
+        ) { response ->
+            response.createPaymentMethodDetachResponse(id = id)
+        }
+    }
+
+    private fun enqueueUpdatePaymentMethod(id: String) {
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("POST"),
+            path("/v1/payment_methods/$id")
+        ) { response ->
+            response.createPaymentMethodUpdateResponse()
+        }
+    }
+
+    private fun createDuplicateCard(id: String, addCbcNetworks: Boolean = false): PaymentMethod {
+        return PaymentMethodFactory.card(id = id)
+            .update(last4 = "4242", addCbcNetworks = addCbcNetworks)
+            .run {
+                copy(
+                    card = card?.copy(
+                        fingerprint = "fingerprint1"
+                    )
+                )
+            }
+    }
+
+    private fun MockResponse.createPaymentMethodsResponse(
+        cards: List<PaymentMethod>,
+    ): MockResponse {
+        val cardsArray = JSONArray()
+
+        cards.forEach { card ->
+            cardsArray.put(PaymentMethodFactory.convertCardToJson(card))
+        }
+
+        return testBodyFromFile(
+            filename = "payment-methods-get-success.json",
+            replacements = listOf(
+                ResponseReplacement(
+                    original = "[PAYMENT_METHODS_HERE]",
+                    new = cardsArray.toString(2)
+                )
+            )
+        )
+    }
+
+    private fun MockResponse.createPaymentMethodDetachResponse(
+        id: String,
+    ): MockResponse {
+        return testBodyFromFile(
+            filename = "payment-method-detach.json",
+            replacements = listOf(
+                ResponseReplacement(
+                    original = "[PAYMENT_METHOD_ID_HERE]",
+                    new = id
+                )
+            )
+        )
+    }
+
+    private fun MockResponse.createPaymentMethodUpdateResponse(): MockResponse {
+        return testBodyFromFile(
+            filename = "payment-method-update.json",
+        )
+    }
+
+    private fun MockResponse.createElementsSessionResponse(
+        cards: List<PaymentMethod>,
+        isPaymentMethodRemoveEnabled: Boolean,
+    ): MockResponse {
+        val removeFeature = if (isPaymentMethodRemoveEnabled) {
+            "enabled"
+        } else {
+            "disabled"
+        }
+
+        val cardsArray = JSONArray()
+
+        cards.forEach { card ->
+            cardsArray.put(PaymentMethodFactory.convertCardToJson(card))
+        }
+
+        val cardsStringified = cardsArray.toString(2)
+
+        return testBodyFromFile(
+            filename = "elements-sessions-customer_sheet_customer_session.json",
+            replacements = listOf(
+                ResponseReplacement(
+                    original = "[PAYMENT_METHOD_REMOVE_FEATURE]",
+                    new = removeFeature,
+                ),
+                ResponseReplacement(
+                    original = "[PAYMENT_METHODS_HERE]",
+                    new = cardsStringified
+                )
+            ),
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSessionCustomerSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSessionCustomerSheetActivityTest.kt
@@ -426,7 +426,7 @@ class CustomerSessionCustomerSheetActivityTest {
             method("POST"),
             path("/v1/payment_methods/$id")
         ) { response ->
-            response.createPaymentMethodUpdateResponse()
+            response.createPaymentMethodUpdateResponse(id)
         }
     }
 
@@ -469,16 +469,22 @@ class CustomerSessionCustomerSheetActivityTest {
             filename = "payment-method-detach.json",
             replacements = listOf(
                 ResponseReplacement(
-                    original = "[PAYMENT_METHOD_ID_HERE]",
+                    original = "PAYMENT_METHOD_ID_HERE",
                     new = id
                 )
             )
         )
     }
 
-    private fun MockResponse.createPaymentMethodUpdateResponse(): MockResponse {
+    private fun MockResponse.createPaymentMethodUpdateResponse(id: String): MockResponse {
         return testBodyFromFile(
             filename = "payment-method-update.json",
+            replacements = listOf(
+                ResponseReplacement(
+                    original = "PAYMENT_METHOD_ID_HERE",
+                    new = id
+                )
+            )
         )
     }
 
@@ -504,7 +510,7 @@ class CustomerSessionCustomerSheetActivityTest {
             filename = "elements-sessions-customer_sheet_customer_session.json",
             replacements = listOf(
                 ResponseReplacement(
-                    original = "[PAYMENT_METHOD_REMOVE_FEATURE]",
+                    original = "PAYMENT_METHOD_REMOVE_FEATURE",
                     new = removeFeature,
                 ),
                 ResponseReplacement(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSessionCustomerSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSessionCustomerSheetActivityTest.kt
@@ -38,8 +38,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalCustomerSheetApi::class, ExperimentalCustomerSessionApi::class)
 @RunWith(AndroidJUnit4::class)
@@ -316,8 +314,6 @@ class CustomerSessionCustomerSheetActivityTest {
         allowsRemovalOfLastSavedPaymentMethod: Boolean = true,
         test: (CustomerSheetActivity) -> Unit,
     ) {
-        val countDownLatch = CountDownLatch(1)
-
         CustomerSheetHacks.initialize(
             application = application,
             lifecycleOwner = TestLifecycleOwner(),
@@ -376,12 +372,7 @@ class CustomerSessionCustomerSheetActivityTest {
                 }
 
                 test(activity)
-
-                countDownLatch.countDown()
             }
-
-            countDownLatch.await(5, TimeUnit.SECONDS)
-            networkRule.validate()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/EditPage.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/EditPage.kt
@@ -1,8 +1,10 @@
 package com.stripe.android.paymentsheet
 
+import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_EDIT_SCREEN_REMOVE_BUTTON
 import com.stripe.android.paymentsheet.ui.TEST_TAG_EDIT_SCREEN_UPDATE_BUTTON
 import com.stripe.android.paymentsheet.ui.TEST_TAG_PAYMENT_SHEET_EDIT_SCREEN
 import com.stripe.android.uicore.elements.DROPDOWN_MENU_CLICKABLE_TEST_TAG
@@ -28,5 +30,9 @@ internal class EditPage(
     fun update() {
         composeTestRule.onNodeWithTag(TEST_TAG_EDIT_SCREEN_UPDATE_BUTTON)
             .performClick()
+    }
+
+    fun onRemoveButton(): SemanticsNodeInteraction {
+        return composeTestRule.onNodeWithTag(PAYMENT_SHEET_EDIT_SCREEN_REMOVE_BUTTON)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/RemoveDialog.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/RemoveDialog.kt
@@ -1,0 +1,15 @@
+package com.stripe.android.paymentsheet
+
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.performClick
+import com.stripe.android.ui.core.elements.TEST_TAG_DIALOG_CONFIRM_BUTTON
+
+class RemoveDialog(private val composeTestRule: ComposeTestRule) {
+    fun confirm(): SemanticsNodeInteraction {
+        return composeTestRule.onNode(
+            hasTestTag(TEST_TAG_DIALOG_CONFIRM_BUTTON)
+        ).performClick()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodsPage.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodsPage.kt
@@ -1,0 +1,71 @@
+package com.stripe.android.paymentsheet
+
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasAnyDescendant
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onNodeWithTag
+import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_EDIT_BUTTON_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
+import com.stripe.android.paymentsheet.ui.TEST_TAG_MODIFY_BADGE
+import com.stripe.android.paymentsheet.ui.TEST_TAG_REMOVE_BADGE
+
+class SavedPaymentMethodsPage(private val composeTestRule: ComposeTestRule) {
+    fun waitUntilVisible() {
+        composeTestRule.waitUntil {
+            composeTestRule
+                .onAllNodes(hasTestTag(SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG))
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+    }
+
+    fun waitForSavedPaymentMethodToBeRemoved(last4: String) {
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodes(
+                savedPaymentMethodMatcher(last4 = last4).and(
+                    SemanticsMatcher("is_placed_in_layout") { node ->
+                        node.layoutInfo.isPlaced
+                    }
+                )
+            )
+                .fetchSemanticsNodes()
+                .isEmpty()
+        }
+    }
+
+    fun onSavedPaymentMethod(last4: String): SemanticsNodeInteraction {
+        return composeTestRule.onNode(savedPaymentMethodMatcher(last4))
+    }
+
+    fun onEditButton(): SemanticsNodeInteraction {
+        return composeTestRule.onNodeWithTag(PAYMENT_SHEET_EDIT_BUTTON_TEST_TAG)
+    }
+
+    fun onRemoveBadgeFor(last4: String): SemanticsNodeInteraction {
+        return composeTestRule.onNode(
+            hasTestTag(TEST_TAG_REMOVE_BADGE).and(hasAnyAncestor(savedPaymentMethodMatcher(last4)))
+        )
+    }
+
+    fun onModifyBadgeFor(last4: String): SemanticsNodeInteraction {
+        return composeTestRule.onNode(
+            hasTestTag(TEST_TAG_MODIFY_BADGE).and(hasAnyAncestor(savedPaymentMethodMatcher(last4)))
+        )
+    }
+
+    private fun savedPaymentMethodMatcher(last4: String): SemanticsMatcher {
+        return hasTestTag(SAVED_PAYMENT_OPTION_TEST_TAG).and(hasText(last4, substring = true))
+    }
+
+    companion object {
+        fun SemanticsNodeInteraction.assertHasModifyBadge() {
+            assert(hasAnyDescendant(hasTestTag(TEST_TAG_MODIFY_BADGE)))
+        }
+    }
+}

--- a/paymentsheet/src/test/resources/elements-sessions-customer_sheet_customer_session.json
+++ b/paymentsheet/src/test/resources/elements-sessions-customer_sheet_customer_session.json
@@ -29,7 +29,7 @@
         "customer_sheet": {
           "enabled": true,
           "features": {
-            "payment_method_remove": "[PAYMENT_METHOD_REMOVE_FEATURE]"
+            "payment_method_remove": "PAYMENT_METHOD_REMOVE_FEATURE"
           }
         }
       }

--- a/paymentsheet/src/test/resources/elements-sessions-customer_sheet_customer_session.json
+++ b/paymentsheet/src/test/resources/elements-sessions-customer_sheet_customer_session.json
@@ -1,0 +1,62 @@
+{
+  "business_name": "Mobile Example Account",
+  "google_pay_preference": "enabled",
+  "merchant_country": "US",
+  "merchant_currency": "usd",
+  "merchant_id": "acct_1HvTI7Lu5o3P18Zp",
+  "meta_pay_signed_container_context": null,
+  "order": null,
+  "ordered_payment_method_types_and_wallets": [
+    "card"
+  ],
+  "card_brand_choice": {
+    "eligible": true,
+    "preferred_networks": ["cartes_bancaires"]
+  },
+  "customer": {
+    "payment_methods": [PAYMENT_METHODS_HERE],
+    "customer_session": {
+      "id": "cuss_654321",
+      "livemode": false,
+      "api_key": "ek_12345",
+      "api_key_expiry": 2147483647,
+      "customer": "cus_12345",
+      "components": {
+        "mobile_payment_element": {
+          "enabled": false,
+          "features": null
+        },
+        "customer_sheet": {
+          "enabled": true,
+          "features": {
+            "payment_method_remove": "[PAYMENT_METHOD_REMOVE_FEATURE]"
+          }
+        }
+      }
+    },
+    "default_payment_method": null
+  },
+  "payment_method_preference": {
+    "object": "payment_method_preference",
+    "country_code": "US",
+    "ordered_payment_method_types": [
+      "card"
+    ],
+    "type": "deferred_intent"
+  },
+  "payment_method_specs": [
+    {
+      "async": false,
+      "fields": [],
+      "type": "card"
+    }
+  ],
+  "paypal_express_config": {
+    "client_id": null,
+    "paypal_merchant_id": null
+  },
+  "shipping_address_settings": {
+    "autocomplete_allowed": true
+  },
+  "unactivated_payment_method_types": []
+}

--- a/paymentsheet/src/test/resources/payment-method-detach.json
+++ b/paymentsheet/src/test/resources/payment-method-detach.json
@@ -1,0 +1,47 @@
+{
+  "id": "[PAYMENT_METHOD_ID_HERE]",
+  "object": "payment_method",
+  "billing_details": {
+    "address": {
+      "city": null,
+      "country": "AE",
+      "line1": null,
+      "line2": null,
+      "postal_code": null,
+      "state": null
+    },
+    "email": null,
+    "name": "CustomerSheet Testing",
+    "phone": null
+  },
+  "card": {
+    "brand": "visa",
+    "checks": {
+      "address_line1_check": null,
+      "address_postal_code_check": null,
+      "cvc_check": null
+    },
+    "country": "US",
+    "display_brand": "visa",
+    "exp_month": 12,
+    "exp_year": 2034,
+    "fingerprint": "LzD7yFi1Cp2DJQs7",
+    "funding": "credit",
+    "generated_from": null,
+    "last4": "4242",
+    "networks": {
+      "available": [
+        "visa"
+      ],
+      "preferred": null
+    },
+    "three_d_secure_usage": {
+      "supported": true
+    },
+    "wallet": null
+  },
+  "created": 1712554485,
+  "customer": null,
+  "livemode": false,
+  "type": "card"
+}

--- a/paymentsheet/src/test/resources/payment-method-detach.json
+++ b/paymentsheet/src/test/resources/payment-method-detach.json
@@ -1,5 +1,5 @@
 {
-  "id": "[PAYMENT_METHOD_ID_HERE]",
+  "id": "PAYMENT_METHOD_ID_HERE",
   "object": "payment_method",
   "billing_details": {
     "address": {

--- a/paymentsheet/src/test/resources/payment-method-update.json
+++ b/paymentsheet/src/test/resources/payment-method-update.json
@@ -1,0 +1,48 @@
+{
+  "id": "[PAYMENT_METHOD_ID_HERE",
+  "object": "payment_method",
+  "billing_details": {
+    "address": {
+      "city": null,
+      "country": "AE",
+      "line1": null,
+      "line2": null,
+      "postal_code": null,
+      "state": null
+    },
+    "email": null,
+    "name": "CustomerSheet Testing",
+    "phone": null
+  },
+  "card": {
+    "brand": "visa",
+    "checks": {
+      "address_line1_check": null,
+      "address_postal_code_check": null,
+      "cvc_check": null
+    },
+    "country": "US",
+    "display_brand": "visa",
+    "exp_month": 12,
+    "exp_year": 2034,
+    "fingerprint": "LzD7yFi1Cp2DJQs7",
+    "funding": "credit",
+    "generated_from": null,
+    "last4": "1001",
+    "networks": {
+      "available": [
+        "visa",
+        "cartes_bancaires"
+      ],
+      "preferred": "visa"
+    },
+    "three_d_secure_usage": {
+      "supported": true
+    },
+    "wallet": null
+  },
+  "created": 1712554485,
+  "customer": null,
+  "livemode": false,
+  "type": "card"
+}

--- a/paymentsheet/src/test/resources/payment-method-update.json
+++ b/paymentsheet/src/test/resources/payment-method-update.json
@@ -1,5 +1,5 @@
 {
-  "id": "[PAYMENT_METHOD_ID_HERE",
+  "id": "PAYMENT_METHOD_ID_HERE",
   "object": "payment_method",
   "billing_details": {
     "address": {

--- a/paymentsheet/src/test/resources/payment-methods-get-success.json
+++ b/paymentsheet/src/test/resources/payment-methods-get-success.json
@@ -1,0 +1,6 @@
+{
+  "object": "list",
+  "data": [PAYMENT_METHODS_HERE],
+  "has_more": false,
+  "url": "/v1/payment_methods"
+}


### PR DESCRIPTION
# Summary
Add integrated `CustomerSheet` activity tests for `CustomerSession`

# Motivation
Ensures new `CustomerSession` behavior for `CustomerSheet` is maintained throughout changes to `CustomerSheet`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
