### PR TITLE
Move `ExternalPaymentMethod` to `ConfirmationDefinition`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
@@ -27,6 +27,7 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.paymentlauncher.PaymentLauncher
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
+import com.stripe.android.paymentsheet.ExternalPaymentMethodInterceptor
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationContract
@@ -69,7 +70,10 @@ internal class DefaultConfirmationHandler(
                 paymentLauncherFactory,
             ),
             ExternalPaymentMethodConfirmationDefinition(
-                errorReporter,
+                externalPaymentMethodConfirmHandlerProvider = {
+                    ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler
+                },
+                errorReporter = errorReporter,
             )
         )
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinition.kt
@@ -1,0 +1,115 @@
+package com.stripe.android.paymentelement.confirmation.epms
+
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
+import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.paymentlauncher.PaymentResult
+import com.stripe.android.paymentsheet.ExternalPaymentMethodContract
+import com.stripe.android.paymentsheet.ExternalPaymentMethodInput
+import com.stripe.android.paymentsheet.ExternalPaymentMethodInterceptor
+import java.lang.IllegalStateException
+
+internal class ExternalPaymentMethodConfirmationDefinition(
+    private val errorReporter: ErrorReporter,
+) : ConfirmationDefinition<
+    ExternalPaymentMethodConfirmationOption,
+    ActivityResultLauncher<ExternalPaymentMethodInput>,
+    Unit,
+    PaymentResult
+    > {
+    override val key: String = "ExternalPaymentMethod"
+
+    override fun option(
+        confirmationOption: ConfirmationHandler.Option
+    ): ExternalPaymentMethodConfirmationOption? {
+        return confirmationOption as? ExternalPaymentMethodConfirmationOption
+    }
+
+    override suspend fun action(
+        confirmationOption: ExternalPaymentMethodConfirmationOption,
+        intent: StripeIntent
+    ): ConfirmationDefinition.ConfirmationAction<Unit> {
+        val externalPaymentMethodType = confirmationOption.type
+        val externalPaymentMethodConfirmHandler =
+            ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler
+
+        return if (externalPaymentMethodConfirmHandler == null) {
+            errorReporter.report(
+                ErrorReporter.ExpectedErrorEvent.EXTERNAL_PAYMENT_METHOD_CONFIRM_HANDLER_NULL,
+                additionalNonPiiParams = mapOf("external_payment_method_type" to externalPaymentMethodType)
+            )
+
+            val error = IllegalStateException(
+                "externalPaymentMethodConfirmHandler is null." +
+                    " Cannot process payment for payment selection: $externalPaymentMethodType"
+            )
+
+            ConfirmationDefinition.ConfirmationAction.Fail(
+                cause = error,
+                message = error.stripeErrorMessage(),
+                errorType = ConfirmationHandler.Result.Failed.ErrorType.ExternalPaymentMethod,
+            )
+        } else {
+            ConfirmationDefinition.ConfirmationAction.Launch(
+                launcherArguments = Unit,
+                deferredIntentConfirmationType = null,
+            )
+        }
+    }
+
+    override fun createLauncher(
+        activityResultCaller: ActivityResultCaller,
+        onResult: (PaymentResult) -> Unit
+    ): ActivityResultLauncher<ExternalPaymentMethodInput> {
+        return activityResultCaller.registerForActivityResult(
+            ExternalPaymentMethodContract(errorReporter),
+            onResult
+        )
+    }
+
+    override fun launch(
+        launcher: ActivityResultLauncher<ExternalPaymentMethodInput>,
+        arguments: Unit,
+        confirmationOption: ExternalPaymentMethodConfirmationOption,
+        intent: StripeIntent,
+    ) {
+        errorReporter.report(
+            ErrorReporter.SuccessEvent.EXTERNAL_PAYMENT_METHODS_LAUNCH_SUCCESS,
+            additionalNonPiiParams = mapOf("external_payment_method_type" to confirmationOption.type)
+        )
+
+        launcher.launch(
+            ExternalPaymentMethodInput(
+                type = confirmationOption.type,
+                billingDetails = confirmationOption.billingDetails,
+            )
+        )
+    }
+
+    override fun toPaymentConfirmationResult(
+        confirmationOption: ExternalPaymentMethodConfirmationOption,
+        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        intent: StripeIntent,
+        result: PaymentResult
+    ): ConfirmationHandler.Result {
+        return when (result) {
+            is PaymentResult.Completed -> ConfirmationHandler.Result.Succeeded(
+                intent = intent,
+                deferredIntentConfirmationType = null,
+            )
+            is PaymentResult.Failed -> ConfirmationHandler.Result.Failed(
+                cause = result.throwable,
+                message = result.throwable.stripeErrorMessage(),
+                type = ConfirmationHandler.Result.Failed.ErrorType.ExternalPaymentMethod,
+            )
+            is PaymentResult.Canceled -> ConfirmationHandler.Result.Canceled(
+                action = ConfirmationHandler.Result.Canceled.Action.None,
+            )
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinition.kt
@@ -9,12 +9,14 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.paymentlauncher.PaymentResult
+import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
 import com.stripe.android.paymentsheet.ExternalPaymentMethodContract
 import com.stripe.android.paymentsheet.ExternalPaymentMethodInput
-import com.stripe.android.paymentsheet.ExternalPaymentMethodInterceptor
 import java.lang.IllegalStateException
+import javax.inject.Provider
 
 internal class ExternalPaymentMethodConfirmationDefinition(
+    private val externalPaymentMethodConfirmHandlerProvider: Provider<ExternalPaymentMethodConfirmHandler?>,
     private val errorReporter: ErrorReporter,
 ) : ConfirmationDefinition<
     ExternalPaymentMethodConfirmationOption,
@@ -35,8 +37,7 @@ internal class ExternalPaymentMethodConfirmationDefinition(
         intent: StripeIntent
     ): ConfirmationDefinition.ConfirmationAction<Unit> {
         val externalPaymentMethodType = confirmationOption.type
-        val externalPaymentMethodConfirmHandler =
-            ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler
+        val externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandlerProvider.get()
 
         return if (externalPaymentMethodConfirmHandler == null) {
             errorReporter.report(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
@@ -1,0 +1,27 @@
+package com.stripe.android.paymentelement.confirmation
+
+internal fun ConfirmationHandler.Result?.asSucceeded(): ConfirmationHandler.Result.Succeeded {
+    return this as ConfirmationHandler.Result.Succeeded
+}
+
+internal fun ConfirmationHandler.Result?.asFailed(): ConfirmationHandler.Result.Failed {
+    return this as ConfirmationHandler.Result.Failed
+}
+
+internal fun ConfirmationHandler.Result?.asCanceled(): ConfirmationHandler.Result.Canceled {
+    return this as ConfirmationHandler.Result.Canceled
+}
+
+internal fun <T> ConfirmationDefinition.ConfirmationAction<T>.asFail():
+    ConfirmationDefinition.ConfirmationAction.Fail<T> {
+    return this as ConfirmationDefinition.ConfirmationAction.Fail<T>
+}
+
+internal fun <T> ConfirmationDefinition.ConfirmationAction<T>.asLaunch():
+    ConfirmationDefinition.ConfirmationAction.Launch<T> {
+    return this as ConfirmationDefinition.ConfirmationAction.Launch<T>
+}
+
+internal fun ConfirmationMediator.Action.asLaunch(): ConfirmationMediator.Action.Launch {
+    return this as ConfirmationMediator.Action.Launch
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
@@ -1055,10 +1055,10 @@ class DefaultConfirmationHandlerTest {
         val intentResult = defaultConfirmationHandler.awaitIntentResult().asFailed()
 
         assertThat(intentResult.cause.message).isEqualTo(
-            "externalPaymentMethodLauncher is null. Cannot process payment for payment selection: paypal"
+            "No launcher for ExternalPaymentMethodConfirmationDefinition was found, did you call register?"
         )
         assertThat(intentResult.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
-        assertThat(intentResult.type).isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.ExternalPaymentMethod)
+        assertThat(intentResult.type).isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.Fatal)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationOption.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationOption.kt
@@ -1,0 +1,6 @@
+package com.stripe.android.paymentelement.confirmation
+
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+class FakeConfirmationOption : ConfirmationHandler.Option

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationFlowTest.kt
@@ -12,31 +12,15 @@ import com.stripe.android.paymentelement.confirmation.asLaunch
 import com.stripe.android.paymentelement.confirmation.asSucceeded
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
-import com.stripe.android.paymentsheet.ExternalPaymentMethodInterceptor
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.utils.DummyActivityResultCaller
 import kotlinx.coroutines.test.runTest
-import org.junit.After
-import org.junit.Before
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 class ExternalPaymentMethodConfirmationFlowTest {
-    @Before
-    fun setup() {
-        ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler =
-            ExternalPaymentMethodConfirmHandler { _, _ ->
-                // Do nothing
-            }
-    }
-
-    @After
-    fun teardown() {
-        ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler = null
-    }
-
     @Test
     fun `on launch, should persist parameters & launch using launcher as expected`() = runTest {
         val savedStateHandle = SavedStateHandle()
@@ -114,7 +98,14 @@ class ExternalPaymentMethodConfirmationFlowTest {
     private fun createExternalPaymentMethodConfirmationMediator(
         savedStateHandle: SavedStateHandle = SavedStateHandle()
     ) = ConfirmationMediator(
-        definition = ExternalPaymentMethodConfirmationDefinition(FakeErrorReporter()),
+        definition = ExternalPaymentMethodConfirmationDefinition(
+            externalPaymentMethodConfirmHandlerProvider = {
+                ExternalPaymentMethodConfirmHandler { _, _ ->
+                    error("Not implemented!")
+                }
+            },
+            errorReporter = FakeErrorReporter()
+        ),
         savedStateHandle = savedStateHandle
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationFlowTest.kt
@@ -1,0 +1,137 @@
+package com.stripe.android.paymentelement.confirmation.epms
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.isInstanceOf
+import com.stripe.android.model.Address
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.ConfirmationMediator
+import com.stripe.android.paymentelement.confirmation.ConfirmationMediator.Parameters
+import com.stripe.android.paymentelement.confirmation.asLaunch
+import com.stripe.android.paymentelement.confirmation.asSucceeded
+import com.stripe.android.payments.paymentlauncher.PaymentResult
+import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
+import com.stripe.android.paymentsheet.ExternalPaymentMethodInterceptor
+import com.stripe.android.testing.FakeErrorReporter
+import com.stripe.android.testing.PaymentIntentFactory
+import com.stripe.android.utils.DummyActivityResultCaller
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class ExternalPaymentMethodConfirmationFlowTest {
+    @Before
+    fun setup() {
+        ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler =
+            ExternalPaymentMethodConfirmHandler { _, _ ->
+                // Do nothing
+            }
+    }
+
+    @After
+    fun teardown() {
+        ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler = null
+    }
+
+    @Test
+    fun `on launch, should persist parameters & launch using launcher as expected`() = runTest {
+        val savedStateHandle = SavedStateHandle()
+        val mediator = createExternalPaymentMethodConfirmationMediator(savedStateHandle)
+
+        var called = false
+        mediator.register(
+            activityResultCaller = DummyActivityResultCaller(
+                onLaunch = { called = true }
+            ),
+            onResult = {}
+        )
+
+        val action = mediator.action(
+            option = EPM_CONFIRMATION_OPTION,
+            intent = PAYMENT_INTENT,
+        )
+
+        assertThat(action).isInstanceOf<ConfirmationMediator.Action.Launch>()
+
+        val launchAction = action.asLaunch()
+
+        launchAction.launch()
+
+        val parameters = savedStateHandle
+            .get<Parameters<ExternalPaymentMethodConfirmationOption>>("ExternalPaymentMethodParameters")
+
+        assertThat(parameters?.confirmationOption).isEqualTo(EPM_CONFIRMATION_OPTION)
+        assertThat(parameters?.intent).isEqualTo(PAYMENT_INTENT)
+        assertThat(parameters?.deferredIntentConfirmationType).isNull()
+
+        assertThat(called).isTrue()
+    }
+
+    @Test
+    fun `on result, should return confirmation result as expected`() = runTest {
+        val countDownLatch = CountDownLatch(1)
+
+        val savedStateHandle = SavedStateHandle().apply {
+            set(
+                "ExternalPaymentMethodParameters",
+                Parameters(
+                    confirmationOption = EPM_CONFIRMATION_OPTION,
+                    intent = PAYMENT_INTENT,
+                    deferredIntentConfirmationType = null,
+                )
+            )
+        }
+
+        val mediator = createExternalPaymentMethodConfirmationMediator(savedStateHandle)
+        val caller = DummyActivityResultCaller()
+
+        var result: ConfirmationHandler.Result? = null
+
+        mediator.register(
+            activityResultCaller = caller,
+            onResult = {
+                result = it
+            }
+        )
+
+        val call = caller.calls.awaitItem()
+
+        call.callback.asExternalPaymentMethodCallback().onActivityResult(PaymentResult.Completed)
+
+        countDownLatch.await(5, TimeUnit.SECONDS)
+
+        assertThat(result).isInstanceOf<ConfirmationHandler.Result.Succeeded>()
+
+        val successResult = result.asSucceeded()
+
+        assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT)
+    }
+
+    private fun createExternalPaymentMethodConfirmationMediator(
+        savedStateHandle: SavedStateHandle = SavedStateHandle()
+    ) = ConfirmationMediator(
+        definition = ExternalPaymentMethodConfirmationDefinition(FakeErrorReporter()),
+        savedStateHandle = savedStateHandle
+    )
+
+    private companion object {
+        private val EPM_CONFIRMATION_OPTION = ExternalPaymentMethodConfirmationOption(
+            type = "paypal",
+            billingDetails = PaymentMethod.BillingDetails(
+                name = "John Doe",
+                address = Address(
+                    line1 = "123 Apple Street",
+                    city = "South San Francisco",
+                    state = "CA",
+                    country = "US",
+                ),
+            )
+        )
+
+        private val PAYMENT_INTENT = PaymentIntentFactory.create()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationUtils.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.paymentelement.confirmation.epms
+
+import androidx.activity.result.ActivityResultCallback
+import com.stripe.android.payments.paymentlauncher.PaymentResult
+
+internal fun ActivityResultCallback<*>.asExternalPaymentMethodCallback(): ActivityResultCallback<PaymentResult> {
+    @Suppress("UNCHECKED_CAST")
+    return this as ActivityResultCallback<PaymentResult>
+}

--- a/paymentsheet/src/test/java/com/stripe/android/utils/DummyActivityResultCaller.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/DummyActivityResultCaller.kt
@@ -6,16 +6,24 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.ActivityResultRegistry
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.app.ActivityOptionsCompat
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
 
-class DummyActivityResultCaller : ActivityResultCaller {
+class DummyActivityResultCaller(
+    private val onLaunch: () -> Unit = { error("Not implemented") }
+) : ActivityResultCaller {
+    private val _calls = Turbine<Call<*, *>>()
+    val calls: ReceiveTurbine<Call<*, *>> = _calls
 
     override fun <I : Any?, O : Any?> registerForActivityResult(
         contract: ActivityResultContract<I, O>,
         callback: ActivityResultCallback<O>
     ): ActivityResultLauncher<I> {
+        _calls.add(Call(contract, callback))
+
         return object : ActivityResultLauncher<I>() {
             override fun launch(input: I, options: ActivityOptionsCompat?) {
-                error("Not implemented")
+                onLaunch()
             }
 
             override fun unregister() {
@@ -35,7 +43,7 @@ class DummyActivityResultCaller : ActivityResultCaller {
     ): ActivityResultLauncher<I> {
         return object : ActivityResultLauncher<I>() {
             override fun launch(input: I, options: ActivityOptionsCompat?) {
-                error("Not implemented")
+                onLaunch()
             }
 
             override fun unregister() {
@@ -47,4 +55,9 @@ class DummyActivityResultCaller : ActivityResultCaller {
             }
         }
     }
+
+    data class Call<I : Any?, O : Any?>(
+        val contract: ActivityResultContract<I, O>,
+        val callback: ActivityResultCallback<O>,
+    )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeActivityResultLauncher.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeActivityResultLauncher.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.utils
+
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.app.ActivityOptionsCompat
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
+
+class FakeActivityResultLauncher<I> : ActivityResultLauncher<I>() {
+    private val _calls = Turbine<Call<I>>()
+    val calls: ReceiveTurbine<Call<I>> = _calls
+
+    override fun launch(input: I, options: ActivityOptionsCompat?) {
+        _calls.add(Call(input))
+    }
+
+    override fun unregister() {
+        throw NotImplementedError("Not implemented!")
+    }
+
+    override fun getContract(): ActivityResultContract<I, *> {
+        throw NotImplementedError("Not implemented!")
+    }
+
+    data class Call<I>(
+        val input: I,
+    )
+}


### PR DESCRIPTION
# Summary
Move `ExternalPaymentMethod` to `ConfirmationDefinition`

# Motivation
Helps separate `ExternalPaymentMethod` confirmation from `DefaultConfirmationHandler` 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified