### PR TITLE
Add `paymentMethodTypes` definition to `CustomerSheet` playground

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
@@ -190,7 +190,8 @@ internal class PaymentSheetPlaygroundViewModel(
                 { customerId -> createSetupIntentClientSecret(customerId, customerState.countryCode) }
             } else {
                 null
-            }
+            },
+            paymentMethodTypes = customerState?.supportedPaymentMethodTypes,
         )
     }
 
@@ -198,6 +199,14 @@ internal class PaymentSheetPlaygroundViewModel(
         playgroundState: PlaygroundState.Customer,
     ): CustomerSheet.CustomerSessionProvider {
         return object : CustomerSheet.CustomerSessionProvider() {
+            override suspend fun intentConfiguration(): kotlin.Result<CustomerSheet.IntentConfiguration> {
+                return kotlin.Result.success(
+                    CustomerSheet.IntentConfiguration.Builder()
+                        .paymentMethodTypes(playgroundState.supportedPaymentMethodTypes)
+                        .build()
+                )
+            }
+
             override suspend fun providesCustomerSessionClientSecret(): kotlin.Result<
                 CustomerSheet.CustomerSessionClientSecret
                 > {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PlaygroundState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PlaygroundState.kt
@@ -23,6 +23,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.PaymentMethod
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundConfigurationData
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettings
 import com.stripe.android.paymentsheet.example.playground.settings.RequireCvcRecollectionDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
 import kotlinx.parcelize.Parcelize
 
 @Stable
@@ -95,6 +96,13 @@ internal sealed interface PlaygroundState : Parcelable {
         val inSetupMode
             get() = snapshot[CustomerSheetPaymentMethodModeDefinition] ==
                 PaymentMethodMode.SetupIntent
+
+        val supportedPaymentMethodTypes: List<String>
+            get() = snapshot[SupportedPaymentMethodsSettingsDefinition]
+                .split(",")
+                .filterNot { value ->
+                    value.isBlank()
+                }
 
         fun customerSheetConfiguration(): CustomerSheet.Configuration {
             return snapshot.customerSheetConfiguration(this)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SupportedPaymentMethodsSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SupportedPaymentMethodsSettingsDefinition.kt
@@ -21,10 +21,6 @@ internal object SupportedPaymentMethodsSettingsDefinition :
         configurationData: PlaygroundConfigurationData
     ) = emptyList<PlaygroundSettingDefinition.Displayable.Option<String>>()
 
-    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
-        return configurationData.integrationType.isPaymentFlow()
-    }
-
     override fun convertToString(value: String): String = value
     override fun convertToValue(value: String): String = value
 }


### PR DESCRIPTION
# Summary
Add `paymentMethodTypes` definition to `CustomerSheet` playground

# Motivation
Looks like we never added this for `CustomerSheet`. Adding it now in order to properly test different payment method types.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified