### PR TITLE
Remove private beta badge for `CustomerSheet` in example app

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/MainActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/MainActivity.kt
@@ -81,9 +81,6 @@ class MainActivity : AppCompatActivity() {
                 subtitleResId = R.string.customer_subtitle,
                 klass = CustomerSheetExampleActivity::class.java,
                 section = MenuItem.Section.CustomerSheet,
-                badge = MenuItem.Badge(
-                    labelResId = R.string.beta_badge_label,
-                )
             ),
             MenuItem(
                 titleResId = R.string.address_element_title,


### PR DESCRIPTION
# Summary
Remove private beta badge for `CustomerSheet` example app

# Motivation
Contrary to what the example app says, this is no longer in private beta.
