### PR TITLE
[Android] Success pane: "Almost there" copy for microdeposits


### DIFF
--- a/financial-connections/res/values/strings.xml
+++ b/financial-connections/res/values/strings.xml
@@ -41,6 +41,7 @@
     <string name="stripe_search">Search</string>
     <string name="stripe_account_picker_dropdown_hint">Choose one</string>
     <string name="stripe_success_pane_title">Success</string>
+    <string name="stripe_success_pane_title_microdeposits">Almost there</string>
     <string name="stripe_success_pane_desc_microdeposits">You can expect micro-deposits to account ••••%1$s in 1–2 days and an email with further instructions.</string>
     <string name="stripe_success_pane_desc_microdeposits_no_account">You can expect micro-deposits to your account in 1–2 days and an email with further instructions.</string>
     <plurals name="stripe_success_pane_desc">

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
@@ -153,6 +153,9 @@ internal class ManualEntryViewModel @AssistedInject constructor(
                 clearCachedAccounts()
                 if (sync.manifest.manualEntryUsesMicrodeposits) {
                     successContentRepository.set(
+                        heading = TextResource.StringId(
+                            R.string.stripe_success_pane_title_microdeposits
+                        ),
                         message = TextResource.StringId(
                             R.string.stripe_success_pane_desc_microdeposits,
                             listOf(account.takeLast(4))


### PR DESCRIPTION
# Summary
Updates copy to reflect delay in time for microdeposits verification.

# Motivation
:notebook_with_decorative_cover: &nbsp;**[Android] Success pane: "Almost there" copy for microdeposits**
:globe_with_meridians: &nbsp;[BANKCON-15605](https://jira.corp.stripe.com/browse/BANKCON-15605)
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots

<img width="262" alt="image" src="https://github.com/user-attachments/assets/7a032c3e-5fd0-4790-a0a7-bbcd63ccc41d">

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->