### PR TITLE
Move confirmation injection to a separate module

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -48,7 +48,6 @@ import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
-import com.stripe.android.paymentelement.confirmation.DefaultConfirmationHandler
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.R
@@ -99,7 +98,7 @@ internal class CustomerSheetViewModel(
     private val eventReporter: CustomerSheetEventReporter,
     private val workContext: CoroutineContext = Dispatchers.IO,
     @Named(IS_LIVE_MODE) private val isLiveModeProvider: () -> Boolean,
-    confirmationHandlerFactory: DefaultConfirmationHandler.Factory,
+    confirmationHandlerFactory: ConfirmationHandler.Factory,
     private val customerSheetLoader: CustomerSheetLoader,
     private val editInteractorFactory: ModifiableEditPaymentMethodViewInteractor.Factory,
     private val errorReporter: ErrorReporter,
@@ -116,7 +115,7 @@ internal class CustomerSheetViewModel(
         eventReporter: CustomerSheetEventReporter,
         workContext: CoroutineContext = Dispatchers.IO,
         @Named(IS_LIVE_MODE) isLiveModeProvider: () -> Boolean,
-        confirmationHandlerFactory: DefaultConfirmationHandler.Factory,
+        confirmationHandlerFactory: ConfirmationHandler.Factory,
         customerSheetLoader: CustomerSheetLoader,
         editInteractorFactory: ModifiableEditPaymentMethodViewInteractor.Factory,
         errorReporter: ErrorReporter,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelComponent.kt
@@ -6,6 +6,7 @@ import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetIntegration
 import com.stripe.android.customersheet.CustomerSheetViewModel
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
+import com.stripe.android.paymentelement.confirmation.ConfirmationModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import dagger.BindsInstance
 import dagger.Component
@@ -13,6 +14,7 @@ import dagger.Component
 @CustomerSheetViewModelScope
 @Component(
     modules = [
+        ConfirmationModule::class,
         CustomerSheetViewModelModule::class,
         StripeRepositoryModule::class,
         GooglePayLauncherModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import android.content.Context
 import android.content.res.Resources
 import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.BuildConfig
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
@@ -18,23 +17,19 @@ import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.NetworkTypeDetector
 import com.stripe.android.core.utils.ContextUtils.packageInfo
+import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.customersheet.CustomerSheetLoader
 import com.stripe.android.customersheet.DefaultCustomerSheetLoader
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.analytics.DefaultCustomerSheetEventReporter
-import com.stripe.android.paymentelement.confirmation.DefaultConfirmationHandler
-import com.stripe.android.paymentelement.confirmation.DefaultIntentConfirmationInterceptor
-import com.stripe.android.paymentelement.confirmation.IntentConfirmationInterceptor
+import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
+import com.stripe.android.paymentelement.confirmation.STATUS_BAR_COLOR_PROVIDER
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.financialconnections.DefaultIsFinancialConnectionsAvailable
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsAvailable
-import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
-import com.stripe.android.paymentsheet.injection.ALLOWS_MANUAL_CONFIRMATION
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncherFactory
-import com.stripe.android.paymentsheet.paymentdatacollection.bacs.DefaultBacsMandateConfirmationLauncherFactory
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.paymentsheet.repositories.RealElementsSessionRepository
 import com.stripe.android.paymentsheet.ui.DefaultEditPaymentMethodViewInteractor
@@ -49,12 +44,6 @@ import kotlin.coroutines.CoroutineContext
 
 @Module
 internal interface CustomerSheetViewModelModule {
-
-    @Binds
-    fun bindsIntentConfirmationInterceptor(
-        impl: DefaultIntentConfirmationInterceptor,
-    ): IntentConfirmationInterceptor
-
     @Binds
     fun bindsCustomerSheetEventReporter(
         impl: DefaultCustomerSheetEventReporter
@@ -114,6 +103,13 @@ internal interface CustomerSheetViewModelModule {
         ): () -> Boolean = { paymentConfiguration.get().publishableKey.startsWith("pk_live") }
 
         @Provides
+        @Named(STATUS_BAR_COLOR_PROVIDER)
+        fun providesStatusBarColor(statusBarColor: Int?): () -> Int? = { statusBarColor }
+
+        @Provides
+        fun providesUserFacingLogger(): UserFacingLogger? = null
+
+        @Provides
         internal fun provideAnalyticsRequestFactory(
             application: Application,
             paymentConfiguration: Provider<PaymentConfiguration>
@@ -133,33 +129,6 @@ internal interface CustomerSheetViewModelModule {
             analyticsRequestFactory = analyticsRequestFactory,
             analyticsRequestExecutor = analyticsRequestExecutor,
         )
-
-        @Provides
-        fun providesBacsMandateConfirmationLauncherFactory(): BacsMandateConfirmationLauncherFactory =
-            DefaultBacsMandateConfirmationLauncherFactory
-
-        @Provides
-        fun providesIntentConfirmationHandlerFactory(
-            savedStateHandle: SavedStateHandle,
-            paymentConfigurationProvider: Provider<PaymentConfiguration>,
-            bacsMandateConfirmationLauncherFactory: BacsMandateConfirmationLauncherFactory,
-            stripePaymentLauncherAssistedFactory: StripePaymentLauncherAssistedFactory,
-            statusBarColor: Int?,
-            intentConfirmationInterceptor: IntentConfirmationInterceptor,
-            errorReporter: ErrorReporter
-        ): DefaultConfirmationHandler.Factory {
-            return DefaultConfirmationHandler.Factory(
-                intentConfirmationInterceptor = intentConfirmationInterceptor,
-                paymentConfigurationProvider = paymentConfigurationProvider,
-                stripePaymentLauncherAssistedFactory = stripePaymentLauncherAssistedFactory,
-                googlePayPaymentMethodLauncherFactory = null,
-                bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,
-                statusBarColor = { statusBarColor },
-                savedStateHandle = savedStateHandle,
-                errorReporter = errorReporter,
-                logger = null
-            )
-        }
 
         @Provides
         fun resources(application: Application): Resources {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationConstants.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationConstants.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.paymentelement.confirmation
+
+/**
+ * Whether the integration allows for manual confirmation
+ */
+internal const val ALLOWS_MANUAL_CONFIRMATION = "ALLOWS_MANUAL_CONFIRMATION"
+
+/**
+ * Color of the status bar on the user's device
+ */
+internal const val STATUS_BAR_COLOR_PROVIDER = "STATUS_BAR_COLOR_PROVIDER"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
@@ -11,6 +11,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.parcelize.Parcelize
 import com.stripe.android.model.PaymentMethod as PaymentMethodModel
@@ -20,6 +21,12 @@ import com.stripe.android.model.PaymentMethod as PaymentMethodModel
  * intended to run only one confirmation process at a time.
  */
 internal interface ConfirmationHandler {
+    /**
+     * Indicates if this handler has been reloaded from process death. This occurs if the handler was confirming
+     * an intent before did not complete the process before process death.
+     */
+    val hasReloadedFromProcessDeath: Boolean
+
     /**
      * An observable indicating the current confirmation state of the handler.
      */
@@ -46,6 +53,14 @@ internal interface ConfirmationHandler {
      * @return confirmation result or null if no confirmation process has been started
      */
     suspend fun awaitIntentResult(): Result?
+
+    /**
+     * A factory for creating a [ConfirmationHandler] instance using a provided [CoroutineScope]. This scope is
+     * used to launch confirmation tasks.
+     */
+    interface Factory {
+        fun create(scope: CoroutineScope): ConfirmationHandler
+    }
 
     /**
      * Defines the set of arguments requires for beginning the confirmation process

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationModule.kt
@@ -1,0 +1,26 @@
+package com.stripe.android.paymentelement.confirmation
+
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncherFactory
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.DefaultBacsMandateConfirmationLauncherFactory
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+
+@Module
+internal interface ConfirmationModule {
+    @Binds
+    fun bindsConfirmationHandlerFactory(
+        defaultConfirmationHandlerFactory: DefaultConfirmationHandler.Factory
+    ): ConfirmationHandler.Factory
+
+    @Binds
+    fun bindsIntentConfirmationInterceptor(
+        defaultConfirmationHandlerFactory: DefaultIntentConfirmationInterceptor
+    ): IntentConfirmationInterceptor
+
+    companion object {
+        @Provides
+        fun providesBacsMandateConfirmationLauncherFactory(): BacsMandateConfirmationLauncherFactory =
+            DefaultBacsMandateConfirmationLauncherFactory
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
@@ -43,6 +43,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Provider
 import kotlin.time.Duration.Companion.seconds
 
@@ -89,7 +91,7 @@ internal class DefaultConfirmationHandler(
      * Indicates if this handler has been reloaded from process death. This occurs if the handler was confirming
      * an intent before did not complete the process before process death.
      */
-    val hasReloadedFromProcessDeath = hasReloadedWhileAwaitingPreConfirm || hasReloadedWhileAwaitingConfirm
+    override val hasReloadedFromProcessDeath = hasReloadedWhileAwaitingPreConfirm || hasReloadedWhileAwaitingConfirm
 
     private val _state = MutableStateFlow(
         if (hasReloadedWhileAwaitingPreConfirm) {
@@ -626,18 +628,18 @@ internal class DefaultConfirmationHandler(
             }
         }
 
-    class Factory(
+    class Factory @Inject constructor(
         private val intentConfirmationInterceptor: IntentConfirmationInterceptor,
         private val paymentConfigurationProvider: Provider<PaymentConfiguration>,
         private val bacsMandateConfirmationLauncherFactory: BacsMandateConfirmationLauncherFactory,
         private val stripePaymentLauncherAssistedFactory: StripePaymentLauncherAssistedFactory,
         private val googlePayPaymentMethodLauncherFactory: GooglePayPaymentMethodLauncherFactory?,
         private val savedStateHandle: SavedStateHandle,
-        private val statusBarColor: () -> Int?,
+        @Named(STATUS_BAR_COLOR_PROVIDER) private val statusBarColor: () -> Int?,
         private val errorReporter: ErrorReporter,
         private val logger: UserFacingLogger?
-    ) {
-        fun create(scope: CoroutineScope): DefaultConfirmationHandler {
+    ) : ConfirmationHandler.Factory {
+        override fun create(scope: CoroutineScope): ConfirmationHandler {
             return DefaultConfirmationHandler(
                 bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,
                 googlePayPaymentMethodLauncherFactory = googlePayPaymentMethodLauncherFactory,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationInterceptor.kt
@@ -21,7 +21,6 @@ import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.DeferredIntentValidator
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
-import com.stripe.android.paymentsheet.injection.ALLOWS_MANUAL_CONFIRMATION
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import javax.inject.Inject
 import javax.inject.Named

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -27,7 +27,6 @@ import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
-import com.stripe.android.paymentelement.confirmation.DefaultConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.DeferredIntentConfirmationType
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -85,7 +84,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     @IOContext workContext: CoroutineContext,
     savedStateHandle: SavedStateHandle,
     linkHandler: LinkHandler,
-    confirmationHandlerFactory: DefaultConfirmationHandler.Factory,
+    confirmationHandlerFactory: ConfirmationHandler.Factory,
     cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
     editInteractorFactory: ModifiableEditPaymentMethodViewInteractor.Factory,
     private val errorReporter: ErrorReporter,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerModule.kt
@@ -3,9 +3,9 @@ package com.stripe.android.paymentsheet.flowcontroller
 import android.app.Application
 import android.content.Context
 import androidx.lifecycle.viewModelScope
+import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.injection.ALLOWS_MANUAL_CONFIRMATION
 import com.stripe.android.paymentsheet.injection.PaymentOptionsViewModelSubcomponent
 import com.stripe.android.uicore.image.StripeImageLoader
 import dagger.Module

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
+import com.stripe.android.paymentelement.confirmation.ConfirmationModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
 import com.stripe.android.paymentsheet.injection.PaymentSheetCommonModule
@@ -16,6 +17,7 @@ import javax.inject.Singleton
 @Component(
     modules = [
         StripeRepositoryModule::class,
+        ConfirmationModule::class,
         PaymentSheetCommonModule::class,
         FlowControllerModule::class,
         GooglePayLauncherModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/NamedConstants.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/NamedConstants.kt
@@ -1,6 +1,0 @@
-package com.stripe.android.paymentsheet.injection
-
-/**
- * Whether the integration allows for manual confirmation
- */
-internal const val ALLOWS_MANUAL_CONFIRMATION = "ALLOWS_MANUAL_CONFIRMATION"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -19,8 +19,6 @@ import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.RealLinkConfigurationCoordinator
 import com.stripe.android.link.injection.LinkAnalyticsComponent
 import com.stripe.android.link.injection.LinkComponent
-import com.stripe.android.paymentelement.confirmation.DefaultIntentConfirmationInterceptor
-import com.stripe.android.paymentelement.confirmation.IntentConfirmationInterceptor
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.paymentsheet.BuildConfig
@@ -33,8 +31,6 @@ import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandler
 import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandlerImpl
 import com.stripe.android.paymentsheet.flowcontroller.DefaultPaymentSelectionUpdater
 import com.stripe.android.paymentsheet.flowcontroller.PaymentSelectionUpdater
-import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncherFactory
-import com.stripe.android.paymentsheet.paymentdatacollection.bacs.DefaultBacsMandateConfirmationLauncherFactory
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionInteractor
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionLauncherFactory
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.DefaultCvcRecollectionInteractor
@@ -92,11 +88,6 @@ internal abstract class PaymentSheetCommonModule {
     ): LinkAccountStatusProvider
 
     @Binds
-    abstract fun bindsIntentConfirmationInterceptor(
-        impl: DefaultIntentConfirmationInterceptor,
-    ): IntentConfirmationInterceptor
-
-    @Binds
     abstract fun bindsPaymentSheetUpdater(
         impl: DefaultPaymentSelectionUpdater,
     ): PaymentSelectionUpdater
@@ -152,12 +143,6 @@ internal abstract class PaymentSheetCommonModule {
                 customerConfig?.id,
                 workContext
             )
-        }
-
-        @Provides
-        @Singleton
-        fun provideBacsMandateConfirmationLauncherFactory(): BacsMandateConfirmationLauncherFactory {
-            return DefaultBacsMandateConfirmationLauncherFactory
         }
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherModule.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.injection
 
 import android.app.Application
 import android.content.Context
+import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import dagger.Binds

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -1,22 +1,14 @@
 package com.stripe.android.paymentsheet.injection
 
 import android.content.Context
-import androidx.lifecycle.SavedStateHandle
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.utils.UserFacingLogger
-import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
-import com.stripe.android.paymentelement.confirmation.DefaultConfirmationHandler
-import com.stripe.android.paymentelement.confirmation.IntentConfirmationInterceptor
-import com.stripe.android.payments.core.analytics.ErrorReporter
-import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
+import com.stripe.android.paymentelement.confirmation.STATUS_BAR_COLOR_PROVIDER
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PaymentSheetContractV2
 import com.stripe.android.paymentsheet.PrefsRepository
-import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncherFactory
 import dagger.Module
 import dagger.Provides
-import javax.inject.Provider
+import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
 
 @Module
@@ -28,27 +20,9 @@ internal class PaymentSheetViewModelModule(private val starterArgs: PaymentSheet
     }
 
     @Provides
-    fun providesIntentConfirmationHandlerFactory(
-        savedStateHandle: SavedStateHandle,
-        paymentConfigurationProvider: Provider<PaymentConfiguration>,
-        bacsMandateConfirmationLauncherFactory: BacsMandateConfirmationLauncherFactory,
-        googlePayPaymentMethodLauncherFactory: GooglePayPaymentMethodLauncherFactory,
-        stripePaymentLauncherAssistedFactory: StripePaymentLauncherAssistedFactory,
-        intentConfirmationInterceptor: IntentConfirmationInterceptor,
-        errorReporter: ErrorReporter,
-        logger: UserFacingLogger,
-    ): DefaultConfirmationHandler.Factory {
-        return DefaultConfirmationHandler.Factory(
-            intentConfirmationInterceptor = intentConfirmationInterceptor,
-            paymentConfigurationProvider = paymentConfigurationProvider,
-            stripePaymentLauncherAssistedFactory = stripePaymentLauncherAssistedFactory,
-            bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,
-            googlePayPaymentMethodLauncherFactory = googlePayPaymentMethodLauncherFactory,
-            statusBarColor = { starterArgs.statusBarColor },
-            savedStateHandle = savedStateHandle,
-            errorReporter = errorReporter,
-            logger = logger,
-        )
+    @Named(STATUS_BAR_COLOR_PROVIDER)
+    fun providesStatusBarColor(): () -> Int? {
+        return { starterArgs.statusBarColor }
     }
 
     @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelSubcomponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelSubcomponent.kt
@@ -1,12 +1,13 @@
 package com.stripe.android.paymentsheet.injection
 
 import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.paymentelement.confirmation.ConfirmationModule
 import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import dagger.BindsInstance
 import dagger.Subcomponent
 
 @Subcomponent(
-    modules = [PaymentSheetViewModelModule::class]
+    modules = [PaymentSheetViewModelModule::class, ConfirmationModule::class]
 )
 internal interface PaymentSheetViewModelSubcomponent {
     val viewModel: PaymentSheetViewModel


### PR DESCRIPTION
# Summary
Move confirmation injection to a separate module

# Motivation
This cleans up dependencies we currently share across all our products.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified