### PR TITLE
Display selected PM in embedded playground.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/embedded/EmbeddedPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/embedded/EmbeddedPlaygroundActivity.kt
@@ -5,11 +5,21 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundConfigurationData
+import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentMethodSelector
+import com.stripe.android.uicore.utils.collectAsState
 
 @OptIn(ExperimentalEmbeddedPaymentElementApi::class)
 internal class EmbeddedPlaygroundActivity : AppCompatActivity() {
@@ -41,7 +51,28 @@ internal class EmbeddedPlaygroundActivity : AppCompatActivity() {
                     configuration = playgroundState.embeddedConfiguration(),
                 )
             }
-            embeddedPaymentElement.Content()
+
+            val scrollState = rememberScrollState()
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(scrollState)
+                    .padding(16.dp)
+            ) {
+                embeddedPaymentElement.Content()
+
+                val selectedPaymentOption by embeddedPaymentElement.paymentOption.collectAsState()
+
+                selectedPaymentOption?.let { selectedPaymentOption ->
+                    PaymentMethodSelector(
+                        isEnabled = true,
+                        paymentMethodLabel = selectedPaymentOption.label,
+                        paymentMethodPainter = selectedPaymentOption.iconPainter,
+                        clickable = false,
+                        onClick = { },
+                    )
+                }
+            }
         }
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/shared/Payment.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/shared/Payment.kt
@@ -32,6 +32,7 @@ fun PaymentMethodSelector(
     isEnabled: Boolean,
     paymentMethodLabel: String,
     paymentMethodPainter: Painter?,
+    clickable: Boolean = isEnabled,
     onClick: () -> Unit,
 ) {
     Row(
@@ -49,8 +50,8 @@ fun PaymentMethodSelector(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.End,
             modifier = Modifier.clickable(
-                enabled = isEnabled,
-                onClick = onClick
+                enabled = clickable,
+                onClick = onClick,
             ).semantics {
                 testTag = PAYMENT_METHOD_SELECTOR_TEST_TAG
                 text = AnnotatedString(paymentMethodLabel)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This wires up (into the playground) the functionality I previously introduced where loading sends the default selected back to the paymentOption state flow.

![Screenshot_20241125_061156](https://github.com/user-attachments/assets/8101326d-f790-4c26-96a8-30eaacec8861)

