### PR TITLE
Set the minimum Java toolchain to Java 17.

### DIFF
--- a/build-configuration/android-application.gradle
+++ b/build-configuration/android-application.gradle
@@ -59,12 +59,6 @@ android {
         jvmTarget = "11"
     }
 
-    kotlin {
-        jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of("21"))
-        }
-    }
-
     packagingOptions {
         resources {
             excludes += ['LICENSE.txt']

--- a/build-configuration/android-application.gradle
+++ b/build-configuration/android-application.gradle
@@ -59,6 +59,14 @@ android {
         jvmTarget = "11"
     }
 
+    if (JavaVersion.current() < JavaVersion.VERSION_17) {
+        kotlin {
+            jvmToolchain {
+                languageVersion.set(JavaLanguageVersion.of("17"))
+            }
+        }
+    }
+
     packagingOptions {
         resources {
             excludes += ['LICENSE.txt']

--- a/build-configuration/android-library.gradle
+++ b/build-configuration/android-library.gradle
@@ -77,12 +77,6 @@ android {
     kotlinOptions {
         jvmTarget = "11"
     }
-
-    kotlin {
-        jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of("21"))
-        }
-    }
 }
 
 if (project.hasProperty("enable_dokka") && project.enable_dokka) {

--- a/build-configuration/android-library.gradle
+++ b/build-configuration/android-library.gradle
@@ -77,6 +77,14 @@ android {
     kotlinOptions {
         jvmTarget = "11"
     }
+
+    if (JavaVersion.current() < JavaVersion.VERSION_17) {
+        kotlin {
+            jvmToolchain {
+                languageVersion.set(JavaLanguageVersion.of("17"))
+            }
+        }
+    }
 }
 
 if (project.hasProperty("enable_dokka") && project.enable_dokka) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I had previously set this to 21 to work around a paparazzi issue, but the actual minimum we need is 17.

Ideally we just ignore this, and everyone is on a newer java toolchain version, which is why I added the check.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Less noise for people trying to build the SDK.