### PR TITLE
Enable IntentPolling for AmazonPay and RevolutPay

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
@@ -117,6 +117,26 @@ object PaymentMethodFactory {
         )
     }
 
+    fun amazonPay(): PaymentMethod {
+        return PaymentMethod(
+            id = "pm_1234",
+            created = 123456789L,
+            liveMode = false,
+            type = PaymentMethod.Type.AmazonPay,
+            code = PaymentMethod.Type.AmazonPay.code,
+        )
+    }
+
+    fun revolutPay(): PaymentMethod {
+        return PaymentMethod(
+            id = "pm_1234",
+            created = 123456789L,
+            liveMode = false,
+            type = PaymentMethod.Type.RevolutPay,
+            code = PaymentMethod.Type.RevolutPay.code,
+        )
+    }
+
     fun convertCardToJson(paymentMethod: PaymentMethod): JSONObject {
         val paymentMethodJson = convertGenericPaymentMethodToJson(paymentMethod)
 

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -355,6 +355,7 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
+            afterRedirectAction = AfterRedirectAction.Poll(),
         ),
         Sunbit(
             "sunbit",
@@ -383,6 +384,7 @@ constructor(
             isVoucher = false,
             requiresMandate = false,
             hasDelayedSettlement = false,
+            afterRedirectAction = AfterRedirectAction.Poll(),
         ),
         Alma(
             "alma",


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- Enable Intent Polling for Revolut Pay and Amazon Pay

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/LPMXP-5330

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
