### PR TITLE
Use display brand in remove dialog description

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
@@ -20,11 +20,9 @@ internal data class DisplayableSavedPaymentMethod(
 
     fun getDescription() = when (paymentMethod.type) {
         PaymentMethod.Type.Card -> {
-            val brand = paymentMethod.card?.displayBrand?.let { CardBrand.fromCode(it) }
-                ?: paymentMethod.card?.brand
             resolvableString(
                 com.stripe.android.R.string.stripe_card_ending_in,
-                brand?.displayName,
+                brandDisplayName(),
                 paymentMethod.card?.last4
             )
         }
@@ -49,5 +47,11 @@ internal data class DisplayableSavedPaymentMethod(
             R.string.stripe_paymentsheet_remove_pm,
             getDescription(),
         )
+    }
+
+    fun brandDisplayName(): String? {
+        val brand = paymentMethod.card?.displayBrand?.let { CardBrand.fromCode(it) }
+            ?: paymentMethod.card?.brand
+        return brand?.displayName
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/RemovePaymentMethodDialogUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/RemovePaymentMethodDialogUI.kt
@@ -41,7 +41,7 @@ private fun DisplayableSavedPaymentMethod.getRemoveDialogTitle() = when (payment
 private fun DisplayableSavedPaymentMethod.getRemoveDialogDescription() = when (paymentMethod.type) {
     PaymentMethod.Type.Card -> resolvableString(
         com.stripe.android.R.string.stripe_card_with_last_4,
-        paymentMethod.card?.brand,
+        this.brandDisplayName(),
         paymentMethod.card?.last4
     )
     PaymentMethod.Type.SepaDebit -> resolvableString(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/RemovePaymentMethodDialogUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/RemovePaymentMethodDialogUITest.kt
@@ -1,0 +1,43 @@
+package com.stripe.android.paymentsheet.ui
+
+import android.os.Build
+import androidx.compose.ui.test.assertAny
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onChildren
+import androidx.compose.ui.test.onNodeWithTag
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.PaymentMethodFixtures.toDisplayableSavedPaymentMethod
+import com.stripe.android.ui.core.elements.TEST_TAG_SIMPLE_DIALOG
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.Test
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.Q])
+class RemovePaymentMethodDialogUITest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun removeDescription_usesSelectedBrandIfAvailable() {
+        val paymentMethod = PaymentMethodFixtures
+            .CARD_WITH_NETWORKS_PAYMENT_METHOD
+            .toDisplayableSavedPaymentMethod()
+
+        composeRule.setContent {
+            RemovePaymentMethodDialogUI(
+                paymentMethod = paymentMethod,
+                onConfirmListener = {},
+                onDismissListener = {}
+            )
+        }
+
+        composeRule.onNodeWithTag(TEST_TAG_SIMPLE_DIALOG).onChildren().assertAny(
+            hasText("Cartes Bancaires ····4242")
+        )
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use display brand in remove dialog description

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Before: For co-branded cards, this description would read as e.g. "Visa ****1001" even when the display brand (shown as the card icon) was Cartes Bancaires. 

Now: The description will read as "Cartes Bancaires ****1001" in the example above.

I previously fixed this for our accessibility text in https://github.com/stripe/stripe-android/pull/9351, but didn't actually update the UI apparently

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screenshots
![fix remove description](https://github.com/user-attachments/assets/8b134ddb-e041-4ca8-bb2f-881984dd7ce5)
