### PR TITLE
Rename isFlowController to canShowWalletsInline.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -82,7 +82,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     private val onEditPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
     private val onSelectSavedPaymentMethod: (PaymentMethod) -> Unit,
     private val walletsState: StateFlow<WalletsState?>,
-    private val isFlowController: Boolean,
+    private val canShowWalletsInline: Boolean,
     private val onMandateTextUpdated: (ResolvableString?) -> Unit,
     private val updateSelection: (PaymentSelection?) -> Unit,
     private val isCurrentScreen: StateFlow<Boolean>,
@@ -147,7 +147,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                 },
                 onUpdatePaymentMethod = { viewModel.savedPaymentMethodMutator.updatePaymentMethod(it) },
                 walletsState = viewModel.walletsState,
-                isFlowController = !viewModel.isCompleteFlow,
+                canShowWalletsInline = !viewModel.isCompleteFlow,
                 updateSelection = viewModel::updateSelection,
                 isCurrentScreen = viewModel.navigationHandler.currentScreen.mapAsStateFlow {
                     it is PaymentSheetScreen.VerticalMode
@@ -303,7 +303,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     }
 
     private fun showsWalletsInline(walletsState: WalletsState?): Boolean {
-        return isFlowController && walletsState != null && walletsState.googlePay != null
+        return canShowWalletsInline && walletsState != null && walletsState.googlePay != null
     }
 
     private fun getDisplayedSavedPaymentMethod(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -457,7 +457,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
                 paymentMethodTypes = listOf("card", "cashapp")
             )
         ),
-        isFlowController = false,
+        canShowWalletsInline = false,
     ) {
         walletsState.value = WalletsState(
             link = WalletsState.Link("email@email.com"),
@@ -488,7 +488,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
                 paymentMethodTypes = listOf("card", "cashapp")
             )
         ),
-        isFlowController = true,
+        canShowWalletsInline = true,
     ) {
         walletsState.value = WalletsState(
             link = WalletsState.Link("email@email.com"),
@@ -522,7 +522,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
                     paymentMethodTypes = listOf("card", "cashapp")
                 )
             ),
-            isFlowController = true,
+            canShowWalletsInline = true,
             updateSelection = { selectedWallet = it },
         ) {
             walletsState.value = WalletsState(
@@ -554,7 +554,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
                 paymentMethodTypes = listOf("card", "cashapp")
             )
         ),
-        isFlowController = true,
+        canShowWalletsInline = true,
     ) {
         walletsState.value = WalletsState(
             link = WalletsState.Link("email@email.com"),
@@ -582,7 +582,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
                 paymentMethodTypes = listOf("card", "cashapp")
             )
         ),
-        isFlowController = true,
+        canShowWalletsInline = true,
     ) {
         walletsState.value = WalletsState(
             link = null,
@@ -1025,7 +1025,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         onEditPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit = { notImplemented() },
         onSelectSavedPaymentMethod: (PaymentMethod) -> Unit = { notImplemented() },
         onUpdatePaymentMethod: (DisplayableSavedPaymentMethod) -> Unit = { notImplemented() },
-        isFlowController: Boolean = false,
+        canShowWalletsInline: Boolean = false,
         updateSelection: (PaymentSelection?) -> Unit = { notImplemented() },
         onMandateTextUpdated: (ResolvableString?) -> Unit = { notImplemented() },
         reportPaymentMethodTypeSelected: (PaymentMethodCode) -> Unit = { notImplemented() },
@@ -1059,7 +1059,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             onEditPaymentMethod = onEditPaymentMethod,
             onSelectSavedPaymentMethod = onSelectSavedPaymentMethod,
             walletsState = walletsState,
-            isFlowController = isFlowController,
+            canShowWalletsInline = canShowWalletsInline,
             onMandateTextUpdated = onMandateTextUpdated,
             updateSelection = { paymentSelection ->
                 selection.value = paymentSelection


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This won't always be flowcontroller/paymentsheet in the future. So renaming it to what it does, rather than what it is.