### PR TITLE
Use setValue instead of configure in FeatureFlagSettingsDefinition

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/FeatureFlagSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/FeatureFlagSettingsDefinition.kt
@@ -1,8 +1,6 @@
 package com.stripe.android.paymentsheet.example.playground.settings
 
 import com.stripe.android.core.utils.FeatureFlag
-import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 
 internal class FeatureFlagSettingsDefinition(
     private val featureFlag: FeatureFlag,
@@ -11,13 +9,8 @@ internal class FeatureFlagSettingsDefinition(
     displayName = featureFlag.name,
     defaultValue = false,
 ) {
-    override fun configure(
-        value: Boolean,
-        configurationBuilder: PaymentSheet.Configuration.Builder,
-        playgroundState: PlaygroundState.Payment,
-        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData
-    ) {
-        super.configure(value, configurationBuilder, playgroundState, configurationData)
+    override fun setValue(value: Boolean) {
+        super.setValue(value)
         featureFlag.setEnabled(value)
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use setValue instead of configure in FeatureFlagSettingsDefinition

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
`configure` is only called for PaymentSheet, so this setting wasn't working for CustomerSheet

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified