### PR TITLE
Setup Firebase App Distribution for PaymentSheet.

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -45,3 +45,4 @@ jobs:
         with:
           appId: "1:577365562050:android:5b7e92d18f8ca8d1e9a15b"
           serviceCredentialsFileContent: ${{ secrets.PAYMENTS_GOOGLE_CLOUD_KEY }}
+          file: paymentsheet-example/build/outputs/apk/release/paymentsheet-example-release.apk

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,7 +4,6 @@ name: Upload aabs on push
 
 on:
   workflow_dispatch:
-  pull_request: # TODO: Remove me!
   push:
     branches:
       - master

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -40,6 +40,8 @@ jobs:
         env:
           EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
           EMERGE_TAG: push
+      - name: Assemble Release
+        run: ./gradlew :paymentsheet-example:assembleRelease
       - name: Firebase App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@a41b2f7ab3f7c2631b6a73fb2f660b517cef45a9
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,6 +4,7 @@ name: Upload aabs on push
 
 on:
   workflow_dispatch:
+  pull_request: # TODO: Remove me!
   push:
     branches:
       - master

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,6 +3,7 @@ name: Upload aabs on push
 # The aab is used as a base reference to compare with aab built from pull requests.
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -38,3 +39,8 @@ jobs:
         env:
           EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
           EMERGE_TAG: push
+      - name: Firebase App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@a41b2f7ab3f7c2631b6a73fb2f660b517cef45a9
+        with:
+          appId: "1:577365562050:android:5b7e92d18f8ca8d1e9a15b"
+          serviceCredentialsFileContent: ${{ secrets.PAYMENTS_GOOGLE_CLOUD_KEY }}

--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -1,6 +1,7 @@
 apply from: configs.androidApplication
 
 apply plugin: 'com.emergetools.android'
+apply plugin: 'com.google.firebase.appdistribution'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: "org.jetbrains.kotlin.plugin.parcelize"
 apply plugin: 'shot'
@@ -117,5 +118,13 @@ android {
     }
     composeOptions {
         kotlinCompilerExtensionVersion "${versions.androidxComposeCompiler}"
+    }
+    buildTypes {
+        release {
+            firebaseAppDistribution {
+                appId = "1:577365562050:android:5b7e92d18f8ca8d1e9a15b"
+                groups = "elements-mobile"
+            }
+        }
     }
 }

--- a/paymentsheet-example/google-services.json
+++ b/paymentsheet-example/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "577365562050",
+    "project_id": "stripe-payments-sdk-prod",
+    "storage_bucket": "stripe-payments-sdk-prod.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:577365562050:android:5b7e92d18f8ca8d1e9a15b",
+        "android_client_info": {
+          "package_name": "com.stripe.android.paymentsheet.example"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyB2kcJSRjIOQDQfRSe7oLySGOzxgRRhZxw"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This sets up [Firebase App Distribution](https://firebase.google.com/docs/app-distribution) for PaymentSheet Example.
1. Adds build configuration (no secrets are checked into the repo)
1. Adds a github action to publish new builds from master (new secret setup with actual secrets `PAYMENTS_GOOGLE_CLOUD_KEY`)
1. The project is https://console.firebase.google.com/u/0/project/stripe-payments-sdk-prod/overview which has pretty limited permissions for most Stripe, but it is a stripe owned account.

Instructions on how to use here: https://trailhead.corp.stripe.com/docs/mobile-sdk/payments/test-paymentsheet-on-android

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2516
