### PR TITLE
Add minimum length to `AuBankAccountNumberConfig`

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBankAccountNumberConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBankAccountNumberConfig.kt
@@ -30,7 +30,7 @@ class AuBankAccountNumberConfig : TextFieldConfig {
     override val keyboard = KeyboardType.Number
 
     override fun filter(userTyped: String) =
-        userTyped.filter { VALID_INPUT_RANGES.contains(it) }.take(LENGTH)
+        userTyped.filter { VALID_INPUT_RANGES.contains(it) }.take(MAXIMUM_LENGTH)
 
     override fun convertToRaw(displayName: String) = displayName
 
@@ -41,17 +41,22 @@ class AuBankAccountNumberConfig : TextFieldConfig {
             return TextFieldStateConstants.Error.Blank
         }
 
-        if (input.length < LENGTH) {
+        if (input.length < MINIMUM_LENGTH) {
             return TextFieldStateConstants.Error.Incomplete(
                 StripeR.string.stripe_becs_widget_account_number_incomplete
             )
+        }
+
+        if (input.length < MAXIMUM_LENGTH) {
+            return TextFieldStateConstants.Valid.Limitless
         }
 
         return TextFieldStateConstants.Valid.Full
     }
 
     private companion object {
-        const val LENGTH = 9
+        const val MINIMUM_LENGTH = 4
+        const val MAXIMUM_LENGTH = 9
         val VALID_INPUT_RANGES = ('0'..'9')
     }
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AuBankAccountNumberConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AuBankAccountNumberConfigTest.kt
@@ -27,11 +27,29 @@ class AuBankAccountNumberConfigTest {
 
     @Test
     fun `verify incomplete bank account number is in incomplete state`() {
-        assertThat(auBankAccountNumberConfig.determineState("123"))
+        assertThat(auBankAccountNumberConfig.determineState("12"))
             .isInstanceOf<TextFieldStateConstants.Error.Incomplete>()
 
-        assertThat(auBankAccountNumberConfig.determineState("123456"))
+        assertThat(auBankAccountNumberConfig.determineState("123"))
             .isInstanceOf<TextFieldStateConstants.Error.Incomplete>()
+    }
+
+    @Test
+    fun `verify valid bank account number but not maximum is in limitless state`() {
+        assertThat(auBankAccountNumberConfig.determineState("1234"))
+            .isInstanceOf<TextFieldStateConstants.Valid.Limitless>()
+
+        assertThat(auBankAccountNumberConfig.determineState("12345"))
+            .isInstanceOf<TextFieldStateConstants.Valid.Limitless>()
+
+        assertThat(auBankAccountNumberConfig.determineState("123456"))
+            .isInstanceOf<TextFieldStateConstants.Valid.Limitless>()
+
+        assertThat(auBankAccountNumberConfig.determineState("1234567"))
+            .isInstanceOf<TextFieldStateConstants.Valid.Limitless>()
+
+        assertThat(auBankAccountNumberConfig.determineState("12345678"))
+            .isInstanceOf<TextFieldStateConstants.Valid.Limitless>()
     }
 
     @Test


### PR DESCRIPTION
# Summary
Add minimum length to `AuBankAccountNumberConfig`.

# Motivation
Resolves https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3682

Au Becs can have a minimum of 5 digits (4 for Cuscal (BSB prefix 80)) however the SDK only allows for an account number with 9 digits. This PR allows for 4-5 digit account numbers for Becs.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified