### PR TITLE
Add group to firebase app distribution.

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -47,3 +47,4 @@ jobs:
           appId: "1:577365562050:android:5b7e92d18f8ca8d1e9a15b"
           serviceCredentialsFileContent: ${{ secrets.PAYMENTS_GOOGLE_CLOUD_KEY }}
           file: paymentsheet-example/build/outputs/apk/release/paymentsheet-example-release.apk
+          groups: elements-mobile


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
https://github.com/stripe/stripe-android/actions/runs/11390237594

The groups weren't being added to automated builds.

