### PR TITLE
Refactor `ConfirmationMediator` tests to isolate from implemented definitions & to track function calls

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationDefinition.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationDefinition.kt
@@ -2,136 +2,61 @@ package com.stripe.android.paymentelement.confirmation
 
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
-import app.cash.turbine.ReceiveTurbine
-import app.cash.turbine.Turbine
-import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
-import kotlinx.parcelize.Parcelize
+import com.stripe.android.paymentsheet.R
 
-internal class FakeConfirmationDefinition(
-    private val onAction: (
-        confirmationOption: PaymentMethodConfirmationOption.Saved,
-        intent: StripeIntent
-    ) -> ConfirmationDefinition.Action<LauncherArgs> = { _, _ ->
-        val exception = IllegalStateException("Failed!")
-
-        ConfirmationDefinition.Action.Fail(
-            cause = exception,
-            message = exception.stripeErrorMessage(),
-            errorType = ConfirmationHandler.Result.Failed.ErrorType.Internal,
-        )
-    },
+internal abstract class FakeConfirmationDefinition<
+    TConfirmationOption : ConfirmationHandler.Option,
+    TLauncher,
+    TLauncherArgs,
+    TLauncherResult : Parcelable,
+    >(
+    private val launcher: TLauncher,
+    private val action: ConfirmationDefinition.Action<TLauncherArgs> = ConfirmationDefinition.Action.Fail(
+        cause = IllegalStateException("Failed!"),
+        message = R.string.stripe_something_went_wrong.resolvableString,
+        errorType = ConfirmationHandler.Result.Failed.ErrorType.Internal,
+    ),
     private val result: ConfirmationDefinition.Result = ConfirmationDefinition.Result.Canceled(
         action = ConfirmationHandler.Result.Canceled.Action.InformCancellation,
     ),
-    private val launcher: Launcher = Launcher(),
 ) : ConfirmationDefinition<
-    PaymentMethodConfirmationOption.Saved,
-    FakeConfirmationDefinition.Launcher,
-    FakeConfirmationDefinition.LauncherArgs,
-    FakeConfirmationDefinition.LauncherResult
+    TConfirmationOption,
+    TLauncher,
+    TLauncherArgs,
+    TLauncherResult
     > {
-    private val _launchCalls = Turbine<LaunchCall>()
-    val launchCalls: ReceiveTurbine<LaunchCall> = _launchCalls
-
-    private val _createLauncherCalls = Turbine<CreateLauncherCall>()
-    val createLauncherCalls: ReceiveTurbine<CreateLauncherCall> = _createLauncherCalls
-
-    private val _toResultCalls = Turbine<ToResultCall>()
-    val toResultCalls: ReceiveTurbine<ToResultCall> =
-        _toResultCalls
-
-    override val key: String = "Test"
-
-    override fun option(
-        confirmationOption: ConfirmationHandler.Option
-    ): PaymentMethodConfirmationOption.Saved? {
-        return confirmationOption as? PaymentMethodConfirmationOption.Saved
-    }
-
     override suspend fun action(
-        confirmationOption: PaymentMethodConfirmationOption.Saved,
+        confirmationOption: TConfirmationOption,
         intent: StripeIntent
-    ): ConfirmationDefinition.Action<LauncherArgs> {
-        return onAction(confirmationOption, intent)
+    ): ConfirmationDefinition.Action<TLauncherArgs> {
+        return action
     }
 
     override fun launch(
-        launcher: Launcher,
-        arguments: LauncherArgs,
-        confirmationOption: PaymentMethodConfirmationOption.Saved,
+        launcher: TLauncher,
+        arguments: TLauncherArgs,
+        confirmationOption: TConfirmationOption,
         intent: StripeIntent
     ) {
-        _launchCalls.add(
-            LaunchCall(
-                launcher = launcher,
-                arguments = arguments,
-                confirmationOption = confirmationOption,
-                intent = intent,
-            )
-        )
+        // Do nothing
     }
 
     override fun createLauncher(
         activityResultCaller: ActivityResultCaller,
-        onResult: (LauncherResult) -> Unit
-    ): Launcher {
-        _createLauncherCalls.add(
-            CreateLauncherCall(
-                activityResultCaller = activityResultCaller,
-                onResult = onResult,
-            )
-        )
-
+        onResult: (TLauncherResult) -> Unit
+    ): TLauncher {
         return launcher
     }
 
     override fun toResult(
-        confirmationOption: PaymentMethodConfirmationOption.Saved,
+        confirmationOption: TConfirmationOption,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
         intent: StripeIntent,
-        result: LauncherResult
+        result: TLauncherResult
     ): ConfirmationDefinition.Result {
-        _toResultCalls.add(
-            ToResultCall(
-                confirmationOption = confirmationOption,
-                deferredIntentConfirmationType = deferredIntentConfirmationType,
-                intent = intent,
-                result = result,
-            )
-        )
-
         return this.result
     }
-
-    class LaunchCall(
-        val launcher: Launcher,
-        val arguments: LauncherArgs,
-        val confirmationOption: PaymentMethodConfirmationOption.Saved,
-        val intent: StripeIntent
-    )
-
-    class CreateLauncherCall(
-        val activityResultCaller: ActivityResultCaller,
-        val onResult: (LauncherResult) -> Unit
-    )
-
-    class ToResultCall(
-        val confirmationOption: PaymentMethodConfirmationOption.Saved,
-        val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        val intent: StripeIntent,
-        val result: LauncherResult
-    )
-
-    class Launcher
-
-    data class LauncherArgs(
-        val amount: Long,
-    )
-
-    @Parcelize
-    data class LauncherResult(
-        val amount: Long,
-    ) : Parcelable
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/RecordingConfirmationDefinition.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/RecordingConfirmationDefinition.kt
@@ -1,0 +1,149 @@
+package com.stripe.android.paymentelement.confirmation
+
+import android.os.Parcelable
+import androidx.activity.result.ActivityResultCaller
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+
+internal class RecordingConfirmationDefinition<
+    TConfirmationOption : ConfirmationHandler.Option,
+    TLauncher,
+    TLauncherArgs,
+    TLauncherResult : Parcelable,
+    > private constructor(
+    private val definition: ConfirmationDefinition<TConfirmationOption, TLauncher, TLauncherArgs, TLauncherResult>
+) : ConfirmationDefinition<
+    TConfirmationOption,
+    TLauncher,
+    TLauncherArgs,
+    TLauncherResult
+    > {
+    private val optionCalls = Turbine<OptionCall>()
+    private val toResultCalls = Turbine<ToResultCall<TConfirmationOption, TLauncherResult>>()
+    private val createLauncherCalls = Turbine<CreateLauncherCall<TLauncherResult>>()
+    private val launchCalls = Turbine<LaunchCall<TConfirmationOption, TLauncher, TLauncherArgs>>()
+    private val actionCalls = Turbine<ActionCall<TConfirmationOption>>()
+
+    override val key: String = definition.key
+
+    override fun option(confirmationOption: ConfirmationHandler.Option): TConfirmationOption? {
+        optionCalls.add(OptionCall(confirmationOption))
+
+        return definition.option(confirmationOption)
+    }
+
+    override fun toResult(
+        confirmationOption: TConfirmationOption,
+        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        intent: StripeIntent,
+        result: TLauncherResult
+    ): ConfirmationDefinition.Result {
+        toResultCalls.add(ToResultCall(confirmationOption, deferredIntentConfirmationType, intent, result))
+
+        return definition.toResult(confirmationOption, deferredIntentConfirmationType, intent, result)
+    }
+
+    override fun createLauncher(
+        activityResultCaller: ActivityResultCaller,
+        onResult: (TLauncherResult) -> Unit
+    ): TLauncher {
+        createLauncherCalls.add(CreateLauncherCall(activityResultCaller, onResult))
+
+        return definition.createLauncher(activityResultCaller, onResult)
+    }
+
+    override fun launch(
+        launcher: TLauncher,
+        arguments: TLauncherArgs,
+        confirmationOption: TConfirmationOption,
+        intent: StripeIntent
+    ) {
+        launchCalls.add(LaunchCall(launcher, arguments, confirmationOption, intent))
+
+        definition.launch(launcher, arguments, confirmationOption, intent)
+    }
+
+    override suspend fun action(
+        confirmationOption: TConfirmationOption,
+        intent: StripeIntent
+    ): ConfirmationDefinition.Action<TLauncherArgs> {
+        actionCalls.add(ActionCall(confirmationOption, intent))
+
+        return definition.action(confirmationOption, intent)
+    }
+
+    class OptionCall(
+        val option: ConfirmationHandler.Option,
+    )
+
+    class ToResultCall<TConfirmationOption : ConfirmationHandler.Option, TLauncherResult>(
+        val confirmationOption: TConfirmationOption,
+        val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        val intent: StripeIntent,
+        val result: TLauncherResult,
+    )
+
+    class CreateLauncherCall<TLauncherResult>(
+        val activityResultCaller: ActivityResultCaller,
+        val onResult: (TLauncherResult) -> Unit
+    )
+
+    class LaunchCall<TConfirmationOption : ConfirmationHandler.Option, TLauncher, TLauncherArgs>(
+        val launcher: TLauncher,
+        val arguments: TLauncherArgs,
+        val confirmationOption: TConfirmationOption,
+        val intent: StripeIntent,
+    )
+
+    class ActionCall<TConfirmationOption : ConfirmationHandler.Option>(
+        val confirmationOption: TConfirmationOption,
+        val intent: StripeIntent,
+    )
+
+    class Scenario<
+        TConfirmationOption : ConfirmationHandler.Option,
+        TLauncher,
+        TLauncherArgs,
+        TLauncherResult : Parcelable,
+        >(
+        val definition: ConfirmationDefinition<TConfirmationOption, TLauncher, TLauncherArgs, TLauncherResult>,
+        val optionCalls: ReceiveTurbine<OptionCall>,
+        val toResultCalls: ReceiveTurbine<ToResultCall<TConfirmationOption, TLauncherResult>>,
+        val createLauncherCalls: ReceiveTurbine<CreateLauncherCall<TLauncherResult>>,
+        val launchCalls: ReceiveTurbine<LaunchCall<TConfirmationOption, TLauncher, TLauncherArgs>>,
+        val actionCalls: ReceiveTurbine<ActionCall<TConfirmationOption>>,
+    )
+
+    companion object {
+        suspend fun <
+            TConfirmationOption : ConfirmationHandler.Option,
+            TLauncher,
+            TLauncherArgs,
+            TLauncherResult : Parcelable,
+            > test(
+            definition: ConfirmationDefinition<TConfirmationOption, TLauncher, TLauncherArgs, TLauncherResult>,
+            scenarioTest: suspend Scenario<TConfirmationOption, TLauncher, TLauncherArgs, TLauncherResult>.() -> Unit
+        ) {
+            val recordingDefinition = RecordingConfirmationDefinition(definition)
+
+            scenarioTest(
+                Scenario(
+                    definition = recordingDefinition,
+                    optionCalls = recordingDefinition.optionCalls,
+                    toResultCalls = recordingDefinition.toResultCalls,
+                    createLauncherCalls = recordingDefinition.createLauncherCalls,
+                    launchCalls = recordingDefinition.launchCalls,
+                    actionCalls = recordingDefinition.actionCalls,
+                )
+            )
+
+            recordingDefinition.optionCalls.ensureAllEventsConsumed()
+            recordingDefinition.toResultCalls.ensureAllEventsConsumed()
+            recordingDefinition.createLauncherCalls.ensureAllEventsConsumed()
+            recordingDefinition.launchCalls.ensureAllEventsConsumed()
+            recordingDefinition.actionCalls.ensureAllEventsConsumed()
+        }
+    }
+}


### PR DESCRIPTION
# Summary
Refactor `ConfirmationMediator` tests to isolate from implemented definitions & to track function calls

# Motivation
The tests for `ConfirmationMediator` use a lot of context from the implemented confirmation definitions in the unit tests. These tests should isolated from any implementation of `ConfirmationDefinition`. This will help setup for better isolation for the tests in `DefaultConfirmationHandler`. We also should track function calls to definitions in these tests to ensure that are being called properly and when expected.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified