### PR TITLE
[FC] Fixes single account skip account selection flows

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SelectAccounts.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SelectAccounts.kt
@@ -13,13 +13,11 @@ internal class SelectAccounts @Inject constructor(
     suspend operator fun invoke(
         selectedAccountIds: Set<String>,
         sessionId: String,
-        updateLocalCache: Boolean
     ): PartnerAccountsList {
         return repository.postAuthorizationSessionSelectedAccounts(
             sessionId = sessionId,
             clientSecret = configuration.financialConnectionsSessionClientSecret,
             selectAccounts = selectedAccountIds.toList(),
-            updateLocalCache = updateLocalCache
         )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
@@ -150,7 +150,6 @@ internal class AccountPickerViewModel @AssistedInject constructor(
                 // If account selection has to be skipped, submit all selectable accounts.
                 payload.skipAccountSelection -> submitAccounts(
                     selectedIds = payload.selectableAccounts.map { it.id }.toSet(),
-                    updateLocalCache = false,
                     isSkipAccountSelection = true
                 )
                 // the user saw an OAuth account selection screen and selected
@@ -158,7 +157,6 @@ internal class AccountPickerViewModel @AssistedInject constructor(
                 // we had done account selection, and submit.
                 payload.userSelectedSingleAccountInInstitution -> submitAccounts(
                     selectedIds = setOf(payload.accounts.first().id),
-                    updateLocalCache = true,
                     isSkipAccountSelection = true
                 )
 
@@ -278,7 +276,6 @@ internal class AccountPickerViewModel @AssistedInject constructor(
             state.payload()?.let {
                 submitAccounts(
                     selectedIds = state.selectedIds,
-                    updateLocalCache = true,
                     isSkipAccountSelection = false
                 )
             } ?: run {
@@ -289,7 +286,6 @@ internal class AccountPickerViewModel @AssistedInject constructor(
 
     private fun submitAccounts(
         selectedIds: Set<String>,
-        updateLocalCache: Boolean,
         isSkipAccountSelection: Boolean
     ) {
         suspend {
@@ -304,7 +300,6 @@ internal class AccountPickerViewModel @AssistedInject constructor(
             val accountsList: PartnerAccountsList = selectAccounts(
                 selectedAccountIds = selectedIds,
                 sessionId = requireNotNull(manifest.activeAuthSession).id,
-                updateLocalCache = updateLocalCache
             )
 
             val consumerSessionClientSecret = consumerSessionProvider.provideConsumerSession()?.clientSecret

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.stripe.android.core.Logger
+import com.stripe.android.core.exception.LocalStripeException
 import com.stripe.android.financialconnections.FinancialConnections
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.AccountSelected
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.AccountsAutoSelected
@@ -23,6 +24,7 @@ import com.stripe.android.financialconnections.domain.PollAuthorizationSessionAc
 import com.stripe.android.financialconnections.domain.SaveAccountToLink
 import com.stripe.android.financialconnections.domain.SelectAccounts
 import com.stripe.android.financialconnections.domain.toCachedPartnerAccounts
+import com.stripe.android.financialconnections.exception.AccountLoadError
 import com.stripe.android.financialconnections.features.accountpicker.AccountPickerClickableText.DATA
 import com.stripe.android.financialconnections.features.accountpicker.AccountPickerState.SelectionMode
 import com.stripe.android.financialconnections.features.accountpicker.AccountPickerState.ViewEffect
@@ -32,6 +34,7 @@ import com.stripe.android.financialconnections.features.notice.NoticeSheetState.
 import com.stripe.android.financialconnections.features.notice.PresentSheet
 import com.stripe.android.financialconnections.model.DataAccessNotice
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
+import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.model.PartnerAccount
 import com.stripe.android.financialconnections.model.PartnerAccountsList
@@ -120,6 +123,9 @@ internal class AccountPickerViewModel @AssistedInject constructor(
             val accounts = partnerAccountList.data.sortedBy { it.allowSelection.not() }
             val dataAccessDisclaimer = sync.text?.accountPicker?.dataAccessNotice
 
+            // Ensure there's available accounts to select.
+            throwErrorIfNoSelectableAccounts(accounts, manifest)
+
             AccountPickerState.Payload(
                 // note that this uses ?? instead of ||, we do NOT want to skip account selection
                 // if EITHER of these are true, we only want to skip account selection when
@@ -144,12 +150,33 @@ internal class AccountPickerViewModel @AssistedInject constructor(
         }.execute { copy(payload = it) }
     }
 
+    private fun throwErrorIfNoSelectableAccounts(
+        accounts: List<PartnerAccount>,
+        manifest: FinancialConnectionsSessionManifest
+    ) {
+        if (accounts.none { it.allowSelection }) {
+            throw AccountLoadError(
+                showManualEntry = manifest.allowManualEntry,
+                canRetry = true,
+                institution = requireNotNull(manifest.activeInstitution),
+                stripeException = LocalStripeException(
+                    displayMessage = "No accounts available to select.",
+                    analyticsValue = null
+                )
+            )
+        }
+    }
+
     private fun onPayloadLoaded() {
         onAsync(AccountPickerState::payload, onSuccess = { payload ->
             when {
                 // If account selection has to be skipped, submit all selectable accounts.
                 payload.skipAccountSelection -> submitAccounts(
-                    selectedIds = payload.selectableAccounts.map { it.id }.toSet(),
+                    selectedIds = payload.selectableAccounts
+                        // ensure just one account is selected on single account flows.
+                        .let { accounts -> if (payload.singleAccount) accounts.take(1) else accounts }
+                        .map { account -> account.id }
+                        .toSet(),
                     isSkipAccountSelection = true
                 )
                 // the user saw an OAuth account selection screen and selected

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsAccountsRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsAccountsRepository.kt
@@ -56,7 +56,6 @@ internal interface FinancialConnectionsAccountsRepository {
         clientSecret: String,
         sessionId: String,
         selectAccounts: List<String>,
-        updateLocalCache: Boolean
     ): PartnerAccountsList
 
     suspend fun postShareNetworkedAccounts(
@@ -192,8 +191,7 @@ private class FinancialConnectionsAccountsRepositoryImpl(
     override suspend fun postAuthorizationSessionSelectedAccounts(
         clientSecret: String,
         sessionId: String,
-        selectAccounts: List<String>,
-        updateLocalCache: Boolean
+        selectAccounts: List<String>
     ): PartnerAccountsList {
         val request = apiRequestFactory.createPost(
             url = authorizationSessionSelectedAccountsUrl,
@@ -208,12 +206,10 @@ private class FinancialConnectionsAccountsRepositoryImpl(
             request,
             PartnerAccountsList.serializer()
         ).also {
-            if (updateLocalCache) {
-                updateCachedAccounts(
-                    "postAuthorizationSessionSelectedAccounts",
-                    it.data
-                )
-            }
+            updateCachedAccounts(
+                "postAuthorizationSessionSelectedAccounts",
+                it.data
+            )
         }
     }
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModelTest.kt
@@ -348,7 +348,6 @@ internal class AccountPickerViewModelTest {
             selectAccounts(
                 selectedAccountIds = any(),
                 sessionId = any(),
-                updateLocalCache = any(),
             )
         ).thenReturn(response)
     }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModelTest.kt
@@ -78,6 +78,7 @@ internal class AccountPickerViewModelTest {
             )
             givenPollAccountsReturns(
                 partnerAccountList().copy(
+                    data = listOf(partnerAccount()),
                     skipAccountSelection = true
                 )
             )
@@ -101,7 +102,8 @@ internal class AccountPickerViewModelTest {
 
         givenPollAccountsReturns(
             partnerAccountList().copy(
-                skipAccountSelection = null
+                data = listOf(partnerAccount()),
+                skipAccountSelection = true
             )
         )
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/AbsFinancialConnectionsAccountsRepository.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/AbsFinancialConnectionsAccountsRepository.kt
@@ -45,7 +45,6 @@ internal abstract class AbsFinancialConnectionsAccountsRepository : FinancialCon
         clientSecret: String,
         sessionId: String,
         selectAccounts: List<String>,
-        updateLocalCache: Boolean
     ): PartnerAccountsList {
         TODO("Not yet implemented")
     }


### PR DESCRIPTION
# Summary
- On single account flows, if multiple accounts are selected we were not caching it.
- As a safety measure, ensure:
  - At least one account is selectable (this should happen backend side)
  - Just one account is auto submitted on single account, skip account selection flows.  

# Motivation
:notebook_with_decorative_cover: &nbsp;**[Android] Update cached accounts after skip account selection**
:globe_with_meridians: &nbsp;[BANKCON-16095](https://jira.corp.stripe.com/browse/BANKCON-16095)
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->