### PR TITLE
Pass lowercase email into `BillingDetails`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -545,7 +545,8 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
 
         return ElementsSessionContext.BillingDetails(
             name = name,
-            email = email,
+            // The createPaymentDetails endpoint does not accept uppercase characters.
+            email = email?.lowercase(),
             phone = phone?.let { phoneController.getE164PhoneNumber(it) },
             address = address?.let {
                 ElementsSessionContext.BillingDetails.Address(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue when passing billing addresses containing uppercase characters to the payment details create endpoint.

(cc @mats-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
