### PR TITLE
Rename `awaitIntentResult` to `awaitResult` & remove comments from `DefaultConfirmationHandler`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -1027,7 +1027,7 @@ internal class CustomerSheetViewModel(
             )
         )
 
-        when (val result = confirmationHandler.awaitIntentResult()) {
+        when (val result = confirmationHandler.awaitResult()) {
             is ConfirmationHandler.Result.Succeeded -> {
                 eventReporter.onAttachPaymentMethodSucceeded(
                     style = CustomerSheetEventReporter.AddPaymentMethodStyle.SetupIntent

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
@@ -35,7 +35,7 @@ internal interface ConfirmationHandler {
     fun register(activityResultCaller: ActivityResultCaller, lifecycleOwner: LifecycleOwner)
 
     /**
-     * Starts the confirmation process. Results can be received through [state] or through [awaitIntentResult].
+     * Starts the confirmation process. Results can be received through [state] or through [awaitResult].
      *
      * @param arguments required set of arguments in order to start the confirmation process
      */
@@ -46,7 +46,7 @@ internal interface ConfirmationHandler {
      *
      * @return confirmation result or null if no confirmation process has been started
      */
-    suspend fun awaitIntentResult(): Result?
+    suspend fun awaitResult(): Result?
 
     /**
      * A factory for creating a [ConfirmationHandler] instance using a provided [CoroutineScope]. This scope is

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
@@ -1,11 +1,9 @@
 package com.stripe.android.paymentelement.confirmation
 
-import android.app.Activity
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.PaymentConfiguration
@@ -40,10 +38,6 @@ import javax.inject.Named
 import javax.inject.Provider
 import kotlin.time.Duration.Companion.seconds
 
-/**
- * This interface handles the process of confirming a [StripeIntent]. This interface can only handle confirming one
- * intent at a time.
- */
 internal class DefaultConfirmationHandler(
     private val intentConfirmationInterceptor: IntentConfirmationInterceptor,
     private val paymentLauncherFactory: (ActivityResultLauncher<PaymentLauncherContract.Args>) -> PaymentLauncher,
@@ -82,10 +76,6 @@ internal class DefaultConfirmationHandler(
 
     private val isAwaitingForResultData = retrieveIsAwaitingForResultData()
 
-    /**
-     * Indicates if this handler has been reloaded from process death. This occurs if the handler was confirming
-     * an intent before did not complete the process before process death.
-     */
     override val hasReloadedFromProcessDeath = isAwaitingForResultData != null
 
     private val _state = MutableStateFlow(
@@ -114,12 +104,6 @@ internal class DefaultConfirmationHandler(
         }
     }
 
-    /**
-     * Registers activities tied to confirmation process to the lifecycle.
-     *
-     * @param activityResultCaller a class that can call [Activity.startActivityForResult]-style APIs
-     * @param lifecycleOwner a class tied to an Android [Lifecycle]
-     */
     override fun register(activityResultCaller: ActivityResultCaller, lifecycleOwner: LifecycleOwner) {
         confirmationMediators.forEach { mediator ->
             mediator.register(activityResultCaller, ::onResult)
@@ -137,13 +121,6 @@ internal class DefaultConfirmationHandler(
         )
     }
 
-    /**
-     * Starts the confirmation process with a given [ConfirmationHandler.Args] instance. Result from this method can
-     * be received from [awaitIntentResult]. This method cannot return a result since the confirmation process can be
-     * handed off to another [Activity] to handle after starting it.
-     *
-     * @param arguments arguments required to confirm a Stripe intent
-     */
     override fun start(
         arguments: ConfirmationHandler.Args,
     ) {
@@ -163,13 +140,7 @@ internal class DefaultConfirmationHandler(
         }
     }
 
-    /**
-     * Waits for an intent result to be returned following a call to start an intent confirmation process through the
-     * [start] method. If no such call has been made, will return null.
-     *
-     * @return result of intent confirmation process or null if not started.
-     */
-    override suspend fun awaitIntentResult(): ConfirmationHandler.Result? {
+    override suspend fun awaitResult(): ConfirmationHandler.Result? {
         return when (val state = _state.value) {
             is ConfirmationHandler.State.Idle -> null
             is ConfirmationHandler.State.Complete -> state.result

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -308,7 +308,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     private suspend fun handlePaymentSheetStateLoaded(state: PaymentSheetState.Full) {
-        val pendingResult = confirmationHandler.awaitIntentResult()
+        val pendingResult = confirmationHandler.awaitResult()
 
         if (pendingResult is ConfirmationHandler.Result.Succeeded) {
             // If we just received a transaction result after process death, we don't error. Instead, we dismiss
@@ -334,7 +334,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
         linkHandler.setupLink(state.linkState)
 
-        val pendingFailedPaymentResult = confirmationHandler.awaitIntentResult()
+        val pendingFailedPaymentResult = confirmationHandler.awaitResult()
             as? ConfirmationHandler.Result.Failed
         val errorMessage = pendingFailedPaymentResult?.cause?.stripeErrorMessage()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
@@ -289,7 +289,7 @@ class DefaultConfirmationHandlerTest {
     }
 
     @Test
-    fun `On intercepted intent complete, should receive 'Succeeded' result through 'awaitIntentResult'`() = runTest {
+    fun `On intercepted intent complete, should receive 'Succeeded' result through 'awaitResult'`() = runTest {
         val interceptor = FakeIntentConfirmationInterceptor()
 
         interceptor.enqueueCompleteStep()
@@ -302,7 +302,7 @@ class DefaultConfirmationHandlerTest {
             arguments = DEFAULT_ARGUMENTS,
         )
 
-        val result = defaultConfirmationHandler.awaitIntentResult()
+        val result = defaultConfirmationHandler.awaitResult()
 
         assertThat(result).isEqualTo(
             ConfirmationHandler.Result.Succeeded(
@@ -313,7 +313,7 @@ class DefaultConfirmationHandlerTest {
     }
 
     @Test
-    fun `On intercepted intent next step failed, should be 'Failed' result through 'awaitIntentResult'`() = runTest {
+    fun `On intercepted intent next step failed, should be 'Failed' result through 'awaitResult'`() = runTest {
         val interceptor = FakeIntentConfirmationInterceptor()
 
         val cause = IllegalStateException("An error occurred!")
@@ -332,7 +332,7 @@ class DefaultConfirmationHandlerTest {
             arguments = DEFAULT_ARGUMENTS,
         )
 
-        val result = defaultConfirmationHandler.awaitIntentResult()
+        val result = defaultConfirmationHandler.awaitResult()
 
         assertThat(result).isEqualTo(
             ConfirmationHandler.Result.Failed(
@@ -361,7 +361,7 @@ class DefaultConfirmationHandlerTest {
                 arguments = DEFAULT_ARGUMENTS,
             )
 
-            val result = defaultConfirmationHandler.awaitIntentResult()
+            val result = defaultConfirmationHandler.awaitResult()
 
             val failedResult = result.asFailed()
 
@@ -521,7 +521,7 @@ class DefaultConfirmationHandlerTest {
                 deferredIntentConfirmationType = null,
             )
 
-            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -564,7 +564,7 @@ class DefaultConfirmationHandlerTest {
                 action = ConfirmationHandler.Result.Canceled.Action.InformCancellation,
             )
 
-            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -611,7 +611,7 @@ class DefaultConfirmationHandlerTest {
                 type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
             )
 
-            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -762,7 +762,7 @@ class DefaultConfirmationHandlerTest {
                 action = ConfirmationHandler.Result.Canceled.Action.None
             )
 
-            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -825,7 +825,7 @@ class DefaultConfirmationHandlerTest {
                 deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
             )
 
-            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -857,13 +857,13 @@ class DefaultConfirmationHandlerTest {
 
         paymentResultCallbackHandler.onResult(InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED))
 
-        val failedResult = defaultConfirmationHandler.awaitIntentResult().asFailed()
+        val failedResult = defaultConfirmationHandler.awaitResult().asFailed()
 
         assertThat(failedResult.type).isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.Internal)
     }
 
     @Test
-    fun `On init with 'SavedStateHandle', should receive result through 'awaitIntentResult'`() = runTest {
+    fun `On init with 'SavedStateHandle', should receive result through 'awaitResult'`() = runTest {
         val savedStateHandle = SavedStateHandle().apply {
             set(
                 "AwaitingConfirmationResult",
@@ -894,7 +894,7 @@ class DefaultConfirmationHandlerTest {
 
         paymentResultCallbackHandler.onResult(InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED))
 
-        val result = defaultConfirmationHandler.awaitIntentResult()
+        val result = defaultConfirmationHandler.awaitResult()
 
         assertThat(result).isEqualTo(
             ConfirmationHandler.Result.Succeeded(
@@ -921,7 +921,7 @@ class DefaultConfirmationHandlerTest {
             arguments = DEFAULT_ARGUMENTS,
         )
 
-        val failedResult = defaultConfirmationHandler.awaitIntentResult().asFailed()
+        val failedResult = defaultConfirmationHandler.awaitResult().asFailed()
 
         assertThat(failedResult.cause).isInstanceOf(InvalidDeferredIntentUsageException::class.java)
         assertThat(failedResult.type).isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.Payment)
@@ -954,7 +954,7 @@ class DefaultConfirmationHandlerTest {
 
         paymentResultCallbackHandler.onResult(InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED))
 
-        val result = defaultConfirmationHandler.awaitIntentResult()
+        val result = defaultConfirmationHandler.awaitResult()
 
         assertThat(result).isEqualTo(
             ConfirmationHandler.Result.Succeeded(
@@ -1004,7 +1004,7 @@ class DefaultConfirmationHandlerTest {
                 deferredIntentConfirmationType = null,
             )
 
-            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -1063,7 +1063,7 @@ class DefaultConfirmationHandlerTest {
             ),
         )
 
-        val intentResult = defaultConfirmationHandler.awaitIntentResult().asFailed()
+        val intentResult = defaultConfirmationHandler.awaitResult().asFailed()
 
         assertThat(intentResult.cause.message).isEqualTo(
             "externalPaymentMethodConfirmHandler is null. Cannot process payment for payment selection: paypal"
@@ -1086,7 +1086,7 @@ class DefaultConfirmationHandlerTest {
             ),
         )
 
-        val intentResult = defaultConfirmationHandler.awaitIntentResult().asFailed()
+        val intentResult = defaultConfirmationHandler.awaitResult().asFailed()
 
         assertThat(intentResult.cause.message).isEqualTo(
             "No launcher for ExternalPaymentMethodConfirmationDefinition was found, did you call register?"
@@ -1129,7 +1129,7 @@ class DefaultConfirmationHandlerTest {
                 deferredIntentConfirmationType = null,
             )
 
-            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -1173,7 +1173,7 @@ class DefaultConfirmationHandlerTest {
                 type = ConfirmationHandler.Result.Failed.ErrorType.ExternalPaymentMethod,
             )
 
-            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -1213,7 +1213,7 @@ class DefaultConfirmationHandlerTest {
                 action = ConfirmationHandler.Result.Canceled.Action.None,
             )
 
-            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -1272,7 +1272,7 @@ class DefaultConfirmationHandlerTest {
 
         bacsMandateConfirmationLauncher.calls.expectNoEvents()
 
-        val result = defaultConfirmationHandler.awaitIntentResult().asFailed()
+        val result = defaultConfirmationHandler.awaitResult().asFailed()
 
         assertThat(result.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
         assertThat(result.type).isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.Fatal)
@@ -1298,7 +1298,7 @@ class DefaultConfirmationHandlerTest {
 
         bacsMandateConfirmationLauncher.calls.expectNoEvents()
 
-        val result = defaultConfirmationHandler.awaitIntentResult().asFailed()
+        val result = defaultConfirmationHandler.awaitResult().asFailed()
 
         assertThat(result.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
         assertThat(result.type).isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.Internal)
@@ -1325,7 +1325,7 @@ class DefaultConfirmationHandlerTest {
 
         bacsMandateConfirmationLauncher.calls.expectNoEvents()
 
-        val result = defaultConfirmationHandler.awaitIntentResult().asFailed()
+        val result = defaultConfirmationHandler.awaitResult().asFailed()
 
         assertThat(result.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
         assertThat(result.type).isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.Internal)
@@ -1413,7 +1413,7 @@ class DefaultConfirmationHandlerTest {
                 action = ConfirmationHandler.Result.Canceled.Action.ModifyPaymentDetails,
             )
 
-            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -1460,7 +1460,7 @@ class DefaultConfirmationHandlerTest {
                 action = ConfirmationHandler.Result.Canceled.Action.None,
             )
 
-            assertThat(defaultConfirmationHandler.awaitIntentResult()).isEqualTo(expectedResult)
+            assertThat(defaultConfirmationHandler.awaitResult()).isEqualTo(expectedResult)
             assertThat(awaitItem()).isEqualTo(ConfirmationHandler.State.Complete(expectedResult))
 
             ensureAllEventsConsumed()
@@ -1487,7 +1487,7 @@ class DefaultConfirmationHandlerTest {
             ),
         )
 
-        val result = defaultConfirmationHandler.awaitIntentResult().asFailed()
+        val result = defaultConfirmationHandler.awaitResult().asFailed()
 
         val message = "GooglePayConfig.currencyCode is required in order to use " +
             "Google Pay when processing a Setup Intent"


### PR DESCRIPTION
# Summary
Rename `awaitIntentResult` to `awaitResult` & remove comments from `DefaultConfirmationHandler`

# Motivation
`awaitIntentResult` was initially named when `DefaultConfirmationHandler` was called `IntentConfirmationHandler`. Renaming this to simply `awaitResult` is more inline with what `ConfirmationHandler` is intended for. Also removed the comments from `DefaultConfirmationHandler`, the interface already has the comments needed to explain overridden function behavior.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified