### PR TITLE
Remove individually applied padding from form elements

### DIFF
--- a/identity-example/src/main/java/com/stripe/android/identity/example/ui/RequirePhoneVerificationUI.kt
+++ b/identity-example/src/main/java/com/stripe/android/identity/example/ui/RequirePhoneVerificationUI.kt
@@ -63,6 +63,7 @@ internal fun RequirePhoneVerificationUI(
                 .padding(horizontal = 20.dp)
         ) {
             SectionElementUI(
+                modifier = Modifier.padding(vertical = 8.dp),
                 enabled = true,
                 element = SectionElement.wrap(
                     PhoneNumberElement(
@@ -71,7 +72,7 @@ internal fun RequirePhoneVerificationUI(
                     )
                 ),
                 hiddenIdentifiers = emptySet(),
-                lastTextFieldIdentifier = IdentifierSpec.Phone
+                lastTextFieldIdentifier = IdentifierSpec.Phone,
             )
         }
     }

--- a/identity/src/main/java/com/stripe/android/identity/ui/AddressSection.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/AddressSection.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.identity.ui
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
@@ -120,6 +121,7 @@ private fun AddressSectionContent(
     navController: NavController
 ) {
     SectionElementUI(
+        modifier = Modifier.padding(vertical = 8.dp),
         enabled = enabled,
         element = sectionElement,
         hiddenIdentifiers = emptySet(),

--- a/identity/src/main/java/com/stripe/android/identity/ui/DOBSection.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/DOBSection.kt
@@ -1,15 +1,18 @@
 package com.stripe.android.identity.ui
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
 import com.stripe.android.identity.R
 import com.stripe.android.identity.networking.Resource
 import com.stripe.android.identity.networking.models.DobParam
@@ -70,10 +73,11 @@ internal fun DOBSection(
     }
 
     SectionElementUI(
+        modifier = Modifier.padding(vertical = 8.dp),
         enabled = enabled,
         element = dobSectionElement,
         hiddenIdentifiers = setOf(),
-        lastTextFieldIdentifier = null
+        lastTextFieldIdentifier = null,
     )
 }
 

--- a/identity/src/main/java/com/stripe/android/identity/ui/IDNumberSection.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/IDNumberSection.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.identity.ui
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
@@ -167,10 +168,11 @@ private fun IDNumberContent(
     }
 
     SectionElementUI(
+        modifier = Modifier.padding(vertical = 8.dp),
         enabled = enabled,
         element = idNumberSectionElement,
         hiddenIdentifiers = emptySet(),
-        lastTextFieldIdentifier = textIdentifiers.lastOrNull()
+        lastTextFieldIdentifier = textIdentifiers.lastOrNull(),
     )
 
     TextButton(

--- a/identity/src/main/java/com/stripe/android/identity/ui/NameSection.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/NameSection.kt
@@ -1,9 +1,12 @@
 package com.stripe.android.identity.ui
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.stripe.android.identity.R
 import com.stripe.android.identity.networking.Resource
 import com.stripe.android.identity.networking.models.NameParam
@@ -54,10 +57,11 @@ internal fun NameSection(
     val lastName by lastNameController.fieldValue.collectAsState()
 
     SectionElementUI(
+        modifier = Modifier.padding(vertical = 8.dp),
         enabled = enabled,
         element = nameSectionElement,
         hiddenIdentifiers = setOf(),
-        lastTextFieldIdentifier = null
+        lastTextFieldIdentifier = null,
     )
 
     LaunchedEffect(firstName, lastName) {

--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignupFields.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignupFields.kt
@@ -47,7 +47,6 @@ internal fun LinkInlineSignupFields(
     Section(
         title = null,
         error = sectionError?.let { stringResource(it) },
-        addVerticalPadding = false,
         modifier = modifier,
     ) {
         if (isShowingPhoneFirst) {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
@@ -93,23 +93,22 @@ private fun FormUIElement(
     lastTextFieldIdentifier: IdentifierSpec?,
 ) {
     when (element) {
-        is SectionElement -> {
-            SectionElementUI(
-                modifier = Modifier.padding(vertical = 8.dp),
-                enabled = enabled,
-                element = element,
-                hiddenIdentifiers = hiddenIdentifiers,
-                lastTextFieldIdentifier = lastTextFieldIdentifier,
-            )
-        }
-        is CheckboxFieldElement -> {
-            CheckboxFieldUI(
-                modifier = Modifier.padding(vertical = 4.dp),
-                controller = element.controller,
-                enabled = enabled
-            )
-        }
-        is StaticTextElement -> StaticTextElementUI(element)
+        is SectionElement -> SectionElementUI(
+            modifier = Modifier.padding(vertical = 8.dp),
+            enabled = enabled,
+            element = element,
+            hiddenIdentifiers = hiddenIdentifiers,
+            lastTextFieldIdentifier = lastTextFieldIdentifier,
+        )
+        is CheckboxFieldElement -> CheckboxFieldUI(
+            modifier = Modifier.padding(vertical = 4.dp),
+            controller = element.controller,
+            enabled = enabled
+        )
+        is StaticTextElement -> StaticTextElementUI(
+            element = element,
+            modifier = Modifier.padding(vertical = 8.dp),
+        )
         is SaveForFutureUseElement -> SaveForFutureUseElementUI(
             modifier = Modifier.padding(vertical = 4.dp),
             enabled = enabled,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
@@ -3,9 +3,11 @@ package com.stripe.android.ui.core
 import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.stripe.android.ui.core.elements.AffirmElementUI
 import com.stripe.android.ui.core.elements.AffirmHeaderElement
 import com.stripe.android.ui.core.elements.AfterpayClearpayElementUI
@@ -70,7 +72,7 @@ fun FormUI(
     Column(
         modifier = modifier.fillMaxWidth(1f)
     ) {
-        elements.forEachIndexed { _, element ->
+        elements.forEachIndexed { index, element ->
             if (!hiddenIdentifiers.contains(element.identifier)) {
                 FormUIElement(
                     element = element,
@@ -91,32 +93,56 @@ private fun FormUIElement(
     lastTextFieldIdentifier: IdentifierSpec?,
 ) {
     when (element) {
-        is SectionElement -> SectionElementUI(
-            enabled,
-            element,
-            hiddenIdentifiers,
-            lastTextFieldIdentifier
-        )
-        is CheckboxFieldElement -> CheckboxFieldUI(
-            controller = element.controller,
-            enabled = enabled
-        )
+        is SectionElement -> {
+            SectionElementUI(
+                modifier = Modifier.padding(vertical = 8.dp),
+                enabled = enabled,
+                element = element,
+                hiddenIdentifiers = hiddenIdentifiers,
+                lastTextFieldIdentifier = lastTextFieldIdentifier,
+            )
+        }
+        is CheckboxFieldElement -> {
+            CheckboxFieldUI(
+                modifier = Modifier.padding(vertical = 4.dp),
+                controller = element.controller,
+                enabled = enabled
+            )
+        }
         is StaticTextElement -> StaticTextElementUI(element)
-        is SaveForFutureUseElement -> SaveForFutureUseElementUI(enabled, element)
-        is AfterpayClearpayHeaderElement -> AfterpayClearpayElementUI(
-            enabled,
-            element
+        is SaveForFutureUseElement -> SaveForFutureUseElementUI(
+            modifier = Modifier.padding(vertical = 4.dp),
+            enabled = enabled,
+            element = element,
         )
-        is AuBecsDebitMandateTextElement -> AuBecsDebitMandateElementUI(element)
-        is AffirmHeaderElement -> AffirmElementUI()
-        is MandateTextElement -> MandateTextUI(element)
+        is AfterpayClearpayHeaderElement -> AfterpayClearpayElementUI(
+            enabled = enabled,
+            element = element,
+            modifier = Modifier.padding(4.dp, 8.dp, 4.dp, 4.dp),
+        )
+        is AuBecsDebitMandateTextElement -> AuBecsDebitMandateElementUI(
+            element = element,
+            modifier = Modifier.padding(vertical = 8.dp),
+        )
+        is AffirmHeaderElement -> AffirmElementUI(
+            modifier = Modifier.padding(vertical = 8.dp),
+        )
+        is MandateTextElement -> MandateTextUI(
+            element = element,
+            modifier = Modifier.padding(top = element.topPadding, bottom = 8.dp)
+        )
         is CardDetailsSectionElement -> CardDetailsSectionElementUI(
             enabled,
             element.controller,
             hiddenIdentifiers,
             lastTextFieldIdentifier
         )
-        is BsbElement -> BsbElementUI(enabled, element, lastTextFieldIdentifier)
+        is BsbElement -> BsbElementUI(
+            enabled = enabled,
+            element = element,
+            lastTextFieldIdentifier = lastTextFieldIdentifier,
+            modifier = Modifier.padding(vertical = 8.dp),
+        )
         is OTPElement -> OTPElementUI(enabled, element)
         is RenderableFormElement -> element.ComposeUI(enabled)
         is EmptyFormElement -> {}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AffirmElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AffirmElementUI.kt
@@ -1,12 +1,10 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.text.EmbeddableImage
@@ -15,7 +13,7 @@ import com.stripe.android.R as StripeR
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun AffirmElementUI() {
+fun AffirmElementUI(modifier: Modifier = Modifier) {
     Html(
         html = stringResource(id = StripeR.string.stripe_affirm_buy_now_pay_later),
         imageLoader = mapOf(
@@ -26,6 +24,6 @@ fun AffirmElementUI() {
         ),
         color = MaterialTheme.stripeColors.subtitle,
         style = MaterialTheme.typography.h6,
-        modifier = Modifier.padding(vertical = 8.dp)
+        modifier = modifier,
     )
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayElementUI.kt
@@ -3,7 +3,6 @@ package com.stripe.android.ui.core.elements
 import android.content.Intent
 import android.net.Uri
 import androidx.annotation.RestrictTo
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -12,7 +11,6 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.unit.dp
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.AfterpayClearpayHeaderElement.Companion.isClearpay
 import com.stripe.android.uicore.shouldUseDarkDynamicColor
@@ -24,7 +22,8 @@ import com.stripe.android.uicore.text.Html
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun AfterpayClearpayElementUI(
     enabled: Boolean,
-    element: AfterpayClearpayHeaderElement
+    element: AfterpayClearpayHeaderElement,
+    modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     val messageFormatString = element.getLabel(context.resources)
@@ -52,7 +51,7 @@ fun AfterpayClearpayElementUI(
                 }
             )
         ),
-        modifier = Modifier.padding(4.dp, 8.dp, 4.dp, 4.dp),
+        modifier = modifier,
         color = MaterialTheme.stripeColors.subtitle,
         style = MaterialTheme.typography.h6,
         urlSpanStyle = SpanStyle(),

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateElementUI.kt
@@ -1,12 +1,10 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.text.Html
 import com.stripe.android.R as StripeR
@@ -14,12 +12,13 @@ import com.stripe.android.R as StripeR
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun AuBecsDebitMandateElementUI(
-    element: AuBecsDebitMandateTextElement
+    element: AuBecsDebitMandateTextElement,
+    modifier: Modifier = Modifier,
 ) {
     Html(
         html = stringResource(id = StripeR.string.stripe_au_becs_mandate, element.merchantName ?: ""),
         color = MaterialTheme.stripeColors.subtitle,
         style = MaterialTheme.typography.body2,
-        modifier = Modifier.padding(vertical = 8.dp)
+        modifier = modifier,
     )
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbElementUI.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -19,7 +20,8 @@ import com.stripe.android.uicore.utils.collectAsState
 fun BsbElementUI(
     enabled: Boolean,
     element: BsbElement,
-    lastTextFieldIdentifier: IdentifierSpec?
+    lastTextFieldIdentifier: IdentifierSpec?,
+    modifier: Modifier = Modifier,
 ) {
     val error by element.textElement.controller.error.collectAsState()
     val bankName by element.bankName.collectAsState()
@@ -53,7 +55,8 @@ fun BsbElementUI(
                         color = MaterialTheme.stripeColors.subtitle
                     )
                 }
-            }
+            },
+            modifier = modifier,
         )
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUI.kt
@@ -4,12 +4,14 @@ import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
 import com.stripe.android.stripecardscan.cardscan.CardScanSheetResult
 import com.stripe.android.stripecardscan.cardscan.exception.UnknownScanException
 import com.stripe.android.ui.core.R
@@ -26,7 +28,7 @@ fun CardDetailsSectionElementUI(
     enabled: Boolean,
     controller: CardDetailsSectionController,
     hiddenIdentifiers: Set<IdentifierSpec>,
-    lastTextFieldIdentifier: IdentifierSpec?
+    lastTextFieldIdentifier: IdentifierSpec?,
 ) {
     Row(
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -53,6 +55,7 @@ fun CardDetailsSectionElementUI(
         }
     }
     SectionElementUI(
+        modifier = Modifier.padding(vertical = 8.dp),
         enabled = enabled,
         element = SectionElement(
             IdentifierSpec.Generic("credit_details"),

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextUI.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -11,7 +10,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import com.stripe.android.uicore.stripeColors
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -20,7 +18,8 @@ const val MANDATE_TEST_TAG = "mandate_test_tag"
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun MandateTextUI(
-    element: MandateTextElement
+    element: MandateTextElement,
+    modifier: Modifier = Modifier,
 ) {
     Text(
         text = stringResource(element.stringResId, *element.args.toTypedArray()),
@@ -29,11 +28,7 @@ fun MandateTextUI(
             fontWeight = FontWeight.Normal,
         ),
         color = MaterialTheme.stripeColors.placeholderText,
-        modifier = Modifier
-            .padding(
-                top = element.topPadding,
-                bottom = 8.dp
-            )
+        modifier = modifier
             .semantics(mergeDescendants = true) {} // makes it a separate accessibile item
             .testTag(MANDATE_TEST_TAG)
     )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/StaticTextElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/StaticTextElementUI.kt
@@ -1,23 +1,21 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.unit.dp
 import com.stripe.android.uicore.elements.H6Text
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun StaticTextElementUI(
-    element: StaticTextElement
+    element: StaticTextElement,
+    modifier: Modifier,
 ) {
     H6Text(
         text = stringResource(element.stringResId),
-        modifier = Modifier
-            .padding(vertical = 8.dp)
+        modifier = modifier
             .semantics(mergeDescendants = true) {} // makes it a separate accessible item
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -127,6 +127,7 @@ internal fun InputAddressScreen(
                 checkboxContent = {
                     viewModel.args.config?.additionalFields?.checkboxLabel?.let { label ->
                         CheckboxElementUI(
+                            modifier = Modifier.padding(vertical = 4.dp),
                             isChecked = checkboxChecked,
                             label = label,
                             isEnabled = formEnabled,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
@@ -346,7 +346,11 @@ private fun PhoneSection(
             .padding(0.dp),
         contentAlignment = Alignment.CenterEnd
     ) {
-        Section(null, sectionErrorString) {
+        Section(
+            modifier = Modifier.padding(vertical = 8.dp),
+            title = null,
+            error = sectionErrorString,
+        ) {
             PhoneNumberElementUI(
                 enabled = !isProcessing,
                 controller = phoneController,
@@ -382,7 +386,11 @@ private fun AddressSection(
         contentAlignment = Alignment.CenterEnd
     ) {
         Column {
-            Section(PaymentsUiCoreR.string.stripe_billing_details, sectionErrorString) {
+            Section(
+                modifier = Modifier.padding(vertical = 8.dp),
+                title = PaymentsUiCoreR.string.stripe_billing_details,
+                error = sectionErrorString,
+            ) {
                 AddressElementUI(
                     enabled = !isProcessing,
                     controller = addressController,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CheckboxElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CheckboxElementUI.kt
@@ -37,7 +37,6 @@ fun CheckboxElementUI(
 
     Row(
         modifier = modifier
-            .padding(vertical = 4.dp)
             .semantics {
                 testTag = automationTestTag
                 stateDescription = accessibilityDescription

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberElementUI.kt
@@ -81,6 +81,7 @@ fun PhoneNumberCollectionSection(
     }
 
     Section(
+        modifier = Modifier.padding(vertical = 8.dp),
         title = sectionTitle,
         error = sectionErrorString,
         isSelected = isSelected

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingElementUI.kt
@@ -1,9 +1,12 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.stripe.android.uicore.utils.collectAsState
 
 const val SAME_AS_SHIPPING_CHECKBOX_TEST_TAG = "SAME_AS_SHIPPING_CHECKBOX_TEST_TAG"
@@ -17,6 +20,7 @@ fun SameAsShippingElementUI(
     val label by controller.label.collectAsState()
 
     CheckboxElementUI(
+        modifier = Modifier.padding(vertical = 4.dp),
         automationTestTag = SAME_AS_SHIPPING_CHECKBOX_TEST_TAG,
         isChecked = checked,
         label = stringResource(label),

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElementUI.kt
@@ -23,6 +23,7 @@ fun SectionElementUI(
     element: SectionElement,
     hiddenIdentifiers: Set<IdentifierSpec>,
     lastTextFieldIdentifier: IdentifierSpec?,
+    modifier: Modifier = Modifier,
     nextFocusDirection: FocusDirection = FocusDirection.Down,
     previousFocusDirection: FocusDirection = FocusDirection.Up
 ) {
@@ -49,6 +50,7 @@ fun SectionElementUI(
         Section(
             controller.label,
             sectionErrorString,
+            modifier = modifier,
             contentOutsideCard = {
                 elementsOutsideCard.forEach { field ->
                     SectionFieldElementUI(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionUI.kt
@@ -9,7 +9,6 @@ import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
@@ -31,21 +30,17 @@ fun Section(
     error: String?,
     modifier: Modifier = Modifier,
     isSelected: Boolean = false,
-    addVerticalPadding: Boolean = true,
     contentOutsideCard: @Composable () -> Unit = {},
     contentInCard: @Composable () -> Unit
 ) {
-    val verticalPadding = remember(addVerticalPadding) {
-        if (addVerticalPadding) 8.dp else 0.dp
-    }
-
-    Column(modifier = modifier.padding(top = verticalPadding)) {
-        SectionTitle(title)
-        SectionCard(
-            isSelected = isSelected,
-            content = contentInCard,
-            modifier = Modifier.padding(bottom = verticalPadding)
-        )
+    Column {
+        Column(modifier = modifier) {
+            SectionTitle(title)
+            SectionCard(
+                isSelected = isSelected,
+                content = contentInCard,
+            )
+        }
         if (error != null) {
             SectionError(error)
         }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
@@ -107,7 +107,12 @@ fun TextFieldSection(
         } ?: stringResource(it.errorMessage)
     }
 
-    Section(title = sectionTitle, error = sectionErrorString, isSelected = isSelected) {
+    Section(
+        modifier = Modifier.padding(vertical = 8.dp),
+        title = sectionTitle,
+        error = sectionErrorString,
+        isSelected = isSelected,
+    ) {
         TextField(
             textFieldController = textFieldController,
             enabled = enabled,


### PR DESCRIPTION
# Summary
This is a prototype of a first step to a solution for fixing form element padding within the form displayed in `PaymentSheet`. Rather than have the individual components define their own padding, the consumers of the elements must define how an element is spaced.

# Motivation
We make a lot of padding assumptions when rendering elements, especially in regards to whether elements are above and/or below a rendered element. This has created problems in trying to properly space other UI elements outside the form because the bottom and top form padding are unknown to the consumer. 

With better control over the padding in `FormUI` we can render the exact amount of padding we need within the form while removing any top padding from the first element and bottom padding from the last element, allowing the consumer better control over how to define the spacing outside the form which help immensely with fixing mandate and error spacing. 