### PR TITLE
[connect] Add component event listeners

### DIFF
--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/appearance/AppearanceViewModel.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/appearance/AppearanceViewModel.kt
@@ -20,7 +20,7 @@ class AppearanceViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val logger: Logger = Logger.getInstance(enableLogging = BuildConfig.DEBUG)
-    private val loggingTag = this::class.java.name
+    private val loggingTag = this::class.java.simpleName
 
     private val _state = MutableStateFlow(AppearanceState())
     val state = _state.asStateFlow()

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/features/payouts/PayoutsExampleActivity.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/features/payouts/PayoutsExampleActivity.kt
@@ -2,6 +2,8 @@ package com.stripe.android.connect.example.ui.features.payouts
 
 import android.content.Context
 import android.view.View
+import android.widget.Toast
+import com.stripe.android.connect.PayoutsListener
 import com.stripe.android.connect.PrivateBetaConnectSDK
 import com.stripe.android.connect.example.R
 import com.stripe.android.connect.example.ui.common.BasicComponentExampleActivity
@@ -13,6 +15,15 @@ class PayoutsExampleActivity : BasicComponentExampleActivity() {
     override val titleRes: Int = R.string.payouts
 
     override fun createComponentView(context: Context): View {
-        return embeddedComponentManager.createPayoutsView(context)
+        return embeddedComponentManager.createPayoutsView(
+            context = context,
+            listener = Listener(),
+        )
+    }
+
+    private inner class Listener : PayoutsListener {
+        override fun onLoadError(error: Throwable) {
+            Toast.makeText(this@PayoutsExampleActivity, error.message, Toast.LENGTH_LONG).show()
+        }
     }
 }

--- a/connect/api/connect.api
+++ b/connect/api/connect.api
@@ -1,3 +1,13 @@
+public abstract interface class com/stripe/android/connect/AccountOnboardingListener : com/stripe/android/connect/StripeEmbeddedComponentListener {
+	public abstract fun onExit ()V
+}
+
+public final class com/stripe/android/connect/AccountOnboardingListener$DefaultImpls {
+	public static fun onExit (Lcom/stripe/android/connect/AccountOnboardingListener;)V
+	public static fun onLoadError (Lcom/stripe/android/connect/AccountOnboardingListener;Ljava/lang/Throwable;)V
+	public static fun onLoaderStart (Lcom/stripe/android/connect/AccountOnboardingListener;)V
+}
+
 public final class com/stripe/android/connect/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
 	public static final field DEBUG Z
@@ -11,6 +21,24 @@ public final class com/stripe/android/connect/EmbeddedComponentManager$Configura
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/connect/EmbeddedComponentManager$Configuration;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public abstract interface class com/stripe/android/connect/PayoutsListener : com/stripe/android/connect/StripeEmbeddedComponentListener {
+}
+
+public final class com/stripe/android/connect/PayoutsListener$DefaultImpls {
+	public static fun onLoadError (Lcom/stripe/android/connect/PayoutsListener;Ljava/lang/Throwable;)V
+	public static fun onLoaderStart (Lcom/stripe/android/connect/PayoutsListener;)V
+}
+
+public abstract interface class com/stripe/android/connect/StripeEmbeddedComponentListener {
+	public abstract fun onLoadError (Ljava/lang/Throwable;)V
+	public abstract fun onLoaderStart ()V
+}
+
+public final class com/stripe/android/connect/StripeEmbeddedComponentListener$DefaultImpls {
+	public static fun onLoadError (Lcom/stripe/android/connect/StripeEmbeddedComponentListener;Ljava/lang/Throwable;)V
+	public static fun onLoaderStart (Lcom/stripe/android/connect/StripeEmbeddedComponentListener;)V
 }
 
 public final class com/stripe/android/connect/appearance/Appearance : android/os/Parcelable {

--- a/connect/src/main/java/com/stripe/android/connect/AccountOnboardingView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/AccountOnboardingView.kt
@@ -6,6 +6,8 @@ import android.widget.FrameLayout
 import androidx.annotation.RestrictTo
 import com.stripe.android.connect.webview.StripeConnectWebViewContainer
 import com.stripe.android.connect.webview.StripeConnectWebViewContainerImpl
+import com.stripe.android.connect.webview.serialization.SetOnExit
+import com.stripe.android.connect.webview.serialization.SetterFunctionCalledMessage
 
 @PrivateBetaConnectSDK
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -13,9 +15,9 @@ class AccountOnboardingView private constructor(
     context: Context,
     attrs: AttributeSet?,
     defStyleAttr: Int,
-    webViewContainerBehavior: StripeConnectWebViewContainerImpl,
+    webViewContainerBehavior: StripeConnectWebViewContainerImpl<AccountOnboardingListener>,
 ) : FrameLayout(context, attrs, defStyleAttr),
-    StripeConnectWebViewContainer by webViewContainerBehavior {
+    StripeConnectWebViewContainer<AccountOnboardingListener> by webViewContainerBehavior {
 
     @JvmOverloads
     constructor(
@@ -23,17 +25,40 @@ class AccountOnboardingView private constructor(
         attrs: AttributeSet? = null,
         defStyleAttr: Int = 0,
         embeddedComponentManager: EmbeddedComponentManager? = null,
+        listener: AccountOnboardingListener? = null,
     ) : this(
         context,
         attrs,
         defStyleAttr,
         StripeConnectWebViewContainerImpl(
             embeddedComponent = StripeEmbeddedComponent.ACCOUNT_ONBOARDING,
-            embeddedComponentManager = embeddedComponentManager
+            embeddedComponentManager = embeddedComponentManager,
+            listener = listener,
+            listenerDelegate = AccountOnboardingListenerDelegate
         )
     )
 
     init {
         webViewContainerBehavior.initializeView(this)
+    }
+}
+
+@PrivateBetaConnectSDK
+interface AccountOnboardingListener : StripeEmbeddedComponentListener {
+    /**
+     * The connected account has exited the onboarding process.
+     */
+    fun onExit() {}
+}
+
+@OptIn(PrivateBetaConnectSDK::class)
+internal object AccountOnboardingListenerDelegate : ComponentListenerDelegate<AccountOnboardingListener> {
+    override fun AccountOnboardingListener.delegate(message: SetterFunctionCalledMessage) {
+        when (message.value) {
+            is SetOnExit -> onExit()
+            else -> {
+                // Ignore.
+            }
+        }
     }
 }

--- a/connect/src/main/java/com/stripe/android/connect/EmbeddedComponentManager.kt
+++ b/connect/src/main/java/com/stripe/android/connect/EmbeddedComponentManager.kt
@@ -28,15 +28,29 @@ class EmbeddedComponentManager(
     /**
      * Create a new [AccountOnboardingView] for inclusion in the view hierarchy.
      */
-    fun createAccountOnboardingView(context: Context): AccountOnboardingView {
-        return AccountOnboardingView(context = context, embeddedComponentManager = this)
+    fun createAccountOnboardingView(
+        context: Context,
+        listener: AccountOnboardingListener? = null
+    ): AccountOnboardingView {
+        return AccountOnboardingView(
+            context = context,
+            embeddedComponentManager = this,
+            listener = listener
+        )
     }
 
     /**
      * Create a new [PayoutsView] for inclusion in the view hierarchy.
      */
-    fun createPayoutsView(context: Context): PayoutsView {
-        return PayoutsView(context = context, embeddedComponentManager = this)
+    fun createPayoutsView(
+        context: Context,
+        listener: PayoutsListener? = null
+    ): PayoutsView {
+        return PayoutsView(
+            context = context,
+            embeddedComponentManager = this,
+            listener = listener
+        )
     }
 
     internal fun getInitialParams(context: Context): ConnectInstanceJs {

--- a/connect/src/main/java/com/stripe/android/connect/PayoutsView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/PayoutsView.kt
@@ -13,9 +13,9 @@ class PayoutsView private constructor(
     context: Context,
     attrs: AttributeSet?,
     defStyleAttr: Int,
-    webViewContainerBehavior: StripeConnectWebViewContainerImpl,
+    webViewContainerBehavior: StripeConnectWebViewContainerImpl<PayoutsListener>,
 ) : FrameLayout(context, attrs, defStyleAttr),
-    StripeConnectWebViewContainer by webViewContainerBehavior {
+    StripeConnectWebViewContainer<PayoutsListener> by webViewContainerBehavior {
 
     @JvmOverloads
     constructor(
@@ -23,13 +23,16 @@ class PayoutsView private constructor(
         attrs: AttributeSet? = null,
         defStyleAttr: Int = 0,
         embeddedComponentManager: EmbeddedComponentManager? = null,
+        listener: PayoutsListener? = null,
     ) : this(
         context,
         attrs,
         defStyleAttr,
         StripeConnectWebViewContainerImpl(
             embeddedComponent = StripeEmbeddedComponent.PAYOUTS,
-            embeddedComponentManager = embeddedComponentManager
+            embeddedComponentManager = embeddedComponentManager,
+            listener = listener,
+            listenerDelegate = ComponentListenerDelegate.ignore(),
         )
     )
 
@@ -37,3 +40,6 @@ class PayoutsView private constructor(
         webViewContainerBehavior.initializeView(this)
     }
 }
+
+@PrivateBetaConnectSDK
+interface PayoutsListener : StripeEmbeddedComponentListener

--- a/connect/src/main/java/com/stripe/android/connect/StripeEmbeddedComponentListener.kt
+++ b/connect/src/main/java/com/stripe/android/connect/StripeEmbeddedComponentListener.kt
@@ -1,0 +1,27 @@
+package com.stripe.android.connect
+
+import com.stripe.android.connect.webview.serialization.SetterFunctionCalledMessage
+
+@PrivateBetaConnectSDK
+interface StripeEmbeddedComponentListener {
+    /**
+     * The component executes this callback function before any UI is displayed to the user.
+     */
+    fun onLoaderStart() {}
+
+    /**
+     * The component executes this callback function when a load failure occurs.
+     */
+    fun onLoadError(error: Throwable) {}
+}
+
+@OptIn(PrivateBetaConnectSDK::class)
+internal fun interface ComponentListenerDelegate<Listener : StripeEmbeddedComponentListener> {
+    fun Listener.delegate(message: SetterFunctionCalledMessage)
+
+    companion object {
+        internal fun <Listener : StripeEmbeddedComponentListener> ignore(): ComponentListenerDelegate<Listener> {
+            return ComponentListenerDelegate { _ -> }
+        }
+    }
+}

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
@@ -27,7 +27,7 @@ import com.stripe.android.connect.webview.serialization.AccountSessionClaimedMes
 import com.stripe.android.connect.webview.serialization.ConnectInstanceJs
 import com.stripe.android.connect.webview.serialization.PageLoadMessage
 import com.stripe.android.connect.webview.serialization.SecureWebViewMessage
-import com.stripe.android.connect.webview.serialization.SetterMessage
+import com.stripe.android.connect.webview.serialization.SetterFunctionCalledMessage
 import com.stripe.android.connect.webview.serialization.toJs
 import com.stripe.android.core.Logger
 import com.stripe.android.core.version.StripeSdkVersion
@@ -269,15 +269,10 @@ internal class StripeConnectWebViewContainerImpl(
 
         @JavascriptInterface
         fun onSetterFunctionCalled(message: String) {
-            val setterMessage = jsonSerializer.decodeFromString<SetterMessage>(message)
-            logger.debug("Setter function called: $setterMessage")
+            val parsed = jsonSerializer.decodeFromString<SetterFunctionCalledMessage>(message)
+            logger.debug("Setter function called: ${parsed.setter}")
 
-            when (setterMessage.setter) {
-                // Emitted when connect js has initialized and the component renders a loading state
-                "setOnLoaderStart" -> {
-                    controller?.onReceivedSetOnLoaderStart()
-                }
-            }
+            controller?.onReceivedSetterFunctionCalled(parsed)
         }
 
         @JavascriptInterface

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerController.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerController.kt
@@ -135,7 +135,7 @@ internal class StripeConnectWebViewContainerController<Listener : StripeEmbedded
             }
             is SetOnLoadError -> {
                 // TODO - wrap error better
-                listener?.onLoadError(RuntimeException(value.type))
+                listener?.onLoadError(RuntimeException("${value.type}: ${value.message}"))
             }
             else -> {
                 with(listenerDelegate) {

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerController.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerController.kt
@@ -13,6 +13,8 @@ import com.stripe.android.connect.EmbeddedComponentManager
 import com.stripe.android.connect.PrivateBetaConnectSDK
 import com.stripe.android.connect.StripeEmbeddedComponent
 import com.stripe.android.connect.webview.serialization.ConnectInstanceJs
+import com.stripe.android.connect.webview.serialization.SetOnLoaderStart
+import com.stripe.android.connect.webview.serialization.SetterFunctionCalledMessage
 import com.stripe.android.core.Logger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -113,14 +115,21 @@ internal class StripeConnectWebViewContainerController(
     }
 
     /**
-     * Callback to invoke upon receiving 'setOnLoaderStart' message.
+     * Callback to invoke upon receiving 'onSetterFunctionCalled' message.
      */
-    fun onReceivedSetOnLoaderStart() {
-        updateState {
-            copy(
-                receivedSetOnLoaderStart = true,
-                isNativeLoadingIndicatorVisible = false,
-            )
+    fun onReceivedSetterFunctionCalled(message: SetterFunctionCalledMessage) {
+        when (message.value) {
+            is SetOnLoaderStart -> {
+                updateState {
+                    copy(
+                        receivedSetOnLoaderStart = true,
+                        isNativeLoadingIndicatorVisible = false,
+                    )
+                }
+            }
+            else -> {
+                logger.debug("Received setter function: ${message.setter}")
+            }
         }
     }
 

--- a/connect/src/main/java/com/stripe/android/connect/webview/serialization/ConnectJson.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/serialization/ConnectJson.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.connect.webview.serialization
+
+import kotlinx.serialization.json.Json
+
+internal val ConnectJson: Json =
+    Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }

--- a/connect/src/main/java/com/stripe/android/connect/webview/serialization/SetterFunctionCalledMessage.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/serialization/SetterFunctionCalledMessage.kt
@@ -1,0 +1,100 @@
+package com.stripe.android.connect.webview.serialization
+
+import com.stripe.android.connect.BuildConfig
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.serializer
+
+@Serializable(with = SetterFunctionCalledMessageSerializer::class)
+internal data class SetterFunctionCalledMessage(
+    val setter: String,
+    val value: Value
+) {
+    init {
+        require(
+            !BuildConfig.DEBUG ||
+                value is UnknownValue ||
+                setter == value.javaClass.simpleName.replaceFirstChar { it.lowercaseChar() }
+        ) {
+            "Setter does not match value type: setter=$setter, value=$value"
+        }
+    }
+
+    sealed interface Value
+
+    @Serializable
+    data class UnknownValue(
+        val value: JsonElement
+    ) : Value
+}
+
+// Values
+
+/**
+ * Emitted when Connect JS has initialized and the component renders a loading state.
+ */
+@Serializable
+internal data class SetOnLoaderStart(
+    val elementTagName: String
+) : SetterFunctionCalledMessage.Value
+
+// Serialization
+
+internal object SetterFunctionCalledMessageSerializer : KSerializer<SetterFunctionCalledMessage> {
+    override val descriptor: SerialDescriptor = JsonObject.serializer().descriptor
+
+    override fun deserialize(decoder: Decoder): SetterFunctionCalledMessage {
+        check(decoder is JsonDecoder)
+        val jsonObject = decoder.decodeJsonElement().jsonObject
+        val setter = jsonObject.getValue("setter").jsonPrimitive.content
+        val valueJson = jsonObject.getValue("value")
+        val valueSerializer = decoder.json.valueSerializerForSetter(setter)
+        val value = valueSerializer
+            ?.let { decoder.json.decodeFromJsonElement(it, valueJson) }
+            ?: SetterFunctionCalledMessage.UnknownValue(
+                value = valueJson
+            )
+        return SetterFunctionCalledMessage(setter = setter, value = value)
+    }
+
+    override fun serialize(encoder: Encoder, value: SetterFunctionCalledMessage) {
+        check(encoder is JsonEncoder)
+        val resultValue =
+            if (value.value is SetterFunctionCalledMessage.UnknownValue) {
+                value.value.value // lol
+            } else {
+                val valueSerializer = encoder.json.valueSerializerForSetter(value.setter)!!
+                encoder.json.encodeToJsonElement(valueSerializer, value.value)
+            }
+        encoder.encodeJsonElement(
+            buildJsonObject {
+                put("setter", JsonPrimitive(value.setter))
+                put("value", resultValue)
+            }
+        )
+    }
+
+    private fun Json.valueSerializerForSetter(setter: String): KSerializer<SetterFunctionCalledMessage.Value>? {
+        val className = buildString {
+            append(SetterFunctionCalledMessage::class.java.`package`!!.name)
+            append(".")
+            append(setter.replaceFirstChar { it.uppercaseChar() })
+        }
+        return runCatching {
+            @Suppress("UNCHECKED_CAST")
+            serializersModule.serializer(Class.forName(className)) as KSerializer<SetterFunctionCalledMessage.Value>
+        }.getOrNull()
+    }
+}

--- a/connect/src/main/java/com/stripe/android/connect/webview/serialization/SetterFunctionCalledMessage.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/serialization/SetterFunctionCalledMessage.kt
@@ -50,6 +50,21 @@ internal data class SetOnLoaderStart(
     val elementTagName: String
 ) : SetterFunctionCalledMessage.Value
 
+/**
+ * The component executes this callback function when a load failure occurs.
+ */
+@Serializable
+internal data class SetOnLoadError(
+    val type: String, // TODO - possibly use an enum or sealed class here.
+    val message: String?,
+) : SetterFunctionCalledMessage.Value
+
+/**
+ * The connected account has exited the onboarding process.
+ */
+@Serializable
+internal data object SetOnExit : SetterFunctionCalledMessage.Value
+
 // Serialization
 
 internal object SetterFunctionCalledMessageSerializer : KSerializer<SetterFunctionCalledMessage> {

--- a/connect/src/main/java/com/stripe/android/connect/webview/serialization/SetterFunctionCalledMessage.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/serialization/SetterFunctionCalledMessage.kt
@@ -22,12 +22,13 @@ internal data class SetterFunctionCalledMessage(
     val setter: String,
     val value: Value
 ) {
+    constructor(value: Value) : this(
+        setter = value.expectedSetterName,
+        value = value
+    )
+
     init {
-        require(
-            !BuildConfig.DEBUG ||
-                value is UnknownValue ||
-                setter == value.javaClass.simpleName.replaceFirstChar { it.lowercaseChar() }
-        ) {
+        require(!BuildConfig.DEBUG || value is UnknownValue || setter == value.expectedSetterName) {
             "Setter does not match value type: setter=$setter, value=$value"
         }
     }
@@ -38,6 +39,14 @@ internal data class SetterFunctionCalledMessage(
     data class UnknownValue(
         val value: JsonElement
     ) : Value
+
+    companion object {
+        val Value.expectedSetterName: String
+            get() {
+                require(this !is UnknownValue)
+                return javaClass.simpleName.replaceFirstChar { it.lowercaseChar() }
+            }
+    }
 }
 
 // Values

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewClientTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewClientTest.kt
@@ -4,13 +4,14 @@ import android.content.Context
 import android.webkit.ValueCallback
 import android.webkit.WebSettings
 import android.webkit.WebView
+import com.stripe.android.connect.ComponentListenerDelegate
 import com.stripe.android.connect.EmbeddedComponentManager
 import com.stripe.android.connect.EmbeddedComponentManager.Configuration
+import com.stripe.android.connect.PayoutsListener
 import com.stripe.android.connect.PrivateBetaConnectSDK
 import com.stripe.android.connect.StripeEmbeddedComponent
 import com.stripe.android.core.Logger
 import com.stripe.android.core.version.StripeSdkVersion
-import kotlinx.serialization.json.Json
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -35,7 +36,7 @@ class StripeConnectWebViewClientTest {
         on { context } doReturn mockContext
     }
 
-    private lateinit var container: StripeConnectWebViewContainerImpl
+    private lateinit var container: StripeConnectWebViewContainerImpl<PayoutsListener>
     private val webViewClient get() = container.stripeWebViewClient
 
     @Before
@@ -55,8 +56,9 @@ class StripeConnectWebViewClientTest {
         container = StripeConnectWebViewContainerImpl(
             embeddedComponent = StripeEmbeddedComponent.PAYOUTS,
             embeddedComponentManager = embeddedComponentManager,
+            listener = null,
             logger = Logger.getInstance(enableLogging = false),
-            jsonSerializer = Json { ignoreUnknownKeys = true },
+            listenerDelegate = ComponentListenerDelegate.ignore()
         )
     }
 

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerControllerTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerControllerTest.kt
@@ -6,8 +6,10 @@ import android.net.Uri
 import android.webkit.WebResourceRequest
 import androidx.lifecycle.testing.TestLifecycleOwner
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.connect.ComponentListenerDelegate
 import com.stripe.android.connect.EmbeddedComponentManager
 import com.stripe.android.connect.EmbeddedComponentManager.Configuration
+import com.stripe.android.connect.PayoutsListener
 import com.stripe.android.connect.PrivateBetaConnectSDK
 import com.stripe.android.connect.StripeEmbeddedComponent
 import com.stripe.android.connect.appearance.Appearance
@@ -37,11 +39,13 @@ class StripeConnectWebViewContainerControllerTest {
         fetchClientSecretCallback = { },
     )
     private val embeddedComponent: StripeEmbeddedComponent = StripeEmbeddedComponent.PAYOUTS
+    private val listener: PayoutsListener = mock()
+    private val listenerDelegate: ComponentListenerDelegate<PayoutsListener> = mock()
     private val mockStripeIntentLauncher: StripeIntentLauncher = mock()
     private val mockLogger: Logger = mock()
 
     private val lifecycleOwner = TestLifecycleOwner()
-    private lateinit var controller: StripeConnectWebViewContainerController
+    private lateinit var controller: StripeConnectWebViewContainerController<PayoutsListener>
 
     @Before
     fun setup() {
@@ -49,6 +53,8 @@ class StripeConnectWebViewContainerControllerTest {
             view = view,
             embeddedComponentManager = embeddedComponentManager,
             embeddedComponent = embeddedComponent,
+            listener = listener,
+            listenerDelegate = listenerDelegate,
             stripeIntentLauncher = mockStripeIntentLauncher,
             logger = mockLogger,
         )

--- a/connect/src/test/java/com/stripe/android/connect/webview/serialization/SetterFunctionCalledMessageTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/serialization/SetterFunctionCalledMessageTest.kt
@@ -25,14 +25,10 @@ class SetterFunctionCalledMessageTest {
     @Test
     fun `should serialize and deserialize correctly`() {
         listOf(
-            SetterFunctionCalledMessage(
-                setter = "setOnLoaderStart",
-                value = SetOnLoaderStart(elementTagName = "foo")
-            ) to """{"setter":"setOnLoaderStart","value":{"elementTagName":"foo"}}""",
-            SetterFunctionCalledMessage(
-                setter = "setOnExit",
-                value = SetOnExit,
-            ) to """{"setter":"setOnExit","value":{}}""",
+            SetterFunctionCalledMessage(SetOnLoaderStart(elementTagName = "foo")) to
+                """{"setter":"setOnLoaderStart","value":{"elementTagName":"foo"}}""",
+            SetterFunctionCalledMessage(SetOnExit) to
+                """{"setter":"setOnExit","value":{}}""",
             SetterFunctionCalledMessage(
                 setter = "foo",
                 value = SetterFunctionCalledMessage.UnknownValue(value = JsonPrimitive("bar"))

--- a/connect/src/test/java/com/stripe/android/connect/webview/serialization/SetterFunctionCalledMessageTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/serialization/SetterFunctionCalledMessageTest.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.connect.webview.serialization
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.Test
+
+class SetterFunctionCalledMessageTest {
+    @Test(expected = IllegalArgumentException::class)
+    fun `should error if setter and value class names don't match`() {
+        SetterFunctionCalledMessage(
+            setter = "foo",
+            value = SetOnLoaderStart(elementTagName = "")
+        )
+    }
+
+    @Test
+    fun `should not validate naming for unknown values`() {
+        SetterFunctionCalledMessage(
+            setter = "foo",
+            value = SetterFunctionCalledMessage.UnknownValue(JsonPrimitive(""))
+        )
+    }
+
+    @Test
+    fun `should serialize and deserialize correct`() {
+        listOf(
+            SetterFunctionCalledMessage(
+                setter = "setOnLoaderStart",
+                value = SetOnLoaderStart(elementTagName = "foo")
+            ) to """{"setter":"setOnLoaderStart","value":{"elementTagName":"foo"}}""",
+            SetterFunctionCalledMessage(
+                setter = "foo",
+                value = SetterFunctionCalledMessage.UnknownValue(value = JsonPrimitive("bar"))
+            ) to """{"setter":"foo","value":"bar"}""",
+        ).forEach { (obj, expectedJson) ->
+            val json = ConnectSdkJson.encodeToString(obj)
+            assertThat(json).isEqualTo(expectedJson)
+            assertThat(ConnectSdkJson.decodeFromString<SetterFunctionCalledMessage>(json)).isEqualTo(obj)
+        }
+    }
+}

--- a/connect/src/test/java/com/stripe/android/connect/webview/serialization/SetterFunctionCalledMessageTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/serialization/SetterFunctionCalledMessageTest.kt
@@ -23,20 +23,24 @@ class SetterFunctionCalledMessageTest {
     }
 
     @Test
-    fun `should serialize and deserialize correct`() {
+    fun `should serialize and deserialize correctly`() {
         listOf(
             SetterFunctionCalledMessage(
                 setter = "setOnLoaderStart",
                 value = SetOnLoaderStart(elementTagName = "foo")
             ) to """{"setter":"setOnLoaderStart","value":{"elementTagName":"foo"}}""",
             SetterFunctionCalledMessage(
+                setter = "setOnExit",
+                value = SetOnExit,
+            ) to """{"setter":"setOnExit","value":{}}""",
+            SetterFunctionCalledMessage(
                 setter = "foo",
                 value = SetterFunctionCalledMessage.UnknownValue(value = JsonPrimitive("bar"))
             ) to """{"setter":"foo","value":"bar"}""",
         ).forEach { (obj, expectedJson) ->
-            val json = ConnectSdkJson.encodeToString(obj)
+            val json = ConnectJson.encodeToString(obj)
             assertThat(json).isEqualTo(expectedJson)
-            assertThat(ConnectSdkJson.decodeFromString<SetterFunctionCalledMessage>(json)).isEqualTo(obj)
+            assertThat(ConnectJson.decodeFromString<SetterFunctionCalledMessage>(json)).isEqualTo(obj)
         }
     }
 }


### PR DESCRIPTION
# Summary

Add embedded component listeners, e.g. `AccountOnboardingListener`.

Significant changes:
 * refactored serialization around `onSetterFunctionCalled` messages
 * added wiring for said messages to forward them to user-provided listeners
 * changed component `*View.setEmbeddedComponentManager(manager, listener)` to `*View.initialize(manager, listener)`
 * extracted out `ConnectJson` instance for easier reuse and configuration

# Motivation
https://jira.corp.stripe.com/browse/MXMOBILE-2506

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots

https://github.com/user-attachments/assets/e1e0326c-0a72-4cea-b623-d9330ccfc331

