### PR TITLE
Move `SameAsShippingElement` outside of `AddressElement`'s `Section` definition

### DIFF
--- a/payments-ui-core/detekt-baseline.xml
+++ b/payments-ui-core/detekt-baseline.xml
@@ -5,8 +5,10 @@
     <ID>ConstructorParameterNaming:CardNumberElement.kt$CardNumberElement$val _identifier: IdentifierSpec</ID>
     <ID>ConstructorParameterNaming:CvcElement.kt$CvcElement$val _identifier: IdentifierSpec</ID>
     <ID>CyclomaticComplexMethod:FormItemSpec.kt$FormItemSpecSerializer$override fun selectDeserializer(element: JsonElement): DeserializationStrategy&lt;FormItemSpec></ID>
+    <ID>CyclomaticComplexMethod:FormUI.kt$@Composable private fun FormUIElement( element: FormElement, enabled: Boolean, hiddenIdentifiers: Set&lt;IdentifierSpec>, lastTextFieldIdentifier: IdentifierSpec?, )</ID>
     <ID>CyclomaticComplexMethod:TransformGoogleToStripeAddress.kt$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun Place.transformGoogleToStripeAddress( context: Context ): com.stripe.android.model.Address</ID>
     <ID>ForbiddenComment:Menu.kt$// TODO: Make sure this gets the rounded corner values</ID>
+    <ID>LongMethod:FormUI.kt$@Composable private fun FormUIElement( element: FormElement, enabled: Boolean, hiddenIdentifiers: Set&lt;IdentifierSpec>, lastTextFieldIdentifier: IdentifierSpec?, )</ID>
     <ID>LongMethod:Menu.kt$@Suppress("ModifierParameter") @Composable internal fun DropdownMenuContent( expandedStates: MutableTransitionState&lt;Boolean>, transformOriginState: MutableState&lt;TransformOrigin>, initialFirstVisibleItemIndex: Int, modifier: Modifier = Modifier, content: LazyListScope.() -> Unit )</ID>
     <ID>LongMethod:TransformGoogleToStripeAddress.kt$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun Place.transformGoogleToStripeAddress( context: Context ): com.stripe.android.model.Address</ID>
     <ID>LongMethod:TransformGoogleToStripeAddressTest.kt$TransformGoogleToStripeAddressTest$@Test fun `test JP address`()</ID>
@@ -36,7 +38,6 @@
     <ID>MaxLineLength:AddressElementTest.kt$AddressElementTest$fun</ID>
     <ID>MaxLineLength:AndroidMenu.kt$*</ID>
     <ID>MaxLineLength:CardDetailsControllerTest.kt$CardDetailsControllerTest$fun</ID>
-    <ID>MaxLineLength:CardNumberConfigTest.kt$CardNumberConfigTest$Truth.assertThat(cardNumberConfig.determineState(CardBrand.Visa, "", CardBrand.Visa.getMaxLengthForCardNumber("")))</ID>
     <ID>MaxLineLength:CardNumberConfigTest.kt$CardNumberConfigTest$Truth.assertThat(cardNumberConfig.visualTransformation.filter(AnnotatedString(CardNumberFixtures.AMEX_NO_SPACES)).text)</ID>
     <ID>MaxLineLength:CardNumberConfigTest.kt$CardNumberConfigTest$Truth.assertThat(cardNumberConfig.visualTransformation.filter(AnnotatedString(CardNumberFixtures.DINERS_CLUB_14_NO_SPACES)).text)</ID>
     <ID>MaxLineLength:CardNumberConfigTest.kt$CardNumberConfigTest$Truth.assertThat(cardNumberConfig.visualTransformation.filter(AnnotatedString(CardNumberFixtures.DINERS_CLUB_16_NO_SPACES)).text)</ID>
@@ -44,11 +45,6 @@
     <ID>MaxLineLength:CardNumberConfigTest.kt$CardNumberConfigTest$Truth.assertThat(cardNumberConfig.visualTransformation.filter(AnnotatedString(CardNumberFixtures.JCB_NO_SPACES)).text)</ID>
     <ID>MaxLineLength:CardNumberConfigTest.kt$CardNumberConfigTest$Truth.assertThat(cardNumberConfig.visualTransformation.filter(AnnotatedString(CardNumberFixtures.UNIONPAY_NO_SPACES)).text)</ID>
     <ID>MaxLineLength:CardNumberConfigTest.kt$CardNumberConfigTest$Truth.assertThat(cardNumberConfig.visualTransformation.filter(AnnotatedString(CardNumberFixtures.VISA_NO_SPACES)).text)</ID>
-    <ID>MaxLineLength:CardNumberConfigTest.kt$CardNumberConfigTest$val state = cardNumberConfig.determineState(CardBrand.Unknown, "0", CardBrand.Unknown.getMaxLengthForCardNumber("0"))</ID>
-    <ID>MaxLineLength:CardNumberConfigTest.kt$CardNumberConfigTest$val state = cardNumberConfig.determineState(CardBrand.Visa, "12", CardBrand.Visa.getMaxLengthForCardNumber("12"))</ID>
-    <ID>MaxLineLength:CardNumberConfigTest.kt$CardNumberConfigTest$val state = cardNumberConfig.determineState(CardBrand.Visa, "1234567890123456789", CardBrand.Visa.getMaxLengthForCardNumber("1234567890123456789"))</ID>
-    <ID>MaxLineLength:CardNumberConfigTest.kt$CardNumberConfigTest$val state = cardNumberConfig.determineState(CardBrand.Visa, "4242424242424242", CardBrand.Visa.getMaxLengthForCardNumber("4242424242424242"))</ID>
-    <ID>MaxLineLength:CardNumberConfigTest.kt$CardNumberConfigTest$val state = cardNumberConfig.determineState(CardBrand.Visa, "4242424242424243", CardBrand.Visa.getMaxLengthForCardNumber("4242424242424243"))</ID>
     <ID>MaxLineLength:CardNumberControllerTest.kt$CardNumberControllerTest$fun</ID>
     <ID>SpreadOperator:BsbElementUI.kt$( it.errorMessage, *args )</ID>
     <ID>SpreadOperator:MandateTextElement.kt$MandateTextElement$(stringResId, *args.toTypedArray())</ID>

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
@@ -32,6 +32,8 @@ import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.OTPElement
 import com.stripe.android.uicore.elements.OTPElementUI
+import com.stripe.android.uicore.elements.SameAsShippingElement
+import com.stripe.android.uicore.elements.SameAsShippingElementUI
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SectionElementUI
 import com.stripe.android.uicore.utils.collectAsState
@@ -113,6 +115,10 @@ private fun FormUIElement(
             modifier = Modifier.padding(vertical = 4.dp),
             enabled = enabled,
             element = element,
+        )
+        is SameAsShippingElement -> SameAsShippingElementUI(
+            controller = element.controller,
+            modifier = Modifier.padding(vertical = 4.dp),
         )
         is AfterpayClearpayHeaderElement -> AfterpayClearpayElementUI(
             enabled = enabled,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
@@ -9,10 +9,10 @@ import com.stripe.android.uicore.elements.AddressType
 import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.DropdownFieldController
+import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SameAsShippingController
 import com.stripe.android.uicore.elements.SameAsShippingElement
-import com.stripe.android.uicore.elements.SectionElement
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -56,19 +56,21 @@ data class AddressSpec(
     fun transform(
         initialValues: Map<IdentifierSpec, String?>,
         shippingValues: Map<IdentifierSpec, String?>?,
-    ): SectionElement? {
+    ): List<FormElement> {
         val label = if (showLabel) R.string.stripe_billing_details else null
         return if (displayFields.size == 1 && displayFields.first() == DisplayField.Country) {
-            createSectionElement(
-                sectionFieldElement = CountryElement(
-                    identifier = IdentifierSpec.Generic("billing_details[address][country]"),
-                    controller = DropdownFieldController(
-                        CountryConfig(this.allowedCountryCodes),
-                        initialValue = initialValues[this.apiPath]
-                    )
-                ),
-                label = label
-            ).takeUnless { hideCountry }
+            listOfNotNull(
+                createSectionElement(
+                    sectionFieldElement = CountryElement(
+                        identifier = IdentifierSpec.Generic("billing_details[address][country]"),
+                        controller = DropdownFieldController(
+                            CountryConfig(this.allowedCountryCodes),
+                            initialValue = initialValues[this.apiPath]
+                        )
+                    ),
+                    label = label
+                ).takeUnless { hideCountry }
+            )
         } else {
             val sameAsShippingElement =
                 shippingValues?.get(IdentifierSpec.SameAsShipping)
@@ -88,12 +90,12 @@ data class AddressSpec(
                 shippingValuesMap = shippingValues,
                 hideCountry = hideCountry,
             )
-            createSectionElement(
-                sectionFieldElements = listOfNotNull(
-                    addressElement,
-                    sameAsShippingElement
+            listOfNotNull(
+                createSectionElement(
+                    sectionFieldElement = addressElement,
+                    label = label
                 ),
-                label = label
+                sameAsShippingElement,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilder.kt
@@ -75,13 +75,12 @@ internal class FormElementsBuilder(
             addAll(uiFormElements)
 
             if (requireBillingAddressCollection) {
-                val addressElement = AddressSpec(allowedCountryCodes = availableCountries).transform(
+                val elements = AddressSpec(allowedCountryCodes = availableCountries).transform(
                     initialValues = arguments.initialValues,
                     shippingValues = arguments.shippingValues,
                 )
-                if (addressElement != null) {
-                    add(addressElement)
-                }
+
+                addAll(elements)
             }
 
             addAll(footerFormElements) // Order footers last.

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElements.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElements.kt
@@ -50,35 +50,32 @@ internal class TransformSpecToElements(
             placeholderOverrideList = placeholderOverrideList,
             requiresMandate = arguments.requiresMandate,
             specs = specs,
-        ).mapNotNull {
-            when (it) {
-                is StaticTextSpec -> it.transform()
-                is AfterpayClearpayTextSpec -> it.transform()
-                is AffirmTextSpec -> it.transform()
-                is EmptyFormSpec -> EmptyFormElement()
-                is MandateTextSpec -> it.transform(arguments.merchantName)
-                is AuBecsDebitMandateTextSpec -> it.transform(arguments.merchantName)
-                is BacsDebitBankAccountSpec -> it.transform(arguments.initialValues)
-                is BacsDebitConfirmSpec -> it.transform(arguments.merchantName, arguments.initialValues)
-                is BsbSpec -> it.transform(arguments.initialValues)
-                is OTPSpec -> it.transform()
-                is NameSpec -> it.transform(arguments.initialValues)
-                is EmailSpec -> it.transform(arguments.initialValues)
-                is PhoneSpec -> it.transform(arguments.initialValues)
-                is SimpleTextSpec -> it.transform(arguments.initialValues)
-                is AuBankAccountNumberSpec -> it.transform(arguments.initialValues)
-                is IbanSpec -> it.transform(arguments.initialValues)
-                is KlarnaHeaderStaticTextSpec -> it.transform()
-                is DropdownSpec -> it.transform(arguments.initialValues)
-                is CountrySpec -> it.transform(arguments.initialValues)
-                is AddressSpec -> it.transform(
-                    arguments.initialValues,
-                    arguments.shippingValues
-                )
-                is SepaMandateTextSpec -> it.transform(arguments.merchantName)
-                is PlaceholderSpec -> null // Placeholders should be processed before calling transform.
-                is CashAppPayMandateTextSpec -> it.transform(arguments.merchantName)
-                is KlarnaMandateTextSpec -> it.transform(arguments.merchantName)
+        ).flatMap { spec ->
+            when (spec) {
+                is StaticTextSpec -> listOf(spec.transform())
+                is AfterpayClearpayTextSpec -> listOf(spec.transform())
+                is AffirmTextSpec -> listOf(spec.transform())
+                is EmptyFormSpec -> listOf(EmptyFormElement())
+                is MandateTextSpec -> listOf(spec.transform(arguments.merchantName))
+                is AuBecsDebitMandateTextSpec -> listOf(spec.transform(arguments.merchantName))
+                is BacsDebitBankAccountSpec -> listOf(spec.transform(arguments.initialValues))
+                is BacsDebitConfirmSpec -> listOf(spec.transform(arguments.merchantName, arguments.initialValues))
+                is BsbSpec -> listOf(spec.transform(arguments.initialValues))
+                is OTPSpec -> listOf(spec.transform())
+                is NameSpec -> listOf(spec.transform(arguments.initialValues))
+                is EmailSpec -> listOf(spec.transform(arguments.initialValues))
+                is PhoneSpec -> listOf(spec.transform(arguments.initialValues))
+                is SimpleTextSpec -> listOf(spec.transform(arguments.initialValues))
+                is AuBankAccountNumberSpec -> listOf(spec.transform(arguments.initialValues))
+                is IbanSpec -> listOf(spec.transform(arguments.initialValues))
+                is KlarnaHeaderStaticTextSpec -> listOf(spec.transform())
+                is DropdownSpec -> listOf(spec.transform(arguments.initialValues))
+                is CountrySpec -> listOf(spec.transform(arguments.initialValues))
+                is AddressSpec -> spec.transform(arguments.initialValues, arguments.shippingValues)
+                is SepaMandateTextSpec -> listOf(spec.transform(arguments.merchantName))
+                is PlaceholderSpec -> listOf() // Placeholders should be processed before calling transform.
+                is CashAppPayMandateTextSpec -> listOf(spec.transform(arguments.merchantName))
+                is KlarnaMandateTextSpec -> listOf(spec.transform(arguments.merchantName))
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -94,8 +94,8 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
             if (billingDetailsCollectionConfiguration.address
                 != PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
             ) {
-                add(
-                    cardBillingElement(
+                addAll(
+                    cardBillingElements(
                         billingDetailsCollectionConfiguration.address.toInternal(),
                         arguments.initialValues,
                         arguments.shippingValues,
@@ -175,11 +175,11 @@ internal fun PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectio
     }
 }
 
-private fun cardBillingElement(
+private fun cardBillingElements(
     collectionMode: BillingDetailsCollectionConfiguration.AddressCollectionMode,
     initialValues: Map<IdentifierSpec, String?>,
     shippingValues: Map<IdentifierSpec, String?>?,
-): FormElement {
+): List<FormElement> {
     val sameAsShippingElement =
         shippingValues?.get(IdentifierSpec.SameAsShipping)
             ?.toBooleanStrictOrNull()
@@ -198,12 +198,12 @@ private fun cardBillingElement(
         collectionMode = collectionMode,
     )
 
-    return SectionElement.wrap(
-        listOfNotNull(
+    return listOfNotNull(
+        SectionElement.wrap(
             addressElement,
-            sameAsShippingElement
+            PaymentsUiCoreR.string.stripe_billing_details,
         ),
-        PaymentsUiCoreR.string.stripe_billing_details
+        sameAsShippingElement,
     )
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
@@ -399,7 +399,7 @@ private fun AddressSection(
                 )
             }
             sameAsShippingElement?.let {
-                SameAsShippingElementUI(it.controller)
+                SameAsShippingElementUI(it.controller, Modifier.padding(vertical = 4.dp))
             }
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.uicore.elements.FormElement
+import com.stripe.android.uicore.elements.SameAsShippingElement
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import org.junit.Test
@@ -74,14 +75,11 @@ class CardDefinitionTest {
                 shippingDetails = AddressDetails(isCheckboxSelected = true)
             )
         )
-        assertThat(formElements).hasSize(2)
+        assertThat(formElements).hasSize(3)
         assertThat(formElements[0].identifier.v1).isEqualTo("card_details")
         assertThat(formElements[1].identifier.v1).isEqualTo("credit_billing_section")
-
-        val billingDetailsElement = formElements[1] as SectionElement
-        assertThat(billingDetailsElement.fields).hasSize(2)
-        assertThat(billingDetailsElement.fields[0].identifier.v1).isEqualTo("credit_billing")
-        assertThat(billingDetailsElement.fields[1].identifier.v1).isEqualTo("same_as_shipping")
+        assertThat(formElements[2].identifier.v1).isEqualTo("same_as_shipping")
+        assertThat(formElements[2]).isInstanceOf(SameAsShippingElement::class.java)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -235,16 +235,20 @@ internal class FormViewModelTest {
             paymentMethodCode = PaymentMethod.Type.SepaDebit.code,
             billingDetails = null
         )
+        val addressElements = AddressSpec(
+            IdentifierSpec.Generic("address"),
+            allowedCountryCodes = setOf("US", "JP")
+        )
+            .transform(emptyMap(), emptyMap())
+            .toTypedArray()
+
         val formViewModel = createViewModel(
             args,
             listOfNotNull(
                 NameSpec().transform(emptyMap()),
                 EmailSpec().transform(emptyMap()),
                 IbanSpec().transform(emptyMap()),
-                AddressSpec(
-                    IdentifierSpec.Generic("address"),
-                    allowedCountryCodes = setOf("US", "JP")
-                ).transform(emptyMap(), emptyMap()),
+                *addressElements,
                 MandateTextSpec(
                     IdentifierSpec.Generic("mandate"),
                     R.string.stripe_sepa_mandate
@@ -316,16 +320,20 @@ internal class FormViewModelTest {
             paymentMethodCode = PaymentMethod.Type.SepaDebit.code,
             billingDetails = null
         )
+        val addressElements = AddressSpec(
+            IdentifierSpec.Generic("address"),
+            allowedCountryCodes = setOf("US", "JP")
+        )
+            .transform(emptyMap(), emptyMap())
+            .toTypedArray()
+
         val formViewModel = createViewModel(
             args,
             listOfNotNull(
                 NameSpec().transform(emptyMap()),
                 EmailSpec().transform(emptyMap()),
                 IbanSpec().transform(emptyMap()),
-                AddressSpec(
-                    IdentifierSpec.Generic("address"),
-                    allowedCountryCodes = setOf("US", "JP")
-                ).transform(emptyMap(), emptyMap()),
+                *addressElements,
                 MandateTextSpec(
                     IdentifierSpec.Generic("mandate"),
                     R.string.stripe_sepa_mandate
@@ -562,6 +570,12 @@ internal class FormViewModelTest {
                 billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
                 billingDetails = PaymentSheet.BillingDetails(),
             )
+            val addressElements = AddressSpec(hideCountry = true)
+                .transform(
+                    initialValues = emptyMap(),
+                    shippingValues = emptyMap(),
+                )
+                .toTypedArray()
             val formViewModel = createViewModel(
                 args,
                 listOfNotNull(
@@ -569,10 +583,7 @@ internal class FormViewModelTest {
                     EmailSpec().transform(emptyMap()),
                     PhoneSpec().transform(emptyMap()),
                     CountrySpec().transform(emptyMap()),
-                    AddressSpec(hideCountry = true).transform(
-                        initialValues = emptyMap(),
-                        shippingValues = emptyMap(),
-                    ),
+                    *addressElements,
                 ),
             )
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingController.kt
@@ -1,9 +1,6 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.mapAsStateFlow
@@ -15,7 +12,7 @@ import kotlinx.coroutines.flow.asStateFlow
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class SameAsShippingController(
     initialValue: Boolean
-) : InputController, SectionFieldComposable {
+) : InputController {
     override val label: StateFlow<Int> = stateFlowOf(R.string.stripe_billing_same_as_shipping)
     private val _value = MutableStateFlow(initialValue)
     val value: StateFlow<Boolean> = _value.asStateFlow()
@@ -36,18 +33,5 @@ class SameAsShippingController(
 
     override fun onRawValueChange(rawValue: String) {
         onValueChange(rawValue.toBooleanStrictOrNull() ?: true)
-    }
-
-    @Composable
-    override fun ComposeUI(
-        enabled: Boolean,
-        field: SectionFieldElement,
-        modifier: Modifier,
-        hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?,
-        nextFocusDirection: FocusDirection,
-        previousFocusDirection: FocusDirection
-    ) {
-        SameAsShippingElementUI(this)
     }
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingElement.kt
@@ -2,21 +2,27 @@ package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.uicore.forms.FormFieldEntry
+import com.stripe.android.uicore.utils.mapAsStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class SameAsShippingElement(
     override val identifier: IdentifierSpec,
     override val controller: SameAsShippingController
-) : SectionSingleFieldElement(identifier) {
-    override val shouldRenderOutsideCard: Boolean
-        get() = true
-
+) : FormElement {
     override val allowsUserInteraction: Boolean = true
     override val mandateText: ResolvableString? = null
 
-    override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
+    fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
         rawValuesMap[identifier]?.let {
             controller.onRawValueChange(it)
+        }
+    }
+
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
+        return controller.formFieldValue.mapAsStateFlow { formFieldEntry ->
+            listOf(identifier to formFieldEntry)
         }
     }
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingElementUI.kt
@@ -1,12 +1,10 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import com.stripe.android.uicore.utils.collectAsState
 
 const val SAME_AS_SHIPPING_CHECKBOX_TEST_TAG = "SAME_AS_SHIPPING_CHECKBOX_TEST_TAG"
@@ -14,13 +12,14 @@ const val SAME_AS_SHIPPING_CHECKBOX_TEST_TAG = "SAME_AS_SHIPPING_CHECKBOX_TEST_T
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun SameAsShippingElementUI(
-    controller: SameAsShippingController
+    controller: SameAsShippingController,
+    modifier: Modifier = Modifier,
 ) {
     val checked by controller.value.collectAsState()
     val label by controller.label.collectAsState()
 
     CheckboxElementUI(
-        modifier = Modifier.padding(vertical = 4.dp),
+        modifier = modifier,
         automationTestTag = SAME_AS_SHIPPING_CHECKBOX_TEST_TAG,
         isChecked = checked,
         label = stringResource(label),


### PR DESCRIPTION
# Summary
Makes `SameAsShippingElement` a `FormElement` rather than a `SectionFieldElement` and updates `AddressSpec` to create a list of elements containing `SameAsShippingElement` rather than nest it inside of `SectionElement` with the definition indicating to render it outside of card.

# Motivation
`renderOutsideOfCard` is a weird concept. Effectively it's an addition to `Section` that isn't really an addition to `Section` and allows for those individual elements to control their own spacing. Especially since the UI definitions of these elements are not visible to the `Section` composable.

Making `SameAsShipping` its own element outside of `Section` use allows us to remove `renderOutsideOfCard` in a separate PR while allowing for control over the `SameAsShippingElement` padding.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified