### PR TITLE
Pass billing details in `ElementsSessionContext`

### DIFF
--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -19,6 +19,7 @@ import com.stripe.android.financialconnections.analytics.FinancialConnectionsEve
 import com.stripe.android.financialconnections.example.data.BackendRepository
 import com.stripe.android.financialconnections.example.data.Settings
 import com.stripe.android.financialconnections.example.settings.ConfirmIntentSetting
+import com.stripe.android.financialconnections.example.settings.EmailSetting
 import com.stripe.android.financialconnections.example.settings.ExperienceSetting
 import com.stripe.android.financialconnections.example.settings.FinancialConnectionsPlaygroundUrlHelper
 import com.stripe.android.financialconnections.example.settings.FlowSetting
@@ -136,7 +137,9 @@ internal class FinancialConnectionsPlaygroundViewModel(
                                 amount = it.amount,
                                 currency = it.currency,
                                 linkMode = LinkMode.LinkPaymentMethod,
-                                billingAddress = null,
+                                billingDetails = ElementsSessionContext.BillingDetails(
+                                    email = settings.get<EmailSetting>().selectedOption,
+                                ),
                             ),
                             experience = settings.get<ExperienceSetting>().selectedOption,
                             integrationType = settings.get<IntegrationTypeSetting>().selectedOption,

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -136,6 +136,7 @@ internal class FinancialConnectionsPlaygroundViewModel(
                                 amount = it.amount,
                                 currency = it.currency,
                                 linkMode = LinkMode.LinkPaymentMethod,
+                                billingAddress = null,
                             ),
                             experience = settings.get<ExperienceSetting>().selectedOption,
                             integrationType = settings.get<IntegrationTypeSetting>().selectedOption,

--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -145,19 +145,19 @@ public final class com/stripe/android/financialconnections/FinancialConnectionsS
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$BillingAddress$Address$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$BillingDetails$Address$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$BillingAddress$Address;
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$BillingDetails$Address;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$BillingAddress$Address;
+	public final fun newArray (I)[Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$BillingDetails$Address;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$BillingAddress$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$BillingDetails$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$BillingAddress;
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$BillingDetails;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$BillingAddress;
+	public final fun newArray (I)[Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$BillingDetails;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -145,6 +145,22 @@ public final class com/stripe/android/financialconnections/FinancialConnectionsS
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$BillingAddress$Address$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$BillingAddress$Address;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$BillingAddress$Address;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$BillingAddress$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$BillingAddress;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$BillingAddress;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext;

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheet.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheet.kt
@@ -7,6 +7,7 @@ import androidx.fragment.app.Fragment
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetForDataLauncher
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetForTokenLauncher
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetLauncher
+import com.stripe.android.financialconnections.utils.filterNotNullValues
 import com.stripe.android.model.LinkMode
 import kotlinx.parcelize.Parcelize
 
@@ -46,6 +47,7 @@ class FinancialConnectionsSheet internal constructor(
         val amount: Long?,
         val currency: String?,
         val linkMode: LinkMode?,
+        val billingAddress: BillingAddress?,
     ) : Parcelable {
 
         val paymentIntentId: String?
@@ -68,6 +70,48 @@ class FinancialConnectionsSheet internal constructor(
             @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             @Parcelize
             data object DeferredIntent : InitializationMode
+        }
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @Parcelize
+        data class BillingAddress(
+            val name: String? = null,
+            val phone: String? = null,
+            val address: Address? = null,
+        ) : Parcelable {
+
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            @Parcelize
+            data class Address(
+                val line1: String? = null,
+                val line2: String? = null,
+                val postalCode: String? = null,
+                val city: String? = null,
+                val state: String? = null,
+                val country: String? = null,
+            ) : Parcelable {
+
+                fun apiParams(): Map<String, Any> {
+                    return buildMap {
+                        line1?.let { put("line1", it) }
+                        line2?.let { put("line2", it) }
+                        postalCode?.let { put("postal_code", it) }
+                        city?.let { put("city", it) }
+                        state?.let { put("state", it) }
+                        country?.let { put("country", it) }
+                    }.filterValues {
+                        it.isNotBlank()
+                    }
+                }
+            }
+
+            fun apiParams(): Map<String, Any> {
+                return mapOf(
+                    "name" to name,
+                    "phone" to phone,
+                    "address" to address?.apiParams(),
+                ).filterNotNullValues()
+            }
         }
     }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheet.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheet.kt
@@ -7,7 +7,6 @@ import androidx.fragment.app.Fragment
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetForDataLauncher
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetForTokenLauncher
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetLauncher
-import com.stripe.android.financialconnections.utils.filterNotNullValues
 import com.stripe.android.model.LinkMode
 import kotlinx.parcelize.Parcelize
 
@@ -47,7 +46,7 @@ class FinancialConnectionsSheet internal constructor(
         val amount: Long?,
         val currency: String?,
         val linkMode: LinkMode?,
-        val billingAddress: BillingAddress?,
+        val billingDetails: BillingDetails?,
     ) : Parcelable {
 
         val paymentIntentId: String?
@@ -74,9 +73,10 @@ class FinancialConnectionsSheet internal constructor(
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @Parcelize
-        data class BillingAddress(
+        data class BillingDetails(
             val name: String? = null,
             val phone: String? = null,
+            val email: String? = null,
             val address: Address? = null,
         ) : Parcelable {
 
@@ -89,29 +89,7 @@ class FinancialConnectionsSheet internal constructor(
                 val city: String? = null,
                 val state: String? = null,
                 val country: String? = null,
-            ) : Parcelable {
-
-                fun apiParams(): Map<String, Any> {
-                    return buildMap {
-                        line1?.let { put("line1", it) }
-                        line2?.let { put("line2", it) }
-                        postalCode?.let { put("postal_code", it) }
-                        city?.let { put("city", it) }
-                        state?.let { put("state", it) }
-                        country?.let { put("country", it) }
-                    }.filterValues {
-                        it.isNotBlank()
-                    }
-                }
-            }
-
-            fun apiParams(): Map<String, Any> {
-                return mapOf(
-                    "name" to name,
-                    "phone" to phone,
-                    "address" to address?.apiParams(),
-                ).filterNotNullValues()
-            }
+            ) : Parcelable
         }
     }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/CreateInstantDebitsResult.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/CreateInstantDebitsResult.kt
@@ -31,17 +31,12 @@ internal class RealCreateInstantDebitsResult @Inject constructor(
             "Consumer session client secret cannot be null"
         }
 
-        val billingEmailAddress = requireNotNull(consumerSession?.emailAddress) {
-            "Consumer session email address cannot be null"
-        }
-
-        val billingAddress = elementsSessionContext?.billingAddress
+        val billingDetails = elementsSessionContext?.billingDetails
 
         val response = consumerRepository.createPaymentDetails(
             consumerSessionClientSecret = clientSecret,
             bankAccountId = bankAccountId,
-            billingAddress = billingAddress,
-            billingEmailAddress = billingEmailAddress,
+            billingDetails = billingDetails,
         )
 
         val paymentDetails = response.paymentDetails.filterIsInstance<BankAccount>().first()
@@ -51,14 +46,13 @@ internal class RealCreateInstantDebitsResult @Inject constructor(
                 paymentDetailsId = paymentDetails.id,
                 consumerSessionClientSecret = clientSecret,
                 expectedPaymentMethodType = elementsSessionContext.linkMode.expectedPaymentMethodType,
-                billingPhone = elementsSessionContext.billingAddress?.phone,
+                billingPhone = elementsSessionContext.billingDetails?.phone,
             ).paymentMethodId
         } else {
             repository.createPaymentMethod(
                 paymentDetailsId = paymentDetails.id,
                 consumerSessionClientSecret = clientSecret,
-                billingAddress = billingAddress,
-                billingEmailAddress = billingEmailAddress,
+                billingDetails = billingDetails,
             ).id
         }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
@@ -3,11 +3,11 @@ package com.stripe.android.financialconnections.repository
 import com.stripe.android.core.Logger
 import com.stripe.android.core.frauddetection.FraudDetectionDataRepository
 import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext
-import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext.BillingAddress
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext.BillingDetails
 import com.stripe.android.financialconnections.domain.IsLinkWithStripe
 import com.stripe.android.financialconnections.repository.api.FinancialConnectionsConsumersApiService
 import com.stripe.android.financialconnections.repository.api.ProvideApiRequestOptions
-import com.stripe.android.financialconnections.utils.filterNotNullValues
+import com.stripe.android.financialconnections.utils.toConsumerBillingAddressParams
 import com.stripe.android.model.AttachConsumerToLinkAccountSession
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetailsCreateParams
@@ -59,8 +59,7 @@ internal interface FinancialConnectionsConsumerSessionRepository {
     suspend fun createPaymentDetails(
         bankAccountId: String,
         consumerSessionClientSecret: String,
-        billingAddress: BillingAddress?,
-        billingEmailAddress: String,
+        billingDetails: BillingDetails?,
     ): ConsumerPaymentDetails
 
     suspend fun sharePaymentDetails(
@@ -206,15 +205,14 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
     override suspend fun createPaymentDetails(
         bankAccountId: String,
         consumerSessionClientSecret: String,
-        billingAddress: BillingAddress?,
-        billingEmailAddress: String,
+        billingDetails: BillingDetails?,
     ): ConsumerPaymentDetails {
         return consumersApiService.createPaymentDetails(
             consumerSessionClientSecret = consumerSessionClientSecret,
             paymentDetailsCreateParams = ConsumerPaymentDetailsCreateParams.BankAccount(
                 bankAccountId = bankAccountId,
-                billingAddress = billingAddress?.consumerApiParams(),
-                billingEmailAddress = billingEmailAddress,
+                billingAddress = billingDetails?.toConsumerBillingAddressParams(),
+                billingEmailAddress = billingDetails?.email,
             ),
             requestSurface = requestSurface,
             requestOptions = provideApiRequestOptions(useConsumerPublishableKey = true),
@@ -229,18 +227,14 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
     ): SharePaymentDetails {
         val fraudDetectionData = fraudDetectionDataRepository.getCached()?.params.orEmpty()
 
-        val extraParams = mapOf(
-            "billing_phone" to billingPhone,
-        ).filterNotNullValues()
-
         return consumersApiService.sharePaymentDetails(
             consumerSessionClientSecret = consumerSessionClientSecret,
             paymentDetailsId = paymentDetailsId,
             expectedPaymentMethodType = expectedPaymentMethodType,
-            billingPhone = elementsSessionContext?.billingAddress?.phone?.takeIf { it.isNotBlank() },
+            billingPhone = elementsSessionContext?.billingDetails?.phone?.takeIf { it.isNotBlank() },
             requestSurface = requestSurface,
             requestOptions = provideApiRequestOptions(useConsumerPublishableKey = false),
-            extraParams = extraParams + fraudDetectionData,
+            extraParams = fraudDetectionData,
         ).getOrThrow()
     }
 
@@ -273,29 +267,5 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
     ) {
         logger.debug("SYNC_CACHE: updating local consumer session from signUp")
         consumerSessionRepository.storeNewConsumerSession(signup.consumerSession, signup.publishableKey)
-    }
-}
-
-private fun BillingAddress.consumerApiParams(): Map<String, Any> {
-    val contactParams = buildMap {
-        name?.let { put("name", it) }
-    }.filter { entry ->
-        entry.value.isNotBlank()
-    }
-
-    val addressParams = address?.consumerApiParams().orEmpty()
-    return contactParams + addressParams
-}
-
-private fun BillingAddress.Address.consumerApiParams(): Map<String, Any> {
-    return buildMap {
-        line1?.let { put("line_1", it) }
-        line2?.let { put("line_2", it) }
-        postalCode?.let { put("postal_code", it) }
-        city?.let { put("locality", it) }
-        state?.let { put("administrative_area", it) }
-        country?.let { put("country_code", it) }
-    }.filterValues {
-        it.isNotBlank()
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/BillingDetailsExtensions.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/BillingDetailsExtensions.kt
@@ -1,0 +1,55 @@
+package com.stripe.android.financialconnections.utils
+
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext.BillingDetails
+
+/**
+ * Creates API params for use with the Stripe core API.
+ *
+ * These params include the phone number and a nested address object.
+ */
+internal fun BillingDetails.toApiParams(): Map<String, Any> {
+    val addressParams = address?.let { address ->
+        buildMap {
+            address.line1?.let { put("line1", it) }
+            address.line2?.let { put("line2", it) }
+            address.postalCode?.let { put("postal_code", it) }
+            address.city?.let { put("city", it) }
+            address.state?.let { put("state", it) }
+            address.country?.let { put("country", it) }
+        }.filterValues {
+            it.isNotBlank()
+        }
+    }
+    return mapOf(
+        "name" to name,
+        "email" to email,
+        "phone" to phone,
+        "address" to addressParams,
+    ).filterNotNullValues()
+}
+
+/**
+ * Creates API params for use with the consumer API.
+ *
+ * These params don't include the phone number and flatten the address.
+ */
+internal fun BillingDetails.toConsumerBillingAddressParams(): Map<String, Any> {
+    val contactParams = buildMap {
+        name?.let { put("name", it) }
+    }.filter { entry ->
+        entry.value.isNotBlank()
+    }
+
+    val addressParams = buildMap {
+        address?.line1?.let { put("line_1", it) }
+        address?.line2?.let { put("line_2", it) }
+        address?.postalCode?.let { put("postal_code", it) }
+        address?.city?.let { put("locality", it) }
+        address?.state?.let { put("administrative_area", it) }
+        address?.country?.let { put("country_code", it) }
+    }.filterValues {
+        it.isNotBlank()
+    }
+
+    return contactParams + addressParams
+}

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
@@ -149,6 +149,7 @@ class FinancialConnectionsSheetViewModelTest {
                             amount = 123,
                             currency = "usd",
                             linkMode = LinkMode.LinkPaymentMethod,
+                            billingAddress = null,
                         ),
                     )
                 )
@@ -180,6 +181,7 @@ class FinancialConnectionsSheetViewModelTest {
                         amount = 123,
                         currency = "usd",
                         linkMode = null,
+                        billingAddress = null,
                     ),
                 )
             )

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
@@ -149,7 +149,7 @@ class FinancialConnectionsSheetViewModelTest {
                             amount = 123,
                             currency = "usd",
                             linkMode = LinkMode.LinkPaymentMethod,
-                            billingAddress = null,
+                            billingDetails = null,
                         ),
                     )
                 )
@@ -181,7 +181,7 @@ class FinancialConnectionsSheetViewModelTest {
                         amount = 123,
                         currency = "usd",
                         linkMode = null,
-                        billingAddress = null,
+                        billingDetails = null,
                     ),
                 )
             )

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/RealCreateInstantDebitsResultTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/RealCreateInstantDebitsResultTest.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.financialconnections.domain
 
 import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext
-import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext.BillingAddress
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext.BillingDetails
 import com.stripe.android.financialconnections.model.PaymentMethod
 import com.stripe.android.financialconnections.repository.CachedConsumerSession
 import com.stripe.android.financialconnections.repository.FinancialConnectionsConsumerSessionRepository
@@ -65,8 +65,7 @@ class RealCreateInstantDebitsResultTest {
         verify(repository).createPaymentMethod(
             paymentDetailsId = "ba_1234",
             consumerSessionClientSecret = "clientSecret",
-            billingAddress = null,
-            billingEmailAddress = "test@test.com",
+            billingDetails = null,
         )
     }
 
@@ -89,8 +88,7 @@ class RealCreateInstantDebitsResultTest {
         verify(repository).createPaymentMethod(
             paymentDetailsId = "ba_1234",
             consumerSessionClientSecret = "clientSecret",
-            billingAddress = null,
-            billingEmailAddress = "test@test.com",
+            billingDetails = null,
         )
     }
 
@@ -99,10 +97,11 @@ class RealCreateInstantDebitsResultTest {
         val consumerRepository = makeConsumerSessionRepository()
         val repository = makeRepository()
 
-        val billingDetails = BillingAddress(
+        val billingDetails = BillingDetails(
             name = "Some name",
             phone = "+15555555555",
-            address = BillingAddress.Address(
+            email = "test@test.com",
+            address = BillingDetails.Address(
                 city = "San Francisco",
                 country = "US",
                 line1 = "123 Main St",
@@ -118,7 +117,7 @@ class RealCreateInstantDebitsResultTest {
             consumerSessionProvider = { makeCachedConsumerSession() },
             elementsSessionContext = makeElementsSessionContext(
                 linkMode = null,
-                billingAddress = billingDetails,
+                billingDetails = billingDetails,
             ),
         )
 
@@ -127,8 +126,7 @@ class RealCreateInstantDebitsResultTest {
         verify(repository).createPaymentMethod(
             paymentDetailsId = "ba_1234",
             consumerSessionClientSecret = "clientSecret",
-            billingAddress = billingDetails,
-            billingEmailAddress = "test@test.com",
+            billingDetails = billingDetails,
         )
     }
 
@@ -137,10 +135,10 @@ class RealCreateInstantDebitsResultTest {
         val consumerRepository = makeConsumerSessionRepository()
         val repository = makeRepository()
 
-        val billingDetails = BillingAddress(
+        val billingDetails = BillingDetails(
             name = "Some name",
             phone = "+15555555555",
-            address = BillingAddress.Address(
+            address = BillingDetails.Address(
                 city = "San Francisco",
                 country = "US",
                 line1 = "123 Main St",
@@ -156,7 +154,7 @@ class RealCreateInstantDebitsResultTest {
             consumerSessionProvider = { makeCachedConsumerSession() },
             elementsSessionContext = makeElementsSessionContext(
                 linkMode = LinkMode.LinkCardBrand,
-                billingAddress = billingDetails,
+                billingDetails = billingDetails,
             ),
         )
 
@@ -186,7 +184,7 @@ class RealCreateInstantDebitsResultTest {
         )
 
         return mock<FinancialConnectionsConsumerSessionRepository> {
-            onBlocking { createPaymentDetails(any(), any(), anyOrNull(), any()) } doReturn consumerPaymentDetails
+            onBlocking { createPaymentDetails(any(), any(), anyOrNull()) } doReturn consumerPaymentDetails
             onBlocking { sharePaymentDetails(any(), any(), any(), anyOrNull()) } doReturn sharePaymentDetails
         }
     }
@@ -197,7 +195,7 @@ class RealCreateInstantDebitsResultTest {
         )
 
         return mock<FinancialConnectionsRepository> {
-            onBlocking { createPaymentMethod(any(), any(), anyOrNull(), any()) } doReturn paymentMethod
+            onBlocking { createPaymentMethod(any(), any(), anyOrNull()) } doReturn paymentMethod
         }
     }
 
@@ -213,14 +211,14 @@ class RealCreateInstantDebitsResultTest {
 
     private fun makeElementsSessionContext(
         linkMode: LinkMode?,
-        billingAddress: BillingAddress? = null,
+        billingDetails: BillingDetails? = null,
     ): ElementsSessionContext {
         return ElementsSessionContext(
             initializationMode = ElementsSessionContext.InitializationMode.PaymentIntent("pi_123"),
             amount = 100L,
             currency = "usd",
             linkMode = linkMode,
-            billingAddress = billingAddress,
+            billingDetails = billingDetails,
         )
     }
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsRepository.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsRepository.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.financialconnections.networking
 
-import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext.BillingAddress
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext.BillingDetails
 import com.stripe.android.financialconnections.financialConnectionsSessionWithNoMoreAccounts
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccountList
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
@@ -46,8 +46,7 @@ internal class FakeFinancialConnectionsRepository : FinancialConnectionsReposito
     override suspend fun createPaymentMethod(
         paymentDetailsId: String,
         consumerSessionClientSecret: String,
-        billingAddress: BillingAddress?,
-        billingEmailAddress: String,
+        billingDetails: BillingDetails?,
     ): PaymentMethod {
         return createPaymentMethod()
     }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsRepository.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsRepository.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.networking
 
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext.BillingAddress
 import com.stripe.android.financialconnections.financialConnectionsSessionWithNoMoreAccounts
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccountList
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
@@ -44,7 +45,9 @@ internal class FakeFinancialConnectionsRepository : FinancialConnectionsReposito
 
     override suspend fun createPaymentMethod(
         paymentDetailsId: String,
-        consumerSessionClientSecret: String
+        consumerSessionClientSecret: String,
+        billingAddress: BillingAddress?,
+        billingEmailAddress: String,
     ): PaymentMethod {
         return createPaymentMethod()
     }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepositoryImplTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepositoryImplTest.kt
@@ -163,6 +163,7 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
                 amount = 1234,
                 currency = "cad",
                 linkMode = LinkMode.LinkPaymentMethod,
+                billingAddress = null,
             )
         )
 
@@ -427,6 +428,7 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
                 consumerSessionClientSecret = anyOrNull(),
                 paymentDetailsId = anyOrNull(),
                 expectedPaymentMethodType = anyOrNull(),
+                billingPhone = anyOrNull(),
                 requestSurface = anyOrNull(),
                 requestOptions = anyOrNull(),
                 extraParams = eq(fraudParams.params),
@@ -441,6 +443,7 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
             consumerSessionClientSecret = consumerSessionClientSecret,
             paymentDetailsId = "pd_123",
             expectedPaymentMethodType = "card",
+            billingPhone = null,
         )
 
         verify(fraudDetectionDataRepository, never()).getLatest()

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepositoryImplTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepositoryImplTest.kt
@@ -163,7 +163,7 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
                 amount = 1234,
                 currency = "cad",
                 linkMode = LinkMode.LinkPaymentMethod,
-                billingAddress = null,
+                billingDetails = null,
             )
         )
 

--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerPaymentDetailsCreateParams.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerPaymentDetailsCreateParams.kt
@@ -78,12 +78,12 @@ sealed interface ConsumerPaymentDetailsCreateParams : StripeParamsModel, Parcela
     data class BankAccount(
         private val bankAccountId: String,
         private val billingAddress: Map<String, @RawValue Any>?,
-        private val billingEmailAddress: String,
+        private val billingEmailAddress: String?,
     ) : ConsumerPaymentDetailsCreateParams {
 
         override fun toParamMap(): Map<String, Any> {
             val billingParams = buildMap {
-                put("billing_email_address", billingEmailAddress)
+                billingEmailAddress?.let { put("billing_email_address", it) }
 
                 if (!billingAddress.isNullOrEmpty()) {
                     put("billing_address", billingAddress)

--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerPaymentDetailsCreateParams.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerPaymentDetailsCreateParams.kt
@@ -77,15 +77,27 @@ sealed interface ConsumerPaymentDetailsCreateParams : StripeParamsModel, Parcela
     @Parcelize
     data class BankAccount(
         private val bankAccountId: String,
+        private val billingAddress: Map<String, @RawValue Any>?,
+        private val billingEmailAddress: String,
     ) : ConsumerPaymentDetailsCreateParams {
 
         override fun toParamMap(): Map<String, Any> {
-            return mapOf(
+            val billingParams = buildMap {
+                put("billing_email_address", billingEmailAddress)
+
+                if (!billingAddress.isNullOrEmpty()) {
+                    put("billing_address", billingAddress)
+                }
+            }
+
+            val accountParams = mapOf(
                 "type" to "bank_account",
                 "bank_account" to mapOf(
                     "account" to bankAccountId,
                 ),
             )
+
+            return accountParams + billingParams
         }
     }
 }

--- a/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
+++ b/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
@@ -86,6 +86,7 @@ interface ConsumersApiService {
         consumerSessionClientSecret: String,
         paymentDetailsId: String,
         expectedPaymentMethodType: String,
+        billingPhone: String?,
         requestSurface: String,
         requestOptions: ApiRequest.Options,
         extraParams: Map<String, Any?>,
@@ -295,6 +296,7 @@ class ConsumersApiServiceImpl(
         consumerSessionClientSecret: String,
         paymentDetailsId: String,
         expectedPaymentMethodType: String,
+        billingPhone: String?,
         requestSurface: String,
         requestOptions: ApiRequest.Options,
         extraParams: Map<String, Any?>,
@@ -312,6 +314,7 @@ class ConsumersApiServiceImpl(
                     "credentials" to mapOf(
                         "consumer_session_client_secret" to consumerSessionClientSecret
                     ),
+                    "billing_phone" to billingPhone,
                 ) + extraParams,
             ),
             responseJsonParser = SharePaymentDetailsJsonParser,

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -29,7 +29,6 @@
     <ID>LongMethod:EditPaymentMethod.kt$@Composable internal fun EditPaymentMethodUi( viewState: EditPaymentMethodViewState, viewActionHandler: (action: EditPaymentMethodViewAction) -> Unit, modifier: Modifier = Modifier )</ID>
     <ID>LongMethod:FormViewModelTest.kt$FormViewModelTest$@Test fun `Verify params are set when element address fields are complete`()</ID>
     <ID>LongMethod:FormViewModelTest.kt$FormViewModelTest$@Test fun `Verify params are set when required address fields are complete`()</ID>
-    <ID>LongMethod:PaymentMethodMetadataTest.kt$PaymentMethodMetadataTest$@Test fun `should create metadata properly with elements session response, payment sheet config, and data specs`()</ID>
     <ID>LongMethod:PaymentMethodVerticalLayoutInteractor.kt$DefaultPaymentMethodVerticalLayoutInteractor.Companion$fun create( viewModel: BaseSheetViewModel, paymentMethodMetadata: PaymentMethodMetadata, customerStateHolder: CustomerStateHolder, ): PaymentMethodVerticalLayoutInteractor</ID>
     <ID>LongMethod:PaymentOptionFactory.kt$PaymentOptionFactory$fun create(selection: PaymentSelection): PaymentOption</ID>
     <ID>LongMethod:PaymentSheetConfigurationKtx.kt$internal fun PaymentSheet.Appearance.parseAppearance()</ID>
@@ -66,6 +65,7 @@
     <ID>MaxLineLength:PaymentSheet.kt$PaymentSheet.IntentConfiguration.SetupFutureUse$*</ID>
     <ID>MaxLineLength:PrimaryButtonTest.kt$PrimaryButtonTest$primaryButton.setAppearanceConfiguration(StripeThemeDefaults.primaryButtonStyle, ColorStateList.valueOf(Color.BLACK))</ID>
     <ID>MaxLineLength:SupportedPaymentMethod.kt$SupportedPaymentMethod$/** This describes the image in the LPM selector. These can be found internally [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0) */</ID>
+    <ID>MaxLineLength:USBankAccountFormViewModelTest.kt$USBankAccountFormViewModelTest$fun</ID>
     <ID>MaxLineLength:USBankAccountFormViewModelTest.kt$USBankAccountFormViewModelTest$viewModel.handlePrimaryButtonClick(currentScreenState as USBankAccountFormScreenState.VerifyWithMicrodeposits)</ID>
     <ID>MaximumLineLength:CardDefinition.kt$internal</ID>
     <ID>ThrowsCount:PaymentSheetConfigurationKtx.kt$internal fun PaymentSheet.Configuration.validate()</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.core.utils.requireApplication
 import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext
 import com.stripe.android.financialconnections.model.BankAccount
@@ -526,7 +527,11 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
             amount = args.formArgs.amount?.value,
             currency = args.formArgs.amount?.currencyCode,
             linkMode = args.linkMode,
-            billingDetails = makeElementsSessionContextBillingDetails(),
+            billingDetails = if (FeatureFlags.instantDebitsBillingDetails.isEnabled) {
+                makeElementsSessionContextBillingDetails()
+            } else {
+                null
+            },
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -526,21 +526,23 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
             amount = args.formArgs.amount?.value,
             currency = args.formArgs.amount?.currencyCode,
             linkMode = args.linkMode,
-            billingAddress = makeElementsSessionContextBillingAddress(),
+            billingDetails = makeElementsSessionContextBillingDetails(),
         )
     }
 
-    private fun makeElementsSessionContextBillingAddress(): ElementsSessionContext.BillingAddress {
+    private fun makeElementsSessionContextBillingDetails(): ElementsSessionContext.BillingDetails {
         val attachDefaultsToPaymentMethod = collectionConfiguration.attachDefaultsToPaymentMethod
         val name = name.value.takeIf { collectingName || attachDefaultsToPaymentMethod }
+        val email = email.value.takeIf { collectingEmail || attachDefaultsToPaymentMethod }
         val phone = phone.value.takeIf { collectingPhone || attachDefaultsToPaymentMethod }
         val address = address.value.takeIf { collectingAddress || attachDefaultsToPaymentMethod }
 
-        return ElementsSessionContext.BillingAddress(
+        return ElementsSessionContext.BillingDetails(
             name = name,
+            email = email,
             phone = phone?.let { phoneController.getE164PhoneNumber(it) },
             address = address?.let {
-                ElementsSessionContext.BillingAddress.Address(
+                ElementsSessionContext.BillingDetails.Address(
                     line1 = it.line1,
                     line2 = it.line2,
                     postalCode = it.postalCode,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -526,6 +526,29 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
             amount = args.formArgs.amount?.value,
             currency = args.formArgs.amount?.currencyCode,
             linkMode = args.linkMode,
+            billingAddress = makeElementsSessionContextBillingAddress(),
+        )
+    }
+
+    private fun makeElementsSessionContextBillingAddress(): ElementsSessionContext.BillingAddress {
+        val attachDefaultsToPaymentMethod = collectionConfiguration.attachDefaultsToPaymentMethod
+        val name = name.value.takeIf { collectingName || attachDefaultsToPaymentMethod }
+        val phone = phone.value.takeIf { collectingPhone || attachDefaultsToPaymentMethod }
+        val address = address.value.takeIf { collectingAddress || attachDefaultsToPaymentMethod }
+
+        return ElementsSessionContext.BillingAddress(
+            name = name,
+            phone = phone?.let { phoneController.getE164PhoneNumber(it) },
+            address = address?.let {
+                ElementsSessionContext.BillingAddress.Address(
+                    line1 = it.line1,
+                    line2 = it.line2,
+                    postalCode = it.postalCode,
+                    city = it.city,
+                    state = it.state,
+                    country = it.country,
+                )
+            },
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -7,6 +7,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext
 import com.stripe.android.financialconnections.model.BankAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
@@ -28,6 +29,7 @@ import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConf
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
+import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -36,6 +38,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import org.junit.Rule
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -80,6 +83,12 @@ class USBankAccountFormViewModelTest {
 
     private val mockCollectBankAccountLauncher = mock<CollectBankAccountLauncher>()
     private val savedStateHandle = SavedStateHandle()
+
+    @get:Rule
+    val instantDebitsBillingDetailsFeatureRule = FeatureFlagTestRule(
+        featureFlag = FeatureFlags.instantDebitsBillingDetails,
+        isEnabled = true,
+    )
 
     @BeforeTest
     fun setUp() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -826,8 +826,9 @@ class USBankAccountFormViewModelTest {
                         amount = 5099,
                         currency = "usd",
                         linkMode = LinkMode.LinkPaymentMethod,
-                        billingAddress = ElementsSessionContext.BillingAddress(
+                        billingDetails = ElementsSessionContext.BillingDetails(
                             name = "Jenny Rose",
+                            email = "email@email.com",
                         ),
                     ),
                 )
@@ -878,8 +879,9 @@ class USBankAccountFormViewModelTest {
                         amount = null,
                         currency = null,
                         linkMode = LinkMode.LinkPaymentMethod,
-                        billingAddress = ElementsSessionContext.BillingAddress(
+                        billingDetails = ElementsSessionContext.BillingDetails(
                             name = "Jenny Rose",
+                            email = "email@email.com",
                         ),
                     ),
                 )
@@ -1088,8 +1090,9 @@ class USBankAccountFormViewModelTest {
                         amount = 5099,
                         currency = "usd",
                         linkMode = null,
-                        billingAddress = ElementsSessionContext.BillingAddress(
+                        billingDetails = ElementsSessionContext.BillingDetails(
                             name = "Some Name",
+                            email = "email@email.com",
                         ),
                     ),
                 )
@@ -1125,7 +1128,9 @@ class USBankAccountFormViewModelTest {
                         amount = 5099,
                         currency = "usd",
                         linkMode = LinkMode.LinkCardBrand,
-                        billingAddress = ElementsSessionContext.BillingAddress(),
+                        billingDetails = ElementsSessionContext.BillingDetails(
+                            email = "email@email.com",
+                        ),
                     ),
                 )
             ),
@@ -1345,11 +1350,12 @@ class USBankAccountFormViewModelTest {
 
         val elementsSessionContext = testElementsSessionContextGeneration(viewModelArgs = args)
 
-        assertThat(elementsSessionContext?.billingAddress).isEqualTo(
-            ElementsSessionContext.BillingAddress(
+        assertThat(elementsSessionContext?.billingDetails).isEqualTo(
+            ElementsSessionContext.BillingDetails(
                 name = "Jenny Rose",
+                email = "email@email.com",
                 phone = "+13105551234",
-                address = ElementsSessionContext.BillingAddress.Address(
+                address = ElementsSessionContext.BillingDetails.Address(
                     line1 = "123 Main Street",
                     line2 = "Apt 456",
                     city = "San Francisco",
@@ -1373,11 +1379,9 @@ class USBankAccountFormViewModelTest {
 
         val elementsSessionContext = testElementsSessionContextGeneration(viewModelArgs = args)
 
-        assertThat(elementsSessionContext?.billingAddress).isEqualTo(
-            ElementsSessionContext.BillingAddress(
-                name = null,
-                phone = null,
-                address = null,
+        assertThat(elementsSessionContext?.billingDetails).isEqualTo(
+            ElementsSessionContext.BillingDetails(
+                email = "email@email.com",
             )
         )
     }
@@ -1394,11 +1398,10 @@ class USBankAccountFormViewModelTest {
 
         val elementsSessionContext = testElementsSessionContextGeneration(viewModelArgs = args)
 
-        assertThat(elementsSessionContext?.billingAddress).isEqualTo(
-            ElementsSessionContext.BillingAddress(
-                name = null,
+        assertThat(elementsSessionContext?.billingDetails).isEqualTo(
+            ElementsSessionContext.BillingDetails(
+                email = "email@email.com",
                 phone = "+13105551234",
-                address = null,
             )
         )
     }

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
@@ -7,6 +7,7 @@ import com.stripe.android.core.BuildConfig
 object FeatureFlags {
     // Add any feature flags here
     val nativeLinkEnabled = FeatureFlag()
+    val instantDebitsBillingDetails = FeatureFlag()
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds the billing address to the `ElementsSessionContext`, allowing us to pass it along when creating the `PaymentMethod` in either the web or native view.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[BANKCON-15709](https://jira.corp.stripe.com/browse/BANKCON-15709)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
