### PR TITLE
Create internal result type for `ConfirmationDefinition`

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -56,6 +56,7 @@
     <ID>MaxLineLength:FlowControllerConfigurationHandlerTest.kt$FlowControllerConfigurationHandlerTest$.</ID>
     <ID>MaxLineLength:InjectableActivityScenario.kt$InjectableActivityScenario$delegate ?: throw IllegalStateException("Cannot move to state $newState since the activity hasn't been launched.")</ID>
     <ID>MaxLineLength:InjectableActivityScenario.kt$InjectableActivityScenario$val d = delegate ?: throw IllegalStateException("Cannot run onActivity since the activity hasn't been launched.")</ID>
+    <ID>MaxLineLength:IntentConfirmationDefinitionTest.kt$IntentConfirmationDefinitionTest$private inline</ID>
     <ID>MaxLineLength:PaymentSheet.kt$PaymentSheet.Address$*</ID>
     <ID>MaxLineLength:PaymentSheet.kt$PaymentSheet.BillingDetails$*</ID>
     <ID>MaxLineLength:PaymentSheet.kt$PaymentSheet.Configuration$*</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationDefinition.kt
@@ -21,7 +21,7 @@ internal interface ConfirmationDefinition<
     suspend fun action(
         confirmationOption: TConfirmationOption,
         intent: StripeIntent,
-    ): ConfirmationAction<TLauncherArgs>
+    ): Action<TLauncherArgs>
 
     fun launch(
         launcher: TLauncher,
@@ -35,29 +35,46 @@ internal interface ConfirmationDefinition<
         onResult: (TLauncherResult) -> Unit,
     ): TLauncher
 
-    fun toPaymentConfirmationResult(
+    fun toResult(
         confirmationOption: TConfirmationOption,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
         intent: StripeIntent,
         result: TLauncherResult,
-    ): ConfirmationHandler.Result
+    ): Result
 
-    sealed interface ConfirmationAction<TLauncherArgs> {
+    sealed interface Result {
+        data class Canceled(
+            val action: ConfirmationHandler.Result.Canceled.Action,
+        ) : Result
+
+        data class Succeeded(
+            val intent: StripeIntent,
+            val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        ) : Result
+
+        data class Failed(
+            val cause: Throwable,
+            val message: ResolvableString,
+            val type: ConfirmationHandler.Result.Failed.ErrorType,
+        ) : Result
+    }
+
+    sealed interface Action<TLauncherArgs> {
         data class Complete<TLauncherArgs>(
             val intent: StripeIntent,
             val confirmationOption: ConfirmationHandler.Option,
             val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        ) : ConfirmationAction<TLauncherArgs>
+        ) : Action<TLauncherArgs>
 
         data class Fail<TLauncherArgs>(
             val cause: Throwable,
             val message: ResolvableString,
             val errorType: ConfirmationHandler.Result.Failed.ErrorType,
-        ) : ConfirmationAction<TLauncherArgs>
+        ) : Action<TLauncherArgs>
 
         data class Launch<TLauncherArgs>(
             val launcherArguments: TLauncherArgs,
             val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        ) : ConfirmationAction<TLauncherArgs>
+        ) : Action<TLauncherArgs>
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediator.kt
@@ -36,13 +36,13 @@ internal class ConfirmationMediator<
 
     fun register(
         activityResultCaller: ActivityResultCaller,
-        onResult: (ConfirmationHandler.Result) -> Unit,
+        onResult: (ConfirmationDefinition.Result) -> Unit,
     ) {
         launcher = definition.createLauncher(
             activityResultCaller
         ) { result ->
             val confirmationResult = persistedParameters?.let { params ->
-                definition.toPaymentConfirmationResult(
+                definition.toResult(
                     confirmationOption = params.confirmationOption,
                     intent = params.intent,
                     result = result,
@@ -53,7 +53,7 @@ internal class ConfirmationMediator<
                     "Arguments should have been initialized before handling result!"
                 )
 
-                ConfirmationHandler.Result.Failed(
+                ConfirmationDefinition.Result.Failed(
                     cause = exception,
                     message = exception.stripeErrorMessage(),
                     type = ConfirmationHandler.Result.Failed.ErrorType.Internal,
@@ -83,7 +83,7 @@ internal class ConfirmationMediator<
             )
 
         return when (val action = definition.action(confirmationOption, intent)) {
-            is ConfirmationDefinition.ConfirmationAction.Launch -> {
+            is ConfirmationDefinition.Action.Launch -> {
                 launcher?.let {
                     Action.Launch(
                         launch = {
@@ -113,14 +113,14 @@ internal class ConfirmationMediator<
                     )
                 }
             }
-            is ConfirmationDefinition.ConfirmationAction.Complete -> {
+            is ConfirmationDefinition.Action.Complete -> {
                 Action.Complete(
                     intent = action.intent,
                     confirmationOption = action.confirmationOption,
                     deferredIntentConfirmationType = action.deferredIntentConfirmationType,
                 )
             }
-            is ConfirmationDefinition.ConfirmationAction.Fail -> {
+            is ConfirmationDefinition.Action.Fail -> {
                 Action.Fail(
                     cause = action.cause,
                     message = action.message,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
@@ -134,7 +134,7 @@ internal class DefaultConfirmationHandler(
      */
     override fun register(activityResultCaller: ActivityResultCaller, lifecycleOwner: LifecycleOwner) {
         confirmationMediators.forEach { mediator ->
-            mediator.register(activityResultCaller, ::onIntentResult)
+            mediator.register(activityResultCaller, ::onResult)
         }
 
         val bacsActivityResultLauncher = activityResultCaller.registerForActivityResult(
@@ -505,6 +505,25 @@ internal class DefaultConfirmationHandler(
                 }
             }
         }
+    }
+
+    private fun onResult(result: ConfirmationDefinition.Result) {
+        val confirmationResult = when (result) {
+            is ConfirmationDefinition.Result.Succeeded -> ConfirmationHandler.Result.Succeeded(
+                intent = result.intent,
+                deferredIntentConfirmationType = result.deferredIntentConfirmationType,
+            )
+            is ConfirmationDefinition.Result.Failed -> ConfirmationHandler.Result.Failed(
+                cause = result.cause,
+                type = result.type,
+                message = result.message,
+            )
+            is ConfirmationDefinition.Result.Canceled -> ConfirmationHandler.Result.Canceled(
+                action = result.action,
+            )
+        }
+
+        onIntentResult(confirmationResult)
     }
 
     private fun onIntentResult(result: ConfirmationHandler.Result) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinition.kt
@@ -35,7 +35,7 @@ internal class ExternalPaymentMethodConfirmationDefinition(
     override suspend fun action(
         confirmationOption: ExternalPaymentMethodConfirmationOption,
         intent: StripeIntent
-    ): ConfirmationDefinition.ConfirmationAction<Unit> {
+    ): ConfirmationDefinition.Action<Unit> {
         val externalPaymentMethodType = confirmationOption.type
         val externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandlerProvider.get()
 
@@ -50,13 +50,13 @@ internal class ExternalPaymentMethodConfirmationDefinition(
                     " Cannot process payment for payment selection: $externalPaymentMethodType"
             )
 
-            ConfirmationDefinition.ConfirmationAction.Fail(
+            ConfirmationDefinition.Action.Fail(
                 cause = error,
                 message = error.stripeErrorMessage(),
                 errorType = ConfirmationHandler.Result.Failed.ErrorType.ExternalPaymentMethod,
             )
         } else {
-            ConfirmationDefinition.ConfirmationAction.Launch(
+            ConfirmationDefinition.Action.Launch(
                 launcherArguments = Unit,
                 deferredIntentConfirmationType = null,
             )
@@ -92,23 +92,23 @@ internal class ExternalPaymentMethodConfirmationDefinition(
         )
     }
 
-    override fun toPaymentConfirmationResult(
+    override fun toResult(
         confirmationOption: ExternalPaymentMethodConfirmationOption,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
         intent: StripeIntent,
         result: PaymentResult
-    ): ConfirmationHandler.Result {
+    ): ConfirmationDefinition.Result {
         return when (result) {
-            is PaymentResult.Completed -> ConfirmationHandler.Result.Succeeded(
+            is PaymentResult.Completed -> ConfirmationDefinition.Result.Succeeded(
                 intent = intent,
                 deferredIntentConfirmationType = null,
             )
-            is PaymentResult.Failed -> ConfirmationHandler.Result.Failed(
+            is PaymentResult.Failed -> ConfirmationDefinition.Result.Failed(
                 cause = result.throwable,
                 message = result.throwable.stripeErrorMessage(),
                 type = ConfirmationHandler.Result.Failed.ErrorType.ExternalPaymentMethod,
             )
-            is PaymentResult.Canceled -> ConfirmationHandler.Result.Canceled(
+            is PaymentResult.Canceled -> ConfirmationDefinition.Result.Canceled(
                 action = ConfirmationHandler.Result.Canceled.Action.None,
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
@@ -108,7 +108,7 @@ class ConfirmationMediatorTest {
     fun `On complete confirmation action, should return mediator complete action`() = runTest {
         val definition = FakeConfirmationDefinition(
             onAction = { confirmationOption, intent ->
-                ConfirmationDefinition.ConfirmationAction.Complete(
+                ConfirmationDefinition.Action.Complete(
                     confirmationOption = confirmationOption,
                     intent = intent,
                     deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
@@ -141,7 +141,7 @@ class ConfirmationMediatorTest {
 
         val definition = FakeConfirmationDefinition(
             onAction = { _, _ ->
-                ConfirmationDefinition.ConfirmationAction.Fail(
+                ConfirmationDefinition.Action.Fail(
                     cause = exception,
                     message = R.string.stripe_something_went_wrong.resolvableString,
                     errorType = errorType,
@@ -174,7 +174,7 @@ class ConfirmationMediatorTest {
 
         val definition = FakeConfirmationDefinition(
             onAction = { _, _ ->
-                ConfirmationDefinition.ConfirmationAction.Launch(
+                ConfirmationDefinition.Action.Launch(
                     launcherArguments = launcherArguments,
                     deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
                 )
@@ -224,7 +224,7 @@ class ConfirmationMediatorTest {
     fun `On confirmation action without registering, should return fail action`() = runTest {
         val definition = FakeConfirmationDefinition(
             onAction = { _, _ ->
-                ConfirmationDefinition.ConfirmationAction.Launch(
+                ConfirmationDefinition.Action.Launch(
                     launcherArguments = FakeConfirmationDefinition.LauncherArgs(amount = 5000),
                     deferredIntentConfirmationType = null,
                 )
@@ -255,7 +255,7 @@ class ConfirmationMediatorTest {
     fun `On confirmation action after un-registering, should return fail action`() = runTest {
         val definition = FakeConfirmationDefinition(
             onAction = { _, _ ->
-                ConfirmationDefinition.ConfirmationAction.Launch(
+                ConfirmationDefinition.Action.Launch(
                     launcherArguments = FakeConfirmationDefinition.LauncherArgs(amount = 5000),
                     deferredIntentConfirmationType = null,
                 )
@@ -297,15 +297,15 @@ class ConfirmationMediatorTest {
         )
         val deferredIntentConfirmationType = DeferredIntentConfirmationType.Client
         val launcherResult = FakeConfirmationDefinition.LauncherResult(amount = 50)
-        val confirmationResult = ConfirmationHandler.Result.Succeeded(
+        val confirmationResult = ConfirmationDefinition.Result.Succeeded(
             intent = intent,
             deferredIntentConfirmationType = deferredIntentConfirmationType,
         )
 
         val definition = FakeConfirmationDefinition(
-            confirmationResult = confirmationResult,
+            result = confirmationResult,
             onAction = { _, _ ->
-                ConfirmationDefinition.ConfirmationAction.Launch(
+                ConfirmationDefinition.Action.Launch(
                     launcherArguments = FakeConfirmationDefinition.LauncherArgs(amount = 5000),
                     deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
                 )
@@ -326,7 +326,7 @@ class ConfirmationMediatorTest {
             paymentMethod = PaymentMethodFactory.card(),
         )
 
-        var receivedResult: ConfirmationHandler.Result? = null
+        var receivedResult: ConfirmationDefinition.Result? = null
 
         mediator.register(
             activityResultCaller = mock(),
@@ -354,7 +354,7 @@ class ConfirmationMediatorTest {
 
         waitForResultLatch.await(2, TimeUnit.SECONDS)
 
-        val toPaymentConfirmationResultCall = definition.toPaymentConfirmationResultCalls.awaitItem()
+        val toPaymentConfirmationResultCall = definition.toResultCalls.awaitItem()
 
         assertThat(toPaymentConfirmationResultCall.confirmationOption).isEqualTo(confirmationOption)
         assertThat(toPaymentConfirmationResultCall.intent).isEqualTo(intent)
@@ -379,7 +379,7 @@ class ConfirmationMediatorTest {
         mediator.register(
             activityResultCaller = activityResultCaller,
             onResult = { result ->
-                assertThat(result).isInstanceOf<ConfirmationHandler.Result.Failed>()
+                assertThat(result).isInstanceOf<ConfirmationDefinition.Result.Failed>()
 
                 val failAction = result.asFailed()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
@@ -82,7 +82,7 @@ internal fun <
     DummyActivityResultCaller.test {
         val mediator = ConfirmationMediator(savedStateHandle, definition)
 
-        var result: ConfirmationHandler.Result? = null
+        var result: ConfirmationDefinition.Result? = null
 
         mediator.register(
             activityResultCaller = activityResultCaller,
@@ -99,7 +99,7 @@ internal fun <
 
         assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
 
-        assertThat(result).isInstanceOf<ConfirmationHandler.Result.Succeeded>()
+        assertThat(result).isInstanceOf<ConfirmationDefinition.Result.Succeeded>()
 
         val successResult = result.asSucceeded()
 
@@ -107,26 +107,24 @@ internal fun <
     }
 }
 
-internal fun ConfirmationHandler.Result?.asSucceeded(): ConfirmationHandler.Result.Succeeded {
-    return this as ConfirmationHandler.Result.Succeeded
+internal fun ConfirmationDefinition.Result?.asSucceeded(): ConfirmationDefinition.Result.Succeeded {
+    return this as ConfirmationDefinition.Result.Succeeded
 }
 
-internal fun ConfirmationHandler.Result?.asFailed(): ConfirmationHandler.Result.Failed {
-    return this as ConfirmationHandler.Result.Failed
+internal fun ConfirmationDefinition.Result?.asFailed(): ConfirmationDefinition.Result.Failed {
+    return this as ConfirmationDefinition.Result.Failed
 }
 
-internal fun ConfirmationHandler.Result?.asCanceled(): ConfirmationHandler.Result.Canceled {
-    return this as ConfirmationHandler.Result.Canceled
+internal fun ConfirmationDefinition.Result?.asCanceled(): ConfirmationDefinition.Result.Canceled {
+    return this as ConfirmationDefinition.Result.Canceled
 }
 
-internal fun <T> ConfirmationDefinition.ConfirmationAction<T>.asFail():
-    ConfirmationDefinition.ConfirmationAction.Fail<T> {
-    return this as ConfirmationDefinition.ConfirmationAction.Fail<T>
+internal fun <T> ConfirmationDefinition.Action<T>.asFail(): ConfirmationDefinition.Action.Fail<T> {
+    return this as ConfirmationDefinition.Action.Fail<T>
 }
 
-internal fun <T> ConfirmationDefinition.ConfirmationAction<T>.asLaunch():
-    ConfirmationDefinition.ConfirmationAction.Launch<T> {
-    return this as ConfirmationDefinition.ConfirmationAction.Launch<T>
+internal fun <T> ConfirmationDefinition.Action<T>.asLaunch(): ConfirmationDefinition.Action.Launch<T> {
+    return this as ConfirmationDefinition.Action.Launch<T>
 }
 
 internal fun ConfirmationMediator.Action.asLaunch(): ConfirmationMediator.Action.Launch {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationDefinition.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationDefinition.kt
@@ -13,16 +13,16 @@ internal class FakeConfirmationDefinition(
     private val onAction: (
         confirmationOption: PaymentMethodConfirmationOption.Saved,
         intent: StripeIntent
-    ) -> ConfirmationDefinition.ConfirmationAction<LauncherArgs> = { _, _ ->
+    ) -> ConfirmationDefinition.Action<LauncherArgs> = { _, _ ->
         val exception = IllegalStateException("Failed!")
 
-        ConfirmationDefinition.ConfirmationAction.Fail(
+        ConfirmationDefinition.Action.Fail(
             cause = exception,
             message = exception.stripeErrorMessage(),
             errorType = ConfirmationHandler.Result.Failed.ErrorType.Internal,
         )
     },
-    private val confirmationResult: ConfirmationHandler.Result = ConfirmationHandler.Result.Canceled(
+    private val result: ConfirmationDefinition.Result = ConfirmationDefinition.Result.Canceled(
         action = ConfirmationHandler.Result.Canceled.Action.InformCancellation,
     ),
     private val launcher: Launcher = Launcher(),
@@ -38,9 +38,9 @@ internal class FakeConfirmationDefinition(
     private val _createLauncherCalls = Turbine<CreateLauncherCall>()
     val createLauncherCalls: ReceiveTurbine<CreateLauncherCall> = _createLauncherCalls
 
-    private val _toPaymentConfirmationResultCalls = Turbine<ToPaymentConfirmationResultCall>()
-    val toPaymentConfirmationResultCalls: ReceiveTurbine<ToPaymentConfirmationResultCall> =
-        _toPaymentConfirmationResultCalls
+    private val _toResultCalls = Turbine<ToResultCall>()
+    val toResultCalls: ReceiveTurbine<ToResultCall> =
+        _toResultCalls
 
     override val key: String = "Test"
 
@@ -53,7 +53,7 @@ internal class FakeConfirmationDefinition(
     override suspend fun action(
         confirmationOption: PaymentMethodConfirmationOption.Saved,
         intent: StripeIntent
-    ): ConfirmationDefinition.ConfirmationAction<LauncherArgs> {
+    ): ConfirmationDefinition.Action<LauncherArgs> {
         return onAction(confirmationOption, intent)
     }
 
@@ -87,14 +87,14 @@ internal class FakeConfirmationDefinition(
         return launcher
     }
 
-    override fun toPaymentConfirmationResult(
+    override fun toResult(
         confirmationOption: PaymentMethodConfirmationOption.Saved,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
         intent: StripeIntent,
         result: LauncherResult
-    ): ConfirmationHandler.Result {
-        _toPaymentConfirmationResultCalls.add(
-            ToPaymentConfirmationResultCall(
+    ): ConfirmationDefinition.Result {
+        _toResultCalls.add(
+            ToResultCall(
                 confirmationOption = confirmationOption,
                 deferredIntentConfirmationType = deferredIntentConfirmationType,
                 intent = intent,
@@ -102,7 +102,7 @@ internal class FakeConfirmationDefinition(
             )
         )
 
-        return confirmationResult
+        return this.result
     }
 
     class LaunchCall(
@@ -117,7 +117,7 @@ internal class FakeConfirmationDefinition(
         val onResult: (LauncherResult) -> Unit
     )
 
-    class ToPaymentConfirmationResultCall(
+    class ToResultCall(
         val confirmationOption: PaymentMethodConfirmationOption.Saved,
         val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
         val intent: StripeIntent,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
@@ -317,7 +317,7 @@ class IntentConfirmationDefinitionTest {
             paymentLauncher = launcher,
         )
 
-        val result = definition.toPaymentConfirmationResult(
+        val result = definition.toResult(
             confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
             intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
@@ -340,7 +340,7 @@ class IntentConfirmationDefinitionTest {
 
         val exception = IllegalStateException("Failed!")
 
-        val result = definition.toPaymentConfirmationResult(
+        val result = definition.toResult(
             confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
             intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
             deferredIntentConfirmationType = null,
@@ -362,7 +362,7 @@ class IntentConfirmationDefinitionTest {
             paymentLauncher = launcher,
         )
 
-        val result = definition.toPaymentConfirmationResult(
+        val result = definition.toResult(
             confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
             intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
             deferredIntentConfirmationType = null,
@@ -389,31 +389,29 @@ class IntentConfirmationDefinitionTest {
         return calls.awaitItem() as T
     }
 
-    private inline fun <reified T> ConfirmationDefinition.ConfirmationAction<T>.asComplete():
-        ConfirmationDefinition.ConfirmationAction.Complete<T> {
-        return this as ConfirmationDefinition.ConfirmationAction.Complete<T>
+    private inline fun <reified T> ConfirmationDefinition.Action<T>.asComplete():
+        ConfirmationDefinition.Action.Complete<T> {
+        return this as ConfirmationDefinition.Action.Complete<T>
     }
 
-    private inline fun <reified T> ConfirmationDefinition.ConfirmationAction<T>.asFail():
-        ConfirmationDefinition.ConfirmationAction.Fail<T> {
-        return this as ConfirmationDefinition.ConfirmationAction.Fail<T>
+    private inline fun <reified T> ConfirmationDefinition.Action<T>.asFail(): ConfirmationDefinition.Action.Fail<T> {
+        return this as ConfirmationDefinition.Action.Fail<T>
     }
 
-    private inline fun <reified T> ConfirmationDefinition.ConfirmationAction<T>.asLaunch():
-        ConfirmationDefinition.ConfirmationAction.Launch<T> {
-        return this as ConfirmationDefinition.ConfirmationAction.Launch<T>
+    private inline fun <reified T> ConfirmationDefinition.Action<T>.asLaunch(): ConfirmationDefinition.Action.Launch<T> {
+        return this as ConfirmationDefinition.Action.Launch<T>
     }
 
-    private fun ConfirmationHandler.Result.asSucceeded(): ConfirmationHandler.Result.Succeeded {
-        return this as ConfirmationHandler.Result.Succeeded
+    private fun ConfirmationDefinition.Result.asSucceeded(): ConfirmationDefinition.Result.Succeeded {
+        return this as ConfirmationDefinition.Result.Succeeded
     }
 
-    private fun ConfirmationHandler.Result.asFailed(): ConfirmationHandler.Result.Failed {
-        return this as ConfirmationHandler.Result.Failed
+    private fun ConfirmationDefinition.Result.asFailed(): ConfirmationDefinition.Result.Failed {
+        return this as ConfirmationDefinition.Result.Failed
     }
 
-    private fun ConfirmationHandler.Result.asCanceled(): ConfirmationHandler.Result.Canceled {
-        return this as ConfirmationHandler.Result.Canceled
+    private fun ConfirmationDefinition.Result.asCanceled(): ConfirmationDefinition.Result.Canceled {
+        return this as ConfirmationDefinition.Result.Canceled
     }
 
     private companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
@@ -264,18 +264,18 @@ internal class IntentConfirmationFlowTest {
         return this as IntentConfirmationDefinition.Args.Confirm
     }
 
-    private fun <TLauncherArgs> ConfirmationDefinition.ConfirmationAction<TLauncherArgs>.asFail():
-        ConfirmationDefinition.ConfirmationAction.Fail<TLauncherArgs> {
-        return this as ConfirmationDefinition.ConfirmationAction.Fail<TLauncherArgs>
+    private fun <TLauncherArgs> ConfirmationDefinition.Action<TLauncherArgs>.asFail():
+        ConfirmationDefinition.Action.Fail<TLauncherArgs> {
+        return this as ConfirmationDefinition.Action.Fail<TLauncherArgs>
     }
 
-    private fun <TLauncherArgs> ConfirmationDefinition.ConfirmationAction<TLauncherArgs>.asComplete():
-        ConfirmationDefinition.ConfirmationAction.Complete<TLauncherArgs> {
-        return this as ConfirmationDefinition.ConfirmationAction.Complete<TLauncherArgs>
+    private fun <TLauncherArgs> ConfirmationDefinition.Action<TLauncherArgs>.asComplete():
+        ConfirmationDefinition.Action.Complete<TLauncherArgs> {
+        return this as ConfirmationDefinition.Action.Complete<TLauncherArgs>
     }
 
-    private fun <TLauncherArgs> ConfirmationDefinition.ConfirmationAction<TLauncherArgs>.asLaunch():
-        ConfirmationDefinition.ConfirmationAction.Launch<TLauncherArgs> {
-        return this as ConfirmationDefinition.ConfirmationAction.Launch<TLauncherArgs>
+    private fun <TLauncherArgs> ConfirmationDefinition.Action<TLauncherArgs>.asLaunch():
+        ConfirmationDefinition.Action.Launch<TLauncherArgs> {
+        return this as ConfirmationDefinition.Action.Launch<TLauncherArgs>
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinitionTest.kt
@@ -83,17 +83,17 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
     }
 
     @Test
-    fun `'toPaymentConfirmationResult' should return 'Complete' when 'PaymentResult' is 'Complete'`() = runTest {
+    fun `'toResult' should return 'Complete' when 'PaymentResult' is 'Complete'`() = runTest {
         val definition = createExternalPaymentMethodConfirmationDefinition()
 
-        val result = definition.toPaymentConfirmationResult(
+        val result = definition.toResult(
             confirmationOption = EPM_CONFIRMATION_OPTION,
             intent = PAYMENT_INTENT,
             deferredIntentConfirmationType = null,
             result = PaymentResult.Completed,
         )
 
-        assertThat(result).isInstanceOf<ConfirmationHandler.Result.Succeeded>()
+        assertThat(result).isInstanceOf<ConfirmationDefinition.Result.Succeeded>()
 
         val successResult = result.asSucceeded()
 
@@ -102,18 +102,18 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
     }
 
     @Test
-    fun `'toPaymentConfirmationResult' should return 'Failed' when 'PaymentResult' is 'Failed'`() = runTest {
+    fun `'toResult' should return 'Failed' when 'PaymentResult' is 'Failed'`() = runTest {
         val definition = createExternalPaymentMethodConfirmationDefinition()
 
         val exception = IllegalStateException("Failed!")
-        val result = definition.toPaymentConfirmationResult(
+        val result = definition.toResult(
             confirmationOption = EPM_CONFIRMATION_OPTION,
             intent = PAYMENT_INTENT,
             deferredIntentConfirmationType = null,
             result = PaymentResult.Failed(exception),
         )
 
-        assertThat(result).isInstanceOf<ConfirmationHandler.Result.Failed>()
+        assertThat(result).isInstanceOf<ConfirmationDefinition.Result.Failed>()
 
         val failedResult = result.asFailed()
 
@@ -123,17 +123,17 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
     }
 
     @Test
-    fun `'toPaymentConfirmationResult' should return 'Canceled' when 'PaymentResult' is 'Canceled'`() = runTest {
+    fun `'toResult' should return 'Canceled' when 'PaymentResult' is 'Canceled'`() = runTest {
         val definition = createExternalPaymentMethodConfirmationDefinition()
 
-        val result = definition.toPaymentConfirmationResult(
+        val result = definition.toResult(
             confirmationOption = EPM_CONFIRMATION_OPTION,
             intent = PAYMENT_INTENT,
             deferredIntentConfirmationType = null,
             result = PaymentResult.Canceled,
         )
 
-        assertThat(result).isInstanceOf<ConfirmationHandler.Result.Canceled>()
+        assertThat(result).isInstanceOf<ConfirmationDefinition.Result.Canceled>()
 
         val canceledResult = result.asCanceled()
 
@@ -152,7 +152,7 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
             intent = PAYMENT_INTENT,
         )
 
-        assertThat(action).isInstanceOf<ConfirmationDefinition.ConfirmationAction.Fail<Unit>>()
+        assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Fail<Unit>>()
 
         val failAction = action.asFail()
 
@@ -188,7 +188,7 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
             intent = PAYMENT_INTENT,
         )
 
-        assertThat(action).isInstanceOf<ConfirmationDefinition.ConfirmationAction.Launch<Unit>>()
+        assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Launch<Unit>>()
 
         val launchAction = action.asLaunch()
 


### PR DESCRIPTION
# Summary
Create `ConfirmationDefinition.Result` for the `ConfirmationDefinition` types to use.

# Motivation
We are going to be introducing next step definitions following this PR. `NextStep` results are meant to be internal to the function of `ConfirmationHandler` so we don't want to expose a `NextStep` type to the consumer.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified