### PR TITLE
dangerous manifest lint check

### DIFF
--- a/lint/src/main/java/com/stripe/android/lint/DangerousManifestConfigurationDetector.kt
+++ b/lint/src/main/java/com/stripe/android/lint/DangerousManifestConfigurationDetector.kt
@@ -34,12 +34,14 @@ internal class DangerousManifestConfigurationDetector : Detector(), XmlScanner {
     }
 
     override fun getApplicableElements() = listOf(
+        "manifest",
         "application",
         "activity",
         "service",
         "receiver",
         "provider",
-        "uses-permission"
+        "uses-permission",
+        "permission"
     )
 
     override fun visitElement(context: XmlContext, element: Element) {
@@ -47,7 +49,7 @@ internal class DangerousManifestConfigurationDetector : Detector(), XmlScanner {
             "manifest" -> checkManifestElement(context, element)
             "application" -> checkApplicationElement(context, element)
             "activity", "service", "receiver", "provider" -> checkComponentElement(context, element)
-            "uses-permission" -> checkPermissionElement(context, element)
+            "uses-permission", "permission" -> checkPermissionElement(context, element)
         }
     }
 

--- a/lint/src/main/java/com/stripe/android/lint/DangerousManifestConfigurationDetector.kt
+++ b/lint/src/main/java/com/stripe/android/lint/DangerousManifestConfigurationDetector.kt
@@ -1,0 +1,142 @@
+package com.stripe.android.lint
+
+import com.android.SdkConstants.ANDROID_URI
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.XmlContext
+import com.android.tools.lint.detector.api.XmlScanner
+import org.w3c.dom.Element
+
+internal class DangerousManifestConfigurationDetector : Detector(), XmlScanner {
+    companion object {
+        val ISSUE = Issue.create(
+            id = "DangerousManifestConfiguration",
+            briefDescription = "Dangerous Manifest Configuration Detected",
+            explanation = "This check flags potentially dangerous configurations in the Android Manifest.",
+            category = Category.SECURITY,
+            priority = 9,
+            severity = Severity.ERROR,
+            implementation = Implementation(DangerousManifestConfigurationDetector::class.java, Scope.MANIFEST_SCOPE)
+        )
+
+        private val DANGEROUS_PERMISSIONS = listOf(
+            "android.permission.READ_PHONE_STATE",
+            "android.permission.RECORD_AUDIO",
+            "android.permission.ACCESS_FINE_LOCATION",
+            "android.permission.READ_EXTERNAL_STORAGE",
+            "android.permission.WRITE_EXTERNAL_STORAGE",
+            "android.permission.SYSTEM_ALERT_WINDOW"
+        )
+    }
+
+    override fun getApplicableElements() = listOf(
+        "application",
+        "activity",
+        "service",
+        "receiver",
+        "provider",
+        "uses-permission"
+    )
+
+    override fun visitElement(context: XmlContext, element: Element) {
+        when (element.tagName) {
+            "manifest" -> checkManifestElement(context, element)
+            "application" -> checkApplicationElement(context, element)
+            "activity", "service", "receiver", "provider" -> checkComponentElement(context, element)
+            "uses-permission" -> checkPermissionElement(context, element)
+        }
+    }
+
+    private fun checkManifestElement(context: XmlContext, element: Element) {
+        checkAttribute(
+            context,
+            element,
+            "installLocation",
+            "preferExternal",
+            "android:installLocation=\"preferExternal\" can make the app vulnerable to tampering"
+        )
+    }
+
+    private fun checkApplicationElement(context: XmlContext, element: Element) {
+        checkAttribute(
+            context,
+            element,
+            "debuggable",
+            "true",
+            "android:debuggable=\"true\" should not be used in production builds"
+        )
+
+        checkAttribute(
+            context,
+            element,
+            "allowBackup",
+            "true",
+            "Consider setting android:allowBackup=\"false\" for security reasons"
+        )
+
+        checkAttribute(
+            context,
+            element,
+            "usesCleartextTraffic",
+            "true",
+            "android:usesCleartextTraffic=\"true\" allows cleartext network traffic"
+        )
+
+        checkAttribute(
+            context,
+            element,
+            "testOnly",
+            "true",
+            "android:testOnly=\"true\" should not be used in production builds"
+        )
+    }
+
+    private fun checkComponentElement(context: XmlContext, element: Element) {
+        val permission = element.getAttributeNS(ANDROID_URI, "permission")
+        if (permission.isNotEmpty() && permission.endsWith(".DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION")) {
+            context.report(
+                ISSUE,
+                element,
+                context.getLocation(element),
+                "Using DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION might not provide intended security"
+            )
+        }
+    }
+
+    private fun checkPermissionElement(context: XmlContext, element: Element) {
+        val name = element.getAttributeNS(ANDROID_URI, "name")
+        if (name in DANGEROUS_PERMISSIONS) {
+            context.report(
+                ISSUE,
+                element,
+                context.getLocation(element),
+                "Using dangerous permission: $name. Ensure it's necessary and handle it securely."
+            )
+        }
+
+        checkAttribute(
+            context,
+            element,
+            "protectionLevel",
+            "dangerous",
+            "android:protectionLevel=\"dangerous\" should be avoided if possible"
+        )
+    }
+
+    private fun checkAttribute(
+        context: XmlContext,
+        element: Element,
+        attributeName: String,
+        dangerousValue: String,
+        message: String
+    ) {
+        val value = element.getAttributeNS(ANDROID_URI, attributeName)
+        if (value == dangerousValue) {
+            context.report(ISSUE, element, context.getLocation(element), message)
+        }
+    }
+}

--- a/lint/src/main/java/com/stripe/android/lint/StripeIssueRegistry.kt
+++ b/lint/src/main/java/com/stripe/android/lint/StripeIssueRegistry.kt
@@ -6,7 +6,7 @@ import com.android.tools.lint.detector.api.CURRENT_API
 
 internal class StripeIssueRegistry : IssueRegistry() {
     override val api = CURRENT_API
-    override val issues = listOf(ComposeCollectAsStateUsageDetector.ISSUE)
+    override val issues = listOf(ComposeCollectAsStateUsageDetector.ISSUE, DangerousManifestConfigurationDetector.ISSUE)
 
     override val vendor = Vendor(
         vendorName = "Stripe Android SDK",

--- a/lint/src/test/java/com/stripe/android/lint/DangerousManifestConfigurationDetectorTest.kt
+++ b/lint/src/test/java/com/stripe/android/lint/DangerousManifestConfigurationDetectorTest.kt
@@ -1,0 +1,189 @@
+package com.stripe.android.lint
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.xml
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.Test
+
+class DangerousManifestConfigurationDetectorTest {
+
+    private fun lintManifest(manifestContent: String) = lint()
+        .files(xml("AndroidManifest.xml", manifestContent).indented())
+        .issues(DangerousManifestConfigurationDetector.ISSUE)
+        .allowMissingSdk() // Allow the test to run without an Android SDK
+
+    @Test
+    fun testManifestInstallLocationPreferExternal() {
+        lintManifest(
+            """
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+                android:installLocation="preferExternal">
+                <application />
+            </manifest>
+            """
+        ).run().expect(
+            """
+            AndroidManifest.xml:1: Error: android:installLocation="preferExternal" can make the app vulnerable to tampering [DangerousManifestConfiguration]
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+            ^
+            1 errors, 0 warnings
+            """
+        )
+    }
+
+    @Test
+    fun testApplicationDebuggable() {
+        lintManifest(
+            """
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+                <application android:debuggable="true" />
+            </manifest>
+            """
+        ).run().expect(
+            """
+            AndroidManifest.xml:2: Error: android:debuggable="true" should not be used in production builds [DangerousManifestConfiguration]
+                <application android:debuggable="true" />
+                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            1 errors, 0 warnings
+            """
+        )
+    }
+
+    @Test
+    fun testApplicationAllowBackup() {
+        lintManifest(
+            """
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+                <application android:allowBackup="true" />
+            </manifest>
+            """
+        ).run().expect(
+            """
+            AndroidManifest.xml:2: Error: Consider setting android:allowBackup="false" for security reasons [DangerousManifestConfiguration]
+                <application android:allowBackup="true" />
+                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            1 errors, 0 warnings
+            """
+        )
+    }
+
+    @Test
+    fun testApplicationUsesCleartextTraffic() {
+        lintManifest(
+            """
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+                <application android:usesCleartextTraffic="true" />
+            </manifest>
+            """
+        ).run().expect(
+            """
+            AndroidManifest.xml:2: Error: android:usesCleartextTraffic="true" allows cleartext network traffic [DangerousManifestConfiguration]
+                <application android:usesCleartextTraffic="true" />
+                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            1 errors, 0 warnings
+            """
+        )
+    }
+
+    @Test
+    fun testApplicationTestOnly() {
+        lintManifest(
+            """
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+                <application android:testOnly="true" />
+            </manifest>
+            """
+        ).run().expect(
+            """
+            AndroidManifest.xml:2: Error: android:testOnly="true" should not be used in production builds [DangerousManifestConfiguration]
+                <application android:testOnly="true" />
+                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            1 errors, 0 warnings
+            """
+        )
+    }
+
+    @Test
+    fun testComponentDynamicReceiverNotExportedPermission() {
+        lintManifest(
+            """
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+                <application>
+                    <receiver android:permission="com.example.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION" />
+                </application>
+            </manifest>
+            """
+        ).run().expect(
+            """
+            AndroidManifest.xml:3: Error: Using DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION might not provide intended security [DangerousManifestConfiguration]
+                    <receiver android:permission="com.example.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION" />
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            1 errors, 0 warnings
+            """
+        )
+    }
+
+    @Test
+    fun testDangerousPermissions() {
+        val dangerousPermissions = listOf(
+            "android.permission.READ_PHONE_STATE",
+            "android.permission.RECORD_AUDIO",
+            "android.permission.ACCESS_FINE_LOCATION",
+            "android.permission.READ_EXTERNAL_STORAGE",
+            "android.permission.WRITE_EXTERNAL_STORAGE",
+            "android.permission.SYSTEM_ALERT_WINDOW"
+        )
+
+        dangerousPermissions.forEach { permission ->
+            val badLine = "<uses-permission android:name=\"$permission\" />"
+            lintManifest(
+                """
+                <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+                    <uses-permission android:name="$permission" />
+                </manifest>
+                """
+            ).run().expect(
+                """
+                AndroidManifest.xml:2: Error: Using dangerous permission: $permission. Ensure it's necessary and handle it securely. [DangerousManifestConfiguration]
+                    $badLine
+                    ${"~".repeat(badLine.length)}
+                1 errors, 0 warnings
+                """
+            )
+        }
+    }
+
+    @Test
+    fun testDangerousProtectionLevel() {
+        lintManifest(
+            """
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+                <permission android:name="com.example.MY_PERMISSION"
+                            android:protectionLevel="dangerous" />
+            </manifest>
+            """
+        ).run().expect(
+            """
+            AndroidManifest.xml:2: Error: android:protectionLevel="dangerous" should be avoided if possible [DangerousManifestConfiguration]
+                <permission android:name="com.example.MY_PERMISSION"
+                ^
+            1 errors, 0 warnings
+            """
+        )
+    }
+
+    @Test
+    fun testNoIssuesReported() {
+        lintManifest(
+            """
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+                <application
+                    android:allowBackup="false"
+                    android:debuggable="false"
+                    android:usesCleartextTraffic="false"
+                    android:testOnly="false" />
+                <uses-permission android:name="android.permission.INTERNET" />
+            </manifest>
+            """
+        ).run().expectClean()
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add lint rule for dangerous manifest settings/permission. These settings will be marked as errors and will cause CI to fail.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[JIRA](https://jira.corp.stripe.com/browse/MOBILESDK-2313)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

