### PR TITLE
Coalesce configuration requests for embedded.

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -384,6 +384,14 @@ public final class com/stripe/android/paymentelement/confirmation/ConfirmationMe
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentelement/embedded/DefaultEmbeddedConfigurationHandler$Arguments$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentelement/embedded/DefaultEmbeddedConfigurationHandler$Arguments;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentelement/embedded/DefaultEmbeddedConfigurationHandler$Arguments;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/paymentelement/embedded/DefaultEmbeddedConfigurationHandler$ConfigurationCache$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentelement/embedded/DefaultEmbeddedConfigurationHandler$ConfigurationCache;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -37,8 +37,6 @@ class EmbeddedPaymentElement internal constructor(
      *
      * This ensures the appropriate payment methods are displayed, collect the right fields, etc.
      * - Note: Upon completion, [paymentOption] may become null if it's no longer available.
-     * - Note: If you call [configure] while a previous call to [configure] is still in progress, the previous call
-     *      returns [ConfigureResult.Cancelled].
      */
     suspend fun configure(
         intentConfiguration: PaymentSheet.IntentConfiguration,
@@ -319,13 +317,6 @@ class EmbeddedPaymentElement internal constructor(
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @ExperimentalEmbeddedPaymentElementApi
         class Succeeded internal constructor() : ConfigureResult
-
-        /**
-         * The configure was cancelled. This is only returned when a subsequent configure call cancels previous ones.
-         */
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        @ExperimentalEmbeddedPaymentElementApi
-        class Cancelled internal constructor() : ConfigureResult
 
         /**
          * The configure call failed e.g. due to network failure or because of an invalid IntentConfiguration.


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This is a likely scenario for users who rotate their devices.

I decided cancellation was no longer a useful response state given how coroutines work (they'd just cancel it themselves!).
