### PR TITLE
Filter card brands in Google Pay

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -158,6 +158,8 @@ public final class com/stripe/android/GooglePayJsonFactory {
 	public final fun createPaymentDataRequest (Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;Lcom/stripe/android/GooglePayJsonFactory$ShippingAddressParameters;ZLcom/stripe/android/GooglePayJsonFactory$MerchantInfo;)Lorg/json/JSONObject;
 	public final fun createPaymentDataRequest (Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;Lcom/stripe/android/GooglePayJsonFactory$ShippingAddressParameters;ZLcom/stripe/android/GooglePayJsonFactory$MerchantInfo;Ljava/lang/Boolean;)Lorg/json/JSONObject;
 	public static synthetic fun createPaymentDataRequest$default (Lcom/stripe/android/GooglePayJsonFactory;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;Lcom/stripe/android/GooglePayJsonFactory$ShippingAddressParameters;ZLcom/stripe/android/GooglePayJsonFactory$MerchantInfo;Ljava/lang/Boolean;ILjava/lang/Object;)Lorg/json/JSONObject;
+	public static final fun getCardBrandFilter ()Lcom/stripe/android/CardBrandFilter;
+	public static final fun setCardBrandFilter (Lcom/stripe/android/CardBrandFilter;)V
 }
 
 public final class com/stripe/android/GooglePayJsonFactory$BillingAddressParameters : android/os/Parcelable {

--- a/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -471,8 +471,8 @@ class GooglePayJsonFactory constructor(
         internal val merchantName: String? = null
     ) : Parcelable
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @JvmStatic
         var cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter
 

--- a/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -259,6 +259,9 @@ class GooglePayJsonFactory constructor(
             .plus(listOf(JCB_CARD_NETWORK).takeIf { isJcbEnabled } ?: emptyList())
             .filter {
                 val cardBrand = networkStringToCardBrandMap[it] ?: CardBrand.Unknown
+                // Note(porter): I encountered strange behavior when using filtered card brands when making the isReady call for Google Pay
+                // It would error out with an unknown error, I believe this is a bug in Google Pay so for the isReadyCall we don't filter card brands
+                // But for subsequent calls we do, which gives the desired behavior.
                 if (isReadyCall) DefaultCardBrandFilter.isAccepted(cardBrand) else cardBrandFilter.isAccepted(cardBrand)
             }
         return JSONObject()

--- a/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -259,8 +259,10 @@ class GooglePayJsonFactory constructor(
             .plus(listOf(JCB_CARD_NETWORK).takeIf { isJcbEnabled } ?: emptyList())
             .filter {
                 val cardBrand = networkStringToCardBrandMap[it] ?: CardBrand.Unknown
-                // Note(porter): I encountered strange behavior when using filtered card brands when making the isReady call for Google Pay
-                // It would error out with an unknown error, I believe this is a bug in Google Pay so for the isReadyCall we don't filter card brands
+                // Note(porter): I encountered strange behavior when using filtered card brands
+                // when making the isReady call for Google Pay
+                // It would error out with an unknown error, I believe this is a bug in
+                // Google Pay so for the isReadyCall we don't filter card brands
                 // But for subsequent calls we do, which gives the desired behavior.
                 if (isReadyCall) DefaultCardBrandFilter.isAccepted(cardBrand) else cardBrandFilter.isAccepted(cardBrand)
             }

--- a/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -472,6 +472,7 @@ class GooglePayJsonFactory constructor(
     ) : Parcelable
 
     companion object {
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @JvmStatic
         var cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.customersheet
 
+import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.common.coroutines.Single
 import com.stripe.android.common.coroutines.awaitWithTimeout
 import com.stripe.android.core.exception.StripeException
@@ -75,6 +76,7 @@ internal class DefaultCustomerSheetLoader(
             configuration = configuration,
             customerSheetSession = customerSheetSession,
         )
+        GooglePayJsonFactory.cardBrandFilter = PaymentSheetCardBrandFilter(configuration.cardBrandAcceptance)
 
         createCustomerSheetState(
             customerSheetSession = customerSheetSession,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.state
 
+import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.common.coroutines.runCatching
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
@@ -105,6 +106,8 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         )
 
         val isGooglePayReady = isGooglePayReady(paymentSheetConfiguration, elementsSession)
+        val cardBrandFilter = PaymentSheetCardBrandFilter(paymentSheetConfiguration.cardBrandAcceptance)
+        GooglePayJsonFactory.cardBrandFilter = cardBrandFilter
 
         val savedSelection = async {
             retrieveSavedSelection(


### PR DESCRIPTION
# Summary
- Adds a static variable to GooglePayJsonFactory to allow setting a card brand filter. While making this a static variable is not my favorite it seems like a better alternative than passing the card brand filter down though many layers, and requiring to make some public API changes to get the card brand filter into the JsonFactory.
- The risk is that merchants who use a standalone Google Pay implementation + PaymentSheet + CBF will have cards filtered in their Google Pay standalone implantation as well. This seems reasonable, and a small risk for the implementation tradeoffs.
- Alternative approach: https://github.com/stripe/stripe-android/pull/9479

# Motivation
- Card brand filtering

# Testing
- Manually verified on Pixel 6 Pro with my real cards (DM for screenshots, don't want to post real card info here.)

# Changelog
N/A