### PR TITLE
Remove AddPaymentMethodActivity from ActivityScenarioFactory

### DIFF
--- a/payments-core/src/test/java/com/stripe/android/auth/PaymentBrowserAuthContractTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/auth/PaymentBrowserAuthContractTest.kt
@@ -4,14 +4,16 @@ import android.app.Activity
 import android.content.Context
 import android.graphics.Color
 import android.os.Parcel
+import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.payments.DefaultReturnUrl
 import com.stripe.android.payments.StripeBrowserLauncherActivity
-import com.stripe.android.view.ActivityScenarioFactory
+import com.stripe.android.utils.createTestActivityRule
 import com.stripe.android.view.PaymentAuthWebViewActivity
+import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.BeforeTest
@@ -25,14 +27,16 @@ class PaymentBrowserAuthContractTest {
     )
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
-    private val activityScenarioFactory = ActivityScenarioFactory(context)
     private lateinit var activity: Activity
+
+    @get:Rule
+    internal val testActivityRule = createTestActivityRule<TestActivity>()
 
     @BeforeTest
     fun setup() {
         PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
 
-        activityScenarioFactory.createAddPaymentMethodActivity().use { activityScenario ->
+        ActivityScenario.launch(TestActivity::class.java).use { activityScenario ->
             activityScenario.onActivity {
                 activity = it
             }
@@ -113,4 +117,6 @@ class PaymentBrowserAuthContractTest {
             isInstantApp = false
         )
     }
+
+    internal class TestActivity : Activity()
 }

--- a/payments-core/src/test/java/com/stripe/android/view/ActivityScenarioFactory.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/ActivityScenarioFactory.kt
@@ -3,12 +3,11 @@ package com.stripe.android.view
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.os.Bundle
 import android.view.View
-import android.view.ViewGroup
+import android.widget.LinearLayout
+import androidx.appcompat.app.AppCompatActivity
 import androidx.test.core.app.ActivityScenario
-import com.stripe.android.PaymentConfiguration
-import com.stripe.android.R
-import com.stripe.android.model.PaymentMethod
 
 internal class ActivityScenarioFactory(
     private val context: Context
@@ -35,62 +34,36 @@ internal class ActivityScenarioFactory(
         )
     }
 
-    fun createAddPaymentMethodActivity() = create<AddPaymentMethodActivity>(
-        AddPaymentMethodActivityStarter.Args.Builder()
-            .setPaymentMethodType(PaymentMethod.Type.Card)
-            .setPaymentConfiguration(PaymentConfiguration.getInstance(context))
-            .setBillingAddressFields(BillingAddressFields.PostalCode)
-            .build()
-    )
-
     /**
-     * Return a view created with an `Activity` context.
+     * Return a view created with an `Activity` context. If you use this, you MUST use
+     * [com.stripe.android.utils.TestActivityRule] in your test.
      */
     fun <ViewType : View> createView(
-        beforeAttach: (ViewType) -> Unit = {},
-        viewFactory: (Activity) -> ViewType,
+        viewFactory: (Activity) -> ViewType
     ): ViewType {
         var view: ViewType? = null
 
-        createAddPaymentMethodActivity()
-            .use { activityScenario ->
-                activityScenario.onActivity { activity ->
-                    activity.setTheme(R.style.StripePaymentSheetDefaultTheme)
+        ActivityScenario.launch<TestActivity>(
+            Intent(context, TestActivity::class.java)
+        ).use { activityScenario ->
+            activityScenario.onActivity { activity ->
+                view = viewFactory(activity)
 
-                    activity.findViewById<ViewGroup>(R.id.add_payment_method_card).let { root ->
-                        root.removeAllViews()
-
-                        view = viewFactory(activity).also {
-                            beforeAttach(it)
-                            root.addView(it)
-                        }
-                    }
-                }
+                activity.layout.addView(view)
             }
+        }
 
         return requireNotNull(view)
     }
 
-    fun <ViewType : View> createViewAndScenario(
-        beforeAttach: (ViewType) -> Unit = {},
-        viewFactory: (Activity) -> ViewType,
-    ): Pair<ViewType, ActivityScenario<AddPaymentMethodActivity>> {
-        var view: ViewType? = null
-        val activityScenario = createAddPaymentMethodActivity()
+    internal class TestActivity : AppCompatActivity() {
+        lateinit var layout: LinearLayout
 
-        activityScenario.onActivity { activity ->
-            activity.setTheme(R.style.StripePaymentSheetDefaultTheme)
+        override fun onCreate(savedInstanceState: Bundle?) {
+            super.onCreate(savedInstanceState)
 
-            activity.findViewById<ViewGroup>(R.id.add_payment_method_card).let { root ->
-                root.removeAllViews()
-
-                view = viewFactory(activity).also {
-                    beforeAttach(it)
-                    root.addView(it)
-                }
-            }
+            layout = LinearLayout(this)
+            setContentView(layout)
         }
-
-        return requireNotNull(view) to activityScenario
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/view/BecsDebitWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/BecsDebitWidgetTest.kt
@@ -7,6 +7,8 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.utils.createTestActivityRule
+import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.BeforeTest
@@ -18,6 +20,9 @@ import kotlin.test.assertFailsWith
 internal class BecsDebitWidgetTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val activityScenarioFactory = ActivityScenarioFactory(context)
+
+    @get:Rule
+    val testActivityRule = createTestActivityRule<ActivityScenarioFactory.TestActivity>()
 
     private val becsDebitWidget: BecsDebitWidget by lazy {
         activityScenarioFactory.createView {

--- a/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -71,7 +71,6 @@ internal class CardMultilineWidgetTest {
     private val noZipCardListener: CardInputListener = mock()
 
     private val context: Context = ApplicationProvider.getApplicationContext()
-    private val activityScenarioFactory = ActivityScenarioFactory(context)
 
     private val accountRangeStore = DefaultCardAccountRangeStore(context)
 
@@ -856,15 +855,7 @@ internal class CardMultilineWidgetTest {
 
     @Test
     fun onFinishInflate_shouldSetPostalCodeInputLayoutHint() = runCardMultilineWidgetTest {
-        var inflatedCardMultilineWidget: CardMultilineWidget? = null
-        activityScenarioFactory
-            .createAddPaymentMethodActivity()
-            .use { activityScenario ->
-                activityScenario.onActivity { activity ->
-                    inflatedCardMultilineWidget = activity.findViewById(R.id.card_multiline_widget)
-                }
-            }
-        assertThat(requireNotNull(inflatedCardMultilineWidget).postalInputLayout.hint)
+        assertThat(cardMultilineWidget.postalInputLayout.hint)
             .isEqualTo("Postal code")
     }
 

--- a/payments-core/src/test/java/com/stripe/android/view/CountryTextInputLayoutTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CountryTextInputLayoutTest.kt
@@ -14,6 +14,8 @@ import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.core.model.getCountryCode
 import com.stripe.android.utils.TestUtils.idleLooper
+import com.stripe.android.utils.createTestActivityRule
+import org.junit.Rule
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
@@ -41,6 +43,9 @@ class CountryTextInputLayoutTest {
     private val activityScenarioFactory = ActivityScenarioFactory(
         ApplicationProvider.getApplicationContext()
     )
+
+    @get:Rule
+    internal val testActivityRule = createTestActivityRule<ActivityScenarioFactory.TestActivity>()
 
     @BeforeTest
     fun setup() {

--- a/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewTest.kt
@@ -6,6 +6,8 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.version.StripeSdkVersion
+import com.stripe.android.utils.createTestActivityRule
+import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.BeforeTest
@@ -16,6 +18,9 @@ class PaymentAuthWebViewTest {
     private val context = ApplicationProvider.getApplicationContext<Context>()
 
     private val activityScenarioFactory = ActivityScenarioFactory(context)
+
+    @get:Rule
+    internal val testActivityRule = createTestActivityRule<ActivityScenarioFactory.TestActivity>()
 
     private val webView: PaymentAuthWebView by lazy {
         activityScenarioFactory.createView {

--- a/payments-core/src/test/java/com/stripe/android/view/ViewWidthAnimatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/ViewWidthAnimatorTest.kt
@@ -9,6 +9,8 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.utils.TestUtils.idleLooper
+import com.stripe.android.utils.createTestActivityRule
+import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.LooperMode
@@ -20,6 +22,9 @@ import kotlin.test.Test
 class ViewWidthAnimatorTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val activityScenarioFactory = ActivityScenarioFactory(context)
+
+    @get:Rule
+    internal val testActivityRule = createTestActivityRule<ActivityScenarioFactory.TestActivity>()
 
     private val view: View by lazy {
         activityScenarioFactory.createView { activity ->


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove AddPaymentMethodActivity from ActivityScenarioFactory

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
AddPaymentMethodActivity is being deleted as part of BI deprecation. This work is necessary to ensure our tests keep working after we delete AddPaymentMethodActivity

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified