### PR TITLE
Fix icon stretching.

### DIFF
--- a/payments-core/res/layout/stripe_card_brand_view.xml
+++ b/payments-core/res/layout/stripe_card_brand_view.xml
@@ -11,7 +11,7 @@
             android:layout_width="32dp"
             android:layout_height="21dp"
             android:visibility="visible"
-            android:background="@drawable/stripe_ic_unknown"/>
+            android:src="@drawable/stripe_ic_unknown"/>
 
         <ImageView
             android:id="@+id/chevron"

--- a/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -167,7 +167,7 @@ internal class CardBrandView @JvmOverloads constructor(
     }
 
     private fun setCardBrandIconAndTint() {
-        iconView.setBackgroundResource(
+        iconView.setImageResource(
             when {
                 shouldShowErrorIcon -> state.brand.errorIcon
                 shouldShowCvc -> state.brand.cvcIcon
@@ -178,7 +178,7 @@ internal class CardBrandView @JvmOverloads constructor(
         val tint = when {
             shouldShowErrorIcon -> null
             shouldShowCvc -> tintColorInt
-            else -> tintColorInt.takeIf { state.brand == Unknown }
+            else -> null
         }
 
         iconView.colorFilter = tint?.let { PorterDuffColorFilter(it, PorterDuff.Mode.LIGHTEN) }
@@ -300,7 +300,7 @@ internal class BrandAdapter(
     private fun updateView(view: View, position: Int) {
         brands.getOrNull(position - 1)?.let { brand ->
             val isSelected = brand == selectedBrand
-            view.findViewById<ImageView>(R.id.brand_icon)?.setBackgroundResource(brand.icon)
+            view.findViewById<ImageView>(R.id.brand_icon)?.setImageResource(brand.icon)
             view.findViewById<ImageView>(R.id.brand_check).apply {
                 if (isSelected) {
                     visibility = View.VISIBLE

--- a/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -1,8 +1,6 @@
 package com.stripe.android.view
 
 import android.content.Context
-import android.graphics.PorterDuff
-import android.graphics.PorterDuffColorFilter
 import android.graphics.Typeface
 import android.os.Parcelable
 import android.util.AttributeSet
@@ -46,7 +44,6 @@ internal class CardBrandView @JvmOverloads constructor(
         val merchantPreferredNetworks: List<CardBrand> = emptyList(),
         val shouldShowCvc: Boolean = false,
         val shouldShowErrorIcon: Boolean = false,
-        val tintColor: Int = 0,
     ) : Parcelable
 
     private var stateFlow = MutableStateFlow(State())
@@ -99,12 +96,6 @@ internal class CardBrandView @JvmOverloads constructor(
         set(value) {
             stateFlow.update { it.copy(shouldShowErrorIcon = value) }
             setCardBrandIconAndTint()
-        }
-
-    internal var tintColorInt: Int
-        get() = state.tintColor
-        set(value) {
-            stateFlow.update { it.copy(tintColor = value) }
         }
 
     init {
@@ -174,14 +165,6 @@ internal class CardBrandView @JvmOverloads constructor(
                 else -> state.brand.icon
             }
         )
-
-        val tint = when {
-            shouldShowErrorIcon -> null
-            shouldShowCvc -> tintColorInt
-            else -> null
-        }
-
-        iconView.colorFilter = tint?.let { PorterDuffColorFilter(it, PorterDuff.Mode.LIGHTEN) }
     }
 
     private fun determineCardBrandToDisplay() {

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -711,7 +711,6 @@ class CardInputWidget @JvmOverloads constructor(
         isShowingFullCard = true
 
         @ColorInt var errorColorInt = cardNumberEditText.defaultErrorColorInt
-        cardBrandView.tintColorInt = cardNumberEditText.hintTextColors.defaultColor
         var cardHintText: String? = null
         var shouldRequestFocus = true
 
@@ -719,11 +718,6 @@ class CardInputWidget @JvmOverloads constructor(
             attrs,
             R.styleable.CardInputView
         ) {
-            cardBrandView.tintColorInt = getColor(
-                R.styleable.CardInputView_cardTint,
-                cardBrandView.tintColorInt
-            )
-
             errorColorInt = getColor(
                 R.styleable.CardInputView_cardTextErrorColor,
                 errorColorInt

--- a/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -381,8 +381,6 @@ class CardMultilineWidget @JvmOverloads constructor(
         initFocusChangeListeners()
         initDeleteEmptyListeners()
 
-        cardBrandView.tintColorInt = cardNumberEditText.hintTextColors.defaultColor
-
         cardNumberEditText.completionCallback = {
             expiryDateEditText.requestFocus()
             cardInputListener?.onCardComplete()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Sets the icon as the foreground, rather than background, to avoid stretching issues.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
#9129
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3594

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

