### PR TITLE
Update link sign up failure error message to use API exception error message

### DIFF
--- a/link/src/main/java/com/stripe/android/link/analytics/DefaultLinkEventsReporter.kt
+++ b/link/src/main/java/com/stripe/android/link/analytics/DefaultLinkEventsReporter.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.link.analytics
 
 import com.stripe.android.core.Logger
-import com.stripe.android.core.exception.InvalidRequestException
+import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.exception.safeAnalyticsMessage
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
@@ -45,12 +45,8 @@ internal class DefaultLinkEventsReporter @Inject constructor(
     }
 
     override fun onSignupFailure(isInline: Boolean, error: Throwable) {
-        val preferredParams = if (error is InvalidRequestException) {
-            error.stripeError?.message?.let {
-                mapOf(FIELD_ERROR_MESSAGE to it)
-            }
-        } else {
-            null
+        val preferredParams = (error as? APIException)?.stripeError?.message?.let {
+            mapOf(FIELD_ERROR_MESSAGE to it)
         }
 
         val params = (preferredParams ?: mapOf(FIELD_ERROR_MESSAGE to error.safeAnalyticsMessage))

--- a/link/src/main/java/com/stripe/android/link/analytics/DefaultLinkEventsReporter.kt
+++ b/link/src/main/java/com/stripe/android/link/analytics/DefaultLinkEventsReporter.kt
@@ -45,8 +45,12 @@ internal class DefaultLinkEventsReporter @Inject constructor(
     }
 
     override fun onSignupFailure(isInline: Boolean, error: Throwable) {
-        val preferredParams = (error as? APIException)?.stripeError?.message?.let {
-            mapOf(FIELD_ERROR_MESSAGE to it)
+        val preferredParams = if (error is APIException) {
+            error.stripeError?.message?.let {
+                mapOf(FIELD_ERROR_MESSAGE to it)
+            }
+        } else {
+            null
         }
 
         val params = (preferredParams ?: mapOf(FIELD_ERROR_MESSAGE to error.safeAnalyticsMessage))

--- a/link/src/test/java/com/stripe/android/link/analytics/DefaultLinkEventsReporterTest.kt
+++ b/link/src/test/java/com/stripe/android/link/analytics/DefaultLinkEventsReporterTest.kt
@@ -1,0 +1,91 @@
+package com.stripe.android.link.analytics
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.Logger
+import com.stripe.android.core.StripeError
+import com.stripe.android.core.exception.APIException
+import com.stripe.android.core.utils.DurationProvider
+import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.testing.FakeAnalyticsRequestExecutor
+import com.stripe.android.testing.FakeErrorReporter
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.TestScope
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.lang.IllegalStateException
+import kotlin.test.Test
+import kotlin.time.Duration
+
+@RunWith(RobolectricTestRunner::class)
+class DefaultLinkEventsReporterTest {
+
+    private val application = ApplicationProvider.getApplicationContext<Application>()
+
+    @Test
+    fun onLinkSignupFailure_sendsCorrectAnalytics() =
+        runScenario { linkEventsReporter, fakeAnalyticsRequestExecutor, testScheduler ->
+            linkEventsReporter.onSignupFailure(isInline = false, error = IllegalStateException("An error occurred"))
+
+            testScheduler.advanceUntilIdle()
+
+            val loggedRequests = fakeAnalyticsRequestExecutor.getExecutedRequests()
+
+            assertThat(loggedRequests).hasSize(1)
+            val loggedParams = loggedRequests.first().params
+            assertThat(loggedParams.get("event")).isEqualTo("link.signup.failure")
+            assertThat(loggedParams.get("error_message")).isEqualTo("unknown")
+            assertThat(loggedParams.get("analytics_value")).isEqualTo("java.lang.IllegalStateException")
+        }
+
+    @Test
+    fun onLinkSignupFailure_withApiException_sendsCorrectAnalytics() =
+        runScenario { linkEventsReporter, fakeAnalyticsRequestExecutor, testScheduler ->
+            val expectedMessage = "ApiException error message"
+            val apiException = APIException(
+                stripeError = StripeError(message = expectedMessage)
+            )
+            linkEventsReporter.onSignupFailure(isInline = false, error = apiException)
+
+            testScheduler.advanceUntilIdle()
+
+            val loggedRequests = fakeAnalyticsRequestExecutor.getExecutedRequests()
+
+            assertThat(loggedRequests).hasSize(1)
+            val loggedParams = loggedRequests.first().params
+            assertThat(loggedParams.get("event")).isEqualTo("link.signup.failure")
+            assertThat(loggedParams.get("error_message")).isEqualTo(expectedMessage)
+            assertThat(loggedParams.get("analytics_value")).isEqualTo("apiError")
+        }
+
+    private fun runScenario(
+        testBlock: (LinkEventsReporter, FakeAnalyticsRequestExecutor, TestCoroutineScheduler) -> Unit
+    ) {
+        val analyticsRequestExecutor = FakeAnalyticsRequestExecutor()
+        val testScope = TestScope()
+        val linkEventsReporter = DefaultLinkEventsReporter(
+            analyticsRequestExecutor = analyticsRequestExecutor,
+            paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
+                context = application,
+                publishableKey = "pk_1234"
+            ),
+            errorReporter = FakeErrorReporter(),
+            workContext = testScope.coroutineContext,
+            logger = Logger.noop(),
+            durationProvider = FakeDurationProvider()
+        )
+
+        testBlock(linkEventsReporter, analyticsRequestExecutor, testScope.testScheduler)
+    }
+
+    class FakeDurationProvider : DurationProvider {
+        override fun start(key: DurationProvider.Key, reset: Boolean) {
+            // Do nothing.
+        }
+
+        override fun end(key: DurationProvider.Key): Duration? {
+            return Duration.ZERO
+        }
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update link sign up failure error message to use API exception error message

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3589

The current analytic isn't sending the error message we expect in our sign up failures alert

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Steps:
- Used the debugger
- Triggered a link sign up failure with an invalid phone number (by entering a US phone number that was too long)
- verified that the error message now reads "The phone number provided was invalid."