### PR TITLE
Remove `contentOutsideCard` & `shouldRenderOutsideCard` from `SectionElement`

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbElementUI.kt
@@ -37,26 +37,24 @@ fun BsbElementUI(
         Section(
             null,
             sectionErrorString,
-            contentInCard = {
-                TextField(
-                    element.textElement.controller,
-                    enabled = enabled,
-                    imeAction = if (lastTextFieldIdentifier == element.identifier) {
-                        ImeAction.Done
-                    } else {
-                        ImeAction.Next
-                    }
-                )
-            },
-            contentOutsideCard = {
-                bankName?.let {
-                    Text(
-                        it,
-                        color = MaterialTheme.stripeColors.subtitle
-                    )
-                }
-            },
             modifier = modifier,
-        )
+        ) {
+            TextField(
+                element.textElement.controller,
+                enabled = enabled,
+                imeAction = if (lastTextFieldIdentifier == element.identifier) {
+                    ImeAction.Done
+                } else {
+                    ImeAction.Next
+                }
+            )
+        }
+
+        bankName?.let {
+            Text(
+                it,
+                color = MaterialTheme.stripeColors.subtitle
+            )
+        }
     }
 }

--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -98,13 +98,6 @@ public final class com/stripe/android/uicore/elements/ComposableSingletons$OTPEl
 	public final fun getLambda-2$stripe_ui_core_release ()Lkotlin/jvm/functions/Function2;
 }
 
-public final class com/stripe/android/uicore/elements/ComposableSingletons$SectionUIKt {
-	public static final field INSTANCE Lcom/stripe/android/uicore/elements/ComposableSingletons$SectionUIKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
-	public fun <init> ()V
-	public final fun getLambda-1$stripe_ui_core_release ()Lkotlin/jvm/functions/Function2;
-}
-
 public final class com/stripe/android/uicore/elements/ComposableSingletons$TextFieldUIKt {
 	public static final field INSTANCE Lcom/stripe/android/uicore/elements/ComposableSingletons$TextFieldUIKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElementUI.kt
@@ -40,50 +40,30 @@ fun SectionElementUI(
             } ?: stringResource(it.errorMessage)
         }
 
-        val elementsInsideCard = element.fields.filter {
-            !it.shouldRenderOutsideCard
-        }
-        val elementsOutsideCard = element.fields.filter {
-            it.shouldRenderOutsideCard
-        }
-
         Section(
             controller.label,
             sectionErrorString,
             modifier = modifier,
-            contentOutsideCard = {
-                elementsOutsideCard.forEach { field ->
-                    SectionFieldElementUI(
-                        enabled,
-                        field,
-                        hiddenIdentifiers = hiddenIdentifiers,
-                        lastTextFieldIdentifier = lastTextFieldIdentifier,
-                        nextFocusDirection = nextFocusDirection,
-                        previousFocusDirection = previousFocusDirection
-                    )
-                }
-            },
-            contentInCard = {
-                elementsInsideCard.forEachIndexed { index, field ->
-                    SectionFieldElementUI(
-                        enabled,
-                        field,
-                        hiddenIdentifiers = hiddenIdentifiers,
-                        lastTextFieldIdentifier = lastTextFieldIdentifier,
-                        nextFocusDirection = nextFocusDirection,
-                        previousFocusDirection = previousFocusDirection
-                    )
-                    if (index != elementsInsideCard.lastIndex) {
-                        Divider(
-                            color = MaterialTheme.stripeColors.componentDivider,
-                            thickness = MaterialTheme.stripeShapes.borderStrokeWidth.dp,
-                            modifier = Modifier.padding(
-                                horizontal = MaterialTheme.stripeShapes.borderStrokeWidth.dp
-                            )
+        ) {
+            element.fields.forEachIndexed { index, field ->
+                SectionFieldElementUI(
+                    enabled,
+                    field,
+                    hiddenIdentifiers = hiddenIdentifiers,
+                    lastTextFieldIdentifier = lastTextFieldIdentifier,
+                    nextFocusDirection = nextFocusDirection,
+                    previousFocusDirection = previousFocusDirection
+                )
+                if (index != element.fields.lastIndex) {
+                    Divider(
+                        color = MaterialTheme.stripeColors.componentDivider,
+                        thickness = MaterialTheme.stripeShapes.borderStrokeWidth.dp,
+                        modifier = Modifier.padding(
+                            horizontal = MaterialTheme.stripeShapes.borderStrokeWidth.dp
                         )
-                    }
+                    )
                 }
             }
-        )
+        }
     }
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionFieldElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionFieldElement.kt
@@ -8,8 +8,6 @@ import kotlinx.coroutines.flow.StateFlow
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface SectionFieldElement {
     val identifier: IdentifierSpec
-    val shouldRenderOutsideCard: Boolean
-        get() = false
 
     /**
      * Whether the field element allows user interaction.

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionUI.kt
@@ -30,21 +30,19 @@ fun Section(
     error: String?,
     modifier: Modifier = Modifier,
     isSelected: Boolean = false,
-    contentOutsideCard: @Composable () -> Unit = {},
-    contentInCard: @Composable () -> Unit
+    content: @Composable () -> Unit
 ) {
     Column {
         Column(modifier = modifier) {
             SectionTitle(title)
             SectionCard(
                 isSelected = isSelected,
-                content = contentInCard,
+                content = content,
             )
         }
         if (error != null) {
             SectionError(error)
         }
-        contentOutsideCard()
     }
 }
 


### PR DESCRIPTION
# Summary
Remove `contentOutsideCard` & `shouldRenderOutsideCard` from `SectionElement`

# Motivation
Simplifies `SectionElement` by removing concept of being able to render outside of a `Section` element while still being apart of the `SectionElement` definition. Any content outside of `Section` (excluding `Section` errors) should be its own element. This will make it easier to control the padding of previously unknown elements attached to the `Section` definition.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified