### PR TITLE
Add `link_context` to event for payment method type selection

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -26,9 +26,12 @@ internal class DefaultEventReporter @Inject internal constructor(
 ) : EventReporter {
 
     private var isDeferred: Boolean = false
-    private var linkEnabled: Boolean = false
+    private var linkMode: LinkMode? = null
     private var googlePaySupported: Boolean = false
     private var currency: String? = null
+
+    private val linkEnabled: Boolean
+        get() = linkMode != null
 
     override fun onInit(
         configuration: PaymentSheet.Configuration,
@@ -62,7 +65,7 @@ internal class DefaultEventReporter @Inject internal constructor(
         requireCvcRecollection: Boolean
     ) {
         this.currency = currency
-        this.linkEnabled = linkMode != null
+        this.linkMode = linkMode
         this.googlePaySupported = googlePaySupported
 
         durationProvider.start(DurationProvider.Key.Checkout)
@@ -152,6 +155,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 isDeferred = isDeferred,
                 currency = currency,
                 linkEnabled = linkEnabled,
+                linkContext = determineLinkContextForPaymentMethodType(code),
                 googlePaySupported = googlePaySupported,
             )
         )
@@ -393,6 +397,18 @@ internal class DefaultEventReporter @Inject internal constructor(
                     additionalParams = event.params,
                 )
             )
+        }
+    }
+
+    private fun determineLinkContextForPaymentMethodType(code: String): String? {
+        return if (code == "link") {
+            if (linkMode == LinkMode.LinkCardBrand) {
+                "link_card_brand"
+            } else {
+                "instant_debits"
+            }
+        } else {
+            null
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -191,6 +191,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     class SelectPaymentMethod(
         code: String,
         currency: String?,
+        linkContext: String?,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
@@ -199,6 +200,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         override val additionalParams: Map<String, Any?> = mapOf(
             FIELD_CURRENCY to currency,
             FIELD_SELECTED_LPM to code,
+            FIELD_LINK_CONTEXT to linkContext,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -623,6 +623,38 @@ class DefaultEventReporterTest {
     }
 
     @Test
+    fun `Send correct link_mode when selecting Bank payment method type for Instant Debits`() {
+        val completeEventReporter = createEventReporter(EventReporter.Mode.Complete) {
+            simulateInit()
+            simulateSuccessfulSetup(linkMode = LinkMode.LinkPaymentMethod)
+        }
+
+        completeEventReporter.onSelectPaymentMethod("link")
+
+        val argumentCaptor = argumentCaptor<AnalyticsRequest>()
+        verify(analyticsRequestExecutor).executeAsync(argumentCaptor.capture())
+
+        val errorType = argumentCaptor.firstValue.params["link_context"] as String
+        assertThat(errorType).isEqualTo("instant_debits")
+    }
+
+    @Test
+    fun `Send correct link_mode when selecting Bank payment method type for Link Card Brand`() {
+        val completeEventReporter = createEventReporter(EventReporter.Mode.Complete) {
+            simulateInit()
+            simulateSuccessfulSetup(linkMode = LinkMode.LinkCardBrand)
+        }
+
+        completeEventReporter.onSelectPaymentMethod("link")
+
+        val argumentCaptor = argumentCaptor<AnalyticsRequest>()
+        verify(analyticsRequestExecutor).executeAsync(argumentCaptor.capture())
+
+        val errorType = argumentCaptor.firstValue.params["link_context"] as String
+        assertThat(errorType).isEqualTo("link_card_brand")
+    }
+
+    @Test
     fun `Send correct link_context when pressing confirm button for Instant Debits`() {
         val completeEventReporter = createEventReporter(EventReporter.Mode.Complete) {
             simulateInit()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds `link_context` to the analytics event for selecting a payment method type in PaymentSheet, allowing us to distinguish between Instant Debits and Link Card Brand.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
