### PR TITLE
Add analytics for Link Card Brand payments

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -533,7 +533,13 @@ internal fun PaymentSelection?.linkContext(): String? {
     return when (this) {
         is PaymentSelection.Link -> "wallet"
         is PaymentSelection.New.USBankAccount -> {
-            "instant_debits".takeIf { instantDebits != null }
+            instantDebits?.let {
+                if (it.linkMode == LinkMode.LinkCardBrand) {
+                    "link_card_brand"
+                } else {
+                    "instant_debits"
+                }
+            }
         }
         is PaymentSelection.GooglePay,
         is PaymentSelection.New,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -8,6 +8,7 @@ import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethod.Type.USBankAccount
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -183,6 +184,7 @@ internal sealed class PaymentSelection : Parcelable {
             @Parcelize
             data class InstantDebitsInfo(
                 val paymentMethodId: String,
+                val linkMode: LinkMode?,
             ) : Parcelable
 
             @Parcelize

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -585,6 +585,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         val instantDebitsInfo = (resultIdentifier as? ResultIdentifier.PaymentMethod)?.let {
             PaymentSelection.New.USBankAccount.InstantDebitsInfo(
                 paymentMethodId = it.id,
+                linkMode = args.linkMode,
             )
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -628,7 +628,7 @@ class DefaultEventReporterTest {
             simulateInit()
         }
 
-        val selection = mockUSBankAccountPaymentSelection(instantDebits = true)
+        val selection = mockUSBankAccountPaymentSelection(linkMode = LinkMode.LinkPaymentMethod)
         completeEventReporter.onPressConfirmButton(selection)
 
         val argumentCaptor = argumentCaptor<AnalyticsRequest>()
@@ -639,12 +639,28 @@ class DefaultEventReporterTest {
     }
 
     @Test
+    fun `Send correct link_context when pressing confirm button for Link Card Brand`() {
+        val completeEventReporter = createEventReporter(EventReporter.Mode.Complete) {
+            simulateInit()
+        }
+
+        val selection = mockUSBankAccountPaymentSelection(linkMode = LinkMode.LinkCardBrand)
+        completeEventReporter.onPressConfirmButton(selection)
+
+        val argumentCaptor = argumentCaptor<AnalyticsRequest>()
+        verify(analyticsRequestExecutor).executeAsync(argumentCaptor.capture())
+
+        val errorType = argumentCaptor.firstValue.params["link_context"] as String
+        assertThat(errorType).isEqualTo("link_card_brand")
+    }
+
+    @Test
     fun `Send correct link_context when pressing confirm button for Link card payments`() {
         val completeEventReporter = createEventReporter(EventReporter.Mode.Complete) {
             simulateInit()
         }
 
-        val selection = mockUSBankAccountPaymentSelection(instantDebits = false)
+        val selection = mockUSBankAccountPaymentSelection(linkMode = null)
         completeEventReporter.onPressConfirmButton(selection)
 
         val argumentCaptor = argumentCaptor<AnalyticsRequest>()
@@ -659,7 +675,7 @@ class DefaultEventReporterTest {
             simulateInit()
         }
 
-        val selection = mockUSBankAccountPaymentSelection(instantDebits = true)
+        val selection = mockUSBankAccountPaymentSelection(linkMode = LinkMode.LinkPaymentMethod)
         completeEventReporter.onPaymentSuccess(selection, deferredIntentConfirmationType = null)
 
         val argumentCaptor = argumentCaptor<AnalyticsRequest>()
@@ -670,12 +686,28 @@ class DefaultEventReporterTest {
     }
 
     @Test
+    fun `Send correct link_context when on payment success for Link Card Brand`() {
+        val completeEventReporter = createEventReporter(EventReporter.Mode.Complete) {
+            simulateInit()
+        }
+
+        val selection = mockUSBankAccountPaymentSelection(linkMode = LinkMode.LinkCardBrand)
+        completeEventReporter.onPaymentSuccess(selection, deferredIntentConfirmationType = null)
+
+        val argumentCaptor = argumentCaptor<AnalyticsRequest>()
+        verify(analyticsRequestExecutor).executeAsync(argumentCaptor.capture())
+
+        val errorType = argumentCaptor.firstValue.params["link_context"] as String
+        assertThat(errorType).isEqualTo("link_card_brand")
+    }
+
+    @Test
     fun `Send correct link_context when on payment success for Link card payments`() {
         val completeEventReporter = createEventReporter(EventReporter.Mode.Complete) {
             simulateInit()
         }
 
-        val selection = mockUSBankAccountPaymentSelection(instantDebits = false)
+        val selection = mockUSBankAccountPaymentSelection(linkMode = null)
         completeEventReporter.onPaymentSuccess(selection, deferredIntentConfirmationType = null)
 
         val argumentCaptor = argumentCaptor<AnalyticsRequest>()
@@ -751,7 +783,7 @@ class DefaultEventReporterTest {
         )
     }
 
-    private fun mockUSBankAccountPaymentSelection(instantDebits: Boolean): PaymentSelection.New.USBankAccount {
+    private fun mockUSBankAccountPaymentSelection(linkMode: LinkMode?): PaymentSelection.New.USBankAccount {
         return PaymentSelection.New.USBankAccount(
             labelResource = "Test",
             iconResource = 0,
@@ -766,7 +798,8 @@ class DefaultEventReporterTest {
             ),
             instantDebits = PaymentSelection.New.USBankAccount.InstantDebitsInfo(
                 paymentMethodId = "pm_123456789",
-            ).takeIf { instantDebits },
+                linkMode = linkMode,
+            ).takeIf { it.linkMode != null },
             screenState = USBankAccountFormScreenState.MandateCollection(
                 resultIdentifier = USBankAccountFormScreenState.ResultIdentifier.PaymentMethod("pm_123456789"),
                 intentId = "intent_1234",


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds analytics for Link Card Brand payments. In these cases, we send `link_card_brand` instead of `instant_debits` as the `link_context`.

(cc @mats-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
