### PR TITLE
[connect] Load Account Onboarding

### DIFF
--- a/connect-example/src/main/java/com/stripe/android/connect/example/Theme.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/Theme.kt
@@ -5,28 +5,16 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.ModalBottomSheetLayout
-import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.darkColors
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.lightColors
-import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
-import com.stripe.android.connect.example.ui.appearance.AppearanceView
-import kotlinx.coroutines.launch
 
 @Composable
 fun ConnectSdkExampleTheme(
@@ -68,52 +56,5 @@ fun MainContent(
         ) {
             content()
         }
-    }
-}
-
-@OptIn(ExperimentalMaterialApi::class)
-@Composable
-fun BasicComponentExampleContent(
-    title: String,
-    navigationIcon: @Composable (() -> Unit)? = null,
-    content: @Composable () -> Unit,
-) {
-    val sheetState = rememberModalBottomSheetState(
-        initialValue = ModalBottomSheetValue.Hidden,
-        skipHalfExpanded = true,
-    )
-    val coroutineScope = rememberCoroutineScope()
-    fun toggleAppearanceSheet() {
-        coroutineScope.launch {
-            if (!sheetState.isVisible) {
-                sheetState.show()
-            } else {
-                sheetState.hide()
-            }
-        }
-    }
-
-    MainContent(
-        title = title,
-        navigationIcon = navigationIcon,
-        actions = {
-            IconButton(onClick = { toggleAppearanceSheet() }) {
-                Icon(
-                    imageVector = Icons.Default.MoreVert,
-                    contentDescription = stringResource(R.string.customize_appearance),
-                )
-            }
-        },
-    ) {
-        ModalBottomSheetLayout(
-            modifier = Modifier.fillMaxSize(),
-            sheetState = sheetState,
-            sheetContent = {
-                AppearanceView(
-                    onDismiss = { coroutineScope.launch { sheetState.hide() } },
-                )
-            },
-            content = content,
-        )
     }
 }

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/common/BasicComponentExample.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/common/BasicComponentExample.kt
@@ -1,0 +1,92 @@
+package com.stripe.android.connect.example.ui.common
+
+import android.content.Context
+import android.view.View
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.viewinterop.AndroidView
+import com.stripe.android.connect.example.ConnectSdkExampleTheme
+import com.stripe.android.connect.example.MainContent
+import com.stripe.android.connect.example.R
+import com.stripe.android.connect.example.ui.appearance.AppearanceView
+import kotlinx.coroutines.launch
+
+@Composable
+fun BasicComponentExample(
+    title: String,
+    finish: () -> Unit,
+    createComponentView: (context: Context) -> View,
+) {
+    ConnectSdkExampleTheme {
+        BackHandler(onBack = finish)
+        BasicComponentExampleContent(
+            title = title,
+            navigationIcon = {
+                BackIconButton(onClick = finish)
+            }
+        ) {
+            AndroidView(modifier = Modifier.fillMaxSize(), factory = { context ->
+                createComponentView(context)
+            })
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun BasicComponentExampleContent(
+    title: String,
+    navigationIcon: @Composable (() -> Unit)? = null,
+    content: @Composable () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(
+        initialValue = ModalBottomSheetValue.Hidden,
+        skipHalfExpanded = true,
+    )
+    val coroutineScope = rememberCoroutineScope()
+    fun toggleAppearanceSheet() {
+        coroutineScope.launch {
+            if (!sheetState.isVisible) {
+                sheetState.show()
+            } else {
+                sheetState.hide()
+            }
+        }
+    }
+
+    MainContent(
+        title = title,
+        navigationIcon = navigationIcon,
+        actions = {
+            IconButton(onClick = { toggleAppearanceSheet() }) {
+                Icon(
+                    imageVector = Icons.Default.MoreVert,
+                    contentDescription = stringResource(R.string.customize_appearance),
+                )
+            }
+        },
+    ) {
+        ModalBottomSheetLayout(
+            modifier = Modifier.fillMaxSize(),
+            sheetState = sheetState,
+            sheetContent = {
+                AppearanceView(
+                    onDismiss = { coroutineScope.launch { sheetState.hide() } },
+                )
+            },
+            content = content,
+        )
+    }
+}

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/common/BasicComponentExampleActivity.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/common/BasicComponentExampleActivity.kt
@@ -1,0 +1,53 @@
+package com.stripe.android.connect.example.ui.common
+
+import android.content.Context
+import android.os.Bundle
+import android.view.View
+import androidx.activity.compose.setContent
+import androidx.annotation.StringRes
+import androidx.compose.ui.res.stringResource
+import androidx.fragment.app.FragmentActivity
+import com.stripe.android.connect.BuildConfig
+import com.stripe.android.connect.EmbeddedComponentManager
+import com.stripe.android.connect.PrivateBetaConnectSDK
+import com.stripe.android.connect.example.data.EmbeddedComponentManagerProvider
+import com.stripe.android.core.Logger
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@OptIn(PrivateBetaConnectSDK::class)
+@AndroidEntryPoint
+abstract class BasicComponentExampleActivity : FragmentActivity() {
+
+    @Inject
+    lateinit var embeddedComponentManagerProvider: EmbeddedComponentManagerProvider
+
+    protected lateinit var embeddedComponentManager: EmbeddedComponentManager
+
+    protected val logger: Logger = Logger.getInstance(enableLogging = BuildConfig.DEBUG)
+
+    @get:StringRes
+    abstract val titleRes: Int
+
+    abstract fun createComponentView(context: Context): View
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        embeddedComponentManager = try {
+            embeddedComponentManagerProvider.provideEmbeddedComponentManager()
+        } catch (e: IllegalStateException) {
+            // TODO - handle app restoration more gracefully
+            logger.error("Error retrieving EmbeddedComponentManager: $e")
+            finish() // we don't have an embedded component manager, so go back to MainActivity to get one
+            return
+        }
+
+        setContent {
+            BasicComponentExample(
+                title = stringResource(titleRes),
+                finish = ::finish,
+                createComponentView = ::createComponentView,
+            )
+        }
+    }
+}

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/features/accountonboarding/AccountOnboardingExampleActivity.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/features/accountonboarding/AccountOnboardingExampleActivity.kt
@@ -1,44 +1,18 @@
 package com.stripe.android.connect.example.ui.features.accountonboarding
 
-import android.os.Bundle
-import androidx.activity.compose.BackHandler
-import androidx.activity.compose.setContent
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.res.stringResource
-import androidx.fragment.app.FragmentActivity
-import androidx.fragment.compose.AndroidFragment
-import com.stripe.android.connect.AccountOnboardingFragment
+import android.content.Context
+import android.view.View
 import com.stripe.android.connect.PrivateBetaConnectSDK
-import com.stripe.android.connect.example.ConnectSdkExampleTheme
-import com.stripe.android.connect.example.MainContent
 import com.stripe.android.connect.example.R
-import com.stripe.android.connect.example.ui.common.BackIconButton
+import com.stripe.android.connect.example.ui.common.BasicComponentExampleActivity
 import dagger.hilt.android.AndroidEntryPoint
 
+@OptIn(PrivateBetaConnectSDK::class)
 @AndroidEntryPoint
-class AccountOnboardingExampleActivity : FragmentActivity() {
+class AccountOnboardingExampleActivity : BasicComponentExampleActivity() {
+    override val titleRes: Int = R.string.account_onboarding
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        setContent {
-            ConnectSdkExampleTheme {
-                MainContent(
-                    title = stringResource(R.string.account_onboarding),
-                    navigationIcon = {
-                        BackIconButton(onClick = this@AccountOnboardingExampleActivity::finish)
-                    }
-                ) {
-                    AccountOnboardingComponentWrapper(onDismiss = this@AccountOnboardingExampleActivity::finish)
-                }
-            }
-        }
-    }
-
-    @OptIn(PrivateBetaConnectSDK::class)
-    @Composable
-    private fun AccountOnboardingComponentWrapper(onDismiss: () -> Unit) {
-        BackHandler(onBack = onDismiss)
-        AndroidFragment<AccountOnboardingFragment>()
+    override fun createComponentView(context: Context): View {
+        return embeddedComponentManager.createAccountOnboardingView(context)
     }
 }

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/features/payouts/PayoutsExampleActivity.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/features/payouts/PayoutsExampleActivity.kt
@@ -1,71 +1,18 @@
 package com.stripe.android.connect.example.ui.features.payouts
 
-import android.os.Bundle
-import androidx.activity.compose.BackHandler
-import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.viewinterop.AndroidView
-import androidx.fragment.app.FragmentActivity
-import com.stripe.android.connect.BuildConfig
-import com.stripe.android.connect.EmbeddedComponentManager
+import android.content.Context
+import android.view.View
 import com.stripe.android.connect.PrivateBetaConnectSDK
-import com.stripe.android.connect.example.BasicComponentExampleContent
-import com.stripe.android.connect.example.ConnectSdkExampleTheme
 import com.stripe.android.connect.example.R
-import com.stripe.android.connect.example.data.EmbeddedComponentManagerProvider
-import com.stripe.android.connect.example.ui.common.BackIconButton
-import com.stripe.android.core.Logger
+import com.stripe.android.connect.example.ui.common.BasicComponentExampleActivity
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 
 @OptIn(PrivateBetaConnectSDK::class)
 @AndroidEntryPoint
-class PayoutsExampleActivity : FragmentActivity() {
+class PayoutsExampleActivity : BasicComponentExampleActivity() {
+    override val titleRes: Int = R.string.payouts
 
-    @Inject lateinit var embeddedComponentManagerProvider: EmbeddedComponentManagerProvider
-
-    private val logger: Logger = Logger.getInstance(enableLogging = BuildConfig.DEBUG)
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        val embeddedComponentManager = try {
-            embeddedComponentManagerProvider.provideEmbeddedComponentManager()
-        } catch (e: IllegalStateException) {
-            // TODO - handle app restoration more gracefully
-            logger.error("(PayoutsExampleActivity) Error retrieving EmbeddedComponentManager: $e")
-            finish() // we don't have an embedded component manager, so go back to MainActivity to get one
-            return
-        }
-
-        setContent {
-            ConnectSdkExampleTheme {
-                BasicComponentExampleContent(
-                    title = stringResource(R.string.payouts),
-                    navigationIcon = {
-                        BackIconButton(onClick = this@PayoutsExampleActivity::finish)
-                    }
-                ) {
-                    PayoutsComponentWrapper(
-                        embeddedComponentManager = embeddedComponentManager,
-                        onDismiss = this@PayoutsExampleActivity::finish,
-                    )
-                }
-            }
-        }
-    }
-
-    @OptIn(PrivateBetaConnectSDK::class)
-    @Composable
-    private fun PayoutsComponentWrapper(
-        embeddedComponentManager: EmbeddedComponentManager,
-        onDismiss: () -> Unit,
-    ) {
-        BackHandler(onBack = onDismiss)
-        AndroidView(modifier = Modifier.fillMaxSize(), factory = { context ->
-            embeddedComponentManager.createPayoutsView(context)
-        })
+    override fun createComponentView(context: Context): View {
+        return embeddedComponentManager.createPayoutsView(context)
     }
 }

--- a/connect/src/main/java/com/stripe/android/connect/AccountOnboardingView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/AccountOnboardingView.kt
@@ -1,0 +1,39 @@
+package com.stripe.android.connect
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.FrameLayout
+import androidx.annotation.RestrictTo
+import com.stripe.android.connect.webview.StripeConnectWebViewContainer
+import com.stripe.android.connect.webview.StripeConnectWebViewContainerImpl
+
+@PrivateBetaConnectSDK
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class AccountOnboardingView private constructor(
+    context: Context,
+    attrs: AttributeSet?,
+    defStyleAttr: Int,
+    webViewContainerBehavior: StripeConnectWebViewContainerImpl,
+) : FrameLayout(context, attrs, defStyleAttr),
+    StripeConnectWebViewContainer by webViewContainerBehavior {
+
+    @JvmOverloads
+    constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0,
+        embeddedComponentManager: EmbeddedComponentManager? = null,
+    ) : this(
+        context,
+        attrs,
+        defStyleAttr,
+        StripeConnectWebViewContainerImpl(
+            embeddedComponent = StripeEmbeddedComponent.ACCOUNT_ONBOARDING,
+            embeddedComponentManager = embeddedComponentManager
+        )
+    )
+
+    init {
+        webViewContainerBehavior.initializeView(this)
+    }
+}

--- a/connect/src/main/java/com/stripe/android/connect/EmbeddedComponentManager.kt
+++ b/connect/src/main/java/com/stripe/android/connect/EmbeddedComponentManager.kt
@@ -26,6 +26,13 @@ class EmbeddedComponentManager(
     internal val appearanceFlow: StateFlow<Appearance> get() = _appearanceFlow.asStateFlow()
 
     /**
+     * Create a new [AccountOnboardingView] for inclusion in the view hierarchy.
+     */
+    fun createAccountOnboardingView(context: Context): AccountOnboardingView {
+        return AccountOnboardingView(context = context, embeddedComponentManager = this)
+    }
+
+    /**
      * Create a new [PayoutsView] for inclusion in the view hierarchy.
      */
     fun createPayoutsView(context: Context): PayoutsView {

--- a/connect/src/main/java/com/stripe/android/connect/StripeEmbeddedComponent.kt
+++ b/connect/src/main/java/com/stripe/android/connect/StripeEmbeddedComponent.kt
@@ -7,6 +7,11 @@ package com.stripe.android.connect
  */
 internal enum class StripeEmbeddedComponent(val componentName: String) {
     /**
+     * Represents the Account Onboarding component: [https://docs.stripe.com/connect/supported-embedded-components/account-onboarding](https://docs.stripe.com/connect/supported-embedded-components/account-onboarding)
+     */
+    ACCOUNT_ONBOARDING("account-onboarding"),
+
+    /**
      * Represents the Payouts component: [https://docs.stripe.com/connect/supported-embedded-components/payouts](https://docs.stripe.com/connect/supported-embedded-components/payouts)
      */
     PAYOUTS("payouts"),


### PR DESCRIPTION
# Summary
Init functional API to load `account-onboarding` component and use it in the example app.

The diff is large because I also refactored the example app code to easily add a basic example component activity. It's mostly straightforward extracting into reusable classes/composables.

# Motivation
https://jira.corp.stripe.com/browse/MXMOBILE-2506

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

https://github.com/user-attachments/assets/330f07cf-862e-42e8-a5a8-0f84be446e6b

