### PR TITLE
Use new update card screen for just one PM in vertical mode

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
@@ -72,7 +72,7 @@ internal fun PaymentMethodVerticalLayoutUI(
         },
         onManageOneSavedPaymentMethod = {
             interactor.handleViewAction(
-                PaymentMethodVerticalLayoutInteractor.ViewAction.TransitionToManageOneSavedPaymentMethod
+                PaymentMethodVerticalLayoutInteractor.ViewAction.OnManageOneSavedPaymentMethod(it)
             )
         },
         imageLoader = imageLoader,
@@ -91,7 +91,7 @@ internal fun PaymentMethodVerticalLayoutUI(
     selection: PaymentSelection?,
     isEnabled: Boolean,
     onViewMorePaymentMethods: () -> Unit,
-    onManageOneSavedPaymentMethod: () -> Unit,
+    onManageOneSavedPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
     onEditPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
     onSelectSavedPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
     imageLoader: StripeImageLoader,
@@ -118,7 +118,7 @@ internal fun PaymentMethodVerticalLayoutUI(
                         savedPaymentMethodAction = savedPaymentMethodAction,
                         onViewMorePaymentMethods = onViewMorePaymentMethods,
                         onEditPaymentMethod = onEditPaymentMethod,
-                        onManageOneSavedPaymentMethod = onManageOneSavedPaymentMethod,
+                        onManageOneSavedPaymentMethod = { onManageOneSavedPaymentMethod(displayedSavedPaymentMethod) },
                     )
                 },
                 onClick = { onSelectSavedPaymentMethod(displayedSavedPaymentMethod) },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUITest.kt
@@ -49,7 +49,7 @@ internal class PaymentMethodVerticalLayoutUITest {
     }
 
     @Test
-    fun oneSavedPm_canBeRemoved_buttonIsEdit_transitionsToManageScreen() = runScenario(
+    fun oneSavedPm_canBeRemoved_buttonIsEdit_callsOnManageOneSavedPm() = runScenario(
         PaymentMethodVerticalLayoutInteractor.State(
             displayablePaymentMethods = emptyList(),
             isProcessing = false,
@@ -62,7 +62,9 @@ internal class PaymentMethodVerticalLayoutUITest {
         assertThat(viewActionRecorder.viewActions).isEmpty()
         composeRule.onNodeWithTag(TEST_TAG_EDIT_SAVED_CARD).performClick()
         viewActionRecorder.consume(
-            PaymentMethodVerticalLayoutInteractor.ViewAction.TransitionToManageOneSavedPaymentMethod
+            PaymentMethodVerticalLayoutInteractor.ViewAction.OnManageOneSavedPaymentMethod(
+                PaymentMethodFixtures.displayableCard()
+            )
         )
         assertThat(viewActionRecorder.viewActions).isEmpty()
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use new update card screen for just one PM in vertical mode

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2655

https://stripe.slack.com/archives/C07RF1UM08M/p1731008154593099

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screen recording
[edit button navigation.webm](https://github.com/user-attachments/assets/c5b61cc4-1ff5-4704-b554-0730fbbc30a4)

