### PR TITLE
Add Link warmup pane for deferred intents

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
@@ -197,5 +197,12 @@ internal interface FinancialConnectionsSheetNativeModule {
         ): ElementsSessionContext? {
             return initialState.elementsSessionContext
         }
+
+        @Provides
+        internal fun providePrefillDetails(
+            initialState: FinancialConnectionsSheetNativeState,
+        ): ElementsSessionContext.PrefillDetails? {
+            return initialState.elementsSessionContext?.prefillDetails
+        }
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ManifestExtensions.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ManifestExtensions.kt
@@ -3,8 +3,6 @@ package com.stripe.android.financialconnections.features.common
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.SynchronizeSessionResponse
 
-private const val EMAIL_LENGTH = 15
-
 internal val FinancialConnectionsSessionManifest.isDataFlow: Boolean
     get() = paymentMethodType == null
 
@@ -18,20 +16,6 @@ internal val FinancialConnectionsSessionManifest.canSaveAccountsToLink: Boolean
 internal fun FinancialConnectionsSessionManifest.getBusinessName(): String? {
     return businessName ?: connectPlatformName
 }
-
-/**
- * Mask the email address to show only the first [EMAIL_LENGTH] characters.
- */
-internal fun FinancialConnectionsSessionManifest.getRedactedEmail(): String? =
-    accountholderCustomerEmailAddress?.let { email ->
-        val content = email.split('@')[0]
-        return if (content.length <= EMAIL_LENGTH) {
-            email
-        } else {
-            val domain = email.split('@')[1]
-            content.substring(0, EMAIL_LENGTH) + "•••@" + domain
-        }
-    }
 
 internal fun FinancialConnectionsSessionManifest.enableRetrieveAuthSession(): Boolean =
     features

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/ApiKeyFixtures.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/ApiKeyFixtures.kt
@@ -14,6 +14,7 @@ import com.stripe.android.financialconnections.model.SynchronizeSessionResponse
 import com.stripe.android.financialconnections.model.VisualUpdate
 import com.stripe.android.financialconnections.repository.CachedConsumerSession
 import com.stripe.android.model.ConsumerSession
+import com.stripe.android.model.ConsumerSessionLookup
 import com.stripe.android.model.ConsumerSessionSignup
 
 internal object ApiKeyFixtures {
@@ -137,6 +138,12 @@ internal object ApiKeyFixtures {
         redactedPhoneNumber = "+1********12",
         redactedFormattedPhoneNumber = "(***) *** **12",
         verificationSessions = emptyList(),
+    )
+
+    fun consumerSessionLookup(exists: Boolean) = ConsumerSessionLookup(
+        exists = exists,
+        consumerSession = if (exists) consumerSession() else null,
+        publishableKey = if (exists) "pk_123" else null,
     )
 
     fun verifiedConsumerSession() = ConsumerSession(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/consent/ConsentViewModelFactory.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/consent/ConsentViewModelFactory.kt
@@ -1,0 +1,48 @@
+package com.stripe.android.financialconnections.features.consent
+
+import com.stripe.android.core.Logger
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext
+import com.stripe.android.financialconnections.TestFinancialConnectionsAnalyticsTracker
+import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
+import com.stripe.android.financialconnections.domain.AcceptConsent
+import com.stripe.android.financialconnections.domain.GetOrFetchSync
+import com.stripe.android.financialconnections.domain.IsLinkWithStripe
+import com.stripe.android.financialconnections.domain.LookupAccount
+import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
+import com.stripe.android.financialconnections.features.notice.PresentSheet
+import com.stripe.android.financialconnections.navigation.NavigationManager
+import com.stripe.android.financialconnections.ui.HandleClickableUrl
+import com.stripe.android.financialconnections.utils.TestNavigationManager
+import org.mockito.kotlin.mock
+
+internal object ConsentViewModelFactory {
+
+    fun create(
+        initialState: ConsentState = ConsentState(),
+        nativeAuthFlowCoordinator: NativeAuthFlowCoordinator = NativeAuthFlowCoordinator(),
+        acceptConsent: AcceptConsent = mock(),
+        getOrFetchSync: GetOrFetchSync = mock(),
+        navigationManager: NavigationManager = TestNavigationManager(),
+        eventTracker: FinancialConnectionsAnalyticsTracker = TestFinancialConnectionsAnalyticsTracker(),
+        handleClickableUrl: HandleClickableUrl = mock(),
+        presentSheet: PresentSheet = mock(),
+        lookupAccount: LookupAccount = mock(),
+        isLinkWithStripe: IsLinkWithStripe = mock(),
+        prefillDetails: ElementsSessionContext.PrefillDetails? = null,
+    ): ConsentViewModel {
+        return ConsentViewModel(
+            initialState = initialState,
+            nativeAuthFlowCoordinator = nativeAuthFlowCoordinator,
+            acceptConsent = acceptConsent,
+            getOrFetchSync = getOrFetchSync,
+            navigationManager = navigationManager,
+            eventTracker = eventTracker,
+            handleClickableUrl = handleClickableUrl,
+            logger = Logger.noop(),
+            presentSheet = presentSheet,
+            lookupAccount = lookupAccount,
+            isLinkWithStripe = isLinkWithStripe,
+            prefillDetails = prefillDetails,
+        )
+    }
+}

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/consent/ConsentViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/consent/ConsentViewModelTest.kt
@@ -1,0 +1,245 @@
+package com.stripe.android.financialconnections.features.consent
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.financialconnections.ApiKeyFixtures
+import com.stripe.android.financialconnections.CoroutineTestRule
+import com.stripe.android.financialconnections.FinancialConnectionsSheet
+import com.stripe.android.financialconnections.domain.AcceptConsent
+import com.stripe.android.financialconnections.domain.GetOrFetchSync
+import com.stripe.android.financialconnections.domain.LookupAccount
+import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
+import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
+import com.stripe.android.financialconnections.model.SynchronizeSessionResponse
+import com.stripe.android.financialconnections.model.VisualUpdate
+import com.stripe.android.financialconnections.navigation.Destination
+import com.stripe.android.financialconnections.navigation.NavigationIntent
+import com.stripe.android.financialconnections.navigation.NavigationManagerImpl
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConsentViewModelTest {
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+
+    @Test
+    fun `Navigates to Link warmup pane if recognizing a returning Link consumer from prefill details`() = runTest {
+        val navigationManager = NavigationManagerImpl()
+        val manifest = ApiKeyFixtures.sessionManifest().copy(
+            accountholderCustomerEmailAddress = null,
+            nextPane = Pane.NETWORKING_LINK_SIGNUP_PANE,
+        )
+
+        val getOrFetchSync = mockManifest(manifest)
+        val acceptConsent = mockAcceptConsent(manifest)
+        val lookupAccount = mockConsumerSessionLookup(exists = true)
+
+        navigationManager.navigationFlow.test {
+            val viewModel = ConsentViewModelFactory.create(
+                isLinkWithStripe = { true },
+                navigationManager = navigationManager,
+                getOrFetchSync = getOrFetchSync,
+                acceptConsent = acceptConsent,
+                lookupAccount = lookupAccount,
+                prefillDetails = FinancialConnectionsSheet.ElementsSessionContext.PrefillDetails(
+                    email = "email@email.com",
+                    phone = null,
+                    phoneCountryCode = null,
+                ),
+            )
+
+            viewModel.onContinueClick()
+
+            assertThat(awaitItem()).isEqualTo(
+                NavigationIntent.NavigateTo(
+                    route = Destination.NetworkingLinkLoginWarmup(Pane.CONSENT),
+                    popUpTo = null,
+                    isSingleTop = true,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `Navigates to Link signup pane if not recognizing a returning Link consumer from prefill details`() = runTest {
+        val navigationManager = NavigationManagerImpl()
+        val manifest = ApiKeyFixtures.sessionManifest().copy(
+            accountholderCustomerEmailAddress = null,
+            nextPane = Pane.NETWORKING_LINK_SIGNUP_PANE,
+        )
+
+        val getOrFetchSync = mockManifest(manifest)
+        val acceptConsent = mockAcceptConsent(manifest)
+        val lookupAccount = mockConsumerSessionLookup(exists = false)
+
+        navigationManager.navigationFlow.test {
+            val viewModel = ConsentViewModelFactory.create(
+                isLinkWithStripe = { true },
+                navigationManager = navigationManager,
+                getOrFetchSync = getOrFetchSync,
+                acceptConsent = acceptConsent,
+                lookupAccount = lookupAccount,
+                prefillDetails = FinancialConnectionsSheet.ElementsSessionContext.PrefillDetails(
+                    email = "email@email.com",
+                    phone = null,
+                    phoneCountryCode = null,
+                ),
+            )
+
+            viewModel.onContinueClick()
+
+            assertThat(awaitItem()).isEqualTo(
+                NavigationIntent.NavigateTo(
+                    route = Destination.NetworkingLinkSignup(Pane.CONSENT),
+                    popUpTo = null,
+                    isSingleTop = true,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `Doesn't attempt to lookup consumer account when in Financial Connections flow`() = runTest {
+        val navigationManager = NavigationManagerImpl()
+        val manifest = ApiKeyFixtures.sessionManifest().copy(
+            accountholderCustomerEmailAddress = null,
+            nextPane = Pane.INSTITUTION_PICKER,
+        )
+
+        val getOrFetchSync = mockManifest(manifest)
+        val acceptConsent = mockAcceptConsent(manifest)
+
+        navigationManager.navigationFlow.test {
+            val viewModel = ConsentViewModelFactory.create(
+                isLinkWithStripe = { false },
+                navigationManager = navigationManager,
+                getOrFetchSync = getOrFetchSync,
+                acceptConsent = acceptConsent,
+                lookupAccount = throwOnConsumerSessionLookup(),
+                prefillDetails = FinancialConnectionsSheet.ElementsSessionContext.PrefillDetails(
+                    email = "email@email.com",
+                    phone = null,
+                    phoneCountryCode = null,
+                ),
+            )
+
+            viewModel.onContinueClick()
+
+            assertThat(awaitItem()).isEqualTo(
+                NavigationIntent.NavigateTo(
+                    route = Destination.InstitutionPicker(Pane.CONSENT),
+                    popUpTo = null,
+                    isSingleTop = true,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `Doesn't attempt to lookup consumer account when accountholder customer email is available`() = runTest {
+        val navigationManager = NavigationManagerImpl()
+        val manifest = ApiKeyFixtures.sessionManifest().copy(
+            accountholderCustomerEmailAddress = "account@holder.ca",
+            nextPane = Pane.NETWORKING_LINK_SIGNUP_PANE,
+        )
+
+        val getOrFetchSync = mockManifest(manifest)
+        val acceptConsent = mockAcceptConsent(manifest)
+
+        navigationManager.navigationFlow.test {
+            val viewModel = ConsentViewModelFactory.create(
+                isLinkWithStripe = { true },
+                navigationManager = navigationManager,
+                getOrFetchSync = getOrFetchSync,
+                acceptConsent = acceptConsent,
+                lookupAccount = throwOnConsumerSessionLookup(),
+                prefillDetails = FinancialConnectionsSheet.ElementsSessionContext.PrefillDetails(
+                    email = "email@email.com",
+                    phone = null,
+                    phoneCountryCode = null,
+                ),
+            )
+
+            viewModel.onContinueClick()
+
+            assertThat(awaitItem()).isEqualTo(
+                NavigationIntent.NavigateTo(
+                    route = Destination.NetworkingLinkSignup(Pane.CONSENT),
+                    popUpTo = null,
+                    isSingleTop = true,
+                )
+            )
+        }
+    }
+
+    private suspend fun mockConsumerSessionLookup(exists: Boolean): LookupAccount {
+        val lookupAccount = mock<LookupAccount>()
+        val consumerSession = ApiKeyFixtures.consumerSessionLookup(exists = exists)
+        whenever(
+            lookupAccount(
+                email = any(),
+                phone = anyOrNull(),
+                phoneCountryCode = anyOrNull(),
+                emailSource = any(),
+                verifiedFlow = any(),
+                sessionId = any(),
+                pane = any(),
+            )
+        ).doReturn(consumerSession)
+        return lookupAccount
+    }
+
+    private suspend fun throwOnConsumerSessionLookup(): LookupAccount {
+        val lookupAccount = mock<LookupAccount>()
+        whenever(
+            lookupAccount(
+                email = any(),
+                phone = anyOrNull(),
+                phoneCountryCode = anyOrNull(),
+                emailSource = any(),
+                verifiedFlow = any(),
+                sessionId = any(),
+                pane = any(),
+            )
+        ).doAnswer {
+            throw IllegalStateException("Not expected to be called")
+        }
+        return lookupAccount
+    }
+
+    private suspend fun mockManifest(
+        manifest: FinancialConnectionsSessionManifest,
+    ): GetOrFetchSync {
+        val getOrFetchSync = mock<GetOrFetchSync>()
+        whenever(getOrFetchSync(any(), any())).doReturn(
+            SynchronizeSessionResponse(
+                manifest = manifest,
+                text = null,
+                visual = VisualUpdate(
+                    reducedBranding = false,
+                    reducedManualEntryProminenceInErrors = false,
+                    merchantLogos = emptyList(),
+                ),
+            )
+        )
+        return getOrFetchSync
+    }
+
+    private suspend fun mockAcceptConsent(
+        manifest: FinancialConnectionsSessionManifest = ApiKeyFixtures.sessionManifest(),
+    ): AcceptConsent {
+        val acceptConsent = mock<AcceptConsent>()
+        whenever(acceptConsent()).doReturn(manifest)
+        return acceptConsent
+    }
+}

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModelTest.kt
@@ -51,6 +51,7 @@ class NetworkingLinkLoginWarmupViewModelTest {
         initialState = state,
         nativeAuthFlowCoordinator = nativeAuthFlowCoordinator,
         lookupAccount = lookupAccount,
+        prefillDetails = null,
     )
 
     @Test

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModelTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.financialconnections.navigation.Destination
 import com.stripe.android.financialconnections.navigation.PopUpToBehavior
 import com.stripe.android.financialconnections.navigation.destination
+import com.stripe.android.financialconnections.repository.ConsumerSessionProvider
 import com.stripe.android.financialconnections.utils.TestHandleError
 import com.stripe.android.financialconnections.utils.TestNavigationManager
 import com.stripe.android.model.ConsumerSessionLookup
@@ -39,6 +40,7 @@ class NetworkingLinkLoginWarmupViewModelTest {
     private val eventTracker = TestFinancialConnectionsAnalyticsTracker()
     private val nativeAuthFlowCoordinator = mock<NativeAuthFlowCoordinator>()
     private val lookupAccount = mock<LookupAccount>()
+    private val consumerSessionProvider = mock<ConsumerSessionProvider>()
 
     private fun buildViewModel(
         state: NetworkingLinkLoginWarmupState
@@ -52,6 +54,7 @@ class NetworkingLinkLoginWarmupViewModelTest {
         nativeAuthFlowCoordinator = nativeAuthFlowCoordinator,
         lookupAccount = lookupAccount,
         prefillDetails = null,
+        consumerSessionProvider = consumerSessionProvider,
     )
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request improves the returning-user experience for IBP consumers when the flow is opened for deferred intents. With those, we don’t have a populated `accountholderCustomerEmailAddress`, so we need to manually look for a consumer account after the user accepts on the consent pane.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
