### PR TITLE
Fix requirement for phone number not being respected for `AddressElement`

### DIFF
--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
@@ -495,6 +495,33 @@ class AddressElementTest {
         assertThat(country()).isEqualTo("US")
     }
 
+    @Test
+    fun `when phone number is required, should not be complete until fully entered`() = runTest {
+        val addressElement = AddressElement(
+            IdentifierSpec.Generic("address"),
+            mapOf(
+                IdentifierSpec.Country to "CA"
+            ),
+            countryDropdownFieldController = countryDropdownFieldController,
+            addressType = AddressType.Normal(
+                phoneNumberState = PhoneNumberState.REQUIRED
+            ),
+            sameAsShippingElement = null,
+            shippingValuesMap = null,
+        )
+
+        val phoneNumberController = addressElement.phoneNumberElement.controller
+
+        phoneNumberController.onRawValueChange("123")
+        assertThat(phoneNumberController.isComplete.value).isFalse()
+
+        phoneNumberController.onRawValueChange("123456")
+        assertThat(phoneNumberController.isComplete.value).isFalse()
+
+        phoneNumberController.onRawValueChange("1234567890")
+        assertThat(phoneNumberController.isComplete.value).isTrue()
+    }
+
     private fun createAddressElement(initialValues: Map<IdentifierSpec, String>): AddressElement {
         return AddressElement(
             IdentifierSpec.Generic("address"),

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/addresselement/AddressElementExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/addresselement/AddressElementExampleActivity.kt
@@ -57,6 +57,12 @@ class AddressElementExampleActivity : AppCompatActivity() {
                         Button(
                             onClick = {
                                 val config = AddressLauncher.Configuration.Builder()
+                                    .additionalFields(
+                                        additionalFields = AddressLauncher.AdditionalFieldsConfiguration(
+                                            phone = AddressLauncher.AdditionalFieldsConfiguration
+                                                .FieldConfiguration.REQUIRED
+                                        )
+                                    )
                                     // Provide your Google Places API key to enable autocomplete
                                     .googlePlacesApiKey(Settings(context).googlePlacesApiKey)
                                     .build()

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/addresselement/AddressElementExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/addresselement/AddressElementExampleActivity.kt
@@ -57,12 +57,6 @@ class AddressElementExampleActivity : AppCompatActivity() {
                         Button(
                             onClick = {
                                 val config = AddressLauncher.Configuration.Builder()
-                                    .additionalFields(
-                                        additionalFields = AddressLauncher.AdditionalFieldsConfiguration(
-                                            phone = AddressLauncher.AdditionalFieldsConfiguration
-                                                .FieldConfiguration.REQUIRED
-                                        )
-                                    )
                                     // Provide your Google Places API key to enable autocomplete
                                     .googlePlacesApiKey(Settings(context).googlePlacesApiKey)
                                     .build()

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
@@ -60,7 +60,7 @@ open class AddressElement(
         PhoneNumberController.createPhoneNumberController(
             initialValue = rawValuesMap[IdentifierSpec.Phone] ?: "",
             showOptionalLabel = addressType.phoneNumberState == PhoneNumberState.OPTIONAL,
-            acceptAnyInput = true,
+            acceptAnyInput = addressType.phoneNumberState != PhoneNumberState.REQUIRED,
         )
     )
 


### PR DESCRIPTION
# Summary
Fix requirement for phone number not being respected for `AddressElement`.

# Motivation
Ensures `AddressElement` phone requirements are respected.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified