### PR TITLE
Remove PaymentFlowActivity from RadarSessionTest

### DIFF
--- a/payments-core/AndroidManifest.xml
+++ b/payments-core/AndroidManifest.xml
@@ -22,6 +22,7 @@
             android:name=".view.PaymentRelayActivity"
             android:theme="@style/StripeTransparentTheme"
             android:exported="false" />
+        <activity android:name=".view.TestActivity"/>
 
         <!--
         Set android:launchMode="singleTop" so that the StripeBrowserLauncherActivity instance that

--- a/payments-core/src/androidTest/java/com/stripe/android/RadarSessionTest.kt
+++ b/payments-core/src/androidTest/java/com/stripe/android/RadarSessionTest.kt
@@ -8,7 +8,7 @@ import com.stripe.android.networking.StripeRepository
 import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.AbsPaymentController
 import com.stripe.android.view.ActivityScenarioFactory
-import com.stripe.android.view.PaymentFlowActivity
+import com.stripe.android.view.TestActivity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -67,9 +67,7 @@ class RadarSessionTest {
 
     @Test
     fun ensureRadarSessionsAttachHCaptchaToken(): Unit = runTest {
-        activityScenarioFactory.create<PaymentFlowActivity>(
-            PaymentSessionFixtures.PAYMENT_FLOW_ARGS
-        ).use { scenario ->
+        activityScenarioFactory.create<TestActivity>().use { scenario ->
             scenario.onActivity { activity ->
                 launch(Dispatchers.Main) {
                     stripe.createRadarSession(activity)

--- a/payments-core/src/main/java/com/stripe/android/view/TestActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/TestActivity.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.view
+
+import androidx.annotation.RestrictTo
+import androidx.annotation.VisibleForTesting
+import androidx.fragment.app.FragmentActivity
+
+@VisibleForTesting
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+internal class TestActivity : FragmentActivity()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove PaymentFlowActivity from RadarSessionTest

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
PaymentFlowActivity will be removed as part of BI deprecation. Removing it now so that this test will keep working.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified