### PR TITLE
Update to java 21 toolchain.

### DIFF
--- a/build-configuration/android-application.gradle
+++ b/build-configuration/android-application.gradle
@@ -61,7 +61,7 @@ android {
 
     kotlin {
         jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of("11"))
+            languageVersion.set(JavaLanguageVersion.of("21"))
         }
     }
 

--- a/build-configuration/android-library.gradle
+++ b/build-configuration/android-library.gradle
@@ -80,7 +80,7 @@ android {
 
     kotlin {
         jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of("11"))
+            languageVersion.set(JavaLanguageVersion.of("21"))
         }
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/view/PaymentUtilsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/PaymentUtilsTest.kt
@@ -68,7 +68,7 @@ class PaymentUtilsTest {
         Locale.setDefault(Locale("ar", "JO")) // Jordan
         val jordanianDinar = Currency.getInstance("JOD")
         assertThat(PaymentUtils.formatPriceString(100123.0, jordanianDinar))
-            .isEqualTo("د.أ.\u200F ١٠٠٫١٢٣")
+            .isEqualTo("\u200F١٠٠٫١٢٣ د.أ.\u200F")
 
         Locale.setDefault(Locale.UK)
         val britishPound = Currency.getInstance(Locale.UK)

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/format/CurrencyFormatterTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/format/CurrencyFormatterTest.kt
@@ -154,7 +154,7 @@ class CurrencyFormatterTest {
                 Locale.FRANCE
             )
         )
-            .isEqualTo("1 234,12 \$US")
+            .isEqualTo("1 234,12 \$US")
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I'm trying to upgrade paprazzi, but that fails because we're still compiling with java 11 toolchain.

This does not change anything for merchants. 
