### PR TITLE
Introduce `ConfirmationActivity` tests with `Google Pay`

### DIFF
--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -85,6 +85,8 @@ dependencies {
     // temporary fix for running compose test in RobolectricTestRunner, see https://github.com/robolectric/robolectric/issues/6593
     testImplementation testLibs.espresso.core
 
+    kspTest libs.daggerCompiler
+
     androidTestImplementation project(':network-testing')
     androidTestImplementation project(':payments-core-testing')
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationActivity.kt
@@ -1,0 +1,156 @@
+package com.stripe.android.paymentelement.confirmation
+
+import android.app.Application
+import android.content.Context
+import android.os.Bundle
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.Logger
+import com.stripe.android.core.injection.CoroutineContextModule
+import com.stripe.android.core.injection.ENABLE_LOGGING
+import com.stripe.android.core.injection.PUBLISHABLE_KEY
+import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
+import com.stripe.android.core.networking.AnalyticsRequestExecutor
+import com.stripe.android.core.utils.UserFacingLogger
+import com.stripe.android.core.utils.requireApplication
+import com.stripe.android.googlepaylauncher.GooglePayEnvironment
+import com.stripe.android.googlepaylauncher.GooglePayRepository
+import com.stripe.android.networking.StripeApiRepository
+import com.stripe.android.networking.StripeRepository
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.paymentsheet.utils.FakeUserFacingLogger
+import com.stripe.android.testing.FakeAnalyticsRequestExecutor
+import com.stripe.android.testing.FakeErrorReporter
+import com.stripe.android.testing.FakeLogger
+import dagger.Binds
+import dagger.BindsInstance
+import dagger.Component
+import dagger.Module
+import dagger.Provides
+import kotlinx.coroutines.flow.flowOf
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+internal class ConfirmationActivity : AppCompatActivity() {
+    val viewModel: TestViewModel by viewModels {
+        TestViewModel.Factory
+    }
+
+    val confirmationHandler by lazy {
+        viewModel.confirmationHandler
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        confirmationHandler.register(activityResultCaller = this, lifecycleOwner = this)
+    }
+
+    class TestViewModel @Inject constructor(
+        confirmationHandlerFactory: ConfirmationHandler.Factory
+    ) : ViewModel() {
+        val confirmationHandler = confirmationHandlerFactory.create(viewModelScope)
+
+        object Factory : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+                val component = DaggerConfirmationTestComponent.builder()
+                    .application(extras.requireApplication())
+                    .allowsManualConfirmation(allowsManualConfirmation = false)
+                    .statusBarColor { null }
+                    .savedStateHandle(extras.createSavedStateHandle())
+                    .build()
+
+                @Suppress("UNCHECKED_CAST")
+                return component.viewModel as T
+            }
+        }
+    }
+}
+
+@Component(
+    modules = [
+        ConfirmationModule::class,
+        CoroutineContextModule::class,
+        ConfirmationTestModule::class,
+    ]
+)
+@Singleton
+internal interface ConfirmationTestComponent {
+    val viewModel: ConfirmationActivity.TestViewModel
+
+    @Component.Builder
+    interface Builder {
+        @BindsInstance
+        fun application(application: Application): Builder
+
+        @BindsInstance
+        fun savedStateHandle(savedStateHandle: SavedStateHandle): Builder
+
+        @BindsInstance
+        fun statusBarColor(@Named(STATUS_BAR_COLOR_PROVIDER) statusBarColor: () -> Int?): Builder
+
+        @BindsInstance
+        fun allowsManualConfirmation(@Named(ALLOWS_MANUAL_CONFIRMATION) allowsManualConfirmation: Boolean): Builder
+
+        fun build(): ConfirmationTestComponent
+    }
+}
+
+@Module
+internal interface ConfirmationTestModule {
+    @Binds
+    fun bindsStripeRepository(repository: StripeApiRepository): StripeRepository
+
+    companion object {
+        @Provides
+        fun providesContext(application: Application): Context = application
+
+        @Provides
+        fun providesErrorReporter(): ErrorReporter = FakeErrorReporter()
+
+        @Provides
+        fun providesUserFacingLogger(): UserFacingLogger = FakeUserFacingLogger()
+
+        @Provides
+        fun providesAnalyticsRequestExecutor(): AnalyticsRequestExecutor = FakeAnalyticsRequestExecutor()
+
+        @Provides
+        fun providesGooglePayRepositoryFactory(): (GooglePayEnvironment) -> GooglePayRepository = { _ ->
+            GooglePayRepository { flowOf(true) }
+        }
+
+        @Provides
+        fun providesLogger(): Logger = FakeLogger()
+
+        @Provides
+        @Named(ENABLE_LOGGING)
+        fun providesEnableLogging(): Boolean = false
+
+        @Provides
+        @Named(PRODUCT_USAGE)
+        fun providesProductUsage(): Set<String> = setOf()
+
+        @Provides
+        fun providesPaymentConfiguration(): PaymentConfiguration = PaymentConfiguration(
+            publishableKey = "pk_123",
+            stripeAccountId = null,
+        )
+
+        @Provides
+        @Named(PUBLISHABLE_KEY)
+        fun providesPublishableKey(config: PaymentConfiguration): () -> String = { config.publishableKey }
+
+        @Provides
+        @Named(STRIPE_ACCOUNT_ID)
+        fun providesStripeAccountId(config: PaymentConfiguration): () -> String? = { config.stripeAccountId }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
@@ -1,0 +1,362 @@
+package com.stripe.android.paymentelement.confirmation.gpay
+
+import android.app.Activity
+import android.app.Application
+import android.app.Instrumentation
+import android.content.Intent
+import androidx.core.os.bundleOf
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.Intents.intending
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.espresso.intent.rule.IntentsRule
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
+import com.stripe.android.isInstanceOf
+import com.stripe.android.paymentelement.confirmation.ConfirmationActivity
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
+import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.createTestActivityRule
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.testing.PaymentIntentFactory
+import com.stripe.android.testing.PaymentMethodFactory
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import com.stripe.android.R as PaymentsCoreR
+
+@RunWith(RobolectricTestRunner::class)
+internal class GooglePayConfirmationActivityTest {
+    private val application = ApplicationProvider.getApplicationContext<Application>()
+
+    @get:Rule
+    val intentsRule = IntentsRule()
+
+    @get:Rule
+    val testActivityRule = createTestActivityRule<ConfirmationActivity>()
+
+    @Test
+    fun googlePaySucceeds() = test {
+        val paymentMethod = PaymentMethodFactory.card()
+
+        intendingGooglePayToBeLaunched(GooglePayPaymentMethodLauncher.Result.Completed(paymentMethod))
+        intendingPaymentConfirmationToBeLaunched(
+            InternalPaymentResult.Completed(PAYMENT_INTENT.copy(paymentMethod = paymentMethod))
+        )
+
+        confirmationHandler.state.test {
+            awaitItem().assertIdle()
+
+            confirmationHandler.start(
+                ConfirmationHandler.Args(
+                    intent = PAYMENT_INTENT,
+                    confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
+                )
+            )
+
+            val confirmingWithGooglePay = awaitItem().assertConfirming()
+
+            assertThat(confirmingWithGooglePay.option).isEqualTo(GOOGLE_PAY_CONFIRMATION_OPTION)
+
+            intendedGooglePayToBeLaunched()
+
+            val confirmingWithSavedPaymentMethod = awaitItem().assertConfirming()
+
+            assertThat(confirmingWithSavedPaymentMethod.option)
+                .isEqualTo(
+                    PaymentMethodConfirmationOption.Saved(
+                        initializationMode = GOOGLE_PAY_CONFIRMATION_OPTION.initializationMode,
+                        shippingDetails = GOOGLE_PAY_CONFIRMATION_OPTION.shippingDetails,
+                        paymentMethod = paymentMethod,
+                        optionsParams = null,
+                    )
+                )
+
+            intendedPaymentConfirmationToBeLaunched()
+
+            val successResult = awaitItem().assertComplete().result.assertSucceeded()
+
+            assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT.copy(paymentMethod = paymentMethod))
+            assertThat(successResult.deferredIntentConfirmationType).isNull()
+        }
+    }
+
+    @Test
+    fun googlePayFailsOnGooglePaySheetFailure() = test {
+        confirmationHandler.state.test {
+            awaitItem().assertIdle()
+
+            intendingGooglePayToBeLaunched(
+                GooglePayPaymentMethodLauncher.Result.Failed(
+                    error = IllegalStateException("An error occurred!"),
+                    errorCode = GooglePayPaymentMethodLauncher.INTERNAL_ERROR
+                )
+            )
+
+            confirmationHandler.start(
+                ConfirmationHandler.Args(
+                    intent = PAYMENT_INTENT,
+                    confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
+                )
+            )
+
+            val confirmingWithGooglePay = awaitItem().assertConfirming()
+
+            assertThat(confirmingWithGooglePay.option).isEqualTo(GOOGLE_PAY_CONFIRMATION_OPTION)
+
+            intendedGooglePayToBeLaunched()
+
+            val failedResult = awaitItem().assertComplete().result.assertFailed()
+
+            assertThat(failedResult.cause).isInstanceOf<IllegalStateException>()
+            assertThat(failedResult.message).isEqualTo(PaymentsCoreR.string.stripe_internal_error.resolvableString)
+            assertThat(failedResult.type).isEqualTo(
+                ConfirmationHandler.Result.Failed.ErrorType.GooglePay(GooglePayPaymentMethodLauncher.INTERNAL_ERROR)
+            )
+        }
+    }
+
+    @Test
+    fun googlePayFailsOnPaymentFailure() = test {
+        confirmationHandler.state.test {
+            awaitItem().assertIdle()
+
+            val paymentMethod = PaymentMethodFactory.card()
+
+            intendingGooglePayToBeLaunched(GooglePayPaymentMethodLauncher.Result.Completed(paymentMethod))
+            intendingPaymentConfirmationToBeLaunched(
+                InternalPaymentResult.Failed(
+                    throwable = IllegalStateException("Failed payment!")
+                )
+            )
+
+            confirmationHandler.start(
+                ConfirmationHandler.Args(
+                    intent = PAYMENT_INTENT,
+                    confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
+                )
+            )
+
+            val confirmingWithGooglePay = awaitItem().assertConfirming()
+
+            assertThat(confirmingWithGooglePay.option).isEqualTo(GOOGLE_PAY_CONFIRMATION_OPTION)
+
+            intendedGooglePayToBeLaunched()
+
+            val confirmingWithSavedPaymentMethod = awaitItem().assertConfirming()
+
+            assertThat(confirmingWithSavedPaymentMethod.option)
+                .isEqualTo(
+                    PaymentMethodConfirmationOption.Saved(
+                        initializationMode = GOOGLE_PAY_CONFIRMATION_OPTION.initializationMode,
+                        shippingDetails = GOOGLE_PAY_CONFIRMATION_OPTION.shippingDetails,
+                        paymentMethod = paymentMethod,
+                        optionsParams = null,
+                    )
+                )
+
+            intendedPaymentConfirmationToBeLaunched()
+
+            val failedResult = awaitItem().assertComplete().result.assertFailed()
+
+            assertThat(failedResult.cause).isInstanceOf<IllegalStateException>()
+            assertThat(failedResult.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
+            assertThat(failedResult.type).isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.Payment)
+        }
+    }
+
+    @Test
+    fun googlePayCancelsOnGooglePaySheetCancellation() = test {
+        confirmationHandler.state.test {
+            awaitItem().assertIdle()
+
+            intendingGooglePayToBeLaunched(GooglePayPaymentMethodLauncher.Result.Canceled)
+
+            confirmationHandler.start(
+                ConfirmationHandler.Args(
+                    intent = PAYMENT_INTENT,
+                    confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
+                )
+            )
+
+            val confirmingWithGooglePay = awaitItem().assertConfirming()
+
+            assertThat(confirmingWithGooglePay.option).isEqualTo(GOOGLE_PAY_CONFIRMATION_OPTION)
+
+            intendedGooglePayToBeLaunched()
+
+            val canceledAction = awaitItem().assertComplete().result.assertCanceled()
+
+            assertThat(canceledAction.action).isEqualTo(ConfirmationHandler.Result.Canceled.Action.InformCancellation)
+        }
+    }
+
+    @Test
+    fun googlePayCancelsOnPaymentScreenCancellation() = test {
+        confirmationHandler.state.test {
+            awaitItem().assertIdle()
+
+            val paymentMethod = PaymentMethodFactory.card()
+
+            intendingGooglePayToBeLaunched(GooglePayPaymentMethodLauncher.Result.Completed(paymentMethod))
+            intendingPaymentConfirmationToBeLaunched(InternalPaymentResult.Canceled)
+
+            confirmationHandler.start(
+                ConfirmationHandler.Args(
+                    intent = PAYMENT_INTENT,
+                    confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
+                )
+            )
+
+            val confirmingWithGooglePay = awaitItem().assertConfirming()
+
+            assertThat(confirmingWithGooglePay.option).isEqualTo(GOOGLE_PAY_CONFIRMATION_OPTION)
+
+            intendedGooglePayToBeLaunched()
+
+            val confirmingWithSavedPaymentMethod = awaitItem().assertConfirming()
+
+            assertThat(confirmingWithSavedPaymentMethod.option)
+                .isEqualTo(
+                    PaymentMethodConfirmationOption.Saved(
+                        initializationMode = GOOGLE_PAY_CONFIRMATION_OPTION.initializationMode,
+                        shippingDetails = GOOGLE_PAY_CONFIRMATION_OPTION.shippingDetails,
+                        paymentMethod = paymentMethod,
+                        optionsParams = null,
+                    )
+                )
+
+            intendedPaymentConfirmationToBeLaunched()
+
+            val canceledAction = awaitItem().assertComplete().result.assertCanceled()
+
+            assertThat(canceledAction.action).isEqualTo(ConfirmationHandler.Result.Canceled.Action.InformCancellation)
+        }
+    }
+
+    private fun test(
+        test: suspend ConfirmationActivity.() -> Unit
+    ) = runTest(UnconfinedTestDispatcher()) {
+        val countDownLatch = CountDownLatch(1)
+
+        ActivityScenario.launch<ConfirmationActivity>(
+            Intent(application, ConfirmationActivity::class.java)
+        ).use { scenario ->
+            scenario.onActivity { activity ->
+                launch {
+                    test(activity)
+                    countDownLatch.countDown()
+                }
+            }
+
+            countDownLatch.await(10, TimeUnit.SECONDS)
+        }
+    }
+
+    private fun intendingGooglePayToBeLaunched(result: GooglePayPaymentMethodLauncher.Result) {
+        intending(hasComponent(GOOGLE_PAY_ACTIVITY_NAME)).respondWith(
+            Instrumentation.ActivityResult(
+                Activity.RESULT_OK,
+                Intent().putExtra("extra_result", result)
+            )
+        )
+    }
+
+    private fun intendingPaymentConfirmationToBeLaunched(result: InternalPaymentResult) {
+        intending(hasComponent(PAYMENT_CONFIRMATION_LAUNCHER_ACTIVITY_NAME)).respondWith(
+            Instrumentation.ActivityResult(
+                Activity.RESULT_OK,
+                Intent().putExtras(bundleOf("extra_args" to result))
+            )
+        )
+    }
+
+    private fun intendedGooglePayToBeLaunched() {
+        intended(hasComponent(GOOGLE_PAY_ACTIVITY_NAME))
+    }
+
+    private fun intendedPaymentConfirmationToBeLaunched() {
+        intended(hasComponent(PAYMENT_CONFIRMATION_LAUNCHER_ACTIVITY_NAME))
+    }
+
+    private fun ConfirmationHandler.State.assertIdle(): ConfirmationHandler.State.Idle {
+        assertThat(this).isInstanceOf<ConfirmationHandler.State.Idle>()
+
+        return this as ConfirmationHandler.State.Idle
+    }
+
+    private fun ConfirmationHandler.State.assertConfirming(): ConfirmationHandler.State.Confirming {
+        assertThat(this).isInstanceOf<ConfirmationHandler.State.Confirming>()
+
+        return this as ConfirmationHandler.State.Confirming
+    }
+
+    private fun ConfirmationHandler.State.assertComplete(): ConfirmationHandler.State.Complete {
+        assertThat(this).isInstanceOf<ConfirmationHandler.State.Complete>()
+
+        return this as ConfirmationHandler.State.Complete
+    }
+
+    private fun ConfirmationHandler.Result?.assertSucceeded(): ConfirmationHandler.Result.Succeeded {
+        assertThat(this).isInstanceOf<ConfirmationHandler.Result.Succeeded>()
+
+        return this as ConfirmationHandler.Result.Succeeded
+    }
+
+    private fun ConfirmationHandler.Result?.assertFailed(): ConfirmationHandler.Result.Failed {
+        assertThat(this).isInstanceOf<ConfirmationHandler.Result.Failed>()
+
+        return this as ConfirmationHandler.Result.Failed
+    }
+
+    private fun ConfirmationHandler.Result?.assertCanceled(): ConfirmationHandler.Result.Canceled {
+        assertThat(this).isInstanceOf<ConfirmationHandler.Result.Canceled>()
+
+        return this as ConfirmationHandler.Result.Canceled
+    }
+
+    private companion object {
+        val PAYMENT_INTENT = PaymentIntentFactory.create().copy(
+            id = "pm_1",
+            amount = 5000,
+            currency = "CAD",
+        )
+
+        val GOOGLE_PAY_CONFIRMATION_OPTION = GooglePayConfirmationOption(
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123_secret_123"
+            ),
+            shippingDetails = null,
+            config = GooglePayConfirmationOption.Config(
+                environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                merchantName = "Test merchant Inc.",
+                merchantCurrencyCode = null,
+                customAmount = null,
+                merchantCountryCode = "CA",
+                customLabel = "Test merchant Inc.",
+                billingDetailsCollectionConfiguration = PaymentSheet
+                    .BillingDetailsCollectionConfiguration(),
+                cardBrandFilter = DefaultCardBrandFilter,
+            )
+        )
+
+        const val GOOGLE_PAY_ACTIVITY_NAME =
+            "com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherActivity"
+
+        const val PAYMENT_CONFIRMATION_LAUNCHER_ACTIVITY_NAME =
+            "com.stripe.android.payments.paymentlauncher.PaymentLauncherConfirmationActivity"
+    }
+}


### PR DESCRIPTION
# Summary
Introduce `ConfirmationActivity` tests with `Google Pay`

# Motivation
Allows for testing `ConfirmationHandler` flows using a shallow activity harness only for testing. These tests use `Robolectric` to simulate an Android environment and verify proper interactions with various confirmation activity flows.

We can further extend this to other confirmation flows such Bacs, EPMs, and just default intents. This `Robolectric` harness also provides a pathway for making real E2E tests with a shallow activity.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified