### PR TITLE
Add intent configuration to configure.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -33,8 +33,8 @@ class EmbeddedPaymentElement internal constructor(
      * - Note: If you call [configure] while a previous call to [configure] is still in progress, the previous call
      *      returns [ConfigureResult.Cancelled].
      */
-    suspend fun configure(): ConfigureResult {
-        return sharedViewModel.configure()
+    suspend fun configure(intentConfiguration: PaymentSheet.IntentConfiguration): ConfigureResult {
+        return sharedViewModel.configure(intentConfiguration)
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/SharedPaymentElementViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/SharedPaymentElementViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import com.stripe.android.paymentelement.EmbeddedPaymentElement.ConfigureResult
 import com.stripe.android.paymentelement.EmbeddedPaymentElement.PaymentOptionDisplayData
 import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
+import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -13,7 +14,7 @@ internal class SharedPaymentElementViewModel : ViewModel() {
     private val _paymentOption: MutableStateFlow<PaymentOptionDisplayData?> = MutableStateFlow(null)
     val paymentOption: StateFlow<PaymentOptionDisplayData?> = _paymentOption.asStateFlow()
 
-    suspend fun configure(): ConfigureResult {
-        return ConfigureResult.Failed(IllegalStateException("Not implemented."))
+    suspend fun configure(intentConfiguration: PaymentSheet.IntentConfiguration): ConfigureResult {
+        return ConfigureResult.Failed(IllegalStateException("Not implemented. $intentConfiguration"))
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Adds PaymentSheet.IntentConfiguration to embedded's configure method.

We ideally want the intent configuration type to live at the top level, but we will change those once we do API review.
