### PR TITLE
Set default for `CustomerSessionRedisplayFiltersSettingsDefinition` to `Always`

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionRedisplayFiltersSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionRedisplayFiltersSettingsDefinition.kt
@@ -10,7 +10,7 @@ internal object CustomerSessionRedisplayFiltersSettingsDefinition :
     by EnumSaveable(
         key = "customer_session_payment_method_redisplay_filters",
         values = RedisplayFilterType.entries.toTypedArray(),
-        defaultValue = RedisplayFilterType.All,
+        defaultValue = RedisplayFilterType.Always,
     ),
     PlaygroundSettingDefinition.Displayable<CustomerSessionRedisplayFiltersSettingsDefinition.RedisplayFilterType> {
     override val displayName: String = "Customer Session Allow Redisplay Filters"


### PR DESCRIPTION
# Summary
Set default for `CustomerSessionRedisplayFiltersSettingsDefinition` to `Always`

# Motivation
Feedback from `CustomerSession` on `PaymentSheet` bug bash. The most likely scenario for `CustomerSession` is that merchants will only show payment methods with allow redisplay set to `Always` (explicit customer consent was given in this case). We should default to this behavior unless we explicitly want to check other behaviors. Follows what iOS does as well.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
