### PR TITLE
Fix `Card Brand Choice` animations when nested in bottom sheet.

### DIFF
--- a/payments-core/res/layout/stripe_card_brand_view.xml
+++ b/payments-core/res/layout/stripe_card_brand_view.xml
@@ -3,8 +3,7 @@
 
     <LinearLayout
         android:layout_height="wrap_content"
-        android:layout_width="wrap_content"
-        android:animateLayoutChanges="true">
+        android:layout_width="wrap_content">
 
         <ImageView
             android:id="@+id/icon"

--- a/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -13,6 +13,7 @@ import android.widget.ImageView
 import android.widget.ListPopupWindow
 import android.widget.TextView
 import androidx.annotation.VisibleForTesting
+import androidx.transition.TransitionManager
 import com.stripe.android.R
 import com.stripe.android.databinding.StripeCardBrandViewBinding
 import com.stripe.android.model.CardBrand
@@ -179,6 +180,8 @@ internal class CardBrandView @JvmOverloads constructor(
 
     private fun updateBrandSpinner() {
         val showDropdown = isCbcEligible && possibleBrands.size > 1 && !shouldShowCvc && !shouldShowErrorIcon
+        val parentViewGroup = parent as? ViewGroup
+
         if (showDropdown) {
             initListPopup()
             this.setOnClickListener {
@@ -188,9 +191,12 @@ internal class CardBrandView @JvmOverloads constructor(
                     listPopup.show()
                 }
             }
+
+            parentViewGroup.animateNextChanges()
             chevron.visibility = View.VISIBLE
         } else {
             this.setOnClickListener(null)
+            parentViewGroup.animateNextChanges()
             chevron.visibility = View.GONE
         }
     }
@@ -235,6 +241,13 @@ internal class CardBrandView @JvmOverloads constructor(
         determineCardBrandToDisplay()
         updateBrandSpinner()
         super.onRestoreInstanceState(savedState?.superState ?: state)
+    }
+
+    private fun ViewGroup?.animateNextChanges() {
+        this?.let {
+            TransitionManager.endTransitions(this)
+            TransitionManager.beginDelayedTransition(this)
+        }
     }
 
     @Parcelize


### PR DESCRIPTION
# Summary
Fix `Card Brand Choice` animations when nested in bottom sheet.

# Motivation
Resolves https://github.com/stripe/stripe-android/issues/9130

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Video
| Before | After |
| ------ | ------ |
| <video src="https://github.com/user-attachments/assets/ab9bc415-75d3-4bbc-b888-3700b2dde543" /> | <video src="https://github.com/user-attachments/assets/4016d4ba-02b1-4586-a54b-f2b7b684590f" /> |
