### PR TITLE
Upgrade `Paparazzi` to 1.3.4

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -55,7 +55,7 @@ ext.versions = [
         nimbusJwt                   : '9.40',
         okhttp                      : '4.12.0',
         okio                        : '3.9.1',
-        paparazzi                   : '1.3.3',
+        paparazzi                   : '1.3.4',
         poko                        : '0.17.1',
         payButtonCompose            : '0.1.3',
         places                      : '3.3.0',

--- a/screenshot-testing/dependencies/dependencies.txt
+++ b/screenshot-testing/dependencies/dependencies.txt
@@ -1,71 +1,68 @@
-+--- app.cash.paparazzi:paparazzi:1.3.3
-|    +--- net.bytebuddy:byte-buddy-agent:1.14.12
-|    +--- net.bytebuddy:byte-buddy:1.14.12
++--- app.cash.paparazzi:paparazzi:1.3.4
+|    +--- net.bytebuddy:byte-buddy-agent:1.14.16
+|    +--- net.bytebuddy:byte-buddy:1.14.16
 |    +--- org.jetbrains.intellij.deps:trove4j:1.0.20200330
 |    +--- com.squareup.moshi:moshi:1.15.1
-|    |    +--- com.squareup.okio:okio:3.7.0 -> 3.8.0
-|    |    |    \--- com.squareup.okio:okio-jvm:3.8.0
+|    |    +--- com.squareup.okio:okio:3.7.0 -> 3.9.0
+|    |    |    \--- com.squareup.okio:okio-jvm:3.9.0
 |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.21 -> 1.9.24
 |    |    |              +--- org.jetbrains:annotations:13.0 -> 23.0.0
-|    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.22 (c)
+|    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 1.9.24 (c)
 |    |    |              +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.24 (c)
-|    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.22 (c)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.21 -> 1.9.22
-|    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 -> 1.9.24 (*)
-|    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.22
-|    |              \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 -> 1.9.24 (*)
+|    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 1.9.24 (c)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.21 -> 1.9.24
+|    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.24 (*)
+|    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.24
+|    |              \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.24 (*)
 |    +--- com.squareup.moshi:moshi-adapters:1.15.1
 |    |    +--- com.squareup.moshi:moshi:1.15.1 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.21 -> 1.9.22 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.21 -> 1.9.24 (*)
 |    +--- com.squareup.moshi:moshi-kotlin:1.15.1
 |    |    +--- com.squareup.moshi:moshi:1.15.1 (*)
-|    |    +--- org.jetbrains.kotlin:kotlin-reflect:1.8.21 -> 1.9.22
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 -> 1.9.24 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.21 -> 1.9.22 (*)
-|    +--- org.jcodec:jcodec:0.2.5
-|    +--- org.jcodec:jcodec-javase:0.2.5
-|    |    \--- org.jcodec:jcodec:0.2.5
-|    +--- dev.drewhamilton.poko:poko-annotations:0.15.2
-|    |    \--- dev.drewhamilton.poko:poko-annotations-jvm:0.15.2
-|    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 -> 1.9.24 (*)
-|    +--- com.android.tools:common:31.2.2
-|    |    +--- com.android.tools:annotations:31.2.2
-|    |    +--- com.google.guava:guava:31.1-jre -> 33.0.0-jre
+|    |    +--- org.jetbrains.kotlin:kotlin-reflect:1.8.21 -> 1.9.24
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.24 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.21 -> 1.9.24 (*)
+|    +--- dev.drewhamilton.poko:poko-annotations:0.15.3
+|    |    \--- dev.drewhamilton.poko:poko-annotations-jvm:0.15.3
+|    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.24 (*)
+|    +--- com.android.tools:common:31.3.2 -> 31.4.1
+|    |    +--- com.android.tools:annotations:31.4.1
+|    |    +--- com.google.guava:guava:32.0.1-jre -> 33.2.0-jre
 |    |    |    +--- com.google.guava:failureaccess:1.0.2
 |    |    |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 |    |    |    +--- com.google.code.findbugs:jsr305:3.0.2
-|    |    |    +--- org.checkerframework:checker-qual:3.41.0
-|    |    |    \--- com.google.errorprone:error_prone_annotations:2.23.0
+|    |    |    +--- org.checkerframework:checker-qual:3.42.0
+|    |    |    \--- com.google.errorprone:error_prone_annotations:2.26.1
 |    |    +--- net.java.dev.jna:jna-platform:5.6.0
 |    |    |    \--- net.java.dev.jna:jna:5.6.0
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.22 (*)
-|    +--- com.android.tools.layoutlib:layoutlib-api:31.2.2
-|    |    +--- com.android.tools:annotations:31.2.2
-|    |    +--- com.android.tools:common:31.2.2 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.20 -> 1.9.24 (*)
+|    +--- com.android.tools.layoutlib:layoutlib-api:31.4.1
+|    |    +--- com.android.tools:annotations:31.4.1
+|    |    +--- com.android.tools:common:31.4.1 (*)
 |    |    +--- net.sf.kxml:kxml2:2.3.0
-|    |    \--- org.jetbrains:annotations:13.0 -> 23.0.0
-|    +--- com.android.tools:ninepatch:31.2.2
-|    |    \--- com.google.guava:guava:31.1-jre -> 33.0.0-jre (*)
-|    +--- com.android.tools:sdk-common:31.2.2
-|    |    +--- com.android.tools.analytics-library:shared:31.2.2
-|    |    |    +--- com.android.tools.analytics-library:protos:31.2.2
-|    |    |    |    \--- com.google.protobuf:protobuf-java:3.19.3
-|    |    |    +--- com.android.tools:annotations:31.2.2
-|    |    |    +--- com.android.tools:common:31.2.2 (*)
-|    |    |    +--- com.google.code.gson:gson:2.10
-|    |    |    +--- com.google.guava:guava:31.1-jre -> 33.0.0-jre (*)
+|    |    \--- org.jetbrains:annotations:23.0.0
+|    +--- com.android.tools:ninepatch:31.3.2
+|    |    \--- com.google.guava:guava:32.0.1-jre -> 33.2.0-jre (*)
+|    +--- com.android.tools:sdk-common:31.3.2
+|    |    +--- com.android.tools.analytics-library:shared:31.3.2
+|    |    |    +--- com.android.tools.analytics-library:protos:31.3.2
+|    |    |    |    \--- com.google.protobuf:protobuf-java:3.22.3
+|    |    |    +--- com.android.tools:annotations:31.3.2 -> 31.4.1
+|    |    |    +--- com.android.tools:common:31.3.2 -> 31.4.1 (*)
+|    |    |    +--- com.google.code.gson:gson:2.10.1
+|    |    |    +--- com.google.guava:guava:32.0.1-jre -> 33.2.0-jre (*)
 |    |    |    +--- net.java.dev.jna:jna-platform:5.6.0 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.22 (*)
-|    |    +--- com.android.tools.build:aapt2-proto:8.2.2-10154469
-|    |    |    \--- com.google.protobuf:protobuf-java:3.19.3
-|    |    +--- com.android.tools:common:31.2.2 (*)
-|    |    +--- com.android.tools.layoutlib:layoutlib-api:31.2.2 (*)
-|    |    +--- com.android.tools:sdklib:31.2.2
-|    |    |    +--- com.android.tools:repository:31.2.2
-|    |    |    |    +--- com.android.tools.analytics-library:shared:31.2.2 (*)
-|    |    |    |    +--- com.android.tools:common:31.2.2 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.20 -> 1.9.24 (*)
+|    |    +--- com.android.tools.build:aapt2-proto:8.3.2-10880808
+|    |    |    \--- com.google.protobuf:protobuf-java:3.22.3
+|    |    +--- com.android.tools:common:31.3.2 -> 31.4.1 (*)
+|    |    +--- com.android.tools.layoutlib:layoutlib-api:31.3.2 -> 31.4.1 (*)
+|    |    +--- com.android.tools:sdklib:31.3.2
+|    |    |    +--- com.android.tools:repository:31.3.2
+|    |    |    |    +--- com.android.tools.analytics-library:shared:31.3.2 (*)
+|    |    |    |    +--- com.android.tools:common:31.3.2 -> 31.4.1 (*)
 |    |    |    |    +--- com.google.jimfs:jimfs:1.1
-|    |    |    |    |    \--- com.google.guava:guava:18.0 -> 33.0.0-jre (*)
+|    |    |    |    |    \--- com.google.guava:guava:18.0 -> 33.2.0-jre (*)
 |    |    |    |    +--- com.sun.activation:javax.activation:1.2.0
 |    |    |    |    +--- org.apache.commons:commons-compress:1.21
 |    |    |    |    +--- org.glassfish.jaxb:jaxb-runtime:2.3.2
@@ -75,12 +72,12 @@
 |    |    |    |    |    +--- org.jvnet.staxex:stax-ex:1.8.1
 |    |    |    |    |    |    \--- jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
 |    |    |    |    |    \--- com.sun.xml.fastinfoset:FastInfoset:1.2.16
-|    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.22 (*)
-|    |    |    +--- com.android.tools:common:31.2.2 (*)
-|    |    |    +--- com.android.tools:dvlib:31.2.2
-|    |    |    |    \--- com.android.tools:common:31.2.2 (*)
-|    |    |    +--- com.android.tools.layoutlib:layoutlib-api:31.2.2 (*)
-|    |    |    +--- com.google.code.gson:gson:2.10
+|    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.20 -> 1.9.24 (*)
+|    |    |    +--- com.android.tools:common:31.3.2 -> 31.4.1 (*)
+|    |    |    +--- com.android.tools:dvlib:31.3.2
+|    |    |    |    \--- com.android.tools:common:31.3.2 -> 31.4.1 (*)
+|    |    |    +--- com.android.tools.layoutlib:layoutlib-api:31.3.2 -> 31.4.1 (*)
+|    |    |    +--- com.google.code.gson:gson:2.10.1
 |    |    |    +--- org.apache.commons:commons-compress:1.21
 |    |    |    +--- org.apache.httpcomponents:httpcore:4.4.16
 |    |    |    +--- org.apache.httpcomponents:httpmime:4.5.6
@@ -89,9 +86,9 @@
 |    |    |    |         +--- commons-logging:commons-logging:1.2
 |    |    |    |         \--- commons-codec:commons-codec:1.10
 |    |    |    \--- org.glassfish.jaxb:jaxb-runtime:2.3.2 (*)
-|    |    +--- com.google.code.gson:gson:2.10
-|    |    +--- com.google.guava:guava:31.1-jre -> 33.0.0-jre (*)
-|    |    +--- com.google.protobuf:protobuf-java:3.19.3
+|    |    +--- com.google.code.gson:gson:2.10.1
+|    |    +--- com.google.guava:guava:32.0.1-jre -> 33.2.0-jre (*)
+|    |    +--- com.google.protobuf:protobuf-java:3.22.3
 |    |    +--- javax.inject:javax.inject:1
 |    |    +--- net.sf.kxml:kxml2:2.3.0
 |    |    +--- org.bouncycastle:bcpkix-jdk15on:1.67
@@ -99,69 +96,67 @@
 |    |    +--- org.bouncycastle:bcprov-jdk15on:1.67
 |    |    +--- org.glassfish.jaxb:jaxb-runtime:2.3.2 (*)
 |    |    +--- org.jetbrains.intellij.deps:trove4j:1.0.20200330
-|    |    +--- org.jetbrains.kotlin:kotlin-reflect:1.9.0 -> 1.9.22 (*)
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0 -> 1.9.22 (*)
-|    |    \--- xerces:xercesImpl:2.12.0
-|    |         \--- xml-apis:xml-apis:1.4.01
+|    |    +--- org.jetbrains.kotlin:kotlin-reflect:1.9.20 -> 1.9.24 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.20 -> 1.9.24 (*)
 |    +--- kxml2:kxml2:2.3.0
 |    |    \--- net.sf.kxml:kxml2:2.3.0
 |    +--- junit:junit:4.13.2
 |    |    \--- org.hamcrest:hamcrest-core:1.3
-|    +--- androidx.annotation:annotation:1.7.1
-|    |    \--- androidx.annotation:annotation-jvm:1.7.1
+|    +--- androidx.annotation:annotation:1.8.0
+|    |    \--- androidx.annotation:annotation-jvm:1.8.0
 |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.9.24 (*)
-|    +--- com.google.guava:guava:33.0.0-jre (*)
-|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0
-|    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.0
+|    +--- com.google.guava:guava:33.2.0-jre (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1
+|    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.1
 |    |         +--- org.jetbrains:annotations:23.0.0
-|    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.0
-|    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.0 (c)
-|    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.0 (c)
-|    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0 (c)
+|    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1
+|    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1 (c)
+|    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.1 (c)
+|    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1 (c)
 |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.21 -> 1.9.24 (*)
-|    +--- com.squareup.okio:okio:3.8.0 (*)
-|    +--- org.jetbrains.kotlin:kotlin-bom:1.9.22
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 -> 1.9.24 (c)
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.22 (c)
-|    |    +--- org.jetbrains.kotlin:kotlin-reflect:1.9.22 (c)
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22 -> 1.9.24 (c)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.22 (c)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.22 -> 1.9.24 (*)
+|    +--- com.squareup.okio:okio:3.9.0 (*)
+|    +--- org.jetbrains.kotlin:kotlin-bom:1.9.24
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.24 (c)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.24 (c)
+|    |    +--- org.jetbrains.kotlin:kotlin-reflect:1.9.24 (c)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.24 (c)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.24 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.24 (*)
 +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.24 (*)
 +--- project :stripe-ui-core
 |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.24 (*)
 |    +--- project :stripe-core
 |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.24 (*)
 |    |    +--- androidx.browser:browser:1.7.0
-|    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.7.1 (*)
+|    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.8.0 (*)
 |    |    |    +--- androidx.collection:collection:1.1.0
-|    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |    |    +--- androidx.concurrent:concurrent-futures:1.0.0 -> 1.1.0
-|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |    |    |    \--- com.google.guava:listenablefuture:1.0 -> 9999.0-empty-to-avoid-conflict-with-guava
 |    |    |    +--- androidx.core:core:1.1.0 -> 1.13.1
-|    |    |    |    +--- androidx.annotation:annotation:1.6.0 -> 1.7.1 (*)
+|    |    |    |    +--- androidx.annotation:annotation:1.6.0 -> 1.8.0 (*)
 |    |    |    |    +--- androidx.annotation:annotation-experimental:1.4.0
 |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.9.24 (*)
 |    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
 |    |    |    |    +--- androidx.concurrent:concurrent-futures:1.0.0 -> 1.1.0 (*)
 |    |    |    |    +--- androidx.interpolator:interpolator:1.0.0
-|    |    |    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.7.1 (*)
+|    |    |    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.8.0 (*)
 |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.2 -> 2.7.0
-|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |    |    |    |    +--- androidx.arch.core:core-common:2.2.0
-|    |    |    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |    |    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |    |    |    |    +--- androidx.arch.core:core-runtime:2.2.0
-|    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |    |    |    |    |    \--- androidx.arch.core:core-common:2.2.0 (*)
 |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.7.0
-|    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.24 (*)
-|    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1 -> 1.8.0
-|    |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0 (*)
-|    |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.0 (*)
+|    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1 -> 1.8.1
+|    |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1 (*)
+|    |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1 (*)
 |    |    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.21 -> 1.9.24 (*)
-|    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1 -> 1.8.0 (*)
+|    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1 -> 1.8.1 (*)
 |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.7.0 (c)
 |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.7.0 (c)
 |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.7.0 (c)
@@ -170,12 +165,12 @@
 |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0 (c)
 |    |    |    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.7.0 (c)
 |    |    |    |    |    +--- androidx.profileinstaller:profileinstaller:1.3.0
-|    |    |    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.7.1 (*)
+|    |    |    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.8.0 (*)
 |    |    |    |    |    |    +--- androidx.concurrent:concurrent-futures:1.1.0 (*)
 |    |    |    |    |    |    +--- androidx.startup:startup-runtime:1.1.1
-|    |    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |    |    |    |    |    |    \--- androidx.tracing:tracing:1.0.0
-|    |    |    |    |    |    |         \--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |    |    |    |    |    |         \--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |    |    |    |    |    \--- com.google.guava:listenablefuture:1.0 -> 9999.0-empty-to-avoid-conflict-with-guava
 |    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.24 (*)
 |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.7.0 (c)
@@ -186,7 +181,7 @@
 |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.7.0 (c)
 |    |    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.7.0 (c)
 |    |    |    |    +--- androidx.versionedparcelable:versionedparcelable:1.1.1
-|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |    |    |    |    \--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
 |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.24 (*)
 |    |    |    |    \--- androidx.core:core-ktx:1.13.1 (c)
@@ -194,8 +189,8 @@
 |    |    |    \--- com.google.guava:listenablefuture:1.0 -> 9999.0-empty-to-avoid-conflict-with-guava
 |    |    +--- com.google.dagger:dagger:2.50
 |    |    |    \--- javax.inject:javax.inject:1
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 -> 1.8.0 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 -> 1.8.0 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 -> 1.8.1 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 -> 1.8.1 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2
 |    |    |    \--- org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.6.2
 |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.21 -> 1.9.24 (*)
@@ -213,7 +208,7 @@
 |    |    |                   \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.21 -> 1.9.24 (*)
 |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.7.0
-|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.24 (*)
 |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.7.0 (c)
 |    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.7.0 (c)
@@ -223,7 +218,7 @@
 |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.7.0 (c)
 |    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.7.0 (c)
 |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.24 (*)
-|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1 -> 1.8.0 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1 -> 1.8.1 (*)
 |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.7.0 (c)
 |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.7.0 (c)
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.7.0 (c)
@@ -237,15 +232,15 @@
 |    |              \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.24 (*)
 |    +--- androidx.activity:activity-ktx:1.8.2
 |    |    +--- androidx.activity:activity:1.8.2
-|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
 |    |    |    +--- androidx.core:core:1.8.0 -> 1.13.1 (*)
 |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 -> 2.7.0 (*)
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 -> 2.7.0 (*)
 |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 -> 2.7.0
-|    |    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.7.1 (*)
+|    |    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.8.0 (*)
 |    |    |    |    +--- androidx.core:core-ktx:1.2.0 -> 1.13.1
-|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |    |    |    |    +--- androidx.core:core:1.13.1 (*)
 |    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.24 (*)
 |    |    |    |    |    \--- androidx.core:core:1.13.1 (c)
@@ -263,13 +258,13 @@
 |    |    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.7.0 (c)
 |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.7.0 (*)
 |    |    |    |    +--- androidx.savedstate:savedstate:1.2.1
-|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |    |    |    |    +--- androidx.arch.core:core-common:2.1.0 -> 2.2.0 (*)
 |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 -> 2.7.0 (*)
 |    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 -> 1.9.24 (*)
 |    |    |    |    |    \--- androidx.savedstate:savedstate-ktx:1.2.1 (c)
 |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.24 (*)
-|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1 -> 1.8.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1 -> 1.8.1 (*)
 |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.7.0 (c)
 |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.7.0 (c)
 |    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.7.0 (c)
@@ -284,10 +279,10 @@
 |    |    |    \--- androidx.activity:activity-ktx:1.8.2 (c)
 |    |    +--- androidx.core:core-ktx:1.9.0 -> 1.13.1 (*)
 |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 -> 2.7.0
-|    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.7.1 (*)
+|    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.8.0 (*)
 |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.7.0 (*)
 |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.24 (*)
-|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1 -> 1.8.0 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1 -> 1.8.1 (*)
 |    |    |    +--- androidx.lifecycle:lifecycle-common:2.7.0 (c)
 |    |    |    +--- androidx.lifecycle:lifecycle-process:2.7.0 (c)
 |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.7.0 (c)
@@ -302,41 +297,41 @@
 |    |    |    \--- androidx.savedstate:savedstate:1.2.1 (c)
 |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.24 (*)
 |    |    \--- androidx.activity:activity:1.8.2 (c)
-|    +--- androidx.annotation:annotation:1.7.1 (*)
+|    +--- androidx.annotation:annotation:1.7.1 -> 1.8.0 (*)
 |    +--- androidx.core:core-ktx:1.13.1 (*)
 |    +--- androidx.compose.foundation:foundation:1.5.4
 |    |    \--- androidx.compose.foundation:foundation-android:1.5.4
-|    |         +--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |         +--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |         +--- androidx.compose.animation:animation:1.5.4
 |    |         |    \--- androidx.compose.animation:animation-android:1.5.4
-|    |         |         +--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |         |         +--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |         |         +--- androidx.compose.animation:animation-core:1.5.4
 |    |         |         |    \--- androidx.compose.animation:animation-core-android:1.5.4
-|    |         |         |         +--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |         |         |         +--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |         |         |         +--- androidx.compose.runtime:runtime:1.5.4
 |    |         |         |         |    \--- androidx.compose.runtime:runtime-android:1.5.4
-|    |         |         |         |         +--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |         |         |         |         +--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |         |         |         |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.21 -> 1.9.24 (*)
-|    |         |         |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.8.0 (*)
-|    |         |         |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.8.0 (*)
+|    |         |         |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.8.1 (*)
+|    |         |         |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.8.1 (*)
 |    |         |         |         |         \--- androidx.compose.runtime:runtime-saveable:1.5.4 (c)
 |    |         |         |         +--- androidx.compose.ui:ui:1.5.4
 |    |         |         |         |    \--- androidx.compose.ui:ui-android:1.5.4
 |    |         |         |         |         +--- androidx.activity:activity-ktx:1.7.0 -> 1.8.2 (*)
-|    |         |         |         |         +--- androidx.annotation:annotation:1.5.0 -> 1.7.1 (*)
+|    |         |         |         |         +--- androidx.annotation:annotation:1.5.0 -> 1.8.0 (*)
 |    |         |         |         |         +--- androidx.autofill:autofill:1.0.0
 |    |         |         |         |         |    \--- androidx.core:core:1.1.0 -> 1.13.1 (*)
 |    |         |         |         |         +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
 |    |         |         |         |         +--- androidx.compose.runtime:runtime:1.5.4 (*)
 |    |         |         |         |         +--- androidx.compose.runtime:runtime-saveable:1.5.4
 |    |         |         |         |         |    \--- androidx.compose.runtime:runtime-saveable-android:1.5.4
-|    |         |         |         |         |         +--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |         |         |         |         |         +--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |         |         |         |         |         +--- androidx.compose.runtime:runtime:1.5.4 (*)
 |    |         |         |         |         |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.21 -> 1.9.24 (*)
 |    |         |         |         |         |         \--- androidx.compose.runtime:runtime:1.5.4 (c)
 |    |         |         |         |         +--- androidx.compose.ui:ui-geometry:1.5.4
 |    |         |         |         |         |    \--- androidx.compose.ui:ui-geometry-android:1.5.4
-|    |         |         |         |         |         +--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |         |         |         |         |         +--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |         |         |         |         |         +--- androidx.compose.runtime:runtime:1.2.1 -> 1.5.4 (*)
 |    |         |         |         |         |         +--- androidx.compose.ui:ui-util:1.5.4
 |    |         |         |         |         |         |    \--- androidx.compose.ui:ui-util-android:1.5.4
@@ -356,11 +351,11 @@
 |    |         |         |         |         |         \--- androidx.compose.ui:ui-util:1.5.4 (c)
 |    |         |         |         |         +--- androidx.compose.ui:ui-graphics:1.5.4
 |    |         |         |         |         |    \--- androidx.compose.ui:ui-graphics-android:1.5.4
-|    |         |         |         |         |         +--- androidx.annotation:annotation:1.2.0 -> 1.7.1 (*)
+|    |         |         |         |         |         +--- androidx.annotation:annotation:1.2.0 -> 1.8.0 (*)
 |    |         |         |         |         |         +--- androidx.compose.runtime:runtime:1.5.4 (*)
 |    |         |         |         |         |         +--- androidx.compose.ui:ui-unit:1.5.4
 |    |         |         |         |         |         |    \--- androidx.compose.ui:ui-unit-android:1.5.4
-|    |         |         |         |         |         |         +--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |         |         |         |         |         |         +--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |         |         |         |         |         |         +--- androidx.compose.runtime:runtime:1.5.4 (*)
 |    |         |         |         |         |         |         +--- androidx.compose.ui:ui-geometry:1.5.4 (*)
 |    |         |         |         |         |         |         +--- androidx.compose.ui:ui-util:1.5.4 (*)
@@ -380,7 +375,7 @@
 |    |         |         |         |         |         \--- androidx.compose.ui:ui-util:1.5.4 (c)
 |    |         |         |         |         +--- androidx.compose.ui:ui-text:1.5.4
 |    |         |         |         |         |    \--- androidx.compose.ui:ui-text-android:1.5.4
-|    |         |         |         |         |         +--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |         |         |         |         |         +--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |         |         |         |         |         +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
 |    |         |         |         |         |         +--- androidx.compose.runtime:runtime:1.5.4 (*)
 |    |         |         |         |         |         +--- androidx.compose.runtime:runtime-saveable:1.5.4 (*)
@@ -389,11 +384,11 @@
 |    |         |         |         |         |         +--- androidx.compose.ui:ui-util:1.5.4 (*)
 |    |         |         |         |         |         +--- androidx.core:core:1.7.0 -> 1.13.1 (*)
 |    |         |         |         |         |         +--- androidx.emoji2:emoji2:1.2.0 -> 1.4.0
-|    |         |         |         |         |         |    +--- androidx.annotation:annotation:1.2.0 -> 1.7.1 (*)
+|    |         |         |         |         |         |    +--- androidx.annotation:annotation:1.2.0 -> 1.8.0 (*)
 |    |         |         |         |         |         |    +--- androidx.collection:collection:1.1.0 (*)
 |    |         |         |         |         |         |    +--- androidx.core:core:1.3.0 -> 1.13.1 (*)
 |    |         |         |         |         |         |    +--- androidx.lifecycle:lifecycle-process:2.4.1 -> 2.7.0
-|    |         |         |         |         |         |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.7.1 (*)
+|    |         |         |         |         |         |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.8.0 (*)
 |    |         |         |         |         |         |    |    +--- androidx.lifecycle:lifecycle-runtime:2.7.0 (*)
 |    |         |         |         |         |         |    |    +--- androidx.startup:startup-runtime:1.1.1 (*)
 |    |         |         |         |         |         |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 1.9.24 (*)
@@ -406,7 +401,7 @@
 |    |         |         |         |         |         |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.7.0 (c)
 |    |         |         |         |         |         |    \--- androidx.startup:startup-runtime:1.0.0 -> 1.1.1 (*)
 |    |         |         |         |         |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.21 -> 1.9.24 (*)
-|    |         |         |         |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.8.0 (*)
+|    |         |         |         |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.8.1 (*)
 |    |         |         |         |         |         +--- androidx.compose.ui:ui:1.5.4 (c)
 |    |         |         |         |         |         +--- androidx.compose.ui:ui-geometry:1.5.4 (c)
 |    |         |         |         |         |         +--- androidx.compose.ui:ui-graphics:1.5.4 (c)
@@ -426,8 +421,8 @@
 |    |         |         |         |         +--- androidx.savedstate:savedstate-ktx:1.2.1 (*)
 |    |         |         |         |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.21 -> 1.9.24 (*)
 |    |         |         |         |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.24 (*)
-|    |         |         |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.8.0 (*)
-|    |         |         |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.8.0 (*)
+|    |         |         |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.8.1 (*)
+|    |         |         |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.8.1 (*)
 |    |         |         |         |         +--- androidx.compose.ui:ui-geometry:1.5.4 (c)
 |    |         |         |         |         +--- androidx.compose.ui:ui-graphics:1.5.4 (c)
 |    |         |         |         |         +--- androidx.compose.ui:ui-text:1.5.4 (c)
@@ -438,11 +433,11 @@
 |    |         |         |         +--- androidx.compose.ui:ui-unit:1.5.4 (*)
 |    |         |         |         +--- androidx.compose.ui:ui-util:1.5.4 (*)
 |    |         |         |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.21 -> 1.9.24 (*)
-|    |         |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.8.0 (*)
+|    |         |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.8.1 (*)
 |    |         |         |         \--- androidx.compose.animation:animation:1.5.4 (c)
 |    |         |         +--- androidx.compose.foundation:foundation-layout:1.5.4
 |    |         |         |    \--- androidx.compose.foundation:foundation-layout-android:1.5.4
-|    |         |         |         +--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |         |         |         +--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |         |         |         +--- androidx.compose.animation:animation-core:1.2.1 -> 1.5.4 (*)
 |    |         |         |         +--- androidx.compose.runtime:runtime:1.5.4 (*)
 |    |         |         |         +--- androidx.compose.ui:ui:1.5.4 (*)
@@ -465,7 +460,7 @@
 |    |         \--- androidx.compose.foundation:foundation-layout:1.5.4 (c)
 |    +--- androidx.compose.material:material:1.5.4
 |    |    \--- androidx.compose.material:material-android:1.5.4
-|    |         +--- androidx.annotation:annotation:1.1.0 -> 1.7.1 (*)
+|    |         +--- androidx.annotation:annotation:1.1.0 -> 1.8.0 (*)
 |    |         +--- androidx.compose.animation:animation:1.5.4 (*)
 |    |         +--- androidx.compose.animation:animation-core:1.5.4 (*)
 |    |         +--- androidx.compose.foundation:foundation:1.5.4 (*)
@@ -499,7 +494,7 @@
 |    +--- androidx.compose.ui:ui:1.5.4 (*)
 |    +--- androidx.compose.ui:ui-tooling-preview:1.5.4
 |    |    \--- androidx.compose.ui:ui-tooling-preview-android:1.5.4
-|    |         +--- androidx.annotation:annotation:1.2.0 -> 1.7.1 (*)
+|    |         +--- androidx.annotation:annotation:1.2.0 -> 1.8.0 (*)
 |    |         +--- androidx.compose.runtime:runtime:1.5.4 (*)
 |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21 -> 1.9.24 (*)
 |    |         +--- androidx.compose.ui:ui:1.5.4 (c)
@@ -509,8 +504,8 @@
 |    |         +--- androidx.compose.ui:ui-unit:1.5.4 (c)
 |    |         \--- androidx.compose.ui:ui-util:1.5.4 (c)
 |    +--- com.jakewharton:disklrucache:2.0.2
-|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 -> 1.8.0 (*)
-|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 -> 1.8.0 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 -> 1.8.1 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3 -> 1.8.1 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2 (*)
 |    +--- com.google.dagger:dagger:2.50 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.24 (*)


### PR DESCRIPTION
# Summary
Upgrade `Paparazzi` to 1.3.4

# Motivation
Looks we started getting `OutOfMemory` for new screenshot tests due to a memory leak from the `layoutlib` used by Paparazzi that prevents proper clean-up of these tests. `1.3.4` fixes this this issue.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified