### PR TITLE
Rename `IntentConfirmationHandler` to `DefaultConfirmationHandler`

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -15,10 +15,10 @@
     <ID>LargeClass:CustomerAdapterTest.kt$CustomerAdapterTest</ID>
     <ID>LargeClass:CustomerSheetViewModel.kt$CustomerSheetViewModel : ViewModel</ID>
     <ID>LargeClass:CustomerSheetViewModelTest.kt$CustomerSheetViewModelTest</ID>
+    <ID>LargeClass:DefaultConfirmationHandlerTest.kt$DefaultConfirmationHandlerTest</ID>
     <ID>LargeClass:DefaultEventReporterTest.kt$DefaultEventReporterTest</ID>
     <ID>LargeClass:DefaultFlowControllerTest.kt$DefaultFlowControllerTest</ID>
     <ID>LargeClass:DefaultPaymentElementLoaderTest.kt$DefaultPaymentElementLoaderTest</ID>
-    <ID>LargeClass:IntentConfirmationHandlerTest.kt$IntentConfirmationHandlerTest</ID>
     <ID>LargeClass:PaymentMethodMetadataTest.kt$PaymentMethodMetadataTest</ID>
     <ID>LargeClass:PaymentOptionsViewModelTest.kt$PaymentOptionsViewModelTest</ID>
     <ID>LargeClass:PaymentSheetActivityTest.kt$PaymentSheetActivityTest</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -50,7 +50,7 @@ import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.ConfirmationHandler
-import com.stripe.android.paymentsheet.IntentConfirmationHandler
+import com.stripe.android.paymentsheet.DefaultConfirmationHandler
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
 import com.stripe.android.paymentsheet.forms.FormFieldValues
@@ -99,7 +99,7 @@ internal class CustomerSheetViewModel(
     private val eventReporter: CustomerSheetEventReporter,
     private val workContext: CoroutineContext = Dispatchers.IO,
     @Named(IS_LIVE_MODE) private val isLiveModeProvider: () -> Boolean,
-    intentConfirmationHandlerFactory: IntentConfirmationHandler.Factory,
+    defaultConfirmationHandlerFactory: DefaultConfirmationHandler.Factory,
     private val customerSheetLoader: CustomerSheetLoader,
     private val editInteractorFactory: ModifiableEditPaymentMethodViewInteractor.Factory,
     private val errorReporter: ErrorReporter,
@@ -116,7 +116,7 @@ internal class CustomerSheetViewModel(
         eventReporter: CustomerSheetEventReporter,
         workContext: CoroutineContext = Dispatchers.IO,
         @Named(IS_LIVE_MODE) isLiveModeProvider: () -> Boolean,
-        intentConfirmationHandlerFactory: IntentConfirmationHandler.Factory,
+        defaultConfirmationHandlerFactory: DefaultConfirmationHandler.Factory,
         customerSheetLoader: CustomerSheetLoader,
         editInteractorFactory: ModifiableEditPaymentMethodViewInteractor.Factory,
         errorReporter: ErrorReporter,
@@ -134,7 +134,7 @@ internal class CustomerSheetViewModel(
         eventReporter = eventReporter,
         workContext = workContext,
         isLiveModeProvider = isLiveModeProvider,
-        intentConfirmationHandlerFactory = intentConfirmationHandlerFactory,
+        defaultConfirmationHandlerFactory = defaultConfirmationHandlerFactory,
         customerSheetLoader = customerSheetLoader,
         editInteractorFactory = editInteractorFactory,
         errorReporter = errorReporter,
@@ -154,7 +154,7 @@ internal class CustomerSheetViewModel(
     private val _result = MutableStateFlow<InternalCustomerSheetResult?>(null)
     val result: StateFlow<InternalCustomerSheetResult?> = _result
 
-    private val intentConfirmationHandler = intentConfirmationHandlerFactory.create(
+    private val intentConfirmationHandler = defaultConfirmationHandlerFactory.create(
         scope = viewModelScope.plus(workContext)
     )
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -99,7 +99,7 @@ internal class CustomerSheetViewModel(
     private val eventReporter: CustomerSheetEventReporter,
     private val workContext: CoroutineContext = Dispatchers.IO,
     @Named(IS_LIVE_MODE) private val isLiveModeProvider: () -> Boolean,
-    defaultConfirmationHandlerFactory: DefaultConfirmationHandler.Factory,
+    confirmationHandlerFactory: DefaultConfirmationHandler.Factory,
     private val customerSheetLoader: CustomerSheetLoader,
     private val editInteractorFactory: ModifiableEditPaymentMethodViewInteractor.Factory,
     private val errorReporter: ErrorReporter,
@@ -116,7 +116,7 @@ internal class CustomerSheetViewModel(
         eventReporter: CustomerSheetEventReporter,
         workContext: CoroutineContext = Dispatchers.IO,
         @Named(IS_LIVE_MODE) isLiveModeProvider: () -> Boolean,
-        defaultConfirmationHandlerFactory: DefaultConfirmationHandler.Factory,
+        confirmationHandlerFactory: DefaultConfirmationHandler.Factory,
         customerSheetLoader: CustomerSheetLoader,
         editInteractorFactory: ModifiableEditPaymentMethodViewInteractor.Factory,
         errorReporter: ErrorReporter,
@@ -134,7 +134,7 @@ internal class CustomerSheetViewModel(
         eventReporter = eventReporter,
         workContext = workContext,
         isLiveModeProvider = isLiveModeProvider,
-        defaultConfirmationHandlerFactory = defaultConfirmationHandlerFactory,
+        confirmationHandlerFactory = confirmationHandlerFactory,
         customerSheetLoader = customerSheetLoader,
         editInteractorFactory = editInteractorFactory,
         errorReporter = errorReporter,
@@ -154,7 +154,7 @@ internal class CustomerSheetViewModel(
     private val _result = MutableStateFlow<InternalCustomerSheetResult?>(null)
     val result: StateFlow<InternalCustomerSheetResult?> = _result
 
-    private val intentConfirmationHandler = defaultConfirmationHandlerFactory.create(
+    private val confirmationHandler = confirmationHandlerFactory.create(
         scope = viewModelScope.plus(workContext)
     )
 
@@ -320,7 +320,7 @@ internal class CustomerSheetViewModel(
         activityResultCaller: ActivityResultCaller,
         lifecycleOwner: LifecycleOwner
     ) {
-        intentConfirmationHandler.register(
+        confirmationHandler.register(
             activityResultCaller = activityResultCaller,
             lifecycleOwner = lifecycleOwner,
         )
@@ -993,7 +993,7 @@ internal class CustomerSheetViewModel(
         clientSecret: String,
         paymentMethod: PaymentMethod
     ) {
-        intentConfirmationHandler.start(
+        confirmationHandler.start(
             arguments = ConfirmationHandler.Args(
                 intent = stripeIntent,
                 confirmationOption = ConfirmationHandler.Option.PaymentMethod.Saved(
@@ -1007,7 +1007,7 @@ internal class CustomerSheetViewModel(
             )
         )
 
-        when (val result = intentConfirmationHandler.awaitIntentResult()) {
+        when (val result = confirmationHandler.awaitIntentResult()) {
             is ConfirmationHandler.Result.Succeeded -> {
                 eventReporter.onAttachPaymentMethodSucceeded(
                     style = CustomerSheetEventReporter.AddPaymentMethodStyle.SetupIntent

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -28,8 +28,8 @@ import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.financialconnections.DefaultIsFinancialConnectionsAvailable
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAvailable
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
+import com.stripe.android.paymentsheet.DefaultConfirmationHandler
 import com.stripe.android.paymentsheet.DefaultIntentConfirmationInterceptor
-import com.stripe.android.paymentsheet.IntentConfirmationHandler
 import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.injection.IS_FLOW_CONTROLLER
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -147,8 +147,8 @@ internal interface CustomerSheetViewModelModule {
             statusBarColor: Int?,
             intentConfirmationInterceptor: IntentConfirmationInterceptor,
             errorReporter: ErrorReporter
-        ): IntentConfirmationHandler.Factory {
-            return IntentConfirmationHandler.Factory(
+        ): DefaultConfirmationHandler.Factory {
+            return DefaultConfirmationHandler.Factory(
                 intentConfirmationInterceptor = intentConfirmationInterceptor,
                 paymentConfigurationProvider = paymentConfigurationProvider,
                 stripePaymentLauncherAssistedFactory = stripePaymentLauncherAssistedFactory,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultConfirmationHandler.kt
@@ -45,7 +45,7 @@ import kotlin.time.Duration.Companion.seconds
  * This interface handles the process of confirming a [StripeIntent]. This interface can only handle confirming one
  * intent at a time.
  */
-internal class IntentConfirmationHandler(
+internal class DefaultConfirmationHandler(
     private val intentConfirmationInterceptor: IntentConfirmationInterceptor,
     private val paymentLauncherFactory: (ActivityResultLauncher<PaymentLauncherContract.Args>) -> PaymentLauncher,
     private val bacsMandateConfirmationLauncherFactory: BacsMandateConfirmationLauncherFactory,
@@ -628,8 +628,8 @@ internal class IntentConfirmationHandler(
         private val errorReporter: ErrorReporter,
         private val logger: UserFacingLogger?
     ) {
-        fun create(scope: CoroutineScope): IntentConfirmationHandler {
-            return IntentConfirmationHandler(
+        fun create(scope: CoroutineScope): DefaultConfirmationHandler {
+            return DefaultConfirmationHandler(
                 bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,
                 googlePayPaymentMethodLauncherFactory = googlePayPaymentMethodLauncherFactory,
                 paymentLauncherFactory = { hostActivityLauncher ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -81,7 +81,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     @IOContext workContext: CoroutineContext,
     savedStateHandle: SavedStateHandle,
     linkHandler: LinkHandler,
-    intentConfirmationHandlerFactory: IntentConfirmationHandler.Factory,
+    defaultConfirmationHandlerFactory: DefaultConfirmationHandler.Factory,
     cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
     editInteractorFactory: ModifiableEditPaymentMethodViewInteractor.Factory,
     private val errorReporter: ErrorReporter,
@@ -211,7 +211,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         }
     }
 
-    private val intentConfirmationHandler = intentConfirmationHandlerFactory.create(viewModelScope.plus(workContext))
+    private val intentConfirmationHandler = defaultConfirmationHandlerFactory.create(viewModelScope.plus(workContext))
 
     init {
         SessionSavedStateHandler.attachTo(this, savedStateHandle)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -29,10 +29,10 @@ import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
 import com.stripe.android.paymentsheet.ConfirmationHandler
+import com.stripe.android.paymentsheet.DefaultConfirmationHandler
 import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.ExternalPaymentMethodInterceptor
 import com.stripe.android.paymentsheet.InitializedViaCompose
-import com.stripe.android.paymentsheet.IntentConfirmationHandler
 import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.PaymentCancellationAction
 import com.stripe.android.paymentsheet.PaymentConfirmationErrorType
@@ -122,7 +122,7 @@ internal class DefaultFlowController @Inject internal constructor(
      */
     lateinit var flowControllerComponent: FlowControllerComponent
 
-    private val intentConfirmationHandler = IntentConfirmationHandler.Factory(
+    private val defaultConfirmationHandler = DefaultConfirmationHandler.Factory(
         intentConfirmationInterceptor = intentConfirmationInterceptor,
         paymentConfigurationProvider = lazyPaymentConfiguration,
         statusBarColor = { null },
@@ -151,7 +151,7 @@ internal class DefaultFlowController @Inject internal constructor(
         }
 
     init {
-        intentConfirmationHandler.register(activityResultCaller, lifecycleOwner)
+        defaultConfirmationHandler.register(activityResultCaller, lifecycleOwner)
 
         paymentOptionActivityLauncher = activityResultCaller.registerForActivityResult(
             PaymentOptionContract(),
@@ -196,7 +196,7 @@ internal class DefaultFlowController @Inject internal constructor(
         )
 
         lifecycleOwner.lifecycleScope.launch {
-            intentConfirmationHandler.state.collectLatest { state ->
+            defaultConfirmationHandler.state.collectLatest { state ->
                 when (state) {
                     is ConfirmationHandler.State.Idle,
                     is ConfirmationHandler.State.Preconfirming,
@@ -396,7 +396,7 @@ internal class DefaultFlowController @Inject internal constructor(
             confirmationOption?.let { option ->
                 val stripeIntent = requireNotNull(state.stripeIntent)
 
-                intentConfirmationHandler.start(
+                defaultConfirmationHandler.start(
                     arguments = ConfirmationHandler.Args(
                         confirmationOption = option,
                         intent = stripeIntent,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -122,7 +122,7 @@ internal class DefaultFlowController @Inject internal constructor(
      */
     lateinit var flowControllerComponent: FlowControllerComponent
 
-    private val defaultConfirmationHandler = DefaultConfirmationHandler.Factory(
+    private val confirmationHandler = DefaultConfirmationHandler.Factory(
         intentConfirmationInterceptor = intentConfirmationInterceptor,
         paymentConfigurationProvider = lazyPaymentConfiguration,
         statusBarColor = { null },
@@ -151,7 +151,7 @@ internal class DefaultFlowController @Inject internal constructor(
         }
 
     init {
-        defaultConfirmationHandler.register(activityResultCaller, lifecycleOwner)
+        confirmationHandler.register(activityResultCaller, lifecycleOwner)
 
         paymentOptionActivityLauncher = activityResultCaller.registerForActivityResult(
             PaymentOptionContract(),
@@ -196,7 +196,7 @@ internal class DefaultFlowController @Inject internal constructor(
         )
 
         lifecycleOwner.lifecycleScope.launch {
-            defaultConfirmationHandler.state.collectLatest { state ->
+            confirmationHandler.state.collectLatest { state ->
                 when (state) {
                     is ConfirmationHandler.State.Idle,
                     is ConfirmationHandler.State.Preconfirming,
@@ -396,7 +396,7 @@ internal class DefaultFlowController @Inject internal constructor(
             confirmationOption?.let { option ->
                 val stripeIntent = requireNotNull(state.stripeIntent)
 
-                defaultConfirmationHandler.start(
+                confirmationHandler.start(
                     arguments = ConfirmationHandler.Args(
                         confirmationOption = option,
                         intent = stripeIntent,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -8,8 +8,8 @@ import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
+import com.stripe.android.paymentsheet.DefaultConfirmationHandler
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
-import com.stripe.android.paymentsheet.IntentConfirmationHandler
 import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.PaymentSheetContractV2
 import com.stripe.android.paymentsheet.PrefsRepository
@@ -37,8 +37,8 @@ internal class PaymentSheetViewModelModule(private val starterArgs: PaymentSheet
         intentConfirmationInterceptor: IntentConfirmationInterceptor,
         errorReporter: ErrorReporter,
         logger: UserFacingLogger,
-    ): IntentConfirmationHandler.Factory {
-        return IntentConfirmationHandler.Factory(
+    ): DefaultConfirmationHandler.Factory {
+        return DefaultConfirmationHandler.Factory(
             intentConfirmationInterceptor = intentConfirmationInterceptor,
             paymentConfigurationProvider = paymentConfigurationProvider,
             stripePaymentLauncherAssistedFactory = stripePaymentLauncherAssistedFactory,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -36,7 +36,7 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncher
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
-import com.stripe.android.paymentsheet.IntentConfirmationHandler
+import com.stripe.android.paymentsheet.DefaultConfirmationHandler
 import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.FakeBacsMandateConfirmationLauncher
@@ -118,7 +118,7 @@ internal object CustomerSheetTestHelper {
             integrationType = integrationType,
             isLiveModeProvider = { isLiveMode },
             logger = Logger.noop(),
-            intentConfirmationHandlerFactory = IntentConfirmationHandler.Factory(
+            defaultConfirmationHandlerFactory = DefaultConfirmationHandler.Factory(
                 intentConfirmationInterceptor = intentConfirmationInterceptor,
                 paymentConfigurationProvider = { paymentConfiguration },
                 bacsMandateConfirmationLauncherFactory = {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -118,7 +118,7 @@ internal object CustomerSheetTestHelper {
             integrationType = integrationType,
             isLiveModeProvider = { isLiveMode },
             logger = Logger.noop(),
-            defaultConfirmationHandlerFactory = DefaultConfirmationHandler.Factory(
+            confirmationHandlerFactory = DefaultConfirmationHandler.Factory(
                 intentConfirmationInterceptor = intentConfirmationInterceptor,
                 paymentConfigurationProvider = { paymentConfiguration },
                 bacsMandateConfirmationLauncherFactory = {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultConfirmationHandlerTest.kt
@@ -58,7 +58,7 @@ import kotlin.time.Duration.Companion.seconds
 import com.stripe.android.R as PaymentsCoreR
 
 @RunWith(AndroidJUnit4::class)
-class IntentConfirmationHandlerTest {
+class DefaultConfirmationHandlerTest {
     @Test
     fun `On 'init', state should be idle`() = runTest {
         val intentConfirmationHandler = createIntentConfirmationHandler()
@@ -1946,8 +1946,8 @@ class IntentConfirmationHandlerTest {
         logger: UserFacingLogger = FakeUserFacingLogger(),
         shouldRegister: Boolean = true,
         coroutineScope: CoroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
-    ): IntentConfirmationHandler {
-        return IntentConfirmationHandler(
+    ): DefaultConfirmationHandler {
+        return DefaultConfirmationHandler(
             intentConfirmationInterceptor = intentConfirmationInterceptor,
             paymentLauncherFactory = { paymentLauncher },
             bacsMandateConfirmationLauncherFactory = { bacsMandateConfirmationLauncher },
@@ -2110,7 +2110,7 @@ class IntentConfirmationHandlerTest {
         /**
          * The external payment method confirm handler is not used in [ExternalPaymentMethodInterceptor] which is
          * not tested here but is instead meant to be used in the launched activity the interceptor attempts to launch.
-         * Since we only care that [IntentConfirmationHandler] is actually attempting to launch the EPM handler as well
+         * Since we only care that [DefaultConfirmationHandler] is actually attempting to launch the EPM handler as well
          * as its interactions, we don't do anything here except for using the handler to validate that we can launch
          * the EPM handler.
          */

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultConfirmationHandlerTest.kt
@@ -61,9 +61,9 @@ import com.stripe.android.R as PaymentsCoreR
 class DefaultConfirmationHandlerTest {
     @Test
     fun `On 'init', state should be idle`() = runTest {
-        val intentConfirmationHandler = createIntentConfirmationHandler()
+        val defaultConfirmationHandler = createDefaultConfirmationHandler()
 
-        intentConfirmationHandler.state.test {
+        defaultConfirmationHandler.state.test {
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Idle)
 
             ensureAllEventsConsumed()
@@ -92,11 +92,11 @@ class DefaultConfirmationHandlerTest {
             cvc = "507"
         )
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor,
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = ConfirmationHandler.Args(
                 intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 confirmationOption = ConfirmationHandler.Option.PaymentMethod.Saved(
@@ -135,12 +135,12 @@ class DefaultConfirmationHandlerTest {
 
     @Test
     fun `On 'start', state should be updated to confirming`() = runTest {
-        val intentConfirmationHandler = createIntentConfirmationHandler()
+        val defaultConfirmationHandler = createDefaultConfirmationHandler()
 
-        intentConfirmationHandler.state.test {
+        defaultConfirmationHandler.state.test {
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Idle)
 
-            intentConfirmationHandler.start(
+            defaultConfirmationHandler.start(
                 arguments = ConfirmationHandler.Args(
                     intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                     confirmationOption = ConfirmationHandler.Option.PaymentMethod.Saved(
@@ -179,11 +179,11 @@ class DefaultConfirmationHandlerTest {
             )
         )
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor,
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = ConfirmationHandler.Args(
                 intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 confirmationOption = ConfirmationHandler.Option.PaymentMethod.New(
@@ -228,11 +228,11 @@ class DefaultConfirmationHandlerTest {
             )
         )
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor,
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = ConfirmationHandler.Args(
                 intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 confirmationOption = ConfirmationHandler.Option.PaymentMethod.Saved(
@@ -261,17 +261,17 @@ class DefaultConfirmationHandlerTest {
     @Test
     fun `On 'start' while handler is already confirming, should not do anything`() = runTest {
         val interceptor = FakeIntentConfirmationInterceptor()
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS,
         )
 
         interceptor.calls.skipItems(1)
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS,
         )
 
@@ -284,15 +284,15 @@ class DefaultConfirmationHandlerTest {
 
         interceptor.enqueueCompleteStep()
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS,
         )
 
-        val result = intentConfirmationHandler.awaitIntentResult()
+        val result = defaultConfirmationHandler.awaitIntentResult()
 
         assertThat(result).isEqualTo(
             ConfirmationHandler.Result.Succeeded(
@@ -314,15 +314,15 @@ class DefaultConfirmationHandlerTest {
             message = message,
         )
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS,
         )
 
-        val result = intentConfirmationHandler.awaitIntentResult()
+        val result = defaultConfirmationHandler.awaitIntentResult()
 
         assertThat(result).isEqualTo(
             ConfirmationHandler.Result.Failed(
@@ -341,17 +341,17 @@ class DefaultConfirmationHandlerTest {
 
             interceptor.enqueueConfirmStep(ConfirmPaymentIntentParams.create(clientSecret = "pi_1234"))
 
-            val intentConfirmationHandler = createIntentConfirmationHandler(
+            val defaultConfirmationHandler = createDefaultConfirmationHandler(
                 intentConfirmationInterceptor = interceptor,
                 paymentLauncher = paymentLauncher,
                 shouldRegister = false,
             )
 
-            intentConfirmationHandler.start(
+            defaultConfirmationHandler.start(
                 arguments = DEFAULT_ARGUMENTS,
             )
 
-            val result = intentConfirmationHandler.awaitIntentResult()
+            val result = defaultConfirmationHandler.awaitIntentResult()
 
             val failedResult = result.asFailed()
 
@@ -371,12 +371,12 @@ class DefaultConfirmationHandlerTest {
             enqueueConfirmStep(confirmParams)
         }
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor,
             paymentLauncher = paymentLauncher,
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS,
         )
 
@@ -400,12 +400,12 @@ class DefaultConfirmationHandlerTest {
             enqueueConfirmStep(confirmParams)
         }
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor,
             paymentLauncher = paymentLauncher,
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
                 intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
             ),
@@ -428,12 +428,12 @@ class DefaultConfirmationHandlerTest {
             enqueueNextActionStep(clientSecret)
         }
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor,
             paymentLauncher = paymentLauncher,
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS,
         )
 
@@ -454,12 +454,12 @@ class DefaultConfirmationHandlerTest {
             enqueueNextActionStep(clientSecret)
         }
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor,
             paymentLauncher = paymentLauncher,
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
                 intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
             ),
@@ -480,21 +480,21 @@ class DefaultConfirmationHandlerTest {
             enqueueConfirmStep(ConfirmPaymentIntentParams.create("pi_123"))
         }
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor,
             shouldRegister = false,
         )
 
         val paymentResultCallbackHandler = FakeResultHandler<InternalPaymentResult>()
 
-        intentConfirmationHandler.registerWithCallbacks(
+        defaultConfirmationHandler.registerWithCallbacks(
             paymentResultCallbackHandler = paymentResultCallbackHandler
         )
 
-        intentConfirmationHandler.state.test {
+        defaultConfirmationHandler.state.test {
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Idle)
 
-            intentConfirmationHandler.start(
+            defaultConfirmationHandler.start(
                 arguments = DEFAULT_ARGUMENTS,
             )
 
@@ -513,7 +513,7 @@ class DefaultConfirmationHandlerTest {
                 deferredIntentConfirmationType = null,
             )
 
-            assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -526,21 +526,21 @@ class DefaultConfirmationHandlerTest {
             enqueueConfirmStep(ConfirmPaymentIntentParams.create("pi_123"))
         }
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor,
             shouldRegister = false,
         )
 
         val paymentResultCallbackHandler = FakeResultHandler<InternalPaymentResult>()
 
-        intentConfirmationHandler.registerWithCallbacks(
+        defaultConfirmationHandler.registerWithCallbacks(
             paymentResultCallbackHandler = paymentResultCallbackHandler
         )
 
-        intentConfirmationHandler.state.test {
+        defaultConfirmationHandler.state.test {
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Idle)
 
-            intentConfirmationHandler.start(
+            defaultConfirmationHandler.start(
                 arguments = DEFAULT_ARGUMENTS,
             )
 
@@ -558,7 +558,7 @@ class DefaultConfirmationHandlerTest {
                 action = PaymentCancellationAction.InformCancellation,
             )
 
-            assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -571,21 +571,21 @@ class DefaultConfirmationHandlerTest {
             enqueueConfirmStep(ConfirmPaymentIntentParams.create("pi_123"))
         }
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor,
             shouldRegister = false,
         )
 
         val paymentResultCallbackHandler = FakeResultHandler<InternalPaymentResult>()
 
-        intentConfirmationHandler.registerWithCallbacks(
+        defaultConfirmationHandler.registerWithCallbacks(
             paymentResultCallbackHandler = paymentResultCallbackHandler
         )
 
-        intentConfirmationHandler.state.test {
+        defaultConfirmationHandler.state.test {
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Idle)
 
-            intentConfirmationHandler.start(
+            defaultConfirmationHandler.start(
                 arguments = DEFAULT_ARGUMENTS,
             )
 
@@ -607,7 +607,7 @@ class DefaultConfirmationHandlerTest {
                 type = PaymentConfirmationErrorType.Payment,
             )
 
-            assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -621,12 +621,12 @@ class DefaultConfirmationHandlerTest {
             enqueueConfirmStep(ConfirmPaymentIntentParams.create("pi_123"))
         }
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor,
             savedStateHandle = savedStateHandle,
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS,
         )
 
@@ -640,12 +640,12 @@ class DefaultConfirmationHandlerTest {
             enqueueNextActionStep("pi_123")
         }
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor,
             savedStateHandle = savedStateHandle,
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS,
         )
 
@@ -661,12 +661,12 @@ class DefaultConfirmationHandlerTest {
             enqueueNextActionStep("pi_123")
         }
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor,
             savedStateHandle = savedStateHandle,
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
                 confirmationOption = EXTERNAL_PAYMENT_METHOD
             ),
@@ -679,12 +679,12 @@ class DefaultConfirmationHandlerTest {
     fun `On start Bacs mandate, should store 'AwaitingPreConfirmResult' in 'SavedStateHandle'`() = runTest {
         val savedStateHandle = SavedStateHandle()
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             savedStateHandle = savedStateHandle,
 
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
                 confirmationOption = createBacsPaymentConfirmationOption(),
             ),
@@ -697,11 +697,11 @@ class DefaultConfirmationHandlerTest {
     fun `On start Google Pay, should store 'AwaitingPreConfirmResult' in 'SavedStateHandle'`() = runTest {
         val savedStateHandle = SavedStateHandle()
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             savedStateHandle = savedStateHandle,
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
                 confirmationOption = GOOGLE_PAY_OPTION,
             ),
@@ -718,12 +718,12 @@ class DefaultConfirmationHandlerTest {
             set("AwaitingPaymentResult", true)
         }
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             savedStateHandle = savedStateHandle,
             coroutineScope = CoroutineScope(dispatcher)
         )
 
-        intentConfirmationHandler.state.test {
+        defaultConfirmationHandler.state.test {
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Confirming)
 
             dispatcher.scheduler.advanceTimeBy(delayTime = 1.01.seconds)
@@ -732,7 +732,7 @@ class DefaultConfirmationHandlerTest {
                 action = PaymentCancellationAction.None
             )
 
-            assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -756,7 +756,7 @@ class DefaultConfirmationHandlerTest {
             set("PaymentConfirmationArguments", bacsArguments)
         }
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             savedStateHandle = savedStateHandle,
             intentConfirmationInterceptor = interceptor,
             coroutineScope = CoroutineScope(dispatcher)
@@ -764,11 +764,11 @@ class DefaultConfirmationHandlerTest {
 
         val bacsMandateConfirmationCallbackHandler = FakeResultHandler<BacsMandateConfirmationResult>()
 
-        intentConfirmationHandler.registerWithCallbacks(
+        defaultConfirmationHandler.registerWithCallbacks(
             bacsMandateConfirmationCallbackHandler = bacsMandateConfirmationCallbackHandler
         )
 
-        intentConfirmationHandler.state.test {
+        defaultConfirmationHandler.state.test {
             assertThat(awaitItem()).isEqualTo(
                 ConfirmationHandler.State.Preconfirming(
                     confirmationOption = confirmationOption,
@@ -789,7 +789,7 @@ class DefaultConfirmationHandlerTest {
                 deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
             )
 
-            assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -803,19 +803,19 @@ class DefaultConfirmationHandlerTest {
             set("IntentConfirmationArguments", DEFAULT_ARGUMENTS.copy(confirmationOption = EXTERNAL_PAYMENT_METHOD))
         }
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             savedStateHandle = savedStateHandle,
         )
 
         val paymentResultCallbackHandler = FakeResultHandler<InternalPaymentResult>()
 
-        intentConfirmationHandler.registerWithCallbacks(
+        defaultConfirmationHandler.registerWithCallbacks(
             paymentResultCallbackHandler = paymentResultCallbackHandler
         )
 
         paymentResultCallbackHandler.onResult(InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED))
 
-        val failedResult = intentConfirmationHandler.awaitIntentResult().asFailed()
+        val failedResult = defaultConfirmationHandler.awaitIntentResult().asFailed()
 
         assertThat(failedResult.type).isEqualTo(PaymentConfirmationErrorType.Internal)
     }
@@ -834,19 +834,19 @@ class DefaultConfirmationHandlerTest {
             )
         }
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             savedStateHandle = savedStateHandle,
         )
 
         val paymentResultCallbackHandler = FakeResultHandler<InternalPaymentResult>()
 
-        intentConfirmationHandler.registerWithCallbacks(
+        defaultConfirmationHandler.registerWithCallbacks(
             paymentResultCallbackHandler = paymentResultCallbackHandler
         )
 
         paymentResultCallbackHandler.onResult(InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED))
 
-        val result = intentConfirmationHandler.awaitIntentResult()
+        val result = defaultConfirmationHandler.awaitIntentResult()
 
         assertThat(result).isEqualTo(
             ConfirmationHandler.Result.Succeeded(
@@ -865,15 +865,15 @@ class DefaultConfirmationHandlerTest {
             )
         }
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor,
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS,
         )
 
-        val failedResult = intentConfirmationHandler.awaitIntentResult().asFailed()
+        val failedResult = defaultConfirmationHandler.awaitIntentResult().asFailed()
 
         assertThat(failedResult.cause).isInstanceOf(InvalidDeferredIntentUsageException::class.java)
         assertThat(failedResult.type).isEqualTo(PaymentConfirmationErrorType.Payment)
@@ -889,24 +889,24 @@ class DefaultConfirmationHandlerTest {
             )
         }
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor,
             shouldRegister = false,
         )
 
         val paymentResultCallbackHandler = FakeResultHandler<InternalPaymentResult>()
 
-        intentConfirmationHandler.registerWithCallbacks(
+        defaultConfirmationHandler.registerWithCallbacks(
             paymentResultCallbackHandler = paymentResultCallbackHandler
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS,
         )
 
         paymentResultCallbackHandler.onResult(InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED))
 
-        val result = intentConfirmationHandler.awaitIntentResult()
+        val result = defaultConfirmationHandler.awaitIntentResult()
 
         assertThat(result).isEqualTo(
             ConfirmationHandler.Result.Succeeded(
@@ -925,21 +925,21 @@ class DefaultConfirmationHandlerTest {
             isDeferred = false,
         )
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor,
             shouldRegister = false,
         )
 
         val paymentResultCallbackHandler = FakeResultHandler<InternalPaymentResult>()
 
-        intentConfirmationHandler.registerWithCallbacks(
+        defaultConfirmationHandler.registerWithCallbacks(
             paymentResultCallbackHandler = paymentResultCallbackHandler
         )
 
-        intentConfirmationHandler.state.test {
+        defaultConfirmationHandler.state.test {
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Idle)
 
-            intentConfirmationHandler.start(
+            defaultConfirmationHandler.start(
                 arguments = DEFAULT_ARGUMENTS,
             )
 
@@ -958,7 +958,7 @@ class DefaultConfirmationHandlerTest {
                 deferredIntentConfirmationType = null,
             )
 
-            assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -971,11 +971,11 @@ class DefaultConfirmationHandlerTest {
 
         val fakeExternalPaymentMethodLauncher = FakeExternalPaymentMethodLauncher()
 
-        val intentConfirmationHandler = createIntentConfirmationHandler().apply {
+        val defaultConfirmationHandler = createDefaultConfirmationHandler().apply {
             setExternalPaymentMethodLauncher(fakeExternalPaymentMethodLauncher)
         }
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
                 confirmationOption = EXTERNAL_PAYMENT_METHOD.copy(
                     billingDetails = PaymentMethod.BillingDetails(
@@ -1009,15 +1009,15 @@ class DefaultConfirmationHandlerTest {
     fun `On external PM with no confirm handler, should return failed result`() = runTest {
         ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler = null
 
-        val intentConfirmationHandler = createIntentConfirmationHandler()
+        val defaultConfirmationHandler = createDefaultConfirmationHandler()
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
                 confirmationOption = EXTERNAL_PAYMENT_METHOD,
             ),
         )
 
-        val intentResult = intentConfirmationHandler.awaitIntentResult().asFailed()
+        val intentResult = defaultConfirmationHandler.awaitIntentResult().asFailed()
 
         assertThat(intentResult.cause.message).isEqualTo(
             "externalPaymentMethodConfirmHandler is null. Cannot process payment for payment selection: paypal"
@@ -1030,17 +1030,17 @@ class DefaultConfirmationHandlerTest {
     fun `On external PM with no launcher, should return failed result`() = runTest {
         ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler = EXTERNAL_PAYMENT_METHOD_CONFIRM_HANDLER
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             shouldRegister = false,
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
                 confirmationOption = EXTERNAL_PAYMENT_METHOD,
             ),
         )
 
-        val intentResult = intentConfirmationHandler.awaitIntentResult().asFailed()
+        val intentResult = defaultConfirmationHandler.awaitIntentResult().asFailed()
 
         assertThat(intentResult.cause.message).isEqualTo(
             "externalPaymentMethodLauncher is null. Cannot process payment for payment selection: paypal"
@@ -1053,18 +1053,18 @@ class DefaultConfirmationHandlerTest {
     fun `On external PM succeeded result, should return intent succeeded result`() = runTest {
         ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler = EXTERNAL_PAYMENT_METHOD_CONFIRM_HANDLER
 
-        val intentConfirmationHandler = createIntentConfirmationHandler()
+        val defaultConfirmationHandler = createDefaultConfirmationHandler()
 
         val epmsCallbackHandler = FakeResultHandler<PaymentResult>()
 
-        intentConfirmationHandler.registerWithCallbacks(
+        defaultConfirmationHandler.registerWithCallbacks(
             externalPaymentMethodsCallbackHandler = epmsCallbackHandler
         )
 
-        intentConfirmationHandler.state.test {
+        defaultConfirmationHandler.state.test {
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Idle)
 
-            intentConfirmationHandler.start(
+            defaultConfirmationHandler.start(
                 arguments = DEFAULT_ARGUMENTS.copy(
                     confirmationOption = EXTERNAL_PAYMENT_METHOD,
                 ),
@@ -1085,7 +1085,7 @@ class DefaultConfirmationHandlerTest {
                 deferredIntentConfirmationType = null,
             )
 
-            assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -1096,18 +1096,18 @@ class DefaultConfirmationHandlerTest {
     fun `On external PM failed result, should return intent failed result`() = runTest {
         ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler = EXTERNAL_PAYMENT_METHOD_CONFIRM_HANDLER
 
-        val intentConfirmationHandler = createIntentConfirmationHandler()
+        val defaultConfirmationHandler = createDefaultConfirmationHandler()
 
         val epmsCallbackHandler = FakeResultHandler<PaymentResult>()
 
-        intentConfirmationHandler.registerWithCallbacks(
+        defaultConfirmationHandler.registerWithCallbacks(
             externalPaymentMethodsCallbackHandler = epmsCallbackHandler
         )
 
-        intentConfirmationHandler.state.test {
+        defaultConfirmationHandler.state.test {
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Idle)
 
-            intentConfirmationHandler.start(
+            defaultConfirmationHandler.start(
                 arguments = DEFAULT_ARGUMENTS.copy(
                     confirmationOption = EXTERNAL_PAYMENT_METHOD,
                 ),
@@ -1131,7 +1131,7 @@ class DefaultConfirmationHandlerTest {
                 type = PaymentConfirmationErrorType.ExternalPaymentMethod,
             )
 
-            assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -1142,18 +1142,18 @@ class DefaultConfirmationHandlerTest {
     fun `On external PM canceled result, should return intent canceled result`() = runTest {
         ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler = EXTERNAL_PAYMENT_METHOD_CONFIRM_HANDLER
 
-        val intentConfirmationHandler = createIntentConfirmationHandler()
+        val defaultConfirmationHandler = createDefaultConfirmationHandler()
 
         val epmsCallbackHandler = FakeResultHandler<PaymentResult>()
 
-        intentConfirmationHandler.registerWithCallbacks(
+        defaultConfirmationHandler.registerWithCallbacks(
             externalPaymentMethodsCallbackHandler = epmsCallbackHandler
         )
 
-        intentConfirmationHandler.state.test {
+        defaultConfirmationHandler.state.test {
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Idle)
 
-            intentConfirmationHandler.start(
+            defaultConfirmationHandler.start(
                 arguments = DEFAULT_ARGUMENTS.copy(
                     confirmationOption = EXTERNAL_PAYMENT_METHOD,
                 ),
@@ -1173,7 +1173,7 @@ class DefaultConfirmationHandlerTest {
                 action = PaymentCancellationAction.None,
             )
 
-            assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -1185,14 +1185,14 @@ class DefaultConfirmationHandlerTest {
         val bacsMandateConfirmationLauncher = FakeBacsMandateConfirmationLauncher()
         val interceptor = FakeIntentConfirmationInterceptor()
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor,
             bacsMandateConfirmationLauncher = bacsMandateConfirmationLauncher,
         ).apply {
             registerWithCallbacks()
         }
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
                 confirmationOption = createBacsPaymentConfirmationOption(),
             ),
@@ -1219,12 +1219,12 @@ class DefaultConfirmationHandlerTest {
     fun `On bacs payment method without registering callbacks, should fail intent confirmation`() = runTest {
         val bacsMandateConfirmationLauncher = FakeBacsMandateConfirmationLauncher()
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             bacsMandateConfirmationLauncher = bacsMandateConfirmationLauncher,
             shouldRegister = false
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
                 confirmationOption = createBacsPaymentConfirmationOption(),
             ),
@@ -1232,7 +1232,7 @@ class DefaultConfirmationHandlerTest {
 
         bacsMandateConfirmationLauncher.calls.expectNoEvents()
 
-        val result = intentConfirmationHandler.awaitIntentResult().asFailed()
+        val result = defaultConfirmationHandler.awaitIntentResult().asFailed()
 
         assertThat(result.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
         assertThat(result.type).isEqualTo(PaymentConfirmationErrorType.Internal)
@@ -1243,11 +1243,11 @@ class DefaultConfirmationHandlerTest {
     fun `On missing name for Bacs, should fail with internal error`() = runTest {
         val bacsMandateConfirmationLauncher = FakeBacsMandateConfirmationLauncher()
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             bacsMandateConfirmationLauncher = bacsMandateConfirmationLauncher,
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
                 confirmationOption = createBacsPaymentConfirmationOption(
                     name = null,
@@ -1257,7 +1257,7 @@ class DefaultConfirmationHandlerTest {
 
         bacsMandateConfirmationLauncher.calls.expectNoEvents()
 
-        val result = intentConfirmationHandler.awaitIntentResult().asFailed()
+        val result = defaultConfirmationHandler.awaitIntentResult().asFailed()
 
         assertThat(result.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
         assertThat(result.type).isEqualTo(PaymentConfirmationErrorType.Internal)
@@ -1270,11 +1270,11 @@ class DefaultConfirmationHandlerTest {
     fun `On missing email for Bacs, should fail with internal error`() = runTest {
         val bacsMandateConfirmationLauncher = FakeBacsMandateConfirmationLauncher()
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             bacsMandateConfirmationLauncher = bacsMandateConfirmationLauncher,
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
                 confirmationOption = createBacsPaymentConfirmationOption(
                     email = null,
@@ -1284,7 +1284,7 @@ class DefaultConfirmationHandlerTest {
 
         bacsMandateConfirmationLauncher.calls.expectNoEvents()
 
-        val result = intentConfirmationHandler.awaitIntentResult().asFailed()
+        val result = defaultConfirmationHandler.awaitIntentResult().asFailed()
 
         assertThat(result.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
         assertThat(result.type).isEqualTo(PaymentConfirmationErrorType.Internal)
@@ -1297,19 +1297,19 @@ class DefaultConfirmationHandlerTest {
     fun `On Bacs mandate confirmed, should continue confirmation process`() = runTest {
         val interceptor = FakeIntentConfirmationInterceptor()
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor,
         )
 
         val bacsMandateConfirmationCallbackHandler = FakeResultHandler<BacsMandateConfirmationResult>()
 
-        intentConfirmationHandler.registerWithCallbacks(
+        defaultConfirmationHandler.registerWithCallbacks(
             bacsMandateConfirmationCallbackHandler = bacsMandateConfirmationCallbackHandler,
         )
 
         val confirmationOption = createBacsPaymentConfirmationOption()
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
                 confirmationOption = confirmationOption
             ),
@@ -1336,23 +1336,23 @@ class DefaultConfirmationHandlerTest {
     fun `On modify Bacs data event, should return canceled result`() = runTest {
         val interceptor = FakeIntentConfirmationInterceptor()
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor,
             shouldRegister = false,
         )
 
         val bacsMandateConfirmationCallbackHandler = FakeResultHandler<BacsMandateConfirmationResult>()
 
-        intentConfirmationHandler.registerWithCallbacks(
+        defaultConfirmationHandler.registerWithCallbacks(
             bacsMandateConfirmationCallbackHandler = bacsMandateConfirmationCallbackHandler,
         )
 
         val confirmationOption = createBacsPaymentConfirmationOption()
 
-        intentConfirmationHandler.state.test {
+        defaultConfirmationHandler.state.test {
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Idle)
 
-            intentConfirmationHandler.start(
+            defaultConfirmationHandler.start(
                 arguments = DEFAULT_ARGUMENTS.copy(
                     confirmationOption = confirmationOption
                 ),
@@ -1379,7 +1379,7 @@ class DefaultConfirmationHandlerTest {
                 action = PaymentCancellationAction.ModifyPaymentDetails,
             )
 
-            assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -1390,23 +1390,23 @@ class DefaultConfirmationHandlerTest {
     fun `On cancel Bacs data event, should return canceled result`() = runTest {
         val interceptor = FakeIntentConfirmationInterceptor()
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = interceptor,
             shouldRegister = false,
         )
 
         val bacsMandateConfirmationCallbackHandler = FakeResultHandler<BacsMandateConfirmationResult>()
 
-        intentConfirmationHandler.registerWithCallbacks(
+        defaultConfirmationHandler.registerWithCallbacks(
             bacsMandateConfirmationCallbackHandler = bacsMandateConfirmationCallbackHandler,
         )
 
         val confirmationOption = createBacsPaymentConfirmationOption()
 
-        intentConfirmationHandler.state.test {
+        defaultConfirmationHandler.state.test {
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Idle)
 
-            intentConfirmationHandler.start(
+            defaultConfirmationHandler.start(
                 arguments = DEFAULT_ARGUMENTS.copy(
                     confirmationOption = confirmationOption,
                 ),
@@ -1433,7 +1433,7 @@ class DefaultConfirmationHandlerTest {
                 action = PaymentCancellationAction.None,
             )
 
-            assertThat(intentConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -1443,11 +1443,11 @@ class DefaultConfirmationHandlerTest {
     @Test
     fun `On start Google Pay with no currency and setup intent, should fail and log`() = runTest {
         val logger = FakeUserFacingLogger()
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             logger = logger
         )
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
                 confirmationOption = GOOGLE_PAY_OPTION.copy(
                     initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(
@@ -1460,7 +1460,7 @@ class DefaultConfirmationHandlerTest {
             ),
         )
 
-        val result = intentConfirmationHandler.awaitIntentResult().asFailed()
+        val result = defaultConfirmationHandler.awaitIntentResult().asFailed()
 
         val message = "GooglePayConfig.currencyCode is required in order to use " +
             "Google Pay when processing a Setup Intent"
@@ -1481,13 +1481,13 @@ class DefaultConfirmationHandlerTest {
             } doReturn googlePayPaymentMethodLauncher
         }
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             googlePayPaymentMethodLauncherFactory = googlePayPaymentMethodLauncherFactory
         )
 
         val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
                 intent = paymentIntent,
                 confirmationOption = GOOGLE_PAY_OPTION.copy(
@@ -1540,13 +1540,13 @@ class DefaultConfirmationHandlerTest {
             } doReturn googlePayPaymentMethodLauncher
         }
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             googlePayPaymentMethodLauncherFactory = googlePayPaymentMethodLauncherFactory
         )
 
         val setupIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD
 
-        intentConfirmationHandler.start(
+        defaultConfirmationHandler.start(
             arguments = DEFAULT_ARGUMENTS.copy(
                 intent = setupIntent,
                 confirmationOption = GOOGLE_PAY_OPTION,
@@ -1582,7 +1582,7 @@ class DefaultConfirmationHandlerTest {
     fun `On Google Pay launcher succeeded, should proceed to intent confirmation`() = runTest {
         val intentConfirmationInterceptor = FakeIntentConfirmationInterceptor()
         val googlePayCallbackHandler = FakeResultHandler<GooglePayPaymentMethodLauncher.Result>()
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = intentConfirmationInterceptor,
         ).apply {
             registerWithCallbacks(
@@ -1590,10 +1590,10 @@ class DefaultConfirmationHandlerTest {
             )
         }
 
-        intentConfirmationHandler.state.test {
+        defaultConfirmationHandler.state.test {
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Idle)
 
-            intentConfirmationHandler.start(
+            defaultConfirmationHandler.start(
                 arguments = DEFAULT_ARGUMENTS.copy(
                     confirmationOption = GOOGLE_PAY_OPTION
                 ),
@@ -1812,7 +1812,7 @@ class DefaultConfirmationHandlerTest {
         val paymentResultCallbackHandler = FakeResultHandler<InternalPaymentResult>()
         val googlePayCallbackHandler = FakeResultHandler<GooglePayPaymentMethodLauncher.Result>()
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = intentConfirmationInterceptor,
         ).apply {
             registerWithCallbacks(
@@ -1821,10 +1821,10 @@ class DefaultConfirmationHandlerTest {
             )
         }
 
-        intentConfirmationHandler.state.test {
+        defaultConfirmationHandler.state.test {
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Idle)
 
-            intentConfirmationHandler.start(
+            defaultConfirmationHandler.start(
                 arguments = DEFAULT_ARGUMENTS.copy(
                     confirmationOption = GOOGLE_PAY_OPTION
                 ),
@@ -1878,7 +1878,7 @@ class DefaultConfirmationHandlerTest {
         val paymentResultCallbackHandler = FakeResultHandler<InternalPaymentResult>()
         val bacsMandateConfirmationCallbackHandler = FakeResultHandler<BacsMandateConfirmationResult>()
 
-        val intentConfirmationHandler = createIntentConfirmationHandler(
+        val defaultConfirmationHandler = createDefaultConfirmationHandler(
             intentConfirmationInterceptor = intentConfirmationInterceptor,
         ).apply {
             registerWithCallbacks(
@@ -1887,10 +1887,10 @@ class DefaultConfirmationHandlerTest {
             )
         }
 
-        intentConfirmationHandler.state.test {
+        defaultConfirmationHandler.state.test {
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Idle)
 
-            intentConfirmationHandler.start(
+            defaultConfirmationHandler.start(
                 arguments = DEFAULT_ARGUMENTS.copy(
                     confirmationOption = BACS_OPTION
                 ),
@@ -1927,7 +1927,7 @@ class DefaultConfirmationHandlerTest {
         }
     }
 
-    private fun createIntentConfirmationHandler(
+    private fun createDefaultConfirmationHandler(
         intentConfirmationInterceptor: IntentConfirmationInterceptor = FakeIntentConfirmationInterceptor(),
         bacsMandateConfirmationLauncher: BacsMandateConfirmationLauncher = FakeBacsMandateConfirmationLauncher(),
         googlePayPaymentMethodLauncherFactory: GooglePayPaymentMethodLauncherFactory =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -1150,7 +1150,7 @@ internal class PaymentSheetActivityTest {
                 workContext = testDispatcher,
                 savedStateHandle = savedStateHandle,
                 linkHandler = linkHandler,
-                defaultConfirmationHandlerFactory = DefaultConfirmationHandler.Factory(
+                confirmationHandlerFactory = DefaultConfirmationHandler.Factory(
                     intentConfirmationInterceptor = fakeIntentConfirmationInterceptor,
                     savedStateHandle = savedStateHandle,
                     stripePaymentLauncherAssistedFactory = stripePaymentLauncherAssistedFactory,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -1150,7 +1150,7 @@ internal class PaymentSheetActivityTest {
                 workContext = testDispatcher,
                 savedStateHandle = savedStateHandle,
                 linkHandler = linkHandler,
-                intentConfirmationHandlerFactory = IntentConfirmationHandler.Factory(
+                defaultConfirmationHandlerFactory = DefaultConfirmationHandler.Factory(
                     intentConfirmationInterceptor = fakeIntentConfirmationInterceptor,
                     savedStateHandle = savedStateHandle,
                     stripePaymentLauncherAssistedFactory = stripePaymentLauncherAssistedFactory,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -3092,7 +3092,7 @@ internal class PaymentSheetViewModelTest {
                 workContext = testDispatcher,
                 savedStateHandle = thisSavedStateHandle,
                 linkHandler = linkHandler,
-                intentConfirmationHandlerFactory = IntentConfirmationHandler.Factory(
+                defaultConfirmationHandlerFactory = DefaultConfirmationHandler.Factory(
                     intentConfirmationInterceptor = intentConfirmationInterceptor,
                     savedStateHandle = thisSavedStateHandle,
                     bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -3092,7 +3092,7 @@ internal class PaymentSheetViewModelTest {
                 workContext = testDispatcher,
                 savedStateHandle = thisSavedStateHandle,
                 linkHandler = linkHandler,
-                defaultConfirmationHandlerFactory = DefaultConfirmationHandler.Factory(
+                confirmationHandlerFactory = DefaultConfirmationHandler.Factory(
                     intentConfirmationInterceptor = intentConfirmationInterceptor,
                     savedStateHandle = thisSavedStateHandle,
                     bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,


### PR DESCRIPTION
# Summary
Rename `IntentConfirmationHandler` to `DefaultConfirmationHandler`

# Motivation
`IntentConfirmationHandler` does not represent all the cases of confirmation however the implementation is our base for handling confirmation.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified