### PR TITLE
[Instant Debits Signup] Navigate to error pane for permission exceptions

### DIFF
--- a/financial-connections/detekt-baseline.xml
+++ b/financial-connections/detekt-baseline.xml
@@ -24,6 +24,7 @@
     <ID>MagicNumber:SharedPartnerAuth.kt$.50f</ID>
     <ID>MatchingDeclarationName:ServerDrivenUi.kt$BulletUI</ID>
     <ID>MatchingDeclarationName:Type.kt$FinancialConnectionsTypography</ID>
+    <ID>MaxLineLength:NetworkingLinkSignupViewModelTest.kt$NetworkingLinkSignupViewModelTest$fun</ID>
     <ID>NestedBlockDepth:InstitutionPickerScreen.kt$private fun LazyListScope.searchResults( isInputEmpty: Boolean, payload: Payload, selectedInstitutionId: String?, onInstitutionSelected: (FinancialConnectionsInstitution, Boolean) -> Unit, institutions: Async&lt;InstitutionResponse>, onManualEntryClick: () -> Unit, onSearchMoreClick: () -> Unit )</ID>
     <ID>SwallowedException:PollAttachPaymentAccount.kt$PollAttachPaymentAccount$e: StripeException</ID>
     <ID>SwallowedException:PollAuthorizationSessionAccounts.kt$PollAuthorizationSessionAccounts$e: StripeException</ID>

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.stripe.android.core.Logger
+import com.stripe.android.core.exception.PermissionException
 import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext
 import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.Click
@@ -17,6 +18,7 @@ import com.stripe.android.financialconnections.analytics.logError
 import com.stripe.android.financialconnections.di.FinancialConnectionsSheetNativeComponent
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.GetOrFetchSync.RefetchCondition
+import com.stripe.android.financialconnections.domain.HandleError
 import com.stripe.android.financialconnections.domain.LookupAccount
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.features.common.getBusinessName
@@ -70,6 +72,7 @@ internal class NetworkingLinkSignupViewModel @AssistedInject constructor(
     private val presentSheet: PresentSheet,
     private val linkSignupHandler: LinkSignupHandler,
     private val elementsSessionContext: ElementsSessionContext?,
+    private val handleError: HandleError,
 ) : FinancialConnectionsViewModel<NetworkingLinkSignupState>(initialState, nativeAuthFlowCoordinator) {
 
     private val pane: Pane
@@ -140,11 +143,11 @@ internal class NetworkingLinkSignupViewModel @AssistedInject constructor(
                 }
             },
             onFail = { error ->
-                eventTracker.logError(
+                handleError(
                     extraMessage = "Error looking up account",
                     error = error,
-                    logger = logger,
-                    pane = pane
+                    pane = pane,
+                    displayErrorScreen = error is PermissionException,
                 )
             },
         )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
@@ -143,11 +143,12 @@ internal class NetworkingLinkSignupViewModel @AssistedInject constructor(
                 }
             },
             onFail = { error ->
+                val displayErrorScreen = stateFlow.value.isInstantDebits && error is PermissionException
                 handleError(
                     extraMessage = "Error looking up account",
                     error = error,
                     pane = pane,
-                    displayErrorScreen = error is PermissionException,
+                    displayErrorScreen = displayErrorScreen,
                 )
             },
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request changes how we handle permission exceptions in the Link signup. Instead of just silently failing, we now show the error pane when it’s a permission exception.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
