### PR TITLE
Add saved payment method type to DisplayableSavedPaymentMethod

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
@@ -5,36 +5,44 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 
-internal data class DisplayableSavedPaymentMethod(
+internal data class DisplayableSavedPaymentMethod private constructor(
     val displayName: ResolvableString,
     val paymentMethod: PaymentMethod,
+    val savedPaymentMethod: SavedPaymentMethod,
     val isCbcEligible: Boolean = false,
 ) {
     fun isModifiable(): Boolean {
-        val hasMultipleNetworks = paymentMethod.card?.networks?.available?.let { available ->
-            available.size > 1
-        } ?: false
+        return when (savedPaymentMethod) {
+            is SavedPaymentMethod.Card -> {
+                val hasMultipleNetworks = savedPaymentMethod.card.networks?.available?.let { available ->
+                    available.size > 1
+                } ?: false
 
-        return isCbcEligible && hasMultipleNetworks
+                return isCbcEligible && hasMultipleNetworks
+            }
+            is SavedPaymentMethod.SepaDebit,
+            is SavedPaymentMethod.USBankAccount,
+            SavedPaymentMethod.Unexpected -> false
+        }
     }
 
-    fun getDescription() = when (paymentMethod.type) {
-        PaymentMethod.Type.Card -> {
+    fun getDescription() = when (savedPaymentMethod) {
+        is SavedPaymentMethod.Card -> {
             resolvableString(
                 com.stripe.android.R.string.stripe_card_ending_in,
                 brandDisplayName(),
-                paymentMethod.card?.last4
+                savedPaymentMethod.card.last4
             )
         }
-        PaymentMethod.Type.SepaDebit -> resolvableString(
+        is SavedPaymentMethod.SepaDebit -> resolvableString(
             R.string.stripe_bank_account_ending_in,
-            paymentMethod.sepaDebit?.last4
+            savedPaymentMethod.sepaDebit.last4
         )
-        PaymentMethod.Type.USBankAccount -> resolvableString(
+        is SavedPaymentMethod.USBankAccount -> resolvableString(
             R.string.stripe_bank_account_ending_in,
-            paymentMethod.usBankAccount?.last4
+            savedPaymentMethod.usBankAccount.last4
         )
-        else -> resolvableString("")
+        is SavedPaymentMethod.Unexpected -> resolvableString("")
     }
 
     fun getModifyDescription() = resolvableString(
@@ -50,8 +58,48 @@ internal data class DisplayableSavedPaymentMethod(
     }
 
     fun brandDisplayName(): String? {
-        val brand = paymentMethod.card?.displayBrand?.let { CardBrand.fromCode(it) }
-            ?: paymentMethod.card?.brand
-        return brand?.displayName
+        return when (savedPaymentMethod) {
+            is SavedPaymentMethod.Card -> {
+                val brand = savedPaymentMethod.card.displayBrand?.let { CardBrand.fromCode(it) }
+                    ?: savedPaymentMethod.card.brand
+                return brand.displayName
+            }
+            is SavedPaymentMethod.USBankAccount,
+            is SavedPaymentMethod.SepaDebit,
+            is SavedPaymentMethod.Unexpected -> null
+        }
     }
+
+    companion object {
+        fun create(
+            displayName: ResolvableString,
+            paymentMethod: PaymentMethod,
+            isCbcEligible: Boolean = false,
+        ): DisplayableSavedPaymentMethod {
+            val savedPaymentMethod = when (paymentMethod.type) {
+                PaymentMethod.Type.Card -> paymentMethod.card?.let { SavedPaymentMethod.Card(it) }
+                PaymentMethod.Type.USBankAccount -> paymentMethod.usBankAccount?.let {
+                    SavedPaymentMethod.USBankAccount(
+                        it
+                    )
+                }
+                PaymentMethod.Type.SepaDebit -> paymentMethod.sepaDebit?.let { SavedPaymentMethod.SepaDebit(it) }
+                else -> null
+            }
+
+            return DisplayableSavedPaymentMethod(
+                displayName = displayName,
+                paymentMethod = paymentMethod,
+                savedPaymentMethod = savedPaymentMethod ?: SavedPaymentMethod.Unexpected,
+                isCbcEligible = isCbcEligible,
+            )
+        }
+    }
+}
+
+internal sealed interface SavedPaymentMethod {
+    data class Card(val card: PaymentMethod.Card) : SavedPaymentMethod
+    data class USBankAccount(val usBankAccount: PaymentMethod.USBankAccount) : SavedPaymentMethod
+    data class SepaDebit(val sepaDebit: PaymentMethod.SepaDebit) : SavedPaymentMethod
+    data object Unexpected : SavedPaymentMethod
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
@@ -26,7 +26,7 @@ internal object PaymentOptionsStateFactory {
             PaymentOptionsItem.Link.takeIf { showLink }
         ) + paymentMethods.map {
             PaymentOptionsItem.SavedPaymentMethod(
-                DisplayableSavedPaymentMethod(
+                DisplayableSavedPaymentMethod.create(
                     displayName = nameProvider(it.type?.code),
                     paymentMethod = it,
                     isCbcEligible = isCbcEligible

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -182,7 +182,7 @@ private fun SavedPaymentMethodsTabLayoutPreview() {
                 PaymentOptionsItem.Link,
                 PaymentOptionsItem.GooglePay,
                 PaymentOptionsItem.SavedPaymentMethod(
-                    DisplayableSavedPaymentMethod(
+                    DisplayableSavedPaymentMethod.create(
                         displayName = "4242".resolvableString,
                         paymentMethod = PaymentMethod(
                             id = "001",
@@ -199,7 +199,7 @@ private fun SavedPaymentMethodsTabLayoutPreview() {
                     canRemovePaymentMethods = true,
                 ),
                 PaymentOptionsItem.SavedPaymentMethod(
-                    DisplayableSavedPaymentMethod(
+                    DisplayableSavedPaymentMethod.create(
                         displayName = "4242".resolvableString,
                         paymentMethod = PaymentMethod(
                             id = "002",

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -264,7 +264,7 @@ private fun Label(
 @Preview
 @Composable
 private fun PreviewUpdatePaymentMethodUI() {
-    val exampleCard = DisplayableSavedPaymentMethod(
+    val exampleCard = DisplayableSavedPaymentMethod.create(
         displayName = "4242".resolvableString,
         paymentMethod = PaymentMethod(
             id = "002",

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
@@ -74,7 +74,7 @@ internal fun SavedPaymentMethodRowButton(
 @Preview
 @Composable
 internal fun PreviewCardSavedPaymentMethodRowButton() {
-    val cardSavedPaymentMethod = DisplayableSavedPaymentMethod(
+    val cardSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
         displayName = "4242".resolvableString,
         paymentMethod = PaymentMethod(
             id = "001",

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodsExtension.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodsExtension.kt
@@ -11,7 +11,7 @@ internal fun PaymentMethod.toDisplayableSavedPaymentMethod(
     providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString,
     paymentMethodMetadata: PaymentMethodMetadata?,
 ): DisplayableSavedPaymentMethod {
-    return DisplayableSavedPaymentMethod(
+    return DisplayableSavedPaymentMethod.create(
         displayName = providePaymentMethodName(type?.code),
         paymentMethod = this,
         isCbcEligible = paymentMethodMetadata?.cbcEligibility is CardBrandChoiceEligibility.Eligible,

--- a/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
@@ -579,7 +579,7 @@ internal object PaymentMethodFixtures {
     }
 
     fun PaymentMethod.toDisplayableSavedPaymentMethod(): DisplayableSavedPaymentMethod {
-        return DisplayableSavedPaymentMethod(
+        return DisplayableSavedPaymentMethod.create(
             displayName = (this.card?.last4 ?: this.usBankAccount?.last4 ?: "").resolvableString,
             paymentMethod = this,
             isCbcEligible = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethodTest.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.isInstanceOf
 import com.stripe.android.model.PaymentMethodFixtures
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -20,7 +21,7 @@ class DisplayableSavedPaymentMethodTest {
     @Test
     fun getDescription_usesDisplayedCardBrand() {
         val visaCardUsingCartesBancaires = PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD
-        val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod(
+        val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
             displayName = "unused".resolvableString,
             paymentMethod = visaCardUsingCartesBancaires
         )
@@ -35,7 +36,7 @@ class DisplayableSavedPaymentMethodTest {
         val cardWithoutDisplayBrand = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
             card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.card?.copy(displayBrand = null)
         )
-        val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod(
+        val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
             displayName = "unused".resolvableString,
             paymentMethod = cardWithoutDisplayBrand
         )
@@ -43,5 +44,72 @@ class DisplayableSavedPaymentMethodTest {
         val description = displayableSavedPaymentMethod.getDescription().resolve(context)
 
         assertThat(description).isEqualTo("Visa ending in 4242")
+    }
+
+    @Test
+    fun create_forCard_createsCard() {
+        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+
+        val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
+            displayName = "unused".resolvableString,
+            paymentMethod = paymentMethod,
+            isCbcEligible = false,
+        )
+
+        assertThat(displayableSavedPaymentMethod.savedPaymentMethod).isInstanceOf<SavedPaymentMethod.Card>()
+    }
+
+    @Test
+    fun create_forUSBankAccount_createsUSBankAccount() {
+        val paymentMethod = PaymentMethodFixtures.US_BANK_ACCOUNT
+
+        val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
+            displayName = "unused".resolvableString,
+            paymentMethod = paymentMethod,
+            isCbcEligible = false,
+        )
+
+        assertThat(displayableSavedPaymentMethod.savedPaymentMethod).isInstanceOf<SavedPaymentMethod.USBankAccount>()
+    }
+
+    @Test
+    fun create_forSepaDebit_createsSepaDebit() {
+        val paymentMethod = PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD
+
+        val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
+            displayName = "unused".resolvableString,
+            paymentMethod = paymentMethod,
+            isCbcEligible = false,
+        )
+
+        assertThat(displayableSavedPaymentMethod.savedPaymentMethod).isInstanceOf<SavedPaymentMethod.SepaDebit>()
+    }
+
+    @Test
+    fun create_missingPaymentMethodInfo_createsUnexpected() {
+        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
+            card = null
+        )
+
+        val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
+            displayName = "unused".resolvableString,
+            paymentMethod = paymentMethod,
+            isCbcEligible = false,
+        )
+
+        assertThat(displayableSavedPaymentMethod.savedPaymentMethod).isInstanceOf<SavedPaymentMethod.Unexpected>()
+    }
+
+    @Test
+    fun create_unexpectedType_createsUnexpected() {
+        val paymentMethod = PaymentMethodFixtures.PAYPAL_PAYMENT_METHOD
+
+        val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
+            displayName = "unused".resolvableString,
+            paymentMethod = paymentMethod,
+            isCbcEligible = false,
+        )
+
+        assertThat(displayableSavedPaymentMethod.savedPaymentMethod).isInstanceOf<SavedPaymentMethod.Unexpected>()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenManageSavedPaymentMethodsScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenManageSavedPaymentMethodsScreenshotTest.kt
@@ -32,7 +32,7 @@ internal class PaymentSheetScreenManageSavedPaymentMethodsScreenshotTest {
         listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
             .plus(PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD)
             .map {
-                DisplayableSavedPaymentMethod(
+                DisplayableSavedPaymentMethod.create(
                     displayName = it.card!!.last4!!.resolvableString,
                     paymentMethod = it,
                     isCbcEligible = true

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenSelectSavedPaymentMethodsScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenSelectSavedPaymentMethodsScreenshotTest.kt
@@ -31,7 +31,7 @@ internal class PaymentSheetScreenSelectSavedPaymentMethodsScreenshotTest {
     val coroutineRule = CoroutineTestRule()
 
     private val savedPaymentOptionItem = PaymentOptionsItem.SavedPaymentMethod(
-        displayableSavedPaymentMethod = DisplayableSavedPaymentMethod(
+        displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
             displayName = "Card 4242".resolvableString,
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             isCbcEligible = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreenshotTest.kt
@@ -50,21 +50,21 @@ class PaymentOptionsScreenshotTest {
             PaymentOptionsItem.AddCard,
             PaymentOptionsItem.GooglePay,
             PaymentOptionsItem.SavedPaymentMethod(
-                DisplayableSavedPaymentMethod(
+                DisplayableSavedPaymentMethod.create(
                     displayName = "Card".resolvableString,
                     paymentMethod = createCard("4242"),
                 ),
                 canRemovePaymentMethods = true,
             ),
             PaymentOptionsItem.SavedPaymentMethod(
-                DisplayableSavedPaymentMethod(
+                DisplayableSavedPaymentMethod.create(
                     displayName = "Card".resolvableString,
                     paymentMethod = createCard("4000"),
                 ),
                 canRemovePaymentMethods = true,
             ),
             PaymentOptionsItem.SavedPaymentMethod(
-                DisplayableSavedPaymentMethod(
+                DisplayableSavedPaymentMethod.create(
                     displayName = "Card".resolvableString,
                     paymentMethod = createCard("1234"),
                 ),
@@ -93,21 +93,21 @@ class PaymentOptionsScreenshotTest {
             PaymentOptionsItem.AddCard,
             PaymentOptionsItem.GooglePay,
             PaymentOptionsItem.SavedPaymentMethod(
-                DisplayableSavedPaymentMethod(
+                DisplayableSavedPaymentMethod.create(
                     displayName = "Card".resolvableString,
                     paymentMethod = createCard("4242"),
                 ),
                 canRemovePaymentMethods = true,
             ),
             PaymentOptionsItem.SavedPaymentMethod(
-                DisplayableSavedPaymentMethod(
+                DisplayableSavedPaymentMethod.create(
                     displayName = "Card".resolvableString,
                     paymentMethod = createCard("4000"),
                 ),
                 canRemovePaymentMethods = true,
             ),
             PaymentOptionsItem.SavedPaymentMethod(
-                DisplayableSavedPaymentMethod(
+                DisplayableSavedPaymentMethod.create(
                     displayName = "Card".resolvableString,
                     paymentMethod = createCard("1234"),
                 ),
@@ -168,21 +168,21 @@ class PaymentOptionsScreenshotTest {
 
     private val paymentOptionsItemsWithRemoveDisabledAndModifiableCard = listOf(
         PaymentOptionsItem.SavedPaymentMethod(
-            DisplayableSavedPaymentMethod(
+            DisplayableSavedPaymentMethod.create(
                 displayName = "Card".resolvableString,
                 paymentMethod = createCard("4242"),
             ),
             canRemovePaymentMethods = false,
         ),
         PaymentOptionsItem.SavedPaymentMethod(
-            DisplayableSavedPaymentMethod(
+            DisplayableSavedPaymentMethod.create(
                 displayName = "Card".resolvableString,
                 paymentMethod = createCard("4000"),
             ),
             canRemovePaymentMethods = false,
         ),
         PaymentOptionsItem.SavedPaymentMethod(
-            DisplayableSavedPaymentMethod(
+            DisplayableSavedPaymentMethod.create(
                 displayName = "Card".resolvableString,
                 paymentMethod = createCard("1234", addNetworks = true),
                 isCbcEligible = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsTest.kt
@@ -161,14 +161,14 @@ class PaymentOptionsTest {
             SavedPaymentMethodTabLayoutUI(
                 paymentOptionsItems = listOf(
                     PaymentOptionsItem.SavedPaymentMethod(
-                        displayableSavedPaymentMethod = DisplayableSavedPaymentMethod(
+                        displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
                             displayName = resolvableString("4242"),
                             paymentMethod = createCard(last4 = "4242"),
                         ),
                         canRemovePaymentMethods = false,
                     ),
                     PaymentOptionsItem.SavedPaymentMethod(
-                        displayableSavedPaymentMethod = DisplayableSavedPaymentMethod(
+                        displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
                             displayName = resolvableString("5555"),
                             paymentMethod = createCard(last4 = "5555"),
                         ),
@@ -198,14 +198,14 @@ class PaymentOptionsTest {
             SavedPaymentMethodTabLayoutUI(
                 paymentOptionsItems = listOf(
                     PaymentOptionsItem.SavedPaymentMethod(
-                        displayableSavedPaymentMethod = DisplayableSavedPaymentMethod(
+                        displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
                             displayName = resolvableString("4242"),
                             paymentMethod = createCard(last4 = "4242"),
                         ),
                         canRemovePaymentMethods = false,
                     ),
                     PaymentOptionsItem.SavedPaymentMethod(
-                        displayableSavedPaymentMethod = DisplayableSavedPaymentMethod(
+                        displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
                             displayName = resolvableString("5555"),
                             paymentMethod = createCard(last4 = "5555"),
                         ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUITest.kt
@@ -325,7 +325,7 @@ class ManageScreenUITest {
         PaymentMethodFixtures.createCards(2)
             .plus(PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD)
             .map {
-                DisplayableSavedPaymentMethod(
+                DisplayableSavedPaymentMethod.create(
                     displayName = it.card!!.last4!!.resolvableString,
                     paymentMethod = it,
                     isCbcEligible = true

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButtonScreenshotTest.kt
@@ -25,7 +25,7 @@ internal class SavedPaymentMethodRowButtonScreenshotTest {
             .padding(16.dp)
     )
 
-    private val savedVisa = DisplayableSavedPaymentMethod(
+    private val savedVisa = DisplayableSavedPaymentMethod.create(
         displayName = "···· 4242".resolvableString,
         paymentMethod = PaymentMethod(
             id = "001",


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add saved payment method type to DisplayableSavedPaymentMethod

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Makes it so that we only need to define which `PaymentMethod.Type`s we support as SPMs in one place. I wanted to make this change because the new update PM screen will work for every SPM type, and I don't want to add one more place where we check for the same PaymentMethod.Types.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified