### PR TITLE
Block disallowed brands in PAN field

### DIFF
--- a/payments-core/res/values/strings.xml
+++ b/payments-core/res/values/strings.xml
@@ -121,6 +121,8 @@
   <!-- Accessibility action for deleting a payment method -->
   <string name="stripe_delete_payment_method">Delete Payment Method</string>
   <string name="stripe_delete_payment_method_prompt_title">Delete payment method?</string>
+  <!-- Error message for card entry form when a user enters a card with a brand that is not accepted. -->
+  <string name="stripe_disallowed_card_brand">%s is not accepted</string>
   <!-- Done button title -->
   <string name="stripe_done">Done</string>
   <!-- Button title to enter editing mode -->
@@ -147,8 +149,6 @@
   <string name="stripe_invalid_card_number">Your card\'s number is invalid.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="stripe_invalid_cvc">Your card\'s security code is invalid.</string>
-  <!-- Error message for card entry form when a user enters a card with a brand that is not accepted. -->
-  <string name="stripe_disallowed_card_brand">%s is not accepted</string>
   <!-- Error when customer's name is invalid -->
   <string name="stripe_invalid_owner_name">Your name is invalid.</string>
   <!-- Shipping form error message -->

--- a/payments-core/res/values/strings.xml
+++ b/payments-core/res/values/strings.xml
@@ -147,6 +147,8 @@
   <string name="stripe_invalid_card_number">Your card\'s number is invalid.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="stripe_invalid_cvc">Your card\'s security code is invalid.</string>
+  <!-- Error message for card entry form when a user enters a card with a brand that is not accepted. -->
+  <string name="stripe_disallowed_card_brand">%s is not accepted</string>
   <!-- Error when customer's name is invalid -->
   <string name="stripe_invalid_owner_name">Your name is invalid.</string>
   <!-- Shipping form error message -->

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -56,9 +56,8 @@ internal class CardDetailsController(
         IdentifierSpec.CardNumber,
         DefaultCardNumberController(
             cardTextFieldConfig = CardNumberConfig(
-                isCBCEligible = cbcEligibility != CardBrandChoiceEligibility.Ineligible,
+                isCardBrandChoiceEligible = cbcEligibility != CardBrandChoiceEligibility.Ineligible,
                 cardBrandFilter = cardBrandFilter
-
             ),
             cardAccountRangeRepository = cardAccountRangeRepositoryFactory.create(),
             uiContext = uiContext,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -55,7 +55,7 @@ internal class CardDetailsController(
     val numberElement = CardNumberElement(
         IdentifierSpec.CardNumber,
         DefaultCardNumberController(
-            cardTextFieldConfig = CardNumberConfig(),
+            cardTextFieldConfig = CardNumberConfig(isCBCEligible = cbcEligibility != CardBrandChoiceEligibility.Ineligible, cardBrandFilter = cardBrandFilter),
             cardAccountRangeRepository = cardAccountRangeRepositoryFactory.create(),
             uiContext = uiContext,
             workContext = workContext,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -55,7 +55,11 @@ internal class CardDetailsController(
     val numberElement = CardNumberElement(
         IdentifierSpec.CardNumber,
         DefaultCardNumberController(
-            cardTextFieldConfig = CardNumberConfig(isCBCEligible = cbcEligibility != CardBrandChoiceEligibility.Ineligible, cardBrandFilter = cardBrandFilter),
+            cardTextFieldConfig = CardNumberConfig(
+                isCBCEligible = cbcEligibility != CardBrandChoiceEligibility.Ineligible,
+                cardBrandFilter = cardBrandFilter
+
+            ),
             cardAccountRangeRepository = cardAccountRangeRepositoryFactory.create(),
             uiContext = uiContext,
             workContext = workContext,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberConfig.kt
@@ -20,8 +20,8 @@ internal class CardNumberConfig(
     override val keyboard: KeyboardType = KeyboardType.NumberPassword
     override val visualTransformation: VisualTransformation = CardNumberVisualTransformation(' ')
 
-    // Hardcoded number of card digits entered before we hit the card metadata service in CBC
-    private var digitsRequiredToFetchBrands = 8
+    // Hardcoded number of card digits + a buffer entered before we hit the card metadata service in CBC
+    private var digitsRequiredToFetchBrands = 9
 
     override fun determineState(brand: CardBrand, number: String, numberAllowedDigits: Int): TextFieldState {
         val luhnValid = CardUtils.isValidLuhnNumber(number)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberConfig.kt
@@ -11,7 +11,7 @@ import com.stripe.android.uicore.elements.TextFieldStateConstants
 import com.stripe.android.R as StripeR
 
 internal class CardNumberConfig(
-    private val isCBCEligible: Boolean,
+    private val isCardBrandChoiceEligible: Boolean,
     private val cardBrandFilter: CardBrandFilter
 ) : CardDetailsTextFieldConfig {
     override val capitalization: KeyboardCapitalization = KeyboardCapitalization.None
@@ -30,7 +30,7 @@ internal class CardNumberConfig(
         return if (number.isBlank()) {
             TextFieldStateConstants.Error.Blank
         } else if (!cardBrandFilter.isAccepted(brand) &&
-            (!isCBCEligible || number.length > digitsRequiredToFetchBrands)
+            (!isCardBrandChoiceEligible || number.length > digitsRequiredToFetchBrands)
         ) {
             /*
               If the merchant is eligible for CBC do not show the disallowed error

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberConfig.kt
@@ -3,13 +3,17 @@ package com.stripe.android.ui.core.elements
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
+import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardUtils
 import com.stripe.android.model.CardBrand
 import com.stripe.android.uicore.elements.TextFieldState
 import com.stripe.android.uicore.elements.TextFieldStateConstants
 import com.stripe.android.R as StripeR
 
-internal class CardNumberConfig : CardDetailsTextFieldConfig {
+internal class CardNumberConfig(
+    private val isCBCEligible: Boolean,
+    private val cardBrandFilter: CardBrandFilter
+)    : CardDetailsTextFieldConfig {
     override val capitalization: KeyboardCapitalization = KeyboardCapitalization.None
     override val debugLabel: String = "Card number"
     override val label: Int = StripeR.string.stripe_acc_label_card_number
@@ -22,6 +26,12 @@ internal class CardNumberConfig : CardDetailsTextFieldConfig {
 
         return if (number.isBlank()) {
             TextFieldStateConstants.Error.Blank
+        } else if (!cardBrandFilter.isAccepted(brand) && (!isCBCEligible || number.length > 8)) {
+            return TextFieldStateConstants.Error.Invalid(
+                errorMessageResId = StripeR.string.stripe_disallowed_card_brand,
+                formatArgs = arrayOf(brand.displayName),
+                preventMoreInput = false,
+            )
         } else if (brand == CardBrand.Unknown) {
             TextFieldStateConstants.Error.Invalid(
                 errorMessageResId = StripeR.string.stripe_invalid_card_number,

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberConfigTest.kt
@@ -7,6 +7,7 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.model.CardBrand
 import com.stripe.android.ui.core.CardNumberFixtures
 import com.stripe.android.uicore.elements.TextFieldStateConstants
+import com.stripe.android.utils.FakeCardBrandFilter
 import com.stripe.android.utils.isInstanceOf
 import org.junit.Test
 import com.stripe.android.R as StripeR

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberConfigTest.kt
@@ -13,89 +13,162 @@ import org.junit.Test
 import com.stripe.android.R as StripeR
 
 class CardNumberConfigTest {
-    private val cardNumberConfig = CardNumberConfig(isCardBrandChoiceEligible = false, cardBrandFilter = DefaultCardBrandFilter)
+
+    private val cardBrandChoiceOptions = listOf(true, false)
 
     @Test
     fun `visualTransformation formats entered value`() {
-        Truth.assertThat(cardNumberConfig.visualTransformation.filter(AnnotatedString(CardNumberFixtures.VISA_NO_SPACES)).text)
-            .isEqualTo(AnnotatedString(CardNumberFixtures.VISA_WITH_SPACES))
+        for (isCardBrandChoiceEligible in cardBrandChoiceOptions) {
+            val cardNumberConfig = CardNumberConfig(
+                isCardBrandChoiceEligible = isCardBrandChoiceEligible,
+                cardBrandFilter = DefaultCardBrandFilter
+            )
 
-        Truth.assertThat(cardNumberConfig.visualTransformation.filter(AnnotatedString(CardNumberFixtures.AMEX_NO_SPACES)).text)
-            .isEqualTo(AnnotatedString(CardNumberFixtures.AMEX_WITH_SPACES))
+            Truth.assertThat(cardNumberConfig.visualTransformation.filter(AnnotatedString(CardNumberFixtures.VISA_NO_SPACES)).text)
+                .isEqualTo(AnnotatedString(CardNumberFixtures.VISA_WITH_SPACES))
 
-        Truth.assertThat(cardNumberConfig.visualTransformation.filter(AnnotatedString(CardNumberFixtures.DISCOVER_NO_SPACES)).text)
-            .isEqualTo(AnnotatedString(CardNumberFixtures.DISCOVER_WITH_SPACES))
+            Truth.assertThat(cardNumberConfig.visualTransformation.filter(AnnotatedString(CardNumberFixtures.AMEX_NO_SPACES)).text)
+                .isEqualTo(AnnotatedString(CardNumberFixtures.AMEX_WITH_SPACES))
 
-        Truth.assertThat(cardNumberConfig.visualTransformation.filter(AnnotatedString(CardNumberFixtures.DINERS_CLUB_14_NO_SPACES)).text)
-            .isEqualTo(AnnotatedString(CardNumberFixtures.DINERS_CLUB_14_WITH_SPACES))
+            Truth.assertThat(cardNumberConfig.visualTransformation.filter(AnnotatedString(CardNumberFixtures.DISCOVER_NO_SPACES)).text)
+                .isEqualTo(AnnotatedString(CardNumberFixtures.DISCOVER_WITH_SPACES))
 
-        Truth.assertThat(cardNumberConfig.visualTransformation.filter(AnnotatedString(CardNumberFixtures.DINERS_CLUB_16_NO_SPACES)).text)
-            .isEqualTo(AnnotatedString(CardNumberFixtures.DINERS_CLUB_16_WITH_SPACES))
+            Truth.assertThat(cardNumberConfig.visualTransformation.filter(AnnotatedString(CardNumberFixtures.DINERS_CLUB_14_NO_SPACES)).text)
+                .isEqualTo(AnnotatedString(CardNumberFixtures.DINERS_CLUB_14_WITH_SPACES))
 
-        Truth.assertThat(cardNumberConfig.visualTransformation.filter(AnnotatedString(CardNumberFixtures.JCB_NO_SPACES)).text)
-            .isEqualTo(AnnotatedString(CardNumberFixtures.JCB_WITH_SPACES))
+            Truth.assertThat(cardNumberConfig.visualTransformation.filter(AnnotatedString(CardNumberFixtures.DINERS_CLUB_16_NO_SPACES)).text)
+                .isEqualTo(AnnotatedString(CardNumberFixtures.DINERS_CLUB_16_WITH_SPACES))
 
-        Truth.assertThat(cardNumberConfig.visualTransformation.filter(AnnotatedString(CardNumberFixtures.UNIONPAY_NO_SPACES)).text)
-            .isEqualTo(AnnotatedString(CardNumberFixtures.UNIONPAY_WITH_SPACES))
+            Truth.assertThat(cardNumberConfig.visualTransformation.filter(AnnotatedString(CardNumberFixtures.JCB_NO_SPACES)).text)
+                .isEqualTo(AnnotatedString(CardNumberFixtures.JCB_WITH_SPACES))
+
+            Truth.assertThat(cardNumberConfig.visualTransformation.filter(AnnotatedString(CardNumberFixtures.UNIONPAY_NO_SPACES)).text)
+                .isEqualTo(AnnotatedString(CardNumberFixtures.UNIONPAY_WITH_SPACES))
+        }
     }
 
     @Test
     fun `only numbers are allowed in the field`() {
-        Truth.assertThat(cardNumberConfig.filter("123^@Number[\uD83E\uDD57."))
-            .isEqualTo("123")
+        for (isCardBrandChoiceEligible in cardBrandChoiceOptions) {
+            val cardNumberConfig = CardNumberConfig(
+                isCardBrandChoiceEligible = isCardBrandChoiceEligible,
+                cardBrandFilter = DefaultCardBrandFilter
+            )
+            Truth.assertThat(cardNumberConfig.filter("123^@Number[\uD83E\uDD57."))
+                .isEqualTo("123")
+        }
     }
 
     @Test
     fun `blank Number returns blank state`() {
-        Truth.assertThat(cardNumberConfig.determineState(CardBrand.Visa, "", CardBrand.Visa.getMaxLengthForCardNumber("")))
-            .isEqualTo(TextFieldStateConstants.Error.Blank)
+        for (isCardBrandChoiceEligible in cardBrandChoiceOptions) {
+            val cardNumberConfig = CardNumberConfig(
+                isCardBrandChoiceEligible = isCardBrandChoiceEligible,
+                cardBrandFilter = DefaultCardBrandFilter
+            )
+            Truth.assertThat(
+                cardNumberConfig.determineState(
+                    CardBrand.Visa,
+                    "",
+                    CardBrand.Visa.getMaxLengthForCardNumber("")
+                )
+            )
+                .isEqualTo(TextFieldStateConstants.Error.Blank)
+        }
     }
 
     @Test
     fun `card brand is invalid`() {
-        val state = cardNumberConfig.determineState(CardBrand.Unknown, "0", CardBrand.Unknown.getMaxLengthForCardNumber("0"))
-        Truth.assertThat(state)
-            .isInstanceOf<TextFieldStateConstants.Error.Invalid>()
-        Truth.assertThat(
-            state.getError()?.errorMessage
-        ).isEqualTo(StripeR.string.stripe_invalid_card_number)
+        for (isCardBrandChoiceEligible in cardBrandChoiceOptions) {
+            val cardNumberConfig = CardNumberConfig(
+                isCardBrandChoiceEligible = isCardBrandChoiceEligible,
+                cardBrandFilter = DefaultCardBrandFilter
+            )
+            val state = cardNumberConfig.determineState(
+                CardBrand.Unknown,
+                "0",
+                CardBrand.Unknown.getMaxLengthForCardNumber("0")
+            )
+            Truth.assertThat(state)
+                .isInstanceOf<TextFieldStateConstants.Error.Invalid>()
+            Truth.assertThat(
+                state.getError()?.errorMessage
+            ).isEqualTo(StripeR.string.stripe_invalid_card_number)
+        }
     }
 
     @Test
     fun `incomplete number is in incomplete state`() {
-        val state = cardNumberConfig.determineState(CardBrand.Visa, "12", CardBrand.Visa.getMaxLengthForCardNumber("12"))
-        Truth.assertThat(state)
-            .isInstanceOf<TextFieldStateConstants.Error.Incomplete>()
-        Truth.assertThat(
-            state.getError()?.errorMessage
-        ).isEqualTo(StripeR.string.stripe_invalid_card_number)
+        for (isCardBrandChoiceEligible in cardBrandChoiceOptions) {
+            val cardNumberConfig = CardNumberConfig(
+                isCardBrandChoiceEligible = isCardBrandChoiceEligible,
+                cardBrandFilter = DefaultCardBrandFilter
+            )
+            val state =
+                cardNumberConfig.determineState(CardBrand.Visa, "12", CardBrand.Visa.getMaxLengthForCardNumber("12"))
+            Truth.assertThat(state)
+                .isInstanceOf<TextFieldStateConstants.Error.Incomplete>()
+            Truth.assertThat(
+                state.getError()?.errorMessage
+            ).isEqualTo(StripeR.string.stripe_invalid_card_number)
+        }
     }
 
     @Test
     fun `card number is too long`() {
-        val state = cardNumberConfig.determineState(CardBrand.Visa, "1234567890123456789", CardBrand.Visa.getMaxLengthForCardNumber("1234567890123456789"))
-        Truth.assertThat(state)
-            .isInstanceOf<TextFieldStateConstants.Error.Invalid>()
-        Truth.assertThat(
-            state.getError()?.errorMessage
-        ).isEqualTo(StripeR.string.stripe_invalid_card_number)
+        for (isCardBrandChoiceEligible in cardBrandChoiceOptions) {
+            val cardNumberConfig = CardNumberConfig(
+                isCardBrandChoiceEligible = isCardBrandChoiceEligible,
+                cardBrandFilter = DefaultCardBrandFilter
+            )
+            val state = cardNumberConfig.determineState(
+                CardBrand.Visa,
+                "1234567890123456789",
+                CardBrand.Visa.getMaxLengthForCardNumber("1234567890123456789")
+            )
+            Truth.assertThat(state)
+                .isInstanceOf<TextFieldStateConstants.Error.Invalid>()
+            Truth.assertThat(
+                state.getError()?.errorMessage
+            ).isEqualTo(StripeR.string.stripe_invalid_card_number)
+        }
     }
 
     @Test
     fun `card number has invalid luhn`() {
-        val state = cardNumberConfig.determineState(CardBrand.Visa, "4242424242424243", CardBrand.Visa.getMaxLengthForCardNumber("4242424242424243"))
-        Truth.assertThat(state)
-            .isInstanceOf<TextFieldStateConstants.Error.Invalid>()
-        Truth.assertThat(
-            state.getError()?.errorMessage
-        ).isEqualTo(StripeR.string.stripe_invalid_card_number)
+        for (isCardBrandChoiceEligible in cardBrandChoiceOptions) {
+            val cardNumberConfig = CardNumberConfig(
+                isCardBrandChoiceEligible = isCardBrandChoiceEligible,
+                cardBrandFilter = DefaultCardBrandFilter
+            )
+            val state = cardNumberConfig.determineState(
+                CardBrand.Visa,
+                "4242424242424243",
+                CardBrand.Visa.getMaxLengthForCardNumber("4242424242424243")
+            )
+            Truth.assertThat(state)
+                .isInstanceOf<TextFieldStateConstants.Error.Invalid>()
+            Truth.assertThat(
+                state.getError()?.errorMessage
+            ).isEqualTo(StripeR.string.stripe_invalid_card_number)
+        }
     }
 
     @Test
     fun `card number is valid`() {
-        val state = cardNumberConfig.determineState(CardBrand.Visa, "4242424242424242", CardBrand.Visa.getMaxLengthForCardNumber("4242424242424242"))
-        Truth.assertThat(state)
-            .isInstanceOf<TextFieldStateConstants.Valid.Full>()
+        for (isCardBrandChoiceEligible in cardBrandChoiceOptions) {
+            val cardNumberConfig = CardNumberConfig(
+                isCardBrandChoiceEligible = isCardBrandChoiceEligible,
+                cardBrandFilter = DefaultCardBrandFilter
+            )
+            val state = cardNumberConfig.determineState(
+                CardBrand.Visa,
+                "4242424242424242",
+                CardBrand.Visa.getMaxLengthForCardNumber("4242424242424242")
+            )
+            Truth.assertThat(state)
+                .isInstanceOf<TextFieldStateConstants.Valid.Full>()
+        }
     }
 
     @Test

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberConfigTest.kt
@@ -2,6 +2,8 @@ package com.stripe.android.ui.core.elements
 
 import androidx.compose.ui.text.AnnotatedString
 import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.model.CardBrand
 import com.stripe.android.ui.core.CardNumberFixtures
 import com.stripe.android.uicore.elements.TextFieldStateConstants
@@ -10,7 +12,7 @@ import org.junit.Test
 import com.stripe.android.R as StripeR
 
 class CardNumberConfigTest {
-    private val cardNumberConfig = CardNumberConfig()
+    private val cardNumberConfig = CardNumberConfig(isCBCEligible = false, cardBrandFilter = DefaultCardBrandFilter)
 
     @Test
     fun `visualTransformation formats entered value`() {
@@ -93,5 +95,95 @@ class CardNumberConfigTest {
         val state = cardNumberConfig.determineState(CardBrand.Visa, "4242424242424242", CardBrand.Visa.getMaxLengthForCardNumber("4242424242424242"))
         Truth.assertThat(state)
             .isInstanceOf<TextFieldStateConstants.Valid.Full>()
+    }
+
+    @Test
+    fun `determineState returns valid for allowed brand without CBC`() {
+        val cardBrandFilter = FakeCardBrandFilter(disallowedBrands = setOf(CardBrand.MasterCard))
+        val cardNumberConfig = CardNumberConfig(
+            isCBCEligible = false,
+            cardBrandFilter = cardBrandFilter
+        )
+
+        val state = cardNumberConfig.determineState(
+            brand = CardBrand.Visa,
+            number = "4242424242424242",
+            numberAllowedDigits = CardBrand.Visa.getMaxLengthForCardNumber("4242424242424242")
+        )
+
+        assertThat(state).isInstanceOf<TextFieldStateConstants.Valid.Full>()
+    }
+
+    @Test
+    fun `determineState returns error for disallowed brand without CBC`() {
+        val cardBrandFilter = FakeCardBrandFilter(disallowedBrands = setOf(CardBrand.MasterCard))
+        val cardNumberConfig = CardNumberConfig(
+            isCBCEligible = false,
+            cardBrandFilter = cardBrandFilter
+        )
+
+        val state = cardNumberConfig.determineState(
+            brand = CardBrand.MasterCard,
+            number = "5555555555554444",
+            numberAllowedDigits = CardBrand.MasterCard.getMaxLengthForCardNumber("5555555555554444")
+        )
+
+        assertThat(state).isInstanceOf<TextFieldStateConstants.Error.Invalid>()
+        assertThat(state.getError()?.errorMessage)
+            .isEqualTo(StripeR.string.stripe_disallowed_card_brand)
+    }
+
+    @Test
+    fun `determineState allows disallowed brand with CBC when number length is less than or equal to 8`() {
+        val cardBrandFilter = FakeCardBrandFilter(disallowedBrands = setOf(CardBrand.MasterCard))
+        val cardNumberConfig = CardNumberConfig(
+            isCBCEligible = true,
+            cardBrandFilter = cardBrandFilter
+        )
+
+        val state = cardNumberConfig.determineState(
+            brand = CardBrand.MasterCard,
+            number = "55555555", // Length is 8
+            numberAllowedDigits = CardBrand.MasterCard.getMaxLengthForCardNumber("55555555")
+        )
+
+        // Since number length is less than or equal to 8, it should not return disallowed brand error
+        assertThat(state).isInstanceOf<TextFieldStateConstants.Error.Incomplete>()
+    }
+
+    @Test
+    fun `determineState returns error for disallowed brand with CBC when number length is greater than 8`() {
+        val cardBrandFilter = FakeCardBrandFilter(disallowedBrands = setOf(CardBrand.MasterCard))
+        val cardNumberConfig = CardNumberConfig(
+            isCBCEligible = true,
+            cardBrandFilter = cardBrandFilter
+        )
+
+        val state = cardNumberConfig.determineState(
+            brand = CardBrand.MasterCard,
+            number = "5555555555554444", // Length is greater than 8
+            numberAllowedDigits = CardBrand.MasterCard.getMaxLengthForCardNumber("5555555555554444")
+        )
+
+        assertThat(state).isInstanceOf<TextFieldStateConstants.Error.Invalid>()
+        assertThat(state.getError()?.errorMessage)
+            .isEqualTo(StripeR.string.stripe_disallowed_card_brand)
+    }
+
+    @Test
+    fun `determineState returns valid for allowed brand with CBC`() {
+        val cardBrandFilter = FakeCardBrandFilter(disallowedBrands = setOf(CardBrand.MasterCard))
+        val cardNumberConfig = CardNumberConfig(
+            isCBCEligible = true,
+            cardBrandFilter = cardBrandFilter
+        )
+
+        val state = cardNumberConfig.determineState(
+            brand = CardBrand.Visa,
+            number = "4242424242424242",
+            numberAllowedDigits = CardBrand.Visa.getMaxLengthForCardNumber("4242424242424242")
+        )
+
+        assertThat(state).isInstanceOf<TextFieldStateConstants.Valid.Full>()
     }
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberConfigTest.kt
@@ -12,7 +12,7 @@ import org.junit.Test
 import com.stripe.android.R as StripeR
 
 class CardNumberConfigTest {
-    private val cardNumberConfig = CardNumberConfig(isCBCEligible = false, cardBrandFilter = DefaultCardBrandFilter)
+    private val cardNumberConfig = CardNumberConfig(isCardBrandChoiceEligible = false, cardBrandFilter = DefaultCardBrandFilter)
 
     @Test
     fun `visualTransformation formats entered value`() {
@@ -101,7 +101,7 @@ class CardNumberConfigTest {
     fun `determineState returns valid for allowed brand without CBC`() {
         val cardBrandFilter = FakeCardBrandFilter(disallowedBrands = setOf(CardBrand.MasterCard))
         val cardNumberConfig = CardNumberConfig(
-            isCBCEligible = false,
+            isCardBrandChoiceEligible = false,
             cardBrandFilter = cardBrandFilter
         )
 
@@ -118,7 +118,7 @@ class CardNumberConfigTest {
     fun `determineState returns error for disallowed brand without CBC`() {
         val cardBrandFilter = FakeCardBrandFilter(disallowedBrands = setOf(CardBrand.MasterCard))
         val cardNumberConfig = CardNumberConfig(
-            isCBCEligible = false,
+            isCardBrandChoiceEligible = false,
             cardBrandFilter = cardBrandFilter
         )
 
@@ -137,7 +137,7 @@ class CardNumberConfigTest {
     fun `determineState allows disallowed brand with CBC when number length is less than or equal to 8`() {
         val cardBrandFilter = FakeCardBrandFilter(disallowedBrands = setOf(CardBrand.MasterCard))
         val cardNumberConfig = CardNumberConfig(
-            isCBCEligible = true,
+            isCardBrandChoiceEligible = true,
             cardBrandFilter = cardBrandFilter
         )
 
@@ -155,7 +155,7 @@ class CardNumberConfigTest {
     fun `determineState returns error for disallowed brand with CBC when number length is greater than 8`() {
         val cardBrandFilter = FakeCardBrandFilter(disallowedBrands = setOf(CardBrand.MasterCard))
         val cardNumberConfig = CardNumberConfig(
-            isCBCEligible = true,
+            isCardBrandChoiceEligible = true,
             cardBrandFilter = cardBrandFilter
         )
 
@@ -174,7 +174,7 @@ class CardNumberConfigTest {
     fun `determineState returns valid for allowed brand with CBC`() {
         val cardBrandFilter = FakeCardBrandFilter(disallowedBrands = setOf(CardBrand.MasterCard))
         val cardNumberConfig = CardNumberConfig(
-            isCBCEligible = true,
+            isCardBrandChoiceEligible = true,
             cardBrandFilter = cardBrandFilter
         )
 

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
@@ -477,7 +477,7 @@ internal class CardNumberControllerTest {
         cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter
     ): DefaultCardNumberController {
         return DefaultCardNumberController(
-            cardTextFieldConfig = CardNumberConfig(),
+            cardTextFieldConfig = CardNumberConfig(isCBCEligible = false, cardBrandFilter = DefaultCardBrandFilter),
             cardAccountRangeRepository = repository,
             uiContext = testDispatcher,
             workContext = testDispatcher,
@@ -521,7 +521,7 @@ internal class CardNumberControllerTest {
 }
 
 @Parcelize
-private class FakeCardBrandFilter(
+class FakeCardBrandFilter(
     private val disallowedBrands: Set<CardBrand>
 ) : CardBrandFilter {
     override fun isAccepted(cardBrand: CardBrand): Boolean {

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
@@ -477,7 +477,7 @@ internal class CardNumberControllerTest {
         cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter
     ): DefaultCardNumberController {
         return DefaultCardNumberController(
-            cardTextFieldConfig = CardNumberConfig(isCBCEligible = false, cardBrandFilter = DefaultCardBrandFilter),
+            cardTextFieldConfig = CardNumberConfig(isCardBrandChoiceEligible = false, cardBrandFilter = DefaultCardBrandFilter),
             cardAccountRangeRepository = repository,
             uiContext = testDispatcher,
             workContext = testDispatcher,

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
@@ -24,6 +24,7 @@ import com.stripe.android.uicore.elements.SimpleTextFieldConfig
 import com.stripe.android.uicore.elements.SimpleTextFieldController
 import com.stripe.android.uicore.elements.TextFieldIcon
 import com.stripe.android.uicore.utils.stateFlowOf
+import com.stripe.android.utils.FakeCardBrandFilter
 import com.stripe.android.utils.TestUtils.idleLooper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
@@ -517,14 +518,5 @@ internal class CardNumberControllerTest {
 
     private companion object {
         const val TEST_TAG = "CardNumberElement"
-    }
-}
-
-@Parcelize
-class FakeCardBrandFilter(
-    private val disallowedBrands: Set<CardBrand>
-) : CardBrandFilter {
-    override fun isAccepted(cardBrand: CardBrand): Boolean {
-        return !disallowedBrands.contains(cardBrand)
     }
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
@@ -478,7 +478,6 @@ internal class CardNumberControllerTest {
     ): DefaultCardNumberController {
         return DefaultCardNumberController(
             cardTextFieldConfig = CardNumberConfig(
-
                 isCardBrandChoiceEligible = false,
                 cardBrandFilter = DefaultCardBrandFilter
             ),

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.parcelize.Parcelize
 import org.junit.After
 import org.junit.Rule
 import org.junit.Test
@@ -478,7 +477,11 @@ internal class CardNumberControllerTest {
         cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter
     ): DefaultCardNumberController {
         return DefaultCardNumberController(
-            cardTextFieldConfig = CardNumberConfig(isCardBrandChoiceEligible = false, cardBrandFilter = DefaultCardBrandFilter),
+            cardTextFieldConfig = CardNumberConfig(
+
+                isCardBrandChoiceEligible = false,
+                cardBrandFilter = DefaultCardBrandFilter
+            ),
             cardAccountRangeRepository = repository,
             uiContext = testDispatcher,
             workContext = testDispatcher,

--- a/payments-ui-core/src/test/java/com/stripe/android/utils/FakeCardBrandFilter.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/utils/FakeCardBrandFilter.kt
@@ -1,0 +1,14 @@
+package com.stripe.android.utils
+
+import com.stripe.android.CardBrandFilter
+import com.stripe.android.model.CardBrand
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+class FakeCardBrandFilter(
+    private val disallowedBrands: Set<CardBrand>
+) : CardBrandFilter {
+    override fun isAccepted(cardBrand: CardBrand): Boolean {
+        return !disallowedBrands.contains(cardBrand)
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -36,6 +36,7 @@ import com.stripe.android.customersheet.util.isUnverifiedUSBankAccount
 import com.stripe.android.customersheet.util.sortPaymentMethods
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
@@ -604,6 +605,7 @@ internal class CustomerSheetViewModel(
                     },
                     canRemove = customerState.canRemove,
                     isLiveMode = requireNotNull(customerState.metadata).stripeIntent.isLiveMode,
+                    cardBrandFilter = PaymentSheetCardBrandFilter(customerState.configuration.cardBrandAcceptance)
                 ),
                 isLiveMode = isLiveModeProvider(),
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -1,8 +1,10 @@
 package com.stripe.android.paymentsheet
 
 import androidx.lifecycle.viewModelScope
+import com.stripe.android.CardBrandFilter
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.orEmpty
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
@@ -44,6 +46,7 @@ internal class SavedPaymentMethodMutator(
     private val isLiveModeProvider: () -> Boolean,
     private val customerStateHolder: CustomerStateHolder,
     private val currentScreen: StateFlow<PaymentSheetScreen>,
+    private val cardBrandFilter: CardBrandFilter,
     isCbcEligible: () -> Boolean,
     isGooglePayReady: StateFlow<Boolean>,
     isLinkEnabled: StateFlow<Boolean?>,
@@ -225,6 +228,7 @@ internal class SavedPaymentMethodMutator(
                     },
                     canRemove = canRemove.value,
                     isLiveMode = isLiveModeProvider(),
+                    cardBrandFilter = cardBrandFilter
                 ),
             )
         )
@@ -332,6 +336,7 @@ internal class SavedPaymentMethodMutator(
                 isNotPaymentFlow = !viewModel.isCompleteFlow,
                 isLiveModeProvider = { requireNotNull(viewModel.paymentMethodMetadata.value).stripeIntent.isLiveMode },
                 currentScreen = viewModel.navigationHandler.currentScreen,
+                cardBrandFilter = PaymentSheetCardBrandFilter(viewModel.config.cardBrandAcceptance)
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditPaymentMethodViewInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditPaymentMethodViewInteractor.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.ui
 
+import com.stripe.android.CardBrandFilter
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.model.CardBrand
@@ -48,6 +49,7 @@ internal interface ModifiableEditPaymentMethodViewInteractor : EditPaymentMethod
             displayName: ResolvableString,
             canRemove: Boolean,
             isLiveMode: Boolean,
+            cardBrandFilter: CardBrandFilter
         ): ModifiableEditPaymentMethodViewInteractor
     }
 }
@@ -60,6 +62,7 @@ internal class DefaultEditPaymentMethodViewInteractor(
     private val updateExecutor: PaymentMethodUpdateOperation,
     private val canRemove: Boolean,
     override val isLiveMode: Boolean,
+    private val cardBrandFilter: CardBrandFilter,
     workContext: CoroutineContext = Dispatchers.Default,
 ) : ModifiableEditPaymentMethodViewInteractor {
     private val choice = MutableStateFlow(initialPaymentMethod.getPreferredChoice())
@@ -77,7 +80,7 @@ internal class DefaultEditPaymentMethodViewInteractor(
         error,
     ) { paymentMethod, choice, status, confirmDeletion, error ->
         val savedChoice = paymentMethod.getPreferredChoice()
-        val availableChoices = paymentMethod.getAvailableNetworks()
+        val availableChoices = paymentMethod.getAvailableNetworks().filter { cardBrandFilter.isAccepted(it.brand) }
 
         EditPaymentMethodViewState(
             last4 = paymentMethod.getLast4(),
@@ -201,6 +204,7 @@ internal class DefaultEditPaymentMethodViewInteractor(
             displayName: ResolvableString,
             canRemove: Boolean,
             isLiveMode: Boolean,
+            cardBrandFilter: CardBrandFilter
         ): ModifiableEditPaymentMethodViewInteractor {
             return DefaultEditPaymentMethodViewInteractor(
                 initialPaymentMethod = initialPaymentMethod,
@@ -210,6 +214,7 @@ internal class DefaultEditPaymentMethodViewInteractor(
                 displayName = displayName,
                 canRemove = canRemove,
                 isLiveMode = isLiveMode,
+                cardBrandFilter = cardBrandFilter
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.customersheet.ui.CustomerSheetScreen
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
@@ -332,6 +333,7 @@ internal class CustomerSheetScreenshotTest {
                 eventHandler = {},
                 canRemove = true,
                 isLiveMode = true,
+                cardBrandFilter = DefaultCardBrandFilter
             ),
             isLiveMode = true,
         )
@@ -364,6 +366,7 @@ internal class CustomerSheetScreenshotTest {
                 eventHandler = {},
                 canRemove = false,
                 isLiveMode = true,
+                cardBrandFilter = DefaultCardBrandFilter
             ),
             isLiveMode = true,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -5,6 +5,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
+import com.stripe.android.CardBrandFilter
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.strings.ResolvableString
@@ -172,6 +173,7 @@ internal object CustomerSheetTestHelper {
                 displayName: ResolvableString,
                 canRemove: Boolean,
                 isLiveMode: Boolean,
+                cardBrandFilter: CardBrandFilter
             ): ModifiableEditPaymentMethodViewInteractor {
                 return DefaultEditPaymentMethodViewInteractor(
                     initialPaymentMethod = initialPaymentMethod,
@@ -182,6 +184,7 @@ internal object CustomerSheetTestHelper {
                     workContext = workContext,
                     canRemove = canRemove,
                     isLiveMode = isLiveMode,
+                    cardBrandFilter = cardBrandFilter
                 )
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FakeEditPaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FakeEditPaymentMethodInteractor.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet
 
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
+import com.stripe.android.CardBrandFilter
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
@@ -56,6 +57,7 @@ internal class FakeEditPaymentMethodInteractor(
             displayName: ResolvableString,
             canRemove: Boolean,
             isLiveMode: Boolean,
+            cardBrandFilter: CardBrandFilter
         ): ModifiableEditPaymentMethodViewInteractor {
             _calls.add(Call(initialPaymentMethod, canRemove))
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.PaymentMethod
@@ -547,6 +548,7 @@ class SavedPaymentMethodMutatorTest {
                 isNotPaymentFlow = true,
                 isLiveModeProvider = { true },
                 currentScreen = currentScreen,
+                cardBrandFilter = DefaultCardBrandFilter
             )
             Scenario(
                 savedPaymentMethodMutator = savedPaymentMethodMutator,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditPaymentMethodViewInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditPaymentMethodViewInteractorTest.kt
@@ -292,7 +292,7 @@ class DefaultEditPaymentMethodViewInteractorTest {
             override fun describeContents(): Int = 0
 
             override fun writeToParcel(parcel: Parcel, flags: Int) {
-                // no-op
+                throw IllegalStateException("Should not invoke writeToParcel")
             }
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditPaymentMethodViewInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditPaymentMethodViewInteractorTest.kt
@@ -304,6 +304,16 @@ class DefaultEditPaymentMethodViewInteractorTest {
         }
     }
 
+    @Test
+    fun `availableBrands should be unmodified when using DefaultCardBrandFilter`() = runTest {
+        val interactor = createInteractor(cardBrandFilter = DefaultCardBrandFilter)
+
+        interactor.viewState.test {
+            val state = awaitItem()
+            assertThat(state.availableBrands).isEqualTo(listOf(VISA_BRAND_CHOICE, CARTES_BANCAIRES_BRAND_CHOICE))
+        }
+    }
+
     private fun createInteractor(
         eventHandler: (EditPaymentMethodViewInteractor.Event) -> Unit = {},
         onRemove: PaymentMethodRemoveOperation = { null },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/ThrowingEditPaymentMethodViewInteractorFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/ThrowingEditPaymentMethodViewInteractorFactory.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.ui
 
+import com.stripe.android.CardBrandFilter
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.model.PaymentMethod
 
@@ -11,7 +12,8 @@ internal object ThrowingEditPaymentMethodViewInteractorFactory : ModifiableEditP
         updateExecutor: PaymentMethodUpdateOperation,
         displayName: ResolvableString,
         canRemove: Boolean,
-        isLiveMode: Boolean
+        isLiveMode: Boolean,
+        cardBrandFilter: CardBrandFilter
     ): ModifiableEditPaymentMethodViewInteractor {
         throw AssertionError("Not expected.")
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/FakeEditPaymentMethodInteractorFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/FakeEditPaymentMethodInteractorFactory.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.utils
 
+import com.stripe.android.CardBrandFilter
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.ui.DefaultEditPaymentMethodViewInteractor
@@ -21,6 +22,7 @@ internal class FakeEditPaymentMethodInteractorFactory(
         displayName: ResolvableString,
         canRemove: Boolean,
         isLiveMode: Boolean,
+        cardBrandFilter: CardBrandFilter
     ): ModifiableEditPaymentMethodViewInteractor {
         return DefaultEditPaymentMethodViewInteractor(
             initialPaymentMethod = initialPaymentMethod,
@@ -31,6 +33,7 @@ internal class FakeEditPaymentMethodInteractorFactory(
             workContext = context,
             canRemove = canRemove,
             isLiveMode = isLiveMode,
+            cardBrandFilter = cardBrandFilter
         )
     }
 }


### PR DESCRIPTION
# Summary
- Show an error when a disallowed brand is entered into the PAN field and block payment
- Filters out disallowed brands in the update card drop down for CBC
   - In the future we may just hide the edit icon and show remove icon in the event there is only 1 possible brand after filtering. Will consider this as post beta polish most likely, however we should still filter the brands in the case maybe there are co-branded cards w/ more than just 2 networks.
- Adds a new localized string that is uploaded to Lokalise
- Future PRs will include:
   - E2E tests
   - Analytics
   - Google Pay 


# Motivation
- CBF

# Testing
- Manual
- New unit tests

# Screenshots
![Screenshot_1729193808](https://github.com/user-attachments/assets/a4591a1d-37f8-409b-a76c-b4e9be6d8c71)


# Changelog
N/A