### PR TITLE
Fix a bug with `US Bank account` not properly sending `allow_redisplay` value.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -1310,6 +1310,7 @@ data class PaymentMethodCreateParams internal constructor(
             paymentMethodId: String,
             requiresMandate: Boolean,
             productUsage: Set<String>,
+            allowRedisplay: PaymentMethod.AllowRedisplay? = null,
         ): PaymentMethodCreateParams {
             return PaymentMethodCreateParams(
                 code = PaymentMethod.Type.Link.code,
@@ -1319,6 +1320,7 @@ data class PaymentMethodCreateParams internal constructor(
                         "payment_method_id" to paymentMethodId,
                     ),
                 ),
+                allowRedisplay = allowRedisplay,
                 productUsage = productUsage,
             )
         }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUsBankAccountInCustomerSheet.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUsBankAccountInCustomerSheet.kt
@@ -3,6 +3,7 @@ package com.stripe.android.lpm
 import com.stripe.android.BasePlaygroundTest
 import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomerSessionSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSheetPaymentMethodModeDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.PaymentMethodMode
 import com.stripe.android.test.core.AuthorizeAction
@@ -25,6 +26,17 @@ internal class TestUsBankAccountInCustomerSheet : BasePlaygroundTest() {
             testParameters = testParameters.copy(
                 authorizationAction = AuthorizeAction.Cancel,
             )
+        )
+    }
+
+    @Test
+    fun testUSBankAccountWithCustomerSession() {
+        testDriver.saveUsBankAccountInCustomerSheet(
+            testParameters = testParameters.copy(
+                authorizationAction = AuthorizeAction.Cancel,
+            ).copyPlaygroundSettings { settings ->
+                settings[CustomerSessionSettingsDefinition] = true
+            }
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -432,7 +432,7 @@ internal class CustomerSheetViewModel(
         }
 
         val customerState = customerState.value
-        val paymentMethodMetadata = customerState.metadata
+        val paymentMethodMetadata = requireNotNull(customerState.metadata)
 
         eventReporter.onPaymentMethodSelected(paymentMethod.code)
 
@@ -443,11 +443,9 @@ internal class CustomerSheetViewModel(
                 paymentMethodCode = paymentMethod.code,
                 formArguments = FormArgumentsFactory.create(
                     paymentMethodCode = paymentMethod.code,
-                    configuration = configuration,
-                    merchantName = configuration.merchantDisplayName,
-                    cbcEligibility = customerState.cbcEligibility,
+                    metadata = paymentMethodMetadata,
                 ),
-                formElements = paymentMethodMetadata?.formElementsForCode(
+                formElements = paymentMethodMetadata.formElementsForCode(
                     code = paymentMethod.code,
                     uiDefinitionFactoryArgumentsFactory = UiDefinitionFactory.Arguments.Factory.Default(
                         cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
@@ -773,24 +771,22 @@ internal class CustomerSheetViewModel(
         isFirstPaymentMethod: Boolean,
     ) {
         val customerState = customerState.value
-        val paymentMethodMetadata = customerState.metadata
+        val paymentMethodMetadata = requireNotNull(customerState.metadata)
 
         val paymentMethodCode = previouslySelectedPaymentMethod?.code
-            ?: paymentMethodMetadata?.supportedPaymentMethodTypes()?.firstOrNull()
+            ?: paymentMethodMetadata.supportedPaymentMethodTypes().firstOrNull()
             ?: PaymentMethod.Type.Card.code
 
         val formArguments = FormArgumentsFactory.create(
             paymentMethodCode = paymentMethodCode,
-            configuration = configuration,
-            merchantName = configuration.merchantDisplayName,
-            cbcEligibility = customerState.cbcEligibility,
+            metadata = paymentMethodMetadata,
         )
 
         val selectedPaymentMethod = previouslySelectedPaymentMethod
-            ?: requireNotNull(paymentMethodMetadata?.supportedPaymentMethodForCode(paymentMethodCode))
+            ?: requireNotNull(paymentMethodMetadata.supportedPaymentMethodForCode(paymentMethodCode))
 
-        val stripeIntent = paymentMethodMetadata?.stripeIntent
-        val formElements = paymentMethodMetadata?.formElementsForCode(
+        val stripeIntent = paymentMethodMetadata.stripeIntent
+        val formElements = paymentMethodMetadata.formElementsForCode(
             code = selectedPaymentMethod.code,
             uiDefinitionFactoryArgumentsFactory = UiDefinitionFactory.Arguments.Factory.Default(
                 cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -213,45 +213,10 @@ internal data class PaymentMethodMetadata(
     fun allowRedisplay(
         customerRequestedSave: PaymentSelection.CustomerRequestedSave,
     ): PaymentMethod.AllowRedisplay {
-        return if (hasIntentToSetup()) {
-            allowRedisplayForSetupIntent(customerRequestedSave)
-        } else {
-            allowRedisplayForPaymentIntent(customerRequestedSave)
-        }
-    }
-
-    private fun allowRedisplayForSetupIntent(
-        customerRequestedSave: PaymentSelection.CustomerRequestedSave,
-    ): PaymentMethod.AllowRedisplay {
-        return when (paymentMethodSaveConsentBehavior) {
-            is PaymentMethodSaveConsentBehavior.Legacy -> PaymentMethod.AllowRedisplay.UNSPECIFIED
-            is PaymentMethodSaveConsentBehavior.Disabled -> {
-                paymentMethodSaveConsentBehavior.overrideAllowRedisplay ?: PaymentMethod.AllowRedisplay.LIMITED
-            }
-            is PaymentMethodSaveConsentBehavior.Enabled -> {
-                if (customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse) {
-                    PaymentMethod.AllowRedisplay.ALWAYS
-                } else {
-                    PaymentMethod.AllowRedisplay.LIMITED
-                }
-            }
-        }
-    }
-
-    private fun allowRedisplayForPaymentIntent(
-        customerRequestedSave: PaymentSelection.CustomerRequestedSave,
-    ): PaymentMethod.AllowRedisplay {
-        return when (paymentMethodSaveConsentBehavior) {
-            is PaymentMethodSaveConsentBehavior.Legacy -> PaymentMethod.AllowRedisplay.UNSPECIFIED
-            is PaymentMethodSaveConsentBehavior.Disabled -> PaymentMethod.AllowRedisplay.UNSPECIFIED
-            is PaymentMethodSaveConsentBehavior.Enabled -> {
-                if (customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse) {
-                    PaymentMethod.AllowRedisplay.ALWAYS
-                } else {
-                    PaymentMethod.AllowRedisplay.UNSPECIFIED
-                }
-            }
-        }
+        return paymentMethodSaveConsentBehavior.allowRedisplay(
+            isSetupIntent = hasIntentToSetup(),
+            customerRequestedSave = customerRequestedSave,
+        )
     }
 
     internal companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodSaveConsentBehavior.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodSaveConsentBehavior.kt
@@ -2,6 +2,7 @@ package com.stripe.android.lpmfoundations.paymentmethod
 
 import android.os.Parcelable
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -29,4 +30,47 @@ internal sealed interface PaymentMethodSaveConsentBehavior : Parcelable {
     data class Disabled(
         val overrideAllowRedisplay: PaymentMethod.AllowRedisplay?
     ) : PaymentMethodSaveConsentBehavior
+
+    fun allowRedisplay(
+        isSetupIntent: Boolean,
+        customerRequestedSave: PaymentSelection.CustomerRequestedSave,
+    ): PaymentMethod.AllowRedisplay {
+        return if (isSetupIntent) {
+            allowRedisplayForSetupIntent(customerRequestedSave)
+        } else {
+            allowRedisplayForPaymentIntent(customerRequestedSave)
+        }
+    }
+
+    private fun allowRedisplayForSetupIntent(
+        customerRequestedSave: PaymentSelection.CustomerRequestedSave,
+    ): PaymentMethod.AllowRedisplay {
+        return when (this) {
+            is Legacy -> PaymentMethod.AllowRedisplay.UNSPECIFIED
+            is Disabled -> overrideAllowRedisplay ?: PaymentMethod.AllowRedisplay.LIMITED
+            is Enabled -> {
+                if (customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse) {
+                    PaymentMethod.AllowRedisplay.ALWAYS
+                } else {
+                    PaymentMethod.AllowRedisplay.LIMITED
+                }
+            }
+        }
+    }
+
+    private fun allowRedisplayForPaymentIntent(
+        customerRequestedSave: PaymentSelection.CustomerRequestedSave,
+    ): PaymentMethod.AllowRedisplay {
+        return when (this) {
+            is Legacy -> PaymentMethod.AllowRedisplay.UNSPECIFIED
+            is Disabled -> PaymentMethod.AllowRedisplay.UNSPECIFIED
+            is Enabled -> {
+                if (customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse) {
+                    PaymentMethod.AllowRedisplay.ALWAYS
+                } else {
+                    PaymentMethod.AllowRedisplay.UNSPECIFIED
+                }
+            }
+        }
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
@@ -1,10 +1,8 @@
 package com.stripe.android.paymentsheet.forms
 
-import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
-import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 
 internal object FormArgumentsFactory {
 
@@ -20,21 +18,8 @@ internal object FormArgumentsFactory {
             shippingDetails = metadata.shippingDetails,
             billingDetailsCollectionConfiguration = metadata.billingDetailsCollectionConfiguration,
             cbcEligibility = metadata.cbcEligibility,
-        )
-    }
-
-    fun create(
-        paymentMethodCode: PaymentMethodCode,
-        configuration: CustomerSheet.Configuration,
-        merchantName: String,
-        cbcEligibility: CardBrandChoiceEligibility,
-    ): FormArguments {
-        return FormArguments(
-            paymentMethodCode = paymentMethodCode,
-            merchantName = merchantName,
-            billingDetails = configuration.defaultBillingDetails,
-            billingDetailsCollectionConfiguration = configuration.billingDetailsCollectionConfiguration,
-            cbcEligibility = cbcEligibility,
+            hasIntentToSetup = metadata.hasIntentToSetup(),
+            paymentMethodSaveConsentBehavior = metadata.paymentMethodSaveConsentBehavior,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArguments.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.paymentdatacollection
 
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
@@ -13,6 +14,8 @@ internal data class FormArguments(
     val amount: Amount? = null,
     val billingDetails: PaymentSheet.BillingDetails? = null,
     val shippingDetails: AddressDetails? = null,
+    val paymentMethodSaveConsentBehavior: PaymentMethodSaveConsentBehavior,
+    val hasIntentToSetup: Boolean,
     val billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration =
         PaymentSheet.BillingDetailsCollectionConfiguration(),
 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -565,6 +565,10 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
                     paymentMethodId = resultIdentifier.id,
                     requiresMandate = true,
                     productUsage = setOf("PaymentSheet"),
+                    allowRedisplay = args.formArgs.paymentMethodSaveConsentBehavior.allowRedisplay(
+                        isSetupIntent = args.formArgs.hasIntentToSetup,
+                        customerRequestedSave = customerRequestedSave,
+                    ),
                 )
             }
             is ResultIdentifier.Session -> {
@@ -577,7 +581,11 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
                         email = email.value,
                         phone = phone.value,
                         address = address.value,
-                    )
+                    ),
+                    allowRedisplay = args.formArgs.paymentMethodSaveConsentBehavior.allowRedisplay(
+                        isSetupIntent = args.formArgs.hasIntentToSetup,
+                        customerRequestedSave = customerRequestedSave,
+                    ),
                 )
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.customersheet.ui.CustomerSheetScreen
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
@@ -98,7 +99,9 @@ internal class CustomerSheetScreenshotTest {
         formArguments = FormArguments(
             paymentMethodCode = PaymentMethod.Type.Card.code,
             cbcEligibility = CardBrandChoiceEligibility.Ineligible,
-            merchantName = ""
+            merchantName = "",
+            hasIntentToSetup = true,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
         ),
         usBankAccountFormArguments = usBankAccountFormArguments,
         supportedPaymentMethods = listOf(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
@@ -128,6 +128,7 @@ internal class FormHelperTest {
                     value = 1099,
                     currencyCode = "usd",
                 ),
+                hasIntentToSetup = true,
                 billingDetails = PaymentSheet.BillingDetails(),
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -4,6 +4,7 @@ import android.content.res.ColorStateList
 import android.graphics.Color
 import androidx.core.graphics.toColorInt
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
@@ -230,7 +231,9 @@ internal object PaymentSheetFixtures {
                 name = "Jenny Rosen",
                 phone = "+18008675309"
             ),
-            cbcEligibility = CardBrandChoiceEligibility.Ineligible
+            cbcEligibility = CardBrandChoiceEligibility.Ineligible,
+            hasIntentToSetup = false,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
         )
 
     internal val PAYPAL_AND_VENMO_EXTERNAL_PAYMENT_METHOD_DATA = """

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1581,6 +1581,7 @@ internal class PaymentSheetViewModelTest {
                     value = 1099,
                     currencyCode = "usd",
                 ),
+                hasIntentToSetup = true,
                 billingDetails = PaymentSheet.BillingDetails(),
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/AccountPreviewScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/AccountPreviewScreenshotTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
@@ -36,6 +37,8 @@ internal class AccountPreviewScreenshotTest {
         amount = null,
         billingDetails = null,
         cbcEligibility = CardBrandChoiceEligibility.Ineligible,
+        hasIntentToSetup = false,
+        paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
     )
 
     private val sameAsShippingElement = SameAsShippingElement(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/BillingDetailsCollectionScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/BillingDetailsCollectionScreenshotTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
@@ -135,6 +136,8 @@ internal class BillingDetailsCollectionScreenshotTest {
             billingDetails = null,
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
             cbcEligibility = CardBrandChoiceEligibility.Ineligible,
+            hasIntentToSetup = false,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.financialconnections.model.BankAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.Address
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.LinkMode
@@ -61,6 +62,8 @@ class USBankAccountFormViewModelTest {
                 email = CUSTOMER_EMAIL
             ),
             cbcEligibility = CardBrandChoiceEligibility.Ineligible,
+            hasIntentToSetup = false,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
         ),
         showCheckbox = false,
         isCompleteFlow = true,
@@ -1128,6 +1131,236 @@ class USBankAccountFormViewModelTest {
 
             val mandateCollectionViewState = awaitItem()
             assertThat(mandateCollectionViewState.mandateText).isEqualTo(expectedResult)
+        }
+    }
+
+    @Test
+    fun `allowRedisplay returns Unspecified when save behavior is Legacy, not setting up, and no checkbox`() =
+        testAllowRedisplay(
+            showCheckbox = false,
+            shouldSave = true,
+            hasIntentForSetup = false,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+            expectedAllowRedisplay = PaymentMethod.AllowRedisplay.UNSPECIFIED,
+        )
+
+    @Test
+    fun `allowRedisplay returns Unspecified when save behavior is Legacy, not setting up, and should not save`() =
+        testAllowRedisplay(
+            showCheckbox = true,
+            shouldSave = false,
+            hasIntentForSetup = false,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+            expectedAllowRedisplay = PaymentMethod.AllowRedisplay.UNSPECIFIED,
+        )
+
+    @Test
+    fun `allowRedisplay returns Unspecified when save behavior is Legacy, not setting up, and should save`() =
+        testAllowRedisplay(
+            showCheckbox = true,
+            shouldSave = true,
+            hasIntentForSetup = false,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+            expectedAllowRedisplay = PaymentMethod.AllowRedisplay.UNSPECIFIED,
+        )
+
+    @Test
+    fun `allowRedisplay returns Unspecified when save behavior is Legacy, setting up, and no checkbox`() =
+        testAllowRedisplay(
+            showCheckbox = false,
+            shouldSave = true,
+            hasIntentForSetup = true,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+            expectedAllowRedisplay = PaymentMethod.AllowRedisplay.UNSPECIFIED,
+        )
+
+    @Test
+    fun `allowRedisplay returns Unspecified when save behavior is Legacy, setting up, and should not save`() =
+        testAllowRedisplay(
+            showCheckbox = true,
+            shouldSave = false,
+            hasIntentForSetup = true,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+            expectedAllowRedisplay = PaymentMethod.AllowRedisplay.UNSPECIFIED,
+        )
+
+    @Test
+    fun `allowRedisplay returns Unspecified when save behavior is Legacy, setting up, and should save`() =
+        testAllowRedisplay(
+            showCheckbox = true,
+            shouldSave = true,
+            hasIntentForSetup = true,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+            expectedAllowRedisplay = PaymentMethod.AllowRedisplay.UNSPECIFIED,
+        )
+
+    @Test
+    fun `allowRedisplay returns Unspecified when save behavior is Enabled, not setting up, and no checkbox`() =
+        testAllowRedisplay(
+            showCheckbox = false,
+            shouldSave = true,
+            hasIntentForSetup = true,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Enabled,
+            expectedAllowRedisplay = PaymentMethod.AllowRedisplay.LIMITED,
+        )
+
+    @Test
+    fun `allowRedisplay returns Unspecified when save behavior is Enabled, not setting up, and should not save`() =
+        testAllowRedisplay(
+            showCheckbox = true,
+            shouldSave = false,
+            hasIntentForSetup = false,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Enabled,
+            expectedAllowRedisplay = PaymentMethod.AllowRedisplay.UNSPECIFIED,
+        )
+
+    @Test
+    fun `allowRedisplay returns Always when save behavior is Enabled, not setting up, and should save`() =
+        testAllowRedisplay(
+            showCheckbox = true,
+            shouldSave = true,
+            hasIntentForSetup = false,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Enabled,
+            expectedAllowRedisplay = PaymentMethod.AllowRedisplay.ALWAYS,
+        )
+
+    @Test
+    fun `allowRedisplay returns Limited when save behavior is Enabled, setting up, and no checkbox`() =
+        testAllowRedisplay(
+            showCheckbox = false,
+            shouldSave = true,
+            hasIntentForSetup = true,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Enabled,
+            expectedAllowRedisplay = PaymentMethod.AllowRedisplay.LIMITED,
+        )
+
+    @Test
+    fun `allowRedisplay returns Limited when save behavior is Enabled, setting up, and should not save`() =
+        testAllowRedisplay(
+            showCheckbox = true,
+            shouldSave = false,
+            hasIntentForSetup = true,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Enabled,
+            expectedAllowRedisplay = PaymentMethod.AllowRedisplay.LIMITED,
+        )
+
+    @Test
+    fun `allowRedisplay returns Always when save behavior is Enabled, setting up, and should save`() =
+        testAllowRedisplay(
+            showCheckbox = true,
+            shouldSave = true,
+            hasIntentForSetup = true,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Enabled,
+            expectedAllowRedisplay = PaymentMethod.AllowRedisplay.ALWAYS,
+        )
+
+    @Test
+    fun `allowRedisplay returns Unspecified when save behavior is Disabled and not setting up`() =
+        testAllowRedisplay(
+            showCheckbox = false,
+            shouldSave = true,
+            hasIntentForSetup = false,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Disabled(
+                overrideAllowRedisplay = null,
+            ),
+            expectedAllowRedisplay = PaymentMethod.AllowRedisplay.UNSPECIFIED,
+        )
+
+    @Test
+    fun `allowRedisplay returns Limited when save behavior is Disabled and setting up`() =
+        testAllowRedisplay(
+            showCheckbox = false,
+            shouldSave = true,
+            hasIntentForSetup = true,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Disabled(
+                overrideAllowRedisplay = null,
+            ),
+            expectedAllowRedisplay = PaymentMethod.AllowRedisplay.LIMITED,
+        )
+
+    @Test
+    fun `allowRedisplay returns Always when save behavior is Disabled, setting up, and has redisplay override`() =
+        testAllowRedisplay(
+            showCheckbox = false,
+            shouldSave = true,
+            hasIntentForSetup = true,
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Disabled(
+                overrideAllowRedisplay = PaymentMethod.AllowRedisplay.ALWAYS,
+            ),
+            expectedAllowRedisplay = PaymentMethod.AllowRedisplay.ALWAYS,
+        )
+
+    private fun testAllowRedisplay(
+        showCheckbox: Boolean,
+        shouldSave: Boolean,
+        hasIntentForSetup: Boolean,
+        paymentMethodSaveConsentBehavior: PaymentMethodSaveConsentBehavior,
+        expectedAllowRedisplay: PaymentMethod.AllowRedisplay,
+    ) {
+        testAllowRedisplay(
+            isInstantDebits = true,
+            showCheckbox = showCheckbox,
+            shouldSave = shouldSave,
+            hasIntentForSetup = hasIntentForSetup,
+            paymentMethodSaveConsentBehavior = paymentMethodSaveConsentBehavior,
+            expectedAllowRedisplay = expectedAllowRedisplay,
+        )
+
+        testAllowRedisplay(
+            isInstantDebits = false,
+            showCheckbox = showCheckbox,
+            shouldSave = shouldSave,
+            hasIntentForSetup = hasIntentForSetup,
+            paymentMethodSaveConsentBehavior = paymentMethodSaveConsentBehavior,
+            expectedAllowRedisplay = expectedAllowRedisplay,
+        )
+    }
+
+    private fun testAllowRedisplay(
+        isInstantDebits: Boolean,
+        showCheckbox: Boolean,
+        shouldSave: Boolean,
+        hasIntentForSetup: Boolean,
+        paymentMethodSaveConsentBehavior: PaymentMethodSaveConsentBehavior,
+        expectedAllowRedisplay: PaymentMethod.AllowRedisplay,
+    ) = runTest {
+        val viewModel = createViewModel(
+            defaultArgs.copy(
+                showCheckbox = showCheckbox,
+                formArgs = defaultArgs.formArgs.copy(
+                    hasIntentToSetup = hasIntentForSetup,
+                    paymentMethodSaveConsentBehavior = paymentMethodSaveConsentBehavior,
+                )
+            )
+        )
+
+        viewModel.result.test {
+            viewModel.handleCollectBankAccountResult(mockVerifiedBankAccount())
+
+            viewModel.saveForFutureUseElement.controller.onValueChange(shouldSave)
+
+            viewModel.handlePrimaryButtonClick(
+                USBankAccountFormScreenState.MandateCollection(
+                    intentId = "pm_1",
+                    bankName = "Test bank",
+                    last4 = "1456",
+                    mandateText = resolvableString("Save"),
+                    primaryButtonText = resolvableString("Confirm"),
+                    resultIdentifier = when (isInstantDebits) {
+                        true -> USBankAccountFormScreenState.ResultIdentifier.PaymentMethod(id = "pm_1")
+                        false -> USBankAccountFormScreenState.ResultIdentifier.Session(id = "session_1")
+                    }
+                )
+            )
+
+            assertThat(awaitItem()?.paymentMethodCreateParams?.toParamMap()).containsEntry(
+                "allow_redisplay",
+                when (expectedAllowRedisplay) {
+                    PaymentMethod.AllowRedisplay.UNSPECIFIED -> "unspecified"
+                    PaymentMethod.AllowRedisplay.LIMITED -> "limited"
+                    PaymentMethod.AllowRedisplay.ALWAYS -> "always"
+                }
+            )
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
@@ -240,6 +240,8 @@ internal class AddPaymentMethodTest {
                 paymentMethodCode = initiallySelectedPaymentMethodType,
                 cbcEligibility = CardBrandChoiceEligibility.Ineligible,
                 merchantName = "Example, Inc.",
+                hasIntentToSetup = false,
+                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
             ),
             formElements = listOf(
                 CheckboxFieldElement(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultAddPaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultAddPaymentMethodInteractorTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.ui
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.forms.FormFieldValues
@@ -238,6 +239,8 @@ class DefaultAddPaymentMethodInteractorTest {
                     preferredNetworks = emptyList(),
                 ),
                 merchantName = "Example, Inc.",
+                hasIntentToSetup = false,
+                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
             )
         },
         formElementsForCode: (PaymentMethodCode) -> List<FormElement> = { emptyList() },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.CardDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.KlarnaDefinition
@@ -146,6 +147,8 @@ internal class VerticalModeFormUITest {
                 billingDetails = null,
                 shippingDetails = null,
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
+                hasIntentToSetup = false,
+                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
             ),
             formElements = CardDefinition.formElements(),
             headerInformation = headerInformation,
@@ -173,6 +176,8 @@ internal class VerticalModeFormUITest {
                 billingDetails = null,
                 shippingDetails = null,
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
+                hasIntentToSetup = false,
+                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
             ),
             formElements = emptyList(),
             headerInformation = headerInformation,
@@ -204,6 +209,8 @@ internal class VerticalModeFormUITest {
                 billingDetails = null,
                 shippingDetails = null,
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
+                hasIntentToSetup = false,
+                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
             ),
             formElements = KlarnaDefinition.formElements(paymentMethodMetadata),
             headerInformation = headerInformation,


### PR DESCRIPTION
# Summary
`US Bank account` is not properly sending `allow_redisplay` value. This means that when using `CustomerSession`, merchants using `allow_redisplay` filters when filtering out payment methods will not properly see saved bank accounts that users have opted in to save because the `allow_redisplay` filter is unspecified.

# Motivation
Ensures `US Bank Account` sends the expected `allow_redisplay` value based on the save behavior the merchant has selected for `PaymentSheet` and the base behavior for `CustomerSheet`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified