### PR TITLE
Refactor DummyActivityResultCaller.

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -155,7 +155,7 @@ internal object CustomerSheetTestHelper {
             editInteractorFactory = editInteractorFactory,
             errorReporter = errorReporter,
         ).apply {
-            registerFromActivity(DummyActivityResultCaller(), TestLifecycleOwner())
+            registerFromActivity(DummyActivityResultCaller.noOp(), TestLifecycleOwner())
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinitionTest.kt
@@ -57,28 +57,28 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
 
         var onResultCalled = false
         val onResult: (PaymentResult) -> Unit = { onResultCalled = true }
-        val activityResultCaller = DummyActivityResultCaller()
+        DummyActivityResultCaller.test {
+            definition.createLauncher(
+                activityResultCaller = activityResultCaller,
+                onResult = onResult,
+            )
 
-        definition.createLauncher(
-            activityResultCaller = activityResultCaller,
-            onResult = onResult,
-        )
+            val call = awaitRegisterCall()
 
-        val call = activityResultCaller.calls.awaitItem()
+            assertThat(call.contract).isInstanceOf<ExternalPaymentMethodContract>()
 
-        assertThat(call.contract).isInstanceOf<ExternalPaymentMethodContract>()
+            val externalPaymentMethodContract = call.contract.asExternalPaymentMethodContract()
 
-        val externalPaymentMethodContract = call.contract.asExternalPaymentMethodContract()
+            assertThat(call.callback).isInstanceOf<ActivityResultCallback<PaymentResult>>()
 
-        assertThat(call.callback).isInstanceOf<ActivityResultCallback<PaymentResult>>()
+            val callback = call.callback.asExternalPaymentMethodCallback()
 
-        val callback = call.callback.asExternalPaymentMethodCallback()
+            assertThat(externalPaymentMethodContract.errorReporter).isEqualTo(errorReporter)
 
-        assertThat(externalPaymentMethodContract.errorReporter).isEqualTo(errorReporter)
+            callback.onActivityResult(PaymentResult.Completed)
 
-        callback.onActivityResult(PaymentResult.Completed)
-
-        assertThat(onResultCalled).isTrue()
+            assertThat(onResultCalled).isTrue()
+        }
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1867,7 +1867,7 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `Confirms intent if intent confirmation interceptor returns an unconfirmed intent`() = runTest {
         val viewModel = createViewModelForDeferredIntent().apply {
-            registerFromActivity(DummyActivityResultCaller(), TestLifecycleOwner())
+            registerFromActivity(DummyActivityResultCaller.noOp(), TestLifecycleOwner())
         }
 
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
@@ -1891,7 +1891,7 @@ internal class PaymentSheetViewModelTest {
     fun `Handles next action if intent confirmation interceptor returns an intent with an outstanding action`() =
         runTest {
             val viewModel = createViewModelForDeferredIntent().apply {
-                registerFromActivity(DummyActivityResultCaller(), TestLifecycleOwner())
+                registerFromActivity(DummyActivityResultCaller.noOp(), TestLifecycleOwner())
             }
 
             val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Follow up to https://github.com/stripe/stripe-android/pull/9675#discussion_r1850654820

Ensure we always consume all the events when using the DummyActivityResultCaller.