### PR TITLE
Use new `Single` interface instead of a `Deferred` wrapper in `CustomerSheet`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/coroutines/Single.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/coroutines/Single.kt
@@ -3,9 +3,23 @@ package com.stripe.android.common.coroutines
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.Duration
 
 internal fun interface Single<T> {
     suspend fun await(): T
+}
+
+internal suspend fun <T> Single<T>.awaitWithTimeout(
+    timeout: Duration,
+    timeoutMessage: () -> String,
+): Result<T> {
+    val result = withTimeoutOrNull(timeout) { await() }
+    return if (result != null) {
+        Result.success(result)
+    } else {
+        Result.failure(IllegalStateException(timeoutMessage()))
+    }
 }
 
 internal fun <T> StateFlow<T?>.asSingle(): Single<T> {

--- a/paymentsheet/src/main/java/com/stripe/android/common/coroutines/Single.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/coroutines/Single.kt
@@ -1,0 +1,15 @@
+package com.stripe.android.common.coroutines
+
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+
+internal fun interface Single<T> {
+    suspend fun await(): T
+}
+
+internal fun <T> StateFlow<T?>.asSingle(): Single<T> {
+    return Single {
+        value ?: filterNotNull().first()
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.customersheet
 
+import com.stripe.android.common.coroutines.Single
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.IS_LIVE_MODE
@@ -19,7 +20,6 @@ import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAv
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.validate
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
@@ -37,7 +37,7 @@ internal class DefaultCustomerSheetLoader(
     private val googlePayRepositoryFactory: @JvmSuppressWildcards (GooglePayEnvironment) -> GooglePayRepository,
     private val isFinancialConnectionsAvailable: IsFinancialConnectionsAvailable,
     private val lpmRepository: LpmRepository,
-    private val initializationDataSourceProvider: Deferred<CustomerSheetInitializationDataSource>,
+    private val initializationDataSourceProvider: Single<CustomerSheetInitializationDataSource>,
     private val errorReporter: ErrorReporter,
     private val workContext: CoroutineContext
 ) : CustomerSheetLoader {
@@ -178,7 +178,7 @@ internal class DefaultCustomerSheetLoader(
     }
 }
 
-private suspend fun <T> Deferred<T>.awaitAsResult(
+private suspend fun <T> Single<T>.awaitAsResult(
     timeout: Duration,
     error: () -> String,
 ): Result<T> {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
+import com.stripe.android.common.coroutines.Single
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
@@ -70,7 +71,6 @@ import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -91,9 +91,9 @@ internal class CustomerSheetViewModel(
     application: Application, // TODO (jameswoo) remove application
     private var originalPaymentSelection: PaymentSelection?,
     private val paymentConfigurationProvider: Provider<PaymentConfiguration>,
-    private val paymentMethodDataSourceProvider: Deferred<CustomerSheetPaymentMethodDataSource>,
-    private val intentDataSourceProvider: Deferred<CustomerSheetIntentDataSource>,
-    private val savedSelectionDataSourceProvider: Deferred<CustomerSheetSavedSelectionDataSource>,
+    private val paymentMethodDataSourceProvider: Single<CustomerSheetPaymentMethodDataSource>,
+    private val intentDataSourceProvider: Single<CustomerSheetIntentDataSource>,
+    private val savedSelectionDataSourceProvider: Single<CustomerSheetSavedSelectionDataSource>,
     private val configuration: CustomerSheet.Configuration,
     private val integrationType: CustomerSheetIntegration.Type,
     private val logger: Logger,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/util/CustomerSheetHacks.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/util/CustomerSheetHacks.kt
@@ -5,6 +5,8 @@ import androidx.activity.ComponentActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.common.coroutines.Single
+import com.stripe.android.common.coroutines.asSingle
 import com.stripe.android.customersheet.CustomerSheetIntegration
 import com.stripe.android.customersheet.data.CustomerSheetInitializationDataSource
 import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
@@ -13,12 +15,7 @@ import com.stripe.android.customersheet.data.CustomerSheetSavedSelectionDataSour
 import com.stripe.android.customersheet.data.injection.DaggerCustomerAdapterDataSourceComponent
 import com.stripe.android.customersheet.data.injection.DaggerCustomerSessionDataSourceComponent
 import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
 
 /**
  * This objects holds references to objects that need to be shared across Activity boundaries
@@ -27,20 +24,20 @@ import kotlinx.coroutines.flow.first
 @OptIn(ExperimentalCustomerSessionApi::class)
 internal object CustomerSheetHacks {
     private val _initializationDataSource = MutableStateFlow<CustomerSheetInitializationDataSource?>(null)
-    val initializationDataSource: Deferred<CustomerSheetInitializationDataSource>
-        get() = _initializationDataSource.asDeferred()
+    val initializationDataSource: Single<CustomerSheetInitializationDataSource>
+        get() = _initializationDataSource.asSingle()
 
     private val _paymentMethodDataSource = MutableStateFlow<CustomerSheetPaymentMethodDataSource?>(null)
-    val paymentMethodDataSource: Deferred<CustomerSheetPaymentMethodDataSource>
-        get() = _paymentMethodDataSource.asDeferred()
+    val paymentMethodDataSource: Single<CustomerSheetPaymentMethodDataSource>
+        get() = _paymentMethodDataSource.asSingle()
 
     private val _savedSelectionDataSource = MutableStateFlow<CustomerSheetSavedSelectionDataSource?>(null)
-    val savedSelectionDataSource: Deferred<CustomerSheetSavedSelectionDataSource>
-        get() = _savedSelectionDataSource.asDeferred()
+    val savedSelectionDataSource: Single<CustomerSheetSavedSelectionDataSource>
+        get() = _savedSelectionDataSource.asSingle()
 
     private val _intentDataSource = MutableStateFlow<CustomerSheetIntentDataSource?>(null)
-    val intentDataSource: Deferred<CustomerSheetIntentDataSource>
-        get() = _intentDataSource.asDeferred()
+    val intentDataSource: Single<CustomerSheetIntentDataSource>
+        get() = _intentDataSource.asSingle()
 
     fun initialize(
         application: Application,
@@ -102,16 +99,5 @@ internal object CustomerSheetHacks {
         _paymentMethodDataSource.value = null
         _savedSelectionDataSource.value = null
         _intentDataSource.value = null
-    }
-}
-
-private fun <T : Any> Flow<T?>.asDeferred(): Deferred<T> {
-    val deferred = CompletableDeferred<T>()
-
-    // Prevent casting to CompletableDeferred and manual completion.
-    return object : Deferred<T> by deferred {
-        override suspend fun await(): T {
-            return this@asDeferred.filterNotNull().first()
-        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/coroutines/SingleKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/coroutines/SingleKtxTest.kt
@@ -1,0 +1,75 @@
+package com.stripe.android.common.coroutines
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
+
+class SingleKtxTest {
+    @Test
+    fun `On converting 'StateFlow' to 'Single' should complete if it has a value`() = runTest {
+        val flow = MutableStateFlow(value = 0)
+
+        assertThat(flow.asSingle().await()).isEqualTo(0)
+    }
+
+    @Test
+    fun `On converting 'StateFlow' to 'Single' should wait until value is set`() = runTest {
+        val countDownLatch = CountDownLatch(1)
+
+        val flow = MutableStateFlow<Int?>(null)
+        val single = flow.asSingle()
+
+        launch {
+            assertThat(single.await()).isEqualTo(0)
+            countDownLatch.countDown()
+        }
+
+        delay(50)
+
+        flow.value = 0
+
+        countDownLatch.await(5, TimeUnit.SECONDS)
+    }
+
+    @Test
+    fun `On await with timeout, should return value if set`() = runTest {
+        val flow = MutableStateFlow(value = 0)
+        val single = flow.asSingle()
+
+        val result = single.awaitWithTimeout(
+            timeout = 1.seconds,
+            timeoutMessage = {
+                "No value was found!"
+            }
+        )
+
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(0)
+    }
+
+    @Test
+    fun `On await with timeout, should fail if timeout message if a value is not set`() = runTest {
+        val flow = MutableStateFlow<Int?>(value = null)
+        val single = flow.asSingle()
+
+        val result = single.awaitWithTimeout(
+            timeout = 1.seconds,
+            timeoutMessage = {
+                "No value was found!"
+            }
+        )
+
+        assertThat(result.isFailure).isTrue()
+
+        val exception = result.exceptionOrNull()
+
+        assertThat(exception).isInstanceOf(IllegalStateException::class.java)
+        assertThat(exception?.message).isEqualTo("No value was found!")
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/coroutines/SingleKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/coroutines/SingleKtxTest.kt
@@ -4,41 +4,36 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.runTest
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.seconds
 
 class SingleKtxTest {
     @Test
-    fun `On converting 'StateFlow' to 'Single' should complete if it has a value`() = runTest {
+    fun `On converting 'StateFlow' to 'Single' should complete if it has a value`() = runBlocking {
         val flow = MutableStateFlow(value = 0)
 
         assertThat(flow.asSingle().await()).isEqualTo(0)
     }
 
     @Test
-    fun `On converting 'StateFlow' to 'Single' should wait until value is set`() = runTest {
-        val countDownLatch = CountDownLatch(1)
-
+    fun `On converting 'StateFlow' to 'Single' should wait until value is set`() = runBlocking {
         val flow = MutableStateFlow<Int?>(null)
         val single = flow.asSingle()
 
-        launch {
+        val job = launch {
             assertThat(single.await()).isEqualTo(0)
-            countDownLatch.countDown()
         }
 
         delay(50)
 
         flow.value = 0
 
-        countDownLatch.await(5, TimeUnit.SECONDS)
+        job.join()
     }
 
     @Test
-    fun `On await with timeout, should return value if set`() = runTest {
+    fun `On await with timeout, should return value if set`() = runBlocking {
         val flow = MutableStateFlow(value = 0)
         val single = flow.asSingle()
 
@@ -54,7 +49,7 @@ class SingleKtxTest {
     }
 
     @Test
-    fun `On await with timeout, should fail if timeout message if a value is not set`() = runTest {
+    fun `On await with timeout, should fail if timeout message if a value is not set`() = runBlocking {
         val flow = MutableStateFlow<Int?>(value = null)
         val single = flow.asSingle()
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.customersheet.state
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ExperimentalCardBrandFilteringApi
+import com.stripe.android.common.coroutines.Single
 import com.stripe.android.customersheet.CustomerPermissions
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetLoader
@@ -32,9 +33,9 @@ import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.testing.PaymentMethodFactory.update
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import com.stripe.android.utils.CompletableSingle
 import com.stripe.android.utils.FakeElementsSessionRepository
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -333,7 +334,7 @@ class DefaultCustomerSheetLoaderTest {
 
     @Test
     fun `Awaits InitializationDataSource if InitializationDataSource is provided after loading started`() = runTest {
-        val initDataSource = CompletableDeferred<CustomerSheetInitializationDataSource>()
+        val initDataSource = CompletableSingle<CustomerSheetInitializationDataSource>()
 
         val configuration = CustomerSheet.Configuration(merchantDisplayName = "Merchant, Inc.")
         val loader = DefaultCustomerSheetLoader(
@@ -395,7 +396,7 @@ class DefaultCustomerSheetLoaderTest {
         val errorReporter = FakeErrorReporter()
 
         val loader = createCustomerSheetLoader(
-            initializationDataSourceProvider = CompletableDeferred(),
+            initializationDataSourceProvider = CompletableSingle(),
             errorReporter = errorReporter,
         )
 
@@ -482,7 +483,7 @@ class DefaultCustomerSheetLoaderTest {
         errorReporter: ErrorReporter = FakeErrorReporter(),
     ): CustomerSheetLoader {
         return createCustomerSheetLoader(
-            initializationDataSourceProvider = CompletableDeferred(initializationDataSource),
+            initializationDataSourceProvider = CompletableSingle(initializationDataSource),
             isGooglePayReady = isGooglePayReady,
             isLiveModeProvider = isLiveModeProvider,
             isFinancialConnectionsAvailable = isFinancialConnectionsAvailable,
@@ -492,7 +493,7 @@ class DefaultCustomerSheetLoaderTest {
     }
 
     private fun createCustomerSheetLoader(
-        initializationDataSourceProvider: Deferred<CustomerSheetInitializationDataSource>,
+        initializationDataSourceProvider: Single<CustomerSheetInitializationDataSource>,
         isGooglePayReady: Boolean = true,
         isLiveModeProvider: () -> Boolean = { false },
         isFinancialConnectionsAvailable: IsFinancialConnectionsAvailable = IsFinancialConnectionsAvailable { false },

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetHacksTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetHacksTest.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.coroutines.Single
 import com.stripe.android.customersheet.CustomerSheetIntegration
 import com.stripe.android.customersheet.FakeCustomerAdapter
 import com.stripe.android.customersheet.data.CustomerAdapterDataSource
@@ -15,7 +16,6 @@ import com.stripe.android.customersheet.data.CustomerSessionSavedSelectionDataSo
 import com.stripe.android.customersheet.util.CustomerSheetHacks
 import com.stripe.android.isInstanceOf
 import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.After
@@ -84,7 +84,7 @@ class CustomerSheetHacksTest {
         assertThat(CustomerSheetHacks.savedSelectionDataSource.awaitWithTimeout()).isNull()
     }
 
-    private suspend fun <T> Deferred<T>.awaitWithTimeout(): T? {
+    private suspend fun <T> Single<T>.awaitWithTimeout(): T? {
         return withTimeoutOrNull(1.seconds) { await() }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -49,9 +49,9 @@ import com.stripe.android.paymentsheet.ui.PaymentMethodUpdateOperation
 import com.stripe.android.paymentsheet.utils.FakeUserFacingLogger
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import com.stripe.android.utils.CompletableSingle
 import com.stripe.android.utils.DummyActivityResultCaller
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.StandardTestDispatcher
 import org.mockito.kotlin.mock
@@ -112,9 +112,9 @@ internal object CustomerSheetTestHelper {
             workContext = workContext,
             originalPaymentSelection = savedPaymentSelection,
             paymentConfigurationProvider = { paymentConfiguration },
-            paymentMethodDataSourceProvider = CompletableDeferred(paymentMethodDataSource),
-            intentDataSourceProvider = CompletableDeferred(intentDataSource),
-            savedSelectionDataSourceProvider = CompletableDeferred(savedSelectionDataSource),
+            paymentMethodDataSourceProvider = CompletableSingle(paymentMethodDataSource),
+            intentDataSourceProvider = CompletableSingle(intentDataSource),
+            savedSelectionDataSourceProvider = CompletableSingle(savedSelectionDataSource),
             stripeRepository = stripeRepository,
             configuration = configuration,
             integrationType = integrationType,

--- a/paymentsheet/src/test/java/com/stripe/android/utils/CompletableSingle.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/CompletableSingle.kt
@@ -1,0 +1,18 @@
+package com.stripe.android.utils
+
+import com.stripe.android.common.coroutines.Single
+import kotlinx.coroutines.CompletableDeferred
+
+internal class CompletableSingle<T>(val value: T? = null) : Single<T> {
+    private val deferred: CompletableDeferred<T> = value?.let {
+        CompletableDeferred(it)
+    } ?: CompletableDeferred()
+
+    override suspend fun await(): T {
+        return deferred.await()
+    }
+
+    fun complete(value: T) {
+        deferred.complete(value)
+    }
+}


### PR DESCRIPTION
# Summary
Use new `Single` interface instead of a `Deferred` wrapper in `CustomerSheet`

# Motivation
Helps with move to Kotlin 2.0

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
