### PR TITLE
[Connect] Hook http and other errors into error listener

### DIFF
--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
@@ -3,10 +3,13 @@ package com.stripe.android.connect.webview
 import android.annotation.SuppressLint
 import android.content.res.ColorStateList
 import android.graphics.Bitmap
+import android.os.Build
 import android.view.LayoutInflater
 import android.webkit.JavascriptInterface
 import android.webkit.WebChromeClient
+import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.FrameLayout
@@ -194,6 +197,25 @@ internal class StripeConnectWebViewContainerImpl<Listener : StripeEmbeddedCompon
         override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
             initJavascriptBridge(view)
             controller?.onPageStarted()
+        }
+
+        override fun onReceivedHttpError(
+            view: WebView,
+            request: WebResourceRequest,
+            errorResponse: WebResourceResponse
+        ) {
+            controller?.onReceivedError(request.url.toString(), errorResponse.statusCode, errorResponse.reasonPhrase)
+        }
+
+        override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {
+            // for some reason errorCode and description are only available in API 23+,
+            // so we simply ignore the description for older devices
+            val errorMessage = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                error.description.toString()
+            } else {
+                null
+            }
+            controller?.onReceivedError(request.url.toString(), errorMessage = errorMessage)
         }
 
         private fun initJavascriptBridge(webView: WebView) {

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
@@ -186,6 +186,7 @@ internal class StripeConnectWebViewContainerImpl<Listener : StripeEmbeddedCompon
         val viewBinding = this.viewBinding ?: return
         viewBinding.stripeWebView.setBackgroundColor(state.backgroundColor)
         viewBinding.stripeWebViewProgressBar.isVisible = state.isNativeLoadingIndicatorVisible
+        viewBinding.stripeWebView.isVisible = !state.isNativeLoadingIndicatorVisible
         if (state.isNativeLoadingIndicatorVisible) {
             viewBinding.stripeWebViewProgressBar.indeterminateTintList =
                 ColorStateList.valueOf(state.nativeLoadingIndicatorColor)

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerController.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerController.kt
@@ -59,6 +59,20 @@ internal class StripeConnectWebViewContainerController<Listener : StripeEmbedded
         updateState { copy(isNativeLoadingIndicatorVisible = !receivedSetOnLoaderStart) }
     }
 
+    fun onReceivedError(requestUrl: String, httpStatusCode: Int? = null, errorMessage: String? = null) {
+        val errorString = buildString {
+            if (httpStatusCode != null) {
+                append("Received $httpStatusCode loading $requestUrl")
+            } else {
+                append("Received error loading $requestUrl")
+            }
+            if (errorMessage != null) {
+                append(": $errorMessage")
+            }
+        }
+        listener?.onLoadError(RuntimeException(errorString)) // TODO - wrap error better
+    }
+
     fun shouldOverrideUrlLoading(context: Context, request: WebResourceRequest): Boolean {
         val url = request.url
         return if (url.host?.lowercase() in ALLOWLISTED_HOSTS) {
@@ -135,7 +149,7 @@ internal class StripeConnectWebViewContainerController<Listener : StripeEmbedded
             }
             is SetOnLoadError -> {
                 // TODO - wrap error better
-                listener?.onLoadError(RuntimeException("${value.type}: ${value.message}"))
+                listener?.onLoadError(RuntimeException("${value.error.type}: ${value.error.message}"))
             }
             else -> {
                 with(listenerDelegate) {

--- a/connect/src/main/java/com/stripe/android/connect/webview/serialization/SetterFunctionCalledMessage.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/serialization/SetterFunctionCalledMessage.kt
@@ -64,9 +64,15 @@ internal data class SetOnLoaderStart(
  */
 @Serializable
 internal data class SetOnLoadError(
-    val type: String, // TODO - possibly use an enum or sealed class here.
-    val message: String?,
-) : SetterFunctionCalledMessage.Value
+    val error: LoadError
+) : SetterFunctionCalledMessage.Value {
+
+    @Serializable
+    data class LoadError(
+        val type: String?, // TODO - possibly use an enum or sealed class here.
+        val message: String?,
+    )
+}
 
 /**
  * The connected account has exited the onboarding process.

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerControllerTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerControllerTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.connect.StripeEmbeddedComponent
 import com.stripe.android.connect.appearance.Appearance
 import com.stripe.android.connect.appearance.Colors
 import com.stripe.android.connect.webview.serialization.SetOnLoadError
+import com.stripe.android.connect.webview.serialization.SetOnLoadError.LoadError
 import com.stripe.android.connect.webview.serialization.SetOnLoaderStart
 import com.stripe.android.connect.webview.serialization.SetterFunctionCalledMessage
 import com.stripe.android.core.Logger
@@ -149,7 +150,7 @@ class StripeConnectWebViewContainerControllerTest {
 
     @Test
     fun `should handle SetOnLoadError`() = runTest {
-        val message = SetterFunctionCalledMessage(SetOnLoadError("", null))
+        val message = SetterFunctionCalledMessage(SetOnLoadError(LoadError("", null)))
         controller.onReceivedSetterFunctionCalled(message)
 
         verify(listener).onLoadError(any())
@@ -164,6 +165,13 @@ class StripeConnectWebViewContainerControllerTest {
         controller.onReceivedSetterFunctionCalled(message)
 
         assertThat(delegateReceivedEvents).contains(message)
+    }
+
+    @Test
+    fun `onReceivedError should forward to listener`() = runTest {
+        controller.onReceivedError("https://stripe.com", 404, "Not Found")
+
+        verify(listener).onLoadError(any())
     }
 
     @Test


### PR DESCRIPTION
# Summary
Hooks http errors and other webview errors into the error listener for the SDK.

[MXMOBILE-2869](https://jira.corp.stripe.com/browse/MXMOBILE-2869)

# Motivation
Even if there's a non-JS error the SDK will still receive it. This matches the iOS implementation.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified


# Screenshots

### http error (403 on resource load)

https://github.com/user-attachments/assets/2a053318-b6eb-4735-9bfb-a0ae7ba36f2b

### generic error (bad key provided to SDK)

https://github.com/user-attachments/assets/f7dd821e-19bd-4221-9be2-08940e236ffb

### non-error case (to demonstrate loading still works)

https://github.com/user-attachments/assets/0aef986d-2310-45bf-b0cd-bf485e6214b0



