### PR TITLE
Filter out saved cards for CBF

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentSheetCardBrandFilter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentSheetCardBrandFilter.kt
@@ -5,6 +5,7 @@ package com.stripe.android.lpmfoundations.paymentmethod
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.ExperimentalCardBrandFilteringApi
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.parcelize.Parcelize
 
@@ -37,6 +38,15 @@ internal class PaymentSheetCardBrandFilter(
                 !isDisallowed
             }
         }
+    }
+
+    fun isAccepted(paymentMethod: PaymentMethod): Boolean {
+        val brand = paymentMethod.card?.displayBrand?.let { displayBrand ->
+            val cardBrand = CardBrand.fromCode(displayBrand)
+            if (cardBrand == CardBrand.Unknown) null else cardBrand
+        } ?: paymentMethod.card?.brand ?: CardBrand.Unknown
+
+        return paymentMethod.type != PaymentMethod.Type.Card || isAccepted(brand)
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -14,6 +14,7 @@ import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.lpmfoundations.luxe.isSaveForFutureUseValueChangeable
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.lpmfoundations.paymentmethod.link.LinkInlineConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.toPaymentSheetSaveConsentBehavior
 import com.stripe.android.model.ElementsSession
@@ -135,6 +136,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
                 customerInfo = customerInfo,
                 metadata = metadata.await(),
                 savedSelection = savedSelection,
+                cardBrandFilter = PaymentSheetCardBrandFilter(paymentSheetConfiguration.cardBrandAcceptance)
             )
         }
 
@@ -261,6 +263,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         customerInfo: CustomerInfo?,
         metadata: PaymentMethodMetadata,
         savedSelection: Deferred<SavedSelection>,
+        cardBrandFilter: PaymentSheetCardBrandFilter
     ): CustomerState? {
         val customerState = when (customerInfo) {
             is CustomerInfo.CustomerSession -> {
@@ -285,7 +288,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         return customerState?.let { state ->
             state.copy(
                 paymentMethods = state.paymentMethods
-                    .withLastUsedPaymentMethodFirst(savedSelection.await())
+                    .withLastUsedPaymentMethodFirst(savedSelection.await()).filter { cardBrandFilter.isAccepted(it) }
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -441,7 +441,7 @@ class DefaultCustomerSheetLoaderTest {
         assertThat(state.customerPaymentMethods.count()).isEqualTo(
             1
         )
-        assertThat(state.customerPaymentMethods.first().card?.brand ?: CardBrand.Unknown).isEqualTo(
+        assertThat(state.customerPaymentMethods.first().card?.brand).isEqualTo(
             CardBrand.AmericanExpress
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -438,10 +438,10 @@ class DefaultCustomerSheetLoaderTest {
         )
 
         val state = loader.load(config).getOrThrow()
-        assertThat(state.customerPaymentMethods.count() ?: 0).isEqualTo(
+        assertThat(state.customerPaymentMethods.count()).isEqualTo(
             1
         )
-        assertThat(state.customerPaymentMethods?.first()?.card?.brand ?: CardBrand.Unknown).isEqualTo(
+        assertThat(state.customerPaymentMethods.first().card?.brand ?: CardBrand.Unknown).isEqualTo(
             CardBrand.AmericanExpress
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -2093,7 +2093,7 @@ internal class DefaultPaymentSheetLoaderTest {
         assertThat(state.customer?.paymentMethods?.count() ?: 0).isEqualTo(
             1
         )
-        assertThat(state.customer?.paymentMethods?.first()?.card?.brand ?: CardBrand.Unknown).isEqualTo(
+        assertThat(state.customer?.paymentMethods?.first()?.card?.brand).isEqualTo(
             CardBrand.AmericanExpress
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.state
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ExperimentalCardBrandFilteringApi
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.model.CountryCode
@@ -13,6 +14,7 @@ import com.stripe.android.link.ui.inline.LinkSignupMode.AlongsideSaveForFutureUs
 import com.stripe.android.link.ui.inline.LinkSignupMode.InsteadOfSaveForFutureUse
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentIntent.ConfirmationMethod.Manual
@@ -38,6 +40,7 @@ import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException.Paymen
 import com.stripe.android.paymentsheet.utils.FakeUserFacingLogger
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentMethodFactory
+import com.stripe.android.testing.PaymentMethodFactory.update
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.ExternalPaymentMethodsRepository
 import com.stripe.android.utils.FakeCustomerRepository
@@ -2046,6 +2049,52 @@ internal class DefaultPaymentSheetLoaderTest {
             initializationMode = initializationMode,
             orderedLpms = listOf("card", "link"),
             requireCvcRecollection = false
+        )
+    }
+
+    @OptIn(ExperimentalCardBrandFilteringApi::class)
+    @Test
+    fun `Should filter out saved cards with disallowed brands`() = runTest {
+        prefsRepository.savePaymentSelection(null)
+
+        val paymentMethods = listOf(
+            PaymentMethodFactory.card(id = "pm_12345").update(
+                last4 = "1001",
+                addCbcNetworks = false,
+                brand = CardBrand.Visa,
+            ),
+            PaymentMethodFactory.card(id = "pm_123456").update(
+                last4 = "1000",
+                addCbcNetworks = false,
+                brand = CardBrand.AmericanExpress,
+            )
+        )
+
+        val loader = createPaymentSheetLoader(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
+            isGooglePayReady = true,
+            customerRepo = FakeCustomerRepository(paymentMethods = paymentMethods),
+        )
+
+        val config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY.copy(
+            cardBrandAcceptance = PaymentSheet.CardBrandAcceptance.disallowed(
+                listOf(PaymentSheet.CardBrandAcceptance.BrandCategory.Visa)
+            )
+        )
+
+        val state = loader.load(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+            ),
+            paymentSheetConfiguration = config,
+            initializedViaCompose = false,
+        ).getOrThrow()
+
+        assertThat(state.customer?.paymentMethods?.count() ?: 0).isEqualTo(
+            1
+        )
+        assertThat(state.customer?.paymentMethods?.first()?.card?.brand ?: CardBrand.Unknown).isEqualTo(
+            CardBrand.AmericanExpress
         )
     }
 


### PR DESCRIPTION
# Summary
- Hides saved cards of brands that are disallowed in
   - PaymentSheet and flow controller
   - CustomerSheet with CustomerSessions and legacy eph keys

# Motivation
- Card brand filtering

# Testing
- Manually verified all E2E cases
- Unit tests

# Changelog
N/A