### PR TITLE
Add `FakeCustomerSheetInitializationDataSource` & use in `DefaultCustomerSheetLoaderTest`

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSheetInitializationDataSource.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSheetInitializationDataSource.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.customersheet.data
+
+internal class FakeCustomerSheetInitializationDataSource(
+    private val onLoadCustomerSheetSession: () -> CustomerSheetDataResult<CustomerSheetSession>,
+) : CustomerSheetInitializationDataSource {
+    override suspend fun loadCustomerSheetSession(): CustomerSheetDataResult<CustomerSheetSession> {
+        return onLoadCustomerSheetSession()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -1,30 +1,32 @@
 package com.stripe.android.customersheet.state
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.core.exception.APIConnectionException
-import com.stripe.android.customersheet.CustomerAdapter
+import com.stripe.android.customersheet.CustomerPermissions
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetLoader
 import com.stripe.android.customersheet.DefaultCustomerSheetLoader
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import com.stripe.android.customersheet.FakeCustomerAdapter
 import com.stripe.android.customersheet.data.CustomerAdapterDataSource
+import com.stripe.android.customersheet.data.CustomerSheetDataResult
 import com.stripe.android.customersheet.data.CustomerSheetInitializationDataSource
+import com.stripe.android.customersheet.data.CustomerSheetSession
+import com.stripe.android.customersheet.data.FakeCustomerSheetInitializationDataSource
 import com.stripe.android.customersheet.util.CustomerSheetHacks
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ElementsSession
-import com.stripe.android.model.ElementsSessionParams
 import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAvailable
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
-import com.stripe.android.paymentsheet.repositories.toElementsSessionParams
+import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.utils.FakeElementsSessionRepository
@@ -72,26 +74,14 @@ class DefaultCustomerSheetLoaderTest {
 
     @Test
     fun `load with configuration should return expected result`() = runTest {
-        val elementsSessionRepository = FakeElementsSessionRepository(
-            stripeIntent = STRIPE_INTENT,
-            error = null,
-            linkSettings = null,
-        )
         val loader = createCustomerSheetLoader(
-            customerAdapter = FakeCustomerAdapter(
-                selectedPaymentOption = CustomerAdapter.Result.success(
-                    CustomerAdapter.PaymentOption.fromId(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!
-                    )
-                ),
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                        PaymentMethodFixtures.US_BANK_ACCOUNT,
-                    )
-                ),
+            savedSelection = SavedSelection.PaymentMethod(
+                id = PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!
             ),
-            elementsSessionRepository = elementsSessionRepository,
+            paymentMethods = listOf(
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                PaymentMethodFixtures.US_BANK_ACCOUNT,
+            ),
         )
 
         val config = CustomerSheet.Configuration(
@@ -117,176 +107,17 @@ class DefaultCustomerSheetLoaderTest {
             )
         )
         assertThat(state.validationError).isNull()
-
-        val mode = elementsSessionRepository.lastParams?.initializationMode
-            as PaymentSheet.InitializationMode.DeferredIntent
-        assertThat(mode.intentConfiguration.paymentMethodTypes)
-            .isEmpty()
-    }
-
-    @Test
-    fun `load should return expected result when customer adapter has paymentMethodTypes`() = runTest {
-        val elementsSessionRepository = FakeElementsSessionRepository(
-            stripeIntent = STRIPE_INTENT,
-            error = null,
-            linkSettings = null,
-        )
-        val loader = createCustomerSheetLoader(
-            customerAdapter = FakeCustomerAdapter(
-                selectedPaymentOption = CustomerAdapter.Result.success(
-                    CustomerAdapter.PaymentOption.fromId(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!
-                    )
-                ),
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                        PaymentMethodFixtures.US_BANK_ACCOUNT,
-                    )
-                ),
-                paymentMethodTypes = listOf("card", "us_bank_account"),
-            ),
-            elementsSessionRepository = elementsSessionRepository,
-        )
-
-        val config = CustomerSheet.Configuration(
-            merchantDisplayName = "Example",
-            googlePayEnabled = true
-        )
-
-        val state = loader.load(config).getOrThrow()
-        assertThat(state.config).isEqualTo(config)
-        assertThat(state.paymentMethodMetadata.stripeIntent).isEqualTo(STRIPE_INTENT)
-        assertThat(state.paymentMethodMetadata.isGooglePayReady).isTrue()
-        assertThat(state.customerPaymentMethods).containsExactly(
-            PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-            PaymentMethodFixtures.US_BANK_ACCOUNT,
-        )
-        assertThat(state.supportedPaymentMethods.map { it.code }).containsExactly("card")
-        assertThat(state.paymentSelection).isEqualTo(
-            PaymentSelection.Saved(
-                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-            )
-        )
-        assertThat(state.customerPermissions.canRemovePaymentMethods).isTrue()
-        assertThat(state.paymentMethodMetadata.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
-        assertThat(state.validationError).isNull()
-
-        val mode = elementsSessionRepository.lastParams?.initializationMode
-            as PaymentSheet.InitializationMode.DeferredIntent
-        assertThat(mode.intentConfiguration.paymentMethodTypes)
-            .isEqualTo(listOf("card", "us_bank_account"))
-    }
-
-    @Test
-    fun `when setup intent cannot be created, supported payment methods should contain at least card`() = runTest {
-        val loader = createCustomerSheetLoader(
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                    )
-                ),
-                canCreateSetupIntents = false,
-            )
-        )
-
-        val config = CustomerSheet.Configuration(merchantDisplayName = "Example")
-
-        val state = loader.load(config).getOrThrow()
-        assertThat(state.config).isEqualTo(config)
-        assertThat(state.paymentMethodMetadata).isNotNull()
-        assertThat(state.paymentMethodMetadata.isGooglePayReady).isFalse()
-        assertThat(state.customerPaymentMethods).containsExactly(
-            PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-        )
-        assertThat(state.supportedPaymentMethods.map { it.code }).containsExactly("card")
-        assertThat(state.customerPermissions.canRemovePaymentMethods).isTrue()
-        assertThat(state.paymentSelection).isNull()
-        assertThat(state.paymentMethodMetadata.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
-        assertThat(state.validationError).isNull()
-    }
-
-    @Test
-    fun `when setup intent cannot be created, elements sessions is called with card only`() = runTest {
-        val elementsSessionRepository = FakeElementsSessionRepository(
-            stripeIntent = STRIPE_INTENT,
-            error = null,
-            linkSettings = null,
-        )
-        val loader = createCustomerSheetLoader(
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                    )
-                ),
-                canCreateSetupIntents = false,
-            ),
-            elementsSessionRepository = elementsSessionRepository,
-        )
-
-        val config = CustomerSheet.Configuration(
-            merchantDisplayName = "Example",
-        )
-
-        assertThat(loader.load(config).getOrThrow()).isNotNull()
-        val params = elementsSessionRepository.lastParams?.initializationMode?.toElementsSessionParams(
-            customer = null,
-            externalPaymentMethods = emptyList(),
-            defaultPaymentMethodId = null,
-        ) as ElementsSessionParams.DeferredIntentType
-        assertThat(params.deferredIntentParams.paymentMethodTypes).containsExactly("card")
-    }
-
-    @Test
-    fun `when setup intent cannot be created, elements sessions is called with card only when paymentMethodTypes is set`() = runTest {
-        val elementsSessionRepository = FakeElementsSessionRepository(
-            stripeIntent = STRIPE_INTENT,
-            error = null,
-            linkSettings = null,
-        )
-        val loader = createCustomerSheetLoader(
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                    )
-                ),
-                canCreateSetupIntents = false,
-                paymentMethodTypes = listOf("card", "us_bank_account"),
-            ),
-            elementsSessionRepository = elementsSessionRepository,
-        )
-
-        val config = CustomerSheet.Configuration(
-            merchantDisplayName = "Example",
-        )
-
-        assertThat(loader.load(config).getOrThrow()).isNotNull()
-        val params = elementsSessionRepository.lastParams?.initializationMode?.toElementsSessionParams(
-            customer = null,
-            externalPaymentMethods = emptyList(),
-            defaultPaymentMethodId = null,
-        ) as ElementsSessionParams.DeferredIntentType
-        assertThat(params.deferredIntentParams.paymentMethodTypes).containsExactly("card")
     }
 
     @Test
     fun `when there is a payment selection, the selected PM should be first in the list`() = runTest {
         val loader = createCustomerSheetLoader(
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_1"),
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_2"),
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_3"),
-                    )
-                ),
-                selectedPaymentOption = CustomerAdapter.Result.success(
-                    CustomerAdapter.PaymentOption.fromId("pm_3")
-                )
-            )
+            paymentMethods = listOf(
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_1"),
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_2"),
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_3"),
+            ),
+            savedSelection = SavedSelection.PaymentMethod(id = "pm_3"),
         )
 
         val config = CustomerSheet.Configuration(merchantDisplayName = "Example")
@@ -314,16 +145,12 @@ class DefaultCustomerSheetLoaderTest {
     @Test
     fun `when there is no payment selection, the order of the payment methods is preserved`() = runTest {
         val loader = createCustomerSheetLoader(
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.success(
-                    listOf(
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_1"),
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_2"),
-                        PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_3"),
-                    )
-                ),
-                selectedPaymentOption = CustomerAdapter.Result.success(null)
-            )
+            paymentMethods = listOf(
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_1"),
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_2"),
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_3"),
+            ),
+            savedSelection = null,
         )
 
         val config = CustomerSheet.Configuration(merchantDisplayName = "Example")
@@ -347,17 +174,10 @@ class DefaultCustomerSheetLoaderTest {
     @Test
     fun `When the FC unavailable, flag disabled, us bank not in intent, then us bank account is not available`() = runTest {
         val loader = createCustomerSheetLoader(
-            customerAdapter = FakeCustomerAdapter(
-                canCreateSetupIntents = true,
-            ),
             isFinancialConnectionsAvailable = { false },
-            elementsSessionRepository = FakeElementsSessionRepository(
-                stripeIntent = STRIPE_INTENT.copy(
-                    paymentMethodTypes = listOf("card")
-                ),
-                error = null,
-                linkSettings = null,
-            )
+            intent = STRIPE_INTENT.copy(
+                paymentMethodTypes = listOf("card")
+            ),
         )
 
         val config = CustomerSheet.Configuration(merchantDisplayName = "Example")
@@ -370,17 +190,10 @@ class DefaultCustomerSheetLoaderTest {
     @Test
     fun `When the FC unavailable, flag disabled, us bank in intent, then us bank account is not available`() = runTest {
         val loader = createCustomerSheetLoader(
-            customerAdapter = FakeCustomerAdapter(
-                canCreateSetupIntents = true,
-            ),
             isFinancialConnectionsAvailable = { false },
-            elementsSessionRepository = FakeElementsSessionRepository(
-                stripeIntent = STRIPE_INTENT.copy(
-                    paymentMethodTypes = listOf("card", "us_bank_account")
-                ),
-                error = null,
-                linkSettings = null,
-            )
+            intent = STRIPE_INTENT.copy(
+                paymentMethodTypes = listOf("card", "us_bank_account")
+            ),
         )
 
         val config = CustomerSheet.Configuration(merchantDisplayName = "Example")
@@ -393,17 +206,10 @@ class DefaultCustomerSheetLoaderTest {
     @Test
     fun `When the FC unavailable, flag enabled, us bank not in intent, then us bank account is not available`() = runTest {
         val loader = createCustomerSheetLoader(
-            customerAdapter = FakeCustomerAdapter(
-                canCreateSetupIntents = true,
-            ),
             isFinancialConnectionsAvailable = { false },
-            elementsSessionRepository = FakeElementsSessionRepository(
-                stripeIntent = STRIPE_INTENT.copy(
-                    paymentMethodTypes = listOf("card")
-                ),
-                error = null,
-                linkSettings = null,
-            )
+            intent = STRIPE_INTENT.copy(
+                paymentMethodTypes = listOf("card")
+            ),
         )
 
         val config = CustomerSheet.Configuration(merchantDisplayName = "Example")
@@ -416,17 +222,10 @@ class DefaultCustomerSheetLoaderTest {
     @Test
     fun `When the FC unavailable, flag enabled, us bank in intent, then us bank account is not available`() = runTest {
         val loader = createCustomerSheetLoader(
-            customerAdapter = FakeCustomerAdapter(
-                canCreateSetupIntents = true,
-            ),
             isFinancialConnectionsAvailable = { false },
-            elementsSessionRepository = FakeElementsSessionRepository(
-                stripeIntent = STRIPE_INTENT.copy(
-                    paymentMethodTypes = listOf("card", "us_bank_account")
-                ),
-                error = null,
-                linkSettings = null,
-            )
+            intent = STRIPE_INTENT.copy(
+                paymentMethodTypes = listOf("card", "us_bank_account")
+            ),
         )
 
         val config = CustomerSheet.Configuration(merchantDisplayName = "Example")
@@ -439,17 +238,10 @@ class DefaultCustomerSheetLoaderTest {
     @Test
     fun `When the FC available, flag disabled, us bank not in intent, then us bank account is not available`() = runTest {
         val loader = createCustomerSheetLoader(
-            customerAdapter = FakeCustomerAdapter(
-                canCreateSetupIntents = true,
-            ),
             isFinancialConnectionsAvailable = { true },
-            elementsSessionRepository = FakeElementsSessionRepository(
-                stripeIntent = STRIPE_INTENT.copy(
-                    paymentMethodTypes = listOf("card")
-                ),
-                error = null,
-                linkSettings = null,
-            )
+            intent = STRIPE_INTENT.copy(
+                paymentMethodTypes = listOf("card")
+            ),
         )
 
         val config = CustomerSheet.Configuration(merchantDisplayName = "Example")
@@ -462,17 +254,10 @@ class DefaultCustomerSheetLoaderTest {
     @Test
     fun `When the FC available, flag disabled, us bank in intent, then us bank account is not available`() = runTest {
         val loader = createCustomerSheetLoader(
-            customerAdapter = FakeCustomerAdapter(
-                canCreateSetupIntents = true,
-            ),
             isFinancialConnectionsAvailable = { true },
-            elementsSessionRepository = FakeElementsSessionRepository(
-                stripeIntent = STRIPE_INTENT.copy(
-                    paymentMethodTypes = listOf("card", "us_bank_account")
-                ),
-                error = null,
-                linkSettings = null,
-            )
+            intent = STRIPE_INTENT.copy(
+                paymentMethodTypes = listOf("card", "us_bank_account")
+            ),
         )
 
         val config = CustomerSheet.Configuration(merchantDisplayName = "Example")
@@ -485,17 +270,10 @@ class DefaultCustomerSheetLoaderTest {
     @Test
     fun `When the FC available, flag enabled, us bank not in intent, then us bank account is not available`() = runTest {
         val loader = createCustomerSheetLoader(
-            customerAdapter = FakeCustomerAdapter(
-                canCreateSetupIntents = true,
-            ),
             isFinancialConnectionsAvailable = { true },
-            elementsSessionRepository = FakeElementsSessionRepository(
-                stripeIntent = STRIPE_INTENT.copy(
-                    paymentMethodTypes = listOf("card")
-                ),
-                error = null,
-                linkSettings = null,
-            )
+            intent = STRIPE_INTENT.copy(
+                paymentMethodTypes = listOf("card"),
+            ),
         )
 
         val config = CustomerSheet.Configuration(merchantDisplayName = "Example")
@@ -508,25 +286,18 @@ class DefaultCustomerSheetLoaderTest {
     @Test
     fun `When the FC available, flag enabled, us bank in intent, then us bank account is available`() = runTest {
         val loader = createCustomerSheetLoader(
-            customerAdapter = FakeCustomerAdapter(
-                canCreateSetupIntents = true,
-            ),
             isFinancialConnectionsAvailable = { true },
-            elementsSessionRepository = FakeElementsSessionRepository(
-                stripeIntent = STRIPE_INTENT.copy(
-                    clientSecret = null,
-                    paymentMethodTypes = listOf("card", "us_bank_account"),
-                    paymentMethodOptionsJsonString = """
+            intent = STRIPE_INTENT.copy(
+                clientSecret = null,
+                paymentMethodTypes = listOf("card", "us_bank_account"),
+                paymentMethodOptionsJsonString = """
                         {
                             "us_bank_account": {
                                 "verification_method": "automatic"
                             }
                         }
-                    """.trimIndent(),
-                ),
-                error = null,
-                linkSettings = null,
-            )
+                """.trimIndent(),
+            ),
         )
 
         val config = CustomerSheet.Configuration(merchantDisplayName = "Example")
@@ -618,56 +389,6 @@ class DefaultCustomerSheetLoaderTest {
     }
 
     @Test
-    fun `On failed to load elements session, show report error`() = runTest {
-        val errorReporter = FakeErrorReporter()
-
-        val loader = createCustomerSheetLoader(
-            elementsSessionRepository = FakeElementsSessionRepository(
-                stripeIntent = STRIPE_INTENT,
-                error = APIConnectionException("Connection failure!"),
-                linkSettings = null,
-            ),
-            errorReporter = errorReporter,
-        )
-
-        loader.load(
-            configuration = CustomerSheet.Configuration(merchantDisplayName = "Merchant, Inc.")
-        )
-
-        assertThat(
-            errorReporter.getLoggedErrors().first()
-        ).isEqualTo(
-            ErrorReporter.ExpectedErrorEvent.CUSTOMER_SHEET_ELEMENTS_SESSION_LOAD_FAILURE.eventName
-        )
-    }
-
-    @Test
-    fun `On failed to load payment methods, show report error`() = runTest {
-        val errorReporter = FakeErrorReporter()
-
-        val loader = createCustomerSheetLoader(
-            customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.failure(
-                    cause = APIConnectionException("Connection failure!"),
-                    displayMessage = null
-                )
-            ),
-            errorReporter = errorReporter,
-        )
-
-        loader.load(
-            configuration = CustomerSheet.Configuration(merchantDisplayName = "Merchant, Inc.")
-        )
-
-        assertThat(
-            errorReporter.getLoggedErrors()
-        ).containsExactly(
-            ErrorReporter.SuccessEvent.CUSTOMER_SHEET_ELEMENTS_SESSION_LOAD_SUCCESS.eventName,
-            ErrorReporter.ExpectedErrorEvent.CUSTOMER_SHEET_PAYMENT_METHODS_LOAD_FAILURE.eventName
-        )
-    }
-
-    @Test
     fun `On timeout while waiting for 'CustomerAdapter' instance, show report error`() = runTest {
         val errorReporter = FakeErrorReporter()
 
@@ -693,25 +414,38 @@ class DefaultCustomerSheetLoaderTest {
         isLiveModeProvider: () -> Boolean = { false },
         isCbcEligible: Boolean? = null,
         isFinancialConnectionsAvailable: IsFinancialConnectionsAvailable = IsFinancialConnectionsAvailable { false },
-        elementsSessionRepository: ElementsSessionRepository = FakeElementsSessionRepository(
-            stripeIntent = STRIPE_INTENT,
-            error = null,
-            linkSettings = null,
-            cardBrandChoice = createCardBrandChoice(isCbcEligible),
+        intent: StripeIntent = STRIPE_INTENT,
+        paymentMethods: List<PaymentMethod> = listOf(),
+        savedSelection: SavedSelection? = null,
+        initializationDataSource: CustomerSheetInitializationDataSource = FakeCustomerSheetInitializationDataSource(
+            onLoadCustomerSheetSession = {
+                CustomerSheetDataResult.success(
+                    CustomerSheetSession(
+                        elementsSession = ElementsSession(
+                            stripeIntent = intent,
+                            linkSettings = null,
+                            customer = null,
+                            externalPaymentMethodData = null,
+                            isGooglePayEnabled = true,
+                            merchantCountry = "US",
+                            paymentMethodSpecs = null,
+                            cardBrandChoice = createCardBrandChoice(isCbcEligible),
+                        ),
+                        paymentMethods = paymentMethods,
+                        savedSelection = savedSelection,
+                        paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+                        permissions = CustomerPermissions(
+                            canRemovePaymentMethods = true,
+                        ),
+                    )
+                )
+            }
         ),
-        customerAdapter: CustomerAdapter = FakeCustomerAdapter(),
         lpmRepository: LpmRepository = this.lpmRepository,
         errorReporter: ErrorReporter = FakeErrorReporter(),
     ): CustomerSheetLoader {
         return createCustomerSheetLoader(
-            initializationDataSourceProvider = CompletableDeferred(
-                CustomerAdapterDataSource(
-                    elementsSessionRepository = elementsSessionRepository,
-                    workContext = UnconfinedTestDispatcher(),
-                    customerAdapter = customerAdapter,
-                    errorReporter = errorReporter,
-                )
-            ),
+            initializationDataSourceProvider = CompletableDeferred(initializationDataSource),
             isGooglePayReady = isGooglePayReady,
             isLiveModeProvider = isLiveModeProvider,
             isFinancialConnectionsAvailable = isFinancialConnectionsAvailable,


### PR DESCRIPTION
# Summary
Add `FakeCustomerSheetInitializationDataSource` & use in `DefaultCustomerSheetLoaderTest`

# Motivation
Replaces direct usage of `CustomerAdapter` in `DefaultCustomerSheetLoaderTest`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified