### PR TITLE
Move `Bacs` to a `ConfirmationDefinition` type

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationDefinition.kt
@@ -52,6 +52,11 @@ internal interface ConfirmationDefinition<
             val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
         ) : Result
 
+        data class NextStep(
+            val intent: StripeIntent,
+            val confirmationOption: ConfirmationHandler.Option,
+        ) : Result
+
         data class Failed(
             val cause: Throwable,
             val message: ResolvableString,
@@ -74,6 +79,7 @@ internal interface ConfirmationDefinition<
 
         data class Launch<TLauncherArgs>(
             val launcherArguments: TLauncherArgs,
+            val receivesResultInProcess: Boolean,
             val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
         ) : Action<TLauncherArgs>
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediator.kt
@@ -100,6 +100,7 @@ internal class ConfirmationMediator<
                                 intent = intent,
                             )
                         },
+                        receivesResultInProcess = action.receivesResultInProcess,
                     )
                 } ?: run {
                     val exception = IllegalStateException(
@@ -133,6 +134,7 @@ internal class ConfirmationMediator<
     sealed interface Action {
         class Launch(
             val launch: () -> Unit,
+            val receivesResultInProcess: Boolean,
         ) : Action
 
         data class Fail(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
@@ -1,0 +1,104 @@
+package com.stripe.android.paymentelement.confirmation.bacs
+import androidx.activity.result.ActivityResultCaller
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
+import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationContract
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncher
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncherFactory
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationResult
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateData
+
+internal class BacsConfirmationDefinition(
+    private val bacsMandateConfirmationLauncherFactory: BacsMandateConfirmationLauncherFactory,
+) : ConfirmationDefinition<
+    BacsConfirmationOption,
+    BacsMandateConfirmationLauncher,
+    BacsMandateData,
+    BacsMandateConfirmationResult,
+    > {
+    override val key: String = "Bacs"
+
+    override fun option(confirmationOption: ConfirmationHandler.Option): BacsConfirmationOption? {
+        return confirmationOption as? BacsConfirmationOption
+    }
+
+    override suspend fun action(
+        confirmationOption: BacsConfirmationOption,
+        intent: StripeIntent
+    ): ConfirmationDefinition.Action<BacsMandateData> {
+        return BacsMandateData.fromConfirmationOption(confirmationOption)?.let { data ->
+            ConfirmationDefinition.Action.Launch(
+                launcherArguments = data,
+                deferredIntentConfirmationType = null,
+                receivesResultInProcess = true,
+            )
+        } ?: run {
+            ConfirmationDefinition.Action.Fail(
+                cause = IllegalArgumentException(
+                    "Given confirmation option does not have expected Bacs data!"
+                ),
+                message = R.string.stripe_something_went_wrong.resolvableString,
+                errorType = ConfirmationHandler.Result.Failed.ErrorType.Internal
+            )
+        }
+    }
+
+    override fun createLauncher(
+        activityResultCaller: ActivityResultCaller,
+        onResult: (BacsMandateConfirmationResult) -> Unit
+    ): BacsMandateConfirmationLauncher {
+        return bacsMandateConfirmationLauncherFactory.create(
+            activityResultCaller.registerForActivityResult(
+                BacsMandateConfirmationContract(),
+                onResult,
+            )
+        )
+    }
+
+    override fun launch(
+        launcher: BacsMandateConfirmationLauncher,
+        arguments: BacsMandateData,
+        confirmationOption: BacsConfirmationOption,
+        intent: StripeIntent,
+    ) {
+        launcher.launch(
+            data = arguments,
+            appearance = confirmationOption.appearance
+        )
+    }
+
+    override fun toResult(
+        confirmationOption: BacsConfirmationOption,
+        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        intent: StripeIntent,
+        result: BacsMandateConfirmationResult,
+    ): ConfirmationDefinition.Result {
+        return when (result) {
+            is BacsMandateConfirmationResult.Confirmed -> {
+                val nextConfirmationOption = PaymentMethodConfirmationOption.New(
+                    initializationMode = confirmationOption.initializationMode,
+                    shippingDetails = confirmationOption.shippingDetails,
+                    createParams = confirmationOption.createParams,
+                    optionsParams = null,
+                    shouldSave = false,
+                )
+
+                ConfirmationDefinition.Result.NextStep(
+                    intent = intent,
+                    confirmationOption = nextConfirmationOption,
+                )
+            }
+            is BacsMandateConfirmationResult.ModifyDetails -> ConfirmationDefinition.Result.Canceled(
+                action = ConfirmationHandler.Result.Canceled.Action.ModifyPaymentDetails,
+            )
+            is BacsMandateConfirmationResult.Cancelled -> ConfirmationDefinition.Result.Canceled(
+                action = ConfirmationHandler.Result.Canceled.Action.None,
+            )
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinition.kt
@@ -59,6 +59,7 @@ internal class ExternalPaymentMethodConfirmationDefinition(
             ConfirmationDefinition.Action.Launch(
                 launcherArguments = Unit,
                 deferredIntentConfirmationType = null,
+                receivesResultInProcess = false,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
@@ -44,12 +44,14 @@ internal class IntentConfirmationDefinition(
                 ConfirmationDefinition.Action.Launch(
                     launcherArguments = Args.NextAction(nextStep.clientSecret),
                     deferredIntentConfirmationType = deferredIntentConfirmationType,
+                    receivesResultInProcess = false,
                 )
             }
             is IntentConfirmationInterceptor.NextStep.Confirm -> {
                 ConfirmationDefinition.Action.Launch(
                     launcherArguments = Args.Confirm(nextStep.confirmParams),
                     deferredIntentConfirmationType = deferredIntentConfirmationType,
+                    receivesResultInProcess = false,
                 )
             }
             is IntentConfirmationInterceptor.NextStep.Fail -> {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
@@ -177,6 +177,7 @@ class ConfirmationMediatorTest {
                 ConfirmationDefinition.Action.Launch(
                     launcherArguments = launcherArguments,
                     deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+                    receivesResultInProcess = false,
                 )
             },
             launcher = launcher,
@@ -201,6 +202,8 @@ class ConfirmationMediatorTest {
 
         val launchAction = action.asLaunch()
 
+        assertThat(launchAction.receivesResultInProcess).isFalse()
+
         launchAction.launch()
 
         val launchCall = definition.launchCalls.awaitItem()
@@ -221,12 +224,47 @@ class ConfirmationMediatorTest {
     }
 
     @Test
+    fun `On launch definition action where result is received in process, 'receivesResultInProcess' should be true`() =
+        runTest {
+            val definition = FakeConfirmationDefinition(
+                onAction = { _, _ ->
+                    ConfirmationDefinition.Action.Launch(
+                        launcherArguments = FakeConfirmationDefinition.LauncherArgs(amount = 5000),
+                        deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+                        receivesResultInProcess = true,
+                    )
+                },
+                launcher = FakeConfirmationDefinition.Launcher(),
+            )
+
+            val mediator = ConfirmationMediator(
+                savedStateHandle = SavedStateHandle(),
+                definition = definition
+            ).apply {
+                register(
+                    activityResultCaller = mock(),
+                    onResult = {}
+                )
+            }
+
+            val action = mediator.action(
+                option = SAVED_CONFIRMATION_OPTION,
+                intent = INTENT,
+            )
+
+            val launchAction = action.asLaunch()
+
+            assertThat(launchAction.receivesResultInProcess).isTrue()
+        }
+
+    @Test
     fun `On confirmation action without registering, should return fail action`() = runTest {
         val definition = FakeConfirmationDefinition(
             onAction = { _, _ ->
                 ConfirmationDefinition.Action.Launch(
                     launcherArguments = FakeConfirmationDefinition.LauncherArgs(amount = 5000),
                     deferredIntentConfirmationType = null,
+                    receivesResultInProcess = false,
                 )
             },
         )
@@ -258,6 +296,7 @@ class ConfirmationMediatorTest {
                 ConfirmationDefinition.Action.Launch(
                     launcherArguments = FakeConfirmationDefinition.LauncherArgs(amount = 5000),
                     deferredIntentConfirmationType = null,
+                    receivesResultInProcess = false,
                 )
             },
         )
@@ -308,6 +347,7 @@ class ConfirmationMediatorTest {
                 ConfirmationDefinition.Action.Launch(
                     launcherArguments = FakeConfirmationDefinition.LauncherArgs(amount = 5000),
                     deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+                    receivesResultInProcess = false,
                 )
             },
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
@@ -7,8 +7,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator.Parameters
-import com.stripe.android.paymentelement.confirmation.epms.ExternalPaymentMethodConfirmationOption
-import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.utils.DummyActivityResultCaller
 import kotlinx.coroutines.test.runTest
 import java.util.concurrent.CountDownLatch
@@ -45,7 +43,7 @@ internal fun <
         launchAction.launch()
 
         val parameters = savedStateHandle
-            .get<Parameters<ExternalPaymentMethodConfirmationOption>>("ExternalPaymentMethodParameters")
+            .get<Parameters<TConfirmationOption>>("${definition.key}Parameters")
 
         assertThat(parameters?.confirmationOption).isEqualTo(confirmationOption)
         assertThat(parameters?.intent).isEqualTo(intent)
@@ -65,6 +63,8 @@ internal fun <
     definition: ConfirmationDefinition<TConfirmationOption, TLauncher, TLauncherArgs, TLauncherResult>,
     confirmationOption: ConfirmationHandler.Option,
     intent: StripeIntent,
+    launcherResult: TLauncherResult,
+    definitionResult: ConfirmationDefinition.Result,
 ) = runTest {
     val countDownLatch = CountDownLatch(1)
 
@@ -95,20 +95,20 @@ internal fun <
 
         val call = awaitRegisterCall()
 
-        call.callback.asCallbackFor<PaymentResult>().onActivityResult(PaymentResult.Completed)
+        call.callback.asCallbackFor<TLauncherResult>().onActivityResult(launcherResult)
 
         assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
 
-        assertThat(result).isInstanceOf<ConfirmationDefinition.Result.Succeeded>()
-
-        val successResult = result.asSucceeded()
-
-        assertThat(successResult.intent).isEqualTo(intent)
+        assertThat(result).isEqualTo(definitionResult)
     }
 }
 
 internal fun ConfirmationDefinition.Result?.asSucceeded(): ConfirmationDefinition.Result.Succeeded {
     return this as ConfirmationDefinition.Result.Succeeded
+}
+
+internal fun ConfirmationDefinition.Result?.asNextStep(): ConfirmationDefinition.Result.NextStep {
+    return this as ConfirmationDefinition.Result.NextStep
 }
 
 internal fun ConfirmationDefinition.Result?.asFailed(): ConfirmationDefinition.Result.Failed {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
@@ -31,6 +31,8 @@ internal fun <
             onResult = {}
         )
 
+        assertThat(awaitNextRegisteredLauncher()).isNotNull()
+
         val action = mediator.action(
             option = confirmationOption,
             intent = intent,
@@ -94,6 +96,8 @@ internal fun <
         )
 
         val call = awaitRegisterCall()
+
+        assertThat(awaitNextRegisteredLauncher()).isNotNull()
 
         call.callback.asCallbackFor<TLauncherResult>().onActivityResult(launcherResult)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
@@ -776,8 +776,10 @@ class DefaultConfirmationHandlerTest {
             enqueueCompleteStep()
         }
 
-        val bacsArguments = DEFAULT_ARGUMENTS.copy(
+        val bacsParameters = ConfirmationMediator.Parameters(
             confirmationOption = BACS_OPTION,
+            intent = DEFAULT_ARGUMENTS.intent,
+            deferredIntentConfirmationType = null,
         )
 
         val savedStateHandle = SavedStateHandle().apply {
@@ -788,7 +790,7 @@ class DefaultConfirmationHandlerTest {
                     receivesResultInProcess = true,
                 ),
             )
-            set("PaymentConfirmationArguments", bacsArguments)
+            set("BacsParameters", bacsParameters)
         }
 
         val defaultConfirmationHandler = createDefaultConfirmationHandler(
@@ -1273,8 +1275,9 @@ class DefaultConfirmationHandlerTest {
         val result = defaultConfirmationHandler.awaitIntentResult().asFailed()
 
         assertThat(result.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
-        assertThat(result.type).isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.Internal)
-        assertThat(result.cause.message).isEqualTo("Required value was null.")
+        assertThat(result.type).isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.Fatal)
+        assertThat(result.cause.message)
+            .isEqualTo("No launcher for BacsConfirmationDefinition was found, did you call register?")
     }
 
     @Test
@@ -1300,7 +1303,7 @@ class DefaultConfirmationHandlerTest {
         assertThat(result.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
         assertThat(result.type).isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.Internal)
         assertThat(result.cause.message).isEqualTo(
-            "Given payment selection could not be converted to Bacs data!"
+            "Given confirmation option does not have expected Bacs data!"
         )
     }
 
@@ -1327,7 +1330,7 @@ class DefaultConfirmationHandlerTest {
         assertThat(result.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
         assertThat(result.type).isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.Internal)
         assertThat(result.cause.message).isEqualTo(
-            "Given payment selection could not be converted to Bacs data!"
+            "Given confirmation option does not have expected Bacs data!"
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinitionTest.kt
@@ -53,34 +53,36 @@ class BacsConfirmationDefinitionTest {
 
     @Test
     fun `'createLauncher' should call factory with registered activity launcher`() = runTest {
-        val bacsMandateConfirmationLauncherFactory = FakeBacsMandateConfirmationLauncherFactory()
-        val definition = createBacsConfirmationDefinition(
-            bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,
-        )
-
-        var onResultCalled = false
-        val onResult: (BacsMandateConfirmationResult) -> Unit = { onResultCalled = true }
         DummyActivityResultCaller.test {
-            definition.createLauncher(
-                activityResultCaller = activityResultCaller,
-                onResult = onResult,
-            )
+            FakeBacsMandateConfirmationLauncherFactory.test {
+                var onResultCalled = false
+                val onResult: (BacsMandateConfirmationResult) -> Unit = { onResultCalled = true }
 
-            val call = awaitRegisterCall()
-            val registeredLauncher = awaitNextRegisteredLauncher()
+                val definition = createBacsConfirmationDefinition(
+                    bacsMandateConfirmationLauncherFactory = factory,
+                )
 
-            assertThat(call.contract).isInstanceOf<BacsMandateConfirmationContract>()
-            assertThat(call.callback).isInstanceOf<ActivityResultCallback<BacsMandateConfirmationResult>>()
+                definition.createLauncher(
+                    activityResultCaller = activityResultCaller,
+                    onResult = onResult,
+                )
 
-            val callback = call.callback.asCallbackFor<BacsMandateConfirmationResult>()
+                val call = awaitRegisterCall()
+                val registeredLauncher = awaitNextRegisteredLauncher()
 
-            callback.onActivityResult(BacsMandateConfirmationResult.Confirmed)
+                assertThat(call.contract).isInstanceOf<BacsMandateConfirmationContract>()
+                assertThat(call.callback).isInstanceOf<ActivityResultCallback<BacsMandateConfirmationResult>>()
 
-            assertThat(onResultCalled).isTrue()
+                val callback = call.callback.asCallbackFor<BacsMandateConfirmationResult>()
 
-            val factoryCall = bacsMandateConfirmationLauncherFactory.calls.awaitItem()
+                callback.onActivityResult(BacsMandateConfirmationResult.Confirmed)
 
-            assertThat(factoryCall.activityResultLauncher).isEqualTo(registeredLauncher)
+                assertThat(onResultCalled).isTrue()
+
+                val factoryCall = awaitCreateBacsLauncherCall()
+
+                assertThat(factoryCall.activityResultLauncher).isEqualTo(registeredLauncher)
+            }
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinitionTest.kt
@@ -1,0 +1,299 @@
+package com.stripe.android.paymentelement.confirmation.bacs
+
+import androidx.activity.result.ActivityResultCallback
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.isInstanceOf
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.FakeConfirmationOption
+import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
+import com.stripe.android.paymentelement.confirmation.asCallbackFor
+import com.stripe.android.paymentelement.confirmation.asCanceled
+import com.stripe.android.paymentelement.confirmation.asFail
+import com.stripe.android.paymentelement.confirmation.asLaunch
+import com.stripe.android.paymentelement.confirmation.asNextStep
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationContract
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncherFactory
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationResult
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateData
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.FakeBacsMandateConfirmationLauncher
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.testing.PaymentIntentFactory
+import com.stripe.android.utils.DummyActivityResultCaller
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class BacsConfirmationDefinitionTest {
+    @Test
+    fun `'key' should be 'Bacs`() {
+        val definition = createBacsConfirmationDefinition()
+
+        assertThat(definition.key).isEqualTo("Bacs")
+    }
+
+    @Test
+    fun `'option' return casted 'BacsPaymentMethodConfirmationOption'`() {
+        val definition = createBacsConfirmationDefinition()
+        val confirmationOption = createBacsConfirmationOption()
+
+        assertThat(definition.option(confirmationOption)).isEqualTo(confirmationOption)
+    }
+
+    @Test
+    fun `'option' return null for unknown option`() {
+        val definition = createBacsConfirmationDefinition()
+
+        assertThat(definition.option(FakeConfirmationOption())).isNull()
+    }
+
+    @Test
+    fun `'createLauncher' should call factory with registered activity launcher`() = runTest {
+        val bacsMandateConfirmationLauncherFactory = FakeBacsMandateConfirmationLauncherFactory()
+        val definition = createBacsConfirmationDefinition(
+            bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,
+        )
+
+        var onResultCalled = false
+        val onResult: (BacsMandateConfirmationResult) -> Unit = { onResultCalled = true }
+        DummyActivityResultCaller.test {
+            definition.createLauncher(
+                activityResultCaller = activityResultCaller,
+                onResult = onResult,
+            )
+
+            val call = awaitRegisterCall()
+            val registeredLauncher = awaitNextRegisteredLauncher()
+
+            assertThat(call.contract).isInstanceOf<BacsMandateConfirmationContract>()
+            assertThat(call.callback).isInstanceOf<ActivityResultCallback<BacsMandateConfirmationResult>>()
+
+            val callback = call.callback.asCallbackFor<BacsMandateConfirmationResult>()
+
+            callback.onActivityResult(BacsMandateConfirmationResult.Confirmed)
+
+            assertThat(onResultCalled).isTrue()
+
+            val factoryCall = bacsMandateConfirmationLauncherFactory.calls.awaitItem()
+
+            assertThat(factoryCall.activityResultLauncher).isEqualTo(registeredLauncher)
+        }
+    }
+
+    @Test
+    fun `'toResult' should return 'NextStep' when 'BacsMandateConfirmationResult' is 'Confirmed'`() = runTest {
+        val definition = createBacsConfirmationDefinition()
+
+        val bacsConfirmationOption = createBacsConfirmationOption()
+
+        val result = definition.toResult(
+            confirmationOption = createBacsConfirmationOption(),
+            intent = PAYMENT_INTENT,
+            deferredIntentConfirmationType = null,
+            result = BacsMandateConfirmationResult.Confirmed,
+        )
+
+        assertThat(result).isInstanceOf<ConfirmationDefinition.Result.NextStep>()
+
+        val successResult = result.asNextStep()
+
+        assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT)
+
+        val confirmationOption = successResult.confirmationOption
+
+        assertThat(confirmationOption).isInstanceOf<PaymentMethodConfirmationOption.New>()
+
+        val newPaymentMethodOption = confirmationOption.asNewPaymentMethodOption()
+
+        assertThat(newPaymentMethodOption.createParams).isEqualTo(bacsConfirmationOption.createParams)
+        assertThat(newPaymentMethodOption.optionsParams).isEqualTo(bacsConfirmationOption.optionsParams)
+        assertThat(newPaymentMethodOption.initializationMode).isEqualTo(bacsConfirmationOption.initializationMode)
+        assertThat(newPaymentMethodOption.shippingDetails).isEqualTo(bacsConfirmationOption.shippingDetails)
+        assertThat(newPaymentMethodOption.shouldSave).isFalse()
+    }
+
+    @Test
+    fun `'toResult' should return 'Canceled' with no action when 'BacsMandateConfirmationResult' is 'Canceled'`() =
+        runTest {
+            val definition = createBacsConfirmationDefinition()
+
+            val result = definition.toResult(
+                confirmationOption = createBacsConfirmationOption(),
+                intent = PAYMENT_INTENT,
+                deferredIntentConfirmationType = null,
+                result = BacsMandateConfirmationResult.Cancelled,
+            )
+
+            assertThat(result).isInstanceOf<ConfirmationDefinition.Result.Canceled>()
+
+            val canceledResult = result.asCanceled()
+
+            assertThat(canceledResult.action).isEqualTo(ConfirmationHandler.Result.Canceled.Action.None)
+        }
+
+    @Test
+    fun `'toResult' should return 'Canceled' with modify action when 'BacsMandateConfirmationResult' is 'Canceled'`() =
+        runTest {
+            val definition = createBacsConfirmationDefinition()
+
+            val result = definition.toResult(
+                confirmationOption = createBacsConfirmationOption(),
+                intent = PAYMENT_INTENT,
+                deferredIntentConfirmationType = null,
+                result = BacsMandateConfirmationResult.ModifyDetails,
+            )
+
+            assertThat(result).isInstanceOf<ConfirmationDefinition.Result.Canceled>()
+
+            val canceledResult = result.asCanceled()
+
+            assertThat(canceledResult.action)
+                .isEqualTo(ConfirmationHandler.Result.Canceled.Action.ModifyPaymentDetails)
+        }
+
+    @Test
+    fun `'Fail' action should be returned if name is missing in confirmation option`() = runTest {
+        val definition = createBacsConfirmationDefinition()
+
+        val action = definition.action(
+            confirmationOption = createBacsConfirmationOption(
+                name = null,
+            ),
+            intent = PAYMENT_INTENT,
+        )
+
+        assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Fail<BacsMandateData>>()
+
+        val failAction = action.asFail()
+
+        assertThat(failAction.cause).isInstanceOf<IllegalArgumentException>()
+        assertThat(failAction.cause.message).isEqualTo(
+            "Given confirmation option does not have expected Bacs data!"
+        )
+        assertThat(failAction.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
+        assertThat(failAction.errorType).isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.Internal)
+    }
+
+    @Test
+    fun `'Fail' action should be returned if email is missing in confirmation option`() = runTest {
+        val definition = createBacsConfirmationDefinition()
+
+        val action = definition.action(
+            confirmationOption = createBacsConfirmationOption(
+                email = null,
+            ),
+            intent = PAYMENT_INTENT,
+        )
+
+        assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Fail<BacsMandateData>>()
+
+        val failAction = action.asFail()
+
+        assertThat(failAction.cause).isInstanceOf<IllegalArgumentException>()
+        assertThat(failAction.cause.message).isEqualTo(
+            "Given confirmation option does not have expected Bacs data!"
+        )
+        assertThat(failAction.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
+        assertThat(failAction.errorType).isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.Internal)
+    }
+
+    @Test
+    fun `'Launch' action should be returned if option is converted to mandate data`() = runTest {
+        val definition = createBacsConfirmationDefinition()
+
+        val action = definition.action(
+            confirmationOption = createBacsConfirmationOption(),
+            intent = PAYMENT_INTENT,
+        )
+
+        assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Launch<BacsMandateData>>()
+
+        val launchAction = action.asLaunch()
+
+        val mandateData = launchAction.launcherArguments
+
+        assertThat(mandateData.name).isEqualTo("John Doe")
+        assertThat(mandateData.email).isEqualTo("johndoe@email.com")
+        assertThat(mandateData.sortCode).isEqualTo("108800")
+        assertThat(mandateData.accountNumber).isEqualTo("00012345")
+
+        assertThat(launchAction.deferredIntentConfirmationType).isNull()
+        assertThat(launchAction.receivesResultInProcess).isTrue()
+    }
+
+    @Test
+    fun `On 'launch', should use launcher to launch`() = runTest {
+        val definition = createBacsConfirmationDefinition()
+
+        val launcher = FakeBacsMandateConfirmationLauncher()
+
+        val appearance = PaymentSheet.Appearance().copy(
+            typography = PaymentSheet.Typography.default.copy(
+                sizeScaleFactor = 2f
+            )
+        )
+        val bacsMandateData = BacsMandateData(
+            name = "John Doe",
+            email = "johndoe@email.com",
+            accountNumber = "00012345",
+            sortCode = "108800",
+        )
+
+        definition.launch(
+            confirmationOption = createBacsConfirmationOption().copy(appearance = appearance),
+            intent = PAYMENT_INTENT,
+            arguments = bacsMandateData,
+            launcher = launcher,
+        )
+
+        val call = launcher.calls.awaitItem()
+
+        assertThat(call.data).isEqualTo(bacsMandateData)
+        assertThat(call.appearance).isEqualTo(appearance)
+    }
+
+    private fun createBacsConfirmationDefinition(
+        bacsMandateConfirmationLauncherFactory: BacsMandateConfirmationLauncherFactory =
+            FakeBacsMandateConfirmationLauncherFactory(),
+    ): BacsConfirmationDefinition {
+        return BacsConfirmationDefinition(
+            bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,
+        )
+    }
+
+    private fun createBacsConfirmationOption(
+        name: String? = "John Doe",
+        email: String? = "johndoe@email.com",
+    ): BacsConfirmationOption {
+        return BacsConfirmationOption(
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123_secret_123"
+            ),
+            createParams = PaymentMethodCreateParams.create(
+                bacsDebit = PaymentMethodCreateParams.BacsDebit(
+                    accountNumber = "00012345",
+                    sortCode = "108800"
+                ),
+                billingDetails = PaymentMethod.BillingDetails(
+                    name = name,
+                    email = email,
+                )
+            ),
+            optionsParams = null,
+            shippingDetails = null,
+            appearance = PaymentSheet.Appearance(),
+        )
+    }
+
+    private fun ConfirmationHandler.Option.asNewPaymentMethodOption(): PaymentMethodConfirmationOption.New {
+        return this as PaymentMethodConfirmationOption.New
+    }
+
+    private companion object {
+        private val PAYMENT_INTENT = PaymentIntentFactory.create()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationFlowTest.kt
@@ -1,0 +1,68 @@
+package com.stripe.android.paymentelement.confirmation.bacs
+
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
+import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
+import com.stripe.android.paymentelement.confirmation.runLaunchTest
+import com.stripe.android.paymentelement.confirmation.runResultTest
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationResult
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.DefaultBacsMandateConfirmationLauncherFactory
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.testing.PaymentIntentFactory
+import org.junit.Test
+
+class BacsConfirmationFlowTest {
+    @Test
+    fun `on launch, should persist parameters & launch using launcher as expected`() = runLaunchTest(
+        confirmationOption = BACS_CONFIRMATION_OPTION,
+        intent = PAYMENT_INTENT,
+        definition = BacsConfirmationDefinition(
+            bacsMandateConfirmationLauncherFactory = DefaultBacsMandateConfirmationLauncherFactory,
+        ),
+    )
+
+    @Test
+    fun `on result, should return confirmation result as expected`() = runResultTest(
+        confirmationOption = BACS_CONFIRMATION_OPTION,
+        intent = PAYMENT_INTENT,
+        definition = BacsConfirmationDefinition(
+            bacsMandateConfirmationLauncherFactory = FakeBacsMandateConfirmationLauncherFactory(),
+        ),
+        launcherResult = BacsMandateConfirmationResult.Confirmed,
+        definitionResult = ConfirmationDefinition.Result.NextStep(
+            intent = PAYMENT_INTENT,
+            confirmationOption = PaymentMethodConfirmationOption.New(
+                initializationMode = BACS_CONFIRMATION_OPTION.initializationMode,
+                createParams = BACS_CONFIRMATION_OPTION.createParams,
+                optionsParams = BACS_CONFIRMATION_OPTION.optionsParams,
+                shippingDetails = BACS_CONFIRMATION_OPTION.shippingDetails,
+                shouldSave = false,
+            ),
+        ),
+    )
+
+    private companion object {
+        private val BACS_CONFIRMATION_OPTION = BacsConfirmationOption(
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123_secret_123"
+            ),
+            createParams = PaymentMethodCreateParams.create(
+                bacsDebit = PaymentMethodCreateParams.BacsDebit(
+                    accountNumber = "00012345",
+                    sortCode = "108800"
+                ),
+                billingDetails = PaymentMethod.BillingDetails(
+                    name = "John Doe",
+                    email = "johndoe@email.com",
+                )
+            ),
+            optionsParams = null,
+            shippingDetails = null,
+            appearance = PaymentSheet.Appearance(),
+        )
+
+        private val PAYMENT_INTENT = PaymentIntentFactory.create()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/FakeBacsMandateConfirmationLauncherFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/FakeBacsMandateConfirmationLauncherFactory.kt
@@ -1,0 +1,26 @@
+package com.stripe.android.paymentelement.confirmation.bacs
+
+import androidx.activity.result.ActivityResultLauncher
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationContract
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncher
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncherFactory
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.FakeBacsMandateConfirmationLauncher
+
+internal class FakeBacsMandateConfirmationLauncherFactory : BacsMandateConfirmationLauncherFactory {
+    private val _calls = Turbine<Call>()
+    val calls: ReceiveTurbine<Call> = _calls
+
+    override fun create(
+        activityResultLauncher: ActivityResultLauncher<BacsMandateConfirmationContract.Args>
+    ): BacsMandateConfirmationLauncher {
+        _calls.add(Call(activityResultLauncher))
+
+        return FakeBacsMandateConfirmationLauncher()
+    }
+
+    class Call(
+        val activityResultLauncher: ActivityResultLauncher<BacsMandateConfirmationContract.Args>
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinitionTest.kt
@@ -59,12 +59,13 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
         var onResultCalled = false
         val onResult: (PaymentResult) -> Unit = { onResultCalled = true }
         DummyActivityResultCaller.test {
-            definition.createLauncher(
+            val launcher = definition.createLauncher(
                 activityResultCaller = activityResultCaller,
                 onResult = onResult,
             )
 
             val call = awaitRegisterCall()
+            val registeredLauncher = awaitNextRegisteredLauncher()
 
             assertThat(call.contract).isInstanceOf<ExternalPaymentMethodContract>()
 
@@ -79,6 +80,8 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
             callback.onActivityResult(PaymentResult.Completed)
 
             assertThat(onResultCalled).isTrue()
+
+            assertThat(launcher).isEqualTo(registeredLauncher)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationFlowTest.kt
@@ -2,8 +2,10 @@ package com.stripe.android.paymentelement.confirmation.epms
 
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.runLaunchTest
 import com.stripe.android.paymentelement.confirmation.runResultTest
+import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentIntentFactory
@@ -36,6 +38,11 @@ class ExternalPaymentMethodConfirmationFlowTest {
             },
             errorReporter = FakeErrorReporter()
         ),
+        launcherResult = PaymentResult.Completed,
+        definitionResult = ConfirmationDefinition.Result.Succeeded(
+            intent = PAYMENT_INTENT,
+            deferredIntentConfirmationType = null,
+        )
     )
 
     private companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/utils/DummyActivityResultCaller.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/DummyActivityResultCaller.kt
@@ -10,6 +10,7 @@ import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 
 class DummyActivityResultCaller private constructor() : ActivityResultCaller {
+    private val registeredLaunchers = Turbine<ActivityResultLauncher<*>>()
     private val registerCalls = Turbine<RegisterCall<*, *>>()
     private val launchCalls = Turbine<Any?>()
 
@@ -19,7 +20,7 @@ class DummyActivityResultCaller private constructor() : ActivityResultCaller {
     ): ActivityResultLauncher<I> {
         registerCalls.add(RegisterCall(contract, callback))
 
-        return object : ActivityResultLauncher<I>() {
+        val launcher = object : ActivityResultLauncher<I>() {
             override fun launch(input: I, options: ActivityOptionsCompat?) {
                 launchCalls.add(input)
             }
@@ -32,6 +33,10 @@ class DummyActivityResultCaller private constructor() : ActivityResultCaller {
                 error("Not implemented")
             }
         }
+
+        registeredLaunchers.add(launcher)
+
+        return launcher
     }
 
     override fun <I : Any?, O : Any?> registerForActivityResult(
@@ -39,7 +44,7 @@ class DummyActivityResultCaller private constructor() : ActivityResultCaller {
         registry: ActivityResultRegistry,
         callback: ActivityResultCallback<O>
     ): ActivityResultLauncher<I> {
-        return object : ActivityResultLauncher<I>() {
+        val launcher = object : ActivityResultLauncher<I>() {
             override fun launch(input: I, options: ActivityOptionsCompat?) {
                 launchCalls.add(input)
             }
@@ -52,6 +57,10 @@ class DummyActivityResultCaller private constructor() : ActivityResultCaller {
                 error("Not implemented")
             }
         }
+
+        registeredLaunchers.add(launcher)
+
+        return launcher
     }
 
     data class RegisterCall<I : Any?, O : Any?>(
@@ -63,7 +72,12 @@ class DummyActivityResultCaller private constructor() : ActivityResultCaller {
         val activityResultCaller: ActivityResultCaller,
         private val registerCalls: ReceiveTurbine<RegisterCall<*, *>>,
         private val launchCalls: ReceiveTurbine<Any?>,
+        private val registeredLaunchers: ReceiveTurbine<ActivityResultLauncher<*>>,
     ) {
+        suspend fun awaitNextRegisteredLauncher(): ActivityResultLauncher<*> {
+            return registeredLaunchers.awaitItem()
+        }
+
         suspend fun awaitRegisterCall(): RegisterCall<*, *> {
             return registerCalls.awaitItem()
         }
@@ -82,6 +96,7 @@ class DummyActivityResultCaller private constructor() : ActivityResultCaller {
                 activityResultCaller = activityResultCaller,
                 registerCalls = activityResultCaller.registerCalls,
                 launchCalls = activityResultCaller.launchCalls,
+                registeredLaunchers = activityResultCaller.registeredLaunchers,
             ).apply {
                 block(this)
                 activityResultCaller.registerCalls.ensureAllEventsConsumed()

--- a/paymentsheet/src/test/java/com/stripe/android/utils/DummyActivityResultCaller.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/DummyActivityResultCaller.kt
@@ -101,6 +101,7 @@ class DummyActivityResultCaller private constructor() : ActivityResultCaller {
                 block(this)
                 activityResultCaller.registerCalls.ensureAllEventsConsumed()
                 activityResultCaller.launchCalls.ensureAllEventsConsumed()
+                activityResultCaller.registeredLaunchers.ensureAllEventsConsumed()
             }
         }
 


### PR DESCRIPTION
# Summary
Move `Bacs` to a `ConfirmationDefinition` type.

# Motivation
Helps move to our goal of making `DefaultConfirmationHandler` injectable.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified