### PR TITLE
Fix improper disposal of memory with screenshot tests.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -226,6 +226,7 @@ ext.testLibs = [
                 annotations: "org.jetbrains.kotlin:kotlin-test-annotations-common:${versions.kotlin}",
                 coroutines : "org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.kotlinCoroutines}",
                 junit      : "org.jetbrains.kotlin:kotlin-test-junit:${versions.kotlin}",
+                reflect    : "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}",
                 test       : "org.jetbrains.kotlin:kotlin-test:${versions.kotlin}",
         ],
         leakCanaryInstrumentation : "com.squareup.leakcanary:leakcanary-android-instrumentation:${versions.leakCanary}",

--- a/screenshot-testing/build.gradle
+++ b/screenshot-testing/build.gradle
@@ -6,6 +6,8 @@ dependencies {
     implementation libs.compose.foundation
     implementation libs.compose.material
 
+    implementation testLibs.kotlin.reflect
+
     // Implemented here instead of using plugin which implements with testImplementation
     api("app.cash.paparazzi:paparazzi:${versions.paparazzi}") {
         exclude group: 'jakarta.activation'

--- a/screenshot-testing/dependencies/dependencies.txt
+++ b/screenshot-testing/dependencies/dependencies.txt
@@ -516,4 +516,5 @@
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.24 (*)
 +--- androidx.compose.ui:ui:1.5.4 (*)
 +--- androidx.compose.foundation:foundation:1.5.4 (*)
-\--- androidx.compose.material:material:1.5.4 (*)
++--- androidx.compose.material:material:1.5.4 (*)
+\--- org.jetbrains.kotlin:kotlin-reflect:1.9.22 (*)

--- a/screenshot-testing/src/main/java/com/stripe/android/screenshottesting/PaparazziRule.kt
+++ b/screenshot-testing/src/main/java/com/stripe/android/screenshottesting/PaparazziRule.kt
@@ -11,11 +11,15 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
 import app.cash.paparazzi.detectEnvironment
+import com.android.ide.common.rendering.api.RenderSession
 import com.android.ide.common.rendering.api.SessionParams
 import com.stripe.android.uicore.StripeTheme
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
 
 class PaparazziRule(
     vararg configOptions: List<PaparazziConfigOption>,
@@ -85,6 +89,8 @@ class PaparazziRule(
                 testCase.reset()
             }
         }
+
+        dispose()
     }
 
     private fun createPaparazziDeviceConfig(): DeviceConfig {
@@ -103,6 +109,16 @@ class PaparazziRule(
             },
             theme = "Theme.MaterialComponents",
         )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun dispose() {
+        val renderSession: RenderSession = (
+            paparazzi::class.memberProperties
+                .first { it.name == "bridgeRenderSession" } as KProperty1<Paparazzi, RenderSession>
+            ).apply { isAccessible = true }.invoke(paparazzi)
+
+        renderSession.disposeWithCompose()
     }
 }
 

--- a/screenshot-testing/src/main/java/com/stripe/android/screenshottesting/RenderSessionCleaner.kt
+++ b/screenshot-testing/src/main/java/com/stripe/android/screenshottesting/RenderSessionCleaner.kt
@@ -1,0 +1,130 @@
+package com.stripe.android.screenshottesting
+
+import androidx.compose.ui.platform.AndroidUiDispatcher
+import androidx.compose.ui.platform.ComposeView
+import com.android.ide.common.rendering.api.RenderSession
+import com.android.ide.common.rendering.api.ViewInfo
+import java.lang.ref.WeakReference
+import java.lang.reflect.InvocationTargetException
+import java.util.concurrent.atomic.AtomicReference
+import java.util.logging.Logger
+
+private const val WINDOW_RECOMPOSER_ANDROID_KT_FQN =
+    "androidx.compose.ui.platform.WindowRecomposer_androidKt"
+private const val COMBINED_CONTEXT_FQN = "kotlin.coroutines.CombinedContext"
+private const val SNAPSHOT_KT_FQN = "androidx.compose.runtime.snapshots.SnapshotKt"
+private const val PAPARAZZI_COMPOSE_VIEW_ADAPTER_FQN = "app.cash.paparazzi.internal.ComposeViewAdapter"
+
+private val LOGGER = Logger.getLogger("DisposeRenderSession")
+
+/**
+ * Initiates a custom [RenderSession] disposal, involving clearing several static collections
+ * including some Compose-related objects as well as executing default [RenderSession.dispose].
+ *
+ * Pulled & modified from the
+ * [Paparazzi GitHub issue](https://github.com/cashapp/paparazzi/issues/915#issuecomment-1783114569) in regards to
+ * this memory leak with `layoutlib` and `Jetpack Compose` that is based on
+ * [Google's own solution](https://issuetracker.google.com/issues/290990640#comment5) for the problem in regards to
+ * Android Studio.
+ *
+ * This should be removed after upgrading Paparazzi to 1.3.4.
+ */
+internal fun RenderSession.disposeWithCompose() {
+    val applyObserversRef = AtomicReference<WeakReference<MutableCollection<*>?>?>(null)
+    val toRunTrampolinedRef = AtomicReference<WeakReference<MutableCollection<*>?>?>(null)
+
+    try {
+        val windowRecomposer: Class<*> = Class.forName(WINDOW_RECOMPOSER_ANDROID_KT_FQN)
+        val animationScaleField = windowRecomposer.getDeclaredField("animationScale")
+        animationScaleField.isAccessible = true
+        val animationScale = animationScaleField[windowRecomposer]
+        if (animationScale is Map<*, *>) {
+            (animationScale as MutableMap<*, *>).clear()
+        }
+    } catch (ex: ReflectiveOperationException) {
+        // If the WindowRecomposer does not exist or the animationScale does not exist anymore,
+        // ignore.
+        LOGGER.warning("Unable to dispose the recompose animationScale $ex")
+    }
+    applyObserversRef.set(WeakReference(findApplyObservers()))
+    toRunTrampolinedRef.set(WeakReference(findToRunTrampolined()))
+
+    execute {
+        rootViews
+            .filterNotNull()
+            .forEach { v -> disposeIfCompose(v) }
+    }
+    val weakApplyObservers = applyObserversRef.get()
+    if (weakApplyObservers != null) {
+        val applyObservers = weakApplyObservers.get()
+        applyObservers?.clear()
+    }
+    val weakToRunTrampolined = toRunTrampolinedRef.get()
+    if (weakToRunTrampolined != null) {
+        val toRunTrampolined = weakToRunTrampolined.get()
+        toRunTrampolined?.clear()
+    }
+    dispose()
+}
+
+/**
+ * Performs dispose() call against View object associated with [ViewInfo] if that object is an
+ * instance of Paparazzi's internal `ComposeViewAdapter` instance.
+ *
+ * @param viewInfo a [ViewInfo] associated with the View object to be potentially disposed of
+ */
+private fun disposeIfCompose(viewInfo: ViewInfo) {
+    val viewObject: Any? = viewInfo.viewObject
+    if (viewObject?.javaClass?.name != PAPARAZZI_COMPOSE_VIEW_ADAPTER_FQN) {
+        return
+    }
+    try {
+        val composeView = viewInfo.children[0].viewObject as ComposeView
+        composeView.disposeComposition()
+    } catch (ex: IllegalAccessException) {
+        LOGGER.warning("Unexpected error while disposing compose view $ex")
+    } catch (ex: InvocationTargetException) {
+        LOGGER.warning("Unexpected error while disposing compose view $ex")
+    }
+}
+
+private fun findApplyObservers(): MutableCollection<*>? {
+    try {
+        val applyObserversField = Class.forName(SNAPSHOT_KT_FQN).getDeclaredField("applyObservers")
+        applyObserversField.isAccessible = true
+        val applyObservers = applyObserversField[null]
+        if (applyObservers is MutableCollection<*>) {
+            return applyObservers
+        }
+        LOGGER.warning("SnapshotsKt.applyObservers found but it is not a List")
+    } catch (ex: ReflectiveOperationException) {
+        LOGGER.warning("Unable to find SnapshotsKt.applyObservers $ex")
+    }
+    return null
+}
+
+private fun findToRunTrampolined(): MutableCollection<*>? {
+    try {
+        val uiDispatcher = AndroidUiDispatcher::class.java
+        val uiDispatcherCompanion = AndroidUiDispatcher.Companion::class.java
+        val uiDispatcherCompanionField = uiDispatcher.getDeclaredField("Companion")
+        val uiDispatcherCompanionObj = uiDispatcherCompanionField[null]
+        val getMainMethod =
+            uiDispatcherCompanion.getDeclaredMethod("getMain").apply { isAccessible = true }
+        val mainObj = getMainMethod.invoke(uiDispatcherCompanionObj)
+        val combinedContext = Class.forName(COMBINED_CONTEXT_FQN)
+        val elementField = combinedContext.getDeclaredField("element").apply { isAccessible = true }
+        val uiDispatcherObj = elementField[mainObj]
+
+        val toRunTrampolinedField =
+            uiDispatcher.getDeclaredField("toRunTrampolined").apply { isAccessible = true }
+        val toRunTrampolinedObj = toRunTrampolinedField[uiDispatcherObj]
+        if (toRunTrampolinedObj is MutableCollection<*>) {
+            return toRunTrampolinedObj
+        }
+        LOGGER.warning("AndroidUiDispatcher.toRunTrampolined found but it is not a MutableCollection")
+    } catch (ex: ReflectiveOperationException) {
+        LOGGER.warning("Unable to find AndroidUiDispatcher.toRunTrampolined $ex")
+    }
+    return null
+}


### PR DESCRIPTION
# Summary
Fix improper disposal of memory with `Jetpack Compose` screenshot tests that occurs after running a lot of screenshot tests with Paparazzi `1.3.3` and lower.

# Motivation
Paparazzi currently does not properly dispose all objects that `Jetpack Compose` sets up for the screenshot test, causing a memory leak that has worsened as more and more screenshot tests were added, finally causing `OutOfMemory` errors to occur. 

The bug is not a result of what Paparazzi does but the Google `layoutlib` library that comes pre-compiled and packaged with Paparazzi `1.3.3` and lower. This bug is fixed in Paparazzi `1.3.4` however `1.3.4` upgrades some Compose dependencies to `1.6` which we don't support just yet. When we officially support Compose 1.6, we should upgrade to `1.3.4` which fixes this issue internally. For now, this hack fixes disposal for this version.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
