### PR TITLE
Catch all errors coming from `CustomerAdapter`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
@@ -67,51 +67,37 @@ internal class CustomerAdapterDataSource @Inject constructor(
         }.toCustomerSheetDataResult()
     }
 
-    override suspend fun retrievePaymentMethods() = withContext(workContext) {
-        runCatchingAdapterTask {
-            customerAdapter.retrievePaymentMethods()
-        }.toCustomerSheetDataResult()
+    override suspend fun retrievePaymentMethods() = runCatchingAdapterTask {
+        customerAdapter.retrievePaymentMethods()
     }
 
     override suspend fun updatePaymentMethod(
         paymentMethodId: String,
         params: PaymentMethodUpdateParams,
-    ) = withContext(workContext) {
-        runCatchingAdapterTask {
-            customerAdapter.updatePaymentMethod(paymentMethodId, params)
-        }.toCustomerSheetDataResult()
+    ) = runCatchingAdapterTask {
+        customerAdapter.updatePaymentMethod(paymentMethodId, params)
     }
 
-    override suspend fun attachPaymentMethod(paymentMethodId: String) = withContext(workContext) {
-        runCatchingAdapterTask {
-            customerAdapter.attachPaymentMethod(paymentMethodId)
-        }.toCustomerSheetDataResult()
+    override suspend fun attachPaymentMethod(paymentMethodId: String) = runCatchingAdapterTask {
+        customerAdapter.attachPaymentMethod(paymentMethodId)
     }
 
-    override suspend fun detachPaymentMethod(paymentMethodId: String) = withContext(workContext) {
-        runCatchingAdapterTask {
-            customerAdapter.detachPaymentMethod(paymentMethodId)
-        }.toCustomerSheetDataResult()
+    override suspend fun detachPaymentMethod(paymentMethodId: String) = runCatchingAdapterTask {
+        customerAdapter.detachPaymentMethod(paymentMethodId)
     }
 
-    override suspend fun retrieveSavedSelection() = withContext(workContext) {
-        runCatchingAdapterTask {
-            customerAdapter.retrieveSelectedPaymentOption().map { result ->
-                result?.toSavedSelection()
-            }
-        }.toCustomerSheetDataResult()
+    override suspend fun retrieveSavedSelection() = runCatchingAdapterTask {
+        customerAdapter.retrieveSelectedPaymentOption().map { result ->
+            result?.toSavedSelection()
+        }
     }
 
-    override suspend fun setSavedSelection(selection: SavedSelection?) = withContext(workContext) {
-        runCatchingAdapterTask {
-            customerAdapter.setSelectedPaymentOption(selection?.toPaymentOption())
-        }.toCustomerSheetDataResult()
+    override suspend fun setSavedSelection(selection: SavedSelection?) = runCatchingAdapterTask {
+        customerAdapter.setSelectedPaymentOption(selection?.toPaymentOption())
     }
 
-    override suspend fun retrieveSetupIntentClientSecret() = withContext(workContext) {
-        runCatchingAdapterTask {
-            customerAdapter.setupIntentClientSecretForCustomerAttach()
-        }.toCustomerSheetDataResult()
+    override suspend fun retrieveSetupIntentClientSecret() = runCatchingAdapterTask {
+        customerAdapter.setupIntentClientSecretForCustomerAttach()
     }
 
     private suspend fun fetchElementsSession(): Result<ElementsSession> {
@@ -167,13 +153,13 @@ internal class CustomerAdapterDataSource @Inject constructor(
 
     private suspend fun <T> runCatchingAdapterTask(
         task: suspend () -> CustomerAdapter.Result<T>
-    ): CustomerAdapter.Result<T> {
-        return runCatching {
+    ): CustomerSheetDataResult<T> = withContext(workContext) {
+        runCatching {
             task()
         }.fold(
-            onSuccess = { it },
+            onSuccess = { it.toCustomerSheetDataResult() },
             onFailure = {
-                CustomerAdapter.Result.failure(cause = it, displayMessage = null)
+                CustomerSheetDataResult.failure(cause = it, displayMessage = null)
             }
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeCustomerAdapter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeCustomerAdapter.kt
@@ -12,6 +12,12 @@ internal class FakeCustomerAdapter(
         CustomerAdapter.Result.success(null),
     private val paymentMethods: CustomerAdapter.Result<List<PaymentMethod>> =
         CustomerAdapter.Result.success(listOf(CARD_PAYMENT_METHOD)),
+    private val onPaymentMethods: (() -> CustomerAdapter.Result<List<PaymentMethod>>)? = {
+        paymentMethods
+    },
+    private val onGetPaymentOption: (() -> CustomerAdapter.Result<CustomerAdapter.PaymentOption?>)? = {
+        selectedPaymentOption
+    },
     private val onSetSelectedPaymentOption:
     ((paymentOption: CustomerAdapter.PaymentOption?) -> CustomerAdapter.Result<Unit>)? = null,
     private val onAttachPaymentMethod: ((paymentMethodId: String) -> CustomerAdapter.Result<PaymentMethod>)? = null,
@@ -22,7 +28,7 @@ internal class FakeCustomerAdapter(
 ) : CustomerAdapter {
 
     override suspend fun retrievePaymentMethods(): CustomerAdapter.Result<List<PaymentMethod>> {
-        return paymentMethods
+        return onPaymentMethods?.invoke() ?: paymentMethods
     }
 
     override suspend fun attachPaymentMethod(paymentMethodId: String): CustomerAdapter.Result<PaymentMethod> {
@@ -57,7 +63,7 @@ internal class FakeCustomerAdapter(
     }
 
     override suspend fun retrieveSelectedPaymentOption(): CustomerAdapter.Result<CustomerAdapter.PaymentOption?> {
-        return selectedPaymentOption
+        return onGetPaymentOption?.invoke() ?: selectedPaymentOption
     }
 
     override suspend fun setupIntentClientSecretForCustomerAttach(): CustomerAdapter.Result<String> {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
@@ -64,6 +64,27 @@ class CustomerAdapterDataSourceTest {
     }
 
     @Test
+    fun `on retrieve payment methods, should catch and fail if an exception is thrown from adapter`() = runTest {
+        val exception = IllegalStateException("Failed to get payment methods!")
+
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                onPaymentMethods = {
+                    throw exception
+                }
+            )
+        )
+
+        val result = dataSource.retrievePaymentMethods()
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<List<PaymentMethod>>>()
+
+        val failedResult = result.asFailure()
+
+        assertThat(failedResult.cause).isEqualTo(exception)
+    }
+
+    @Test
     fun `on retrieve payment option, should complete successfully from adapter`() = runTest {
         val paymentOptionId = "pm_1"
         val dataSource = createCustomerAdapterDataSource(
@@ -106,6 +127,27 @@ class CustomerAdapterDataSourceTest {
     }
 
     @Test
+    fun `on retrieve payment option, should catch and fail if an exception is thrown from adapter`() = runTest {
+        val exception = IllegalStateException("Failed to retrieve saved selection!")
+
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                onGetPaymentOption = {
+                    throw exception
+                }
+            )
+        )
+
+        val result = dataSource.retrieveSavedSelection()
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<SavedSelection?>>()
+
+        val failedResult = result.asFailure()
+
+        assertThat(failedResult.cause).isEqualTo(exception)
+    }
+
+    @Test
     fun `on set saved selection, should complete successfully from adapter`() = runTest {
         val dataSource = createCustomerAdapterDataSource(
             adapter = FakeCustomerAdapter(
@@ -117,7 +159,7 @@ class CustomerAdapterDataSourceTest {
 
         val result = dataSource.setSavedSelection(SavedSelection.GooglePay)
 
-        assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<SavedSelection?>>()
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<Unit>>()
     }
 
     @Test
@@ -135,13 +177,34 @@ class CustomerAdapterDataSourceTest {
 
         val result = dataSource.setSavedSelection(SavedSelection.GooglePay)
 
-        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<SavedSelection?>>()
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<Unit>>()
 
         val failedResult = result.asFailure()
 
         assertThat(failedResult.cause).isInstanceOf(IllegalStateException::class.java)
         assertThat(failedResult.cause.message).isEqualTo("Failed to retrieve!")
         assertThat(failedResult.displayMessage).isEqualTo("Something went wrong!")
+    }
+
+    @Test
+    fun `on set saved selection, should catch and fail if an exception is thrown from adapter`() = runTest {
+        val exception = IllegalStateException("Failed to set selection!")
+
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                onSetSelectedPaymentOption = {
+                    throw exception
+                }
+            )
+        )
+
+        val result = dataSource.setSavedSelection(SavedSelection.GooglePay)
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<Unit>>()
+
+        val failedResult = result.asFailure()
+
+        assertThat(failedResult.cause).isEqualTo(exception)
     }
 
     @Test
@@ -189,6 +252,27 @@ class CustomerAdapterDataSourceTest {
     }
 
     @Test
+    fun `on attach payment method, should catch and fail if an exception is thrown from adapter`() = runTest {
+        val exception = IllegalStateException("Failed to attach!")
+
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                onAttachPaymentMethod = {
+                    throw exception
+                }
+            )
+        )
+
+        val result = dataSource.attachPaymentMethod(paymentMethodId = "pm_1")
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<PaymentMethod>>()
+
+        val failedResult = result.asFailure()
+
+        assertThat(failedResult.cause).isEqualTo(exception)
+    }
+
+    @Test
     fun `on detach payment method, should complete successfully from adapter`() = runTest {
         val paymentMethod = PaymentMethodFactory.card(id = "pm_1")
         val dataSource = createCustomerAdapterDataSource(
@@ -230,6 +314,27 @@ class CustomerAdapterDataSourceTest {
         assertThat(failedResult.cause).isInstanceOf(IllegalStateException::class.java)
         assertThat(failedResult.cause.message).isEqualTo("Failed to retrieve!")
         assertThat(failedResult.displayMessage).isEqualTo("Something went wrong!")
+    }
+
+    @Test
+    fun `on detach payment method, should catch and fail if an exception is thrown from adapter`() = runTest {
+        val exception = IllegalStateException("Failed to detach!")
+
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                onDetachPaymentMethod = {
+                    throw exception
+                }
+            )
+        )
+
+        val result = dataSource.detachPaymentMethod(paymentMethodId = "pm_1")
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<PaymentMethod>>()
+
+        val failedResult = result.asFailure()
+
+        assertThat(failedResult.cause).isEqualTo(exception)
     }
 
     @Test
@@ -280,6 +385,30 @@ class CustomerAdapterDataSourceTest {
         assertThat(failedResult.cause).isInstanceOf(IllegalStateException::class.java)
         assertThat(failedResult.cause.message).isEqualTo("Failed to retrieve!")
         assertThat(failedResult.displayMessage).isEqualTo("Something went wrong!")
+    }
+
+    @Test
+    fun `on update payment method, should catch and fail if an exception is thrown from adapter`() = runTest {
+        val exception = IllegalStateException("Failed to update!")
+
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                onUpdatePaymentMethod = { _, _ ->
+                    throw exception
+                }
+            )
+        )
+
+        val result = dataSource.updatePaymentMethod(
+            paymentMethodId = "pm_1",
+            params = PaymentMethodUpdateParams.createCard(expiryYear = 2028, expiryMonth = 7),
+        )
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<PaymentMethod>>()
+
+        val failedResult = result.asFailure()
+
+        assertThat(failedResult.cause).isEqualTo(exception)
     }
 
     @Test
@@ -345,6 +474,27 @@ class CustomerAdapterDataSourceTest {
         assertThat(failedResult.cause).isInstanceOf(IllegalStateException::class.java)
         assertThat(failedResult.cause.message).isEqualTo("Failed to retrieve!")
         assertThat(failedResult.displayMessage).isEqualTo("Something went wrong!")
+    }
+
+    @Test
+    fun `on fetch setup intent client secret, should catch & fail if exception is thrown from adapter`() = runTest {
+        val exception = IllegalStateException("Failed to update!")
+
+        val dataSource = createCustomerAdapterDataSource(
+            adapter = FakeCustomerAdapter(
+                onSetupIntentClientSecretForCustomerAttach = {
+                    throw exception
+                }
+            )
+        )
+
+        val result = dataSource.retrieveSetupIntentClientSecret()
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<String>>()
+
+        val failedResult = result.asFailure()
+
+        assertThat(failedResult.cause).isEqualTo(exception)
     }
 
     @Test


### PR DESCRIPTION
# Summary
Catch all errors coming from `CustomerAdapter`.

# Motivation
While we can guarantee that `StripeCustomerAdapter` catches all errors since we maintain it, merchants may implement `CustomerAdapter` with throw logic. We should catch these errors and return them as results.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
