### PR TITLE
Ignore TextField focus exception

### DIFF
--- a/maestro/financial-connections/Testmode-Token-NME.yaml
+++ b/maestro/financial-connections/Testmode-Token-NME.yaml
@@ -68,3 +68,4 @@ tags:
 - scrollUntilVisible:
     element:
       text: ".*Completed.*"
+- stopRecording

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/FocusManagerKt.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/FocusManagerKt.kt
@@ -11,10 +11,18 @@ import com.stripe.android.core.Logger
  * We should log + silently fail instead of crashing when this exception occurs.
  */
 internal fun FocusManager.moveFocusSafely(focusDirection: FocusDirection): Boolean {
+    fun logError(e: Exception) {
+        Logger.getInstance(BuildConfig.DEBUG).warning("Skipping moving focus due to exception: $e")
+    }
+
     try {
         return this.moveFocus(focusDirection)
     } catch (e: IllegalArgumentException) {
-        Logger.getInstance(BuildConfig.DEBUG).warning("Skipping moving focus due to exception: $e")
+        logError(e)
+        // This indicates that focus was not moved.
+        return false
+    } catch (e: IllegalStateException) {
+        logError(e)
         // This indicates that focus was not moved.
         return false
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request ignores an exception we encounter in the OTP element after upgrading to Compose 1.7 (closed pull request [here](https://github.com/stripe/stripe-android/pull/9482)).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
