### PR TITLE
Decouple PaymentSheetState from PaymentElementLoader.

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -2098,6 +2098,14 @@ public final class com/stripe/android/paymentsheet/state/LinkState$Creator : and
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentsheet/state/PaymentElementLoader$State$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/state/PaymentElementLoader$State;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/state/PaymentElementLoader$State;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/paymentsheet/state/PaymentSheetState$Full$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/state/PaymentSheetState$Full;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -293,7 +293,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         }
 
         result.fold(
-            onSuccess = { handlePaymentSheetStateLoaded(it) },
+            onSuccess = { handlePaymentSheetStateLoaded(PaymentSheetState.Full(it)) },
             onFailure = { handlePaymentSheetStateLoadFailure(it) },
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
@@ -99,7 +99,7 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
                     onConfigured(state.validationError)
                 } else {
                     viewModel.previousConfigureRequest = configureRequest
-                    onInitSuccess(state, configuration, configureRequest)
+                    onInitSuccess(PaymentSheetState.Full(state), configuration, configureRequest)
                     onConfigured()
                 }
             },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetState.kt
@@ -21,6 +21,15 @@ internal sealed interface PaymentSheetState : Parcelable {
         val validationError: PaymentSheetLoadingException?,
         val paymentMethodMetadata: PaymentMethodMetadata,
     ) : PaymentSheetState {
+        constructor(state: PaymentElementLoader.State) : this(
+            config = state.config,
+            customer = state.customer,
+            linkState = state.linkState,
+            paymentSelection = state.paymentSelection,
+            validationError = state.validationError,
+            paymentMethodMetadata = state.paymentMethodMetadata,
+        )
+
         val showSavedPaymentMethods: Boolean
             get() = (customer != null && customer.paymentMethods.isNotEmpty()) || paymentMethodMetadata.isGooglePayReady
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -119,7 +119,7 @@ internal class DefaultPaymentElementLoaderTest {
                 initializedViaCompose = false,
             ).getOrThrow()
         ).isEqualTo(
-            PaymentSheetState.Full(
+            PaymentElementLoader.State(
                 config = config.asCommonConfiguration(),
                 customer = CustomerState(
                     id = config.customer!!.id,
@@ -2302,7 +2302,7 @@ internal class DefaultPaymentElementLoaderTest {
         paymentSheetConfiguration: PaymentSheet.Configuration,
         isReloadingAfterProcessDeath: Boolean = false,
         initializedViaCompose: Boolean,
-    ): Result<PaymentSheetState.Full> = load(
+    ): Result<PaymentElementLoader.State> = load(
         initializationMode = initializationMode,
         configuration = paymentSheetConfiguration.asCommonConfiguration(),
         isReloadingAfterProcessDeath = isReloadingAfterProcessDeath,

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
@@ -11,7 +11,6 @@ import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException
-import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import kotlinx.coroutines.delay
 import kotlin.time.Duration
@@ -42,13 +41,13 @@ internal class FakePaymentElementLoader(
         configuration: CommonConfiguration,
         isReloadingAfterProcessDeath: Boolean,
         initializedViaCompose: Boolean,
-    ): Result<PaymentSheetState.Full> {
+    ): Result<PaymentElementLoader.State> {
         delay(delay)
         return if (shouldFail) {
             Result.failure(IllegalStateException("oh no"))
         } else {
             Result.success(
-                PaymentSheetState.Full(
+                PaymentElementLoader.State(
                     config = configuration,
                     customer = customer,
                     linkState = linkState,

--- a/paymentsheet/src/test/java/com/stripe/android/utils/RelayingPaymentElementLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/RelayingPaymentElementLoader.kt
@@ -7,13 +7,12 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException
-import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.testing.PaymentIntentFactory
 import kotlinx.coroutines.channels.Channel
 
 internal class RelayingPaymentElementLoader : PaymentElementLoader {
 
-    private val results = Channel<Result<PaymentSheetState.Full>>(capacity = 1)
+    private val results = Channel<Result<PaymentElementLoader.State>>(capacity = 1)
 
     fun enqueueSuccess(
         stripeIntent: StripeIntent = PaymentIntentFactory.create(),
@@ -21,7 +20,7 @@ internal class RelayingPaymentElementLoader : PaymentElementLoader {
     ) {
         enqueue(
             Result.success(
-                PaymentSheetState.Full(
+                PaymentElementLoader.State(
                     customer = null,
                     config = PaymentSheet.Configuration("Example").asCommonConfiguration(),
                     paymentSelection = null,
@@ -38,7 +37,7 @@ internal class RelayingPaymentElementLoader : PaymentElementLoader {
         enqueue(Result.failure(error))
     }
 
-    private fun enqueue(result: Result<PaymentSheetState.Full>) {
+    private fun enqueue(result: Result<PaymentElementLoader.State>) {
         results.trySend(result)
     }
 
@@ -47,7 +46,7 @@ internal class RelayingPaymentElementLoader : PaymentElementLoader {
         onfiguration: CommonConfiguration,
         isReloadingAfterProcessDeath: Boolean,
         initializedViaCompose: Boolean,
-    ): Result<PaymentSheetState.Full> {
+    ): Result<PaymentElementLoader.State> {
         return results.receive()
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I don't want to use PaymentSheetState for EmbeddedPaymentElement. So decoupling the result from the loader.
