### PR TITLE
Add french traductions for stripecardscan and camera-core modules

### DIFF
--- a/camera-core/res/values-fr/strings.xml
+++ b/camera-core/res/values-fr/strings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="stripe_camera_permission_denied_message" description="Message shown to the user when camera permission is denied">Veuillez autoriser l\'accès à la caméra pour numériser votre carte</string>
+    <string name="stripe_camera_permission_denied_ok" description="Affirmative button shown as part of the permission denied dialog">OK</string>
+    <string name="stripe_camera_permission_denied_cancel" description="Negative button shown as part of the permission denied dialog">Annuler</string>
+
+    <string name="stripe_error_camera_title" description="Title of the dialog shown to the user when an error using the camera occurs">Problème de caméra</string>
+    <string name="stripe_error_camera_open" description="Message of the dialog shown to the user when an error starting the camera occurs">La caméra n\'a pas pu être activée</string>
+    <string name="stripe_error_camera_access" description="Message of the dialog shown to the user when an error accessing the camera occurs">L\'autorisation a été refusée pour activer la caméra</string>
+    <string name="stripe_error_camera_unsupported" description="Message of the dialog shown to the user when the camera is not supported">Cet appareil ne prend pas en charge les fonctionnalités requises de la caméra</string>
+    <string name="stripe_error_camera_acknowledge_button" description="Affirmative button shown as part of the camera error dialog">Fermer</string>
+</resources>

--- a/stripecardscan/res/values-fr/strings.xml
+++ b/stripecardscan/res/values-fr/strings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="stripe_card_scan_title" description="Text displayed above the scan window for paymentsheet, instructing the user how to scan card">Placez votre carte dans le rectangle pour la numériser</string>
+    <string name="stripe_card_scan_instructions" description="Text displayed above the scan window, instructing the user how to scan card">Numérisez votre carte</string>
+    <string name="stripe_card_scan_privacy_link_text" description="Privacy link text in scan window. THIS STRING SHOULD NOT BE MODIFIED"><![CDATA[Nous utilisons Stripe pour vérifier les informations de votre carte. Stripe peut utiliser et stocker vos données conformément à sa politique de confidentialité. <a href="https://support.stripe.com/questions/stripes-card-image-verification"><u>En savoir plus</u></a>]]></string>
+
+    <string name="stripe_camera_permission_settings_message" description="Message shown to the user when camera permission is denied in fragment">Veuillez autoriser l\'accès à la caméra dans les paramètres pour numériser votre carte</string>
+
+    <string name="stripe_close_button_description" description="Text used to close the scan window">Fermer</string>
+    <string name="stripe_torch_button_description" description="Text used to turn on the camera torch">Lampe</string>
+    <string name="stripe_swap_camera_button_description" description="Text used to swap the camera">Changer de caméra</string>
+</resources>


### PR DESCRIPTION
# Summary

Add french traductions for stripecardscan and camera-core modules

# Motivation

We need to have french traductions for scan card messages

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![IMG_20241118_155301](https://github.com/user-attachments/assets/ef664cda-b9fa-440f-86cb-4bc8eaa07d40) | ![IMG_20241118_155111](https://github.com/user-attachments/assets/7124d425-19e8-4b08-bc41-49ab7d4d174f)|
 


