### PR TITLE
Remove Google Pay launcher init events

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
@@ -12,14 +12,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.lifecycleScope
-import com.stripe.android.PaymentConfiguration
-import com.stripe.android.core.networking.AnalyticsRequestExecutor
-import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.googlepaylauncher.GooglePayLauncher.Result
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
-import com.stripe.android.networking.PaymentAnalyticsEvent
-import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
@@ -41,8 +36,6 @@ class GooglePayLauncher internal constructor(
     private val readyCallback: ReadyCallback,
     private val activityResultLauncher: ActivityResultLauncher<GooglePayLauncherContract.Args>,
     private val googlePayRepositoryFactory: (GooglePayEnvironment) -> GooglePayRepository,
-    paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
-    analyticsRequestExecutor: AnalyticsRequestExecutor
 ) {
     private var isReady = false
 
@@ -86,12 +79,6 @@ class GooglePayLauncher internal constructor(
                 )
             )
         },
-        PaymentAnalyticsRequestFactory(
-            activity,
-            PaymentConfiguration.getInstance(activity).publishableKey,
-            setOf(PRODUCT_USAGE)
-        ),
-        DefaultAnalyticsRequestExecutor()
     )
 
     /**
@@ -133,19 +120,9 @@ class GooglePayLauncher internal constructor(
                 )
             )
         },
-        paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
-            context = fragment.requireContext(),
-            publishableKey = PaymentConfiguration.getInstance(fragment.requireContext()).publishableKey,
-            defaultProductUsageTokens = setOf(PRODUCT_USAGE),
-        ),
-        analyticsRequestExecutor = DefaultAnalyticsRequestExecutor(),
     )
 
     init {
-        analyticsRequestExecutor.executeAsync(
-            paymentAnalyticsRequestFactory.createRequest(PaymentAnalyticsEvent.GooglePayLauncherInit)
-        )
-
         lifecycleScope.launch {
             val repository = googlePayRepositoryFactory(config.environment)
             readyCallback.onReady(
@@ -389,12 +366,6 @@ fun rememberGooglePayLauncher(
                     )
                 )
             },
-            PaymentAnalyticsRequestFactory(
-                context,
-                PaymentConfiguration.getInstance(context).publishableKey,
-                setOf(GooglePayLauncher.PRODUCT_USAGE)
-            ),
-            DefaultAnalyticsRequestExecutor()
         )
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -14,13 +14,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.lifecycleScope
-import com.stripe.android.PaymentConfiguration
-import com.stripe.android.core.networking.AnalyticsRequestExecutor
-import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher.Result
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.networking.PaymentAnalyticsEvent
-import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -45,14 +40,7 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
     @Assisted private val readyCallback: ReadyCallback,
     @Assisted private val activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
     @Assisted private val skipReadyCheck: Boolean,
-    context: Context,
     private val googlePayRepositoryFactory: (GooglePayEnvironment) -> GooglePayRepository,
-    paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
-        context,
-        PaymentConfiguration.getInstance(context).publishableKey,
-        setOf(PRODUCT_USAGE_TOKEN)
-    ),
-    analyticsRequestExecutor: AnalyticsRequestExecutor = DefaultAnalyticsRequestExecutor(),
 ) {
     private var isReady = false
 
@@ -124,7 +112,6 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
         readyCallback,
         activityResultLauncher,
         false,
-        context,
         googlePayRepositoryFactory = {
             DefaultGooglePayRepository(
                 context = context,
@@ -141,10 +128,6 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
     )
 
     init {
-        analyticsRequestExecutor.executeAsync(
-            paymentAnalyticsRequestFactory.createRequest(PaymentAnalyticsEvent.GooglePayPaymentMethodLauncherInit)
-        )
-
         if (!skipReadyCheck) {
             lifecycleScope.launch {
                 val repository = googlePayRepositoryFactory(config.environment)

--- a/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsEvent.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsEvent.kt
@@ -96,9 +96,6 @@ internal enum class PaymentAnalyticsEvent(val code: String) : AnalyticsEvent {
 
     RadarSessionCreate("radar_session_create"),
 
-    GooglePayLauncherInit("googlepaylauncher_init"),
-    GooglePayPaymentMethodLauncherInit("googlepaypaymentmethodlauncher_init"),
-
     CardMetadataPublishableKeyAvailable("card_metadata_pk_available"),
     CardMetadataPublishableKeyUnavailable("card_metadata_pk_unavailable"),
 

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherTest.kt
@@ -1,16 +1,11 @@
 package com.stripe.android.googlepaylauncher
 
 import androidx.activity.ComponentActivity
-import androidx.lifecycle.lifecycleScope
 import androidx.test.espresso.intent.rule.IntentsTestRule
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.ApiKeyFixtures
-import com.stripe.android.googlepaylauncher.utils.LauncherIntegrationType
 import com.stripe.android.googlepaylauncher.utils.runGooglePayLauncherTest
-import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import org.junit.Rule
 import org.junit.runner.RunWith
-import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
@@ -25,35 +20,6 @@ internal class GooglePayLauncherTest {
     fun `presentForPaymentIntent() should successfully return a result when Google Pay is available`() {
         runGooglePayLauncherTest { _, launcher ->
             launcher.presentForPaymentIntent("pi_123_secret_456")
-        }
-    }
-
-    @Test
-    fun `init should fire expected event`() {
-        runGooglePayLauncherTest(
-            integrationTypes = listOf(LauncherIntegrationType.Activity),
-            expectResult = false,
-        ) { activity, _ ->
-            val firedEvents = mutableListOf<String>()
-
-            // Have to use the internal constructor here to provide a mock request executor
-            // ¯\_(ツ)_/¯
-            GooglePayLauncher(
-                lifecycleScope = activity.lifecycleScope,
-                config = CONFIG,
-                readyCallback = mock(),
-                activityResultLauncher = mock(),
-                googlePayRepositoryFactory = {
-                    FakeGooglePayRepository(value = true)
-                },
-                paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
-                    context = activity,
-                    publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-                ),
-                analyticsRequestExecutor = { firedEvents += it.params["event"].toString() },
-            )
-
-            assertThat(firedEvents).containsExactly("stripe_android.googlepaylauncher_init")
         }
     }
 

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherTest.kt
@@ -1,17 +1,11 @@
 package com.stripe.android.googlepaylauncher
 
 import androidx.activity.ComponentActivity
-import androidx.lifecycle.lifecycleScope
 import androidx.test.espresso.intent.rule.IntentsTestRule
-import com.google.common.truth.Truth.assertThat
-import com.stripe.android.ApiKeyFixtures
-import com.stripe.android.googlepaylauncher.utils.LauncherIntegrationType
 import com.stripe.android.googlepaylauncher.utils.runGooglePayPaymentMethodLauncherTest
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
-import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import org.junit.Rule
 import org.junit.runner.RunWith
-import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
@@ -30,34 +24,6 @@ class GooglePayPaymentMethodLauncherTest {
             result = result,
         ) { _, launcher ->
             launcher.present(currencyCode = "usd")
-        }
-    }
-
-    @Test
-    fun `init should fire expected event`() {
-        runGooglePayPaymentMethodLauncherTest(
-            integrationTypes = listOf(LauncherIntegrationType.Activity),
-            expectResult = false,
-        ) { activity, _ ->
-            val firedEvents = mutableListOf<String>()
-
-            val launcher = GooglePayPaymentMethodLauncher(
-                lifecycleScope = activity.lifecycleScope,
-                config = CONFIG,
-                readyCallback = mock(),
-                activityResultLauncher = mock(),
-                skipReadyCheck = true,
-                context = activity,
-                googlePayRepositoryFactory = mock(),
-                paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
-                    context = activity,
-                    publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-                ),
-                analyticsRequestExecutor = { firedEvents += it.params["event"].toString() },
-            )
-            launcher.present(currencyCode = "usd")
-
-            assertThat(firedEvents).containsExactly("stripe_android.googlepaypaymentmethodlauncher_init")
         }
     }
 


### PR DESCRIPTION
# Summary
Remove initialization events for `Google Pay` in the Android SDK.

# Motivation
Removes noisy initialization events

Resolves https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3192

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified