### PR TITLE
[FC] Removes deprecated `linkedAccount` field

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -7,6 +7,9 @@
 ### PaymentSheet
 - PaymentSheet displays payment methods in either a vertical or horizontal layout. Prior to this major version, PaymentSheet defaulted to a horizontal layout. Now, Stripe optimizes the layout automatically. To set a specific layout instead, set the `PaymentSheet.Configuration.Builder.paymentMethodLayout` property to either Horizontal or Vertical.
 
+### Financial Connections
+- Deprecated `PaymentMethod#linkedAccount` has been removed. Use `PaymentMethod#financialConnectionsAccount` instead.
+
 ## Migrating from versions < 20.26.0
 - Changes to `PaymentSheetContract`:
   * The class has been deprecated and will be removed in a future release. Use the `PaymentSheet` constructor or the new `rememberPaymentSheet()` method.

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
@@ -187,7 +187,6 @@ object PaymentMethodFactory {
         usBankAccountJson.put("financial_connections_account", usBankAccount.financialConnectionsAccount)
         usBankAccountJson.put("fingerprint", usBankAccount.fingerprint)
         usBankAccountJson.put("last4", usBankAccount.last4)
-        usBankAccountJson.put("linked_account", usBankAccount.linkedAccount)
         usBankAccountJson.put("routing_number", usBankAccount.routingNumber)
 
         val networksJson = JSONObject()

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -3632,7 +3632,6 @@ public final class com/stripe/android/model/PaymentMethod$USBankAccount : com/st
 	public final field financialConnectionsAccount Ljava/lang/String;
 	public final field fingerprint Ljava/lang/String;
 	public final field last4 Ljava/lang/String;
-	public final field linkedAccount Ljava/lang/String;
 	public final field networks Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;
 	public final field routingNumber Ljava/lang/String;
 	public final fun component1 ()Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -1132,20 +1132,6 @@ constructor(
          */
         @JvmField val routingNumber: String?,
     ) : TypeData() {
-        /**
-         * The token of the Linked Account used to create the payment method
-         *
-         * [us_bank_account.linkedAccount](https://stripe.com/docs/api/payment_methods/object#payment_method_object-us_bank_account-linked_account)
-         */
-        @Deprecated(
-            message = "Renamed to 'financialConnectionsAccount', " +
-                "'linkedAccount' will be removed in a future major update",
-            replaceWith = ReplaceWith(expression = "financialConnectionsAccount")
-        )
-        @IgnoredOnParcel
-        @JvmField
-        val linkedAccount: String? = financialConnectionsAccount
-
         override val type: Type get() = Type.USBankAccount
 
         @Parcelize

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentMethodJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentMethodJsonParserTest.kt
@@ -153,8 +153,6 @@ class PaymentMethodJsonParserTest {
 
         assertThat(usBankAccount.type)
             .isEqualTo(PaymentMethod.Type.USBankAccount)
-        assertThat(usBankAccount.usBankAccount?.linkedAccount)
-            .isEqualTo("fca_111")
         assertThat(usBankAccount.usBankAccount?.financialConnectionsAccount)
             .isEqualTo("fca_111")
     }


### PR DESCRIPTION
# Summary
[FC] Removes deprecated `linkedAccount` field

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
