### PR TITLE
Upgrade `download-artifact` & `upload-artifact` to `v4`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: ./.github/actions/stripe_setup
       - name: End-to-end tests
         run: ./gradlew :stripe-test-e2e:testDebugUnitTest
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: unit-test-report
@@ -35,7 +35,7 @@ jobs:
       - uses: ./.github/actions/stripe_setup
       - name: Build example projects
         run: ./gradlew :paymentsheet-example:assembleAndroidTest
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: test-failures

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -16,7 +16,7 @@ jobs:
           STRIPE_END_TO_END_TESTS_BACKEND_URL: ${{ secrets.STRIPE_END_TO_END_TESTS_BACKEND_URL }}
           STRIPE_END_TO_END_TESTS_PUBLISHABLE_KEY: ${{ secrets.STRIPE_END_TO_END_TESTS_PUBLISHABLE_KEY }}
         run: ./gradlew :stripe-test-e2e:testDebugUnitTest
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: unit-test-report

--- a/.github/workflows/identity_pull_request.yml
+++ b/.github/workflows/identity_pull_request.yml
@@ -15,9 +15,9 @@ jobs:
       - name: Build base branch
         run: ./gradlew :identity-example:assembleRelease && mv identity-example/build/outputs/apk/theme1/release/identity-example-theme1-release.apk identity-example/build/outputs/apk/theme1/release/identity-example-release-base.apk
       - name: Upload APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: apk
+          name: identity-base-apk
           path: identity-example/build/outputs/apk/theme1/release/identity-example-release-base.apk
 
   # Checkout PR branch and build the APK
@@ -30,9 +30,9 @@ jobs:
       - name: Build PR branch
         run: ./gradlew :identity-example:assembleRelease && mv identity-example/build/outputs/apk/theme1/release/identity-example-theme1-release.apk identity-example/build/outputs/apk/theme1/release/identity-example-release-pr.apk
       - name: Upload APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: apk
+          name: identity-pr-apk
           path: identity-example/build/outputs/apk/theme1/release/identity-example-release-pr.apk
 
   # Execute Diffuse only when the two APKs are built successfully
@@ -44,11 +44,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download APKs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: apk
           path: apk
-          pattern: identity-example-release-*.apk
+          pattern: identity-*-apk
+          merge-multiple: true
       - name: diffuse
         id: diffuse
         uses: usefulness/diffuse-action@41995fe8ff6be0a8847e63bdc5a4679c704b455c
@@ -77,7 +77,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload diffuse output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: diffuse-output
           path: ${{ steps.diffuse.outputs.diff-file }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,9 +22,9 @@ jobs:
       - name: Build in master
         run: ./gradlew :paymentsheet-example:assembleRelease && mv paymentsheet-example/build/outputs/apk/release/paymentsheet-example-release.apk paymentsheet-example/build/outputs/apk/release/paymentsheet-example-release-master.apk
       - name: Upload APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: apk
+          name: paymentsheet-base-apk
           path: paymentsheet-example/build/outputs/apk/release/paymentsheet-example-release-master.apk
 
   # Checkout PR branch and build the APK
@@ -36,9 +36,9 @@ jobs:
       - name: Build from PR
         run: ./gradlew :paymentsheet-example:assembleRelease && mv paymentsheet-example/build/outputs/apk/release/paymentsheet-example-release.apk paymentsheet-example/build/outputs/apk/release/paymentsheet-example-release-pr.apk
       - name: Upload APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: apk
+          name: paymentsheet-pr-apk
           path: paymentsheet-example/build/outputs/apk/release/paymentsheet-example-release-pr.apk
 
   # Execute Diffuse only when the two APKs are built successfully
@@ -50,11 +50,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download APKs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: apk
           path: apk
-          pattern: paymentsheet-example-release-*.apk
+          pattern: paymentsheet-*-apk
+          merge-multiple: true
       - name: diffuse
         id: diffuse
         uses: usefulness/diffuse-action@41995fe8ff6be0a8847e63bdc5a4679c704b455c
@@ -83,7 +83,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload diffuse output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: diffuse-output
           path: ${{ steps.diffuse.outputs.diff-file }}


### PR DESCRIPTION
# Summary
Upgrade `download-artifact` & `upload-artifact` to `v4`

# Motivation
`v3` is being being deprecated and will begin to fail in our workflows starting December 5th, 2024 (with warning failures on November 14th & 21st). Upgrading now will mitigate the potential of these workflows being blocked on these dates.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified