### PR TITLE
Remove --tag flag from tag push command

### DIFF
--- a/scripts/deploy/create_github_release.rb
+++ b/scripts/deploy/create_github_release.rb
@@ -65,7 +65,7 @@ private def tag_release
 
     # There's no way to create a "draft" tag, so we skip pushing tags if this is a dry run.
     if(!@is_dry_run)
-        execute_or_fail("git push --tag origin #{tag_name}")
+        execute_or_fail("git push origin #{tag_name}")
     end
 end
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove --tag flag from tag push command

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fixes an issue during our release where pushing the release's tag will fail if another conflicting tag is present locally. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

I have some local conflicting tags. I ran the old command and it failed:
```
amk$ git push --tag origin 20.90.0
Enumerating objects: 2, done.
Counting objects: 100% (2/2), done.
Delta compression using up to 10 threads
Compressing objects: 100% (2/2), done.
Writing objects: 100% (2/2), 669 bytes | 669.00 KiB/s, done.
Total 2 (delta 0), reused 1 (delta 0), pack-reused 0 (from 0)
To github.com:stripe/stripe-android.git
 * [new tag]               20.90.0 -> 20.90.0
 ! [rejected]              v20.49.0 -> v20.49.0 (already exists)
error: failed to push some refs to 'github.com:stripe/stripe-android.git'
hint: Updates were rejected because the tag already exists in the remote.
```

I ran with the new command and it succeeded:
```
amk$ git push origin 20.90.0
Everything up-to-date
```

Verified that it succeeded by seeing that it showed up in our repo [tags](https://github.com/stripe/stripe-android/tags) (but then I deleted it because it was useless!)