### PR TITLE
Remove unused `eligibleForNetworking` property

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/LinkAccountSessionPaymentAccount.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/LinkAccountSessionPaymentAccount.kt
@@ -12,9 +12,6 @@ internal data class LinkAccountSessionPaymentAccount(
     @Required
     val id: String,
 
-    @SerialName(value = "eligible_for_networking")
-    val eligibleForNetworking: Boolean? = null,
-
     @SerialName(value = "microdeposit_verification_method")
     val microdepositVerificationMethod: MicrodepositVerificationMethod = UNKNOWN,
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PollAttachPaymentAccountTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PollAttachPaymentAccountTest.kt
@@ -51,7 +51,6 @@ internal class PollAttachPaymentAccountTest {
         )
         val paymentAccount = LinkAccountSessionPaymentAccount(
             id = "acct_123",
-            eligibleForNetworking = true,
             microdepositVerificationMethod = DESCRIPTOR_CODE,
         )
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request removes the unused `eligibleForNetworking` property, which is being removed on [Web and backend](https://git.corp.stripe.com/stripe-internal/pay-server/pull/929759) as well.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
