### PR TITLE
Improve prefill in bank flows

### DIFF
--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -140,6 +140,11 @@ internal class FinancialConnectionsPlaygroundViewModel(
                                 billingDetails = ElementsSessionContext.BillingDetails(
                                     email = settings.get<EmailSetting>().selectedOption,
                                 ),
+                                prefillDetails = ElementsSessionContext.PrefillDetails(
+                                    email = settings.get<EmailSetting>().selectedOption,
+                                    phone = null,
+                                    phoneCountryCode = null,
+                                ),
                             ),
                             experience = settings.get<ExperienceSetting>().selectedOption,
                             integrationType = settings.get<IntegrationTypeSetting>().selectedOption,

--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -193,6 +193,14 @@ public final class com/stripe/android/financialconnections/FinancialConnectionsS
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$PrefillDetails$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$PrefillDetails;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$ElementsSessionContext$PrefillDetails;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/financialconnections/FinancialConnectionsSheetComposeKt {
 	public static final fun rememberFinancialConnectionsSheet (Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)Lcom/stripe/android/financialconnections/FinancialConnectionsSheet;
 	public static final fun rememberFinancialConnectionsSheetForToken (Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)Lcom/stripe/android/financialconnections/FinancialConnectionsSheet;

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheet.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheet.kt
@@ -47,6 +47,7 @@ class FinancialConnectionsSheet internal constructor(
         val currency: String?,
         val linkMode: LinkMode?,
         val billingDetails: BillingDetails?,
+        val prefillDetails: PrefillDetails,
     ) : Parcelable {
 
         val paymentIntentId: String?
@@ -91,6 +92,14 @@ class FinancialConnectionsSheet internal constructor(
                 val country: String? = null,
             ) : Parcelable
         }
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @Parcelize
+        data class PrefillDetails(
+            val email: String?,
+            val phone: String?,
+            val phoneCountryCode: String?,
+        ) : Parcelable
     }
 
     /**

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -176,11 +176,6 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
         val elementsSessionContext = initialState.initialArgs.elementsSessionContext
         val linkMode = elementsSessionContext?.linkMode
 
-        val prefillDetails = elementsSessionContext?.prefillDetails
-        val email = prefillDetails?.email
-        val phone = prefillDetails?.phone
-        val phoneCountry = prefillDetails?.phoneCountryCode
-
         val queryParams = mutableListOf(hostedAuthUrl)
         if (isInstantDebits) {
             // For Instant Debits, add a query parameter to the hosted auth URL so that payment account creation
@@ -189,9 +184,11 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
             linkMode?.let { queryParams.add("link_mode=${it.value}") }
         }
 
-        email?.let { queryParams.add("email=$it") }
-        phone?.let { queryParams.add("linkMobilePhone=$it") }
-        phoneCountry?.let { queryParams.add("linkMobilePhoneCountry=$it") }
+        elementsSessionContext?.prefillDetails?.run {
+            email?.let { queryParams.add("email=$it") }
+            phone?.let { queryParams.add("linkMobilePhone=$it") }
+            phoneCountryCode?.let { queryParams.add("linkMobilePhoneCountry=$it") }
+        }
 
         return queryParams.joinToString("&")
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -54,7 +54,6 @@ import com.stripe.android.financialconnections.navigation.topappbar.TopAppBarSta
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsViewModel
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
 import com.stripe.android.financialconnections.utils.parcelable
-import com.stripe.android.model.LinkMode
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -128,16 +127,13 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
             logNoBrowserAvailableAndFinish()
             return
         }
+
         val manifest = sync.manifest
-        val isInstantDebits = stateFlow.value.isInstantDebits
         val nativeAuthFlowEnabled = nativeRouter.nativeAuthFlowEnabled(manifest)
         nativeRouter.logExposure(manifest)
 
-        val linkMode = initialState.initialArgs.elementsSessionContext?.linkMode
         val hostedAuthUrl = buildHostedAuthUrl(
             hostedAuthUrl = manifest.hostedAuthUrl,
-            isInstantDebits = isInstantDebits,
-            linkMode = linkMode,
         )
         if (hostedAuthUrl == null) {
             finishWithResult(
@@ -171,14 +167,19 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
         }
     }
 
-    private fun buildHostedAuthUrl(
-        hostedAuthUrl: String?,
-        isInstantDebits: Boolean,
-        linkMode: LinkMode?,
-    ): String? {
+    private fun buildHostedAuthUrl(hostedAuthUrl: String?): String? {
         if (hostedAuthUrl == null) {
             return null
         }
+
+        val isInstantDebits = stateFlow.value.isInstantDebits
+        val elementsSessionContext = initialState.initialArgs.elementsSessionContext
+        val linkMode = elementsSessionContext?.linkMode
+
+        val prefillDetails = elementsSessionContext?.prefillDetails
+        val email = prefillDetails?.email
+        val phone = prefillDetails?.phone
+        val phoneCountry = prefillDetails?.phoneCountryCode
 
         val queryParams = mutableListOf(hostedAuthUrl)
         if (isInstantDebits) {
@@ -187,6 +188,10 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
             queryParams.add("return_payment_method=true")
             linkMode?.let { queryParams.add("link_mode=${it.value}") }
         }
+
+        email?.let { queryParams.add("email=$it") }
+        phone?.let { queryParams.add("linkMobilePhone=$it") }
+        phoneCountry?.let { queryParams.add("linkMobilePhoneCountry=$it") }
 
         return queryParams.joinToString("&")
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupScreen.kt
@@ -151,7 +151,9 @@ private fun NetworkingLinkSignupLoaded(
     LaunchedEffect(showFullForm) {
         if (showFullForm) {
             scrollState.animateScrollToBottom()
-            phoneNumberFocusRequester.requestFocus()
+            if (payload.focusPhoneFieldOnShow) {
+                phoneNumberFocusRequester.requestFocus()
+            }
         }
     }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetActivityArgs.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetActivityArgs.kt
@@ -20,14 +20,16 @@ sealed class FinancialConnectionsSheetActivityArgs(
     @Parcelize
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class ForData(
-        override val configuration: FinancialConnectionsSheet.Configuration
-    ) : FinancialConnectionsSheetActivityArgs(configuration, elementsSessionContext = null)
+        override val configuration: FinancialConnectionsSheet.Configuration,
+        override val elementsSessionContext: FinancialConnectionsSheet.ElementsSessionContext? = null,
+    ) : FinancialConnectionsSheetActivityArgs(configuration, elementsSessionContext)
 
     @Parcelize
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class ForToken(
-        override val configuration: FinancialConnectionsSheet.Configuration
-    ) : FinancialConnectionsSheetActivityArgs(configuration, elementsSessionContext = null)
+        override val configuration: FinancialConnectionsSheet.Configuration,
+        override val elementsSessionContext: FinancialConnectionsSheet.ElementsSessionContext? = null,
+    ) : FinancialConnectionsSheetActivityArgs(configuration, elementsSessionContext)
 
     @Parcelize
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForDataLauncher.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForDataLauncher.kt
@@ -56,7 +56,8 @@ class FinancialConnectionsSheetForDataLauncher(
     ) {
         activityResultLauncher.launch(
             FinancialConnectionsSheetActivityArgs.ForData(
-                configuration
+                configuration = configuration,
+                elementsSessionContext = elementsSessionContext,
             )
         )
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForTokenLauncher.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForTokenLauncher.kt
@@ -54,7 +54,8 @@ internal class FinancialConnectionsSheetForTokenLauncher(
     ) {
         activityResultLauncher.launch(
             FinancialConnectionsSheetActivityArgs.ForToken(
-                configuration
+                configuration = configuration,
+                elementsSessionContext = elementsSessionContext,
             )
         )
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetNativeActivityArgs.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetNativeActivityArgs.kt
@@ -6,7 +6,7 @@ import com.stripe.android.financialconnections.model.SynchronizeSessionResponse
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-internal data class FinancialConnectionsSheetNativeActivityArgs constructor(
+internal data class FinancialConnectionsSheetNativeActivityArgs(
     val configuration: FinancialConnectionsSheet.Configuration,
     val initialSyncResponse: SynchronizeSessionResponse,
     val elementsSessionContext: FinancialConnectionsSheet.ElementsSessionContext? = null,

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
@@ -150,6 +150,11 @@ class FinancialConnectionsSheetViewModelTest {
                             currency = "usd",
                             linkMode = LinkMode.LinkPaymentMethod,
                             billingDetails = null,
+                            prefillDetails = ElementsSessionContext.PrefillDetails(
+                                email = null,
+                                phone = null,
+                                phoneCountryCode = null,
+                            )
                         ),
                     )
                 )
@@ -182,6 +187,11 @@ class FinancialConnectionsSheetViewModelTest {
                         currency = "usd",
                         linkMode = null,
                         billingDetails = null,
+                        prefillDetails = ElementsSessionContext.PrefillDetails(
+                            email = null,
+                            phone = null,
+                            phoneCountryCode = null,
+                        )
                     ),
                 )
             )
@@ -192,6 +202,47 @@ class FinancialConnectionsSheetViewModelTest {
             val viewEffect = it.viewEffect as OpenAuthFlowWithUrl
             assertThat(viewEffect.url).isEqualTo(
                 "${syncResponse.manifest.hostedAuthUrl}&return_payment_method=true"
+            )
+        }
+    }
+
+    @Test
+    fun `init - hosted auth url contains prefill details`() = runTest {
+        // Given
+        whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)
+        whenever(getOrFetchSync(any())).thenReturn(syncResponse)
+        whenever(nativeRouter.nativeAuthFlowEnabled(any())).thenReturn(false)
+
+        // When
+        val viewModel = createViewModel(
+            defaultInitialState.copy(
+                initialArgs = ForInstantDebits(
+                    configuration = configuration,
+                    elementsSessionContext = ElementsSessionContext(
+                        initializationMode = ElementsSessionContext.InitializationMode.PaymentIntent("pi_123"),
+                        amount = 123,
+                        currency = "usd",
+                        linkMode = null,
+                        billingDetails = null,
+                        prefillDetails = ElementsSessionContext.PrefillDetails(
+                            email = "email@email.com",
+                            phone = "5555551234",
+                            phoneCountryCode = "US",
+                        )
+                    ),
+                )
+            )
+        )
+
+        // Then
+        withState(viewModel) {
+            val viewEffect = it.viewEffect as OpenAuthFlowWithUrl
+            assertThat(viewEffect.url).isEqualTo(
+                syncResponse.manifest.hostedAuthUrl +
+                    "&return_payment_method=true" +
+                    "&email=email@email.com" +
+                    "&linkMobilePhone=5555551234" +
+                    "&linkMobilePhoneCountry=US"
             )
         }
     }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/RealCreateInstantDebitsResultTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/RealCreateInstantDebitsResultTest.kt
@@ -219,6 +219,11 @@ class RealCreateInstantDebitsResultTest {
             currency = "usd",
             linkMode = linkMode,
             billingDetails = billingDetails,
+            prefillDetails = ElementsSessionContext.PrefillDetails(
+                email = null,
+                phone = null,
+                phoneCountryCode = null,
+            )
         )
     }
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
@@ -122,6 +122,7 @@ class NetworkingLinkSignupViewModelTest {
                 amount = null,
                 currency = null,
                 linkMode = LinkMode.LinkPaymentMethod,
+                billingDetails = null,
                 prefillDetails = ElementsSessionContext.PrefillDetails(
                     email = "email@email.com",
                     phone = "5555555555",

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
@@ -9,6 +9,8 @@ import com.stripe.android.financialconnections.ApiKeyFixtures.consumerSessionSig
 import com.stripe.android.financialconnections.ApiKeyFixtures.sessionManifest
 import com.stripe.android.financialconnections.ApiKeyFixtures.syncResponse
 import com.stripe.android.financialconnections.CoroutineTestRule
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext.InitializationMode
 import com.stripe.android.financialconnections.TestFinancialConnectionsAnalyticsTracker
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.ConsentAgree.analyticsValue
 import com.stripe.android.financialconnections.domain.GetCachedAccounts
@@ -32,6 +34,7 @@ import com.stripe.android.financialconnections.repository.FinancialConnectionsCo
 import com.stripe.android.financialconnections.utils.TestHandleError
 import com.stripe.android.financialconnections.utils.UriUtils
 import com.stripe.android.model.ConsumerSessionLookup
+import com.stripe.android.model.LinkMode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -58,6 +61,7 @@ class NetworkingLinkSignupViewModelTest {
     private fun buildViewModel(
         state: NetworkingLinkSignupState,
         signupHandler: LinkSignupHandler = mockLinkSignupHandlerForNetworking(),
+        elementsSessionContext: ElementsSessionContext? = null,
     ) = NetworkingLinkSignupViewModel(
         getOrFetchSync = getOrFetchSync,
         logger = Logger.noop(),
@@ -69,6 +73,7 @@ class NetworkingLinkSignupViewModelTest {
         nativeAuthFlowCoordinator = nativeAuthFlowCoordinator,
         presentSheet = mock(),
         linkSignupHandler = signupHandler,
+        elementsSessionContext = elementsSessionContext,
     )
 
     @Test
@@ -93,6 +98,43 @@ class NetworkingLinkSignupViewModelTest {
         val state = viewModel.stateFlow.value
         val payload = requireNotNull(state.payload())
         assertThat(payload.emailController.fieldValue.value).isEqualTo("test@test.com")
+    }
+
+    @Test
+    fun `init - creates controllers with Elements billing details`() = runTest {
+        val manifest = sessionManifest()
+
+        whenever(getOrFetchSync(any())).thenReturn(
+            syncResponse().copy(
+                manifest = manifest,
+                text = TextUpdate(
+                    consent = null,
+                    networkingLinkSignupPane = networkingLinkSignupPane(),
+                )
+            )
+        )
+        whenever(lookupAccount(any())).thenReturn(ConsumerSessionLookup(exists = false))
+
+        val viewModel = buildViewModel(
+            state = NetworkingLinkSignupState(),
+            elementsSessionContext = ElementsSessionContext(
+                initializationMode = InitializationMode.PaymentIntent("pi_1234"),
+                amount = null,
+                currency = null,
+                linkMode = LinkMode.LinkPaymentMethod,
+                prefillDetails = ElementsSessionContext.PrefillDetails(
+                    email = "email@email.com",
+                    phone = "5555555555",
+                    phoneCountryCode = "US",
+                ),
+            )
+        )
+
+        val state = viewModel.stateFlow.value
+        val payload = requireNotNull(state.payload())
+        assertThat(payload.emailController.fieldValue.value).isEqualTo("email@email.com")
+        assertThat(payload.phoneController.fieldValue.value).isEqualTo("5555555555")
+        assertThat(payload.phoneController.countryDropdownController.rawFieldValue.value).isEqualTo("US")
     }
 
     @Test

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepositoryImplTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepositoryImplTest.kt
@@ -164,6 +164,11 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
                 currency = "cad",
                 linkMode = LinkMode.LinkPaymentMethod,
                 billingDetails = null,
+                prefillDetails = ElementsSessionContext.PrefillDetails(
+                    email = null,
+                    phone = null,
+                    phoneCountryCode = null,
+                ),
             )
         )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -532,6 +532,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
             } else {
                 null
             },
+            prefillDetails = makePrefillDetails(),
         )
     }
 
@@ -556,6 +557,14 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
                     country = it.country,
                 )
             },
+        )
+    }
+
+    private fun makePrefillDetails(): ElementsSessionContext.PrefillDetails {
+        return ElementsSessionContext.PrefillDetails(
+            email = email.value ?: defaultBillingDetails?.email,
+            phone = phone.value ?: defaultBillingDetails?.phone,
+            phoneCountryCode = phoneController.getCountryCode(),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -839,6 +839,11 @@ class USBankAccountFormViewModelTest {
                             name = "Jenny Rose",
                             email = "email@email.com",
                         ),
+                        prefillDetails = ElementsSessionContext.PrefillDetails(
+                            email = "email@email.com",
+                            phone = null,
+                            phoneCountryCode = "US",
+                        ),
                     ),
                 )
             ),
@@ -891,6 +896,11 @@ class USBankAccountFormViewModelTest {
                         billingDetails = ElementsSessionContext.BillingDetails(
                             name = "Jenny Rose",
                             email = "email@email.com",
+                        ),
+                        prefillDetails = ElementsSessionContext.PrefillDetails(
+                            email = "email@email.com",
+                            phone = null,
+                            phoneCountryCode = "US",
                         ),
                     ),
                 )
@@ -1103,6 +1113,11 @@ class USBankAccountFormViewModelTest {
                             name = "Some Name",
                             email = "email@email.com",
                         ),
+                        prefillDetails = ElementsSessionContext.PrefillDetails(
+                            email = "email@email.com",
+                            phone = null,
+                            phoneCountryCode = "US",
+                        ),
                     ),
                 )
             ),
@@ -1139,6 +1154,11 @@ class USBankAccountFormViewModelTest {
                         linkMode = LinkMode.LinkCardBrand,
                         billingDetails = ElementsSessionContext.BillingDetails(
                             email = "email@email.com",
+                        ),
+                        prefillDetails = ElementsSessionContext.PrefillDetails(
+                            email = "email@email.com",
+                            phone = null,
+                            phoneCountryCode = "US",
                         ),
                     ),
                 )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds `PrefillDetails` to `ElementsSessionContext`, which helps us prefill the form in the bank auth flow — both in the native and in the web flow.

This is irrespective of https://github.com/stripe/stripe-android/pull/9446, which is about the billing details we use when we construct the `PaymentMethod` object.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
