### PR TITLE
Move `Google Pay` to a `ConfirmationDefinition` type

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
@@ -1,0 +1,179 @@
+package com.stripe.android.paymentelement.confirmation.gpay
+
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.core.utils.UserFacingLogger
+import com.stripe.android.googlepaylauncher.GooglePayEnvironment
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
+import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
+import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import com.stripe.android.R as PaymentsCoreR
+
+internal class GooglePayConfirmationDefinition(
+    private val googlePayPaymentMethodLauncherFactory: GooglePayPaymentMethodLauncherFactory,
+    private val userFacingLogger: UserFacingLogger?,
+) : ConfirmationDefinition<
+    GooglePayConfirmationOption,
+    ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
+    Unit,
+    GooglePayPaymentMethodLauncher.Result,
+    > {
+    override val key: String = "GooglePay"
+
+    override fun option(confirmationOption: ConfirmationHandler.Option): GooglePayConfirmationOption? {
+        return confirmationOption as? GooglePayConfirmationOption
+    }
+
+    override suspend fun action(
+        confirmationOption: GooglePayConfirmationOption,
+        intent: StripeIntent
+    ): ConfirmationDefinition.Action<Unit> {
+        if (
+            confirmationOption.config.merchantCurrencyCode == null &&
+            !confirmationOption.initializationMode.isProcessingPayment
+        ) {
+            val message = "GooglePayConfig.currencyCode is required in order to use " +
+                "Google Pay when processing a Setup Intent"
+
+            userFacingLogger?.logWarningWithoutPii(message)
+
+            return ConfirmationDefinition.Action.Fail(
+                cause = IllegalStateException(message),
+                message = R.string.stripe_something_went_wrong.resolvableString,
+                errorType = ConfirmationHandler.Result.Failed.ErrorType.MerchantIntegration,
+            )
+        }
+
+        return ConfirmationDefinition.Action.Launch(
+            launcherArguments = Unit,
+            receivesResultInProcess = true,
+            deferredIntentConfirmationType = null,
+        )
+    }
+
+    override fun createLauncher(
+        activityResultCaller: ActivityResultCaller,
+        onResult: (GooglePayPaymentMethodLauncher.Result) -> Unit
+    ): ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args> {
+        return activityResultCaller.registerForActivityResult(
+            GooglePayPaymentMethodLauncherContractV2(),
+            onResult,
+        )
+    }
+
+    override fun launch(
+        launcher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
+        arguments: Unit,
+        confirmationOption: GooglePayConfirmationOption,
+        intent: StripeIntent,
+    ) {
+        val config = confirmationOption.config
+        val googlePayLauncher = createGooglePayLauncher(
+            factory = googlePayPaymentMethodLauncherFactory,
+            activityLauncher = launcher,
+            config = confirmationOption.config,
+        )
+
+        googlePayLauncher.present(
+            currencyCode = intent.asPaymentIntent()?.currency
+                ?: config.merchantCurrencyCode.orEmpty(),
+            amount = when (intent) {
+                is PaymentIntent -> intent.amount ?: 0L
+                is SetupIntent -> config.customAmount ?: 0L
+            },
+            transactionId = intent.id,
+            label = config.customLabel,
+        )
+    }
+
+    override fun toResult(
+        confirmationOption: GooglePayConfirmationOption,
+        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        intent: StripeIntent,
+        result: GooglePayPaymentMethodLauncher.Result,
+    ): ConfirmationDefinition.Result {
+        return when (result) {
+            is GooglePayPaymentMethodLauncher.Result.Completed -> {
+                val nextConfirmationOption = PaymentMethodConfirmationOption.Saved(
+                    paymentMethod = result.paymentMethod,
+                    initializationMode = confirmationOption.initializationMode,
+                    shippingDetails = confirmationOption.shippingDetails,
+                    optionsParams = null,
+                )
+
+                ConfirmationDefinition.Result.NextStep(
+                    confirmationOption = nextConfirmationOption,
+                    intent = intent,
+                )
+            }
+            is GooglePayPaymentMethodLauncher.Result.Failed -> {
+                ConfirmationDefinition.Result.Failed(
+                    cause = result.error,
+                    message = when (result.errorCode) {
+                        GooglePayPaymentMethodLauncher.NETWORK_ERROR ->
+                            PaymentsCoreR.string.stripe_failure_connection_error.resolvableString
+                        else -> PaymentsCoreR.string.stripe_internal_error.resolvableString
+                    },
+                    type = ConfirmationHandler.Result.Failed.ErrorType.GooglePay(result.errorCode),
+                )
+            }
+            is GooglePayPaymentMethodLauncher.Result.Canceled -> {
+                ConfirmationDefinition.Result.Canceled(
+                    action = ConfirmationHandler.Result.Canceled.Action.InformCancellation,
+                )
+            }
+        }
+    }
+
+    private fun createGooglePayLauncher(
+        factory: GooglePayPaymentMethodLauncherFactory,
+        activityLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
+        config: GooglePayConfirmationOption.Config,
+    ): GooglePayPaymentMethodLauncher {
+        return factory.create(
+            lifecycleScope = CoroutineScope(Dispatchers.Default),
+            config = GooglePayPaymentMethodLauncher.Config(
+                environment = when (config.environment) {
+                    PaymentSheet.GooglePayConfiguration.Environment.Production -> GooglePayEnvironment.Production
+                    else -> GooglePayEnvironment.Test
+                },
+                merchantCountryCode = config.merchantCountryCode,
+                merchantName = config.merchantName,
+                isEmailRequired = config.billingDetailsCollectionConfiguration.collectsEmail,
+                billingAddressConfig = config.billingDetailsCollectionConfiguration.toBillingAddressConfig(),
+            ),
+            readyCallback = {
+                // Do nothing since we are skipping the ready check below
+            },
+            activityResultLauncher = activityLauncher,
+            skipReadyCheck = true,
+            cardBrandFilter = config.cardBrandFilter
+        )
+    }
+
+    private fun StripeIntent.asPaymentIntent(): PaymentIntent? {
+        return this as? PaymentIntent
+    }
+
+    private val PaymentElementLoader.InitializationMode.isProcessingPayment: Boolean
+        get() = when (this) {
+            is PaymentElementLoader.InitializationMode.PaymentIntent -> true
+            is PaymentElementLoader.InitializationMode.SetupIntent -> false
+            is PaymentElementLoader.InitializationMode.DeferredIntent -> {
+                intentConfiguration.mode is PaymentSheet.IntentConfiguration.Mode.Payment
+            }
+        }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
@@ -1,0 +1,484 @@
+package com.stripe.android.paymentelement.confirmation.gpay
+
+import androidx.activity.result.ActivityResultCallback
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.core.utils.UserFacingLogger
+import com.stripe.android.googlepaylauncher.GooglePayEnvironment
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
+import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
+import com.stripe.android.isInstanceOf
+import com.stripe.android.model.wallets.Wallet
+import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.FakeConfirmationOption
+import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
+import com.stripe.android.paymentelement.confirmation.asCallbackFor
+import com.stripe.android.paymentelement.confirmation.asCanceled
+import com.stripe.android.paymentelement.confirmation.asFail
+import com.stripe.android.paymentelement.confirmation.asFailed
+import com.stripe.android.paymentelement.confirmation.asLaunch
+import com.stripe.android.paymentelement.confirmation.asNextStep
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.paymentsheet.utils.FakeUserFacingLogger
+import com.stripe.android.paymentsheet.utils.RecordingGooglePayPaymentMethodLauncherFactory
+import com.stripe.android.testing.PaymentIntentFactory
+import com.stripe.android.testing.PaymentMethodFactory
+import com.stripe.android.testing.SetupIntentFactory
+import com.stripe.android.utils.DummyActivityResultCaller
+import com.stripe.android.utils.FakeActivityResultLauncher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import com.stripe.android.R as PaymentsCoreR
+
+class GooglePayConfirmationDefinitionTest {
+    @Test
+    fun `'key' should be 'GooglePay`() {
+        val definition = createGooglePayConfirmationDefinition()
+
+        assertThat(definition.key).isEqualTo("GooglePay")
+    }
+
+    @Test
+    fun `'option' return casted 'GooglePayConfirmationOption'`() {
+        val definition = createGooglePayConfirmationDefinition()
+
+        assertThat(definition.option(GOOGLE_PAY_CONFIRMATION_OPTION)).isEqualTo(GOOGLE_PAY_CONFIRMATION_OPTION)
+    }
+
+    @Test
+    fun `'option' return null for unknown option`() {
+        val definition = createGooglePayConfirmationDefinition()
+
+        assertThat(definition.option(FakeConfirmationOption())).isNull()
+    }
+
+    @Test
+    fun `'createLauncher' should register launcher properly for activity result`() = runTest {
+        val definition = createGooglePayConfirmationDefinition()
+
+        var onResultCalled = false
+        val onResult: (GooglePayPaymentMethodLauncher.Result) -> Unit = { onResultCalled = true }
+        DummyActivityResultCaller.test {
+            definition.createLauncher(
+                activityResultCaller = activityResultCaller,
+                onResult = onResult,
+            )
+
+            val call = awaitRegisterCall()
+
+            assertThat(awaitNextRegisteredLauncher()).isNotNull()
+
+            assertThat(call.contract).isInstanceOf<GooglePayPaymentMethodLauncherContractV2>()
+            assertThat(call.callback).isInstanceOf<ActivityResultCallback<GooglePayPaymentMethodLauncher.Result>>()
+
+            val callback = call.callback.asCallbackFor<GooglePayPaymentMethodLauncher.Result>()
+
+            callback.onActivityResult(GooglePayPaymentMethodLauncher.Result.Completed(PaymentMethodFactory.card()))
+
+            assertThat(onResultCalled).isTrue()
+        }
+    }
+
+    @Test
+    fun `'toResult' should return 'NextStep' when ' GooglePayLauncherResult' is 'Completed'`() = runTest {
+        val definition = createGooglePayConfirmationDefinition()
+
+        val paymentMethod = PaymentMethodFactory.card().run {
+            copy(
+                card = card?.copy(
+                    wallet = Wallet.GooglePayWallet(dynamicLast4 = card?.last4),
+                )
+            )
+        }
+        val result = definition.toResult(
+            confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
+            intent = PAYMENT_INTENT,
+            deferredIntentConfirmationType = null,
+            result = GooglePayPaymentMethodLauncher.Result.Completed(
+                paymentMethod = paymentMethod,
+            ),
+        )
+
+        assertThat(result).isInstanceOf<ConfirmationDefinition.Result.NextStep>()
+
+        val successResult = result.asNextStep()
+
+        assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT)
+        assertThat(successResult.confirmationOption).isInstanceOf<PaymentMethodConfirmationOption.Saved>()
+    }
+
+    @Test
+    fun `'toResult' should return 'Failed' when 'GooglePayLauncherResult' is 'Failed'`() = runTest {
+        val definition = createGooglePayConfirmationDefinition()
+
+        val exception = IllegalStateException("Failed!")
+        val result = definition.toResult(
+            confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
+            intent = PAYMENT_INTENT,
+            deferredIntentConfirmationType = null,
+            result = GooglePayPaymentMethodLauncher.Result.Failed(
+                errorCode = 400,
+                error = exception
+            ),
+        )
+
+        assertThat(result).isInstanceOf<ConfirmationDefinition.Result.Failed>()
+
+        val failedResult = result.asFailed()
+
+        assertThat(failedResult.cause).isEqualTo(exception)
+        assertThat(failedResult.message).isEqualTo(PaymentsCoreR.string.stripe_internal_error.resolvableString)
+        assertThat(failedResult.type).isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.GooglePay(400))
+    }
+
+    @Test
+    fun `'toResult' should return 'Failed' with network error message if network error code is returned`() = runTest {
+        val definition = createGooglePayConfirmationDefinition()
+
+        val exception = IllegalStateException("Failed!")
+        val result = definition.toResult(
+            confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
+            intent = PAYMENT_INTENT,
+            deferredIntentConfirmationType = null,
+            result = GooglePayPaymentMethodLauncher.Result.Failed(
+                errorCode = GooglePayPaymentMethodLauncher.NETWORK_ERROR,
+                error = exception
+            ),
+        )
+
+        assertThat(result).isInstanceOf<ConfirmationDefinition.Result.Failed>()
+
+        val failedResult = result.asFailed()
+
+        assertThat(failedResult.cause).isEqualTo(exception)
+        assertThat(failedResult.message)
+            .isEqualTo(PaymentsCoreR.string.stripe_failure_connection_error.resolvableString)
+        assertThat(failedResult.type).isEqualTo(
+            ConfirmationHandler.Result.Failed.ErrorType.GooglePay(GooglePayPaymentMethodLauncher.NETWORK_ERROR)
+        )
+    }
+
+    @Test
+    fun `'toResult' should return 'Canceled' when 'GooglePayLauncherResult' is 'Canceled'`() = runTest {
+        val definition = createGooglePayConfirmationDefinition()
+
+        val result = definition.toResult(
+            confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
+            intent = PAYMENT_INTENT,
+            deferredIntentConfirmationType = null,
+            result = GooglePayPaymentMethodLauncher.Result.Canceled,
+        )
+
+        assertThat(result).isInstanceOf<ConfirmationDefinition.Result.Canceled>()
+
+        val canceledResult = result.asCanceled()
+
+        assertThat(canceledResult.action).isEqualTo(ConfirmationHandler.Result.Canceled.Action.InformCancellation)
+    }
+
+    @Test
+    fun `'Fail' action should be returned if currency code is not provided with a setup intent`() =
+        runActionTest(
+            initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(
+                clientSecret = "si_123_secret_123",
+            ),
+            shouldHaveCurrencyCodeFailure = true,
+            merchantCurrencyCode = null,
+        )
+
+    @Test
+    fun `'Fail' action should be returned if currency code is not provided with a deferred intent in setup mode`() =
+        runActionTest(
+            initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Setup(),
+                ),
+            ),
+            shouldHaveCurrencyCodeFailure = true,
+            merchantCurrencyCode = null,
+        )
+
+    @Test
+    fun `'Launch' action should be returned if currency code is provided with a setup intent`() =
+        runActionTest(
+            initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(
+                clientSecret = "si_123_secret_123",
+            ),
+            shouldHaveCurrencyCodeFailure = false,
+            merchantCurrencyCode = "USD",
+        )
+
+    @Test
+    fun `'Launch' action should be returned if currency code is provided with a deferred intent in setup mode`() =
+        runActionTest(
+            initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Setup(),
+                ),
+            ),
+            shouldHaveCurrencyCodeFailure = false,
+            merchantCurrencyCode = "USD",
+        )
+
+    @Test
+    fun `'Launch' action should be returned if currency code is not provided with a payment intent`() =
+        runActionTest(
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123_secret_123",
+            ),
+            shouldHaveCurrencyCodeFailure = false,
+            merchantCurrencyCode = null,
+        )
+
+    @Test
+    fun `'Launch' action should be returned if currency code is provided with a payment intent`() =
+        runActionTest(
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123_secret_123",
+            ),
+            shouldHaveCurrencyCodeFailure = false,
+            merchantCurrencyCode = "USD",
+        )
+
+    @Test
+    fun `'Launch' action should be returned if currency code is not provided with deferred intent in payment mode`() =
+        runActionTest(
+            initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                        amount = 1099,
+                        currency = "USD",
+                    ),
+                ),
+            ),
+            shouldHaveCurrencyCodeFailure = false,
+            merchantCurrencyCode = null,
+        )
+
+    @Test
+    fun `'Launch' action should be returned if currency code is provided with deferred intent in payment mode`() =
+        runActionTest(
+            initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                        amount = 1099,
+                        currency = "USD",
+                    ),
+                ),
+            ),
+            shouldHaveCurrencyCodeFailure = false,
+            merchantCurrencyCode = "USD",
+        )
+
+    @Test
+    fun `On 'launch', should create google pay launcher properly`() = runTest {
+        RecordingGooglePayPaymentMethodLauncherFactory.test(mock()) {
+            val definition = createGooglePayConfirmationDefinition(factory)
+            val launcher = FakeActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>()
+
+            definition.launch(
+                confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
+                intent = PAYMENT_INTENT,
+                arguments = Unit,
+                launcher = launcher,
+            )
+
+            val createGooglePayLauncherCall = createGooglePayPaymentMethodLauncherCalls.awaitItem()
+
+            assertThat(createGooglePayLauncherCall.activityResultLauncher).isEqualTo(launcher)
+            assertThat(createGooglePayLauncherCall.skipReadyCheck).isTrue()
+            assertThat(createGooglePayLauncherCall.cardBrandFilter).isEqualTo(DefaultCardBrandFilter)
+
+            assertThat(createGooglePayLauncherCall.config.environment).isEqualTo(GooglePayEnvironment.Test)
+            assertThat(createGooglePayLauncherCall.config.merchantName).isEqualTo("Test merchant Inc.")
+            assertThat(createGooglePayLauncherCall.config.merchantCountryCode).isEqualTo("US")
+            assertThat(createGooglePayLauncherCall.config.allowCreditCards).isTrue()
+            assertThat(createGooglePayLauncherCall.config.existingPaymentMethodRequired).isTrue()
+            assertThat(createGooglePayLauncherCall.config.isEmailRequired).isFalse()
+            assertThat(createGooglePayLauncherCall.config.billingAddressConfig.isRequired).isTrue()
+            assertThat(createGooglePayLauncherCall.config.billingAddressConfig.isPhoneNumberRequired).isFalse()
+            assertThat(createGooglePayLauncherCall.config.billingAddressConfig.format)
+                .isEqualTo(GooglePayPaymentMethodLauncher.BillingAddressConfig.Format.Full)
+        }
+    }
+
+    @Test
+    fun `On 'launch', should use payment intent currency code if available`() = runTest {
+        val googlePayLauncher = mock<GooglePayPaymentMethodLauncher>()
+
+        RecordingGooglePayPaymentMethodLauncherFactory.test(googlePayLauncher) {
+            val definition = createGooglePayConfirmationDefinition(factory)
+            val launcher = FakeActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>()
+
+            definition.launch(
+                confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION.copy(
+                    config = GOOGLE_PAY_CONFIRMATION_OPTION.config.copy(
+                        merchantCurrencyCode = "USD",
+                    ),
+                ),
+                intent = PAYMENT_INTENT.copy(currency = "CAD"),
+                arguments = Unit,
+                launcher = launcher,
+            )
+
+            assertThat(createGooglePayPaymentMethodLauncherCalls.awaitItem()).isNotNull()
+
+            verify(googlePayLauncher, times(1)).present(
+                currencyCode = "CAD",
+                amount = 1000L,
+                transactionId = "pi_12345",
+                label = null
+            )
+        }
+    }
+
+    @Test
+    fun `On 'launch', should use payment intent currency & amount`() = runTest {
+        val googlePayLauncher = mock<GooglePayPaymentMethodLauncher>()
+
+        RecordingGooglePayPaymentMethodLauncherFactory.test(googlePayLauncher) {
+            val definition = createGooglePayConfirmationDefinition(factory)
+            val launcher = FakeActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>()
+
+            definition.launch(
+                confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION.copy(
+                    config = GOOGLE_PAY_CONFIRMATION_OPTION.config.copy(
+                        merchantCurrencyCode = "USD",
+                        customLabel = "Merchant Inc."
+                    ),
+                ),
+                intent = PAYMENT_INTENT.copy(currency = "CAD"),
+                arguments = Unit,
+                launcher = launcher,
+            )
+
+            assertThat(createGooglePayPaymentMethodLauncherCalls.awaitItem()).isNotNull()
+
+            verify(googlePayLauncher, times(1)).present(
+                currencyCode = "CAD",
+                amount = 1000L,
+                transactionId = "pi_12345",
+                label = "Merchant Inc."
+            )
+        }
+    }
+
+    @Test
+    fun `On 'launch', should use set currency & custom amount when using setup intent`() = runTest {
+        val googlePayLauncher = mock<GooglePayPaymentMethodLauncher>()
+
+        RecordingGooglePayPaymentMethodLauncherFactory.test(googlePayLauncher) {
+            val definition = createGooglePayConfirmationDefinition(factory)
+            val launcher = FakeActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>()
+
+            definition.launch(
+                confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION.copy(
+                    config = GOOGLE_PAY_CONFIRMATION_OPTION.config.copy(
+                        merchantCurrencyCode = "USD",
+                        customAmount = 2099L,
+                        customLabel = "Merchant Inc."
+                    ),
+                ),
+                intent = SetupIntentFactory.create(),
+                arguments = Unit,
+                launcher = launcher,
+            )
+
+            assertThat(createGooglePayPaymentMethodLauncherCalls.awaitItem()).isNotNull()
+
+            verify(googlePayLauncher, times(1)).present(
+                currencyCode = "USD",
+                amount = 2099L,
+                transactionId = "pi_12345",
+                label = "Merchant Inc."
+            )
+        }
+    }
+
+    private fun runActionTest(
+        initializationMode: PaymentElementLoader.InitializationMode,
+        merchantCurrencyCode: String?,
+        shouldHaveCurrencyCodeFailure: Boolean,
+    ) = runTest {
+        val userFacingLogger = FakeUserFacingLogger()
+        val definition = createGooglePayConfirmationDefinition(userFacingLogger = userFacingLogger)
+
+        val action = definition.action(
+            confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION.copy(
+                initializationMode = initializationMode,
+                config = GOOGLE_PAY_CONFIRMATION_OPTION.config.copy(
+                    merchantCurrencyCode = merchantCurrencyCode,
+                ),
+            ),
+            intent = SetupIntentFactory.create(),
+        )
+
+        if (shouldHaveCurrencyCodeFailure) {
+            assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Fail<Unit>>()
+
+            val failAction = action.asFail()
+            val failureMessage = "GooglePayConfig.currencyCode is required in order to use " +
+                "Google Pay when processing a Setup Intent"
+
+            assertThat(userFacingLogger.getLoggedMessages()).containsExactly(failureMessage)
+
+            assertThat(failAction.cause).isInstanceOf<IllegalStateException>()
+            assertThat(failAction.cause.message).isEqualTo(failureMessage)
+            assertThat(failAction.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
+            assertThat(failAction.errorType)
+                .isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.MerchantIntegration)
+        } else {
+            assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Launch<Unit>>()
+
+            val launchAction = action.asLaunch()
+
+            assertThat(launchAction.receivesResultInProcess).isTrue()
+            assertThat(launchAction.deferredIntentConfirmationType).isNull()
+            assertThat(launchAction.launcherArguments).isEqualTo(Unit)
+        }
+    }
+
+    private fun createGooglePayConfirmationDefinition(
+        googlePayPaymentMethodLauncherFactory: GooglePayPaymentMethodLauncherFactory =
+            RecordingGooglePayPaymentMethodLauncherFactory(
+                googlePayPaymentMethodLauncher = mock()
+            ),
+        userFacingLogger: UserFacingLogger = FakeUserFacingLogger()
+    ): GooglePayConfirmationDefinition {
+        return GooglePayConfirmationDefinition(
+            googlePayPaymentMethodLauncherFactory = googlePayPaymentMethodLauncherFactory,
+            userFacingLogger = userFacingLogger,
+        )
+    }
+
+    private companion object {
+        private val GOOGLE_PAY_CONFIRMATION_OPTION = GooglePayConfirmationOption(
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123_secret_123",
+            ),
+            shippingDetails = null,
+            config = GooglePayConfirmationOption.Config(
+                environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                merchantName = "Test merchant Inc.",
+                merchantCountryCode = "US",
+                merchantCurrencyCode = "CA",
+                customAmount = 1099,
+                customLabel = null,
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                ),
+                cardBrandFilter = DefaultCardBrandFilter,
+            )
+        )
+
+        private val PAYMENT_INTENT = PaymentIntentFactory.create()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
@@ -1,0 +1,123 @@
+package com.stripe.android.paymentelement.confirmation.gpay
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
+import com.stripe.android.isInstanceOf
+import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
+import com.stripe.android.paymentelement.confirmation.ConfirmationMediator
+import com.stripe.android.paymentelement.confirmation.ConfirmationMediator.Parameters
+import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
+import com.stripe.android.paymentelement.confirmation.asLaunch
+import com.stripe.android.paymentelement.confirmation.runResultTest
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.paymentsheet.utils.RecordingGooglePayPaymentMethodLauncherFactory
+import com.stripe.android.testing.PaymentIntentFactory
+import com.stripe.android.testing.PaymentMethodFactory
+import com.stripe.android.utils.DummyActivityResultCaller
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+
+class GooglePayConfirmationFlowTest {
+    @Test
+    fun `on launch, should persist parameters & launch using launcher as expected`() = runTest {
+        val googlePayPaymentMethodLauncher = mock<GooglePayPaymentMethodLauncher>()
+        val savedStateHandle = SavedStateHandle()
+        val mediator = ConfirmationMediator(
+            savedStateHandle = savedStateHandle,
+            definition = GooglePayConfirmationDefinition(
+                googlePayPaymentMethodLauncherFactory = RecordingGooglePayPaymentMethodLauncherFactory(
+                    googlePayPaymentMethodLauncher = googlePayPaymentMethodLauncher,
+                ),
+                userFacingLogger = null,
+            ),
+        )
+
+        DummyActivityResultCaller.test {
+            mediator.register(
+                activityResultCaller = activityResultCaller,
+                onResult = {}
+            )
+
+            assertThat(awaitRegisterCall()).isNotNull()
+            assertThat(awaitNextRegisteredLauncher()).isNotNull()
+
+            val action = mediator.action(
+                option = GOOGLE_PAY_CONFIRMATION_OPTION,
+                intent = PAYMENT_INTENT,
+            )
+
+            assertThat(action).isInstanceOf<ConfirmationMediator.Action.Launch>()
+
+            val launchAction = action.asLaunch()
+
+            launchAction.launch()
+
+            val parameters = savedStateHandle
+                .get<Parameters<GooglePayConfirmationOption>>("GooglePayParameters")
+
+            assertThat(parameters?.confirmationOption).isEqualTo(GOOGLE_PAY_CONFIRMATION_OPTION)
+            assertThat(parameters?.intent).isEqualTo(PAYMENT_INTENT)
+            assertThat(parameters?.deferredIntentConfirmationType).isNull()
+
+            verify(googlePayPaymentMethodLauncher, times(1)).present(
+                currencyCode = "usd",
+                amount = 1000L,
+                transactionId = "pi_12345",
+                label = null,
+            )
+        }
+    }
+
+    @Test
+    fun `on result, should return confirmation result as expected`() = runResultTest(
+        confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
+        intent = PAYMENT_INTENT,
+        definition = GooglePayConfirmationDefinition(
+            googlePayPaymentMethodLauncherFactory = RecordingGooglePayPaymentMethodLauncherFactory(mock()),
+            userFacingLogger = null,
+        ),
+        launcherResult = GooglePayPaymentMethodLauncher.Result.Completed(PAYMENT_METHOD),
+        definitionResult = ConfirmationDefinition.Result.NextStep(
+            intent = PAYMENT_INTENT,
+            confirmationOption = PaymentMethodConfirmationOption.Saved(
+                initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                    clientSecret = "pi_123_secret_123",
+                ),
+                paymentMethod = PAYMENT_METHOD,
+                optionsParams = null,
+                shippingDetails = null,
+            )
+        )
+    )
+
+    private companion object {
+        private val GOOGLE_PAY_CONFIRMATION_OPTION = GooglePayConfirmationOption(
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123_secret_123",
+            ),
+            shippingDetails = null,
+            config = GooglePayConfirmationOption.Config(
+                environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                merchantName = "Test merchant Inc.",
+                merchantCountryCode = "US",
+                merchantCurrencyCode = "CA",
+                customAmount = 1099,
+                customLabel = null,
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                ),
+                cardBrandFilter = DefaultCardBrandFilter,
+            )
+        )
+
+        private val PAYMENT_METHOD = PaymentMethodFactory.card()
+
+        private val PAYMENT_INTENT = PaymentIntentFactory.create()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -150,7 +150,7 @@ internal class DefaultFlowControllerTest {
     private val googlePayPaymentMethodLauncher = mock<GooglePayPaymentMethodLauncher>()
 
     private val googlePayPaymentMethodLauncherFactory =
-        RecordingGooglePayPaymentMethodLauncherFactory(googlePayPaymentMethodLauncher)
+        RecordingGooglePayPaymentMethodLauncherFactory.noOp(googlePayPaymentMethodLauncher)
 
     private val linkActivityResultLauncher =
         mock<ActivityResultLauncher<LinkActivityContract.Args>>()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -357,9 +357,13 @@ internal class DefaultFlowControllerTest {
         val viewModel = createViewModel()
         val flowController = createFlowController(viewModel = viewModel)
 
-        flowController.configureExpectingSuccess()
+        flowController.configureExpectingSuccess(
+            configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
+        )
 
         viewModel.paymentSelection = PaymentSelection.GooglePay
+
+        flowController.confirm()
 
         val errorCode = GooglePayPaymentMethodLauncher.INTERNAL_ERROR
 
@@ -1113,11 +1117,16 @@ internal class DefaultFlowControllerTest {
     fun `onGooglePayResult() when canceled should invoke callback with canceled result`() = runTest {
         verifyNoInteractions(eventReporter)
 
-        val flowController = createFlowController()
+        val viewModel = createViewModel()
+        val flowController = createFlowController(viewModel = viewModel)
 
         flowController.configureExpectingSuccess(
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
         )
+
+        viewModel.paymentSelection = PaymentSelection.GooglePay
+
+        flowController.confirm()
 
         googlePayLauncherResultCallback?.invoke(
             GooglePayPaymentMethodLauncher.Result.Canceled

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/RecordingGooglePayPaymentMethodLauncherFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/RecordingGooglePayPaymentMethodLauncherFactory.kt
@@ -1,15 +1,19 @@
 package com.stripe.android.paymentsheet.utils
 
 import androidx.activity.result.ActivityResultLauncher
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.runTest
 
 internal class RecordingGooglePayPaymentMethodLauncherFactory(
     private val googlePayPaymentMethodLauncher: GooglePayPaymentMethodLauncher,
 ) : GooglePayPaymentMethodLauncherFactory {
+    private val calls = Turbine<Call>()
 
     var config: GooglePayPaymentMethodLauncher.Config? = null
         private set
@@ -22,7 +26,46 @@ internal class RecordingGooglePayPaymentMethodLauncherFactory(
         skipReadyCheck: Boolean,
         cardBrandFilter: CardBrandFilter
     ): GooglePayPaymentMethodLauncher {
+        calls.add(
+            Call(
+                config = config,
+                activityResultLauncher = activityResultLauncher,
+                skipReadyCheck = skipReadyCheck,
+                cardBrandFilter = cardBrandFilter,
+            )
+        )
+
         this.config = config
         return googlePayPaymentMethodLauncher
+    }
+
+    data class Call(
+        val config: GooglePayPaymentMethodLauncher.Config,
+        val activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
+        val skipReadyCheck: Boolean,
+        val cardBrandFilter: CardBrandFilter,
+    )
+
+    class Scenario(
+        val factory: GooglePayPaymentMethodLauncherFactory,
+        val createGooglePayPaymentMethodLauncherCalls: ReceiveTurbine<Call>
+    )
+
+    companion object {
+        fun test(
+            launcher: GooglePayPaymentMethodLauncher,
+            test: suspend Scenario.() -> Unit
+        ) = runTest {
+            val factory = RecordingGooglePayPaymentMethodLauncherFactory(launcher)
+
+            test(
+                Scenario(
+                    factory = factory,
+                    createGooglePayPaymentMethodLauncherCalls = factory.calls,
+                )
+            )
+
+            factory.calls.ensureAllEventsConsumed()
+        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/RecordingGooglePayPaymentMethodLauncherFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/RecordingGooglePayPaymentMethodLauncherFactory.kt
@@ -10,7 +10,7 @@ import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLaun
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.runTest
 
-internal class RecordingGooglePayPaymentMethodLauncherFactory(
+internal class RecordingGooglePayPaymentMethodLauncherFactory private constructor(
     private val googlePayPaymentMethodLauncher: GooglePayPaymentMethodLauncher,
 ) : GooglePayPaymentMethodLauncherFactory {
     private val calls = Turbine<Call>()
@@ -66,6 +66,10 @@ internal class RecordingGooglePayPaymentMethodLauncherFactory(
             )
 
             factory.calls.ensureAllEventsConsumed()
+        }
+
+        fun noOp(launcher: GooglePayPaymentMethodLauncher): RecordingGooglePayPaymentMethodLauncherFactory {
+            return RecordingGooglePayPaymentMethodLauncherFactory(launcher)
         }
     }
 }


### PR DESCRIPTION
# Summary
Move `Google Pay` to a `ConfirmationDefinition` type

# Motivation
Last confirmation type in `DefaultConfirmationHandler` that needs to be become a definition.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified