### PR TITLE
Coalesce customer ephemeral key calls.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/coroutines/CoalescingOrchestrator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/coroutines/CoalescingOrchestrator.kt
@@ -1,0 +1,79 @@
+package com.stripe.android.common.coroutines
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+
+/**
+ * This class intends to simplify workflows where calling a factory multiple times in parallel only results in a single
+ * call to the underlying factory, but the data returned is shared between all callers.
+ */
+internal class CoalescingOrchestrator<T : Any>(
+    private val factory: suspend () -> T,
+    private val keepDataInMemory: (T) -> Boolean = { false },
+    // This should only be used for testing.
+    private val awaitListener: (() -> Unit)? = null,
+) {
+    @Volatile
+    private lateinit var data: T
+    @Volatile
+    private var dataInitialized: Boolean = false
+
+    @Volatile
+    private var deferred: Deferred<T>? = null
+    private val lock: Any = Any()
+
+    tailrec suspend fun get(): T {
+        if (dataInitialized) {
+            return data
+        }
+
+        val result = coroutineScope {
+            val deferredToAwait: Deferred<T>
+            synchronized(lock) {
+                if (dataInitialized) {
+                    return@coroutineScope data
+                }
+                val localDeferred = deferred
+                if (localDeferred != null && !localDeferred.isCancelled) {
+                    deferredToAwait = localDeferred
+                } else {
+                    deferredToAwait = loadDataAsync(this@coroutineScope)
+                }
+            }
+            try {
+                awaitListener?.invoke()
+                deferredToAwait.await()
+            } catch (_: CancellationException) {
+                // The `deferredToAwait` was cancelled before we could await it by another thread.
+                null
+            }
+        }
+        if (result != null) {
+            return result
+        }
+        // Null returned due to cancellation. Try again by calling ourself.
+        return get()
+    }
+
+    private fun loadDataAsync(scope: CoroutineScope): Deferred<T> {
+        val local = scope.async(start = CoroutineStart.LAZY) {
+            val result = factory()
+            synchronized(lock) {
+                if (keepDataInMemory(result)) {
+                    data = result
+                    dataInitialized = true
+                }
+                deferred = null
+            }
+            result
+        }
+
+        deferred = local
+
+        return local
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/coroutines/CoalescingOrchestrator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/coroutines/CoalescingOrchestrator.kt
@@ -19,6 +19,7 @@ internal class CoalescingOrchestrator<T : Any>(
 ) {
     @Volatile
     private lateinit var data: T
+
     @Volatile
     private var dataInitialized: Boolean = false
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet
 
 import android.content.Context
+import com.stripe.android.common.coroutines.CoalescingOrchestrator
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
@@ -36,6 +37,10 @@ internal class StripeCustomerAdapter @Inject internal constructor(
 
     @Volatile
     private var cachedCustomerEphemeralKey: CachedCustomerEphemeralKey? = null
+
+    private val customerEphemeralKeyCoalescingOrchestrator = CoalescingOrchestrator(
+        factory = customerEphemeralKeyProvider::provideCustomerEphemeralKey,
+    )
 
     override val canCreateSetupIntents: Boolean
         get() = setupIntentClientSecretProvider != null
@@ -189,7 +194,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 )
             }?.result ?: run {
                 val newCachedCustomerEphemeralKey = CachedCustomerEphemeralKey(
-                    result = customerEphemeralKeyProvider.provideCustomerEphemeralKey(),
+                    result = customerEphemeralKeyCoalescingOrchestrator.get(),
                     date = timeProvider(),
                 )
                 cachedCustomerEphemeralKey = newCachedCustomerEphemeralKey

--- a/paymentsheet/src/test/java/com/stripe/android/common/coroutines/CoalescingOrchestratorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/coroutines/CoalescingOrchestratorTest.kt
@@ -1,0 +1,174 @@
+package com.stripe.android.common.coroutines
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+
+@OptIn(DelicateCoroutinesApi::class)
+internal class CoalescingOrchestratorTest {
+    @Test
+    fun testGetReturnsData(): Unit = runBlocking {
+        val subject = CoalescingOrchestrator({ "it works" }, { true })
+        assertThat(subject.get()).isEqualTo("it works")
+    }
+
+    @Test
+    fun testGetOnlyCallsFactoryOnceWhenStoringInMemory(): Unit = runBlocking {
+        val factoryCount = AtomicInteger(0)
+        val subject = CoalescingOrchestrator(
+            factory = {
+                factoryCount.incrementAndGet()
+                "it works"
+            },
+            keepDataInMemory = { true }
+        )
+        assertThat(subject.get()).isEqualTo("it works")
+        assertThat(subject.get()).isEqualTo("it works")
+        assertThat(factoryCount.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun testGetCallsFactoryTwiceWhenNotStoringInMemory(): Unit = runBlocking {
+        val factoryCount = AtomicInteger(0)
+        val subject = CoalescingOrchestrator(
+            factory = {
+                "it works ${factoryCount.getAndIncrement()}"
+            },
+            keepDataInMemory = { false }
+        )
+        assertThat(subject.get()).isEqualTo("it works 0")
+        assertThat(subject.get()).isEqualTo("it works 1")
+        assertThat(factoryCount.get()).isEqualTo(2)
+    }
+
+    @Test
+    fun testGetCallsFactoryUntilKeepDataInMemoryIsTrue(): Unit = runBlocking {
+        val factoryCount = AtomicInteger(0)
+        val keepDataInMemoryCount = AtomicInteger(0)
+        val subject = CoalescingOrchestrator(
+            factory = {
+                "it works ${factoryCount.getAndIncrement()}"
+            },
+            keepDataInMemory = {
+                keepDataInMemoryCount.getAndIncrement()
+                it == "it works 1"
+            }
+        )
+        assertThat(subject.get()).isEqualTo("it works 0")
+        assertThat(subject.get()).isEqualTo("it works 1")
+        assertThat(subject.get()).isEqualTo("it works 1")
+        assertThat(subject.get()).isEqualTo("it works 1")
+        assertThat(factoryCount.get()).isEqualTo(2)
+        assertThat(keepDataInMemoryCount.get()).isEqualTo(2)
+    }
+
+    @Test
+    fun testCancellation() {
+        val factoryCount = AtomicInteger(0)
+        var countDownLatch = CountDownLatch(1)
+        val deferred = CompletableDeferred<String>()
+        val subject = CoalescingOrchestrator(
+            factory = {
+                factoryCount.incrementAndGet()
+                countDownLatch.countDown()
+                deferred.await()
+            },
+            keepDataInMemory = { true },
+        )
+
+        val job1 = GlobalScope.launch(Dispatchers.IO) {
+            subject.get()
+        }
+        runBlocking {
+            assertThat(countDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
+            job1.cancelAndJoin()
+        }
+        countDownLatch = CountDownLatch(1)
+
+        val job2 = GlobalScope.async(Dispatchers.IO) {
+            subject.get()
+        }
+        runBlocking {
+            assertThat(countDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
+            deferred.complete("it works")
+            assertThat(job2.await()).isEqualTo("it works")
+        }
+        assertThat(factoryCount.get()).isEqualTo(2)
+    }
+
+    @Test
+    fun testCancellingOneDoesNotAffectOther() {
+        val factoryCount = AtomicInteger(0)
+        val deferred = CompletableDeferred<String>()
+        val countDownLatch = CountDownLatch(2)
+        val subject = CoalescingOrchestrator(
+            factory = {
+                val result = deferred.await()
+                factoryCount.incrementAndGet()
+                result
+            },
+            keepDataInMemory = { false },
+            awaitListener = {
+                countDownLatch.countDown()
+            },
+        )
+
+        val job1 = GlobalScope.async(Dispatchers.IO) {
+            subject.get()
+        }
+        val job2 = GlobalScope.async(Dispatchers.IO) {
+            subject.get()
+        }
+        runBlocking {
+            assertThat(countDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
+            job2.cancelAndJoin()
+            deferred.complete("it works")
+            assertThat(job1.await()).isEqualTo("it works")
+        }
+
+        assertThat(factoryCount.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun testParallelCallsFactoryOnce() {
+        val factoryCount = AtomicInteger(0)
+        val deferred = CompletableDeferred<String>()
+        val countDownLatch = CountDownLatch(2)
+        val subject = CoalescingOrchestrator(
+            factory = {
+                factoryCount.incrementAndGet()
+                deferred.await()
+            },
+            keepDataInMemory = { false },
+            awaitListener = {
+                countDownLatch.countDown()
+            }
+        )
+
+        val job1 = GlobalScope.async(Dispatchers.IO) {
+            subject.get()
+        }
+        val job2 = GlobalScope.async(Dispatchers.IO) {
+            subject.get()
+        }
+        runBlocking {
+            assertThat(countDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
+            deferred.complete("it works")
+            assertThat(job1.await()).isEqualTo("it works")
+            assertThat(job2.await()).isEqualTo("it works")
+        }
+
+        assertThat(factoryCount.get()).isEqualTo(1)
+        assertThat(countDownLatch.count).isEqualTo(0)
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Multiple parallel calls to customer ephemeral key provider now only call the underlying ephemeral key provider once.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fixes #8837

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
