### PR TITLE
Set `billingDetails` parameter in hosted auth URL

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -132,9 +132,11 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
         val nativeAuthFlowEnabled = nativeRouter.nativeAuthFlowEnabled(manifest)
         nativeRouter.logExposure(manifest)
 
-        val hostedAuthUrl = buildHostedAuthUrl(
-            hostedAuthUrl = manifest.hostedAuthUrl,
+        val hostedAuthUrl = HostedAuthUrlBuilder.create(
+            args = initialState.initialArgs,
+            manifest = manifest,
         )
+
         if (hostedAuthUrl == null) {
             finishWithResult(
                 state = stateFlow.value,
@@ -165,32 +167,6 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
                 }
             }
         }
-    }
-
-    private fun buildHostedAuthUrl(hostedAuthUrl: String?): String? {
-        if (hostedAuthUrl == null) {
-            return null
-        }
-
-        val isInstantDebits = stateFlow.value.isInstantDebits
-        val elementsSessionContext = initialState.initialArgs.elementsSessionContext
-        val linkMode = elementsSessionContext?.linkMode
-
-        val queryParams = mutableListOf(hostedAuthUrl)
-        if (isInstantDebits) {
-            // For Instant Debits, add a query parameter to the hosted auth URL so that payment account creation
-            // takes place on the web side of the flow and the payment method ID is returned to the app.
-            queryParams.add("return_payment_method=true")
-            linkMode?.let { queryParams.add("link_mode=${it.value}") }
-        }
-
-        elementsSessionContext?.prefillDetails?.run {
-            email?.let { queryParams.add("email=$it") }
-            phone?.let { queryParams.add("linkMobilePhone=$it") }
-            phoneCountryCode?.let { queryParams.add("linkMobilePhoneCountry=$it") }
-        }
-
-        return queryParams.joinToString("&")
     }
 
     private fun logNoBrowserAvailableAndFinish() {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/HostedAuthUrlBuilder.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/HostedAuthUrlBuilder.kt
@@ -1,0 +1,61 @@
+package com.stripe.android.financialconnections
+
+import com.stripe.android.core.networking.QueryStringFactory
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext.BillingDetails
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext.PrefillDetails
+import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityArgs
+import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
+import com.stripe.android.financialconnections.utils.toApiParams
+import com.stripe.android.model.LinkMode
+
+internal object HostedAuthUrlBuilder {
+
+    fun create(
+        args: FinancialConnectionsSheetActivityArgs,
+        manifest: FinancialConnectionsSessionManifest,
+    ): String? {
+        return create(
+            hostedAuthUrl = manifest.hostedAuthUrl,
+            isInstantDebits = args is FinancialConnectionsSheetActivityArgs.ForInstantDebits,
+            linkMode = args.elementsSessionContext?.linkMode,
+            billingDetails = args.elementsSessionContext?.billingDetails,
+            prefillDetails = args.elementsSessionContext?.prefillDetails,
+        )
+    }
+
+    private fun create(
+        hostedAuthUrl: String?,
+        isInstantDebits: Boolean,
+        linkMode: LinkMode?,
+        billingDetails: BillingDetails?,
+        prefillDetails: PrefillDetails?,
+    ): String? {
+        if (hostedAuthUrl == null) {
+            return null
+        }
+
+        val queryParams = mutableListOf(hostedAuthUrl)
+        if (isInstantDebits) {
+            // For Instant Debits, add a query parameter to the hosted auth URL so that payment account creation
+            // takes place on the web side of the flow and the payment method ID is returned to the app.
+            queryParams.add("return_payment_method=true")
+            linkMode?.let { queryParams.add("link_mode=${it.value}") }
+            billingDetails?.let { queryParams.add(makeBillingDetailsQueryParams(it)) }
+        }
+
+        prefillDetails?.run {
+            email?.let { queryParams.add("email=$it") }
+            phone?.let { queryParams.add("linkMobilePhone=$it") }
+            phoneCountryCode?.let { queryParams.add("linkMobilePhoneCountry=$it") }
+        }
+
+        return queryParams.joinToString("&")
+    }
+
+    private fun makeBillingDetailsQueryParams(billingAddress: BillingDetails): String {
+        val params = mapOf(
+            "billing_details" to billingAddress.toApiParams(),
+        )
+        return QueryStringFactory.createFromParamsWithEmptyValues(params)
+    }
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/HostedAuthUrlBuilder.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/HostedAuthUrlBuilder.kt
@@ -54,7 +54,7 @@ internal object HostedAuthUrlBuilder {
 
     private fun makeBillingDetailsQueryParams(billingAddress: BillingDetails): String {
         val params = mapOf(
-            "billing_details" to billingAddress.toApiParams(),
+            "billingDetails" to billingAddress.toApiParams(),
         )
         return QueryStringFactory.createFromParamsWithEmptyValues(params)
     }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
@@ -248,6 +248,60 @@ class FinancialConnectionsSheetViewModelTest {
     }
 
     @Test
+    fun `init - hosted auth url contains billing details`() = runTest {
+        // Given
+        whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)
+        whenever(getOrFetchSync(any())).thenReturn(syncResponse)
+        whenever(nativeRouter.nativeAuthFlowEnabled(any())).thenReturn(false)
+
+        // When
+        val viewModel = createViewModel(
+            defaultInitialState.copy(
+                initialArgs = ForInstantDebits(
+                    configuration = configuration,
+                    elementsSessionContext = ElementsSessionContext(
+                        initializationMode = ElementsSessionContext.InitializationMode.PaymentIntent("pi_123"),
+                        amount = 123,
+                        currency = "usd",
+                        linkMode = null,
+                        billingDetails = ElementsSessionContext.BillingDetails(
+                            name = "John Doe",
+                            address = ElementsSessionContext.BillingDetails.Address(
+                                line1 = "123 Main St",
+                                line2 = "",
+                                city = "Toronto",
+                                state = "ON",
+                                postalCode = "A1B 2C3",
+                                country = "CA",
+                            ),
+                            email = "email@email.com",
+                            phone = null,
+                        ),
+                        prefillDetails = ElementsSessionContext.PrefillDetails(
+                            email = null,
+                            phone = null,
+                            phoneCountryCode = null,
+                        )
+                    ),
+                )
+            )
+        )
+
+        // Then
+        withState(viewModel) {
+            val viewEffect = it.viewEffect as OpenAuthFlowWithUrl
+            assertThat(viewEffect.url).contains("billingDetails%5Bname%5D=John+Doe")
+            assertThat(viewEffect.url).contains("billingDetails%5Bemail%5D=email%40email.com")
+            assertThat(viewEffect.url).contains("billingDetails%5Baddress%5D%5Bline1%5D=123+Main+St")
+            assertThat(viewEffect.url).contains("billingDetails%5Baddress%5D%5Bcity%5D=Toronto")
+            assertThat(viewEffect.url).contains("billingDetails%5Baddress%5D%5Bstate%5D=ON")
+            assertThat(viewEffect.url).contains("billingDetails%5Baddress%5D%5Bpostal_code%5D=A1B+2C3")
+            assertThat(viewEffect.url).contains("billingDetails%5Baddress%5D%5Bcountry%5D=CA")
+            assertThat(viewEffect.url).doesNotContain("billingDetails%5Baddress%5D%5Bline2%5D")
+        }
+    }
+
+    @Test
     fun `init - when data flow and non-native, hosted auth url without query params is launched`() = runTest {
         // Given
         whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds the `billingDetails` query parameter to the mobile web flow of Instant Debits.

The Web part is being worked on [here](https://git.corp.stripe.com/stripe-internal/pay-server/pull/926242).

(cc @mats-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
