### PR TITLE
Add `prefix` to form field value in `PhoneNumberController`

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandler.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandler.kt
@@ -49,7 +49,7 @@ internal class LinkSignupHandlerForInstantDebits @Inject constructor(
 
         val signup = consumerRepository.signUp(
             email = state.validEmail!!,
-            phoneNumber = phoneController.getE164PhoneNumber(state.validPhone!!),
+            phoneNumber = state.validPhone!!,
             country = phoneController.getCountryCode(),
         )
 
@@ -95,7 +95,7 @@ internal class LinkSignupHandlerForNetworking @Inject constructor(
         saveAccountToLink.new(
             country = phoneController.getCountryCode(),
             email = state.validEmail!!,
-            phoneNumber = phoneController.getE164PhoneNumber(state.validPhone!!),
+            phoneNumber = state.validPhone!!,
             selectedAccounts = selectedAccounts,
             shouldPollAccountNumbers = manifest.isDataFlow,
         )

--- a/link/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
@@ -190,13 +190,11 @@ internal class InlineSignupViewModel @AssistedInject constructor(
 
         return if (email != null && phoneNumber != null && signUpMode != null) {
             val isNameValid = !requiresNameCollection || !name.isNullOrBlank()
-
-            val phone = phoneController.getE164PhoneNumber(phoneNumber)
             val country = phoneController.getCountryCode()
 
             UserInput.SignUp(
                 email = email,
-                phone = phone,
+                phone = phoneNumber,
                 country = country,
                 name = name,
                 consentAction = signUpMode.toConsentAction(

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PhoneNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PhoneNumberControllerTest.kt
@@ -167,4 +167,17 @@ internal class PhoneNumberControllerTest {
             assertThat(awaitItem()).isTrue()
         }
     }
+
+    @Test
+    fun `when phone number is entered, form field value should contain prefix`() = runTest {
+        val phoneNumberController = PhoneNumberController.createPhoneNumberController(
+            initiallySelectedCountryCode = "CA",
+        )
+
+        phoneNumberController.onValueChange("(122) 252-5252")
+
+        phoneNumberController.formFieldValue.test {
+            assertThat(awaitItem().value).isEqualTo("+11222525252")
+        }
+    }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetNetworkRequests.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetNetworkRequests.kt
@@ -51,7 +51,7 @@ internal fun billingDetailsParams(): RequestMatcher {
 internal fun fullBillingDetailsParams(): RequestMatcher {
     return RequestMatchers.composite(
         bodyPart(urlEncode("billing_details[name]"), urlEncode(CustomerSheetPage.NAME)),
-        bodyPart(urlEncode("billing_details[phone]"), CustomerSheetPage.PHONE_NUMBER),
+        bodyPart(urlEncode("billing_details[phone]"), urlEncode("+1${CustomerSheetPage.PHONE_NUMBER}")),
         bodyPart(urlEncode("billing_details[email]"), urlEncode(CustomerSheetPage.EMAIL)),
         bodyPart(urlEncode("billing_details[address][line1]"), urlEncode(CustomerSheetPage.ADDRESS_LINE_ONE)),
         bodyPart(urlEncode("billing_details[address][line2]"), urlEncode(CustomerSheetPage.ADDRESS_LINE_TWO)),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -522,7 +522,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
             name = name,
             // The createPaymentDetails endpoint does not accept uppercase characters.
             email = email?.lowercase(),
-            phone = phone?.let { phoneController.getE164PhoneNumber(it) },
+            phone = phone,
             address = address?.let {
                 ElementsSessionContext.BillingDetails.Address(
                     line1 = it.line1,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -263,7 +263,7 @@ class USBankAccountFormViewModelTest {
         val input = PaymentSelection.New.USBankAccount.Input(
             name = "Some One",
             email = "someone@email.com",
-            phone = "1112223456",
+            phone = "+11112223456",
             address = Address(
                 line1 = "123 Not Main Street",
                 line2 = "Apt 123",
@@ -308,7 +308,7 @@ class USBankAccountFormViewModelTest {
         val input = PaymentSelection.New.USBankAccount.Input(
             name = "Some One",
             email = "someone@email.com",
-            phone = "1112223456",
+            phone = "+11112223456",
             address = Address(
                 line1 = "123 Not Main Street",
                 line2 = "Apt 123",
@@ -363,7 +363,7 @@ class USBankAccountFormViewModelTest {
                     billingDetails = PaymentSheet.BillingDetails(
                         name = CUSTOMER_NAME,
                         email = CUSTOMER_EMAIL,
-                        phone = CUSTOMER_PHONE_COUNTRY_CODE + CUSTOMER_PHONE,
+                        phone = CUSTOMER_PHONE,
                         address = CUSTOMER_ADDRESS,
                     ),
                     billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
@@ -505,7 +505,7 @@ class USBankAccountFormViewModelTest {
                         billingDetails = PaymentSheet.BillingDetails(
                             name = CUSTOMER_NAME,
                             email = CUSTOMER_EMAIL,
-                            phone = CUSTOMER_PHONE_COUNTRY_CODE + CUSTOMER_PHONE,
+                            phone = CUSTOMER_PHONE,
                             address = CUSTOMER_ADDRESS,
                         ),
                         billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
@@ -1626,8 +1626,7 @@ class USBankAccountFormViewModelTest {
         const val CUSTOMER_EMAIL = "email@email.com"
         const val STRIPE_ACCOUNT_ID = "stripe_account_id"
         const val CUSTOMER_COUNTRY = "US"
-        const val CUSTOMER_PHONE_COUNTRY_CODE = "+1"
-        const val CUSTOMER_PHONE = "3105551234"
+        const val CUSTOMER_PHONE = "+13105551234"
         val CUSTOMER_ADDRESS = PaymentSheet.Address(
             line1 = "123 Main Street",
             line2 = "Apt 456",

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberController.kt
@@ -77,8 +77,8 @@ class PhoneNumberController private constructor(
     override val isComplete = combineAsStateFlow(fieldValue, phoneNumberMinimumLength) { value, minLength ->
         value.length >= (minLength ?: 0) || acceptAnyInput
     }
-    override val formFieldValue = combineAsStateFlow(fieldValue, isComplete) { fieldValue, isComplete ->
-        FormFieldEntry(fieldValue, isComplete)
+    override val formFieldValue = combineAsStateFlow(rawFieldValue, isComplete) { rawFieldValue, isComplete ->
+        FormFieldEntry(rawFieldValue, isComplete)
     }
 
     override val error: StateFlow<FieldError?> = combineAsStateFlow(


### PR DESCRIPTION
# Summary
Adds prefix of the selected to the phone number `formFieldValue` in `PhoneNumberController`

# Motivation
`formFieldValue` indicates the final value we want to send for a customer's phone number when creating a payment method, signing up for `Link`, etc. Unfortunately on Android, we've been sending just the user's filtered text input and did not include the prefix of the selected country. This PR adds the prefix to the form field value in order to ensure the phone is transmitted properly.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
