### PR TITLE
Restore removed consumer payment details fields

### DIFF
--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/RealCreateInstantDebitsResultTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/RealCreateInstantDebitsResultTest.kt
@@ -174,6 +174,8 @@ class RealCreateInstantDebitsResultTest {
                     id = "ba_1234",
                     bankName = "Stripe Bank",
                     last4 = "4242",
+                    bankIconCode = null,
+                    isDefault = false,
                 )
             )
         )

--- a/link/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/link/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -1,12 +1,15 @@
 package com.stripe.android.link
 
+import com.stripe.android.core.model.CountryCode
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.model.StripeIntentFixtures
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardParams
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.ConsumerSessionLookup
 import com.stripe.android.model.ConsumerSessionSignup
+import com.stripe.android.model.CvcCheck
 import com.stripe.android.model.PaymentMethodCreateParams
 import org.mockito.kotlin.mock
 
@@ -65,11 +68,22 @@ internal object TestFactory {
         )
     )
 
+    private val CONSUMER_PAYMENT_DETAILS_CARD = ConsumerPaymentDetails.Card(
+        id = "pm_123",
+        last4 = "4242",
+        expiryYear = 2023,
+        expiryMonth = 12,
+        brand = CardBrand.AmericanExpress,
+        cvcCheck = CvcCheck.Pass,
+        isDefault = true,
+        billingAddress = ConsumerPaymentDetails.BillingAddress(
+            countryCode = CountryCode.US,
+            postalCode = "12312"
+        )
+    )
+
     val LINK_NEW_PAYMENT_DETAILS = LinkPaymentDetails.New(
-        paymentDetails = ConsumerPaymentDetails.Card(
-            id = "pm_123",
-            last4 = "4242",
-        ),
+        paymentDetails = CONSUMER_PAYMENT_DETAILS_CARD,
         paymentMethodCreateParams = PAYMENT_METHOD_CREATE_PARAMS,
         originalParams = mock()
     )
@@ -78,10 +92,7 @@ internal object TestFactory {
 
     val CONSUMER_PAYMENT_DETAILS: ConsumerPaymentDetails = ConsumerPaymentDetails(
         paymentDetails = listOf(
-            ConsumerPaymentDetails.Card(
-                id = "pm_123",
-                last4 = "4242",
-            )
+            CONSUMER_PAYMENT_DETAILS_CARD
         )
     )
 

--- a/link/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
+++ b/link/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
@@ -13,7 +13,6 @@ import com.stripe.android.model.PaymentMethodCreateParams
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import org.mockito.kotlin.mock
 
 internal open class FakeLinkAccountManager : LinkAccountManager {
     private val _linkAccount = MutableStateFlow<LinkAccount?>(null)
@@ -29,13 +28,7 @@ internal open class FakeLinkAccountManager : LinkAccountManager {
     var signInWithUserInputResult: Result<LinkAccount> = Result.success(LinkAccount(ConsumerSession("", "", "", "")))
     var logOutResult: Result<ConsumerSession> = Result.success(ConsumerSession("", "", "", ""))
     var createCardPaymentDetailsResult: Result<LinkPaymentDetails> = Result.success(
-        value = LinkPaymentDetails.Saved(
-            paymentDetails = ConsumerPaymentDetails.Card(
-                id = "pm_123",
-                last4 = "4242",
-            ),
-            paymentMethodCreateParams = mock(),
-        )
+        value = TestFactory.LINK_NEW_PAYMENT_DETAILS
     )
     var listPaymentDetailsResult: Result<ConsumerPaymentDetails> = Result.success(TestFactory.CONSUMER_PAYMENT_DETAILS)
     var linkAccountFromLookupResult: LinkAccount? = null

--- a/payments-core/src/main/java/com/stripe/android/model/ExpirationDate.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ExpirationDate.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.model
 
-import com.stripe.android.view.DateUtils
+import com.stripe.android.core.utils.DateUtils
 
 sealed class ExpirationDate {
     internal data class Unvalidated(

--- a/payments-core/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
@@ -10,6 +10,7 @@ import android.widget.EditText
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.R
+import com.stripe.android.core.utils.DateUtils
 import com.stripe.android.model.ExpirationDate
 import kotlin.math.min
 import kotlin.properties.Delegates

--- a/payments-core/src/test/java/com/stripe/android/model/ConsumerFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ConsumerFixtures.kt
@@ -84,6 +84,28 @@ object ConsumerFixtures {
         """.trimIndent()
     )
 
+    val CONSUMER_SINGLE_CARD_PAYMENT_DETAILS_NULL_VALUES_JSON = JSONObject(
+        """
+            {
+              "redacted_payment_details": {
+                  "id": "QAAAKJ6",
+                  "bank_account_details": null,
+                  "billing_address": null,
+                  "billing_email_address": "",
+                  "card_details": {
+                    "brand": "MASTERCARD",
+                    "checks": null,
+                    "exp_month": 12,
+                    "exp_year": 2023,
+                    "last4": "4444"
+                  },
+                  "is_default": null,
+                  "type": "CARD"
+              }
+            }
+        """.trimIndent()
+    )
+
     val CONSUMER_SINGLE_BANK_ACCOUNT_PAYMENT_DETAILS_JSON = JSONObject(
         """
             {
@@ -109,6 +131,38 @@ object ConsumerFixtures {
                   "billing_email_address": "",
                   "card_details": null,
                   "is_default": true,
+                  "type": "BANK_ACCOUNT"
+                }
+              ]
+            }
+        """.trimIndent()
+    )
+
+    val CONSUMER_SINGLE_BANK_ACCOUNT_PAYMENT_DETAILS_NULL_VALUES_JSON = JSONObject(
+        """
+            {
+              "redacted_payment_details": [
+                {
+                  "id": "wAAACGA",
+                  "bank_account_details": {
+                    "bank_icon_code": null,
+                    "bank_name": null,
+                    "last4": "6789"
+                  },
+                  "billing_address": {
+                    "administrative_area": null,
+                    "country_code": null,
+                    "dependent_locality": null,
+                    "line_1": null,
+                    "line_2": null,
+                    "locality": null,
+                    "name": null,
+                    "postal_code": null,
+                    "sorting_code": null
+                  },
+                  "billing_email_address": "",
+                  "card_details": null,
+                  "is_default": null,
                   "type": "BANK_ACCOUNT"
                 }
               ]

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParserTest.kt
@@ -37,6 +37,28 @@ class ConsumerPaymentDetailsJsonParserTest {
     }
 
     @Test
+    fun `parse optional card payment details correctly`() {
+        assertEquals(
+            ConsumerPaymentDetailsJsonParser
+                .parse(ConsumerFixtures.CONSUMER_SINGLE_CARD_PAYMENT_DETAILS_NULL_VALUES_JSON),
+            ConsumerPaymentDetails(
+                listOf(
+                    ConsumerPaymentDetails.Card(
+                        id = "QAAAKJ6",
+                        expiryYear = 2023,
+                        expiryMonth = 12,
+                        isDefault = false,
+                        brand = CardBrand.MasterCard,
+                        last4 = "4444",
+                        cvcCheck = CvcCheck.Unknown,
+                        billingAddress = null
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
     fun `parse single bank account payment details`() {
         assertEquals(
             ConsumerPaymentDetails(
@@ -52,6 +74,25 @@ class ConsumerPaymentDetailsJsonParserTest {
             ),
             ConsumerPaymentDetailsJsonParser
                 .parse(ConsumerFixtures.CONSUMER_SINGLE_BANK_ACCOUNT_PAYMENT_DETAILS_JSON),
+        )
+    }
+
+    @Test
+    fun `parse optional bank account payment details correctly`() {
+        assertEquals(
+            ConsumerPaymentDetails(
+                listOf(
+                    ConsumerPaymentDetails.BankAccount(
+                        id = "wAAACGA",
+                        last4 = "6789",
+                        bankName = null,
+                        bankIconCode = null,
+                        isDefault = false,
+                    )
+                )
+            ),
+            ConsumerPaymentDetailsJsonParser
+                .parse(ConsumerFixtures.CONSUMER_SINGLE_BANK_ACCOUNT_PAYMENT_DETAILS_NULL_VALUES_JSON),
         )
     }
 

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParserTest.kt
@@ -1,7 +1,10 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.CountryCode
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerFixtures
 import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.CvcCheck
 import org.json.JSONObject
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -17,7 +20,16 @@ class ConsumerPaymentDetailsJsonParserTest {
                 listOf(
                     ConsumerPaymentDetails.Card(
                         id = "QAAAKJ6",
+                        expiryYear = 2023,
+                        expiryMonth = 12,
+                        isDefault = true,
+                        brand = CardBrand.MasterCard,
                         last4 = "4444",
+                        cvcCheck = CvcCheck.Pass,
+                        billingAddress = ConsumerPaymentDetails.BillingAddress(
+                            countryCode = CountryCode.US,
+                            postalCode = "12312"
+                        )
                     )
                 )
             )
@@ -33,6 +45,8 @@ class ConsumerPaymentDetailsJsonParserTest {
                         id = "wAAACGA",
                         last4 = "6789",
                         bankName = "STRIPE TEST BANK",
+                        bankIconCode = null,
+                        isDefault = true,
                     )
                 )
             ),
@@ -49,15 +63,35 @@ class ConsumerPaymentDetailsJsonParserTest {
                     ConsumerPaymentDetails.Card(
                         id = "QAAAKJ6",
                         last4 = "4444",
+                        expiryYear = 2023,
+                        expiryMonth = 12,
+                        isDefault = true,
+                        brand = CardBrand.MasterCard,
+                        cvcCheck = CvcCheck.Pass,
+                        billingAddress = ConsumerPaymentDetails.BillingAddress(
+                            countryCode = CountryCode.US,
+                            postalCode = "12312"
+                        )
                     ),
                     ConsumerPaymentDetails.Card(
                         id = "QAAAKIL",
                         last4 = "4242",
+                        expiryYear = 2024,
+                        expiryMonth = 4,
+                        brand = CardBrand.Visa,
+                        cvcCheck = CvcCheck.Fail,
+                        isDefault = false,
+                        billingAddress = ConsumerPaymentDetails.BillingAddress(
+                            countryCode = CountryCode.US,
+                            postalCode = "42424"
+                        )
                     ),
                     ConsumerPaymentDetails.BankAccount(
                         id = "wAAACGA",
                         last4 = "6789",
                         bankName = "STRIPE TEST BANK",
+                        bankIconCode = null,
+                        isDefault = false,
                     )
                 )
             ),
@@ -143,10 +177,28 @@ class ConsumerPaymentDetailsJsonParserTest {
                     ConsumerPaymentDetails.Card(
                         id = "QAAAKJ6",
                         last4 = "4444",
+                        expiryYear = 2023,
+                        expiryMonth = 12,
+                        brand = CardBrand.AmericanExpress,
+                        cvcCheck = CvcCheck.Pass,
+                        isDefault = true,
+                        billingAddress = ConsumerPaymentDetails.BillingAddress(
+                            countryCode = CountryCode.US,
+                            postalCode = "12312"
+                        )
                     ),
                     ConsumerPaymentDetails.Card(
                         id = "QAAAKIL",
                         last4 = "4242",
+                        expiryYear = 2024,
+                        expiryMonth = 4,
+                        brand = CardBrand.DinersClub,
+                        cvcCheck = CvcCheck.Fail,
+                        isDefault = false,
+                        billingAddress = ConsumerPaymentDetails.BillingAddress(
+                            countryCode = CountryCode.US,
+                            postalCode = "42424"
+                        )
                     )
                 )
             )

--- a/payments-core/src/test/java/com/stripe/android/view/DateUtilsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/DateUtilsTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.view
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.utils.DateUtils
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.util.Calendar

--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerPaymentDetails.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerPaymentDetails.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.model.StripeModel
+import com.stripe.android.core.utils.DateUtils
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -15,6 +16,7 @@ data class ConsumerPaymentDetails(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     sealed class PaymentDetails(
         open val id: String,
+        open val isDefault: Boolean,
         open val type: String,
     ) : Parcelable {
 
@@ -26,7 +28,27 @@ data class ConsumerPaymentDetails(
     data class Card(
         override val id: String,
         override val last4: String,
-    ) : PaymentDetails(id, type = TYPE) {
+        override val isDefault: Boolean,
+        val expiryYear: Int,
+        val expiryMonth: Int,
+        val brand: CardBrand,
+        val cvcCheck: CvcCheck,
+        val billingAddress: BillingAddress? = null
+    ) : PaymentDetails(
+        id = id,
+        isDefault = isDefault,
+        type = TYPE
+    ) {
+
+        val requiresCardDetailsRecollection: Boolean
+            get() = isExpired || cvcCheck.requiresRecollection
+
+        val isExpired: Boolean
+            get() = !DateUtils.isExpiryDataValid(
+                expiryMonth = expiryMonth,
+                expiryYear = expiryYear
+            )
+
         companion object {
             const val TYPE = "card"
         }
@@ -37,7 +59,7 @@ data class ConsumerPaymentDetails(
     data class Passthrough(
         override val id: String,
         override val last4: String,
-    ) : PaymentDetails(id, type = TYPE) {
+    ) : PaymentDetails(id = id, type = TYPE, isDefault = false) {
         companion object {
             const val TYPE = "card"
         }
@@ -48,8 +70,14 @@ data class ConsumerPaymentDetails(
     data class BankAccount(
         override val id: String,
         override val last4: String,
+        override val isDefault: Boolean,
         val bankName: String?,
-    ) : PaymentDetails(id, type = TYPE) {
+        val bankIconCode: String?,
+    ) : PaymentDetails(
+        id = id,
+        type = TYPE,
+        isDefault = isDefault
+    ) {
         companion object {
             const val TYPE = "bank_account"
         }

--- a/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParser.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParser.kt
@@ -52,7 +52,7 @@ object ConsumerPaymentDetailsJsonParser : ModelJsonParser<ConsumerPaymentDetails
             when (it.lowercase()) {
                 "card" -> {
                     val cardDetails = json.getJSONObject(FIELD_CARD_DETAILS)
-                    val checks = cardDetails.getJSONObject(FIELD_CARD_CHECKS)
+                    val checks = cardDetails.optJSONObject(FIELD_CARD_CHECKS)
 
                     ConsumerPaymentDetails.Card(
                         id = json.getString(FIELD_ID),
@@ -60,9 +60,9 @@ object ConsumerPaymentDetailsJsonParser : ModelJsonParser<ConsumerPaymentDetails
                         expiryMonth = cardDetails.getInt(FIELD_CARD_EXPIRY_MONTH),
                         brand = CardBrand.fromCode(cardBrandFix(cardDetails.getString(FIELD_CARD_BRAND))),
                         last4 = cardDetails.getString(FIELD_CARD_LAST_4),
-                        cvcCheck = CvcCheck.fromCode(checks.getString(FIELD_CARD_CVC_CHECK)),
+                        cvcCheck = CvcCheck.fromCode(checks?.getString(FIELD_CARD_CVC_CHECK)),
                         billingAddress = parseBillingAddress(json),
-                        isDefault = json.getBoolean(FIELD_IS_DEFAULT),
+                        isDefault = json.optBoolean(FIELD_IS_DEFAULT),
                     )
                 }
                 "bank_account" -> {
@@ -72,7 +72,7 @@ object ConsumerPaymentDetailsJsonParser : ModelJsonParser<ConsumerPaymentDetails
                         last4 = bankAccountDetails.getString(FIELD_BANK_ACCOUNT_LAST_4),
                         bankName = optString(bankAccountDetails, FIELD_BANK_ACCOUNT_BANK_NAME),
                         bankIconCode = optString(bankAccountDetails, FIELD_BANK_ACCOUNT_BANK_ICON_CODE),
-                        isDefault = json.getBoolean(FIELD_IS_DEFAULT),
+                        isDefault = json.optBoolean(FIELD_IS_DEFAULT),
                     )
                 }
                 else -> null
@@ -80,7 +80,7 @@ object ConsumerPaymentDetailsJsonParser : ModelJsonParser<ConsumerPaymentDetails
         }
 
     private fun parseBillingAddress(json: JSONObject) =
-        json.getJSONObject(FIELD_BILLING_ADDRESS).let { address ->
+        json.optJSONObject(FIELD_BILLING_ADDRESS)?.let { address ->
             ConsumerPaymentDetails.BillingAddress(
                 optString(address, FIELD_ADDRESS_COUNTRY_CODE)?.let { CountryCode(it) },
                 optString(address, FIELD_ADDRESS_POSTAL_CODE)

--- a/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParser.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParser.kt
@@ -1,9 +1,12 @@
 package com.stripe.android.model.parsers
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.model.StripeJsonUtils.optString
 import com.stripe.android.core.model.parsers.ModelJsonParser
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.CvcCheck
 import org.json.JSONObject
 
 private const val FIELD_PAYMENT_DETAILS = "redacted_payment_details"
@@ -14,6 +17,20 @@ private const val FIELD_CARD_LAST_4 = "last4"
 private const val FIELD_BANK_ACCOUNT_DETAILS = "bank_account_details"
 private const val FIELD_BANK_ACCOUNT_LAST_4 = "last4"
 private const val FIELD_BANK_ACCOUNT_BANK_NAME = "bank_name"
+
+private const val FIELD_BILLING_ADDRESS = "billing_address"
+private const val FIELD_ADDRESS_COUNTRY_CODE = "country_code"
+private const val FIELD_ADDRESS_POSTAL_CODE = "postal_code"
+
+private const val FIELD_CARD_EXPIRY_YEAR = "exp_year"
+private const val FIELD_CARD_EXPIRY_MONTH = "exp_month"
+private const val FIELD_CARD_BRAND = "brand"
+private const val FIELD_CARD_CHECKS = "checks"
+private const val FIELD_CARD_CVC_CHECK = "cvc_check"
+
+private const val FIELD_BANK_ACCOUNT_BANK_ICON_CODE = "bank_icon_code"
+
+private const val FIELD_IS_DEFAULT = "is_default"
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object ConsumerPaymentDetailsJsonParser : ModelJsonParser<ConsumerPaymentDetails> {
@@ -35,9 +52,17 @@ object ConsumerPaymentDetailsJsonParser : ModelJsonParser<ConsumerPaymentDetails
             when (it.lowercase()) {
                 "card" -> {
                     val cardDetails = json.getJSONObject(FIELD_CARD_DETAILS)
+                    val checks = cardDetails.getJSONObject(FIELD_CARD_CHECKS)
+
                     ConsumerPaymentDetails.Card(
-                        json.getString(FIELD_ID),
-                        cardDetails.getString(FIELD_CARD_LAST_4),
+                        id = json.getString(FIELD_ID),
+                        expiryYear = cardDetails.getInt(FIELD_CARD_EXPIRY_YEAR),
+                        expiryMonth = cardDetails.getInt(FIELD_CARD_EXPIRY_MONTH),
+                        brand = CardBrand.fromCode(cardBrandFix(cardDetails.getString(FIELD_CARD_BRAND))),
+                        last4 = cardDetails.getString(FIELD_CARD_LAST_4),
+                        cvcCheck = CvcCheck.fromCode(checks.getString(FIELD_CARD_CVC_CHECK)),
+                        billingAddress = parseBillingAddress(json),
+                        isDefault = json.getBoolean(FIELD_IS_DEFAULT),
                     )
                 }
                 "bank_account" -> {
@@ -46,9 +71,30 @@ object ConsumerPaymentDetailsJsonParser : ModelJsonParser<ConsumerPaymentDetails
                         id = json.getString(FIELD_ID),
                         last4 = bankAccountDetails.getString(FIELD_BANK_ACCOUNT_LAST_4),
                         bankName = optString(bankAccountDetails, FIELD_BANK_ACCOUNT_BANK_NAME),
+                        bankIconCode = optString(bankAccountDetails, FIELD_BANK_ACCOUNT_BANK_ICON_CODE),
+                        isDefault = json.getBoolean(FIELD_IS_DEFAULT),
                     )
                 }
                 else -> null
             }
         }
+
+    private fun parseBillingAddress(json: JSONObject) =
+        json.getJSONObject(FIELD_BILLING_ADDRESS).let { address ->
+            ConsumerPaymentDetails.BillingAddress(
+                optString(address, FIELD_ADDRESS_COUNTRY_CODE)?.let { CountryCode(it) },
+                optString(address, FIELD_ADDRESS_POSTAL_CODE)
+            )
+        }
+
+    /**
+     * Fixes the incorrect brand enum values returned from the server in this service.
+     */
+    private fun cardBrandFix(original: String) = original.lowercase().let {
+        when (it) {
+            "american_express" -> "amex"
+            "diners_club" -> "diners"
+            else -> it
+        }
+    }
 }

--- a/payments-model/src/test/java/com/stripe/android/model/CardPaymentDetailTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/model/CardPaymentDetailTest.kt
@@ -28,7 +28,7 @@ class CardPaymentDetailTest {
     }
 
     @Test
-    fun `isExpired should be false when expiry date is in the past`() {
+    fun `isExpired should be false when expiry date is in the future`() {
         assertThat(card.isExpired).isFalse()
     }
 

--- a/payments-model/src/test/java/com/stripe/android/model/CardPaymentDetailTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/model/CardPaymentDetailTest.kt
@@ -3,8 +3,6 @@ package com.stripe.android.model
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.model.CountryCode
 import org.junit.Test
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 
 class CardPaymentDetailTest {
 
@@ -34,12 +32,9 @@ class CardPaymentDetailTest {
 
     @Test
     fun `requiresCardDetailsRecollection should be true when isExpired and cvc needs collection`() {
-        val cvcCheck: CvcCheck = mock()
-        whenever(cvcCheck.requiresRecollection).thenReturn(true)
-
         assertThat(
             card.copy(
-                cvcCheck = cvcCheck,
+                cvcCheck = CvcCheck.Fail,
                 expiryYear = 2005
             ).requiresCardDetailsRecollection
         ).isTrue()
@@ -47,12 +42,9 @@ class CardPaymentDetailTest {
 
     @Test
     fun `requiresCardDetailsRecollection should be true when isExpired and cvc does not require collection`() {
-        val cvcCheck: CvcCheck = mock()
-        whenever(cvcCheck.requiresRecollection).thenReturn(false)
-
         assertThat(
             card.copy(
-                cvcCheck = cvcCheck,
+                cvcCheck = CvcCheck.Pass,
                 expiryYear = 2005
             ).requiresCardDetailsRecollection
         ).isTrue()
@@ -60,24 +52,18 @@ class CardPaymentDetailTest {
 
     @Test
     fun `requiresCardDetailsRecollection should be true when isNotExpired and cvc requires collection`() {
-        val cvcCheck: CvcCheck = mock()
-        whenever(cvcCheck.requiresRecollection).thenReturn(true)
-
         assertThat(
             card.copy(
-                cvcCheck = cvcCheck,
+                cvcCheck = CvcCheck.Fail,
             ).requiresCardDetailsRecollection
         ).isTrue()
     }
 
     @Test
     fun `requiresCardDetailsRecollection should be false when isNotExpired and cvc does not require collection`() {
-        val cvcCheck: CvcCheck = mock()
-        whenever(cvcCheck.requiresRecollection).thenReturn(false)
-
         assertThat(
             card.copy(
-                cvcCheck = cvcCheck,
+                cvcCheck = CvcCheck.Pass,
             ).requiresCardDetailsRecollection
         ).isFalse()
     }

--- a/payments-model/src/test/java/com/stripe/android/model/CardPaymentDetailTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/model/CardPaymentDetailTest.kt
@@ -1,0 +1,84 @@
+package com.stripe.android.model
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.model.CountryCode
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class CardPaymentDetailTest {
+
+    private val card = ConsumerPaymentDetails.Card(
+        id = "QAAAKIL",
+        last4 = "4242",
+        expiryYear = 2500,
+        expiryMonth = 4,
+        brand = CardBrand.Visa,
+        cvcCheck = CvcCheck.Fail,
+        isDefault = false,
+        billingAddress = ConsumerPaymentDetails.BillingAddress(
+            countryCode = CountryCode.US,
+            postalCode = "42424"
+        )
+    )
+
+    @Test
+    fun `isExpired should be true when expiry date is in the past`() {
+        assertThat(card.copy(expiryYear = 2005).isExpired).isTrue()
+    }
+
+    @Test
+    fun `isExpired should be false when expiry date is in the past`() {
+        assertThat(card.isExpired).isFalse()
+    }
+
+    @Test
+    fun `requiresCardDetailsRecollection should be true when isExpired and cvc needs collection`() {
+        val cvcCheck: CvcCheck = mock()
+        whenever(cvcCheck.requiresRecollection).thenReturn(true)
+
+        assertThat(
+            card.copy(
+                cvcCheck = cvcCheck,
+                expiryYear = 2005
+            ).requiresCardDetailsRecollection
+        ).isTrue()
+    }
+
+    @Test
+    fun `requiresCardDetailsRecollection should be true when isExpired and cvc does not require collection`() {
+        val cvcCheck: CvcCheck = mock()
+        whenever(cvcCheck.requiresRecollection).thenReturn(false)
+
+        assertThat(
+            card.copy(
+                cvcCheck = cvcCheck,
+                expiryYear = 2005
+            ).requiresCardDetailsRecollection
+        ).isTrue()
+    }
+
+    @Test
+    fun `requiresCardDetailsRecollection should be true when isNotExpired and cvc requires collection`() {
+        val cvcCheck: CvcCheck = mock()
+        whenever(cvcCheck.requiresRecollection).thenReturn(true)
+
+        assertThat(
+            card.copy(
+                cvcCheck = cvcCheck,
+            ).requiresCardDetailsRecollection
+        ).isTrue()
+    }
+
+    @Test
+    fun `requiresCardDetailsRecollection should be false when isNotExpired and cvc does not require collection`() {
+        val cvcCheck: CvcCheck = mock()
+        whenever(cvcCheck.requiresRecollection).thenReturn(false)
+
+        assertThat(
+            card.copy(
+                cvcCheck = cvcCheck,
+            ).requiresCardDetailsRecollection
+        ).isFalse()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/LinkHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/LinkHandlerTest.kt
@@ -5,6 +5,7 @@ import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.test
 import app.cash.turbine.turbineScope
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.model.CountryCode
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkConfiguration
@@ -21,6 +22,7 @@ import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.CvcCheck
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodOptionsParams
@@ -513,6 +515,15 @@ private fun runLinkInlineTest(
             paymentDetails = ConsumerPaymentDetails.Card(
                 id = "pm_123",
                 last4 = "4242",
+                expiryYear = 2024,
+                expiryMonth = 4,
+                brand = CardBrand.DinersClub,
+                cvcCheck = CvcCheck.Fail,
+                isDefault = false,
+                billingAddress = ConsumerPaymentDetails.BillingAddress(
+                    countryCode = CountryCode.US,
+                    postalCode = "42424"
+                )
             ),
             paymentMethodCreateParams = mock(),
             originalParams = mock(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -1,8 +1,11 @@
 package com.stripe.android.paymentsheet.utils
 
+import com.stripe.android.core.model.CountryCode
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkPaymentDetails
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.CvcCheck
 import com.stripe.android.model.PaymentMethod
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -12,6 +15,15 @@ object LinkTestUtils {
         paymentDetails = ConsumerPaymentDetails.Card(
             id = "pm_123",
             last4 = "4242",
+            expiryYear = 2024,
+            expiryMonth = 4,
+            brand = CardBrand.DinersClub,
+            cvcCheck = CvcCheck.Fail,
+            isDefault = false,
+            billingAddress = ConsumerPaymentDetails.BillingAddress(
+                countryCode = CountryCode.US,
+                postalCode = "42424"
+            )
         ),
         paymentMethodCreateParams = mock(),
     )
@@ -20,6 +32,15 @@ object LinkTestUtils {
         paymentDetails = ConsumerPaymentDetails.Card(
             id = "pm_123",
             last4 = "4242",
+            expiryYear = 2024,
+            expiryMonth = 4,
+            brand = CardBrand.DinersClub,
+            cvcCheck = CvcCheck.Fail,
+            isDefault = false,
+            billingAddress = ConsumerPaymentDetails.BillingAddress(
+                countryCode = CountryCode.US,
+                postalCode = "42424"
+            )
         ),
         paymentMethodCreateParams = mock(),
         originalParams = mock()

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeLinkConfigurationCoordinator.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeLinkConfigurationCoordinator.kt
@@ -1,13 +1,16 @@
 package com.stripe.android.utils
 
+import com.stripe.android.core.model.CountryCode
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.injection.LinkComponent
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.UserInput
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerSession
+import com.stripe.android.model.CvcCheck
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.Flow
@@ -21,6 +24,15 @@ class FakeLinkConfigurationCoordinator(
             paymentDetails = ConsumerPaymentDetails.Card(
                 id = "pm_123",
                 last4 = "4242",
+                expiryYear = 2024,
+                expiryMonth = 4,
+                brand = CardBrand.DinersClub,
+                cvcCheck = CvcCheck.Fail,
+                isDefault = false,
+                billingAddress = ConsumerPaymentDetails.BillingAddress(
+                    countryCode = CountryCode.US,
+                    postalCode = "42424"
+                )
             ),
             paymentMethodCreateParams = mock(),
             originalParams = mock(),

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/DateUtils.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/DateUtils.kt
@@ -1,10 +1,13 @@
-package com.stripe.android.view
+package com.stripe.android.core.utils
 
 import androidx.annotation.IntRange
+import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import java.util.Calendar
 
-internal object DateUtils {
+@SuppressWarnings("MagicNumber")
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+object DateUtils {
 
     private const val MAX_VALID_YEAR = 9980
 

--- a/stripe-core/src/test/java/com/stripe/android/core/utils/DateUtilsTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/utils/DateUtilsTest.kt
@@ -1,7 +1,6 @@
-package com.stripe.android.view
+package com.stripe.android.core.utils
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.core.utils.DateUtils
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.util.Calendar


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Restore consumer payment details fields that were removed [here](https://github.com/stripe/stripe-android/pull/7968) following native link's removal.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
These fields are required to display the list of payment methods on the wallet screen. I have confirmed that the fields still work. There's a screen recording of the wallet screen using the updated payment details below.

[JIRA](https://jira.corp.stripe.com/browse/MOBILESDK-2503)


https://github.com/user-attachments/assets/acd75932-5e46-49bd-aa81-703b92437416



# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
