### PR TITLE
Pass `link_mode` to LAS creation

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -6929,6 +6929,14 @@ public final class com/stripe/android/payments/bankaccount/CollectBankAccountCon
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/payments/bankaccount/CollectBankAccountConfiguration$USBankAccountInternal$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/payments/bankaccount/CollectBankAccountConfiguration$USBankAccountInternal;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/payments/bankaccount/CollectBankAccountConfiguration$USBankAccountInternal;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public abstract interface class com/stripe/android/payments/bankaccount/CollectBankAccountLauncher {
 	public static final field Companion Lcom/stripe/android/payments/bankaccount/CollectBankAccountLauncher$Companion;
 	public abstract fun presentWithPaymentIntent (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/bankaccount/CollectBankAccountConfiguration;)V

--- a/payments-core/detekt-baseline.xml
+++ b/payments-core/detekt-baseline.xml
@@ -39,6 +39,7 @@
     <ID>LongMethod:CardFormView.kt$CardFormView$private fun setupCardWidget()</ID>
     <ID>LongMethod:CardFormViewTest.kt$CardFormViewTest$@Test fun testCardValidCallback()</ID>
     <ID>LongMethod:CardInputWidget.kt$CardInputWidget$private fun initView(attrs: AttributeSet?)</ID>
+    <ID>LongMethod:CollectBankAccountViewModel.kt$CollectBankAccountViewModel$private suspend fun createFinancialConnectionsSession()</ID>
     <ID>LongMethod:CustomerSessionOperationExecutor.kt$CustomerSessionOperationExecutor$@JvmSynthetic internal suspend fun execute( ephemeralKey: EphemeralKey, operation: EphemeralOperation )</ID>
     <ID>LongMethod:CustomerSessionTest.kt$CustomerSessionTest$@BeforeTest fun setup()</ID>
     <ID>LongMethod:CustomerSessionTest.kt$CustomerSessionTest$private suspend fun setupErrorProxy()</ID>

--- a/payments-core/src/main/java/com/stripe/android/model/CreateFinancialConnectionsSessionForDeferredPaymentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/CreateFinancialConnectionsSessionForDeferredPaymentParams.kt
@@ -12,6 +12,7 @@ data class CreateFinancialConnectionsSessionForDeferredPaymentParams(
     val hostedSurface: String?,
     val customer: String?,
     val onBehalfOf: String?,
+    val linkMode: LinkMode?,
 
     // PaymentIntent only params
     val amount: Int?,
@@ -27,8 +28,9 @@ data class CreateFinancialConnectionsSessionForDeferredPaymentParams(
             PARAM_CUSTOMER to customer,
             PARAM_ON_BEHALF_OF to onBehalfOf,
             PARAM_HOSTED_SURFACE to hostedSurface,
+            PARAM_LINK_MODE to (linkMode?.value ?: "LINK_DISABLED"),
             PARAM_AMOUNT to amount,
-            PARAM_CURRENCY to currency
+            PARAM_CURRENCY to currency,
         )
     }
 
@@ -41,6 +43,7 @@ data class CreateFinancialConnectionsSessionForDeferredPaymentParams(
         const val PARAM_VERIFICATION_METHOD = "verification_method"
         const val PARAM_CUSTOMER = "customer"
         const val PARAM_ON_BEHALF_OF = "on_behalf_of"
+        const val PARAM_LINK_MODE = "link_mode"
         const val PARAM_AMOUNT = "amount"
         const val PARAM_CURRENCY = "currency"
     }

--- a/payments-core/src/main/java/com/stripe/android/model/CreateFinancialConnectionsSessionParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/CreateFinancialConnectionsSessionParams.kt
@@ -68,6 +68,9 @@ sealed interface CreateFinancialConnectionsSessionParams {
 }
 
 private fun LinkMode?.valueForHostedSurface(hostedSurface: String?): String? {
+    // This is to align with the Web behavior, where we only send the link_mode
+    // for flows hosted in a Stripe-owned surface. To make sure a value is sent even if link_mode
+    // is null, we default to LINK_DISABLED.
     return if (hostedSurface != null) {
         this?.value ?: "LINK_DISABLED"
     } else {

--- a/payments-core/src/main/java/com/stripe/android/model/CreateFinancialConnectionsSessionParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/CreateFinancialConnectionsSessionParams.kt
@@ -27,7 +27,7 @@ sealed interface CreateFinancialConnectionsSessionParams {
                 PARAM_HOSTED_SURFACE to hostedSurface,
                 PARAM_PRODUCT to "instant_debits",
                 PARAM_ATTACH_REQUIRED to true,
-                PARAM_LINK_MODE to linkMode.valueOrDisabled,
+                PARAM_LINK_MODE to linkMode.valueForHostedSurface(hostedSurface),
                 PARAM_PAYMENT_METHOD_DATA to paymentMethod.toParamMap()
             ).filterNotNullValues()
         }
@@ -51,7 +51,7 @@ sealed interface CreateFinancialConnectionsSessionParams {
             return mapOf(
                 PARAM_CLIENT_SECRET to clientSecret,
                 PARAM_HOSTED_SURFACE to hostedSurface,
-                PARAM_LINK_MODE to linkMode.valueOrDisabled,
+                PARAM_LINK_MODE to linkMode.valueForHostedSurface(hostedSurface),
                 PARAM_PAYMENT_METHOD_DATA to paymentMethod.toParamMap()
             ).filterNotNullValues()
         }
@@ -67,5 +67,10 @@ sealed interface CreateFinancialConnectionsSessionParams {
     }
 }
 
-private val LinkMode?.valueOrDisabled: String
-    get() = this?.value ?: "LINK_DISABLED"
+private fun LinkMode?.valueForHostedSurface(hostedSurface: String?): String? {
+    return if (hostedSurface != null) {
+        this?.value ?: "LINK_DISABLED"
+    } else {
+        null
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/model/CreateFinancialConnectionsSessionParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/CreateFinancialConnectionsSessionParams.kt
@@ -11,7 +11,8 @@ sealed interface CreateFinancialConnectionsSessionParams {
     data class InstantDebits(
         val clientSecret: String,
         val customerEmailAddress: String?,
-        val hostedSurface: String?
+        val hostedSurface: String?,
+        val linkMode: LinkMode?,
     ) : CreateFinancialConnectionsSessionParams {
 
         override fun toMap(): Map<String, Any> {
@@ -26,6 +27,7 @@ sealed interface CreateFinancialConnectionsSessionParams {
                 PARAM_HOSTED_SURFACE to hostedSurface,
                 PARAM_PRODUCT to "instant_debits",
                 PARAM_ATTACH_REQUIRED to true,
+                PARAM_LINK_MODE to linkMode.valueOrDisabled,
                 PARAM_PAYMENT_METHOD_DATA to paymentMethod.toParamMap()
             ).filterNotNullValues()
         }
@@ -36,7 +38,8 @@ sealed interface CreateFinancialConnectionsSessionParams {
         val clientSecret: String,
         val customerName: String,
         val customerEmailAddress: String?,
-        val hostedSurface: String?
+        val hostedSurface: String?,
+        val linkMode: LinkMode?,
     ) : CreateFinancialConnectionsSessionParams {
         override fun toMap(): Map<String, Any> {
             val paymentMethod = PaymentMethodCreateParams.createUSBankAccount(
@@ -48,6 +51,7 @@ sealed interface CreateFinancialConnectionsSessionParams {
             return mapOf(
                 PARAM_CLIENT_SECRET to clientSecret,
                 PARAM_HOSTED_SURFACE to hostedSurface,
+                PARAM_LINK_MODE to linkMode.valueOrDisabled,
                 PARAM_PAYMENT_METHOD_DATA to paymentMethod.toParamMap()
             ).filterNotNullValues()
         }
@@ -59,5 +63,9 @@ sealed interface CreateFinancialConnectionsSessionParams {
         const val PARAM_ATTACH_REQUIRED = "attach_required"
         const val PARAM_PRODUCT = "product"
         const val PARAM_PAYMENT_METHOD_DATA = "payment_method_data"
+        const val PARAM_LINK_MODE = "link_mode"
     }
 }
+
+private val LinkMode?.valueOrDisabled: String
+    get() = this?.value ?: "LINK_DISABLED"

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
@@ -136,8 +136,16 @@ sealed interface CollectBankAccountConfiguration : Parcelable {
         val email: String?
     ) : Parcelable, CollectBankAccountConfiguration
 
-    @Parcelize
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @Parcelize
+    data class USBankAccountInternal(
+        val name: String,
+        val email: String?,
+        val elementsSessionContext: ElementsSessionContext?,
+    ) : Parcelable, CollectBankAccountConfiguration
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @Parcelize
     data class InstantDebits(
         val email: String?,
         val elementsSessionContext: ElementsSessionContext?,

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/CreateFinancialConnectionsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/CreateFinancialConnectionsSession.kt
@@ -4,6 +4,7 @@ import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.CreateFinancialConnectionsSessionForDeferredPaymentParams
 import com.stripe.android.model.CreateFinancialConnectionsSessionParams
 import com.stripe.android.model.FinancialConnectionsSession
+import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.VerificationMethodParam
@@ -89,6 +90,7 @@ internal class CreateFinancialConnectionsSession @Inject constructor(
         customerId: String?,
         onBehalfOf: String?,
         hostedSurface: String?,
+        linkMode: LinkMode?,
         amount: Int?,
         currency: String?
     ): Result<FinancialConnectionsSession> {
@@ -102,6 +104,7 @@ internal class CreateFinancialConnectionsSession @Inject constructor(
                 verificationMethod = VerificationMethodParam.Automatic,
                 customer = customerId,
                 onBehalfOf = onBehalfOf,
+                linkMode = linkMode,
                 amount = amount,
                 currency = currency,
             ),
@@ -122,7 +125,18 @@ internal class CreateFinancialConnectionsSession @Inject constructor(
                     clientSecret = clientSecret,
                     customerName = name,
                     customerEmailAddress = email,
-                    hostedSurface = hostedSurface
+                    hostedSurface = hostedSurface,
+                    linkMode = null,
+                )
+            }
+
+            is CollectBankAccountConfiguration.USBankAccountInternal -> {
+                CreateFinancialConnectionsSessionParams.USBankAccount(
+                    clientSecret = clientSecret,
+                    customerName = name,
+                    customerEmailAddress = email,
+                    hostedSurface = hostedSurface,
+                    linkMode = elementsSessionContext?.linkMode,
                 )
             }
 
@@ -130,7 +144,8 @@ internal class CreateFinancialConnectionsSession @Inject constructor(
                 CreateFinancialConnectionsSessionParams.InstantDebits(
                     clientSecret = clientSecret,
                     customerEmailAddress = email,
-                    hostedSurface = hostedSurface
+                    hostedSurface = hostedSurface,
+                    linkMode = elementsSessionContext?.linkMode,
                 )
             }
         }

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountActivity.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.lifecycleScope
 import com.stripe.android.payments.bankaccount.CollectBankAccountConfiguration
 import com.stripe.android.payments.bankaccount.CollectBankAccountConfiguration.InstantDebits
 import com.stripe.android.payments.bankaccount.CollectBankAccountConfiguration.USBankAccount
+import com.stripe.android.payments.bankaccount.CollectBankAccountConfiguration.USBankAccountInternal
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResultInternal.Failed
 import com.stripe.android.payments.bankaccount.ui.CollectBankAccountViewEffect.FinishWithResult
@@ -58,6 +59,11 @@ internal class CollectBankAccountActivity : AppCompatActivity() {
             )
 
             is USBankAccount -> FinancialConnectionsPaymentsProxy.createForACH(
+                activity = this,
+                onComplete = viewModel::onConnectionsForACHResult
+            )
+
+            is USBankAccountInternal -> FinancialConnectionsPaymentsProxy.createForACH(
                 activity = this,
                 onComplete = viewModel::onConnectionsForACHResult
             )

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -37,6 +37,7 @@ import com.stripe.android.model.CreateFinancialConnectionsSessionParams
 import com.stripe.android.model.DeferredIntentParams
 import com.stripe.android.model.ElementsSessionFixtures
 import com.stripe.android.model.ElementsSessionParams
+import com.stripe.android.model.LinkMode
 import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
@@ -1764,6 +1765,7 @@ internal class StripeApiRepositoryTest {
                     verificationMethod = VerificationMethodParam.Automatic,
                     customer = "customer_id",
                     onBehalfOf = null,
+                    linkMode = LinkMode.LinkPaymentMethod,
                     amount = 1000,
                     hostedSurface = "payment_element",
                     currency = "usd"
@@ -1782,11 +1784,44 @@ internal class StripeApiRepositoryTest {
                 assertThat(this["verification_method"]).isEqualTo("automatic")
                 assertThat(this["customer"]).isEqualTo("customer_id")
                 assertThat(this["on_behalf_of"]).isEqualTo(null)
+                assertThat(this["link_mode"]).isEqualTo("LINK_PAYMENT_METHOD")
                 assertThat(this["amount"]).isEqualTo(1000)
                 assertThat(this["hosted_surface"]).isEqualTo("payment_element")
                 assertThat(this["currency"]).isEqualTo("usd")
             }
         }
+
+    @Test
+    fun `createDeferredFinancialConnectionsSession() sends correct link_mode if disabled`() = runTest {
+        val stripeResponse = StripeResponse(
+            code = 200,
+            body = FinancialConnectionsFixtures.SESSION.toString(),
+            headers = emptyMap()
+        )
+        whenever(stripeNetworkClient.executeRequest(any<ApiRequest>())).thenReturn(stripeResponse)
+
+        create().createFinancialConnectionsSessionForDeferredPayments(
+            params = CreateFinancialConnectionsSessionForDeferredPaymentParams(
+                uniqueId = "uuid",
+                initialInstitution = "initial_institution",
+                manualEntryOnly = false,
+                searchSession = "search_session_id",
+                verificationMethod = VerificationMethodParam.Automatic,
+                customer = "customer_id",
+                onBehalfOf = null,
+                linkMode = null,
+                amount = 1000,
+                hostedSurface = "payment_element",
+                currency = "usd"
+            ),
+            requestOptions = DEFAULT_OPTIONS,
+        )
+
+        verify(stripeNetworkClient).executeRequest(apiRequestArgumentCaptor.capture())
+        val params = requireNotNull(apiRequestArgumentCaptor.firstValue.params)
+
+        assertThat(params["link_mode"]).isEqualTo("LINK_DISABLED")
+    }
 
     @Test
     fun `sharePaymentDetails() sends all parameters`() =
@@ -1951,7 +1986,8 @@ internal class StripeApiRepositoryTest {
                 clientSecret = clientSecret,
                 customerName = customerName,
                 hostedSurface = "payment_element",
-                customerEmailAddress = customerEmailAddress
+                customerEmailAddress = customerEmailAddress,
+                linkMode = LinkMode.Passthrough,
             ),
             DEFAULT_OPTIONS
         )
@@ -1966,6 +2002,7 @@ internal class StripeApiRepositoryTest {
         with(params) {
             assertThat(this["client_secret"]).isEqualTo(clientSecret)
             assertThat(this["hosted_surface"]).isEqualTo("payment_element")
+            assertThat(this["link_mode"]).isEqualTo("PASSTHROUGH")
             withNestedParams("payment_method_data") {
                 assertThat(this["type"]).isEqualTo("us_bank_account")
                 withNestedParams("billing_details") {
@@ -1993,7 +2030,8 @@ internal class StripeApiRepositoryTest {
             params = CreateFinancialConnectionsSessionParams.InstantDebits(
                 clientSecret = clientSecret,
                 customerEmailAddress = customerEmailAddress,
-                hostedSurface = "payment_element"
+                hostedSurface = "payment_element",
+                linkMode = LinkMode.LinkCardBrand,
             ),
             DEFAULT_OPTIONS
         )
@@ -2010,6 +2048,7 @@ internal class StripeApiRepositoryTest {
             assertThat(this["product"]).isEqualTo("instant_debits")
             assertThat(this["hosted_surface"]).isEqualTo("payment_element")
             assertThat(this["attach_required"]).isEqualTo(true)
+            assertThat(this["link_mode"]).isEqualTo("LINK_CARD_BRAND")
             withNestedParams("payment_method_data") {
                 assertThat(this["type"]).isEqualTo("link")
                 withNestedParams("billing_details") {
@@ -2039,7 +2078,8 @@ internal class StripeApiRepositoryTest {
                 clientSecret = clientSecret,
                 customerName = customerName,
                 hostedSurface = "payment_element",
-                customerEmailAddress = customerEmailAddress
+                customerEmailAddress = customerEmailAddress,
+                linkMode = null,
             ),
             DEFAULT_OPTIONS
         )
@@ -2055,6 +2095,7 @@ internal class StripeApiRepositoryTest {
         with(params) {
             assertThat(this["client_secret"]).isEqualTo(clientSecret)
             assertThat(this["hosted_surface"]).isEqualTo("payment_element")
+            assertThat(this["link_mode"]).isEqualTo("LINK_DISABLED")
             withNestedParams("payment_method_data") {
                 assertThat(this["type"]).isEqualTo("us_bank_account")
                 withNestedParams("billing_details") {
@@ -2082,7 +2123,8 @@ internal class StripeApiRepositoryTest {
             params = CreateFinancialConnectionsSessionParams.InstantDebits(
                 clientSecret = clientSecret,
                 customerEmailAddress = customerEmailAddress,
-                hostedSurface = "payment_element"
+                hostedSurface = "payment_element",
+                linkMode = null,
             ),
             DEFAULT_OPTIONS
         )
@@ -2100,6 +2142,7 @@ internal class StripeApiRepositoryTest {
             assertThat(this["product"]).isEqualTo("instant_debits")
             assertThat(this["hosted_surface"]).isEqualTo("payment_element")
             assertThat(this["attach_required"]).isEqualTo(true)
+            assertThat(this["link_mode"]).isEqualTo("LINK_DISABLED")
             withNestedParams("payment_method_data") {
                 assertThat(this["type"]).isEqualTo("link")
                 withNestedParams("billing_details") {

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/CreateFinancialConnectionsSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/CreateFinancialConnectionsSessionTest.kt
@@ -58,7 +58,8 @@ class CreateFinancialConnectionsSessionTest {
                     clientSecret = clientSecret,
                     customerName = customerName,
                     hostedSurface = "payment_element",
-                    customerEmailAddress = null
+                    customerEmailAddress = null,
+                    linkMode = null,
                 ),
                 requestOptions = ApiRequest.Options(publishableKey)
             )
@@ -96,7 +97,8 @@ class CreateFinancialConnectionsSessionTest {
                     clientSecret = clientSecret,
                     customerName = customerName,
                     hostedSurface = "payment_element",
-                    customerEmailAddress = null
+                    customerEmailAddress = null,
+                    linkMode = null,
                 ),
                 requestOptions = ApiRequest.Options(publishableKey)
             )
@@ -159,7 +161,8 @@ class CreateFinancialConnectionsSessionTest {
                     clientSecret = clientSecret,
                     customerName = customerName,
                     customerEmailAddress = null,
-                    hostedSurface = "payment_element"
+                    hostedSurface = "payment_element",
+                    linkMode = null,
                 ),
                 requestOptions = ApiRequest.Options(
                     apiKey = publishableKey,
@@ -199,7 +202,8 @@ class CreateFinancialConnectionsSessionTest {
                     clientSecret = clientSecret,
                     customerName = customerName,
                     customerEmailAddress = null,
-                    hostedSurface = "payment_element"
+                    hostedSurface = "payment_element",
+                    linkMode = null,
                 ),
                 requestOptions = ApiRequest.Options(publishableKey)
             )
@@ -255,6 +259,7 @@ class CreateFinancialConnectionsSessionTest {
                     customerId = customerId,
                     hostedSurface = "payment_element",
                     onBehalfOf = onBehalfOf,
+                    linkMode = null,
                     amount = amount,
                     currency = currency
                 )
@@ -271,6 +276,7 @@ class CreateFinancialConnectionsSessionTest {
                         customer = customerId,
                         hostedSurface = "payment_element",
                         onBehalfOf = onBehalfOf,
+                        linkMode = null,
                         amount = amount,
                         currency = currency
                     )
@@ -308,6 +314,7 @@ class CreateFinancialConnectionsSessionTest {
                     elementsSessionId = elementsSessionId,
                     customerId = customerId,
                     onBehalfOf = onBehalfOf,
+                    linkMode = null,
                     amount = amount,
                     currency = currency,
                     hostedSurface = "payment_element"
@@ -324,6 +331,7 @@ class CreateFinancialConnectionsSessionTest {
                         verificationMethod = VerificationMethodParam.Automatic,
                         customer = customerId,
                         onBehalfOf = onBehalfOf,
+                        linkMode = null,
                         amount = amount,
                         currency = currency,
                         hostedSurface = "payment_element"

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
@@ -445,6 +445,7 @@ class CollectBankAccountViewModelTest {
                     elementsSessionId = "elements_session_id",
                     customerId = "customer_id",
                     onBehalfOf = "on_behalf_of_id",
+                    linkMode = null,
                     amount = 1000,
                     currency = "usd",
                     hostedSurface = "payment_element"
@@ -464,6 +465,7 @@ class CollectBankAccountViewModelTest {
                     elementsSessionId = "elements_session_id",
                     customerId = "customer_id",
                     onBehalfOf = "on_behalf_of_id",
+                    linkMode = null,
                     amount = null,
                     currency = null,
                     hostedSurface = "payment_element"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -493,6 +493,21 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
     }
 
     private fun createInstantDebitsConfiguration(): CollectBankAccountConfiguration.InstantDebits {
+        return CollectBankAccountConfiguration.InstantDebits(
+            email = email.value,
+            elementsSessionContext = makeElementsSessionContext(),
+        )
+    }
+
+    private fun createUSBankAccountConfiguration(): CollectBankAccountConfiguration.USBankAccountInternal {
+        return CollectBankAccountConfiguration.USBankAccountInternal(
+            name = name.value,
+            email = email.value,
+            elementsSessionContext = makeElementsSessionContext(),
+        )
+    }
+
+    private fun makeElementsSessionContext(): ElementsSessionContext {
         val initializationMode = if (args.clientSecret == null) {
             ElementsSessionContext.InitializationMode.DeferredIntent
         } else if (args.isPaymentFlow) {
@@ -501,21 +516,11 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
             ElementsSessionContext.InitializationMode.SetupIntent(args.stripeIntentId!!)
         }
 
-        return CollectBankAccountConfiguration.InstantDebits(
-            email = email.value,
-            elementsSessionContext = ElementsSessionContext(
-                initializationMode = initializationMode,
-                amount = args.formArgs.amount?.value,
-                currency = args.formArgs.amount?.currencyCode,
-                linkMode = args.linkMode,
-            ),
-        )
-    }
-
-    private fun createUSBankAccountConfiguration(): CollectBankAccountConfiguration.USBankAccount {
-        return CollectBankAccountConfiguration.USBankAccount(
-            name = name.value,
-            email = email.value,
+        return ElementsSessionContext(
+            initializationMode = initializationMode,
+            amount = args.formArgs.amount?.value,
+            currency = args.formArgs.amount?.currencyCode,
+            linkMode = args.linkMode,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -526,14 +526,16 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
 
     private fun collectBankAccountForDeferredIntent() {
         val elementsSessionId = args.stripeIntentId ?: return
+        val elementsSessionContext = makeElementsSessionContext()
 
         if (args.isPaymentFlow) {
             collectBankAccountLauncher?.presentWithDeferredPayment(
                 publishableKey = lazyPaymentConfig.get().publishableKey,
                 stripeAccountId = lazyPaymentConfig.get().stripeAccountId,
-                configuration = CollectBankAccountConfiguration.USBankAccount(
-                    name.value,
-                    email.value
+                configuration = CollectBankAccountConfiguration.USBankAccountInternal(
+                    name = name.value,
+                    email = email.value,
+                    elementsSessionContext = elementsSessionContext,
                 ),
                 elementsSessionId = elementsSessionId,
                 customerId = null,
@@ -545,9 +547,10 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
             collectBankAccountLauncher?.presentWithDeferredSetup(
                 publishableKey = lazyPaymentConfig.get().publishableKey,
                 stripeAccountId = lazyPaymentConfig.get().stripeAccountId,
-                configuration = CollectBankAccountConfiguration.USBankAccount(
-                    name.value,
-                    email.value
+                configuration = CollectBankAccountConfiguration.USBankAccountInternal(
+                    name = name.value,
+                    email = email.value,
+                    elementsSessionContext = elementsSessionContext,
                 ),
                 elementsSessionId = elementsSessionId,
                 customerId = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -1050,9 +1050,15 @@ class USBankAccountFormViewModelTest {
             stripeAccountId = anyOrNull(),
             clientSecret = any(),
             configuration = eq(
-                CollectBankAccountConfiguration.USBankAccount(
+                CollectBankAccountConfiguration.USBankAccountInternal(
                     name = "Some Name",
                     email = "email@email.com",
+                    elementsSessionContext = ElementsSessionContext(
+                        initializationMode = ElementsSessionContext.InitializationMode.PaymentIntent("id_12345"),
+                        amount = 5099,
+                        currency = "usd",
+                        linkMode = null,
+                    ),
                 )
             ),
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -795,7 +795,8 @@ class USBankAccountFormViewModelTest {
     fun `Launches collect bank account for deferred payment screen when deferred payment`() = runTest {
         val viewModel = createViewModel(
             defaultArgs.copy(
-                clientSecret = null
+                clientSecret = null,
+                linkMode = LinkMode.LinkPaymentMethod,
             )
         )
 
@@ -806,9 +807,7 @@ class USBankAccountFormViewModelTest {
 
         assertThat(
             currentScreenState
-        ).isInstanceOf<
-            USBankAccountFormScreenState.BillingDetailsCollection
-            >()
+        ).isInstanceOf<USBankAccountFormScreenState.BillingDetailsCollection>()
 
         viewModel.handlePrimaryButtonClick(
             currentScreenState as USBankAccountFormScreenState.BillingDetailsCollection
@@ -817,7 +816,18 @@ class USBankAccountFormViewModelTest {
         verify(mockCollectBankAccountLauncher).presentWithDeferredPayment(
             publishableKey = any(),
             stripeAccountId = any(),
-            configuration = any(),
+            configuration = eq(
+                CollectBankAccountConfiguration.USBankAccountInternal(
+                    name = "Jenny Rose",
+                    email = "email@email.com",
+                    elementsSessionContext = ElementsSessionContext(
+                        initializationMode = ElementsSessionContext.InitializationMode.DeferredIntent,
+                        amount = 5099,
+                        currency = "usd",
+                        linkMode = LinkMode.LinkPaymentMethod,
+                    ),
+                )
+            ),
             elementsSessionId = any(),
             customerId = anyOrNull(),
             onBehalfOf = any(),
@@ -831,7 +841,11 @@ class USBankAccountFormViewModelTest {
         val viewModel = createViewModel(
             defaultArgs.copy(
                 clientSecret = null,
-                isPaymentFlow = false
+                isPaymentFlow = false,
+                linkMode = LinkMode.LinkPaymentMethod,
+                formArgs = defaultArgs.formArgs.copy(
+                    amount = null,
+                )
             )
         )
 
@@ -842,9 +856,7 @@ class USBankAccountFormViewModelTest {
 
         assertThat(
             currentScreenState
-        ).isInstanceOf<
-            USBankAccountFormScreenState.BillingDetailsCollection
-            >()
+        ).isInstanceOf<USBankAccountFormScreenState.BillingDetailsCollection>()
 
         viewModel.handlePrimaryButtonClick(
             currentScreenState as USBankAccountFormScreenState.BillingDetailsCollection
@@ -853,7 +865,18 @@ class USBankAccountFormViewModelTest {
         verify(mockCollectBankAccountLauncher).presentWithDeferredSetup(
             publishableKey = any(),
             stripeAccountId = any(),
-            configuration = any(),
+            configuration = eq(
+                CollectBankAccountConfiguration.USBankAccountInternal(
+                    name = "Jenny Rose",
+                    email = "email@email.com",
+                    elementsSessionContext = ElementsSessionContext(
+                        initializationMode = ElementsSessionContext.InitializationMode.DeferredIntent,
+                        amount = null,
+                        currency = null,
+                        linkMode = LinkMode.LinkPaymentMethod,
+                    ),
+                )
+            ),
             elementsSessionId = any(),
             customerId = anyOrNull(),
             onBehalfOf = any(),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds a `link_mode` field to the LAS creation request. If Link is not enabled, we send `LINK_DISABLED` just like Web does.

(cc @selinafeng-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[BANKCON-15654](https://jira.corp.stripe.com/browse/BANKCON-15654)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
