### PR TITLE
Re-enable recording in Maestro test

### DIFF
--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
@@ -4,7 +4,7 @@ tags:
   - edge
   - testmode-payments
 ---
-#- startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-' + new Date().getTime()}
+- startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-' + new Date().getTime()}
 - clearState
 - openLink: stripeconnectionsexample://playground?integration_type=Standalone&experience=FinancialConnections&flow=PaymentIntent&financial_connections_override_native=native&merchant=testmode&permissions=payment_method&financial_connections_test_mode=true&financial_connections_confirm_intent=true
 - tapOn:
@@ -41,4 +41,4 @@ tags:
 - scrollUntilVisible:
     element:
       text: ".*Intent Confirmed!.*"
-#- stopRecording
+- stopRecording


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request re-enables recording in a Maestro test that I accidentally turned off as part of https://github.com/stripe/stripe-android/pull/8753.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
