### PR TITLE
Fix `CardBrandView` dropdown is not removed when CVC is shown

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -59,7 +59,7 @@ internal class CardBrandView @JvmOverloads constructor(
         get() = state.isCbcEligible
         set(value) {
             stateFlow.update { it.copy(isCbcEligible = value) }
-            updateBrandSpinner()
+            updateBrandSpinner(animate = true)
         }
 
     var brand: CardBrand
@@ -67,7 +67,7 @@ internal class CardBrandView @JvmOverloads constructor(
         set(value) {
             stateFlow.update { it.copy(brand = value) }
             determineCardBrandToDisplay()
-            updateBrandSpinner()
+            updateBrandSpinner(animate = true)
         }
 
     var possibleBrands: List<CardBrand>
@@ -75,7 +75,7 @@ internal class CardBrandView @JvmOverloads constructor(
         set(value) {
             stateFlow.update { it.copy(possibleBrands = value) }
             determineCardBrandToDisplay()
-            updateBrandSpinner()
+            updateBrandSpinner(animate = true)
         }
 
     var merchantPreferredNetworks: List<CardBrand>
@@ -90,6 +90,7 @@ internal class CardBrandView @JvmOverloads constructor(
         set(value) {
             stateFlow.update { it.copy(shouldShowCvc = value) }
             setCardBrandIconAndTint()
+            updateBrandSpinner(animate = false)
         }
 
     var shouldShowErrorIcon: Boolean
@@ -104,7 +105,7 @@ internal class CardBrandView @JvmOverloads constructor(
         isFocusable = false
 
         determineCardBrandToDisplay()
-        updateBrandSpinner()
+        updateBrandSpinner(animate = false)
     }
 
     fun paymentMethodCreateParamsNetworks(): PaymentMethodCreateParams.Card.Networks? {
@@ -178,7 +179,7 @@ internal class CardBrandView @JvmOverloads constructor(
         setCardBrandIconAndTint()
     }
 
-    private fun updateBrandSpinner() {
+    private fun updateBrandSpinner(animate: Boolean) {
         val showDropdown = isCbcEligible && possibleBrands.size > 1 && !shouldShowCvc && !shouldShowErrorIcon
         val parentViewGroup = parent as? ViewGroup
 
@@ -192,11 +193,18 @@ internal class CardBrandView @JvmOverloads constructor(
                 }
             }
 
-            parentViewGroup.animateNextChanges()
+            if (animate) {
+                parentViewGroup.animateNextChanges()
+            }
+
             chevron.visibility = View.VISIBLE
         } else {
             this.setOnClickListener(null)
-            parentViewGroup.animateNextChanges()
+
+            if (animate) {
+                parentViewGroup.animateNextChanges()
+            }
+
             chevron.visibility = View.GONE
         }
     }
@@ -239,7 +247,7 @@ internal class CardBrandView @JvmOverloads constructor(
         val savedState = state as? SavedState
         this.state = savedState?.state ?: State()
         determineCardBrandToDisplay()
-        updateBrandSpinner()
+        updateBrandSpinner(animate = false)
         super.onRestoreInstanceState(savedState?.superState ?: state)
     }
 

--- a/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -1742,6 +1742,7 @@ internal class CardInputWidgetTest {
             expiryDateEditText.append("12")
             expiryDateEditText.append("50")
             cvcEditText.append("123")
+            cardNumberEditText.requestFocus()
 
             onView(withId(R.id.card_brand_view)).perform(click())
             onData(anything()).inRoot(isPlatformPopup()).atPosition(1).perform(click())


### PR DESCRIPTION
# Summary
Fix an issue with `CardBrandView` in which the dropdown is not removed when the CVC logo is shown.

# Motivation
Partially mitigates https://github.com/stripe/stripe-react-native/issues/1764 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Video
[Fix.webm](https://github.com/user-attachments/assets/4541d65b-2a8e-4c0a-bc26-793ad0a8c5cb)